### PR TITLE
editor: Add git diff-hunk signs to editor gutter

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1658,10 +1658,12 @@
     "enable_status": true,
     // Whether to enable git diff display.
     "enable_diff": true,
-    // Control whether the git gutter is shown. May take 2 values:
+    // Control whether the git gutter is shown. May take 3 values:
     // 1. Show the gutter
     //      "git_gutter": "tracked_files"
-    // 2. Hide the gutter
+    // 2. Show the gutter with per-line signs
+    //      "git_gutter": "tracked_files_with_signs"
+    // 3. Hide the gutter
     //      "git_gutter": "hide"
     "git_gutter": "tracked_files",
     /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1666,6 +1666,8 @@
     // 3. Hide the gutter
     //      "git_gutter": "hide"
     "git_gutter": "tracked_files",
+    // Minimum contrast used when rendering diff hunk signs in the gutter.
+    "git_gutter_sign_minimum_contrast": 70.0,
     /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.
     ///
     /// Default: 0

--- a/crates/editor/src/config.rs
+++ b/crates/editor/src/config.rs
@@ -208,6 +208,15 @@ impl Editor {
         }
     }
 
+    pub fn set_show_git_diff_hunk_signs_gutter(
+        &mut self,
+        show_git_diff_hunk_signs_gutter: bool,
+        cx: &mut Context<Self>,
+    ) {
+        self.show_git_diff_hunk_signs_gutter = Some(show_git_diff_hunk_signs_gutter);
+        cx.notify();
+    }
+
     pub fn set_show_code_actions(&mut self, show_code_actions: bool, cx: &mut Context<Self>) {
         self.show_code_actions = Some(show_code_actions);
         cx.notify();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -986,6 +986,7 @@ pub struct Editor {
     show_line_numbers: Option<bool>,
     use_relative_line_numbers: Option<bool>,
     show_git_diff_gutter: Option<bool>,
+    show_git_diff_hunk_signs_gutter: Option<bool>,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
     show_bookmarks: Option<bool>,
@@ -1213,6 +1214,7 @@ pub struct EditorSnapshot {
     show_line_numbers: Option<bool>,
     number_deleted_lines: bool,
     show_git_diff_gutter: Option<bool>,
+    show_git_diff_hunk_signs_gutter: Option<bool>,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
     show_breakpoints: Option<bool>,
@@ -1250,6 +1252,7 @@ pub struct GutterDimensions {
     pub width: Pixels,
     pub margin: Pixels,
     pub git_blame_entries_width: Option<Pixels>,
+    pub diff_hunk_signs_width: Pixels,
 }
 
 impl GutterDimensions {
@@ -2290,6 +2293,7 @@ impl Editor {
             enable_code_lens: full_mode,
             enable_mouse_wheel_zoom: full_mode,
             show_git_diff_gutter: None,
+            show_git_diff_hunk_signs_gutter: None,
             show_code_actions: None,
             show_runnables: None,
             show_bookmarks: None,
@@ -2989,6 +2993,7 @@ impl Editor {
             show_line_numbers: self.show_line_numbers,
             number_deleted_lines: self.number_deleted_lines,
             show_git_diff_gutter: self.show_git_diff_gutter,
+            show_git_diff_hunk_signs_gutter: self.show_git_diff_hunk_signs_gutter,
             semantic_tokens_enabled: self.semantic_token_state.enabled(),
             show_code_actions: self.show_code_actions,
             show_runnables: self.show_runnables,
@@ -11572,9 +11577,18 @@ impl EditorSnapshot {
             let show_git_gutter = self.show_git_diff_gutter.unwrap_or_else(|| {
                 matches!(
                     ProjectSettings::get_global(cx).git.git_gutter,
-                    GitGutterSetting::TrackedFiles
+                    GitGutterSetting::TrackedFiles | GitGutterSetting::TrackedFilesWithSigns
                 )
             });
+
+            let show_diff_hunk_signs_gutter = show_git_gutter
+                && self.show_git_diff_hunk_signs_gutter.unwrap_or_else(|| {
+                    matches!(
+                        ProjectSettings::get_global(cx).git.git_gutter,
+                        GitGutterSetting::TrackedFilesWithSigns
+                    )
+                });
+
             let gutter_settings = EditorSettings::get_global(cx).gutter;
             let show_line_numbers = self
                 .show_line_numbers
@@ -11627,6 +11641,12 @@ impl EditorSnapshot {
 
             let shows_folds = is_singleton && gutter_settings.folds;
 
+            let diff_hunk_signs_gutter_width = if show_diff_hunk_signs_gutter {
+                ch_width * 2.0 + px(2.0)
+            } else {
+                px(0.)
+            };
+
             let right_padding = if shows_folds && show_line_numbers {
                 ch_width * 4.0
             } else if shows_folds || (!is_singleton && show_line_numbers) {
@@ -11640,9 +11660,13 @@ impl EditorSnapshot {
             GutterDimensions {
                 left_padding,
                 right_padding,
-                width: line_gutter_width + left_padding + right_padding,
+                width: line_gutter_width
+                    + diff_hunk_signs_gutter_width
+                    + left_padding
+                    + right_padding,
                 margin: GutterDimensions::default_gutter_margin(font_id, font_size, cx),
                 git_blame_entries_width,
+                diff_hunk_signs_width: diff_hunk_signs_gutter_width,
             }
         } else if self.offset_content {
             GutterDimensions::default_with_margin(font_id, font_size, cx)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11580,14 +11580,6 @@ impl EditorSnapshot {
                 )
             });
 
-            let show_diff_hunk_signs_gutter = show_git_gutter
-                && self.show_git_diff_hunk_signs_gutter.unwrap_or_else(|| {
-                    matches!(
-                        ProjectSettings::get_global(cx).git.git_gutter,
-                        GitGutterSetting::TrackedFilesWithSigns
-                    )
-                });
-
             let gutter_settings = EditorSettings::get_global(cx).gutter;
             let show_line_numbers = self
                 .show_line_numbers

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1252,7 +1252,6 @@ pub struct GutterDimensions {
     pub width: Pixels,
     pub margin: Pixels,
     pub git_blame_entries_width: Option<Pixels>,
-    pub diff_hunk_signs_width: Pixels,
 }
 
 impl GutterDimensions {
@@ -11641,12 +11640,6 @@ impl EditorSnapshot {
 
             let shows_folds = is_singleton && gutter_settings.folds;
 
-            let diff_hunk_signs_gutter_width = if show_diff_hunk_signs_gutter {
-                ch_width * 2.0 + px(2.0)
-            } else {
-                px(0.)
-            };
-
             let right_padding = if shows_folds && show_line_numbers {
                 ch_width * 4.0
             } else if shows_folds || (!is_singleton && show_line_numbers) {
@@ -11660,13 +11653,9 @@ impl EditorSnapshot {
             GutterDimensions {
                 left_padding,
                 right_padding,
-                width: line_gutter_width
-                    + diff_hunk_signs_gutter_width
-                    + left_padding
-                    + right_padding,
+                width: line_gutter_width + left_padding + right_padding,
                 margin: GutterDimensions::default_gutter_margin(font_id, font_size, cx),
                 git_blame_entries_width,
-                diff_hunk_signs_width: diff_hunk_signs_gutter_width,
             }
         } else if self.offset_content {
             GutterDimensions::default_with_margin(font_id, font_size, cx)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2881,7 +2881,13 @@ impl EditorElement {
 
         let is_light = cx.theme().appearance().is_light();
         let gutter_bg_color = cx.theme().colors().editor_gutter_background;
-        let scroll_top = gutter.scroll_position.y * ScrollPixelOffset::from(gutter.line_height);
+        let git_gutter_sign_minimum_contrast = ProjectSettings::get_global(cx)
+            .git
+            .git_gutter_sign_minimum_contrast
+            .clamp(0.0, 100.0);
+        let scroll_line_height = ScrollPixelOffset::from(gutter.line_height);
+        let scroll_top_line_height =
+            gutter.scroll_position.y * scroll_line_height % scroll_line_height;
 
         gutter
             .row_infos
@@ -2899,6 +2905,7 @@ impl EditorElement {
                             is_light,
                             gutter_bg_color,
                             cx.theme().colors().version_control_added,
+                            git_gutter_sign_minimum_contrast,
                         ),
                     ),
                     DiffHunkStatusKind::Modified => (
@@ -2907,6 +2914,7 @@ impl EditorElement {
                             is_light,
                             gutter_bg_color,
                             cx.theme().colors().version_control_modified,
+                            git_gutter_sign_minimum_contrast,
                         ),
                     ),
                     DiffHunkStatusKind::Deleted => (
@@ -2915,6 +2923,7 @@ impl EditorElement {
                             is_light,
                             gutter_bg_color,
                             cx.theme().colors().version_control_deleted,
+                            git_gutter_sign_minimum_contrast,
                         ),
                     ),
                 };
@@ -2928,10 +2937,7 @@ impl EditorElement {
                             - gutter.dimensions.right_padding
                             - gutter.dimensions.diff_hunk_signs_width
                             + (gutter.dimensions.diff_hunk_signs_width - shaped_line.width) / 2.0,
-                        ix as f32 * gutter.line_height
-                            - Pixels::from(
-                                scroll_top % ScrollPixelOffset::from(gutter.line_height),
-                            ),
+                        ix as f32 * gutter.line_height - Pixels::from(scroll_top_line_height),
                     );
 
                 Some(DiffHunkSignLayout {
@@ -10838,11 +10844,12 @@ fn compute_diff_hunk_sign_color(
     is_light: bool,
     gutter_bg_color: Hsla,
     diff_hunk_color: Hsla,
+    min_contrast: f32,
 ) -> Hsla {
     let diff_hunk_status_bg_opacity = if is_light { 0.16 } else { 0.12 };
     let diff_hunk_bg_color = diff_hunk_color.opacity(diff_hunk_status_bg_opacity);
     let diff_hunk_sign_bg_color = gutter_bg_color.blend(diff_hunk_bg_color);
-    ensure_minimum_contrast(diff_hunk_color, diff_hunk_sign_bg_color, 70.0)
+    ensure_minimum_contrast(diff_hunk_color, diff_hunk_sign_bg_color, min_contrast)
 }
 
 #[cfg(test)]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2903,7 +2903,7 @@ impl EditorElement {
                         compute_diff_hunk_sign_color(
                             is_light,
                             gutter_bg_color,
-                            cx.theme().colors().version_control_added,
+                            cx.theme().colors().editor_line_number,
                             git_gutter_sign_minimum_contrast,
                         ),
                     ),
@@ -2912,7 +2912,7 @@ impl EditorElement {
                         compute_diff_hunk_sign_color(
                             is_light,
                             gutter_bg_color,
-                            cx.theme().colors().version_control_modified,
+                            cx.theme().colors().editor_line_number,
                             git_gutter_sign_minimum_contrast,
                         ),
                     ),
@@ -2921,7 +2921,7 @@ impl EditorElement {
                         compute_diff_hunk_sign_color(
                             is_light,
                             gutter_bg_color,
-                            cx.theme().colors().version_control_deleted,
+                            cx.theme().colors().editor_line_number,
                             git_gutter_sign_minimum_contrast,
                         ),
                     ),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1667,7 +1667,11 @@ impl EditorElement {
             .map(|hunk| (hunk, None))
             .collect::<Vec<_>>();
         let git_gutter_setting = ProjectSettings::get_global(cx).git.git_gutter;
-        if let GitGutterSetting::TrackedFiles = git_gutter_setting {
+        let show_git_gutter_diff_hunks = matches!(
+            git_gutter_setting,
+            GitGutterSetting::TrackedFiles | GitGutterSetting::TrackedFilesWithSigns
+        );
+        if show_git_gutter_diff_hunks {
             for (hunk, hitbox) in &mut display_hunks {
                 if matches!(hunk, DisplayDiffHunk::Unfolded { .. }) {
                     let hunk_bounds = Self::diff_hunk_bounds(
@@ -2805,13 +2809,13 @@ impl EditorElement {
                     + point(
                         gutter.hitbox.size.width
                             - shaped_line.width
+                            - gutter.dimensions.diff_hunk_signs_width
                             - gutter.dimensions.right_padding,
                         ix as f32 * gutter.line_height
                             - Pixels::from(
                                 scroll_top % ScrollPixelOffset::from(gutter.line_height),
                             ),
                     );
-
                 #[cfg(not(test))]
                 let hitbox = Some(window.insert_hitbox(
                     Bounds::new(line_origin, size(shaped_line.width, gutter.line_height)),
@@ -2847,6 +2851,72 @@ impl EditorElement {
                 .push(segment);
         }
         Arc::new(line_numbers)
+    }
+
+    fn layout_gutter_diff_hunk_signs(
+        &self,
+        gutter: &Gutter,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Arc<HashMap<MultiBufferRow, DiffHunkSignLayout>> {
+        let show_git_gutter = gutter.snapshot.show_git_diff_gutter.unwrap_or_else(|| {
+            matches!(
+                ProjectSettings::get_global(cx).git.git_gutter,
+                GitGutterSetting::TrackedFiles | GitGutterSetting::TrackedFilesWithSigns
+            )
+        });
+        let show_git_gutter_signs = show_git_gutter
+            && gutter
+                .snapshot
+                .show_git_diff_hunk_signs_gutter
+                .unwrap_or_else(|| {
+                    matches!(
+                        ProjectSettings::get_global(cx).git.git_gutter,
+                        GitGutterSetting::TrackedFilesWithSigns
+                    )
+                });
+        if !show_git_gutter_signs {
+            return Arc::default();
+        }
+        let mut diff_hunk_signs: HashMap<MultiBufferRow, DiffHunkSignLayout> = HashMap::default();
+        let scroll_top = gutter.scroll_position.y * ScrollPixelOffset::from(gutter.line_height);
+        for (ix, row_info) in gutter.row_infos.iter().enumerate() {
+            let Some(diff_status) = row_info.diff_status else {
+                continue;
+            };
+            let (diff_sign, color) = match diff_status.kind {
+                DiffHunkStatusKind::Added => ("+", cx.theme().colors().version_control_added),
+                DiffHunkStatusKind::Modified => ("~", cx.theme().colors().version_control_modified),
+                DiffHunkStatusKind::Deleted => ("-", cx.theme().colors().version_control_deleted),
+            };
+            let shaped_line = self.shape_line_number(SharedString::from(diff_sign), color, window);
+            let line_origin = gutter.hitbox.origin
+                + point(
+                    gutter.hitbox.size.width
+                        - gutter.dimensions.right_padding
+                        - gutter.dimensions.diff_hunk_signs_width
+                        + (gutter.dimensions.diff_hunk_signs_width - shaped_line.width) / 2.0,
+                    ix as f32 * gutter.line_height
+                        - Pixels::from(scroll_top % ScrollPixelOffset::from(gutter.line_height)),
+                );
+
+            let display_row = DisplayRow(gutter.range.start.0 + ix as u32);
+            let buffer_row = DisplayPoint::new(display_row, 0)
+                .to_point(gutter.snapshot)
+                .row;
+            let multi_buffer_row = MultiBufferRow(buffer_row);
+
+            diff_hunk_signs.insert(
+                multi_buffer_row,
+                DiffHunkSignLayout {
+                    segment: DiffHunkSignSegment {
+                        shaped_line,
+                        origin: line_origin,
+                    },
+                },
+            );
+        }
+        Arc::new(diff_hunk_signs)
     }
 
     fn layout_crease_toggles(
@@ -5206,6 +5276,24 @@ impl EditorElement {
         }
     }
 
+    fn paint_gutter_diff_hunk_signs(
+        &mut self,
+        layout: &mut EditorLayout,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let line_height = layout.position_map.line_height;
+        for diff_hunk_sign_layout in layout.diff_hunk_signs.values() {
+            let DiffHunkSignSegment {
+                shaped_line,
+                origin,
+            } = &diff_hunk_sign_layout.segment;
+            shaped_line
+                .paint(*origin, line_height, TextAlign::Left, None, window, cx)
+                .log_err();
+        }
+    }
+
     fn paint_gutter_diff_hunks(
         &self,
         layout: &mut EditorLayout,
@@ -5457,7 +5545,7 @@ impl EditorElement {
             .unwrap_or_else(|| {
                 matches!(
                     ProjectSettings::get_global(cx).git.git_gutter,
-                    GitGutterSetting::TrackedFiles
+                    GitGutterSetting::TrackedFiles | GitGutterSetting::TrackedFilesWithSigns
                 )
             });
         if show_git_gutter {
@@ -8488,6 +8576,8 @@ impl Element for EditorElement {
                         cx,
                     );
 
+                    let diff_hunk_signs = self.layout_gutter_diff_hunk_signs(&gutter, window, cx);
+
                     let mut expand_toggles =
                         window.with_element_namespace("expand_toggles", |window| {
                             self.layout_expand_toggles(
@@ -9413,6 +9503,7 @@ impl Element for EditorElement {
                         document_colors,
                         line_elements,
                         line_numbers,
+                        diff_hunk_signs,
                         blamed_display_rows,
                         inline_diagnostics,
                         inline_blame_layout,
@@ -9512,6 +9603,7 @@ impl Element for EditorElement {
                         if layout.gutter_hitbox.size.width > Pixels::ZERO {
                             self.paint_blamed_display_rows(layout, window, cx);
                             self.paint_line_numbers(layout, window, cx);
+                            self.paint_gutter_diff_hunk_signs(layout, window, cx);
                         }
 
                         self.paint_text(layout, window, cx);
@@ -9627,6 +9719,7 @@ pub struct EditorLayout {
     highlighted_rows: BTreeMap<DisplayRow, LineHighlight>,
     line_elements: SmallVec<[AnyElement; 1]>,
     line_numbers: Arc<HashMap<MultiBufferRow, LineNumberLayout>>,
+    diff_hunk_signs: Arc<HashMap<MultiBufferRow, DiffHunkSignLayout>>,
     display_hunks: Vec<(DisplayDiffHunk, Option<Hitbox>)>,
     blamed_display_rows: Option<Vec<AnyElement>>,
     inline_diagnostics: HashMap<DisplayRow, AnyElement>,
@@ -9675,6 +9768,17 @@ struct LineNumberSegment {
 #[derive(Debug)]
 struct LineNumberLayout {
     segments: SmallVec<[LineNumberSegment; 1]>,
+}
+
+#[derive(Debug)]
+struct DiffHunkSignSegment {
+    shaped_line: ShapedLine,
+    origin: gpui::Point<Pixels>,
+}
+
+#[derive(Debug)]
+struct DiffHunkSignLayout {
+    segment: DiffHunkSignSegment,
 }
 
 struct ColoredRange<T> {
@@ -10717,7 +10821,7 @@ mod tests {
         display_map::{BlockPlacement, BlockProperties, DisplayMap},
         editor_tests::{init_test, update_test_language_settings},
     };
-    use gpui::{TestAppContext, VisualTestContext, font};
+    use gpui::{TestAppContext, UpdateGlobal, VisualTestContext, font};
     use language::{Buffer, SelectionGoal, language_settings, tree_sitter_python};
     use log::info;
     use rand::{RngCore, rngs::StdRng};
@@ -10783,6 +10887,7 @@ mod tests {
             width: px(30.0),
             margin: Pixels::ZERO,
             git_blame_entries_width: None,
+            diff_hunk_signs_width: Pixels::ZERO,
         };
         const EMPTY_ROW_INFO: RowInfo = RowInfo {
             buffer_id: None,
@@ -11258,6 +11363,148 @@ mod tests {
             layouts.get(&MultiBufferRow(DELETED_LINE)).is_none(),
             "Deleted line should not have a line number"
         );
+    }
+
+    #[gpui::test]
+    fn test_layout_diff_hunk_signs_enabled_and_disabled(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.git.get_or_insert_default().git_gutter =
+                        Some(settings::GitGutterSetting::TrackedFilesWithSigns);
+                });
+            });
+        });
+
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(&sample_text(4, 4, 'a'), cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+
+        let editor = window.root(cx).unwrap();
+        let style = editor.update(cx, |editor, cx| editor.style(cx).clone());
+        let line_height = window
+            .update(cx, |_, window, _| {
+                style.text.line_height_in_pixels(window.rem_size())
+            })
+            .unwrap();
+        let element = EditorElement::new(&editor, style);
+        let snapshot = window
+            .update(cx, |editor, window, cx| editor.snapshot(window, cx))
+            .unwrap();
+
+        let diff_hunk_signs_enabled = cx
+            .update_window(*window, |_, window, cx| {
+                let dimensions = GutterDimensions {
+                    left_padding: Pixels::ZERO,
+                    right_padding: px(20.),
+                    diff_hunk_signs_width: px(20.),
+                    width: px(80.),
+                    margin: Pixels::ZERO,
+                    git_blame_entries_width: None,
+                };
+                let row_infos = (0..4)
+                    .map(|row| RowInfo {
+                        buffer_row: Some(row),
+                        diff_status: match row {
+                            0 => Some(DiffHunkStatus::added_none()),
+                            1 => Some(DiffHunkStatus::modified_none()),
+                            2 => Some(DiffHunkStatus::deleted(
+                                buffer_diff::DiffHunkSecondaryStatus::NoSecondaryHunk,
+                            )),
+                            _ => None,
+                        },
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>();
+                let diff_hunk_signs = element.layout_gutter_diff_hunk_signs(
+                    &Gutter {
+                        dimensions: &dimensions,
+                        row_infos: &row_infos,
+                        range: DisplayRow(0)..DisplayRow(4),
+                        ..test_gutter(line_height, &snapshot)
+                    },
+                    window,
+                    cx,
+                );
+                diff_hunk_signs
+            })
+            .unwrap();
+        assert_eq!(diff_hunk_signs_enabled.len(), 3);
+        assert_eq!(
+            diff_hunk_signs_enabled[&MultiBufferRow(0)]
+                .segment
+                .shaped_line
+                .text
+                .as_ref(),
+            "+"
+        );
+        assert_eq!(
+            diff_hunk_signs_enabled[&MultiBufferRow(1)]
+                .segment
+                .shaped_line
+                .text
+                .as_ref(),
+            "~"
+        );
+        assert_eq!(
+            diff_hunk_signs_enabled[&MultiBufferRow(2)]
+                .segment
+                .shaped_line
+                .text
+                .as_ref(),
+            "-"
+        );
+        assert!(diff_hunk_signs_enabled.get(&MultiBufferRow(3)).is_none());
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.git.get_or_insert_default().git_gutter =
+                        Some(settings::GitGutterSetting::TrackedFiles);
+                });
+            });
+        });
+        let diff_hunk_signs_disabled = cx
+            .update_window(*window, |_, window, cx| {
+                let dimensions = GutterDimensions {
+                    left_padding: Pixels::ZERO,
+                    right_padding: px(20.),
+                    diff_hunk_signs_width: px(20.),
+                    width: px(80.),
+                    margin: Pixels::ZERO,
+                    git_blame_entries_width: None,
+                };
+                let row_infos = (0..4)
+                    .map(|row| RowInfo {
+                        buffer_row: Some(row),
+                        diff_status: match row {
+                            0 => Some(DiffHunkStatus::added_none()),
+                            1 => Some(DiffHunkStatus::modified_none()),
+                            2 => Some(DiffHunkStatus::deleted(
+                                buffer_diff::DiffHunkSecondaryStatus::NoSecondaryHunk,
+                            )),
+                            _ => None,
+                        },
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>();
+                let diff_hunk_signs = element.layout_gutter_diff_hunk_signs(
+                    &Gutter {
+                        line_height,
+                        dimensions: &dimensions,
+                        row_infos: &row_infos,
+                        range: DisplayRow(0)..DisplayRow(4),
+                        ..test_gutter(line_height, &snapshot)
+                    },
+                    window,
+                    cx,
+                );
+                diff_hunk_signs
+            })
+            .unwrap();
+        assert!(diff_hunk_signs_disabled.is_empty());
     }
 
     #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2809,7 +2809,6 @@ impl EditorElement {
                     + point(
                         gutter.hitbox.size.width
                             - shaped_line.width
-                            - gutter.dimensions.diff_hunk_signs_width
                             - gutter.dimensions.right_padding,
                         ix as f32 * gutter.line_height
                             - Pixels::from(
@@ -2933,10 +2932,8 @@ impl EditorElement {
 
                 let line_origin = gutter.hitbox.origin
                     + point(
-                        gutter.hitbox.size.width
-                            - gutter.dimensions.right_padding
-                            - gutter.dimensions.diff_hunk_signs_width
-                            + (gutter.dimensions.diff_hunk_signs_width - shaped_line.width) / 2.0,
+                        gutter.hitbox.size.width - gutter.dimensions.right_padding
+                            + (gutter.dimensions.right_padding - shaped_line.width) / 2.0,
                         ix as f32 * gutter.line_height - Pixels::from(scroll_top_line_height),
                     );
 
@@ -10927,7 +10924,6 @@ mod tests {
             width: px(30.0),
             margin: Pixels::ZERO,
             git_blame_entries_width: None,
-            diff_hunk_signs_width: Pixels::ZERO,
         };
         const EMPTY_ROW_INFO: RowInfo = RowInfo {
             buffer_id: None,
@@ -11439,7 +11435,6 @@ mod tests {
                 let dimensions = GutterDimensions {
                     left_padding: Pixels::ZERO,
                     right_padding: px(20.),
-                    diff_hunk_signs_width: px(20.),
                     width: px(80.),
                     margin: Pixels::ZERO,
                     git_blame_entries_width: None,
@@ -11490,7 +11485,6 @@ mod tests {
                 let dimensions = GutterDimensions {
                     left_padding: Pixels::ZERO,
                     right_padding: px(20.),
-                    diff_hunk_signs_width: px(20.),
                     width: px(80.),
                     margin: Pixels::ZERO,
                     git_blame_entries_width: None,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2880,14 +2880,39 @@ impl EditorElement {
         }
         let mut diff_hunk_signs: HashMap<MultiBufferRow, DiffHunkSignLayout> = HashMap::default();
         let scroll_top = gutter.scroll_position.y * ScrollPixelOffset::from(gutter.line_height);
+
+        let is_light = cx.theme().appearance().is_light();
+        let gutter_bg_color = cx.theme().colors().editor_gutter_background;
+
         for (ix, row_info) in gutter.row_infos.iter().enumerate() {
             let Some(diff_status) = row_info.diff_status else {
                 continue;
             };
             let (diff_sign, color) = match diff_status.kind {
-                DiffHunkStatusKind::Added => ("+", cx.theme().colors().version_control_added),
-                DiffHunkStatusKind::Modified => ("~", cx.theme().colors().version_control_modified),
-                DiffHunkStatusKind::Deleted => ("-", cx.theme().colors().version_control_deleted),
+                DiffHunkStatusKind::Added => (
+                    "+",
+                    compute_diff_hunk_sign_color(
+                        is_light,
+                        gutter_bg_color,
+                        cx.theme().colors().version_control_added,
+                    ),
+                ),
+                DiffHunkStatusKind::Modified => (
+                    "~",
+                    compute_diff_hunk_sign_color(
+                        is_light,
+                        gutter_bg_color,
+                        cx.theme().colors().version_control_modified,
+                    ),
+                ),
+                DiffHunkStatusKind::Deleted => (
+                    "-",
+                    compute_diff_hunk_sign_color(
+                        is_light,
+                        gutter_bg_color,
+                        cx.theme().colors().version_control_deleted,
+                    ),
+                ),
             };
             let shaped_line = self.shape_line_number(SharedString::from(diff_sign), color, window);
             let line_origin = gutter.hitbox.origin
@@ -10810,6 +10835,17 @@ fn compute_auto_height_layout(
     };
 
     Some(size(width, final_height))
+}
+
+fn compute_diff_hunk_sign_color(
+    is_light: bool,
+    gutter_bg_color: Hsla,
+    diff_hunk_color: Hsla,
+) -> Hsla {
+    let diff_hunk_status_bg_opacity = if is_light { 0.16 } else { 0.12 };
+    let diff_hunk_bg_color = diff_hunk_color.opacity(diff_hunk_status_bg_opacity);
+    let diff_hunk_sign_bg_color = gutter_bg_color.blend(diff_hunk_bg_color);
+    ensure_minimum_contrast(diff_hunk_color, diff_hunk_sign_bg_color, 70.0)
 }
 
 #[cfg(test)]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2858,7 +2858,7 @@ impl EditorElement {
         gutter: &Gutter,
         window: &mut Window,
         cx: &mut App,
-    ) -> Arc<HashMap<MultiBufferRow, DiffHunkSignLayout>> {
+    ) -> Vec<DiffHunkSignLayout> {
         let show_git_gutter = gutter.snapshot.show_git_diff_gutter.unwrap_or_else(|| {
             matches!(
                 ProjectSettings::get_global(cx).git.git_gutter,
@@ -2876,72 +2876,70 @@ impl EditorElement {
                     )
                 });
         if !show_git_gutter_signs {
-            return Arc::default();
+            return Vec::default();
         }
-        let mut diff_hunk_signs: HashMap<MultiBufferRow, DiffHunkSignLayout> = HashMap::default();
-        let scroll_top = gutter.scroll_position.y * ScrollPixelOffset::from(gutter.line_height);
 
         let is_light = cx.theme().appearance().is_light();
         let gutter_bg_color = cx.theme().colors().editor_gutter_background;
+        let scroll_top = gutter.scroll_position.y * ScrollPixelOffset::from(gutter.line_height);
 
-        for (ix, row_info) in gutter.row_infos.iter().enumerate() {
-            let Some(diff_status) = row_info.diff_status else {
-                continue;
-            };
-            let (diff_sign, color) = match diff_status.kind {
-                DiffHunkStatusKind::Added => (
-                    "+",
-                    compute_diff_hunk_sign_color(
-                        is_light,
-                        gutter_bg_color,
-                        cx.theme().colors().version_control_added,
-                    ),
-                ),
-                DiffHunkStatusKind::Modified => (
-                    "~",
-                    compute_diff_hunk_sign_color(
-                        is_light,
-                        gutter_bg_color,
-                        cx.theme().colors().version_control_modified,
-                    ),
-                ),
-                DiffHunkStatusKind::Deleted => (
-                    "-",
-                    compute_diff_hunk_sign_color(
-                        is_light,
-                        gutter_bg_color,
-                        cx.theme().colors().version_control_deleted,
-                    ),
-                ),
-            };
-            let shaped_line = self.shape_line_number(SharedString::from(diff_sign), color, window);
-            let line_origin = gutter.hitbox.origin
-                + point(
-                    gutter.hitbox.size.width
-                        - gutter.dimensions.right_padding
-                        - gutter.dimensions.diff_hunk_signs_width
-                        + (gutter.dimensions.diff_hunk_signs_width - shaped_line.width) / 2.0,
-                    ix as f32 * gutter.line_height
-                        - Pixels::from(scroll_top % ScrollPixelOffset::from(gutter.line_height)),
-                );
+        gutter
+            .row_infos
+            .iter()
+            .enumerate()
+            .filter_map(|(ix, row_info)| {
+                let Some(diff_status) = row_info.diff_status else {
+                    return None;
+                };
 
-            let display_row = DisplayRow(gutter.range.start.0 + ix as u32);
-            let buffer_row = DisplayPoint::new(display_row, 0)
-                .to_point(gutter.snapshot)
-                .row;
-            let multi_buffer_row = MultiBufferRow(buffer_row);
+                let (diff_sign, color) = match diff_status.kind {
+                    DiffHunkStatusKind::Added => (
+                        "+",
+                        compute_diff_hunk_sign_color(
+                            is_light,
+                            gutter_bg_color,
+                            cx.theme().colors().version_control_added,
+                        ),
+                    ),
+                    DiffHunkStatusKind::Modified => (
+                        "~",
+                        compute_diff_hunk_sign_color(
+                            is_light,
+                            gutter_bg_color,
+                            cx.theme().colors().version_control_modified,
+                        ),
+                    ),
+                    DiffHunkStatusKind::Deleted => (
+                        "-",
+                        compute_diff_hunk_sign_color(
+                            is_light,
+                            gutter_bg_color,
+                            cx.theme().colors().version_control_deleted,
+                        ),
+                    ),
+                };
 
-            diff_hunk_signs.insert(
-                multi_buffer_row,
-                DiffHunkSignLayout {
-                    segment: DiffHunkSignSegment {
-                        shaped_line,
-                        origin: line_origin,
-                    },
-                },
-            );
-        }
-        Arc::new(diff_hunk_signs)
+                let shaped_line =
+                    self.shape_line_number(SharedString::from(diff_sign), color, window);
+
+                let line_origin = gutter.hitbox.origin
+                    + point(
+                        gutter.hitbox.size.width
+                            - gutter.dimensions.right_padding
+                            - gutter.dimensions.diff_hunk_signs_width
+                            + (gutter.dimensions.diff_hunk_signs_width - shaped_line.width) / 2.0,
+                        ix as f32 * gutter.line_height
+                            - Pixels::from(
+                                scroll_top % ScrollPixelOffset::from(gutter.line_height),
+                            ),
+                    );
+
+                Some(DiffHunkSignLayout {
+                    shaped_line,
+                    origin: line_origin,
+                })
+            })
+            .collect_vec()
     }
 
     fn layout_crease_toggles(
@@ -5308,13 +5306,17 @@ impl EditorElement {
         cx: &mut App,
     ) {
         let line_height = layout.position_map.line_height;
-        for diff_hunk_sign_layout in layout.diff_hunk_signs.values() {
-            let DiffHunkSignSegment {
-                shaped_line,
-                origin,
-            } = &diff_hunk_sign_layout.segment;
-            shaped_line
-                .paint(*origin, line_height, TextAlign::Left, None, window, cx)
+        for diff_hunk_sign_layout in &layout.diff_hunk_signs {
+            diff_hunk_sign_layout
+                .shaped_line
+                .paint(
+                    diff_hunk_sign_layout.origin,
+                    line_height,
+                    TextAlign::Left,
+                    None,
+                    window,
+                    cx,
+                )
                 .log_err();
         }
     }
@@ -9744,7 +9746,7 @@ pub struct EditorLayout {
     highlighted_rows: BTreeMap<DisplayRow, LineHighlight>,
     line_elements: SmallVec<[AnyElement; 1]>,
     line_numbers: Arc<HashMap<MultiBufferRow, LineNumberLayout>>,
-    diff_hunk_signs: Arc<HashMap<MultiBufferRow, DiffHunkSignLayout>>,
+    diff_hunk_signs: Vec<DiffHunkSignLayout>,
     display_hunks: Vec<(DisplayDiffHunk, Option<Hitbox>)>,
     blamed_display_rows: Option<Vec<AnyElement>>,
     inline_diagnostics: HashMap<DisplayRow, AnyElement>,
@@ -9796,14 +9798,9 @@ struct LineNumberLayout {
 }
 
 #[derive(Debug)]
-struct DiffHunkSignSegment {
+struct DiffHunkSignLayout {
     shaped_line: ShapedLine,
     origin: gpui::Point<Pixels>,
-}
-
-#[derive(Debug)]
-struct DiffHunkSignLayout {
-    segment: DiffHunkSignSegment,
 }
 
 struct ColoredRange<T> {
@@ -11468,31 +11465,10 @@ mod tests {
             })
             .unwrap();
         assert_eq!(diff_hunk_signs_enabled.len(), 3);
-        assert_eq!(
-            diff_hunk_signs_enabled[&MultiBufferRow(0)]
-                .segment
-                .shaped_line
-                .text
-                .as_ref(),
-            "+"
-        );
-        assert_eq!(
-            diff_hunk_signs_enabled[&MultiBufferRow(1)]
-                .segment
-                .shaped_line
-                .text
-                .as_ref(),
-            "~"
-        );
-        assert_eq!(
-            diff_hunk_signs_enabled[&MultiBufferRow(2)]
-                .segment
-                .shaped_line
-                .text
-                .as_ref(),
-            "-"
-        );
-        assert!(diff_hunk_signs_enabled.get(&MultiBufferRow(3)).is_none());
+        assert_eq!(diff_hunk_signs_enabled[0].shaped_line.text.as_ref(), "+");
+        assert_eq!(diff_hunk_signs_enabled[1].shaped_line.text.as_ref(), "~");
+        assert_eq!(diff_hunk_signs_enabled[2].shaped_line.text.as_ref(), "-");
+        assert!(diff_hunk_signs_enabled.get(3).is_none());
 
         cx.update(|cx| {
             settings::SettingsStore::update_global(cx, |store, cx| {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -460,6 +460,8 @@ pub struct GitSettings {
     ///
     /// Default: tracked_files
     pub git_gutter: settings::GitGutterSetting,
+    pub git_gutter_sign_minimum_contrast: f32,
+
     /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.
     ///
     /// Default: 0
@@ -678,6 +680,9 @@ impl Settings for ProjectSettings {
         let git_settings = GitSettings {
             enabled: git_enabled,
             git_gutter: git.git_gutter.unwrap(),
+            git_gutter_sign_minimum_contrast: git
+                .git_gutter_sign_minimum_contrast
+                .unwrap_or_default(),
             gutter_debounce: git.gutter_debounce.unwrap_or_default(),
             inline_blame: {
                 let inline = git.inline_blame.unwrap();

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -525,6 +525,10 @@ pub struct GitSettings {
     ///
     /// Default: tracked_files
     pub git_gutter: Option<GitGutterSetting>,
+    /// Minimum contrast used when rendering diff hunk signs in the gutter.
+    ///
+    /// Default: 70.0
+    pub git_gutter_sign_minimum_contrast: Option<f32>,
     /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.
     ///
     /// Default: 0

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -614,6 +614,7 @@ pub enum GitGutterSetting {
     /// Show git gutter in tracked files.
     #[default]
     TrackedFiles,
+    TrackedFilesWithSigns,
     /// Hide git gutter
     Hide,
 }

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7554,7 +7554,7 @@ fn version_control_page() -> SettingsPage {
         ]
     }
 
-    fn git_gutter_section() -> [SettingsPageItem; 3] {
+    fn git_gutter_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("Git Gutter"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -7566,6 +7566,29 @@ fn version_control_page() -> SettingsPage {
                     pick: |settings_content| settings_content.git.as_ref()?.git_gutter.as_ref(),
                     write: |settings_content, value, _| {
                         settings_content.git.get_or_insert_default().git_gutter = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Signs Minimum Contrast",
+                description: "Minimum contrast value used for diff hunk signs in the gutter.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git.git_gutter_sign_minimum_contrast"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git
+                            .as_ref()?
+                            .git_gutter_sign_minimum_contrast
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _app: &App| {
+                        settings_content
+                            .git
+                            .get_or_insert_default()
+                            .git_gutter_sign_minimum_contrast = value;
                     },
                 }),
                 metadata: None,


### PR DESCRIPTION
Closes #46817

**Summary**:

* I've added a Zed setting to the Git Gutter Visibility dropdown to allow for choosing to display the git-gutter UI with git-diff characters.
* When the setting is enabled, the git-diff characters are displayed next to the line-numbers inside the editor gutter, and the characters are only displayed when the git-diff hunk is expanded.
  * Note, the editor gutter will display the plus `+` and minus `-` characters next to the line-number.
  * At the moment, the git-diff characters are rendered as text and colored based on the editor theme.

Release Notes:

- Add support for displaying Git diff-signs characters inside the Editor gutter when viewing an expanded diff-hunk.

Screenshots:

#### Expanded Diff Hunk
<img width="1161" height="799" alt="Screenshot 2026-03-03 at 13 26 56" src="https://github.com/user-attachments/assets/3e99c297-7cb6-4537-a555-37af5ddbc57a" />

#### Source Control View
<img width="1171" height="804" alt="Screenshot 2026-03-03 at 13 23 18" src="https://github.com/user-attachments/assets/b57dd785-2f72-48a2-a993-99dba3f69c14" />
