### PR TITLE
vim: Fix Helix line motions with newline selections

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -153,7 +153,29 @@ impl Vim {
                         current_head = movement::left(map, selection.end)
                     }
 
+                    if matches!(motion, Motion::StartOfLine { .. } | Motion::EndOfLine { .. }) {
+                        let current_char = map
+                            .buffer_chars_at(current_head.to_offset(map, Bias::Left))
+                            .next()
+                            .map(|(ch, _)| ch);
+                        if current_char == Some('\n') {
+                            current_head = movement::saturating_left(map, current_head);
+                        }
+                    }
+
                     let (new_head, goal) = match motion {
+                        Motion::EndOfLine { .. } => {
+                            let (point, _goal) = motion
+                                .move_point(
+                                    map,
+                                    current_head,
+                                    selection.goal,
+                                    times,
+                                    &text_layout_details,
+                                )
+                                .unwrap_or((current_head, selection.goal));
+                            (movement::saturating_left(map, point), SelectionGoal::None)
+                        }
                         // Going to next word start is special cased
                         // since Vim differs from Helix in that motion
                         // Vim: `w` goes to the first character of a word
@@ -859,6 +881,7 @@ impl Vim {
 
 #[cfg(test)]
 mod test {
+    use editor::MultiBufferOffset;
     use gpui::{UpdateGlobal, VisualTestContext};
     use indoc::indoc;
     use project::FakeFs;
@@ -1459,6 +1482,55 @@ mod test {
         cx.set_state("ˇhello", Mode::HelixNormal);
         cx.simulate_keystrokes("l v l l");
         cx.assert_state("h«ellˇ»o", Mode::HelixSelect);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_start_of_line_when_newline_selected(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state("my text«\nˇ»next", Mode::HelixSelect);
+
+        let initial_head = cx.update_editor(|editor, _, cx| {
+            editor
+                .selections
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
+                .head()
+        });
+
+        cx.simulate_keystrokes("^");
+
+        let head_after_start_of_line = cx.update_editor(|editor, _, cx| {
+            editor
+                .selections
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
+                .head()
+        });
+
+        assert_ne!(head_after_start_of_line, initial_head);
+        assert_eq!(head_after_start_of_line, MultiBufferOffset(0));
+        assert_eq!(cx.mode(), Mode::HelixSelect);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_end_of_line_when_newline_selected(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state("my text«\nˇ»next", Mode::HelixSelect);
+        cx.simulate_keystrokes("$");
+
+        let head_after_end_of_line = cx.update_editor(|editor, _, cx| {
+            editor
+                .selections
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
+                .head()
+        });
+
+        assert_eq!(head_after_end_of_line, MultiBufferOffset(6));
+        assert_eq!(cx.mode(), Mode::HelixSelect);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes #41743

Problem:
- In Helix Select mode, when the selected character is a newline, line motions can be computed from the wrong side of the line boundary.
- This makes line-based motions behave as if the next line is selected.

Repro:
1. Enable Helix mode.
2. Select the newline character between two lines in Helix Select mode.
3. Trigger line motions (`^` / `$`).

Fix:
- In `helix_select_motion`, normalize line-motion cursor anchoring when the selected character is `\n` by stepping to the previous display position.
- Add explicit `EndOfLine` handling in Helix Select mode to align with Helix normal-mode semantics (position on line content, not past line boundary).

Proof:
- Added regression tests for newline-selected Helix Select mode:
  - `test_helix_select_start_of_line_when_newline_selected`
  - `test_helix_select_end_of_line_when_newline_selected`

Risk:
- Low. Changes are scoped to Helix Select motion handling for `StartOfLine`/`EndOfLine` and covered by targeted tests.

Tests:
- `cargo test -p vim test_helix_select_ -- --nocapture`
- `cargo test -p vim end_of_line -- --nocapture`

Release Notes:

- Fixed Helix Select mode line motions when a newline character is selected so `^`/`$` stay on the intended line.
