### PR TITLE
markdown_preview: Fix not re-rendering issue when editing by agent

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -277,6 +277,7 @@ impl MarkdownPreviewView {
             |this, editor, event: &EditorEvent, window, cx| {
                 match event {
                     EditorEvent::Edited { .. }
+                    | EditorEvent::BufferEdited { .. }
                     | EditorEvent::DirtyChanged
                     | EditorEvent::ExcerptsEdited { .. } => {
                         this.parse_markdown_from_active_editor(true, window, cx);


### PR DESCRIPTION
Closes #47900 

## Root cause

The current markdown preview only re-renders on `EditorEvent::Edited, DirtyChanged, ExcerptsEdited`, but agent edits are implemented via [`buffer.edit()`](https://github.com/dongdong867/zed/blob/eb3f92708b6dc67bb534c1c44a200c0cb5c4997b/crates/agent/src/edit_agent.rs#L375) which does not guaranty to emit the `EditorEvent::Edited` event. Causing the markdown preview stuck on the last received parsed markdown.

## Applied fix

Subscribing to `EditorEvent::BufferEdited` when initializing the markdown preview view. This will cause the view to update when received `BufferEdited` event including agent edits to the file.

## As is/ To be

As is | To be
--- | ---
<video src="https://github.com/user-attachments/assets/a0b13467-7758-4572-ae01-bcbc40beff6c" /> | <video src="https://github.com/user-attachments/assets/3b5463f3-46ad-4fe6-8563-ceb4347035db" />

---

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed markdown preview not re-rendering when edited by agent