### PR TITLE
Add .cppm (C++20 module interface) to C++ file extensions

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
+path_suffixes = ["cc", "hh", "cpp", "cppm", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
 line_comments = ["// ", "/// ", "//! "]
 first_line_pattern = '^//.*-\*-\s*C\+\+\s*-\*-'
 decrease_indent_patterns = [

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -89,7 +89,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     (
         "cpp",
         &[
-            "c++", "h++", "cc", "cpp", "cxx", "hh", "hpp", "hxx", "inl", "ixx",
+            "c++", "h++", "cc", "cpp", "cppm", "cxx", "hh", "hpp", "hxx", "inl", "ixx",
         ],
     ),
     ("crystal", &["cr", "ecr"]),


### PR DESCRIPTION
`.cppm` is the widely used extension for C++20 module interface units, supported by MSVC, Clang, and GCC. Currently Zed doesn't recognize it as C++, so users get no syntax highlighting or LSP support.

Changes:
`crates/languages/src/cpp/config.toml`: add cppm to path_suffixes
`crates/theme/src/icon_theme.rs`: add cppm to the C++ icon matcher

https://github.com/search?q=path%3A*.cppm&type=code

Release Notes:

- N/A