### PR TITLE
command_palette: Fix keymap editor not matching actions with underscored namespaces

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -39,24 +39,28 @@ pub struct CommandPalette {
     picker: Entity<Picker<CommandPaletteDelegate>>,
 }
 
-/// Removes subsequent whitespace characters and double colons from the query.
+/// Removes subsequent whitespace characters and double colons from the query, and converts
+/// underscores to spaces.
 ///
 /// This improves the likelihood of a match by either humanized name or keymap-style name.
+/// Underscores are converted to spaces because `humanize_action_name` converts them to spaces
+/// when building the search candidates (e.g. `terminal_panel::Toggle` -> `terminal panel: toggle`).
 pub fn normalize_action_query(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let mut last_char = None;
 
     for char in input.trim().chars() {
-        match (last_char, char) {
+        let normalized_char = if char == '_' { ' ' } else { char };
+        match (last_char, normalized_char) {
             (Some(':'), ':') => continue,
-            (Some(last_char), char) if last_char.is_whitespace() && char.is_whitespace() => {
+            (Some(last_char), c) if last_char.is_whitespace() && c.is_whitespace() => {
                 continue;
             }
             _ => {
-                last_char = Some(char);
+                last_char = Some(normalized_char);
             }
         }
-        result.push(char);
+        result.push(normalized_char);
     }
 
     result
@@ -766,6 +770,14 @@ mod tests {
         assert_eq!(
             normalize_action_query("editor: :GoToDefinition"),
             "editor: :GoToDefinition"
+        );
+        assert_eq!(
+            normalize_action_query("terminal_panel::Toggle"),
+            "terminal panel:Toggle"
+        );
+        assert_eq!(
+            normalize_action_query("project_panel::ToggleFocus"),
+            "project panel:ToggleFocus"
         );
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/50223

## Summary

When clicking **Change Keybinding** from the command palette on an action whose namespace contains underscores (e.g. `terminal_panel::Toggle`, `project_panel::ToggleFocus`), the keymap editor showed **"No matches found for the provided query"**. Actions without underscores (e.g. `zed::OpenLog`) worked fine.

I opened this issue for this https://github.com/zed-industries/zed/issues/50223, but took the liberty of sending a PR.

**Root cause:** `normalize_action_query` preserved underscores in the query, but the search candidates are built with `humanize_action_name` which converts underscores to spaces. The fuzzy matcher looked for `_` in a candidate like `"terminal panel: toggle"` where it doesn't exist, so matching always failed.

**Fix:** `normalize_action_query` now converts underscores to spaces before the deduplication checks, consistent with `humanize_action_name`. This also correctly collapses consecutive underscores with adjacent spaces.

All three call sites of `normalize_action_query` (command palette search, keymap editor filter, action completion provider) match against humanized candidates, so the fix improves consistency across all of them.

## Before (Left) / After (Right)
<img width="2560" height="1053" alt="Screenshot 2026-02-28 at 17 56 05" src="https://github.com/user-attachments/assets/195530b6-57af-4270-9370-03744cb55e81" />
<img width="2557" height="1062" alt="Screenshot 2026-02-28 at 17 55 38" src="https://github.com/user-attachments/assets/1e8637cd-86c9-496e-bc2b-f9f2d0ac23dc" />


Release Notes:

- Fixed keymap editor showing no results when opening "Change Keybinding" from the command palette for actions with underscores in their namespace (e.g. `terminal_panel::Toggle`, `project_panel::ToggleFocus`)