### PR TITLE
editor: Refactor excerpts removed event handling

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1007,11 +1007,6 @@ impl DisplayMap {
     }
 
     #[instrument(skip_all)]
-    pub(super) fn clear_folded_buffer(&mut self, buffer_id: language::BufferId) {
-        self.block_map.folded_buffers.remove(&buffer_id);
-    }
-
-    #[instrument(skip_all)]
     pub fn insert_creases(
         &mut self,
         creases: impl IntoIterator<Item = Crease<Anchor>>,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24147,9 +24147,13 @@ impl Editor {
                     self.display_map.update(cx, |display_map, cx| {
                         display_map.invalidate_semantic_highlights(*buffer_id);
                         display_map.clear_lsp_folding_ranges(*buffer_id, cx);
-                        display_map.clear_folded_buffer(*buffer_id);
                     });
                 }
+
+                self.display_map.update(cx, |display_map, cx| {
+                    display_map.unfold_buffers(removed_buffer_ids.iter().copied(), cx);
+                });
+
                 jsx_tag_auto_close::refresh_enabled_in_any_buffer(self, multibuffer, cx);
                 cx.emit(EditorEvent::ExcerptsRemoved {
                     ids: ids.clone(),


### PR DESCRIPTION
Refactor the changes introduced in https://github.com/zed-industries/zed/pull/50525, in order to remove the `DisplayMap.clear_folded_buffer` method and update the editor's handling of `multi_buffer::Event::ExcerptsRemoved` to actually call `DisplayMap.unfold_buffers`, which correctly updates the `BlockMap` using its `BlockMapWriter`, ensuring that the block map is synced.

Before you mark this PR as ready for review, make sure that you have:
- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects
- [X] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
