### PR TITLE
lsp_button: Fix not being able to stop LSP server after restarting them

### DIFF
--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -947,6 +947,40 @@ impl LspButton {
                 });
                 updated = true;
             }
+            LspStoreEvent::LanguageServerAdded(new_server_id, new_server_name, worktree_id) => {
+                self.server_state.update(cx, |state, cx| {
+                    for servers_for_path in state
+                        .language_servers
+                        .servers_per_buffer_abs_path
+                        .values_mut()
+                    {
+                        let path_worktree_id = servers_for_path
+                            .worktree
+                            .as_ref()
+                            .and_then(|w| w.upgrade())
+                            .map(|w| w.read(cx).id());
+
+                        if path_worktree_id != *worktree_id {
+                            continue;
+                        }
+
+                        let old_ids: Vec<_> = servers_for_path
+                            .servers
+                            .iter()
+                            .filter(|(old_id, name)| {
+                                *old_id != new_server_id && name.as_ref() == Some(new_server_name)
+                            })
+                            .map(|(id, _)| *id)
+                            .collect();
+
+                        for old_id in old_ids {
+                            let name = servers_for_path.servers.remove(&old_id).flatten();
+                            servers_for_path.servers.insert(*new_server_id, name);
+                        }
+                    }
+                });
+                updated = true;
+            }
             _ => {}
         };
 


### PR DESCRIPTION
This happened when a server failed to update its state with a health check. My fix was checking if we should replace a shutdown server in the list with a newly added server that has the same name and belongs to the same worktree. 

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- lsp_button: Fix bug where Zed would fail to stop a server
