### PR TITLE
markdown: Fix markdown copy range resolution

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1083,7 +1083,7 @@ mod tests {
                         MarkdownEvent::SubstitutedText(parsed) => {
                             rendered_text.push_str(parsed.as_str())
                         }
-                        MarkdownEvent::Text | MarkdownEvent::Code => {
+                        MarkdownEvent::Text | MarkdownEvent::Code { .. } => {
                             rendered_text.push_str(&text[range.clone()])
                         }
                         _ => {}

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1,5 +1,6 @@
 pub mod parser;
 mod path_range;
+mod source_spans;
 
 use base64::Engine as _;
 use futures::FutureExt as _;
@@ -10,6 +11,7 @@ use language::LanguageName;
 use log::Level;
 pub use path_range::{LineCol, PathWithRange};
 use settings::Settings as _;
+pub use source_spans::MarkdownSpan;
 use theme::ThemeSettings;
 use ui::Checkbox;
 use ui::CopyButton;
@@ -35,6 +37,7 @@ use language::{CharClassifier, Language, LanguageRegistry, Rope};
 use parser::CodeBlockMetadata;
 use parser::{MarkdownEvent, MarkdownTag, MarkdownTagEnd, parse_links_only, parse_markdown};
 use pulldown_cmark::Alignment;
+use source_spans::{MarkdownRangeResolver, SourceSpanBuilder};
 use sum_tree::TreeMap;
 use theme::SyntaxTheme;
 use ui::{ScrollAxes, Scrollbars, WithScrollbar, prelude::*};
@@ -428,18 +431,24 @@ impl Markdown {
     }
 
     pub fn selected_text(&self) -> Option<String> {
-        if self.selection.end <= self.selection.start {
+        let mut range = self.clamp_source_range(self.selection.start..self.selection.end);
+        if self.parsed_markdown.source == self.source {
+            range = MarkdownRangeResolver::new(self.parsed_markdown.spans()).resolve(range);
+        }
+
+        if range.is_empty() {
             None
         } else {
-            Some(self.source[self.selection.start..self.selection.end].to_string())
+            Some(self.source[range].to_string())
         }
     }
 
     fn copy(&self, text: &RenderedText, _: &mut Window, cx: &mut Context<Self>) {
-        if self.selection.end <= self.selection.start {
+        let selection = self.clamp_source_range(self.selection.start..self.selection.end);
+        if selection.is_empty() {
             return;
         }
-        let text = text.text_for_range(self.selection.start..self.selection.end);
+        let text = text.text_for_range(selection);
         cx.write_to_clipboard(ClipboardItem::new_string(text));
     }
 
@@ -448,15 +457,26 @@ impl Markdown {
             cx.write_to_clipboard(ClipboardItem::new_string(text));
             return;
         }
-        if self.selection.end <= self.selection.start {
+
+        let Some(text) = self.selected_text() else {
             return;
-        }
-        let text = self.source[self.selection.start..self.selection.end].to_string();
+        };
         cx.write_to_clipboard(ClipboardItem::new_string(text));
     }
 
     fn capture_selection_for_context_menu(&mut self) {
         self.context_menu_selected_text = self.selected_text();
+    }
+
+    fn clamp_source_range(&self, selection: Range<usize>) -> Range<usize> {
+        let source_length = self.source.len();
+        let start = selection.start.min(source_length);
+        let end = selection.end.min(source_length);
+        if start <= end {
+            start..end
+        } else {
+            start..start
+        }
     }
 
     fn parse(&mut self, cx: &mut Context<Self>) {
@@ -483,6 +503,7 @@ impl Markdown {
                 return (
                     ParsedMarkdown {
                         events: Arc::from(parse_links_only(source.as_ref())),
+                        spans: Arc::from([]),
                         source,
                         languages_by_name: TreeMap::default(),
                         languages_by_path: TreeMap::default(),
@@ -492,6 +513,7 @@ impl Markdown {
             }
 
             let (events, language_names, paths) = parse_markdown(&source);
+            let mut source_span_builder = SourceSpanBuilder::new();
             let mut images_by_source_offset = HashMap::default();
             let mut languages_by_name = TreeMap::default();
             let mut languages_by_path = TreeMap::default();
@@ -520,6 +542,7 @@ impl Markdown {
             }
 
             for (range, event) in &events {
+                source_span_builder.push_event(range, event);
                 if let MarkdownEvent::Start(MarkdownTag::Image { dest_url, .. }) = event
                     && let Some(data_url) = dest_url.strip_prefix("data:")
                 {
@@ -543,11 +566,13 @@ impl Markdown {
                     }
                 }
             }
+            let spans: Vec<MarkdownSpan> = source_span_builder.into();
 
             (
                 ParsedMarkdown {
                     source,
                     events: Arc::from(events),
+                    spans: Arc::from(spans),
                     languages_by_name,
                     languages_by_path,
                 },
@@ -656,6 +681,7 @@ impl Selection {
 pub struct ParsedMarkdown {
     pub source: SharedString,
     pub events: Arc<[(Range<usize>, MarkdownEvent)]>,
+    pub spans: Arc<[MarkdownSpan]>,
     pub languages_by_name: TreeMap<SharedString, Arc<Language>>,
     pub languages_by_path: TreeMap<Arc<str>, Arc<Language>>,
 }
@@ -667,6 +693,10 @@ impl ParsedMarkdown {
 
     pub fn events(&self) -> &Arc<[(Range<usize>, MarkdownEvent)]> {
         &self.events
+    }
+
+    pub fn spans(&self) -> &[MarkdownSpan] {
+        &self.spans
     }
 }
 
@@ -1424,7 +1454,7 @@ impl Element for MarkdownElement {
                 MarkdownEvent::SubstitutedText(text) => {
                     builder.push_text(text, range.clone());
                 }
-                MarkdownEvent::Code => {
+                MarkdownEvent::Code { .. } => {
                     builder.push_text_style(self.style.inline_code.clone());
                     builder.push_text(&parsed_markdown.source[range.clone()], range.clone());
                     builder.pop_text_style();
@@ -2201,9 +2231,17 @@ impl RenderedText {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, size};
+    use gpui::{TestAppContext, VisualTestContext, size};
     use language::{Language, LanguageConfig, LanguageMatcher};
     use std::sync::Arc;
+
+    struct TestWindow;
+
+    impl Render for TestWindow {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+        }
+    }
 
     fn ensure_theme_initialized(cx: &mut TestAppContext) {
         cx.update(|cx| {
@@ -2271,25 +2309,26 @@ mod tests {
         render_markdown_with_language_registry(markdown, None, cx)
     }
 
+    fn create_markdown<'a>(
+        source: &str,
+        language_registry: Option<Arc<LanguageRegistry>>,
+        cx: &'a mut TestAppContext,
+    ) -> (Entity<Markdown>, &'a mut VisualTestContext) {
+        ensure_theme_initialized(cx);
+
+        let (_, cx) = cx.add_window_view(|_, _| TestWindow);
+        let markdown =
+            cx.new(|cx| Markdown::new(source.to_string().into(), language_registry, None, cx));
+        cx.run_until_parked();
+        (markdown, cx)
+    }
+
     fn render_markdown_with_language_registry(
         markdown: &str,
         language_registry: Option<Arc<LanguageRegistry>>,
         cx: &mut TestAppContext,
     ) -> RenderedText {
-        struct TestWindow;
-
-        impl Render for TestWindow {
-            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
-                div()
-            }
-        }
-
-        ensure_theme_initialized(cx);
-
-        let (_, cx) = cx.add_window_view(|_, _| TestWindow);
-        let markdown =
-            cx.new(|cx| Markdown::new(markdown.to_string().into(), language_registry, None, cx));
-        cx.run_until_parked();
+        let (markdown, cx) = create_markdown(markdown, language_registry, cx);
         let (rendered, _) = cx.draw(
             Default::default(),
             size(px(600.0), px(600.0)),
@@ -2304,6 +2343,21 @@ mod tests {
             },
         );
         rendered.text
+    }
+
+    fn selected_text_for(
+        source: &str,
+        selection: Range<usize>,
+        cx: &mut TestAppContext,
+    ) -> Option<String> {
+        let (markdown, cx) = create_markdown(source, None, cx);
+        cx.update(|_, cx| {
+            markdown.update(cx, |markdown, _| {
+                markdown.selection.start = selection.start;
+                markdown.selection.end = selection.end;
+                markdown.selected_text()
+            })
+        })
     }
 
     #[gpui::test]
@@ -2488,6 +2542,43 @@ mod tests {
         // which extract directly from the source. With the bug, this would be 5..10
         // which includes the closing backtick at position 9.
         assert_eq!(word_range, 5..9);
+    }
+
+    #[gpui::test]
+    fn test_selected_text_matches_source_for_range(cx: &mut TestAppContext) {
+        let source = "[Test of selection](link)";
+        let selection = 1..5;
+        let selected_text = selected_text_for(source, selection, cx);
+        assert_eq!(selected_text, Some("Test".to_string()));
+    }
+
+    #[gpui::test]
+    fn test_selected_text_clamps_end_overflow(cx: &mut TestAppContext) {
+        let selected_text = selected_text_for("abc", 0..999, cx);
+        assert_eq!(selected_text, Some("abc".to_string()));
+    }
+
+    #[gpui::test]
+    fn test_selected_text_returns_none_for_reversed_range(cx: &mut TestAppContext) {
+        let selected_text = selected_text_for("abcdef", 5..2, cx);
+        assert_eq!(selected_text, None);
+    }
+
+    #[gpui::test]
+    fn test_selected_text_falls_back_to_raw_clamped_range_when_parse_is_stale(
+        cx: &mut TestAppContext,
+    ) {
+        let (markdown, cx) = create_markdown("**How**", None, cx);
+        let selected_text = cx.update(|_, cx| {
+            markdown.update(cx, |markdown, _| {
+                markdown.source = "How".into();
+                markdown.selection.start = 0;
+                markdown.selection.end = 3;
+                markdown.selected_text()
+            })
+        });
+
+        assert_eq!(selected_text, Some("How".to_string()));
     }
 
     #[gpui::test]

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -309,10 +309,11 @@ pub fn parse_markdown(
                 }
             }
             pulldown_cmark::Event::Code(_) => {
-                let content_range = extract_code_content_range(&text[range.clone()]);
-                let content_range =
-                    content_range.start + range.start..content_range.end + range.start;
-                events.push((content_range, MarkdownEvent::Code))
+                let wrapper_range = range.clone();
+                let content_range = extract_code_content_range(&text[wrapper_range.clone()]);
+                let content_range = content_range.start + wrapper_range.start
+                    ..content_range.end + wrapper_range.start;
+                events.push((content_range, MarkdownEvent::Code { wrapper_range }))
             }
             pulldown_cmark::Event::Html(_) => events.push((range, MarkdownEvent::Html)),
             pulldown_cmark::Event::InlineHtml(_) => events.push((range, MarkdownEvent::InlineHtml)),
@@ -384,7 +385,7 @@ pub enum MarkdownEvent {
     /// and smart punctuation.
     SubstitutedText(String),
     /// An inline code node.
-    Code,
+    Code { wrapper_range: Range<usize> },
     /// An HTML node.
     Html,
     /// An inline HTML node.
@@ -751,6 +752,24 @@ mod tests {
 
         let input = "``let x = 5;`";
         assert_eq!(extract_code_content_range(input), 0..13);
+    }
+
+    #[test]
+    fn test_inline_code_event_keeps_wrapper_range() {
+        let events = parse_markdown("`code`").0;
+        assert_eq!(
+            events,
+            vec![
+                (0..6, Start(Paragraph)),
+                (
+                    1..5,
+                    Code {
+                        wrapper_range: 0..6
+                    }
+                ),
+                (0..6, End(MarkdownTagEnd::Paragraph))
+            ]
+        );
     }
 
     #[test]

--- a/crates/markdown/src/source_spans.rs
+++ b/crates/markdown/src/source_spans.rs
@@ -1,0 +1,550 @@
+use crate::parser::{MarkdownEvent, MarkdownTag, MarkdownTagEnd};
+use std::ops::Range;
+
+/// Source-level metadata for one inline markdown wrapper.
+///
+/// `wrapper_range` always points to the full source slice that includes markdown syntax
+/// (for example `**bold**`, `` `code` ``, or `[label](dest)`).
+///
+/// `content_range` points to the visible text region inside that wrapper.
+/// During span construction it may be `None`, but `finish_spans` removes those entries
+/// before resolution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MarkdownSpan {
+    /// Full markdown wrapper range in source, including opening and closing syntax markers.
+    pub wrapper_range: Range<usize>,
+    /// Visible content range inside `wrapper_range` used for boundary snapping/expansion.
+    /// `None` is only expected before construction is finalized (or in defensive fallback paths).
+    pub content_range: Option<Range<usize>>,
+}
+
+impl MarkdownSpan {
+    fn new(wrapper_range: Range<usize>) -> Self {
+        Self {
+            wrapper_range,
+            content_range: None,
+        }
+    }
+
+    fn extend_content(&mut self, source_range: &Range<usize>) {
+        self.content_range = Some(match self.content_range.take() {
+            Some(existing_range) => {
+                existing_range.start.min(source_range.start)
+                    ..existing_range.end.max(source_range.end)
+            }
+            None => source_range.clone(),
+        });
+    }
+
+    #[inline]
+    fn bounds(&self) -> Option<(&Range<usize>, &Range<usize>)> {
+        self.content_range
+            .as_ref()
+            .map(|content_range| (&self.wrapper_range, content_range))
+    }
+
+    fn snap(&self, range: &mut Range<usize>) -> bool {
+        let Some((wrapper_range, content_range)) = self.bounds() else {
+            return false;
+        };
+
+        let start = range.start;
+        let end = range.end;
+        let snap_start_open = start > wrapper_range.start && start < content_range.start;
+        let snap_start_close = start >= content_range.end && start < wrapper_range.end;
+        let snap_end_open = end > wrapper_range.start && end <= content_range.start;
+        let snap_end_close = end > content_range.end && end < wrapper_range.end;
+
+        if !(snap_start_open || snap_start_close || snap_end_open || snap_end_close) {
+            return false;
+        }
+
+        if snap_start_open {
+            range.start = wrapper_range.start;
+        } else if snap_start_close {
+            range.start = wrapper_range.end;
+        }
+
+        if snap_end_open {
+            range.end = wrapper_range.start;
+        } else if snap_end_close {
+            range.end = wrapper_range.end;
+        }
+
+        true
+    }
+
+    fn trim_partial(&self, range: &mut Range<usize>) -> bool {
+        let Some((wrapper_range, content_range)) = self.bounds() else {
+            return false;
+        };
+
+        let original_start = range.start;
+        let original_end = range.end;
+        let at_left_boundary = original_start == wrapper_range.start;
+        let at_right_boundary = original_end == wrapper_range.end;
+        if !at_left_boundary && !at_right_boundary {
+            return false;
+        }
+
+        let trim_start = at_left_boundary
+            && original_end > content_range.start
+            && original_end < content_range.end;
+        let trim_end = at_right_boundary
+            && original_start > content_range.start
+            && original_start < content_range.end;
+
+        if trim_start {
+            range.start = content_range.start;
+        }
+
+        if trim_end {
+            range.end = content_range.end;
+        }
+
+        trim_start || trim_end
+    }
+
+    fn expand(&self, normalized_range: &Range<usize>, range: &mut Range<usize>) {
+        let Some((wrapper_range, content_range)) = self.bounds() else {
+            return;
+        };
+
+        let covers_content = normalized_range.start <= content_range.start
+            && normalized_range.end >= content_range.end;
+        if !covers_content {
+            return;
+        }
+
+        let left_aligned = normalized_range.start == content_range.start
+            || normalized_range.start == wrapper_range.start;
+        let right_aligned =
+            normalized_range.end == content_range.end || normalized_range.end == wrapper_range.end;
+        if !left_aligned && !right_aligned {
+            return;
+        }
+
+        let expand_left =
+            left_aligned && (right_aligned || normalized_range.end >= wrapper_range.end);
+        let expand_right =
+            right_aligned && (left_aligned || normalized_range.start <= wrapper_range.start);
+
+        if expand_left {
+            range.start = range.start.min(wrapper_range.start);
+        }
+
+        if expand_right {
+            range.end = range.end.max(wrapper_range.end);
+        }
+    }
+}
+
+/// Incrementally builds inline source spans from markdown parser events.
+///
+/// This keeps just enough transient state (`span_stack`) to handle nested wrappers
+/// in a single event pass, so callers can derive spans while doing other work over
+/// the same event stream (for example image extraction).
+pub(crate) struct SourceSpanBuilder {
+    /// Collected spans in encounter order.
+    spans: Vec<MarkdownSpan>,
+    /// Stack of indices into `spans` representing currently open inline wrappers.
+    span_stack: Vec<usize>,
+}
+
+impl From<SourceSpanBuilder> for Vec<MarkdownSpan> {
+    /// Finalizes builder output by dropping wrappers that never accumulated visible content.
+    fn from(source_span_builder: SourceSpanBuilder) -> Self {
+        source_span_builder.into_spans()
+    }
+}
+
+impl SourceSpanBuilder {
+    /// Creates an empty builder for a new event stream.
+    pub(crate) fn new() -> Self {
+        Self {
+            spans: Vec::new(),
+            span_stack: Vec::new(),
+        }
+    }
+
+    fn begin_span(&mut self, wrapper_range: Range<usize>) {
+        let span_index = self.spans.len();
+        self.spans.push(MarkdownSpan::new(wrapper_range));
+        self.span_stack.push(span_index);
+    }
+
+    fn end_span(&mut self) {
+        self.span_stack.pop();
+    }
+
+    fn expand_open_spans(&mut self, source_range: &Range<usize>) {
+        for &span_index in &self.span_stack {
+            if let Some(span) = self.spans.get_mut(span_index) {
+                span.extend_content(source_range);
+            }
+        }
+    }
+
+    fn push_closed_span(&mut self, wrapper_range: Range<usize>, content_range: Range<usize>) {
+        let mut span = MarkdownSpan::new(wrapper_range);
+        span.extend_content(&content_range);
+        self.spans.push(span);
+    }
+
+    /// Incorporates one parser event into the current span state.
+    ///
+    /// Only inline wrappers that affect source-copy semantics are tracked.
+    pub(crate) fn push_event(&mut self, range: &Range<usize>, event: &MarkdownEvent) {
+        match event {
+            MarkdownEvent::Start(
+                MarkdownTag::Strong
+                | MarkdownTag::Emphasis
+                | MarkdownTag::Strikethrough
+                | MarkdownTag::Link { .. }
+                | MarkdownTag::Superscript
+                | MarkdownTag::Subscript,
+            ) => {
+                self.begin_span(range.clone());
+            }
+            MarkdownEvent::End(
+                MarkdownTagEnd::Strong
+                | MarkdownTagEnd::Emphasis
+                | MarkdownTagEnd::Strikethrough
+                | MarkdownTagEnd::Link
+                | MarkdownTagEnd::Superscript
+                | MarkdownTagEnd::Subscript,
+            ) => {
+                self.end_span();
+            }
+            MarkdownEvent::Text | MarkdownEvent::SubstitutedText(_) => {
+                self.expand_open_spans(range);
+            }
+            MarkdownEvent::Code { wrapper_range } => {
+                self.push_closed_span(wrapper_range.clone(), range.clone());
+            }
+            _ => {}
+        }
+    }
+
+    /// Finalizes builder output by dropping wrappers that never accumulated visible content.
+    pub(crate) fn into_spans(mut self) -> Vec<MarkdownSpan> {
+        self.spans.retain(|span| span.content_range.is_some());
+        self.spans
+    }
+}
+
+/// Stateless resolver over parse-time markdown spans.
+///
+/// It applies copy semantics to a source selection:
+/// - snap edges out of hidden wrapper syntax,
+/// - trim unbalanced partial wrappers,
+/// - expand to full wrappers when the selection semantically covers formatted content.
+pub(crate) struct MarkdownRangeResolver<'a> {
+    /// Precomputed inline wrapper spans extracted from markdown events.
+    spans: &'a [MarkdownSpan],
+}
+
+impl<'a> MarkdownRangeResolver<'a> {
+    pub(crate) fn new(spans: &'a [MarkdownSpan]) -> Self {
+        Self { spans }
+    }
+
+    /// Resolves a selection range to a markdown source range suitable for copy.
+    ///
+    /// The returned range avoids leaking unmatched wrapper syntax while preserving
+    /// full wrappers when the selection semantically covers formatted content.
+    pub(crate) fn resolve(&self, range: Range<usize>) -> Range<usize> {
+        let range = self.normalize_edges(range);
+        if range.start >= range.end {
+            return range;
+        }
+
+        self.expand_wrappers(range)
+    }
+
+    fn normalize_edges(&self, mut range: Range<usize>) -> Range<usize> {
+        loop {
+            let mut snapped = range.clone();
+            for span in self.spans {
+                span.snap(&mut snapped);
+            }
+
+            if snapped.start > snapped.end {
+                snapped.end = snapped.start;
+            }
+            if snapped.start >= snapped.end {
+                return snapped;
+            }
+
+            let mut trimmed = snapped.clone();
+            for span in self.spans {
+                span.trim_partial(&mut trimmed);
+            }
+
+            if trimmed.start > trimmed.end {
+                trimmed.end = trimmed.start;
+            }
+            if trimmed.start >= trimmed.end || trimmed == range {
+                return trimmed;
+            }
+            range = trimmed;
+        }
+    }
+
+    fn expand_wrappers(&self, mut range: Range<usize>) -> Range<usize> {
+        loop {
+            let mut next = range.clone();
+
+            for span in self.spans {
+                span.expand(&range, &mut next);
+            }
+
+            if next.start > next.end {
+                next.end = next.start;
+            }
+            if next == range {
+                return next;
+            }
+            range = next;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MarkdownRangeResolver, MarkdownSpan, SourceSpanBuilder};
+    use crate::parser::parse_markdown;
+    use std::ops::Range;
+
+    fn spans_for(source: &str) -> Vec<MarkdownSpan> {
+        let (events, _, _) = parse_markdown(source);
+        let mut source_span_builder = SourceSpanBuilder::new();
+        for (range, event) in &events {
+            source_span_builder.push_event(range, event);
+        }
+        source_span_builder.into()
+    }
+
+    fn resolved_range_for(source: &str, selection: Range<usize>) -> Range<usize> {
+        let (events, _, _) = parse_markdown(source);
+        let mut source_span_builder = SourceSpanBuilder::new();
+        for (range, event) in &events {
+            source_span_builder.push_event(range, event);
+        }
+        let spans: Vec<MarkdownSpan> = source_span_builder.into();
+        let source_length = source.len();
+        let start = selection.start.min(source_length);
+        let end = selection.end.min(source_length);
+        let clamped_range = if start <= end {
+            start..end
+        } else {
+            start..start
+        };
+
+        MarkdownRangeResolver::new(spans.as_slice()).resolve(clamped_range)
+    }
+
+    #[test]
+    fn test_build_source_spans_for_strong() {
+        let source = "**bold**";
+        let spans = spans_for(source);
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        assert_eq!(&source[span.wrapper_range.clone()], "**bold**");
+        assert_eq!(
+            span.content_range
+                .as_ref()
+                .map(|content_range| &source[content_range.clone()]),
+            Some("bold")
+        );
+    }
+
+    #[test]
+    fn test_build_source_spans_for_link() {
+        let source = "[label](https://example.com)";
+        let spans = spans_for(source);
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        assert_eq!(&source[span.wrapper_range.clone()], source);
+        assert_eq!(
+            span.content_range
+                .as_ref()
+                .map(|content_range| &source[content_range.clone()]),
+            Some("label")
+        );
+    }
+
+    #[test]
+    fn test_build_source_spans_for_inline_code() {
+        let source = "Use `code` here";
+        let spans = spans_for(source);
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        assert_eq!(&source[span.wrapper_range.clone()], "`code`");
+        assert_eq!(
+            span.content_range
+                .as_ref()
+                .map(|content_range| &source[content_range.clone()]),
+            Some("code")
+        );
+    }
+
+    #[test]
+    fn test_resolved_range_expands_strong_wrapper() {
+        let source = "- **How** should the new flow work?";
+
+        let expanded = resolved_range_for(source, 4..9);
+        assert_eq!(expanded, 2..9);
+        assert_eq!(&source[expanded], "**How**");
+    }
+
+    #[test]
+    fn test_resolved_range_trims_wrapper_suffix_for_partial_selection() {
+        let source = "- **How** should the new flow work?";
+
+        let range = 5..9;
+        let expanded = resolved_range_for(source, range.clone());
+        let expected_start = source.find("ow").expect("partial content should exist");
+        let expected = expected_start..expected_start + "ow".len();
+        assert_eq!(expanded, expected);
+        assert_eq!(&source[expanded], "ow");
+    }
+
+    #[test]
+    fn test_resolved_range_expands_full_link_selection() {
+        let source = "[label](https://example.com)";
+
+        let label_start = source.find("label").expect("label should exist");
+        let label_end = label_start + "label".len();
+        let expanded = resolved_range_for(source, label_start..label_end);
+        assert_eq!(expanded, 0..source.len());
+    }
+
+    #[test]
+    fn test_resolved_range_expands_nested_wrappers() {
+        let source = "***x***";
+
+        let content_start = source.find('x').expect("content should exist");
+        let expanded = resolved_range_for(source, content_start..content_start + 1);
+        assert_eq!(expanded, 0..source.len());
+    }
+
+    #[test]
+    fn test_resolved_range_keeps_partial_inline_code_without_backticks() {
+        let source = "`Test of selection`";
+        let content_start = source.find("Test").expect("content should exist");
+
+        let partial = content_start..content_start + "Test".len();
+        let expanded = resolved_range_for(source, partial.clone());
+        assert_eq!(expanded, partial);
+        assert_eq!(&source[expanded], "Test");
+    }
+
+    #[test]
+    fn test_resolved_range_keeps_partial_link_label_without_wrapper() {
+        let source = "[Test of selection](link)";
+        let label_start = source.find("Test").expect("label should exist");
+        let label_end = label_start + "Test of selection".len();
+
+        let left_partial = label_start..label_start + "Test".len();
+        let left_expanded = resolved_range_for(source, left_partial.clone());
+        assert_eq!(left_expanded, left_partial);
+        assert_eq!(&source[left_expanded], "Test");
+
+        let right_partial = label_end - "selection".len()..label_end;
+        let right_expanded = resolved_range_for(source, right_partial.clone());
+        assert_eq!(right_expanded, right_partial);
+        assert_eq!(&source[right_expanded], "selection");
+    }
+
+    #[test]
+    fn test_resolved_range_trims_link_suffix_when_start_is_inside_label() {
+        let link_label = "dummy_guide.md";
+        let link_destination = "file:///tmp/dummy_guide.md";
+        let source = concat!(
+            "See details in ",
+            "[dummy_guide.md]",
+            "(file:///tmp/dummy_guide.md)."
+        );
+        let link_prefix = format!("[{link_label}](");
+        let link_start = source.find(&link_prefix).expect("link should exist");
+        let content_start = link_start + 1;
+        let content_end = content_start + link_label.len();
+        let selected_end = source[link_start..]
+            .find(')')
+            .map(|offset| link_start + offset + 1)
+            .expect("link wrapper end should exist");
+
+        let selected_start = source.find("guide.md").expect("partial label should exist");
+        let expanded = resolved_range_for(source, selected_start..selected_end);
+
+        assert_eq!(expanded, selected_start..content_end);
+        assert_eq!(&source[expanded.clone()], "guide.md");
+        assert!(!source[expanded.clone()].starts_with(&format!("]({link_destination})")));
+    }
+
+    #[test]
+    fn test_resolved_range_for_multiline_list_selection() {
+        let source = concat!(
+            "1. **Lorem heading item**\n",
+            "Lorem ipsum dolor sit amet.\n",
+            "Aliquam tincidunt [ref](file:///tmp/ref.md)"
+        );
+
+        let selection_start = source
+            .find("Lorem heading item")
+            .expect("selection start should exist");
+        let selection_end = source.len();
+        let expanded = resolved_range_for(source, selection_start..selection_end);
+
+        let expected_start = source
+            .find("**Lorem heading item**")
+            .expect("bold wrapper should exist");
+        assert_eq!(expanded, expected_start..selection_end);
+        assert_eq!(
+            &source[expanded],
+            concat!(
+                "**Lorem heading item**\n",
+                "Lorem ipsum dolor sit amet.\n",
+                "Aliquam tincidunt [ref](file:///tmp/ref.md)"
+            )
+        );
+    }
+
+    #[test]
+    fn test_resolved_range_skips_previous_link_suffix_in_long_list() {
+        let link_label = "dummy_guide.md";
+        let link_destination = "file:///tmp/dummy_guide.md";
+        let source = concat!(
+            "1. **First item title**  \n",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.  \n",
+            "[dummy_guide.md](file:///tmp/dummy_guide.md)\n",
+            "\n",
+            "2. **Second item title**  \n",
+            "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.  \n",
+            "[dummy_guide.md](file:///tmp/dummy_guide.md)"
+        );
+        let link_prefix = format!("[{link_label}](");
+
+        let second_item_start = source
+            .find("2. **Second item title**")
+            .expect("second item should exist");
+        let first_link_start = source
+            .find(&link_prefix)
+            .expect("first item link should exist");
+        assert!(first_link_start < second_item_start);
+        let first_link_content_end = first_link_start + 1 + link_label.len();
+        let first_link_wrapper_end = source[first_link_start..]
+            .find(')')
+            .map(|offset| first_link_start + offset + 1)
+            .expect("first item link wrapper end should exist");
+        let selection_start = first_link_content_end;
+
+        let expanded = resolved_range_for(source, selection_start..source.len());
+        let copied = &source[expanded.clone()];
+
+        assert!(expanded.start >= first_link_wrapper_end);
+        assert!(!copied.starts_with(&format!("]({link_destination})")));
+        assert!(copied.trim_start().starts_with("2. **Second item title**"));
+    }
+}


### PR DESCRIPTION
## Summary

Markdown copy could break formatting when selection edges landed inside wrapper syntax, producing output like `bold**` instead of `**bold**`. This PR makes copy range resolution span-aware, so copied markdown keeps valid boundaries.

## Why

The old flow used raw source slicing. That works for plain text but is fragile for formatted markdown. Using parse-time span metadata makes selection-to-source mapping consistent for wrappers like bold, links, and inline code.

## What changed

The markdown parser now keeps wrapper bounds for inline code, and markdown copy resolution now runs through source-span normalization and wrapper expansion logic. Copy still falls back to clamped raw selection when parsed source is stale. Tests were expanded across parser, resolver, and markdown integration paths.

## Cases covered

| Case | Description | Before | After |
|---|---|---|---|
| 1. Full formatted token selection | Selecting visible text inside a full formatted token now copies the full markdown wrapper. | ![Case 1 before](https://github.com/user-attachments/assets/81d71a48-e944-4d57-aef0-23f96b05296d) | ![Case 1 after](https://github.com/user-attachments/assets/35b19911-0af5-4864-96f5-41e38e5f71db) |
| 2. Partial formatted token selection | Selecting only part of formatted content now copies only that part, without leaking wrapper syntax. | ![Case 2 before](https://github.com/user-attachments/assets/2613e306-b0b8-4c97-8590-7b4726893957) | ![Case 2 after](https://github.com/user-attachments/assets/e44b3636-04b6-476c-b5fd-8a023f930520) |
| 3a. Link boundary handling | Selections near link edges no longer leak broken suffixes like `](...)`. | ![Case 3a before](https://github.com/user-attachments/assets/6ca9f80c-4686-4c07-af3e-30ccc4e807a5) | ![Case 3a after](https://github.com/user-attachments/assets/4072982a-1416-4852-ab10-8c4b4b906b7b) |
| 3b. Link boundary handling (additional) | Additional boundary scenario for links now resolves cleanly. | ![Case 3b before](https://github.com/user-attachments/assets/db3ec7c4-2209-44ad-971b-c3178dab607b) | ![Case 3b after](https://github.com/user-attachments/assets/759f7356-96b7-4d73-a3c7-fc93a72fa100) |
| 4. Multiline list boundary handling | Selections spanning list items now start cleanly and do not inherit suffix fragments from prior items. | ![Case 4 before](https://github.com/user-attachments/assets/36287603-ad93-48e3-927e-5fcc6b101467) | ![Case 4 after](https://github.com/user-attachments/assets/8dc657b6-dd55-4bb0-bb4c-c23fd4890517) |
| 5. List boundary with inline style wrapper | If a selection begins at a list-item boundary inside visible styled text, copy now preserves complete inline style wrappers. | ![Case 5 before](https://github.com/user-attachments/assets/8ac28059-09ca-410f-b6a9-1e827e9479a7) | ![Case 5 after](https://github.com/user-attachments/assets/4476d86d-6d14-4604-b6d7-f0ce6cb8de8b) |

Closes #42958

- [x] Added solid test coverage and/or manual testing screenshots
- [x] Completed self-review, including security and performance considerations
- [x] Aligned UI changes with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed markdown copy behavior for formatted selections.