### PR TITLE
python: Register LSP adapters directly to the LanguageRegistry

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -179,7 +179,13 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         },
         LanguageInfo {
             name: "python",
-            adapters: vec![basedpyright_lsp_adapter, ruff_lsp_adapter],
+            adapters: vec![
+                basedpyright_lsp_adapter,
+                ruff_lsp_adapter,
+                ty_lsp_adapter,
+                py_lsp_adapter,
+                python_lsp_adapter,
+            ],
             context: Some(python_context_provider),
             toolchain: Some(python_toolchain_provider),
             manifest_name: Some(SharedString::new_static("pyproject.toml").into()),
@@ -281,9 +287,6 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         typescript_lsp_adapter,
     );
 
-    languages.register_available_lsp_adapter(python_lsp_adapter.name(), python_lsp_adapter);
-    languages.register_available_lsp_adapter(py_lsp_adapter.name(), py_lsp_adapter);
-    languages.register_available_lsp_adapter(ty_lsp_adapter.name(), ty_lsp_adapter);
     // Register Tailwind for the existing languages that should have it by default.
     //
     // This can be driven by the `language_servers` setting once we have a way for

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -89,8 +89,8 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
   "languages": {
     "Python": {
       "language_servers": [
-        // Disable basedpyright and enable ty, and otherwise
-        // use the default configuration.
+        // Disable basedpyright and enable ty, and include all
+        // other registered language servers (ruff, pylsp, pyright).
         "ty",
         "!basedpyright",
         "..."


### PR DESCRIPTION
The purpose of `register_available_lsp_adapter()` is to allow language servers to be reused across multiple languages. Since adapters like `ty`, `pylsp`, and `pyright` are specific to Python, there is no need to register them for other languages. Additionally, registering them directly to the global `LanguageRegistry` results in negligible resource consumption.

We can then use the default settings to control the default language server for Python, as referenced here:

https://github.com/zed-industries/zed/blob/9c9337a8021f74511625517c3f4fa021106609eb/assets/settings/default.json#L2119-L2130

Additionally, the documentation for Python has been updated to clarify that the `"..."` syntax does not mean "keep the rest at default," but rather "include all other available servers."

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing (no sure how to add test for this)
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
