### PR TITLE
context_server: Add Context Server (MCP) Logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "command_palette_hooks",
  "component",
  "context_server",
+ "context_server_tools",
  "db",
  "editor",
  "eval_utils",
@@ -3583,10 +3584,28 @@ dependencies = [
  "settings",
  "slotmap",
  "smol",
+ "strum 0.27.2",
  "tempfile",
  "terminal",
  "url",
  "util",
+]
+
+[[package]]
+name = "context_server_tools"
+version = "0.1.0"
+dependencies = [
+ "collections",
+ "context_server",
+ "editor",
+ "gpui",
+ "itertools 0.14.0",
+ "language",
+ "lsp",
+ "project",
+ "strum 0.27.2",
+ "ui",
+ "workspace",
 ]
 
 [[package]]
@@ -21791,6 +21810,8 @@ dependencies = [
  "command_palette",
  "component",
  "component_preview",
+ "context_server",
+ "context_server_tools",
  "copilot",
  "copilot_chat",
  "copilot_ui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "crates/component",
     "crates/component_preview",
     "crates/context_server",
+    "crates/context_server_tools",
     "crates/copilot",
     "crates/copilot_chat",
     "crates/crashes",
@@ -292,6 +293,7 @@ command_palette_hooks = { path = "crates/command_palette_hooks" }
 component = { path = "crates/component" }
 component_preview = { path = "crates/component_preview" }
 context_server = { path = "crates/context_server" }
+context_server_tools = { path = "crates/context_server_tools" }
 copilot = { path = "crates/copilot" }
 copilot_chat = { path = "crates/copilot_chat" }
 copilot_ui = { path = "crates/copilot_ui" }

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -49,6 +49,7 @@ collections.workspace = true
 command_palette_hooks.workspace = true
 component.workspace = true
 context_server.workspace = true
+context_server_tools.workspace = true
 db.workspace = true
 editor.workspace = true
 eval_utils = { workspace = true, optional = true }

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -754,6 +754,18 @@ impl AgentConfiguration {
                                 .ok();
                             }
                         }))
+                        .entry("Server Logs", None, {
+                            let workspace = workspace.clone();
+                            let context_server_id = context_server_id.clone();
+                            move |window, cx| {
+                                context_server_tools::open_server_logs(
+                                    workspace.clone(),
+                                    context_server_id.clone(),
+                                    window,
+                                    cx,
+                                );
+                            }
+                        })
                         .separator()
                         .entry("Uninstall", None, {
                             let fs = fs.clone();

--- a/crates/context_server/Cargo.toml
+++ b/crates/context_server/Cargo.toml
@@ -31,6 +31,7 @@ serde.workspace = true
 settings.workspace = true
 slotmap.workspace = true
 smol.workspace = true
+strum.workspace = true
 tempfile.workspace = true
 url = { workspace = true, features = ["serde"] }
 util.workspace = true

--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, anyhow};
 use collections::HashMap;
 use futures::{FutureExt, StreamExt, channel::oneshot, future, select};
-use gpui::{AppContext as _, AsyncApp, BackgroundExecutor, Task};
+use gpui::{AppContext, AsyncApp, BackgroundExecutor, Task};
 use parking_lot::Mutex;
 use postage::barrier;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -18,7 +18,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use util::{ResultExt, TryFutureExt};
+use util::ResultExt;
 
 use crate::{
     transport::{StdioTransport, Transport},
@@ -38,6 +38,18 @@ pub const INTERNAL_ERROR: i32 = -32603;
 type ResponseHandler = Box<dyn Send + FnOnce(Result<String, Error>)>;
 type NotificationHandler = Box<dyn Send + FnMut(Value, AsyncApp)>;
 type RequestHandler = Box<dyn Send + FnMut(RequestId, &RawValue, AsyncApp)>;
+pub type IoHandler = Box<dyn Send + FnMut(IoKind, &str)>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoKind {
+    /// Inbound messages. For local (stdio) servers, this corresponds to the stdout stream. For HTTP servers, this is the SSE message payload.
+    Recv,
+    /// Outbound messages. For local (stdio) servers, this corresponds to the stdin stream. For HTTP servers, this is the HTTP POST payload.
+    Send,
+    /// Standard error stream. Only applicable to local (stdio) servers.
+    StdErr,
+    ProtocolLog(crate::types::LoggingLevel),
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -53,6 +65,7 @@ pub(crate) struct Client {
     name: Arc<str>,
     subscription_set: Arc<Mutex<NotificationSubscriptionSet>>,
     response_handlers: Arc<Mutex<Option<HashMap<RequestId, ResponseHandler>>>>,
+    io_handlers: Arc<Mutex<HashMap<i32, IoHandler>>>,
     #[allow(clippy::type_complexity)]
     #[allow(dead_code)]
     io_tasks: Mutex<Option<(Task<Option<()>>, Task<Option<()>>)>>,
@@ -196,48 +209,60 @@ impl Client {
         let response_handlers =
             Arc::new(Mutex::new(Some(HashMap::<_, ResponseHandler>::default())));
         let request_handlers = Arc::new(Mutex::new(HashMap::<_, RequestHandler>::default()));
+        let io_handlers = Arc::new(Mutex::new(HashMap::<i32, IoHandler>::default()));
 
         let receive_input_task = cx.spawn({
             let subscription_set = subscription_set.clone();
             let response_handlers = response_handlers.clone();
             let request_handlers = request_handlers.clone();
             let transport = transport.clone();
+            let io_handlers = io_handlers.clone();
             async move |cx| {
                 Self::handle_input(
                     transport,
                     subscription_set,
                     request_handlers,
                     response_handlers,
+                    io_handlers,
                     cx,
                 )
-                .log_err()
                 .await
+                .log_err()
             }
         });
-        let receive_err_task = cx.spawn({
+        let receive_err_task = cx.background_spawn({
             let transport = transport.clone();
-            async move |_| Self::handle_err(transport).log_err().await
+            let io_handlers = io_handlers.clone();
+            async move { Self::handle_err(transport, io_handlers).await.log_err() }
         });
-        let input_task = cx.spawn(async move |_| {
-            let (input, err) = futures::join!(receive_input_task, receive_err_task);
+        let input_task = cx.background_spawn(async move {
+            let (input, err): (Option<()>, Option<()>) =
+                futures::join!(receive_input_task, receive_err_task);
             input.or(err)
         });
 
         let output_task = cx.background_spawn({
             let transport = transport.clone();
-            Self::handle_output(
-                transport,
-                outbound_rx,
-                output_done_tx,
-                response_handlers.clone(),
-            )
-            .log_err()
+            let response_handlers = response_handlers.clone();
+            let io_handlers = io_handlers.clone();
+            async move {
+                Self::handle_output(
+                    transport,
+                    outbound_rx,
+                    output_done_tx,
+                    response_handlers,
+                    io_handlers,
+                )
+                .await
+                .log_err()
+            }
         });
 
         Ok(Self {
             server_id,
             subscription_set,
             response_handlers,
+            io_handlers,
             name: server_name,
             next_id: Default::default(),
             outbound_tx,
@@ -260,12 +285,18 @@ impl Client {
         subscription_set: Arc<Mutex<NotificationSubscriptionSet>>,
         request_handlers: Arc<Mutex<HashMap<&'static str, RequestHandler>>>,
         response_handlers: Arc<Mutex<Option<HashMap<RequestId, ResponseHandler>>>>,
+        io_handlers: Arc<Mutex<HashMap<i32, IoHandler>>>,
         cx: &mut AsyncApp,
     ) -> anyhow::Result<()> {
         let mut receiver = transport.receive();
 
         while let Some(message) = receiver.next().await {
             log::trace!("recv: {}", &message);
+
+            for handler in io_handlers.lock().values_mut() {
+                handler(IoKind::Recv, &message);
+            }
+
             if let Ok(request) = serde_json::from_str::<AnyRequest>(&message) {
                 let mut request_handlers = request_handlers.lock();
                 if let Some(handler) = request_handlers.get_mut(request.method) {
@@ -276,17 +307,22 @@ impl Client {
                     );
                 }
             } else if let Ok(response) = serde_json::from_str::<AnyResponse>(&message) {
-                if let Some(handlers) = response_handlers.lock().as_mut()
-                    && let Some(handler) = handlers.remove(&response.id)
+                if let Some(handler) = response_handlers
+                    .lock()
+                    .as_mut()
+                    .and_then(|handlers| handlers.remove(&response.id))
                 {
                     handler(Ok(message.to_string()));
                 }
             } else if let Ok(notification) = serde_json::from_str::<AnyNotification>(&message) {
+                if notification.method == "notifications/message" {
+                    Self::handle_mcp_log(&notification, &io_handlers);
+                }
                 subscription_set.lock().notify(
                     &notification.method,
                     notification.params.unwrap_or(Value::Null),
                     cx,
-                )
+                );
             } else {
                 log::error!("Unhandled JSON from context_server: {}", message);
             }
@@ -299,9 +335,15 @@ impl Client {
 
     /// Handles the stderr output from the context server.
     /// Continuously reads and logs any error messages from the server.
-    async fn handle_err(transport: Arc<dyn Transport>) -> anyhow::Result<()> {
+    async fn handle_err(
+        transport: Arc<dyn Transport>,
+        io_handlers: Arc<Mutex<HashMap<i32, IoHandler>>>,
+    ) -> anyhow::Result<()> {
         while let Some(err) = transport.receive_err().next().await {
             log::debug!("context server stderr: {}", err.trim());
+            for handler in io_handlers.lock().values_mut() {
+                handler(IoKind::StdErr, &err);
+            }
         }
 
         Ok(())
@@ -315,6 +357,7 @@ impl Client {
         outbound_rx: channel::Receiver<String>,
         output_done_tx: barrier::Sender,
         response_handlers: Arc<Mutex<Option<HashMap<RequestId, ResponseHandler>>>>,
+        io_handlers: Arc<Mutex<HashMap<i32, IoHandler>>>,
     ) -> anyhow::Result<()> {
         let _clear_response_handlers = util::defer({
             let response_handlers = response_handlers.clone();
@@ -324,6 +367,11 @@ impl Client {
         });
         while let Ok(message) = outbound_rx.recv().await {
             log::trace!("outgoing message: {}", message);
+
+            for handler in io_handlers.lock().values_mut() {
+                handler(IoKind::Send, &message);
+            }
+
             transport.send(message).await?;
         }
         drop(output_done_tx);
@@ -463,6 +511,62 @@ impl Client {
         NotificationSubscription {
             id: notification_subscriptions.add_handler(method, f),
             set: self.subscription_set.clone(),
+        }
+    }
+
+    /// Parses and handles an incoming `notifications/message` log notification according to the MCP specs.
+    /// See: https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging
+    fn handle_mcp_log(
+        notification: &AnyNotification,
+        io_handlers: &Arc<Mutex<HashMap<i32, IoHandler>>>,
+    ) {
+        if let Ok(params) = serde_json::from_value::<crate::types::MessageParams>(
+            notification
+                .params
+                .clone()
+                .unwrap_or(serde_json::Value::Null),
+        ) {
+            let data_str = if let serde_json::Value::String(s) = &params.data {
+                s.clone()
+            } else {
+                params.data.to_string()
+            };
+
+            let level_str = params.level.as_ref();
+
+            let msg = if let Some(logger) = &params.logger {
+                format!("[{level_str}] [{logger}] {data_str}")
+            } else {
+                format!("[{level_str}] {data_str}")
+            };
+            for handler in io_handlers.lock().values_mut() {
+                handler(IoKind::ProtocolLog(params.level), &msg);
+            }
+        }
+    }
+
+    pub fn on_io<F>(&self, f: F) -> IoSubscription
+    where
+        F: 'static + Send + FnMut(IoKind, &str),
+    {
+        let id = self.next_id.fetch_add(1, SeqCst);
+        self.io_handlers.lock().insert(id, Box::new(f));
+        IoSubscription {
+            id,
+            io_handlers: Arc::downgrade(&self.io_handlers),
+        }
+    }
+}
+
+pub struct IoSubscription {
+    id: i32,
+    io_handlers: std::sync::Weak<Mutex<HashMap<i32, IoHandler>>>,
+}
+
+impl Drop for IoSubscription {
+    fn drop(&mut self) {
+        if let Some(handlers) = self.io_handlers.upgrade() {
+            handlers.lock().remove(&self.id);
         }
     }
 }

--- a/crates/context_server/src/context_server.rs
+++ b/crates/context_server/src/context_server.rs
@@ -1,10 +1,13 @@
 pub mod client;
 pub mod listener;
+pub mod log_store;
 pub mod protocol;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test;
 pub mod transport;
 pub mod types;
+
+pub use log_store::init;
 
 use collections::HashMap;
 use http_client::HttpClient;
@@ -36,11 +39,31 @@ enum ContextServerTransport {
     Custom(Arc<dyn crate::transport::Transport>),
 }
 
+pub struct ContextServerIoSubscription {
+    id: i32,
+    io_subscribers: std::sync::Weak<parking_lot::Mutex<HashMap<i32, client::IoHandler>>>,
+}
+
+impl Drop for ContextServerIoSubscription {
+    fn drop(&mut self) {
+        if let Some(subscribers) = self.io_subscribers.upgrade() {
+            subscribers.lock().remove(&self.id);
+        }
+    }
+}
+
 pub struct ContextServer {
     id: ContextServerId,
     client: RwLock<Option<Arc<crate::protocol::InitializedContextServerProtocol>>>,
     configuration: ContextServerTransport,
     request_timeout: Option<Duration>,
+    /// A list of external subscribers listening to this server's I/O events.
+    io_subscribers: Arc<parking_lot::Mutex<HashMap<i32, client::IoHandler>>>,
+    /// The next ID to assign to a new I/O subscriber.
+    next_io_subscription_id: std::sync::atomic::AtomicI32,
+    /// The subscription to the currently active inner client's I/O stream.
+    /// Replaced when the server is restarted.
+    _client_io_subscription: parking_lot::Mutex<Option<client::IoSubscription>>,
 }
 
 impl ContextServer {
@@ -57,6 +80,9 @@ impl ContextServer {
                 working_directory.map(|directory| directory.to_path_buf()),
             ),
             request_timeout: None,
+            io_subscribers: Arc::new(parking_lot::Mutex::new(collections::HashMap::default())),
+            next_io_subscription_id: std::sync::atomic::AtomicI32::new(0),
+            _client_io_subscription: parking_lot::Mutex::new(None),
         }
     }
 
@@ -94,6 +120,23 @@ impl ContextServer {
             client: RwLock::new(None),
             configuration: ContextServerTransport::Custom(transport),
             request_timeout,
+            io_subscribers: Arc::new(parking_lot::Mutex::new(collections::HashMap::default())),
+            next_io_subscription_id: std::sync::atomic::AtomicI32::new(0),
+            _client_io_subscription: parking_lot::Mutex::new(None),
+        }
+    }
+
+    pub fn on_io<F>(&self, f: F) -> ContextServerIoSubscription
+    where
+        F: 'static + Send + FnMut(client::IoKind, &str),
+    {
+        let id = self
+            .next_io_subscription_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.io_subscribers.lock().insert(id, Box::new(f));
+        ContextServerIoSubscription {
+            id,
+            io_subscribers: Arc::downgrade(&self.io_subscribers),
         }
     }
 
@@ -110,7 +153,7 @@ impl ContextServer {
     }
 
     fn new_client(&self, cx: &AsyncApp) -> Result<Client> {
-        Ok(match &self.configuration {
+        let client = match &self.configuration {
             ContextServerTransport::Stdio(command, working_directory) => Client::stdio(
                 client::ContextServerId(self.id.0.clone()),
                 client::ModelContextServerBinary {
@@ -124,12 +167,21 @@ impl ContextServer {
             )?,
             ContextServerTransport::Custom(transport) => Client::new(
                 client::ContextServerId(self.id.0.clone()),
-                self.id().0,
+                self.id.0.clone(),
                 transport.clone(),
                 self.request_timeout,
                 cx.clone(),
             )?,
-        })
+        };
+
+        let io_subscribers = self.io_subscribers.clone();
+        *self._client_io_subscription.lock() = Some(client.on_io(move |kind, msg| {
+            for subscriber in io_subscribers.lock().values_mut() {
+                subscriber(kind, msg);
+            }
+        }));
+
+        Ok(client)
     }
 
     async fn initialize(&self, client: Client) -> Result<()> {

--- a/crates/context_server/src/log_store.rs
+++ b/crates/context_server/src/log_store.rs
@@ -1,0 +1,1012 @@
+use std::collections::VecDeque;
+
+use collections::HashMap;
+use futures::StreamExt as _;
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global};
+
+use crate::ContextServerId;
+use crate::types::{LoggingLevel, RpcDirection};
+
+const SEND_LINE: &str = "\n// Send:";
+const RECEIVE_LINE: &str = "\n// Receive:";
+const MAX_STORED_LOG_ENTRIES: usize = 2000;
+
+/// Initializes the global log store for context servers.
+///
+/// Unlike LSP logs (which are initialized as a side effect inside `language_tools::init`),
+/// we use a more decoupled approach for MCP. By separating the core logging storage
+/// from the UI component, the MCP client can safely log messages to its global store regardless
+/// of whether the developer tools UI is ever registered or opened, preventing potential `cx.update_global` panics.
+pub fn init(cx: &mut App) -> Entity<ContextServerLogStore> {
+    let (io_tx, mut io_rx) =
+        futures::channel::mpsc::unbounded::<(ContextServerId, crate::client::IoKind, String)>();
+
+    let log_store = cx.new(|cx| {
+        cx.spawn(async move |log_store, cx| {
+            while let Some((server_id, io_kind, message)) = io_rx.next().await {
+                if let Some(log_store) = log_store.upgrade() {
+                    log_store.update(cx, |log_store: &mut ContextServerLogStore, cx| {
+                        log_store.on_io(server_id, io_kind, &message, cx);
+                    });
+                }
+            }
+        })
+        .detach();
+
+        ContextServerLogStore::new(io_tx)
+    });
+    cx.set_global(GlobalContextServerLogStore(log_store.clone()));
+    log_store
+}
+
+pub struct GlobalContextServerLogStore(pub Entity<ContextServerLogStore>);
+
+impl Global for GlobalContextServerLogStore {}
+
+#[derive(Debug)]
+pub enum Event {
+    NewContextServerLogEntry {
+        id: ContextServerId,
+        kind: LogKind,
+        text: String,
+    },
+}
+
+impl EventEmitter<Event> for ContextServerLogStore {}
+
+pub struct ContextServerLogStore {
+    pub servers: HashMap<ContextServerId, ContextServerState>,
+    io_tx:
+        futures::channel::mpsc::UnboundedSender<(ContextServerId, crate::client::IoKind, String)>,
+}
+
+#[derive(Clone)]
+pub struct ContextServerState {
+    pub name: String,
+    pub log_messages: VecDeque<LogMessage>,
+    pub stderr_messages: VecDeque<StderrMessage>,
+    pub rpc_state: Option<RpcState>,
+    pub toggled_log_kind: Option<LogKind>,
+    pub log_level: LoggingLevel,
+    _io_logs_subscription: Option<std::sync::Arc<crate::ContextServerIoSubscription>>,
+}
+
+impl std::fmt::Debug for ContextServerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContextServerState")
+            .field("name", &self.name)
+            .field("log_messages", &self.log_messages)
+            .field("stderr_messages", &self.stderr_messages)
+            .field("rpc_state", &self.rpc_state)
+            .field("toggled_log_kind", &self.toggled_log_kind)
+            .field("log_level", &self.log_level)
+            .finish_non_exhaustive()
+    }
+}
+
+pub trait Message: AsRef<str> {
+    type Level: Copy + std::fmt::Debug;
+    fn should_include(&self, _: Self::Level) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LogMessage {
+    message: String,
+    pub level: LoggingLevel,
+}
+
+impl AsRef<str> for LogMessage {
+    fn as_ref(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Message for LogMessage {
+    type Level = LoggingLevel;
+
+    fn should_include(&self, level: Self::Level) -> bool {
+        self.level >= level
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RpcMessage {
+    message: String,
+}
+
+impl AsRef<str> for RpcMessage {
+    fn as_ref(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Message for RpcMessage {
+    type Level = ();
+}
+
+#[derive(Debug, Clone)]
+pub struct StderrMessage {
+    message: String,
+}
+
+impl AsRef<str> for StderrMessage {
+    fn as_ref(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Message for StderrMessage {
+    type Level = ();
+}
+
+#[derive(Debug, Clone)]
+pub struct RpcState {
+    pub rpc_messages: VecDeque<RpcMessage>,
+    last_message_kind: Option<MessageKind>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum MessageKind {
+    Send,
+    Receive,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum LogKind {
+    Rpc,
+    Stderr,
+    Trace,
+    #[default]
+    Logs,
+    ServerInfo,
+}
+
+impl ContextServerLogStore {
+    pub fn new(
+        io_tx: futures::channel::mpsc::UnboundedSender<(
+            ContextServerId,
+            crate::client::IoKind,
+            String,
+        )>,
+    ) -> Self {
+        Self {
+            servers: HashMap::default(),
+            io_tx,
+        }
+    }
+
+    pub fn add_context_server(
+        &mut self,
+        server: std::sync::Arc<crate::ContextServer>,
+        name: String,
+        cx: &mut Context<Self>,
+    ) {
+        let id = server.id();
+        let io_tx = self.io_tx.clone();
+        let server_id = id.clone();
+
+        let io_logs_subscription = Some(std::sync::Arc::new(server.on_io(
+            move |io_kind, message| {
+                let _ = io_tx.unbounded_send((server_id.clone(), io_kind, message.to_string()));
+            },
+        )));
+
+        self.servers
+            .entry(id)
+            .and_modify(|state| {
+                state.name = name.clone();
+                state._io_logs_subscription = io_logs_subscription.clone();
+            })
+            .or_insert_with(|| {
+                cx.notify();
+                ContextServerState {
+                    name,
+                    rpc_state: Some(RpcState {
+                        rpc_messages: VecDeque::with_capacity(MAX_STORED_LOG_ENTRIES),
+                        last_message_kind: None,
+                    }),
+                    log_messages: VecDeque::with_capacity(MAX_STORED_LOG_ENTRIES),
+                    stderr_messages: VecDeque::with_capacity(MAX_STORED_LOG_ENTRIES),
+                    toggled_log_kind: None,
+                    log_level: LoggingLevel::Debug,
+                    _io_logs_subscription: io_logs_subscription,
+                }
+            });
+    }
+
+    fn on_io(
+        &mut self,
+        id: ContextServerId,
+        io_kind: crate::client::IoKind,
+        message: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let is_received = match io_kind {
+            crate::client::IoKind::Recv => true,
+            crate::client::IoKind::Send => false,
+            crate::client::IoKind::StdErr => {
+                self.add_stderr(id, message.to_string(), cx);
+                return;
+            }
+            crate::client::IoKind::ProtocolLog(level) => {
+                self.add_log(id, level, message.to_string(), cx);
+                return;
+            }
+        };
+
+        let direction = if is_received {
+            RpcDirection::Receive
+        } else {
+            RpcDirection::Send
+        };
+
+        let pretty_message = if let Ok(value) = serde_json::from_str::<serde_json::Value>(message) {
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| message.to_owned())
+        } else {
+            message.to_owned()
+        };
+
+        self.add_rpc(id, direction, pretty_message, cx);
+    }
+
+    pub fn remove_context_server(&mut self, id: ContextServerId, cx: &mut Context<Self>) {
+        self.servers.remove(&id);
+        cx.notify();
+    }
+
+    pub fn add_log(
+        &mut self,
+        id: ContextServerId,
+        level: LoggingLevel,
+        message: String,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(state) = self.servers.get_mut(&id) {
+            let current_level = state.log_level;
+            Self::push_new_message(
+                &mut state.log_messages,
+                LogMessage {
+                    message: message.clone(),
+                    level,
+                },
+                current_level,
+            );
+            cx.emit(Event::NewContextServerLogEntry {
+                id,
+                kind: LogKind::Logs,
+                text: message,
+            });
+        }
+    }
+
+    pub fn add_rpc(
+        &mut self,
+        id: ContextServerId,
+        direction: RpcDirection,
+        message: String,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(state) = self
+            .servers
+            .get_mut(&id)
+            .and_then(|state| state.rpc_state.as_mut())
+        else {
+            return;
+        };
+
+        let kind = match direction {
+            RpcDirection::Send => MessageKind::Send,
+            RpcDirection::Receive => MessageKind::Receive,
+        };
+
+        let rpc_log_lines = &mut state.rpc_messages;
+        if state.last_message_kind != Some(kind) {
+            while rpc_log_lines.len() >= MAX_STORED_LOG_ENTRIES {
+                rpc_log_lines.pop_front();
+            }
+            let line_before_message = match kind {
+                MessageKind::Send => SEND_LINE,
+                MessageKind::Receive => RECEIVE_LINE,
+            };
+
+            rpc_log_lines.push_back(RpcMessage {
+                message: line_before_message.to_string(),
+            });
+
+            cx.emit(Event::NewContextServerLogEntry {
+                id: id.clone(),
+                kind: LogKind::Rpc,
+                text: line_before_message.to_string(),
+            });
+        }
+
+        state.last_message_kind = Some(kind);
+
+        while rpc_log_lines.len() >= MAX_STORED_LOG_ENTRIES {
+            rpc_log_lines.pop_front();
+        }
+
+        rpc_log_lines.push_back(RpcMessage {
+            message: message.trim().to_owned(),
+        });
+
+        cx.emit(Event::NewContextServerLogEntry {
+            id,
+            kind: LogKind::Rpc,
+            text: message,
+        });
+    }
+
+    pub fn enable_rpc_trace(&mut self, id: ContextServerId) {
+        if let Some(state) = self.servers.get_mut(&id) {
+            state.rpc_state.get_or_insert_with(|| RpcState {
+                rpc_messages: VecDeque::with_capacity(MAX_STORED_LOG_ENTRIES),
+                last_message_kind: None,
+            });
+        }
+    }
+
+    pub fn disable_rpc_trace(&mut self, id: ContextServerId) {
+        if let Some(state) = self.servers.get_mut(&id) {
+            state.rpc_state = None;
+        }
+    }
+
+    pub fn get_server_state(&mut self, id: ContextServerId) -> Option<&mut ContextServerState> {
+        self.servers.get_mut(&id)
+    }
+
+    pub fn server_logs(&self, id: &ContextServerId) -> Option<&VecDeque<LogMessage>> {
+        Some(&self.servers.get(id)?.log_messages)
+    }
+
+    pub fn server_rpc(&self, id: &ContextServerId) -> Option<&VecDeque<RpcMessage>> {
+        self.servers
+            .get(id)?
+            .rpc_state
+            .as_ref()
+            .map(|s| &s.rpc_messages)
+    }
+
+    pub fn server_stderr(&self, id: &ContextServerId) -> Option<&VecDeque<StderrMessage>> {
+        Some(&self.servers.get(id)?.stderr_messages)
+    }
+
+    pub fn add_stderr(&mut self, id: ContextServerId, message: String, cx: &mut Context<Self>) {
+        if let Some(state) = self.servers.get_mut(&id) {
+            Self::push_new_message(
+                &mut state.stderr_messages,
+                StderrMessage {
+                    message: message.clone(),
+                },
+                (),
+            );
+            cx.emit(Event::NewContextServerLogEntry {
+                id,
+                kind: LogKind::Stderr,
+                text: message,
+            });
+        }
+    }
+
+    pub fn toggle_logs(
+        &mut self,
+        server_id: ContextServerId,
+        enabled: bool,
+        toggled_log_kind: LogKind,
+    ) {
+        if let Some(server_state) = self.servers.get_mut(&server_id) {
+            if enabled {
+                server_state.toggled_log_kind = Some(toggled_log_kind);
+            } else {
+                server_state.toggled_log_kind = None;
+            }
+        }
+    }
+
+    fn push_new_message<T: Message>(
+        log_lines: &mut VecDeque<T>,
+        message: T,
+        current_severity: <T as Message>::Level,
+    ) -> Option<String> {
+        while log_lines.len() >= MAX_STORED_LOG_ENTRIES {
+            log_lines.pop_front();
+        }
+        let visible = message.should_include(current_severity);
+
+        let visible_message = visible.then(|| message.as_ref().to_string());
+        log_lines.push_back(message);
+        visible_message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ContextServerId;
+
+    fn new_test_store(
+        cx: &mut gpui::TestAppContext,
+    ) -> (
+        Entity<ContextServerLogStore>,
+        futures::channel::mpsc::UnboundedReceiver<(ContextServerId, crate::client::IoKind, String)>,
+    ) {
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+        let store = cx.new(|_| ContextServerLogStore::new(tx));
+        (store, rx)
+    }
+
+    fn insert_test_server(store: &mut ContextServerLogStore, id: &ContextServerId, name: &str) {
+        store.servers.insert(
+            id.clone(),
+            ContextServerState {
+                name: name.into(),
+                rpc_state: Some(RpcState {
+                    rpc_messages: VecDeque::new(),
+                    last_message_kind: None,
+                }),
+                log_messages: VecDeque::new(),
+                stderr_messages: VecDeque::new(),
+                toggled_log_kind: None,
+                log_level: LoggingLevel::Debug,
+                _io_logs_subscription: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_should_include() {
+        let debug_msg = LogMessage {
+            message: "msg".into(),
+            level: LoggingLevel::Debug,
+        };
+        let info_msg = LogMessage {
+            message: "msg".into(),
+            level: LoggingLevel::Info,
+        };
+        let error_msg = LogMessage {
+            message: "msg".into(),
+            level: LoggingLevel::Error,
+        };
+
+        assert!(debug_msg.should_include(LoggingLevel::Debug));
+        assert!(!debug_msg.should_include(LoggingLevel::Info));
+        assert!(!debug_msg.should_include(LoggingLevel::Error));
+
+        assert!(info_msg.should_include(LoggingLevel::Debug));
+        assert!(info_msg.should_include(LoggingLevel::Info));
+        assert!(!info_msg.should_include(LoggingLevel::Error));
+
+        assert!(error_msg.should_include(LoggingLevel::Debug));
+        assert!(error_msg.should_include(LoggingLevel::Info));
+        assert!(error_msg.should_include(LoggingLevel::Error));
+    }
+
+    #[test]
+    fn test_rpc_message_always_included() {
+        let rpc = RpcMessage {
+            message: "anything".into(),
+        };
+        assert!(rpc.should_include(()));
+    }
+
+    #[gpui::test]
+    fn test_log_store_limits(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            for i in 0..MAX_STORED_LOG_ENTRIES + 10 {
+                store.add_log(id.clone(), LoggingLevel::Info, format!("Message {}", i), cx);
+            }
+
+            let logs = store.server_logs(&id).unwrap();
+            assert_eq!(logs.len(), MAX_STORED_LOG_ENTRIES);
+            assert_eq!(logs.front().unwrap().message, "Message 10");
+            assert_eq!(
+                logs.back().unwrap().message,
+                format!("Message {}", MAX_STORED_LOG_ENTRIES + 9)
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_rpc_store_limits(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            for i in 0..MAX_STORED_LOG_ENTRIES + 10 {
+                store.add_rpc(id.clone(), RpcDirection::Send, format!("rpc {}", i), cx);
+            }
+
+            let rpc = store.server_rpc(&id).unwrap();
+            assert!(rpc.len() <= MAX_STORED_LOG_ENTRIES);
+        });
+    }
+
+    #[gpui::test]
+    fn test_rpc_message_boundaries(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.add_rpc(id.clone(), RpcDirection::Send, "req 1".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Send, "req 2".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Receive, "res 1".into(), cx);
+
+            let rpc = store.server_rpc(&id).unwrap();
+            // Should contain: SEND_LINE, "req 1", "req 2", RECEIVE_LINE, "res 1"
+            assert_eq!(rpc.len(), 5);
+            assert_eq!(rpc[0].message, SEND_LINE);
+            assert_eq!(rpc[1].message, "req 1");
+            assert_eq!(rpc[2].message, "req 2");
+            assert_eq!(rpc[3].message, RECEIVE_LINE);
+            assert_eq!(rpc[4].message, "res 1");
+        });
+    }
+
+    #[gpui::test]
+    fn test_rpc_direction_headers_not_repeated_for_same_direction(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.add_rpc(id.clone(), RpcDirection::Send, "a".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Send, "b".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Send, "c".into(), cx);
+
+            let rpc = store.server_rpc(&id).unwrap();
+            // One SEND header + 3 messages
+            assert_eq!(rpc.len(), 4);
+            assert_eq!(rpc[0].message, SEND_LINE);
+        });
+    }
+
+    #[gpui::test]
+    fn test_rpc_direction_alternating_inserts_headers(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.add_rpc(id.clone(), RpcDirection::Send, "s1".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Receive, "r1".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Send, "s2".into(), cx);
+            store.add_rpc(id.clone(), RpcDirection::Receive, "r2".into(), cx);
+
+            let rpc = store.server_rpc(&id).unwrap();
+            // SEND, s1, RECEIVE, r1, SEND, s2, RECEIVE, r2
+            assert_eq!(rpc.len(), 8);
+            assert_eq!(rpc[0].message, SEND_LINE);
+            assert_eq!(rpc[1].message, "s1");
+            assert_eq!(rpc[2].message, RECEIVE_LINE);
+            assert_eq!(rpc[3].message, "r1");
+            assert_eq!(rpc[4].message, SEND_LINE);
+            assert_eq!(rpc[5].message, "s2");
+            assert_eq!(rpc[6].message, RECEIVE_LINE);
+            assert_eq!(rpc[7].message, "r2");
+        });
+    }
+
+    #[gpui::test]
+    fn test_add_rpc_noop_when_rpc_disabled(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+            store.disable_rpc_trace(id.clone());
+
+            store.add_rpc(id.clone(), RpcDirection::Send, "ignored".into(), cx);
+
+            assert!(store.server_rpc(&id).is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn test_add_rpc_noop_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("nonexistent".into());
+
+        store.update(cx, |store, cx| {
+            // Should not panic
+            store.add_rpc(id.clone(), RpcDirection::Send, "msg".into(), cx);
+        });
+    }
+
+    #[gpui::test]
+    fn test_add_log_noop_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("nonexistent".into());
+
+        store.update(cx, |store, cx| {
+            // Should not panic
+            store.add_log(id.clone(), LoggingLevel::Info, "msg".into(), cx);
+            assert!(store.server_logs(&id).is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn test_remove_context_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+            store.add_log(id.clone(), LoggingLevel::Info, "hello".into(), cx);
+            store.add_stderr(id.clone(), "stderr line".into(), cx);
+            assert!(store.server_logs(&id).is_some());
+            assert!(store.server_stderr(&id).is_some());
+
+            store.remove_context_server(id.clone(), cx);
+
+            assert!(store.server_logs(&id).is_none());
+            assert!(store.server_rpc(&id).is_none());
+            assert!(store.server_stderr(&id).is_none());
+            assert!(store.get_server_state(id).is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn test_toggle_logs(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, _cx| {
+            insert_test_server(store, &id, "test");
+
+            assert_eq!(store.servers.get(&id).unwrap().toggled_log_kind, None);
+
+            store.toggle_logs(id.clone(), true, LogKind::Rpc);
+            assert_eq!(
+                store.servers.get(&id).unwrap().toggled_log_kind,
+                Some(LogKind::Rpc),
+            );
+
+            store.toggle_logs(id.clone(), true, LogKind::Logs);
+            assert_eq!(
+                store.servers.get(&id).unwrap().toggled_log_kind,
+                Some(LogKind::Logs),
+            );
+
+            store.toggle_logs(id.clone(), false, LogKind::Logs);
+            assert_eq!(store.servers.get(&id).unwrap().toggled_log_kind, None);
+        });
+    }
+
+    #[gpui::test]
+    fn test_toggle_logs_noop_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("nonexistent".into());
+
+        store.update(cx, |store, _cx| {
+            // Should not panic
+            store.toggle_logs(id, true, LogKind::Rpc);
+        });
+    }
+
+    #[gpui::test]
+    fn test_enable_disable_rpc_trace(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+            assert!(store.server_rpc(&id).is_some());
+
+            store.disable_rpc_trace(id.clone());
+            assert!(store.server_rpc(&id).is_none());
+
+            store.enable_rpc_trace(id.clone());
+            assert!(store.server_rpc(&id).is_some());
+            assert!(store.server_rpc(&id).unwrap().is_empty());
+
+            // Adding a message after re-enable should work
+            store.add_rpc(id.clone(), RpcDirection::Send, "after re-enable".into(), cx);
+            let rpc = store.server_rpc(&id).unwrap();
+            assert_eq!(rpc.len(), 2); // header + message
+        });
+    }
+
+    #[gpui::test]
+    fn test_enable_rpc_trace_noop_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("nonexistent".into());
+
+        store.update(cx, |store, _cx| {
+            // Should not panic
+            store.enable_rpc_trace(id.clone());
+            store.disable_rpc_trace(id);
+        });
+    }
+
+    #[gpui::test]
+    fn test_on_io_recv_routes_to_rpc(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.on_io(
+                id.clone(),
+                crate::client::IoKind::Recv,
+                r#"{"jsonrpc":"2.0"}"#,
+                cx,
+            );
+
+            let rpc = store.server_rpc(&id).unwrap();
+            assert!(!rpc.is_empty());
+            assert_eq!(rpc[0].message, RECEIVE_LINE);
+        });
+    }
+
+    #[gpui::test]
+    fn test_on_io_send_routes_to_rpc(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.on_io(id.clone(), crate::client::IoKind::Send, "outgoing", cx);
+
+            let rpc = store.server_rpc(&id).unwrap();
+            assert!(!rpc.is_empty());
+            assert_eq!(rpc[0].message, SEND_LINE);
+            assert_eq!(rpc[1].message, "outgoing");
+        });
+    }
+
+    #[gpui::test]
+    fn test_on_io_stderr_routes_to_stderr(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.on_io(
+                id.clone(),
+                crate::client::IoKind::StdErr,
+                "error output",
+                cx,
+            );
+
+            let stderr = store.server_stderr(&id).unwrap();
+            assert_eq!(stderr.len(), 1);
+            assert_eq!(stderr[0].as_ref(), "error output");
+
+            // Logs should be untouched
+            let logs = store.server_logs(&id).unwrap();
+            assert!(logs.is_empty());
+
+            // RPC should be untouched
+            let rpc = store.server_rpc(&id).unwrap();
+            assert!(rpc.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn test_on_io_protocol_log_routes_to_log(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.on_io(
+                id.clone(),
+                crate::client::IoKind::ProtocolLog(LoggingLevel::Warning),
+                "protocol warning",
+                cx,
+            );
+
+            let logs = store.server_logs(&id).unwrap();
+            assert_eq!(logs.len(), 1);
+            assert_eq!(logs[0].message, "protocol warning");
+            assert_eq!(logs[0].level, LoggingLevel::Warning);
+        });
+    }
+
+    #[gpui::test]
+    fn test_on_io_pretty_prints_json(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.on_io(
+                id.clone(),
+                crate::client::IoKind::Recv,
+                r#"{"a":1,"b":2}"#,
+                cx,
+            );
+
+            let rpc = store.server_rpc(&id).unwrap();
+            // The message should be pretty-printed (contains newlines)
+            let message = &rpc[1].message;
+            assert!(
+                message.contains('\n'),
+                "expected pretty-printed JSON, got: {}",
+                message
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_on_io_non_json_passed_through(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.on_io(id.clone(), crate::client::IoKind::Send, "not json {{{", cx);
+
+            let rpc = store.server_rpc(&id).unwrap();
+            assert_eq!(rpc[1].message, "not json {{{");
+        });
+    }
+
+    #[gpui::test]
+    fn test_push_new_message_returns_none_when_filtered(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            // Set log level to Error so Debug messages are filtered
+            store.servers.get_mut(&id).unwrap().log_level = LoggingLevel::Error;
+
+            // add_log still stores the message (push_new_message stores all)
+            store.add_log(id.clone(), LoggingLevel::Debug, "debug msg".into(), cx);
+
+            let logs = store.server_logs(&id).unwrap();
+            assert_eq!(logs.len(), 1);
+            assert_eq!(logs[0].level, LoggingLevel::Debug);
+            // The message is stored but should_include returns false at Error threshold
+            assert!(!logs[0].should_include(LoggingLevel::Error));
+        });
+    }
+
+    #[gpui::test]
+    fn test_server_logs_and_rpc_return_none_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("nonexistent".into());
+
+        store.update(cx, |store, _cx| {
+            assert!(store.server_logs(&id).is_none());
+            assert!(store.server_rpc(&id).is_none());
+            assert!(store.server_stderr(&id).is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn test_get_server_state_returns_none_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+
+        store.update(cx, |store, _cx| {
+            assert!(
+                store
+                    .get_server_state(ContextServerId("nope".into()))
+                    .is_none()
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_stderr_store_limits(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            for i in 0..MAX_STORED_LOG_ENTRIES + 10 {
+                store.add_stderr(id.clone(), format!("stderr {}", i), cx);
+            }
+
+            let stderr = store.server_stderr(&id).unwrap();
+            assert_eq!(stderr.len(), MAX_STORED_LOG_ENTRIES);
+            assert_eq!(stderr.front().unwrap().as_ref(), "stderr 10");
+            assert_eq!(
+                stderr.back().unwrap().as_ref(),
+                format!("stderr {}", MAX_STORED_LOG_ENTRIES + 9)
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_add_stderr_noop_for_unknown_server(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("nonexistent".into());
+
+        store.update(cx, |store, cx| {
+            store.add_stderr(id.clone(), "msg".into(), cx);
+            assert!(store.server_stderr(&id).is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn test_add_rpc_trims_message_whitespace(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+        let id = ContextServerId("test".into());
+
+        store.update(cx, |store, cx| {
+            insert_test_server(store, &id, "test");
+
+            store.add_rpc(id.clone(), RpcDirection::Send, "  padded  \n".into(), cx);
+
+            let rpc = store.server_rpc(&id).unwrap();
+            assert_eq!(rpc[1].message, "padded");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_add_server_restart(cx: &mut gpui::TestAppContext) {
+        let (store, _rx) = new_test_store(cx);
+
+        let server_cmd = crate::ContextServerCommand {
+            path: "test".into(),
+            args: vec![],
+            env: None,
+            timeout: None,
+        };
+        let id = ContextServerId("test_server".into());
+        let server1 = std::sync::Arc::new(crate::ContextServer::stdio(
+            id.clone(),
+            server_cmd.clone(),
+            None,
+        ));
+
+        store.update(cx, |store, cx| {
+            store.add_context_server(server1, "Initial Name".to_string(), cx);
+
+            // Add a log message to ensure it doesn't get cleared on restart
+            store.add_log(id.clone(), LoggingLevel::Info, "First run log".into(), cx);
+        });
+
+        // Verify state after first add
+        store.update(cx, |store, _| {
+            let state = store.servers.get(&id).unwrap();
+            assert_eq!(state.name, "Initial Name");
+            assert_eq!(state.log_messages.len(), 1);
+            assert!(state._io_logs_subscription.is_some());
+        });
+
+        // Simulate server restart (new ContextServer instance with the same ID)
+        let server2 =
+            std::sync::Arc::new(crate::ContextServer::stdio(id.clone(), server_cmd, None));
+
+        store.update(cx, |store, cx| {
+            store.add_context_server(server2, "Restarted Name".to_string(), cx);
+        });
+
+        // Verify state after restart
+        store.update(cx, |store, _| {
+            let state = store.servers.get(&id).unwrap();
+            // Name should be updated
+            assert_eq!(state.name, "Restarted Name");
+            // The old logs should still be there (not cleared/overwritten by a new ContextServerState)
+            assert_eq!(state.log_messages.len(), 1);
+            assert_eq!(state.log_messages[0].message, "First run log");
+            // There should still be an IO subscription active
+            assert!(state._io_logs_subscription.is_some());
+        });
+    }
+}

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -583,17 +583,50 @@ pub struct ResourceTemplate {
     pub mime_type: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum LoggingLevel {
+#[derive(
     Debug,
+    Serialize,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    strum::EnumIter,
+    strum::Display,
+    strum::AsRefStr,
+    strum::EnumString,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+pub enum LoggingLevel {
+    #[strum(to_string = "Debug")]
+    Debug,
+    #[strum(to_string = "Info")]
     Info,
+    #[strum(to_string = "Notice")]
     Notice,
+    #[strum(to_string = "Warning")]
     Warning,
+    #[strum(to_string = "Error")]
     Error,
+    #[strum(to_string = "Critical")]
     Critical,
+    #[strum(to_string = "Alert")]
     Alert,
+    #[strum(to_string = "Emergency")]
     Emergency,
+}
+
+impl<'de> Deserialize<'de> for LoggingLevel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::str::FromStr;
+        let s = String::deserialize(deserializer)?;
+        Ok(LoggingLevel::from_str(&s).unwrap_or(LoggingLevel::Info))
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -755,4 +788,81 @@ pub struct Root {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextServerLogEvent {
+    Rpc {
+        direction: RpcDirection,
+        message: String,
+    },
+    Log {
+        level: LoggingLevel,
+        message: String,
+    },
+    Stderr {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcDirection {
+    Send,
+    Receive,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_logging_level_deserialization() {
+        // Valid log levels according to MCP specification
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("debug")).unwrap(),
+            LoggingLevel::Debug
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("info")).unwrap(),
+            LoggingLevel::Info
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("notice")).unwrap(),
+            LoggingLevel::Notice
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("warning")).unwrap(),
+            LoggingLevel::Warning
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("error")).unwrap(),
+            LoggingLevel::Error
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("critical")).unwrap(),
+            LoggingLevel::Critical
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("alert")).unwrap(),
+            LoggingLevel::Alert
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("emergency")).unwrap(),
+            LoggingLevel::Emergency
+        );
+
+        // Invalid log level gracefully falls back to Info
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("foo")).unwrap(),
+            LoggingLevel::Info
+        );
+        assert_eq!(
+            serde_json::from_value::<LoggingLevel>(json!("FATAL")).unwrap(), // case sensitive in current string fallback
+            LoggingLevel::Info
+        );
+
+        // Integer/different types will still fail deserialization as String::deserialize expects string
+        assert!(serde_json::from_value::<LoggingLevel>(json!(42)).is_err());
+    }
 }

--- a/crates/context_server_tools/Cargo.toml
+++ b/crates/context_server_tools/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "context_server_tools"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/context_server_tools.rs"
+
+[features]
+test-support = []
+
+[dependencies]
+collections.workspace = true
+context_server.workspace = true
+editor.workspace = true
+gpui.workspace = true
+itertools.workspace = true
+language.workspace = true
+lsp.workspace = true
+project.workspace = true
+strum.workspace = true
+ui.workspace = true
+workspace.workspace = true

--- a/crates/context_server_tools/src/context_server_log_view.rs
+++ b/crates/context_server_tools/src/context_server_log_view.rs
@@ -1,0 +1,1015 @@
+use collections::VecDeque;
+use context_server::log_store::{ContextServerLogStore, Event, LogKind, Message};
+use context_server::{
+    ContextServerId, log_store::GlobalContextServerLogStore, types::LoggingLevel,
+};
+use editor::{Editor, EditorEvent, actions::MoveToEnd, scroll::Autoscroll};
+use gpui::{
+    App, Context, Corner, Entity, EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement,
+    Render, Styled, Subscription, Task, Window, actions, div,
+};
+use language::language_settings::SoftWrap;
+use project::search::SearchQuery;
+use std::{any::TypeId, borrow::Cow, sync::Arc};
+use strum::IntoEnumIterator;
+use ui::{Button, Checkbox, ContextMenu, Label, PopoverMenu, ToggleState, prelude::*};
+use workspace::{
+    SplitDirection, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace, WorkspaceId,
+    item::{Item, ItemHandle},
+    searchable::{Direction, SearchEvent, SearchToken, SearchableItem, SearchableItemHandle},
+};
+
+actions!(
+    dev,
+    [
+        /// Opens the Context Server logs viewer.
+        OpenContextServerLogs
+    ]
+);
+
+pub fn open_server_logs(
+    workspace: gpui::WeakEntity<Workspace>,
+    server_id: ContextServerId,
+    window: &mut Window,
+    cx: &mut gpui::App,
+) {
+    let log_store = cx.global::<GlobalContextServerLogStore>().0.clone();
+    workspace
+        .update(cx, |workspace, cx| {
+            let project = workspace.project().clone();
+
+            let existing_view = workspace.panes().into_iter().find_map(|pane| {
+                pane.read(cx)
+                    .items()
+                    .find_map(|item| item.downcast::<ContextServerLogView>())
+            });
+
+            let log_view = if let Some(view) = existing_view {
+                workspace.activate_item(&view, true, true, window, cx);
+                view
+            } else {
+                let new_view =
+                    cx.new(|cx| ContextServerLogView::new(project, log_store, window, cx));
+                workspace.split_item(
+                    SplitDirection::Right,
+                    ItemHandle::boxed_clone(&new_view),
+                    window,
+                    cx,
+                );
+                new_view
+            };
+
+            log_view.update(cx, |log_view, cx| {
+                log_view.show_logs_for_server(server_id, window, cx);
+            });
+        })
+        .ok();
+}
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(move |workspace: &mut Workspace, _, _cx| {
+        workspace.register_action(move |workspace, _: &OpenContextServerLogs, window, cx| {
+            let log_store = cx.global::<GlobalContextServerLogStore>().0.clone();
+            let project = workspace.project().clone();
+            let new_tool = cx.new(|cx| ContextServerLogView::new(project, log_store, window, cx));
+            workspace.split_item(
+                SplitDirection::Right,
+                ItemHandle::boxed_clone(&new_tool),
+                window,
+                cx,
+            );
+        });
+    })
+    .detach();
+}
+
+pub struct ContextServerLogView {
+    pub(crate) editor: Entity<Editor>,
+    editor_subscriptions: Vec<Subscription>,
+    project: Entity<project::Project>,
+    log_store: Entity<ContextServerLogStore>,
+    current_server_id: Option<ContextServerId>,
+    active_entry_kind: LogKind,
+    focus_handle: FocusHandle,
+    _log_store_subscriptions: Vec<Subscription>,
+}
+
+pub struct ContextServerLogToolbarItemView {
+    log_view: Option<Entity<ContextServerLogView>>,
+    _log_view_subscription: Option<Subscription>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct LogMenuItem {
+    pub server_id: ContextServerId,
+    pub server_name: String,
+    pub rpc_trace_enabled: bool,
+    pub has_stderr: bool,
+    pub selected_entry: LogKind,
+}
+
+impl ContextServerLogView {
+    pub fn new(
+        project: Entity<project::Project>,
+        log_store: Entity<ContextServerLogStore>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let server_id = log_store.read(cx).servers.keys().next().cloned();
+
+        let model_changes_subscription =
+            cx.observe_in(&log_store, window, move |this, store, window, cx| {
+                let first_server_id = store.read(cx).servers.keys().next();
+                if let Some(current_server) = &this.current_server_id {
+                    if !store.read(cx).servers.contains_key(current_server) {
+                        if let Some(server_id) = first_server_id {
+                            match this.active_entry_kind {
+                                LogKind::Rpc => {
+                                    this.show_rpc_trace_for_server(server_id.clone(), window, cx)
+                                }
+                                LogKind::Stderr => {
+                                    this.show_stderr_for_server(server_id.clone(), window, cx)
+                                }
+                                LogKind::Logs | LogKind::Trace | LogKind::ServerInfo => {
+                                    this.show_logs_for_server(server_id.clone(), window, cx)
+                                }
+                            }
+                        }
+                    }
+                } else if let Some(server_id) = first_server_id {
+                    match this.active_entry_kind {
+                        LogKind::Rpc => {
+                            this.show_rpc_trace_for_server(server_id.clone(), window, cx)
+                        }
+                        LogKind::Stderr => {
+                            this.show_stderr_for_server(server_id.clone(), window, cx)
+                        }
+                        LogKind::Logs | LogKind::Trace | LogKind::ServerInfo => {
+                            this.show_logs_for_server(server_id.clone(), window, cx)
+                        }
+                    }
+                }
+
+                cx.notify();
+            });
+
+        let events_subscriptions = cx.subscribe_in(
+            &log_store,
+            window,
+            move |log_view, _, e, window, cx| match e {
+                Event::NewContextServerLogEntry { id, kind, text } => {
+                    if log_view.current_server_id.as_ref() == Some(id)
+                        && *kind == log_view.active_entry_kind
+                    {
+                        log_view.editor.update(cx, |editor, cx| {
+                            editor.set_read_only(false);
+                            let last_offset = editor.buffer().read(cx).len(cx);
+                            let newest_cursor_is_at_end = editor
+                                .selections
+                                .newest::<editor::MultiBufferOffset>(&editor.display_snapshot(cx))
+                                .start
+                                >= last_offset;
+                            editor.edit(
+                                vec![
+                                    (last_offset..last_offset, text.as_str()),
+                                    (last_offset..last_offset, "\n"),
+                                ],
+                                cx,
+                            );
+                            if text.len() > 1024 {
+                                let b = editor.buffer().read(cx).as_singleton().unwrap().read(cx);
+                                let fold_offset =
+                                    b.as_rope().ceil_char_boundary(last_offset.0 + 1024);
+                                editor.fold_ranges(
+                                    vec![
+                                        editor::MultiBufferOffset(fold_offset)
+                                            ..editor::MultiBufferOffset(b.as_rope().len()),
+                                    ],
+                                    false,
+                                    window,
+                                    cx,
+                                );
+                            }
+
+                            if newest_cursor_is_at_end {
+                                editor.request_autoscroll(Autoscroll::bottom(), cx);
+                            }
+                            editor.set_read_only(true);
+                        });
+                    }
+                }
+            },
+        );
+        let (editor, editor_subscriptions) = Self::editor_for_logs(String::new(), window, cx);
+
+        let focus_handle = cx.focus_handle();
+        let focus_subscription = cx.on_focus(&focus_handle, window, |log_view, window, cx| {
+            window.focus(&log_view.editor.focus_handle(cx), cx);
+        });
+
+        let mut mcp_log_view = Self {
+            focus_handle,
+            editor,
+            editor_subscriptions,
+            project,
+            log_store,
+            current_server_id: None,
+            active_entry_kind: LogKind::Logs,
+            _log_store_subscriptions: vec![
+                model_changes_subscription,
+                events_subscriptions,
+                focus_subscription,
+            ],
+        };
+        if let Some(server_id) = server_id {
+            mcp_log_view.show_logs_for_server(server_id, window, cx);
+        }
+        mcp_log_view
+    }
+
+    pub(crate) fn menu_items(&self, cx: &mut App) -> Option<Vec<LogMenuItem>> {
+        let log_store = self.log_store.read(cx);
+
+        let mut rows = log_store
+            .servers
+            .iter()
+            .map(|(server_id, state)| LogMenuItem {
+                server_id: server_id.clone(),
+                server_name: format_server_name(
+                    &state.name,
+                    &self
+                        .project
+                        .read(cx)
+                        .worktree_root_names(cx)
+                        .collect::<Vec<_>>(),
+                ),
+                rpc_trace_enabled: state.rpc_state.is_some(),
+                has_stderr: !state.stderr_messages.is_empty(),
+                selected_entry: self.active_entry_kind,
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|a, b| a.server_name.cmp(&b.server_name));
+        Some(rows)
+    }
+
+    pub fn show_logs_for_server(
+        &mut self,
+        server_id: ContextServerId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let log_contents = self.log_store.update(cx, |this, _| {
+            let level = this
+                .get_server_state(server_id.clone())
+                .map(|s| s.log_level)
+                .unwrap_or(LoggingLevel::Debug);
+
+            this.server_logs(&server_id).map(|v| log_contents(v, level))
+        });
+
+        if let Some(log_contents) = log_contents {
+            self.current_server_id = Some(server_id.clone());
+            self.active_entry_kind = LogKind::Logs;
+            let (editor, editor_subscriptions) = Self::editor_for_logs(log_contents, window, cx);
+            self.set_editor_language(&editor, "Log", cx);
+            self.editor = editor;
+            self.editor_subscriptions = editor_subscriptions;
+            cx.notify();
+        }
+        self.editor.read(cx).focus_handle(cx).focus(window, cx);
+        self.log_store.update(cx, |log_store, _| {
+            log_store.toggle_logs(server_id, true, LogKind::Logs);
+        });
+    }
+
+    fn show_stderr_for_server(
+        &mut self,
+        server_id: ContextServerId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let stderr_contents = self.log_store.update(cx, |this, _| {
+            this.server_stderr(&server_id).map(|v| log_contents(v, ()))
+        });
+
+        if let Some(stderr_contents) = stderr_contents {
+            self.current_server_id = Some(server_id.clone());
+            self.active_entry_kind = LogKind::Stderr;
+            let (editor, editor_subscriptions) = Self::editor_for_logs(stderr_contents, window, cx);
+            self.set_editor_language(&editor, "Log", cx);
+            self.editor = editor;
+            self.editor_subscriptions = editor_subscriptions;
+            cx.notify();
+        }
+        self.editor.read(cx).focus_handle(cx).focus(window, cx);
+        self.log_store.update(cx, |log_store, _| {
+            log_store.toggle_logs(server_id, true, LogKind::Stderr);
+        });
+    }
+
+    fn update_log_level(
+        &mut self,
+        server_id: ContextServerId,
+        level: LoggingLevel,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let log_contents = self.log_store.update(cx, |this, _| {
+            if let Some(state) = this.get_server_state(server_id.clone()) {
+                state.log_level = level;
+            }
+
+            this.server_logs(&server_id).map(|v| log_contents(v, level))
+        });
+
+        if let Some(log_contents) = log_contents {
+            self.editor.update(cx, |editor, cx| {
+                editor.set_text(log_contents, window, cx);
+                editor.move_to_end(&MoveToEnd, window, cx);
+            });
+            cx.notify();
+        }
+
+        self.editor.read(cx).focus_handle(cx).focus(window, cx);
+    }
+
+    fn show_rpc_trace_for_server(
+        &mut self,
+        server_id: ContextServerId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.toggle_rpc_trace_for_server(server_id.clone(), true, window, cx);
+        let rpc_log = self.log_store.update(cx, |log_store, _| {
+            log_store.enable_rpc_trace(server_id.clone());
+            log_store
+                .server_rpc(&server_id)
+                .map(|messages| log_contents(messages, ()))
+        });
+
+        if let Some(rpc_log) = rpc_log {
+            self.current_server_id = Some(server_id);
+            self.active_entry_kind = LogKind::Rpc;
+            let (editor, editor_subscriptions) = Self::editor_for_logs(rpc_log, window, cx);
+            self.set_editor_language(&editor, "JSON", cx);
+            self.editor = editor;
+            self.editor_subscriptions = editor_subscriptions;
+            cx.notify();
+        }
+
+        self.editor.read(cx).focus_handle(cx).focus(window, cx);
+    }
+
+    fn toggle_rpc_trace_for_server(
+        &mut self,
+        server_id: ContextServerId,
+        enabled: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.log_store.update(cx, |log_store, _| {
+            if enabled {
+                log_store.enable_rpc_trace(server_id.clone());
+            } else {
+                log_store.disable_rpc_trace(server_id.clone());
+            }
+            log_store.toggle_logs(server_id.clone(), enabled, LogKind::Rpc);
+        });
+        if !enabled && Some(&server_id) == self.current_server_id.as_ref() {
+            self.show_logs_for_server(server_id, window, cx);
+            cx.notify();
+        }
+    }
+
+    fn set_editor_language(
+        &self,
+        editor: &Entity<Editor>,
+        language_name: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let language = self
+            .project
+            .read(cx)
+            .languages()
+            .language_for_name(language_name);
+        editor
+            .read(cx)
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("log buffer should be a singleton")
+            .update(cx, |_, cx| {
+                cx.spawn({
+                    let buffer = cx.entity();
+                    async move |_, cx| {
+                        // Language may not be available if an extension is not installed.
+                        if let Ok(language) = language.await {
+                            buffer.update(cx, |buffer, cx| {
+                                buffer.set_language(Some(language), cx);
+                            });
+                        }
+                    }
+                })
+                .detach();
+            });
+    }
+
+    fn editor_for_logs(
+        log_contents: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> (Entity<Editor>, Vec<Subscription>) {
+        let editor = initialize_new_editor(log_contents, true, window, cx);
+        let editor_subscription = cx.subscribe(&editor, |_, _, event: &EditorEvent, cx| {
+            cx.emit(event.clone())
+        });
+        let search_subscription = cx.subscribe(&editor, |_, _, event: &SearchEvent, cx| {
+            cx.emit(event.clone())
+        });
+        (editor, vec![editor_subscription, search_subscription])
+    }
+}
+
+fn initialize_new_editor(
+    content: String,
+    move_to_end: bool,
+    window: &mut Window,
+    cx: &mut App,
+) -> Entity<Editor> {
+    cx.new(|cx| {
+        let mut editor = Editor::multi_line(window, cx);
+        editor.hide_minimap_by_default(window, cx);
+        editor.set_text(content, window, cx);
+        editor.set_show_git_diff_gutter(false, cx);
+        editor.set_show_runnables(false, cx);
+        editor.set_show_breakpoints(false, cx);
+        editor.set_read_only(true);
+        editor.set_show_edit_predictions(Some(false), window, cx);
+        editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+        if move_to_end {
+            editor.move_to_end(&MoveToEnd, window, cx);
+        }
+        editor
+    })
+}
+
+fn log_contents<T: Message>(lines: &VecDeque<T>, level: <T as Message>::Level) -> String {
+    lines
+        .iter()
+        .filter(|message| message.should_include(level))
+        .flat_map(|message| [message.as_ref(), "\n"])
+        .collect()
+}
+
+impl Render for ContextServerLogView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.editor.update(cx, |editor, cx| {
+            editor.render(window, cx).into_any_element()
+        })
+    }
+}
+
+impl Focusable for ContextServerLogView {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Item for ContextServerLogView {
+    type Event = EditorEvent;
+
+    fn to_item_events(event: &Self::Event, f: &mut dyn FnMut(workspace::item::ItemEvent)) {
+        Editor::to_item_events(event, f)
+    }
+
+    fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
+        "Context Server Logs".into()
+    }
+
+    fn telemetry_event_text(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn as_searchable(
+        &self,
+        handle: &Entity<Self>,
+        _: &App,
+    ) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(handle.clone()))
+    }
+
+    fn act_as_type<'a>(
+        &'a self,
+        type_id: TypeId,
+        self_handle: &'a Entity<Self>,
+        _: &'a App,
+    ) -> Option<gpui::AnyEntity> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self_handle.clone().into())
+        } else if type_id == TypeId::of::<Editor>() {
+            Some(self.editor.clone().into())
+        } else {
+            None
+        }
+    }
+
+    fn can_split(&self) -> bool {
+        true
+    }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: Option<WorkspaceId>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<Entity<Self>>>
+    where
+        Self: Sized,
+    {
+        Task::ready(Some(cx.new(|cx| {
+            let mut new_view = Self::new(self.project.clone(), self.log_store.clone(), window, cx);
+            if let Some(server_id) = &self.current_server_id {
+                match self.active_entry_kind {
+                    LogKind::Rpc => {
+                        new_view.show_rpc_trace_for_server(server_id.clone(), window, cx)
+                    }
+                    LogKind::Stderr => {
+                        new_view.show_stderr_for_server(server_id.clone(), window, cx)
+                    }
+                    LogKind::Logs | LogKind::Trace | LogKind::ServerInfo => {
+                        new_view.show_logs_for_server(server_id.clone(), window, cx)
+                    }
+                }
+            }
+            new_view
+        })))
+    }
+}
+
+impl SearchableItem for ContextServerLogView {
+    type Match = <Editor as SearchableItem>::Match;
+
+    fn clear_matches(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.editor.update(cx, |e, cx| e.clear_matches(window, cx))
+    }
+
+    fn update_matches(
+        &mut self,
+        matches: &[Self::Match],
+        active_match_index: Option<usize>,
+        token: SearchToken,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editor.update(cx, |e, cx| {
+            e.update_matches(matches, active_match_index, token, window, cx)
+        })
+    }
+
+    fn query_suggestion(&mut self, window: &mut Window, cx: &mut Context<Self>) -> String {
+        self.editor
+            .update(cx, |e, cx| e.query_suggestion(window, cx))
+    }
+
+    fn activate_match(
+        &mut self,
+        index: usize,
+        matches: &[Self::Match],
+        token: SearchToken,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editor.update(cx, |e, cx| {
+            e.activate_match(index, matches, token, window, cx)
+        })
+    }
+
+    fn select_matches(
+        &mut self,
+        matches: &[Self::Match],
+        token: SearchToken,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editor
+            .update(cx, |e, cx| e.select_matches(matches, token, window, cx))
+    }
+
+    fn find_matches(
+        &mut self,
+        query: Arc<SearchQuery>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> gpui::Task<Vec<Self::Match>> {
+        self.editor
+            .update(cx, |e, cx| e.find_matches(query, window, cx))
+    }
+
+    fn replace(
+        &mut self,
+        _: &Self::Match,
+        _: &SearchQuery,
+        _token: SearchToken,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) {
+    }
+    fn supported_options(&self) -> workspace::searchable::SearchOptions {
+        workspace::searchable::SearchOptions {
+            case: true,
+            word: true,
+            regex: true,
+            find_in_results: false,
+            replacement: false,
+            selection: false,
+        }
+    }
+
+    fn active_match_index(
+        &mut self,
+        direction: Direction,
+        matches: &[Self::Match],
+        token: SearchToken,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<usize> {
+        self.editor.update(cx, |e, cx| {
+            e.active_match_index(direction, matches, token, window, cx)
+        })
+    }
+}
+
+const RPC_MESSAGES: &str = "RPC Messages";
+const STDERR_LOGS: &str = "Stderr";
+const LOGS: &str = "Logs";
+
+impl EventEmitter<ToolbarItemEvent> for ContextServerLogToolbarItemView {}
+
+impl ToolbarItemView for ContextServerLogToolbarItemView {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> workspace::ToolbarItemLocation {
+        if let Some(item) = active_pane_item {
+            if let Some(log_view) = item.downcast::<ContextServerLogView>() {
+                self.log_view = Some(log_view.clone());
+                self._log_view_subscription = Some(cx.observe(&log_view, |_, _, cx| {
+                    cx.notify();
+                }));
+                return ToolbarItemLocation::PrimaryLeft;
+            }
+        }
+        self.log_view = None;
+        self._log_view_subscription = None;
+        ToolbarItemLocation::Hidden
+    }
+}
+
+impl Render for ContextServerLogToolbarItemView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(log_view) = self.log_view.clone() else {
+            return div();
+        };
+
+        let (menu_rows, current_server_id) = log_view.update(cx, |log_view, cx| {
+            let menu_rows = log_view.menu_items(cx).unwrap_or_default();
+            let current_server_id = log_view.current_server_id.clone();
+            (menu_rows, current_server_id)
+        });
+
+        let current_server = current_server_id.and_then(|current_server_id| {
+            menu_rows
+                .iter()
+                .find(|e| e.server_id == current_server_id)
+                .cloned()
+        });
+
+        let available_language_servers: Vec<_> = menu_rows
+            .into_iter()
+            .map(|row| (row.server_id, row.server_name, row.selected_entry))
+            .collect();
+
+        let log_toolbar_view = cx.weak_entity();
+
+        let server_menu = PopoverMenu::new("ContextServerLogView")
+            .anchor(Corner::TopLeft)
+            .trigger(
+                Button::new(
+                    "context_server_menu_header",
+                    current_server
+                        .as_ref()
+                        .map(|row| Cow::Owned(row.server_name.to_string()))
+                        .unwrap_or_else(|| "No server selected".into()),
+                )
+                .icon(IconName::ChevronDown)
+                .icon_size(IconSize::Small)
+                .icon_color(Color::Muted),
+            )
+            .menu({
+                let log_view = log_view.clone();
+                move |window, cx| {
+                    let log_view = log_view.clone();
+                    ContextMenu::build(window, cx, |mut menu, window, _| {
+                        for (server_id, name, active_entry_kind) in
+                            available_language_servers.iter()
+                        {
+                            let label = name.clone();
+                            let server_id = server_id.clone();
+                            let active_entry_kind = *active_entry_kind;
+                            menu = menu.entry(
+                                label,
+                                None,
+                                window.handler_for(&log_view, move |view, window, cx| {
+                                    view.current_server_id = Some(server_id.clone());
+                                    view.active_entry_kind = active_entry_kind;
+                                    match view.active_entry_kind {
+                                        LogKind::Rpc => {
+                                            view.toggle_rpc_trace_for_server(
+                                                server_id.clone(),
+                                                true,
+                                                window,
+                                                cx,
+                                            );
+                                            view.show_rpc_trace_for_server(
+                                                server_id.clone(),
+                                                window,
+                                                cx,
+                                            );
+                                        }
+                                        LogKind::Stderr => view.show_stderr_for_server(
+                                            server_id.clone(),
+                                            window,
+                                            cx,
+                                        ),
+                                        LogKind::Logs | LogKind::Trace | LogKind::ServerInfo => {
+                                            view.show_logs_for_server(server_id.clone(), window, cx)
+                                        }
+                                    }
+                                    cx.notify();
+                                }),
+                            );
+                        }
+                        menu
+                    })
+                    .into()
+                }
+            });
+
+        let view_selector = current_server.map(|server| {
+            let server_id = server.server_id;
+            let rpc_trace_enabled = server.rpc_trace_enabled;
+            let has_stderr = server.has_stderr;
+            let log_view = log_view.clone();
+            let label = match server.selected_entry {
+                LogKind::Rpc => RPC_MESSAGES,
+                LogKind::Stderr => STDERR_LOGS,
+                _ => LOGS,
+            };
+            PopoverMenu::new("ContextServerViewSelector")
+                .anchor(Corner::TopLeft)
+                .trigger(
+                    Button::new("context_server_menu_header", label)
+                        .icon(IconName::ChevronDown)
+                        .icon_size(IconSize::Small)
+                        .icon_color(Color::Muted),
+                )
+                .menu(move |window, cx| {
+                    let log_toolbar_view = log_toolbar_view.upgrade()?;
+                    let log_view = log_view.clone();
+                    let server_id = server_id.clone();
+                    Some(ContextMenu::build(
+                        window,
+                        cx,
+                        move |mut this, window, _| {
+                            let server_id = server_id.clone();
+                            this = this.entry(
+                                LOGS,
+                                None,
+                                window.handler_for(&log_view, {
+                                    let server_id = server_id.clone();
+                                    move |view, window, cx| {
+                                        view.show_logs_for_server(server_id.clone(), window, cx);
+                                    }
+                                }),
+                            );
+                            if has_stderr {
+                                this = this.entry(
+                                    STDERR_LOGS,
+                                    None,
+                                    window.handler_for(&log_view, {
+                                        let server_id = server_id.clone();
+                                        move |view, window, cx| {
+                                            view.show_stderr_for_server(
+                                                server_id.clone(),
+                                                window,
+                                                cx,
+                                            );
+                                        }
+                                    }),
+                                );
+                            }
+                            this.custom_entry(
+                                {
+                                    let log_toolbar_view = log_toolbar_view.clone();
+                                    let server_id = server_id.clone();
+                                    move |window, _| {
+                                        h_flex()
+                                            .w_full()
+                                            .justify_between()
+                                            .child(Label::new(RPC_MESSAGES))
+                                            .child(
+                                                div().child(
+                                                    Checkbox::new(
+                                                        "ContextServerLogEnableRpcTrace",
+                                                        if rpc_trace_enabled {
+                                                            ToggleState::Selected
+                                                        } else {
+                                                            ToggleState::Unselected
+                                                        },
+                                                    )
+                                                    .on_click({
+                                                        let server_id = server_id.clone();
+                                                        window.listener_for(
+                                                            &log_toolbar_view,
+                                                            move |view, selection, window, cx| {
+                                                                let enabled = matches!(
+                                                                    selection,
+                                                                    ToggleState::Selected
+                                                                );
+                                                                view.toggle_rpc_logging_for_server(
+                                                                    server_id.clone(),
+                                                                    enabled,
+                                                                    window,
+                                                                    cx,
+                                                                );
+                                                                cx.stop_propagation();
+                                                            },
+                                                        )
+                                                    }),
+                                                ),
+                                            )
+                                            .into_any_element()
+                                    }
+                                },
+                                window.handler_for(&log_view, move |view, window, cx| {
+                                    view.show_rpc_trace_for_server(server_id.clone(), window, cx);
+                                }),
+                            )
+                        },
+                    ))
+                })
+        });
+
+        h_flex()
+            .size_full()
+            .gap_1()
+            .justify_between()
+            .child(
+                h_flex()
+                    .gap_0p5()
+                    .child(server_menu)
+                    .children(view_selector)
+                    .child(
+                        log_view.update(cx, |this, _cx| match this.active_entry_kind {
+                            LogKind::Logs => {
+                                let log_view = log_view.clone();
+                                div().child(
+                                    PopoverMenu::new("context-server-log-level-menu")
+                                        .anchor(Corner::TopLeft)
+                                        .trigger(
+                                            Button::new(
+                                                "context_server_log_level_selector",
+                                                "Log level",
+                                            )
+                                            .icon(IconName::ChevronDown)
+                                            .icon_size(IconSize::Small)
+                                            .icon_color(Color::Muted),
+                                        )
+                                        .menu({
+                                            let log_view = log_view;
+
+                                            move |window, cx| {
+                                                let id = log_view.read(cx).current_server_id.clone()?;
+
+                                                let log_level =
+                                                    log_view.update(cx, |this, cx| {
+                                                        this.log_store.update(cx, |this, _| {
+                                                            Some(
+                                                                this.get_server_state(id.clone())?
+                                                                    .log_level,
+                                                            )
+                                                        })
+                                                    })?;
+
+                                                Some(ContextMenu::build(
+                                                    window,
+                                                    cx,
+                                                    |mut menu, window, cx| {
+                                                        let log_view = log_view.clone();
+
+                                                        for option in LoggingLevel::iter() {
+                                                            let label = option.to_string();
+                                                            menu = menu.entry(label.clone(), None, {
+                                                                let log_view = log_view.clone();
+                                                                let id = id.clone();
+                                                                move |window, cx| {
+                                                                    log_view.update(cx, |this, cx| {
+                                                                        this.update_log_level(
+                                                                            id.clone(), option, window, cx,
+                                                                        );
+                                                                    });
+                                                                }
+                                                            });
+                                                            if option == log_level {
+                                                                menu.select_last(window, cx);
+                                                            }
+                                                        }
+
+                                                        menu
+                                                    },
+                                                ))
+                                            }
+                                        }),
+                                )
+                            }
+                            _ => div(),
+                        }),
+                    ),
+            )
+            .child(
+                Button::new("clear_log_button", "Clear").on_click(cx.listener(
+                    |this, _, window, cx| {
+                        if let Some(log_view) = this.log_view.as_ref() {
+                            log_view.update(cx, |log_view, cx| {
+                                log_view.editor.update(cx, |editor, cx| {
+                                    editor.set_read_only(false);
+                                    editor.clear(window, cx);
+                                    editor.set_read_only(true);
+                                });
+                            })
+                        }
+                    },
+                )),
+            )
+    }
+}
+
+impl ContextServerLogToolbarItemView {
+    pub fn new() -> Self {
+        Self {
+            log_view: None,
+            _log_view_subscription: None,
+        }
+    }
+
+    fn toggle_rpc_logging_for_server(
+        &mut self,
+        id: ContextServerId,
+        enabled: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(log_view) = &self.log_view {
+            log_view.update(cx, |log_view, cx| {
+                log_view.toggle_rpc_trace_for_server(id.clone(), enabled, window, cx);
+                if !enabled && Some(&id) == log_view.current_server_id.as_ref() {
+                    log_view.show_logs_for_server(id.clone(), window, cx);
+                    cx.notify();
+                } else if enabled {
+                    log_view.show_rpc_trace_for_server(id, window, cx);
+                    cx.notify();
+                }
+                window.focus(&log_view.focus_handle, cx);
+            });
+        }
+        cx.notify();
+    }
+}
+
+impl EventEmitter<EditorEvent> for ContextServerLogView {}
+impl EventEmitter<SearchEvent> for ContextServerLogView {}
+
+fn format_server_name(id: &str, worktree_root_names: &[&str]) -> String {
+    if worktree_root_names.is_empty() {
+        id.to_string()
+    } else {
+        format!("{} ({})", id, worktree_root_names.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_server_name() {
+        assert_eq!(format_server_name("my-server", &[]), "my-server");
+        assert_eq!(format_server_name("my-server", &["foo"]), "my-server (foo)");
+        assert_eq!(
+            format_server_name("my-server", &["foo", "bar"]),
+            "my-server (foo, bar)"
+        );
+    }
+}

--- a/crates/context_server_tools/src/context_server_tools.rs
+++ b/crates/context_server_tools/src/context_server_tools.rs
@@ -1,0 +1,11 @@
+pub mod context_server_log_view;
+
+use gpui::App;
+
+pub use context_server_log_view::{
+    ContextServerLogToolbarItemView, ContextServerLogView, open_server_logs,
+};
+
+pub fn init(cx: &mut App) {
+    context_server_log_view::init(cx);
+}

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -7,9 +7,17 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use collections::{HashMap, HashSet};
-use context_server::{ContextServer, ContextServerCommand, ContextServerId};
-use futures::{FutureExt as _, future::Either, future::join_all};
-use gpui::{App, AsyncApp, Context, Entity, EventEmitter, Subscription, Task, WeakEntity, actions};
+use context_server::{
+    ContextServer, ContextServerCommand, ContextServerId, log_store::GlobalContextServerLogStore,
+};
+use futures::{
+    FutureExt as _,
+    future::{Either, join_all},
+};
+use gpui::{
+    App, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task, WeakEntity,
+    actions,
+};
 use itertools::Itertools;
 use registry::ContextServerDescriptorRegistry;
 use remote::RemoteClient;
@@ -594,13 +602,20 @@ impl ContextServerStore {
         ) {
             self.stop_server(&id, cx).log_err();
         }
+
+        cx.update_global(|log_store: &mut GlobalContextServerLogStore, cx| {
+            log_store.0.update(cx, |log_store, cx| {
+                log_store.add_context_server(server.clone(), id.to_string(), cx);
+            });
+        });
+
         let task = cx.spawn({
             let id = server.id();
             let server = server.clone();
             let configuration = configuration.clone();
 
             async move |this, cx| {
-                match server.clone().start(cx).await {
+                match server.clone().start(&cx).await {
                     Ok(_) => {
                         debug_assert!(server.client().is_some());
 
@@ -617,7 +632,18 @@ impl ContextServerStore {
                         .log_err()
                     }
                     Err(err) => {
-                        log::error!("{} context server failed to start: {}", id, err);
+                        let error_message = format!("context server failed to start: {}", err);
+                        log::error!("{} {}", id, error_message);
+                        cx.update_global(|log_store: &mut GlobalContextServerLogStore, cx| {
+                            log_store.0.update(cx, |log_store, cx| {
+                                log_store.add_log(
+                                    id.clone(),
+                                    context_server::types::LoggingLevel::Error,
+                                    error_message,
+                                    cx,
+                                );
+                            });
+                        });
                         this.update(cx, |this, cx| {
                             this.update_server_state(
                                 id.clone(),
@@ -652,6 +678,13 @@ impl ContextServerStore {
             .remove(id)
             .context("Context server not found")?;
         drop(state);
+
+        cx.update_global(|log_store: &mut GlobalContextServerLogStore, cx| {
+            log_store.0.update(cx, |log_store, cx| {
+                log_store.remove_context_server(id.clone(), cx);
+            });
+        });
+
         cx.emit(ServerStatusChangedEvent {
             server_id: id.clone(),
             status: ContextServerStatus::Stopped,

--- a/crates/project/tests/integration/context_server_store.rs
+++ b/crates/project/tests/integration/context_server_store.rs
@@ -817,10 +817,7 @@ async fn test_remote_context_server(cx: &mut TestAppContext) {
 
     let _server_events = assert_server_events(
         &store,
-        vec![
-            (server_id.clone(), ContextServerStatus::Starting),
-            (server_id.clone(), ContextServerStatus::Running),
-        ],
+        vec![(server_id.clone(), ContextServerStatus::Starting)],
         cx,
     );
     cx.run_until_parked();
@@ -1030,6 +1027,7 @@ async fn setup_context_server_test(
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
+        context_server::init(cx);
         let mut settings = ProjectSettings::get_global(cx).clone();
         for (id, config) in context_server_configurations {
             settings.context_servers.insert(id, config);

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -82,10 +82,12 @@ cli.workspace = true
 client.workspace = true
 codestral.workspace = true
 collab_ui.workspace = true
+context_server = { path = "../context_server" }
 collections.workspace = true
 command_palette.workspace = true
 component.workspace = true
 component_preview.workspace = true
+context_server_tools.workspace = true
 copilot.workspace = true
 copilot_chat.workspace = true
 copilot_ui.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -567,6 +567,7 @@ fn main() {
         debugger_ui::init(cx);
         debugger_tools::init(cx);
         client::init(&client, cx);
+        context_server::init(cx);
 
         let system_id = cx.foreground_executor().block_on(system_id).ok();
         let installation_id = cx.foreground_executor().block_on(installation_id).ok();
@@ -727,6 +728,7 @@ fn main() {
         theme_selector::init(cx);
         settings_profile_selector::init(cx);
         language_tools::init(cx);
+        context_server_tools::init(cx);
         call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
         notifications::init(app_state.client.clone(), app_state.user_store.clone(), cx);
         collab_ui::init(&app_state, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1206,6 +1206,10 @@ fn initialize_pane(
             toolbar.add_item(lsp_log_item, window, cx);
             let dap_log_item = cx.new(|_| debugger_tools::DapLogToolbarItemView::new());
             toolbar.add_item(dap_log_item, window, cx);
+            let context_server_log_item =
+                cx.new(|_| context_server_tools::ContextServerLogToolbarItemView::new());
+            toolbar.add_item(context_server_log_item, window, cx);
+
             let acp_tools_item = cx.new(|_| acp_tools::AcpToolsToolbarItemView::new());
             toolbar.add_item(acp_tools_item, window, cx);
             let telemetry_log_item =


### PR DESCRIPTION
Adds a new developer tool for viewing Model Context Protocol (MCP) server logs, and RPC messages to mirror the functionality provided for language servers.

- Introduce `context_server_tools` crate for providing the MCP log view UI component (`ContextServerLogView`)
- Introduce `ContextServerLogStore` for holding in-memory server logs and parsing `notifications/message` logs.
- Add standard error stream log
- Forward `RpcDirection::Receive` and `RpcDirection::Send` [MCP log messages](https://modelcontextprotocol.io/specification/2024-11-05/server/utilities/logging) directly to the UI.

Closes: #48925

Release Notes:

- Added Model Context Protocol (MCP) logs developer tool for diagnosing server interactions


https://github.com/user-attachments/assets/4e0dd880-1301-4576-9fc4-9c481758d037

