### PR TITLE
clangd: Skip cached binaries on unsupported Linux architectures

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -147,17 +147,26 @@ impl LspInstaller for CLspAdapter {
         container_dir: PathBuf,
         _: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary> {
+        if let Err(error) = ensure_arch_compatibility() {
+            log::info!("Skipping cached clangd binary: {error:#}");
+            return None;
+        }
+
         get_cached_server_binary(container_dir).await
     }
 }
 
 fn ensure_arch_compatibility() -> Result<()> {
-    let arch = consts::ARCH;
-    if consts::OS == "linux" && !["x86_64", "x86"].contains(&arch) {
+    ensure_arch_compatibility_for_platform(consts::OS, consts::ARCH)
+}
+
+fn ensure_arch_compatibility_for_platform(os: &str, arch: &str) -> Result<()> {
+    if os == "linux" && !["x86_64", "x86"].contains(&arch) {
         anyhow::bail!(
             "Clangd does not provide prebuilt binaries for {arch} to fetch from GitHub. Consider installing the binary manually."
         )
     }
+
     Ok(())
 }
 
@@ -653,5 +662,22 @@ mod tests {
 
             buffer
         });
+    }
+
+    #[test]
+    fn test_ensure_arch_compatibility_for_platform() {
+        assert!(ensure_arch_compatibility_for_platform("linux", "x86_64").is_ok());
+        assert!(ensure_arch_compatibility_for_platform("linux", "x86").is_ok());
+        assert!(ensure_arch_compatibility_for_platform("macos", "aarch64").is_ok());
+        assert!(ensure_arch_compatibility_for_platform("windows", "aarch64").is_ok());
+
+        let error = ensure_arch_compatibility_for_platform("linux", "aarch64")
+            .expect_err("linux aarch64 should not be considered a downloadable clangd platform");
+        assert!(
+            error
+                .to_string()
+                .contains("Clangd does not provide prebuilt binaries for aarch64"),
+            "unexpected error: {error:?}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #46182

## Problem
On Linux `aarch64`, older cached Zed-managed clangd downloads can still be selected before the download path runs, which can surface the old runtime error:

- `Exec format error (os error 8)`

This happens because those cached binaries are x86_64 artifacts from upstream `clangd-linux-*.zip`.

## Repro
1. Use remote Linux `aarch64` with a previously cached Zed-managed clangd binary.
2. Open a C/C++ project in Zed.
3. Language server startup can attempt that cached binary and fail with exec format mismatch.

## Fix
- Reuse the existing clangd architecture-compatibility gate when resolving cached binaries.
- On unsupported Linux architectures, skip cached Zed-managed clangd binaries instead of returning them.
- Keep failing with the explicit “no prebuilt binaries for this arch; install manually” path instead of attempting execution.

## Tests
- Added `test_ensure_arch_compatibility_for_platform` in `crates/languages/src/c.rs`.
- Local test execution was not possible in this environment (`cargo` is unavailable in shell PATH).

## Risk
Low. The behavior change only affects cached Zed-managed clangd binaries on unsupported Linux architectures. User-installed clangd discovery remains unchanged.

Release Notes:

- Fixed stale cached clangd binaries being reused on unsupported Linux architectures, avoiding `Exec format error` in that path.
