### PR TITLE
Add PR 50413 to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -38,3 +38,7 @@ ffdda588b41f7d9d270ffe76cab116f828ad545e
 # 2026-02-27 Format Tree-sitter query files
 # https://github.com/zed-industries/zed/pull/50138
 5ed538f49c54ca464bb9d1e59446060a3a925668
+
+# 2026-02-28 Format proto files
+# https://github.com/zed-industries/zed/pull/50413
+56a88a848be09cbcb66bcb3d85ec1f5644909f72


### PR DESCRIPTION
This PR adds https://github.com/zed-industries/zed/pull/50413 to the `.git-blame-ignore-revs` file.

Release Notes:

- N/A
