### PR TITLE
Preserve missing final newline after format on save

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -12723,6 +12723,85 @@ async fn test_document_format_during_save(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_document_format_on_save_without_final_newline(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.ensure_final_newline_on_save = Some(false);
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.rs"), Default::default()).await;
+
+    let project = Project::test(fs, [path!("/file.rs").as_ref()], cx).await;
+
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                document_formatting_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), buffer, window, cx)
+    });
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("one\ntwo\nthree", window, cx)
+    });
+    assert!(cx.read(|cx| editor.is_dirty(cx)));
+
+    let fake_server = fake_servers.next().await.unwrap();
+    fake_server.set_request_handler::<lsp::request::Formatting, _, _>(move |params, _| async move {
+        assert_eq!(
+            params.text_document.uri,
+            lsp::Uri::from_file_path(path!("/file.rs")).unwrap()
+        );
+        assert_eq!(params.options.insert_final_newline, Some(false));
+        assert_eq!(params.options.trim_final_newlines, Some(false));
+        Ok(Some(vec![
+            lsp::TextEdit::new(
+                lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(1, 3)),
+                "TWO".to_string(),
+            ),
+            lsp::TextEdit::new(
+                lsp::Range::new(lsp::Position::new(2, 5), lsp::Position::new(2, 5)),
+                "\n".to_string(),
+            ),
+        ]))
+    });
+
+    let save = editor
+        .update_in(cx, |editor, window, cx| {
+            editor.save(
+                SaveOptions {
+                    format: true,
+                    autosave: false,
+                },
+                project.clone(),
+                window,
+                cx,
+            )
+        })
+        .unwrap();
+    save.await;
+
+    assert_eq!(editor.update(cx, |editor, cx| editor.text(cx)), "one\nTWO\nthree");
+    assert!(!cx.read(|cx| editor.is_dirty(cx)));
+}
+
+#[gpui::test]
 async fn test_redo_after_noop_format(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.ensure_final_newline_on_save = Some(false);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1633,6 +1633,35 @@ impl LocalLspStore {
             })
         }
 
+        fn buffer_has_final_newline(buffer: &Buffer) -> bool {
+            buffer.reversed_chars_at(buffer.len()).next() == Some('\n')
+        }
+
+        fn remove_final_newlines(buffer: &mut Buffer, cx: &mut Context<Buffer>) {
+            let len = buffer.len();
+            if len == 0 {
+                return;
+            }
+
+            let mut first_trailing_newline = len;
+            for chunk in buffer.as_rope().reversed_chunks_in_range(0..len) {
+                let non_newline_len = chunk.trim_end_matches('\n').len();
+                first_trailing_newline -= chunk.len();
+                first_trailing_newline += non_newline_len;
+                if non_newline_len > 0 {
+                    break;
+                }
+            }
+
+            if first_trailing_newline < len {
+                buffer.edit([(first_trailing_newline..len, "")], None, cx);
+            }
+        }
+
+        let had_final_newline_before_formatting = buffer
+            .handle
+            .read_with(cx, |buffer, _| buffer_has_final_newline(buffer));
+
         // handle whitespace formatting
         if settings.remove_trailing_whitespace_on_save {
             zlog::trace!(logger => "removing trailing whitespace");
@@ -2200,6 +2229,19 @@ impl LocalLspStore {
                         // add it so it's included, and merge it into the format transaction when its created later
                     }
                 }
+            }
+        }
+
+        if !settings.ensure_final_newline_on_save && !had_final_newline_before_formatting {
+            // Some formatters ignore `insertFinalNewline`; preserve the user's original EOF style.
+            let final_newline_was_added = buffer
+                .handle
+                .read_with(cx, |buffer, _| buffer_has_final_newline(buffer));
+            if final_newline_was_added {
+                zlog::trace!(logger => "removing final newline added during formatting");
+                extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
+                    remove_final_newlines(buffer, cx);
+                })?;
             }
         }
 

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -2635,9 +2635,12 @@ mod test {
         state::Mode,
         test::{NeovimBackedTestContext, VimTestContext},
     };
-    use editor::{Editor, EditorSettings};
+    use editor::{Editor, EditorSettings, Inlay, test::editor_lsp_test_context::EditorLspTestContext};
     use gpui::{Context, TestAppContext};
     use indoc::indoc;
+    use language::Point;
+    use lsp::ServerCapabilities;
+    use multi_buffer::MultiBufferRow;
     use settings::Settings;
     use util::path;
     use workspace::{OpenOptions, Workspace};
@@ -2758,6 +2761,140 @@ mod test {
         cx.simulate_keystrokes("enter");
         assert!(!cx.has_pending_prompt());
         assert_eq!(fs.load(path).await.unwrap().replace("\r\n", "\n"), "@@\n");
+    }
+
+    #[gpui::test]
+    async fn test_command_write_helix_preserves_missing_final_newline(
+        cx: &mut TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.update_global(|store: &mut settings::SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project
+                    .all_languages
+                    .defaults
+                    .ensure_final_newline_on_save = Some(false);
+            });
+        });
+
+        let path = Path::new(path!("/root/dir/file.rs"));
+        let fs = cx.workspace(|workspace, _, cx| workspace.project().read(cx).fs().clone());
+
+        cx.set_state("one\ntwo\nthreeˇ", Mode::HelixNormal);
+        cx.simulate_keystrokes(": w enter");
+        cx.run_until_parked();
+
+        assert_eq!(
+            fs.load(path).await.unwrap().replace("\r\n", "\n"),
+            "one\ntwo\nthree"
+        );
+        cx.assert_state("one\ntwo\nthreeˇ", Mode::HelixNormal);
+    }
+
+    #[gpui::test]
+    async fn test_command_write_helix_with_inlay_near_eof(cx: &mut TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.update_global(|store: &mut settings::SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project
+                    .all_languages
+                    .defaults
+                    .ensure_final_newline_on_save = Some(false);
+            });
+        });
+
+        let path = Path::new(path!("/root/dir/file.rs"));
+        let fs = cx.workspace(|workspace, _, cx| workspace.project().read(cx).fs().clone());
+
+        cx.set_state("fn test_new() {\n    assert!(true);\n}ˇ\n}", Mode::HelixNormal);
+        cx.update_editor(|editor, _window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let inlay_anchor =
+                snapshot.anchor_after(Point::new(2, snapshot.line_len(MultiBufferRow(2))));
+            let inlay = Inlay::mock_hint(1, inlay_anchor, " fn test_new");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes(": w enter");
+        cx.run_until_parked();
+
+        let (buffer_max_row, display_max_row, cursor_row) = cx.update_editor(|editor, _, cx| {
+            let display_snapshot = editor.display_snapshot(cx);
+            let newest = editor.selections.newest_display(&display_snapshot);
+            (
+                display_snapshot.buffer_snapshot().max_point().row,
+                display_snapshot.max_point().row().0,
+                newest.head().row().0,
+            )
+        });
+
+        assert_eq!(
+            fs.load(path).await.unwrap().replace("\r\n", "\n"),
+            "fn test_new() {\n    assert!(true);\n}\n}"
+        );
+        assert_eq!(display_max_row, buffer_max_row);
+        assert!(cursor_row <= display_max_row);
+        cx.assert_state("fn test_new() {\n    assert!(true);\n}ˇ\n}", Mode::HelixNormal);
+    }
+
+    #[gpui::test]
+    async fn test_command_write_helix_format_on_save_preserves_missing_final_newline(
+        cx: &mut TestAppContext,
+    ) {
+        VimTestContext::init(cx);
+        let lsp_test_context = EditorLspTestContext::new_rust(
+            ServerCapabilities {
+                document_formatting_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        let mut cx = VimTestContext::new_with_lsp(lsp_test_context, true);
+        cx.enable_helix();
+        cx.update_global(|store: &mut settings::SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project
+                    .all_languages
+                    .defaults
+                    .ensure_final_newline_on_save = Some(false);
+            });
+        });
+
+        let path = Path::new(path!("/root/dir/file.rs"));
+        let fs = cx.workspace(|workspace, _, cx| workspace.project().read(cx).fs().clone());
+
+        cx.set_state("one\ntwo\nthreeˇ", Mode::HelixNormal);
+        cx.lsp
+            .set_request_handler::<lsp::request::Formatting, _, _>(move |params, _| async move {
+                assert_eq!(params.options.insert_final_newline, Some(false));
+                assert_eq!(params.options.trim_final_newlines, Some(false));
+                Ok(Some(vec![
+                    lsp::TextEdit::new(
+                        lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(1, 3)),
+                        "TWO".to_string(),
+                    ),
+                    lsp::TextEdit::new(
+                        lsp::Range::new(lsp::Position::new(2, 5), lsp::Position::new(2, 5)),
+                        "\n".to_string(),
+                    ),
+                ]))
+            });
+
+        cx.simulate_keystrokes(": w enter");
+        cx.run_until_parked();
+
+        assert_eq!(
+            fs.load(path).await.unwrap().replace("\r\n", "\n"),
+            "one\nTWO\nthree"
+        );
+        cx.assert_state("one\nTWO\nthreeˇ", Mode::HelixNormal);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes #37793

## Problem
When `ensure_final_newline_on_save` is `false`, format-on-save can still add a trailing newline. This is especially visible in Helix mode when saving valid code.

## Repro
1. Set `helix_mode = true`
2. Set `ensure_final_newline_on_save = false`
3. Save a file without a trailing newline while format-on-save is enabled
4. A formatter edit can append a final newline anyway

## Fix
- Record whether the buffer had a final newline before formatting starts.
- After formatter/code-action edits, if the setting is disabled and the buffer originally had no final newline, remove trailing newline(s) added during formatting.
- Keep existing behavior unchanged when the buffer already had a final newline.

## Tests
- Added `test_document_format_on_save_without_final_newline`.
- Added `test_command_write_helix_preserves_missing_final_newline`.
- Added `test_command_write_helix_with_inlay_near_eof`.
- Added `test_command_write_helix_format_on_save_preserves_missing_final_newline`.
- Verified `test_document_format_during_save` still passes.

Release Notes:

- Fixed format-on-save adding a trailing newline when `ensure_final_newline_on_save` is disabled and the file originally had no final newline.

