### PR TITLE
Add ctrl-enter keybind (macOS) to type newline in search bars

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -449,6 +449,13 @@
     },
   },
   {
+    "context": "BufferSearchBar || ProjectSearchBar",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-enter": "editor::Newline",
+    },
+  },
+  {
     "context": "ProjectSearchBar",
     "use_key_equivalents": true,
     "bindings": {


### PR DESCRIPTION
I've been using https://github.com/zed-industries/zed/issues/15046#issuecomment-3259286451 for half a year now, and it seems worthy of inclusion in the default keymap.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added `ctrl-enter` keybind on macOS to type a newline in search bars
