### PR TITLE
Fix external file drops in terminal tabs outside terminal panel

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1382,18 +1382,8 @@ fn add_paths_to_terminal(
     window: &mut Window,
     cx: &mut Context<Pane>,
 ) {
-    if let Some(terminal_view) = pane
-        .active_item()
-        .and_then(|item| item.downcast::<TerminalView>())
-    {
-        window.focus(&terminal_view.focus_handle(cx), cx);
-        let mut new_text = paths.iter().map(|path| format!(" {path:?}")).join("");
-        new_text.push(' ');
-        terminal_view.update(cx, |terminal_view, cx| {
-            terminal_view.terminal().update(cx, |terminal, _| {
-                terminal.paste(&new_text);
-            });
-        });
+    if let Some(active_item) = pane.active_item() {
+        active_item.handle_external_paths_drop(paths, window, cx);
     }
 }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1425,6 +1425,33 @@ impl Item for TerminalView {
         }
     }
 
+    fn handle_external_paths_drop(
+        &mut self,
+        paths: &[PathBuf],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(project) = self.project.upgrade() else {
+            return false;
+        };
+        if !project.read(cx).is_local() {
+            return false;
+        }
+
+        window.focus(&self.focus_handle(cx), cx);
+        let mut pasted_text = String::new();
+        for path in paths {
+            pasted_text.push(' ');
+            pasted_text.push_str(&format!("{path:?}"));
+        }
+        pasted_text.push(' ');
+
+        self.terminal.update(cx, |terminal, _cx| {
+            terminal.paste(&pasted_text);
+        });
+        true
+    }
+
     fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {
         workspace::item::ItemBufferKind::Singleton
     }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -26,7 +26,7 @@ use std::{
     any::{Any, TypeId},
     cell::RefCell,
     ops::Range,
-    path::Path,
+    path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
     time::Duration,
@@ -225,6 +225,14 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
         _: Arc<dyn Any + Send>,
         _window: &mut Window,
         _: &mut Context<Self>,
+    ) -> bool {
+        false
+    }
+    fn handle_external_paths_drop(
+        &mut self,
+        _paths: &[PathBuf],
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
     ) -> bool {
         false
     }
@@ -472,6 +480,12 @@ pub trait ItemHandle: 'static + Send {
     fn project_entry_ids(&self, cx: &App) -> SmallVec<[ProjectEntryId; 3]>;
     fn project_paths(&self, cx: &App) -> SmallVec<[ProjectPath; 3]>;
     fn project_item_model_ids(&self, cx: &App) -> SmallVec<[EntityId; 3]>;
+    fn handle_external_paths_drop(
+        &self,
+        paths: &[PathBuf],
+        window: &mut Window,
+        cx: &mut App,
+    ) -> bool;
     fn for_each_project_item(
         &self,
         _: &App,
@@ -683,6 +697,17 @@ impl<T: Item> ItemHandle for Entity<T> {
             result.push(id);
         });
         result
+    }
+
+    fn handle_external_paths_drop(
+        &self,
+        paths: &[PathBuf],
+        window: &mut Window,
+        cx: &mut App,
+    ) -> bool {
+        self.update(cx, |item, cx| {
+            item.handle_external_paths_drop(paths, window, cx)
+        })
     }
 
     fn for_each_project_item(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3944,6 +3944,11 @@ impl Pane {
         {
             return;
         }
+        if self.active_item().is_some_and(|active_item| {
+            active_item.handle_external_paths_drop(paths.paths(), window, cx)
+        }) {
+            return;
+        }
         let mut to_pane = cx.entity();
         let mut split_direction = self.drag_split_direction;
         let paths = paths.paths().to_vec();
@@ -4833,11 +4838,98 @@ mod tests {
         Member,
         item::test::{TestItem, TestProjectItem},
     };
-    use gpui::{AppContext, Axis, TestAppContext, VisualTestContext, size};
+    use gpui::{
+        AppContext, Axis, FocusHandle, SharedString, TestAppContext, VisualTestContext, size,
+    };
     use project::FakeFs;
+    use serde_json::json;
     use settings::SettingsStore;
     use theme::LoadThemes;
-    use util::TryFutureExt;
+    use util::{TryFutureExt, path};
+
+    struct ExternalPathsDropTestItem {
+        consume_external_paths_drop: bool,
+        dropped_paths: Vec<PathBuf>,
+        focus_handle: FocusHandle,
+    }
+
+    impl ExternalPathsDropTestItem {
+        fn new(consume_external_paths_drop: bool, cx: &mut Context<Self>) -> Self {
+            Self {
+                consume_external_paths_drop,
+                dropped_paths: Vec::new(),
+                focus_handle: cx.focus_handle(),
+            }
+        }
+    }
+
+    impl Render for ExternalPathsDropTestItem {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div().track_focus(&self.focus_handle(cx))
+        }
+    }
+
+    impl EventEmitter<ItemEvent> for ExternalPathsDropTestItem {}
+
+    impl Focusable for ExternalPathsDropTestItem {
+        fn focus_handle(&self, _cx: &App) -> FocusHandle {
+            self.focus_handle.clone()
+        }
+    }
+
+    impl Item for ExternalPathsDropTestItem {
+        type Event = ItemEvent;
+
+        fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
+            "drop-target".into()
+        }
+
+        fn to_item_events(event: &Self::Event, f: &mut dyn FnMut(ItemEvent)) {
+            f(*event)
+        }
+
+        fn handle_external_paths_drop(
+            &mut self,
+            paths: &[PathBuf],
+            _window: &mut Window,
+            _cx: &mut Context<Self>,
+        ) -> bool {
+            self.dropped_paths = paths.to_vec();
+            self.consume_external_paths_drop
+        }
+    }
+
+    #[gpui::test]
+    async fn test_external_paths_drop_can_be_handled_by_active_item(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/root"), json!({ "drop-target.txt": "contents" }))
+            .await;
+
+        let project = Project::test(fs, [path!("/root").as_ref()], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        let item = pane.update_in(cx, |pane, window, cx| {
+            let item = cx.new(|cx| ExternalPathsDropTestItem::new(true, cx));
+            pane.add_item(Box::new(item.clone()), false, false, None, window, cx);
+            item
+        });
+
+        let dropped_path = path!("/root/drop-target.txt").to_path_buf();
+        let external_paths = ExternalPaths(vec![dropped_path.clone()].into());
+        pane.update_in(cx, |pane, window, cx| {
+            pane.handle_external_paths_drop(&external_paths, window, cx);
+        });
+        cx.run_until_parked();
+
+        item.read_with(cx, |item, _| {
+            assert_eq!(item.dropped_paths, vec![dropped_path.clone()]);
+        });
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(pane.items_len(), 1);
+        });
+    }
 
     #[gpui::test]
     async fn test_add_item_capped_to_max_tabs(cx: &mut TestAppContext) {


### PR DESCRIPTION
Fixes #49800

## Problem
Dropping files from the OS into a terminal tab only pasted paths when that terminal lived inside the terminal panel. If the same terminal tab was moved into a regular workspace pane, pane-level drop handling opened files/directories instead of pasting paths into the terminal.

## Repro
1. Open a terminal tab from the terminal panel.
2. Move/split that terminal tab into a regular pane.
3. Drag a file from Finder/Explorer into that terminal tab.
4. Observe file-open behavior instead of path paste.

## Fix
- Added an item-level external-path drop hook on `workspace::Item` and `ItemHandle`.
- Updated generic pane external-path drop handling to first let the active item consume the drop.
- Implemented this hook in `TerminalView` to paste quoted paths into the terminal input (local projects only).
- Updated terminal panel path-drop helper to use the same item-level hook so terminal drop behavior is consistent in both panel and regular panes.

## Tests
- Added `test_external_paths_drop_can_be_handled_by_active_item` in `crates/workspace/src/pane.rs`.
- Ran: `cargo check -p workspace --lib`
- Ran: `cargo test -p terminal_view test_custom_title_initially_none -- --nocapture`
- Note: `cargo test -p workspace ...` currently fails on an unrelated pre-existing compile error in `crates/workspace/src/persistence.rs` (`RemoteConnectionOptions::Mock(_)` match arm missing).

## Risk
Low. The pane behavior change only applies to external-path drops and only when the active item explicitly opts in by returning `true` from the new hook. Existing items keep previous behavior via default `false`.

Release Notes:

- Fixed dropping external files into terminal tabs so paths are pasted even when the terminal tab is outside the terminal panel.

