### PR TITLE
agent_ui: Add "Paste as Plain Text" to message editor context menu

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -154,6 +154,7 @@ impl MessageEditor {
                             Box::new(editor::actions::Copy),
                         )
                         .action("Paste", Box::new(editor::actions::Paste))
+                        .action("Paste as Plain Text", Box::new(PasteRaw))
                 }))
             });
 


### PR DESCRIPTION
Add the existing `PasteRaw` action to the right-click context menu in
the message editor, making it more discoverable. Previously it was only
available via the keyboard shortcut (Cmd+Shift+V / Ctrl+Shift+V) or
the command palette.

Release Notes:

- Added "Paste as Plain Text" to the agent panel message editor right-click menu