### PR TITLE
markdown_preview: Fix multiple mermaid rendering issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8663,7 +8663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "mermaid-rs-renderer"
 version = "0.2.0"
-source = "git+https://github.com/zed-industries/mermaid-rs-renderer?rev=a1f8fc03bf7293018136fb8e60d83551d2dd5732#a1f8fc03bf7293018136fb8e60d83551d2dd5732"
+source = "git+https://github.com/zed-industries/mermaid-rs-renderer?rev=374db9ead5426697c6c2111151d9f246899bc638#374db9ead5426697c6c2111151d9f246899bc638"
 dependencies = [
  "anyhow",
  "fontdb 0.16.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,7 +370,7 @@ markdown_preview = { path = "crates/markdown_preview" }
 svg_preview = { path = "crates/svg_preview" }
 media = { path = "crates/media" }
 menu = { path = "crates/menu" }
-mermaid-rs-renderer = { git = "https://github.com/zed-industries/mermaid-rs-renderer", rev = "a1f8fc03bf7293018136fb8e60d83551d2dd5732", default-features = false }
+mermaid-rs-renderer = { git = "https://github.com/zed-industries/mermaid-rs-renderer", rev = "374db9ead5426697c6c2111151d9f246899bc638", default-features = false }
 migrator = { path = "crates/migrator" }
 mistral = { path = "crates/mistral" }
 multi_buffer = { path = "crates/multi_buffer" }


### PR DESCRIPTION
Closes #50172
Closes #50238
Closes #50243
Closes #50196

Updates `mermaid-rs-renderer` with the following fixes:

- Fix ampersand in node labels splitting nodes incorrectly ([`374db9e`](https://github.com/zed-industries/mermaid-rs-renderer/commit/374db9e))
- Add gantt compact display mode via yaml frontmatter ([`d1bf282`](https://github.com/zed-industries/mermaid-rs-renderer/commit/d1bf282))
- Fix class diagram stereotype annotations rendered as members ([`6203d71`](https://github.com/zed-industries/mermaid-rs-renderer/commit/6203d71))
- Fix dotted lines being indistinguishable from solid ([`94fb543`](https://github.com/zed-industries/mermaid-rs-renderer/commit/94fb543))
- Fix class diagram arrowheads hidden under node boxes ([`cd79c56`](https://github.com/zed-industries/mermaid-rs-renderer/commit/cd79c56))
- Fix text not rendering in some cases ([`9534cb1`](https://github.com/zed-industries/mermaid-rs-renderer/commit/9534cb1))

Release Notes:

- Fixed multiple mermaid diagram rendering issues in markdown preview.