### PR TITLE
Pass project working directory to ThreadHistory

### DIFF
--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -741,15 +741,21 @@ impl ConnectionView {
                         } else {
                             None
                         };
-                        let cwd = this
-                            .project
-                            .read(cx)
-                            .visible_worktrees(cx)
-                            .next()
-                            .map(|worktree| worktree.read(cx).abs_path().to_path_buf());
+                        let cwd =
+                            this.project
+                                .read(cx)
+                                .visible_worktrees(cx)
+                                .find_map(|worktree| {
+                                    let worktree = worktree.read(cx);
+                                    if worktree.is_single_file() {
+                                        worktree.abs_path().parent().map(|p| p.to_path_buf())
+                                    } else {
+                                        Some(worktree.abs_path().to_path_buf())
+                                    }
+                                });
                         this.history.update(cx, |history, cx| {
                             history.set_session_list(session_list, cx);
-                            history.set_cwd(cwd);
+                            history.set_cwd(cwd, cx);
                         });
                         this.set_server_state(
                             ServerState::Connected(ConnectedServerState {

--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -741,8 +741,15 @@ impl ConnectionView {
                         } else {
                             None
                         };
+                        let cwd = this
+                            .project
+                            .read(cx)
+                            .visible_worktrees(cx)
+                            .next()
+                            .map(|worktree| worktree.read(cx).abs_path().to_path_buf());
                         this.history.update(cx, |history, cx| {
                             history.set_session_list(session_list, cx);
+                            history.set_cwd(cwd);
                         });
                         this.set_server_state(
                             ServerState::Connected(ConnectedServerState {

--- a/crates/agent_ui/src/thread_history.rs
+++ b/crates/agent_ui/src/thread_history.rs
@@ -9,7 +9,7 @@ use gpui::{
     App, Entity, EventEmitter, FocusHandle, Focusable, ScrollStrategy, Task,
     UniformListScrollHandle, WeakEntity, Window, uniform_list,
 };
-use std::{fmt::Display, ops::Range, rc::Rc};
+use std::{fmt::Display, ops::Range, path::PathBuf, rc::Rc};
 use text::Bias;
 use time::{OffsetDateTime, UtcOffset};
 use ui::{
@@ -38,6 +38,7 @@ pub struct ThreadHistory {
     visible_items: Vec<ListItemType>,
     local_timezone: UtcOffset,
     confirming_delete_history: bool,
+    cwd: Option<PathBuf>,
     _visible_items_task: Task<()>,
     _refresh_task: Task<()>,
     _watch_task: Option<Task<()>>,
@@ -111,6 +112,7 @@ impl ThreadHistory {
             .unwrap(),
             search_query: SharedString::default(),
             confirming_delete_history: false,
+            cwd: None,
             _subscriptions: vec![search_editor_subscription],
             _visible_items_task: Task::ready(()),
             _refresh_task: Task::ready(()),
@@ -216,6 +218,10 @@ impl ThreadHistory {
         }));
     }
 
+    pub fn set_cwd(&mut self, cwd: Option<PathBuf>) {
+        self.cwd = cwd;
+    }
+
     pub(crate) fn refresh_full_history(&mut self, cx: &mut Context<Self>) {
         self.refresh_sessions(true, true, cx);
     }
@@ -275,6 +281,7 @@ impl ThreadHistory {
         // If a new refresh arrives while pagination is in progress, the previous
         // `_refresh_task` is cancelled. This is intentional (latest refresh wins),
         // but means sessions may be in a partial state until the new refresh completes.
+        let cwd = self.cwd.clone();
         self._refresh_task = cx.spawn(async move |this, cx| {
             let mut cursor: Option<String> = None;
             let mut is_first_page = true;
@@ -282,6 +289,7 @@ impl ThreadHistory {
             loop {
                 let request = AgentSessionListRequest {
                     cursor: cursor.clone(),
+                    cwd: cwd.clone(),
                     ..Default::default()
                 };
                 let task = cx.update(|cx| session_list.list_sessions(request, cx));

--- a/crates/agent_ui/src/thread_history.rs
+++ b/crates/agent_ui/src/thread_history.rs
@@ -218,8 +218,9 @@ impl ThreadHistory {
         }));
     }
 
-    pub fn set_cwd(&mut self, cwd: Option<PathBuf>) {
+    pub fn set_cwd(&mut self, cwd: Option<PathBuf>, cx: &mut Context<Self>) {
         self.cwd = cwd;
+        cx.notify();
     }
 
     pub(crate) fn refresh_full_history(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
Closes #50342 

# Pass project working directory to ThreadHistory

## Summary

- Resolve the active project absolute working directory from the visible worktree when the ACP connection becomes ready.
- Persist this path in `ThreadHistory` via a new `set_cwd` method.
- Include `cwd` in every `AgentSessionListRequest` generated by history refreshes (including paginated requests).

## Problem

Issue #50342 reports that OpenCode ACP session history in Zed shows only global sessions after creating threads in a project.

Repro from the issue:

1. Start Zed.
2. Connect OpenCode ACP.
3. Create a thread in Zed.

Thread history refreshes were not sending project working directory context to `list_sessions`, so backend filtering/scoping by project path could not happen.

## Root Cause

`ConnectionView` initialized thread history with a session list provider but did not pass the current project directory. `ThreadHistory::refresh_sessions` built `AgentSessionListRequest` with cursor-only pagination data, leaving `cwd` unset.

<img width="885" height="307" alt="image" src="https://github.com/user-attachments/assets/896de11b-1e9d-48a5-83b9-b6f0ef15cb71" />
The session/list is being called without the cwd.

And this is how opencode deals with session/list

<img width="543" height="295" alt="image" src="https://github.com/user-attachments/assets/55be14ba-bdd2-4a65-b38b-131ef4cbf27e" />

I tested the dev build with my changes, and the history threads of the working project appears when using opencode and Kilo Code (that is a fork of opencode)

## Solution

- `ConnectionView` now reads the first visible worktree absolute path from the current project and passes it to `ThreadHistory`.
- `ThreadHistory` stores this value in a new `cwd: Option<PathBuf>` field.
- `refresh_sessions` now forwards the stored `cwd` in each `AgentSessionListRequest`.
- If no visible worktree is available, `cwd` remains `None` and behavior stays unchanged.

## Impact

- Session history requests can be scoped using the active project directory.
- Thread history is now consistent with the project context where sessions are created.
- Thread history appears :)

Release Notes:

- Fixed OpenCode ACP thread history refreshes by passing the current project working directory (`cwd`) to backend session list requests.
