### PR TITLE
vim: Fix Helix linewise selection around EOF inlay hints

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -859,8 +859,10 @@ impl Vim {
 
 #[cfg(test)]
 mod test {
+    use editor::{Inlay, ToPoint};
     use gpui::{UpdateGlobal, VisualTestContext};
     use indoc::indoc;
+    use multi_buffer::MultiBufferRow;
     use project::FakeFs;
     use search::{ProjectSearchView, project_search};
     use serde_json::json;
@@ -1446,6 +1448,244 @@ mod test {
             line four
             ˇ»line five"},
             Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_lines_with_inlay_hint_near_eof(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            }ˇ
+            }
+
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, _window, cx| {
+            let range = editor.selections.newest_anchor().range();
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let cursor_point = range.start.to_point(&snapshot);
+            let end_of_line = snapshot.anchor_after(language::Point::new(
+                cursor_point.row,
+                snapshot.line_len(MultiBufferRow(cursor_point.row)),
+            ));
+            let inlay = Inlay::mock_hint(1, end_of_line, " mod test");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            «}
+            ˇ»}
+
+            "},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_move_down_with_inlay_hint_near_eof(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            }ˇ
+            }
+
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, _window, cx| {
+            let range = editor.selections.newest_anchor().range();
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let cursor_point = range.start.to_point(&snapshot);
+            let end_of_line = snapshot.anchor_after(language::Point::new(
+                cursor_point.row,
+                snapshot.line_len(MultiBufferRow(cursor_point.row)),
+            ));
+            let inlay = Inlay::mock_hint(1, end_of_line, " mod test");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+
+        cx.simulate_keystrokes("j");
+        cx.assert_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            }
+            }ˇ
+
+            "},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_line_after_move_down_with_inlay_hint_near_eof(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);ˇ
+            }
+            }
+
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, _window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let hint_position = snapshot.anchor_after(language::Point::new(
+                2,
+                snapshot.line_len(MultiBufferRow(2)),
+            ));
+            let inlay = Inlay::mock_hint(1, hint_position, " mod test");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+
+        cx.simulate_keystrokes("j x");
+        cx.assert_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            «}
+            ˇ»}
+
+            "},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_move_down_with_inlay_on_second_to_last_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);ˇ
+            }
+
+            tail
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, _window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let hint_position = snapshot.anchor_after(language::Point::new(
+                2,
+                snapshot.line_len(MultiBufferRow(2)),
+            ));
+            let inlay = Inlay::mock_hint(1, hint_position, " mod test");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+
+        cx.simulate_keystrokes("j");
+        cx.assert_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            }ˇ
+
+            tail
+            "},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_line_with_inlay_on_second_to_last_line(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            }ˇ
+
+            tail
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, _window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let hint_position = snapshot.anchor_after(language::Point::new(
+                2,
+                snapshot.line_len(MultiBufferRow(2)),
+            ));
+            let inlay = Inlay::mock_hint(1, hint_position, " mod test");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            «}
+            ˇ»
+            tail
+            "},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_visual_line_with_inlay_on_second_to_last_line(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            }ˇ
+
+            tail
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, _window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let hint_position = snapshot.anchor_after(language::Point::new(
+                2,
+                snapshot.line_len(MultiBufferRow(2)),
+            ));
+            let inlay = Inlay::mock_hint(1, hint_position, " mod test");
+            editor.splice_inlays(&[], vec![inlay], cx);
+        });
+
+        cx.simulate_keystrokes("shift-v");
+        cx.assert_state(
+            indoc! {"
+            fn test_new() {
+                assert!(true);
+            «}ˇ»
+
+            tail
+            "},
+            Mode::VisualLine,
         );
     }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -38,7 +38,7 @@ use language::{
 };
 pub use mode_indicator::ModeIndicator;
 use motion::Motion;
-use multi_buffer::ToPoint as _;
+use multi_buffer::{MultiBufferRow, ToPoint as _};
 use normal::search::SearchSubmit;
 use object::Object;
 use schemars::JsonSchema;
@@ -1273,6 +1273,15 @@ impl Vim {
                         selection.collapse_to(point, selection.goal)
                     } else if !last_mode.is_visual() && mode.is_visual() {
                         if selection.is_empty() {
+                            if last_mode == Mode::HelixNormal && mode == Mode::VisualLine {
+                                let point = selection.start.to_point(map);
+                                let line_length =
+                                    map.buffer_snapshot().line_len(MultiBufferRow(point.row));
+                                if point.column == line_length && point.column > 0 {
+                                    selection.start =
+                                        movement::saturating_left(map, selection.start);
+                                }
+                            }
                             selection.end = movement::right(map, selection.start);
                         }
                     }


### PR DESCRIPTION
Fixes #35616

## Problem
In Helix mode, when an inlay hint sits at end-of-line near EOF, entering visual-line mode (`shift-v`) can anchor from the newline boundary instead of the line character. That makes linewise selection behave inconsistently around trailing empty lines.

## Repro
1. Enable Helix mode and inlay hints.
2. Put cursor on a line ending with `}` near EOF where an inlay hint is shown after that `}`.
3. Press `shift-v`.

## Fix
- Normalize the cursor start point when switching from `HelixNormal` into `VisualLine`:
  - if the cursor is on a non-empty line-end boundary (`column == line_len`), shift it left by one display position before expanding the visual selection.
- Keep existing behavior for other modes and positions unchanged.

## Tests
Added/updated regression coverage in `crates/vim/src/helix.rs` for inlay-hint EOF edge cases:
- `test_helix_move_down_with_inlay_hint_near_eof`
- `test_helix_select_lines_with_inlay_hint_near_eof`
- `test_helix_select_line_after_move_down_with_inlay_hint_near_eof`
- `test_helix_move_down_with_inlay_on_second_to_last_line`
- `test_helix_select_line_with_inlay_on_second_to_last_line`
- `test_helix_visual_line_with_inlay_on_second_to_last_line`

Ran:
- `cargo test -p vim inlay -- --nocapture`
- `cargo test -p vim test_helix_select_lines -- --nocapture`
- `cargo test -p vim visual_line -- --nocapture`
(using Rust toolchain `1.93.1` in this environment)

## Risk
Low. The runtime behavior change is limited to `HelixNormal -> VisualLine` transitions when the cursor sits on a non-empty line-end boundary.

Release Notes:

- Fixed Helix visual-line selection near EOF with inlay hints so linewise selection anchors on the intended line.
