### PR TITLE
Add `libva-devel` as required deps for `dnf` section

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -91,6 +91,7 @@ if [[ -n $dnf ]] || [[ -n $yum ]]; then
     alsa-lib-devel
     fontconfig-devel
     glib2-devel
+    libva-devel
     wayland-devel
     libxcb-devel
     libxkbcommon-x11-devel


### PR DESCRIPTION
If I follow the steps outlined in https://zed.dev/docs/development/linux then `cargo run` on my Fedora workstation fails because the install script is missing `libva-devel` as a required dependency under `dnf` / `yum` sections.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
