### PR TITLE
Restore accidental change

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -276,7 +276,7 @@ fn main() {
 
     zlog::init();
 
-    if true {
+    if stdout_is_a_pty() {
         zlog::init_output_stdout();
     } else {
         let result = zlog::init_output_file(paths::log_file(), Some(paths::old_log_file()));


### PR DESCRIPTION
I'm not sure why, but my dev builds on linux don't output to stdout

Release Notes:

- N/A *or* Added/Fixed/Improved ...
