### PR TITLE
 linux: Fix space key ignored on X11 due to update_key/update_mask conflict

### DIFF
--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -1060,4 +1060,116 @@ mod tests {
             Point::new(px(5.0), px(5.1))
         ),);
     }
+
+    #[cfg(any(feature = "wayland", feature = "x11"))]
+    mod xkb_tests {
+        use crate::{Keystroke, Modifiers};
+        use xkbcommon::xkb;
+
+        fn create_us_xkb_state() -> xkb::State {
+            let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+            let keymap = xkb::Keymap::new_from_names(
+                &context,
+                &"evdev",
+                &"pc105",
+                &"us",
+                &"",
+                None,
+                xkb::KEYMAP_COMPILE_NO_FLAGS,
+            )
+            .expect("Failed to create US keymap");
+            xkb::State::new(&keymap)
+        }
+
+        // Evdev keycodes + 8 = XKB keycodes
+        const KEYCODE_SPACE: u32 = 65;
+        const KEYCODE_A: u32 = 38;
+        const KEYCODE_B: u32 = 56;
+        const KEYCODE_BRACKETLEFT: u32 = 34;
+
+        #[test]
+        fn test_from_xkb_space_with_update_mask_only() {
+            let mut state = create_us_xkb_state();
+
+            // Simulate the KeyPress flow: update_mask from event state, then from_xkb.
+            // No update_key() should be needed for correct keysym resolution.
+            state.update_mask(0, 0, 0, 0, 0, 0);
+            let keystroke =
+                Keystroke::from_xkb(&state, Modifiers::default(), xkb::Keycode::new(KEYCODE_SPACE));
+            assert_eq!(keystroke.key, "space");
+            assert_eq!(keystroke.key_char.as_deref(), Some(" "));
+        }
+
+        #[test]
+        fn test_from_xkb_letters_with_update_mask_only() {
+            let mut state = create_us_xkb_state();
+
+            state.update_mask(0, 0, 0, 0, 0, 0);
+            let keystroke =
+                Keystroke::from_xkb(&state, Modifiers::default(), xkb::Keycode::new(KEYCODE_A));
+            assert_eq!(keystroke.key, "a");
+            assert_eq!(keystroke.key_char.as_deref(), Some("a"));
+
+            // Second key press without update_key in between
+            state.update_mask(0, 0, 0, 0, 0, 0);
+            let keystroke =
+                Keystroke::from_xkb(&state, Modifiers::default(), xkb::Keycode::new(KEYCODE_B));
+            assert_eq!(keystroke.key, "b");
+            assert_eq!(keystroke.key_char.as_deref(), Some("b"));
+        }
+
+        #[test]
+        fn test_from_xkb_shift_bracket_with_update_mask_only() {
+            let mut state = create_us_xkb_state();
+
+            // Simulate Shift+[ → { using update_mask to set shift as depressed.
+            // Shift modifier bit is 0x01 in XKB.
+            let shift_mod = 1u32;
+            state.update_mask(shift_mod, 0, 0, 0, 0, 0);
+            let keystroke = Keystroke::from_xkb(
+                &state,
+                Modifiers {
+                    shift: true,
+                    ..Default::default()
+                },
+                xkb::Keycode::new(KEYCODE_BRACKETLEFT),
+            );
+            assert_eq!(keystroke.key, "{");
+        }
+
+        #[test]
+        fn test_from_xkb_sequential_keys_without_update_key() {
+            let mut state = create_us_xkb_state();
+
+            // Simulate typing "a b" (a, space, b) using only update_mask, no update_key.
+            // This verifies that skipping update_key doesn't corrupt state for
+            // subsequent key presses.
+            let keys_and_expected = [
+                (KEYCODE_A, "a", Some("a")),
+                (KEYCODE_SPACE, "space", Some(" ")),
+                (KEYCODE_B, "b", Some("b")),
+                (KEYCODE_SPACE, "space", Some(" ")),
+            ];
+
+            for (keycode, expected_key, expected_char) in keys_and_expected {
+                state.update_mask(0, 0, 0, 0, 0, 0);
+                let keystroke = Keystroke::from_xkb(
+                    &state,
+                    Modifiers::default(),
+                    xkb::Keycode::new(keycode),
+                );
+                assert_eq!(
+                    keystroke.key, expected_key,
+                    "keycode {keycode}: expected key={expected_key:?}, got {:?}",
+                    keystroke.key,
+                );
+                assert_eq!(
+                    keystroke.key_char.as_deref(),
+                    expected_char,
+                    "keycode {keycode}: expected key_char={expected_char:?}, got {:?}",
+                    keystroke.key_char,
+                );
+            }
+        }
+    }
 }

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -1016,8 +1016,13 @@ impl X11Client {
                         return Some(());
                     }
 
-                    // should be called after key_get_one_sym
-                    state.xkb.update_key(code, xkbc::KeyDirection::Down);
+                    log::debug!(
+                        "x11 KeyPress: keycode={}, keysym={}, key={:?}, key_char={:?}",
+                        code.raw(),
+                        xkbc::keysym_get_name(keysym),
+                        keystroke.key,
+                        keystroke.key_char,
+                    );
 
                     if let Some(mut compose_state) = state.compose_state.take() {
                         compose_state.feed(keysym);
@@ -1085,9 +1090,6 @@ impl X11Client {
                     if keysym.is_modifier_key() {
                         return Some(());
                     }
-
-                    // should be called after key_get_one_sym
-                    state.xkb.update_key(code, xkbc::KeyDirection::Up);
 
                     keystroke
                 };
@@ -2563,18 +2565,35 @@ fn valid_scale_factor(scale_factor: f32) -> bool {
     scale_factor.is_sign_positive() && scale_factor.is_normal()
 }
 
+/// Sync xkb depressed modifier state from the X11 event's modifier bits.
+///
+/// This is needed because fast macro key sequences (e.g. Shift+[) can have
+/// their XkbStateNotify events arrive out of order, making the xkb state stale.
+/// The event's own `state` field is authoritative for depressed modifiers at
+/// the time of the key press.
+///
+/// Only depressed modifiers are overridden — latched/locked modifiers and all
+/// layout groups are preserved from the current xkb state to avoid breaking
+/// multi-layout keyboard configurations.
 #[inline]
 fn update_xkb_mask_from_event_state(xkb: &mut xkbc::State, event_state: xproto::KeyButMask) {
-    let depressed_mods = event_state.remove((ModMask::LOCK | ModMask::M2).bits());
+    // KeyButMask contains both modifier bits (0-7) and mouse button bits (8-15).
+    // Strip CapsLock and NumLock (they're tracked as locked, not depressed),
+    // and strip button bits which aren't modifier state.
+    let modifier_bits_only: u32 = u16::from(event_state) as u32 & 0xFF;
+    let depressed_mods = modifier_bits_only & !((ModMask::LOCK | ModMask::M2).bits() as u32);
+
     let latched_mods = xkb.serialize_mods(xkbc::STATE_MODS_LATCHED);
     let locked_mods = xkb.serialize_mods(xkbc::STATE_MODS_LOCKED);
+    let depressed_layout = xkb.serialize_layout(xkbc::STATE_LAYOUT_DEPRESSED);
+    let latched_layout = xkb.serialize_layout(xkbc::STATE_LAYOUT_LATCHED);
     let locked_layout = xkb.serialize_layout(xkbc::STATE_LAYOUT_LOCKED);
     xkb.update_mask(
-        depressed_mods.into(),
+        depressed_mods,
         latched_mods,
         locked_mods,
-        0,
-        0,
+        depressed_layout,
+        latched_layout,
         locked_layout,
     );
 }

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -1016,14 +1016,6 @@ impl X11Client {
                         return Some(());
                     }
 
-                    log::debug!(
-                        "x11 KeyPress: keycode={}, keysym={}, key={:?}, key_char={:?}",
-                        code.raw(),
-                        xkbc::keysym_get_name(keysym),
-                        keystroke.key,
-                        keystroke.key_char,
-                    );
-
                     if let Some(mut compose_state) = state.compose_state.take() {
                         compose_state.feed(keysym);
                         match compose_state.status() {
@@ -2580,7 +2572,10 @@ fn update_xkb_mask_from_event_state(xkb: &mut xkbc::State, event_state: xproto::
     // KeyButMask contains both modifier bits (0-7) and mouse button bits (8-15).
     // Strip CapsLock and NumLock (they're tracked as locked, not depressed),
     // and strip button bits which aren't modifier state.
-    let modifier_bits_only: u32 = u16::from(event_state) as u32 & 0xFF;
+    // X11 modifier bits occupy the low 8 bits of the 16-bit KeyButMask;
+    // bits 8-15 are mouse button state.
+    const X11_MODIFIER_MASK: u32 = 0xFF;
+    let modifier_bits_only: u32 = u16::from(event_state) as u32 & X11_MODIFIER_MASK;
     let depressed_mods = modifier_bits_only & !((ModMask::LOCK | ModMask::M2).bits() as u32);
 
     let latched_mods = xkb.serialize_mods(xkbc::STATE_MODS_LATCHED);
@@ -2596,4 +2591,66 @@ fn update_xkb_mask_from_event_state(xkb: &mut xkbc::State, event_state: xproto::
         latched_layout,
         locked_layout,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xkbcommon::xkb as xkbc;
+
+    fn create_us_xkb_state() -> xkbc::State {
+        let context = xkbc::Context::new(xkbc::CONTEXT_NO_FLAGS);
+        let keymap = xkbc::Keymap::new_from_names(
+            &context,
+            &"evdev",
+            &"pc105",
+            &"us",
+            &"",
+            None,
+            xkbc::KEYMAP_COMPILE_NO_FLAGS,
+        )
+        .expect("Failed to create US keymap");
+        xkbc::State::new(&keymap)
+    }
+
+    #[test]
+    fn test_update_xkb_mask_strips_mouse_button_bits() {
+        let mut state = create_us_xkb_state();
+
+        let event_state = xproto::KeyButMask::from(0x101u16); // Shift + Button1
+        update_xkb_mask_from_event_state(&mut state, event_state);
+
+        let depressed = state.serialize_mods(xkbc::STATE_MODS_DEPRESSED);
+        assert_eq!(depressed & 0x01, 0x01, "Shift should be depressed");
+        assert_eq!(depressed & 0x100, 0, "Button1 bit should be stripped");
+    }
+
+    #[test]
+    fn test_update_xkb_mask_strips_capslock_and_numlock() {
+        let mut state = create_us_xkb_state();
+
+        let capslock_numlock = (ModMask::LOCK | ModMask::M2).bits();
+        let event_state = xproto::KeyButMask::from(capslock_numlock);
+        update_xkb_mask_from_event_state(&mut state, event_state);
+
+        let depressed = state.serialize_mods(xkbc::STATE_MODS_DEPRESSED);
+        assert_eq!(depressed, 0, "CapsLock and NumLock should not appear as depressed");
+    }
+
+    #[test]
+    fn test_update_xkb_mask_preserves_locked_layout() {
+        let mut state = create_us_xkb_state();
+
+        state.update_mask(0, 0, 0, 0, 0, 0);
+        let locked_layout_before = state.serialize_layout(xkbc::STATE_LAYOUT_LOCKED);
+
+        let event_state = xproto::KeyButMask::from(0u16);
+        update_xkb_mask_from_event_state(&mut state, event_state);
+
+        let locked_layout_after = state.serialize_layout(xkbc::STATE_LAYOUT_LOCKED);
+        assert_eq!(
+            locked_layout_before, locked_layout_after,
+            "Locked layout group should be preserved"
+        );
+    }
 }


### PR DESCRIPTION
Closes #49329

## Summary

On X11, the space key (and potentially other keys) could be silently ignored because `update_key()` was called after `from_xkb()` resolved the keysym. This created a conflict with
`update_mask()` — when both were used, `update_key()` could advance the XKB state in a way that made subsequent `update_mask()` calls produce stale or incorrect modifier state, causing keys
like space to resolve to `NoSymbol`.

The fix:
- **Removes `update_key()` calls** from both KeyPress and KeyRelease handlers. The X11 event's own `state` field (via `update_mask()`) is the authoritative source for modifier state and is
sufficient.
- **Fixes `update_xkb_mask_from_event_state()`** to correctly mask off mouse button bits and preserve depressed/latched layout groups, avoiding breakage with multi-layout keyboard
configurations.

This also fixes the related issue where non-US keyboard layouts (Spanish, German, etc.) had broken spacebar input on X11.

Also related to #20465 and #46673.

## Test plan

- [x] Added XKB unit tests verifying space, letters, Shift+bracket, and sequential key presses all resolve correctly using only `update_mask` (no `update_key`)
- [x] Manual testing on X11 with US keyboard layout — space key works
- [x] Manual testing on X11 with non-US keyboard layout — space key works

Release Notes:

- Fixed space key (and other keys) being ignored on X11, particularly with non-US keyboard layouts (#49329).