### PR TITLE
agent: Remove subagents feature flag

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
-use feature_flags::{
-    FeatureFlagAppExt as _, StreamingEditFileToolFeatureFlag, SubagentsFeatureFlag,
-};
+use feature_flags::{FeatureFlagAppExt as _, StreamingEditFileToolFeatureFlag};
 
 use agent_client_protocol as acp;
 use agent_settings::{
@@ -1387,7 +1385,7 @@ impl Thread {
         self.add_tool(TerminalTool::new(self.project.clone(), environment.clone()));
         self.add_tool(WebSearchTool);
 
-        if cx.has_flag::<SubagentsFeatureFlag>() && self.depth() < MAX_SUBAGENT_DEPTH {
+        if self.depth() < MAX_SUBAGENT_DEPTH {
             self.add_tool(SpawnAgentTool::new(environment));
         }
     }

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -2,10 +2,9 @@ mod profile_modal_header;
 
 use std::sync::Arc;
 
-use agent::{AgentTool, ContextServerRegistry, SpawnAgentTool};
+use agent::ContextServerRegistry;
 use agent_settings::{AgentProfile, AgentProfileId, AgentSettings, builtin_profiles};
 use editor::Editor;
-use feature_flags::{FeatureFlagAppExt as _, SubagentsFeatureFlag};
 use fs::Fs;
 use gpui::{DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription, prelude::*};
 use language_model::{LanguageModel, LanguageModelRegistry};
@@ -363,10 +362,7 @@ impl ManageProfilesModal {
                 let supported_by_provider = provider.as_ref().map_or(true, |provider| {
                     agent::tool_supports_provider(name, provider)
                 });
-                let enabled_by_feature_flag =
-                    *name != SpawnAgentTool::NAME || cx.has_flag::<SubagentsFeatureFlag>();
-
-                supported_by_provider && enabled_by_feature_flag
+                supported_by_provider
             })
             .map(Arc::from)
             .collect();

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -37,16 +37,6 @@ impl FeatureFlag for AgentSharingFeatureFlag {
     const NAME: &'static str = "agent-sharing";
 }
 
-pub struct SubagentsFeatureFlag;
-
-impl FeatureFlag for SubagentsFeatureFlag {
-    const NAME: &'static str = "subagents";
-
-    fn enabled_for_staff() -> bool {
-        true
-    }
-}
-
 pub struct DiffReviewFeatureFlag;
 
 impl FeatureFlag for DiffReviewFeatureFlag {


### PR DESCRIPTION
Release Notes:

- agent: Add new `spawn_agent` tool which allows the Zed Agent to utilize subagents for doing tasks in parallel and better context management.
