### PR TITLE
project_panel: Fix Reveal in File Manager for WSL projects

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6457,7 +6457,7 @@ impl Render for ProjectPanel {
                             el.on_action(cx.listener(Self::trash))
                         })
                 })
-                .when(project.is_local(), |el| {
+                .when(project.is_local() || project.is_via_wsl_with_host_interop(cx), |el| {
                     el.on_action(cx.listener(Self::reveal_in_finder))
                         .on_action(cx.listener(Self::open_system))
                         .on_action(cx.listener(Self::open_in_terminal))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6457,11 +6457,14 @@ impl Render for ProjectPanel {
                             el.on_action(cx.listener(Self::trash))
                         })
                 })
-                .when(project.is_local() || project.is_via_wsl_with_host_interop(cx), |el| {
-                    el.on_action(cx.listener(Self::reveal_in_finder))
-                        .on_action(cx.listener(Self::open_system))
-                        .on_action(cx.listener(Self::open_in_terminal))
-                })
+                .when(
+                    project.is_local() || project.is_via_wsl_with_host_interop(cx),
+                    |el| {
+                        el.on_action(cx.listener(Self::reveal_in_finder))
+                            .on_action(cx.listener(Self::open_system))
+                            .on_action(cx.listener(Self::open_in_terminal))
+                    },
+                )
                 .when(project.is_via_remote_server(), |el| {
                     el.on_action(cx.listener(Self::open_in_terminal))
                         .on_action(cx.listener(Self::download_from_remote))


### PR DESCRIPTION
Closes #46767

## Summary

The "Reveal in File Manager" action was shown in the context menu for WSL projects (guarded by `is_via_wsl_with_host_interop`), but the action handler in `Render` was only registered when `project.is_local()` — which returns `false` for WSL. Dispatching the action without a handler caused a crash.

Adds the same `is_via_wsl_with_host_interop(cx)` check to the handler registration.

## Testing

- Ran `cargo test -p project_panel` — 78 passed, 0 failed
- Manual testing: connected to WSL Ubuntu, right-clicked a file in the project panel, used "Reveal in File Manager" — Windows Explorer opened correctly without crashing

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed a crash when using "Reveal in File Manager" on files in WSL projects (#46767).
