### PR TITLE
editor: Fix selection above and below for multibyte strings

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15544,12 +15544,11 @@ impl Editor {
                     && let Some(oldest_selection) =
                         columnar_selections.iter().find(|s| s.id == *oldest_id)
                 {
-                    let absolute_x_range =
-                        selections_collection::absolute_x_range_for_selection(
-                            &display_map,
-                            oldest_selection,
-                            &text_layout_details,
-                        );
+                    let absolute_x_range = selections_collection::absolute_x_range_for_selection(
+                        &display_map,
+                        oldest_selection,
+                        &text_layout_details,
+                    );
                     for id in &group.stack {
                         map.insert(*id, absolute_x_range.clone());
                     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15570,11 +15570,8 @@ impl Editor {
         for selection in columnar_selections {
             if let Some(group) = last_added_item_per_group.get_mut(&selection.id) {
                 if above == group.above {
-                    let range = selection.display_range(&display_map).sorted();
-                    debug_assert_eq!(range.start.row(), range.end.row());
-                    let row = range.start.row();
-
                     let maybe_new_selection = if skip_soft_wrap {
+                        let row = selection.start.to_display_point(&display_map).row();
                         let absolute_x_range = absolute_x_ranges_by_selection_id
                             .remove(&selection.id)
                             .unwrap_or_else(|| {
@@ -15594,6 +15591,9 @@ impl Editor {
                             &text_layout_details,
                         )
                     } else {
+                        let range = selection.display_range(&display_map).sorted();
+                        debug_assert_eq!(range.start.row(), range.end.row());
+                        let row = range.start.row();
                         let positions =
                             if let SelectionGoal::HorizontalRange { start, end } = selection.goal {
                                 Pixels::from(start)..Pixels::from(end)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15532,24 +15532,26 @@ impl Editor {
             display_map.max_point().row()
         };
 
-        // When `skip_soft_wrap` is true, we use buffer columns instead of pixel
-        // positions to place new selections, so we need to keep track of the
-        // column range of the oldest selection in each group, because
-        // intermediate selections may have been clamped to shorter lines.
-        // selections may have been clamped to shorter lines.
-        let mut goal_columns_by_selection_id = if skip_soft_wrap {
+        // When `skip_soft_wrap` is true, we store absolute pixel positions
+        // (measured from the start of the buffer line) from the oldest
+        // selection in each group. This ensures proper visual alignment
+        // across buffer rows, even when lines contain multi-byte UTF-8
+        // characters or are soft-wrapped.
+        let mut absolute_x_ranges_by_selection_id = if skip_soft_wrap {
             let mut map = HashMap::default();
             for group in state.groups.iter() {
-                if let Some(oldest_id) = group.stack.first() {
-                    if let Some(oldest_selection) =
+                if let Some(oldest_id) = group.stack.first()
+                    && let Some(oldest_selection) =
                         columnar_selections.iter().find(|s| s.id == *oldest_id)
-                    {
-                        let start_col = oldest_selection.start.column;
-                        let end_col = oldest_selection.end.column;
-                        let goal_columns = start_col.min(end_col)..start_col.max(end_col);
-                        for id in &group.stack {
-                            map.insert(*id, goal_columns.clone());
-                        }
+                {
+                    let absolute_x_range =
+                        selections_collection::absolute_x_range_for_selection(
+                            &display_map,
+                            oldest_selection,
+                            &text_layout_details,
+                        );
+                    for id in &group.stack {
+                        map.insert(*id, absolute_x_range.clone());
                     }
                 }
             }
@@ -15571,35 +15573,37 @@ impl Editor {
                     let range = selection.display_range(&display_map).sorted();
                     debug_assert_eq!(range.start.row(), range.end.row());
                     let row = range.start.row();
-                    let positions =
-                        if let SelectionGoal::HorizontalRange { start, end } = selection.goal {
-                            Pixels::from(start)..Pixels::from(end)
-                        } else {
-                            let start_x =
-                                display_map.x_for_display_point(range.start, &text_layout_details);
-                            let end_x =
-                                display_map.x_for_display_point(range.end, &text_layout_details);
-                            start_x.min(end_x)..start_x.max(end_x)
-                        };
 
                     let maybe_new_selection = if skip_soft_wrap {
-                        let goal_columns = goal_columns_by_selection_id
+                        let absolute_x_range = absolute_x_ranges_by_selection_id
                             .remove(&selection.id)
                             .unwrap_or_else(|| {
-                                let start_col = selection.start.column;
-                                let end_col = selection.end.column;
-                                start_col.min(end_col)..start_col.max(end_col)
+                                selections_collection::absolute_x_range_for_selection(
+                                    &display_map,
+                                    &selection,
+                                    &text_layout_details,
+                                )
                             });
                         self.selections.find_next_columnar_selection_by_buffer_row(
                             &display_map,
                             row,
                             end_row,
                             above,
-                            &goal_columns,
+                            &absolute_x_range,
                             selection.reversed,
                             &text_layout_details,
                         )
                     } else {
+                        let positions =
+                            if let SelectionGoal::HorizontalRange { start, end } = selection.goal {
+                                Pixels::from(start)..Pixels::from(end)
+                            } else {
+                                let start_x = display_map
+                                    .x_for_display_point(range.start, &text_layout_details);
+                                let end_x = display_map
+                                    .x_for_display_point(range.end, &text_layout_details);
+                                start_x.min(end_x)..start_x.max(end_x)
+                            };
                         self.selections.find_next_columnar_selection_by_display_row(
                             &display_map,
                             row,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -28581,8 +28581,8 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
 
     // Set up text where selections are in the middle of a soft-wrapped line.
     // When adding selection below with `skip_soft_wrap` set to `true`, the new
-    // selection should be at the same buffer column, not the same pixel
-    // position.
+    // selection should land on the next buffer line, not the next wrapped
+    // display row.
     cx.set_state(indoc!(
         r#"1. Very long line to show «howˇ» a wrapped line would look
            2. Very long line to show how a wrapped line would look"#
@@ -28602,14 +28602,107 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
             cx,
         );
 
-        // Assert that there's now 2 selections, both selecting the same column
-        // range in the buffer row.
+        // Both lines have identical content, so visual pixel alignment
+        // produces the same buffer columns.
         let display_map = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = editor.selections.all::<Point>(&display_map);
         assert_eq!(selections.len(), 2);
         assert_eq!(selections[0].start.column, selections[1].start.column);
         assert_eq!(selections[0].end.column, selections[1].end.column);
     });
+}
+
+#[gpui::test]
+async fn test_add_selection_above_below_multibyte(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // 'á' is 2 bytes in UTF-8. Cursor after 3 'a's at pixel 3em should
+    // land at the same visual position after 3 'á's (byte 6), not at
+    // byte 3 which is in the middle of the second 'á'.
+    cx.set_state(indoc! {"
+        aaaˇaaa
+        áááááá
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.add_selection_below(
+            &AddSelectionBelow {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.assert_editor_state(indoc! {"
+        aaaˇaaa
+        áááˇááá
+    "});
+
+    // Same alignment going upward.
+    cx.set_state(indoc! {"
+        aaaaaa
+        áááˇááá
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.add_selection_above(
+            &AddSelectionAbove {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.assert_editor_state(indoc! {"
+        aaaˇaaa
+        áááˇááá
+    "});
+
+    // Selection range: selecting first 3 chars should select the visually
+    // equivalent range on the multibyte line.
+    cx.set_state(indoc! {"
+        «aaaˇ»aaa
+        áááááá
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.add_selection_below(
+            &AddSelectionBelow {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.assert_editor_state(indoc! {"
+        «aaaˇ»aaa
+        «áááˇ»ááá
+    "});
+
+    // Selection range going upward.
+    cx.set_state(indoc! {"
+        aaaaaa
+        «áááˇ»ááá
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.add_selection_above(
+            &AddSelectionAbove {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.assert_editor_state(indoc! {"
+        «aaaˇ»aaa
+        «áááˇ»ááá
+    "});
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -28515,6 +28515,8 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
     ));
 
     cx.update_editor(|editor, window, cx| {
+        // Enable soft wrapping with a narrow width to force soft wrapping and
+        // confirm that more than 2 rows are being displayed.
         editor.set_wrap_width(Some(100.0.into()), cx);
         assert!(editor.display_text(cx).lines().count() > 2);
 
@@ -28587,6 +28589,8 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
     ));
 
     cx.update_editor(|editor, window, cx| {
+        // Enable soft wrapping with a narrow width to force soft wrapping and
+        // confirm that more than 2 rows are being displayed.
         editor.set_wrap_width(Some(100.0.into()), cx);
         assert!(editor.display_text(cx).lines().count() > 2);
 
@@ -28598,6 +28602,7 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
             cx,
         );
 
+        // Assert that both selections are visually aligned at the same column.
         let display_map = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = editor.selections.all::<Point>(&display_map);
         assert_eq!(selections.len(), 2);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -28515,8 +28515,6 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
     ));
 
     cx.update_editor(|editor, window, cx| {
-        // Enable soft wrapping with a narrow width to force soft wrapping and
-        // confirm that more than 2 rows are being displayed.
         editor.set_wrap_width(Some(100.0.into()), cx);
         assert!(editor.display_text(cx).lines().count() > 2);
 
@@ -28589,8 +28587,6 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
     ));
 
     cx.update_editor(|editor, window, cx| {
-        // Enable soft wrapping with a narrow width to force soft wrapping and
-        // confirm that more than 2 rows are being displayed.
         editor.set_wrap_width(Some(100.0.into()), cx);
         assert!(editor.display_text(cx).lines().count() > 2);
 
@@ -28602,8 +28598,6 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
             cx,
         );
 
-        // Both lines have identical content, so visual pixel alignment
-        // produces the same buffer columns.
         let display_map = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = editor.selections.all::<Point>(&display_map);
         assert_eq!(selections.len(), 2);
@@ -28703,6 +28697,50 @@ async fn test_add_selection_above_below_multibyte(cx: &mut TestAppContext) {
         «aaaˇ»aaa
         «áááˇ»ááá
     "});
+}
+
+#[gpui::test]
+async fn test_add_selection_below_cross_wrap_boundary(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Line 1 wraps at col 11 (word boundary after "bbbbb"), line 2 wraps
+    // at col 8 (word boundary after "aaaaaaa"). The selection at cols 6-10
+    // fits within line 1's first display row but crosses line 2's earlier
+    // wrap boundary, producing a cross-display-row selection.
+    cx.set_state(indoc!(
+        r#"aaaa b«bbbbˇ» cccc ddd
+           aaaaaaa bbbbb cccc
+           aaaa bbbbb cccc ddd"#
+    ));
+
+    cx.update_editor(|editor, window, cx| {
+        editor.set_wrap_width(Some(100.0.into()), cx);
+
+        editor.add_selection_below(
+            &AddSelectionBelow {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+
+        editor.add_selection_below(
+            &AddSelectionBelow {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+
+        let display_map = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
+        let selections = editor.selections.all::<Point>(&display_map);
+        assert_eq!(selections.len(), 3);
+        for (i, selection) in selections.iter().enumerate() {
+            assert_eq!(selection.start, Point::new(i as u32, 6));
+            assert_eq!(selection.end, Point::new(i as u32, 10));
+        }
+    });
 }
 
 #[gpui::test]

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1321,7 +1321,7 @@ fn resolve_absolute_x_to_display_point(
         // Use `<=` so that a point exactly at a wrap boundary stays on the current
         // wrapped row. This is not a round-trip identity for wrap-boundary positions,
         // but we only resolve across different buffer rows, so it's fine.
-        if remaining_x <= content_width || is_last_row_of_buffer {
+        if remaining_x <= content_width + gpui::px(0.1) || is_last_row_of_buffer {
             let col = line.closest_index_for_x(remaining_x) as u32;
             return DisplayPoint::new(row, col);
         }

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -407,48 +407,53 @@ impl SelectionsCollection {
         })
     }
 
-    /// Attempts to build a selection in the provided buffer row using the
-    /// same buffer column range as specified.
+    /// Attempts to build a selection in the provided buffer row using
+    /// absolute pixel positions measured from the start of the buffer line.
     /// Returns `None` if the range is not empty but it starts past the line's
     /// length, meaning that the line isn't long enough to be contained within
     /// part of the provided range.
-    pub fn build_columnar_selection_from_buffer_columns(
+    pub fn build_columnar_selection_from_buffer_row(
         &mut self,
         display_map: &DisplaySnapshot,
         buffer_row: u32,
-        positions: &Range<u32>,
+        absolute_x_range: &Range<Pixels>,
         reversed: bool,
         text_layout_details: &TextLayoutDetails,
     ) -> Option<Selection<Point>> {
-        let is_empty = positions.start == positions.end;
-        let line_len = display_map
-            .buffer_snapshot()
-            .line_len(multi_buffer::MultiBufferRow(buffer_row));
+        let is_empty = absolute_x_range.start == absolute_x_range.end;
+        let start_display = resolve_absolute_x_to_display_point(
+            display_map,
+            buffer_row,
+            absolute_x_range.start,
+            text_layout_details,
+        );
 
         let (start, end) = if is_empty {
-            let column = std::cmp::min(positions.start, line_len);
-            let point = Point::new(buffer_row, column);
-            (point, point)
+            (start_display, start_display)
         } else {
-            if positions.start >= line_len {
+            let buffer_line_len = display_map
+                .buffer_snapshot()
+                .line_len(multi_buffer::MultiBufferRow(buffer_row));
+            let start_buffer = start_display.to_point(display_map);
+            if start_buffer.column >= buffer_line_len {
                 return None;
             }
-
-            let start = Point::new(buffer_row, positions.start);
-            let end_column = std::cmp::min(positions.end, line_len);
-            let end = Point::new(buffer_row, end_column);
-            (start, end)
+            let end_display = resolve_absolute_x_to_display_point(
+                display_map,
+                buffer_row,
+                absolute_x_range.end,
+                text_layout_details,
+            );
+            (start_display, end_display)
         };
 
-        let start_display_point = start.to_display_point(display_map);
-        let end_display_point = end.to_display_point(display_map);
-        let start_x = display_map.x_for_display_point(start_display_point, text_layout_details);
-        let end_x = display_map.x_for_display_point(end_display_point, text_layout_details);
+        let start_x = display_map.x_for_display_point(start, text_layout_details);
+        let end_x = display_map.x_for_display_point(end, text_layout_details);
 
         Some(Selection {
             id: post_inc(&mut self.next_selection_id),
-            start,
-            end,
+            start: start.to_point(display_map),
+            end: end.to_point(display_map),
             reversed,
             goal: SelectionGoal::HorizontalRange {
                 start: start_x.min(end_x).into(),
@@ -498,7 +503,7 @@ impl SelectionsCollection {
         start_row: DisplayRow,
         end_row: DisplayRow,
         above: bool,
-        goal_columns: &Range<u32>,
+        absolute_x_range: &Range<Pixels>,
         reversed: bool,
         text_layout_details: &TextLayoutDetails,
     ) -> Option<Selection<Point>> {
@@ -507,13 +512,17 @@ impl SelectionsCollection {
         while row != end_row {
             let new_row =
                 display_map.start_of_relative_buffer_row(DisplayPoint::new(row, 0), direction);
-            row = new_row.row();
+            let new_display_row = new_row.row();
+            if new_display_row == row {
+                break;
+            }
+            row = new_display_row;
             let buffer_row = new_row.to_point(display_map).row;
 
-            if let Some(selection) = self.build_columnar_selection_from_buffer_columns(
+            if let Some(selection) = self.build_columnar_selection_from_buffer_row(
                 display_map,
                 buffer_row,
-                goal_columns,
+                absolute_x_range,
                 reversed,
                 text_layout_details,
             ) {
@@ -1246,6 +1255,80 @@ fn resolve_selections_display<'a>(
         }
     });
     coalesce_selections(selections)
+}
+
+/// For wrapped lines, accumulates the content widths of preceding wrapped
+/// display rows to get the absolute x from buffer line start.
+pub(crate) fn absolute_x_for_buffer_point(
+    display_map: &DisplaySnapshot,
+    buffer_point: Point,
+    text_layout_details: &TextLayoutDetails,
+) -> Pixels {
+    let first_display_row = Point::new(buffer_point.row, 0)
+        .to_display_point(display_map)
+        .row();
+    let target_display_point = buffer_point.to_display_point(display_map);
+    let target_row = target_display_point.row();
+
+    let mut absolute_x = gpui::px(0.);
+    let mut row = first_display_row;
+    while row < target_row {
+        absolute_x += display_map.layout_row(row, text_layout_details).width;
+        row.0 += 1;
+    }
+    absolute_x += display_map.x_for_display_point(target_display_point, text_layout_details);
+
+    absolute_x
+}
+
+/// Computes the absolute pixel x range for a selection's start and end points,
+/// normalized so that `range.start <= range.end`.
+pub(crate) fn absolute_x_range_for_selection(
+    display_map: &DisplaySnapshot,
+    selection: &Selection<Point>,
+    text_layout_details: &TextLayoutDetails,
+) -> Range<Pixels> {
+    let start_abs_x =
+        absolute_x_for_buffer_point(display_map, selection.start, text_layout_details);
+    let end_abs_x =
+        absolute_x_for_buffer_point(display_map, selection.end, text_layout_details);
+    start_abs_x.min(end_abs_x)..start_abs_x.max(end_abs_x)
+}
+
+/// Iterates through a buffer line's wrapped display rows, subtracting each
+/// row's content width, to find which display row the absolute x falls on.
+fn resolve_absolute_x_to_display_point(
+    display_map: &DisplaySnapshot,
+    buffer_row: u32,
+    absolute_x: Pixels,
+    text_layout_details: &TextLayoutDetails,
+) -> DisplayPoint {
+    let first_display_row = Point::new(buffer_row, 0)
+        .to_display_point(display_map)
+        .row();
+    let mut row = first_display_row;
+    let mut remaining_x = absolute_x;
+    let max_row = display_map.max_point().row();
+
+    loop {
+        let line = display_map.layout_row(row, text_layout_details);
+        let content_width = line.width;
+
+        let next_row = DisplayRow(row.0 + 1);
+        let is_last_row_of_buffer = next_row > max_row
+            || DisplayPoint::new(next_row, 0).to_point(display_map).row != buffer_row;
+
+        // Use `<=` so that a point exactly at a wrap boundary stays on the current
+        // wrapped row. This is not a round-trip identity for wrap-boundary positions,
+        // but we only resolve across different buffer rows, so it's fine.
+        if remaining_x <= content_width || is_last_row_of_buffer {
+            let col = line.closest_index_for_x(remaining_x) as u32;
+            return DisplayPoint::new(row, col);
+        }
+
+        remaining_x -= content_width;
+        row = next_row;
+    }
 }
 
 /// Resolves the passed in anchors to [`MultiBufferDimension`]s `D`

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1290,8 +1290,7 @@ pub(crate) fn absolute_x_range_for_selection(
 ) -> Range<Pixels> {
     let start_abs_x =
         absolute_x_for_buffer_point(display_map, selection.start, text_layout_details);
-    let end_abs_x =
-        absolute_x_for_buffer_point(display_map, selection.end, text_layout_details);
+    let end_abs_x = absolute_x_for_buffer_point(display_map, selection.end, text_layout_details);
     start_abs_x.min(end_abs_x)..start_abs_x.max(end_abs_x)
 }
 


### PR DESCRIPTION
- Fixes: #50820

When `skip_soft_wrap` is true, columnar selection alignment used byte offsets (buffer columns) to place cursors across buffer rows. This breaks with multi-byte UTF-8 characters.

For example, consider file:

```
aaaaaa
áááááá
```

If you put the cursor in the middle and then add selection via keystroke to the another line, it jumps instead of landing on the same position:

```
aaa|aaa
á|ááááá
```

```
aaaaaa|
ááá|ááá
```

This PR switches to absolute pixel positions measured from the buffer line start, so alignment is visual rather than byte-based.

Release Notes:

- Fixed multi-cursor column selection misaligning on lines with multi-byte characters.