### PR TITLE
agent: Enable @diagnostics for acp agents

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -70,16 +70,16 @@ impl PromptCompletionProviderDelegate for Entity<MessageEditor> {
     }
 
     fn supported_modes(&self, cx: &App) -> Vec<PromptContextType> {
-        let mut supported = vec![PromptContextType::File, PromptContextType::Symbol];
+        let mut supported = vec![
+            PromptContextType::File,
+            PromptContextType::Symbol,
+            PromptContextType::Diagnostics,
+        ];
         if self.read(cx).prompt_capabilities.borrow().embedded_context {
             if self.read(cx).thread_store.is_some() {
                 supported.push(PromptContextType::Thread);
             }
-            supported.extend(&[
-                PromptContextType::Diagnostics,
-                PromptContextType::Fetch,
-                PromptContextType::Rules,
-            ]);
+            supported.extend(&[PromptContextType::Fetch, PromptContextType::Rules]);
         }
         supported
     }
@@ -450,6 +450,8 @@ impl MessageEditor {
                                             ),
                                         ),
                                     ))
+                                } else if matches!(uri, MentionUri::Diagnostics { .. }) {
+                                    content.clone().into()
                                 } else {
                                     acp::ContentBlock::ResourceLink(acp::ResourceLink::new(
                                         uri.name(),


### PR DESCRIPTION
This change allows the user to send the error messages from the diagnostics panel to the acp agent as text. Since the editor already has all the information, I think this would be a nice addition to the acp workflow.

Whats actually happening is that we just copy the contents of `mentionUri::Diagnostics` to text and send that to the acp instead of linking up the LSP errors directly.

Screenshots:
<img width="30%" height="2102" alt="CleanShot 2026-03-01 at 16 57 28@2x" src="https://github.com/user-attachments/assets/d5fc9efd-b27d-48ea-8701-ccc895991285" />
<img width="30%" height="2030" alt="CleanShot 2026-03-01 at 16 58 09@2x" src="https://github.com/user-attachments/assets/63fbce1d-adcf-47f9-bab9-e105a996a5b9" />
<img width="30%" height="2032" alt="CleanShot 2026-03-01 at 16 58 28@2x" src="https://github.com/user-attachments/assets/004a7d3a-be4d-43fe-aa24-3b2d5ebfc12b" />


Screenshot 1: Diagnostics show up since there is an error
Screenshot 2: Diagnostics error is solved by agent
Screenshot 3: Diagnistics does not show up anymore.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) // re-using zeds component

Release Notes:

- Added `@diagnostics` to acp agent chat.
