### PR TITLE
git_graph: Make canvas column resizeable

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -2726,13 +2726,11 @@ impl Render for GitGraph {
                         state.commit_ratio();
                     });
                 }))
-                .on_drag_move::<CanvasDraggedSplitHandle>(cx.listener(
-                    |this, event, window, cx| {
-                        this.canvas_split_state.update(cx, |state, cx| {
-                            state.on_drag_move(event, window, cx);
-                        });
-                    },
-                ))
+                .on_drag_move::<CanvasDraggedSplitHandle>(cx.listener(|this, event, window, cx| {
+                    this.canvas_split_state.update(cx, |state, cx| {
+                        state.on_drag_move(event, window, cx);
+                    });
+                }))
                 .when(self.selected_entry_idx.is_some(), |this| {
                     this.child(self.render_commit_view_resize_handle(window, cx))
                         .child(self.render_commit_detail_panel(window, cx))

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -2464,16 +2464,22 @@ impl GitGraph {
 
     fn render_canvas_resize_handle(
         &self,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        let hovered = window.use_state(cx, |_window, _cx| false);
+        let bg = if *hovered.read(cx) {
+            cx.theme().colors().border_focused
+        } else {
+            cx.theme().colors().border_variant
+        };
         div()
             .id("canvas-split-resize-container")
             .relative()
             .h_full()
             .flex_shrink_0()
             .w(px(1.))
-            .bg(cx.theme().colors().border_variant)
+            .bg(bg)
             .child(
                 div()
                     .id("canvas-split-resize-handle")
@@ -2483,6 +2489,7 @@ impl GitGraph {
                     .h_full()
                     .cursor_col_resize()
                     .block_mouse_except_scroll()
+                    .on_hover(move |&was_hovered, _, cx| hovered.write(cx, was_hovered))
                     .on_click(cx.listener(|this, event: &ClickEvent, _window, cx| {
                         if event.click_count() >= 2 {
                             this.canvas_split_state.update(cx, |state, _| {

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -225,6 +225,37 @@ struct SearchState {
     pub selected_index: Option<usize>,
 }
 
+struct CanvasDraggedSplitHandle;
+
+struct CanvasSplitState {
+    width: Option<Pixels>,
+}
+
+impl CanvasSplitState {
+    pub fn new() -> Self {
+        Self { width: None }
+    }
+
+    pub fn width(&self) -> Option<Pixels> {
+        self.width
+    }
+
+    pub fn on_drag_move(
+        &mut self,
+        drag_event: &DragMoveEvent<CanvasDraggedSplitHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        let drag_position = drag_event.event.position;
+        let bounds = drag_event.bounds;
+        self.width = Some(drag_position.x - bounds.left());
+    }
+
+    fn on_double_click(&mut self) {
+        self.width = None
+    }
+}
+
 pub struct SplitState {
     left_ratio: f32,
     visible_left_ratio: f32,
@@ -914,6 +945,7 @@ pub struct GitGraph {
     _commit_diff_task: Option<Task<()>>,
     commit_details_split_state: Entity<SplitState>,
     repo_id: RepositoryId,
+    canvas_split_state: Entity<CanvasSplitState>,
     changed_files_scroll_handle: UniformListScrollHandle,
     pending_select_sha: Option<Oid>,
 }
@@ -1032,6 +1064,7 @@ impl GitGraph {
             log_order,
             commit_details_split_state: cx.new(|_cx| SplitState::new()),
             repo_id,
+            canvas_split_state: cx.new(|_cx| CanvasSplitState::new()),
             changed_files_scroll_handle: UniformListScrollHandle::new(),
             pending_select_sha: None,
         };
@@ -2089,8 +2122,6 @@ impl GitGraph {
         let vertical_scroll_offset = scroll_offset_y - (first_visible_row as f32 * row_height);
         let horizontal_scroll_offset = self.horizontal_scroll_offset;
 
-        let max_lanes = self.graph_data.max_lanes.max(6);
-        let graph_width = LANE_WIDTH * max_lanes as f32 + LEFT_PADDING * 2.0;
         let last_visible_row =
             first_visible_row + (viewport_height / row_height).ceil() as usize + 1;
 
@@ -2330,8 +2361,7 @@ impl GitGraph {
                 })
             },
         )
-        .w(graph_width)
-        .h_full()
+        .size_full()
     }
 
     fn row_at_position(&self, position_y: Pixels, cx: &Context<Self>) -> Option<usize> {
@@ -2432,6 +2462,42 @@ impl GitGraph {
         }
     }
 
+    fn render_canvas_resize_handle(
+        &self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        div()
+            .id("canvas-split-resize-container")
+            .relative()
+            .h_full()
+            .flex_shrink_0()
+            .w(px(1.))
+            .bg(cx.theme().colors().border_variant)
+            .child(
+                div()
+                    .id("canvas-split-resize-handle")
+                    .absolute()
+                    .left(px(-RESIZE_HANDLE_WIDTH / 2.0))
+                    .w(px(RESIZE_HANDLE_WIDTH))
+                    .h_full()
+                    .cursor_col_resize()
+                    .block_mouse_except_scroll()
+                    .on_click(cx.listener(|this, event: &ClickEvent, _window, cx| {
+                        if event.click_count() >= 2 {
+                            this.canvas_split_state.update(cx, |state, _| {
+                                state.on_double_click();
+                            });
+                        }
+                        cx.stop_propagation();
+                    }))
+                    .on_drag(CanvasDraggedSplitHandle, |_, _, _, cx| {
+                        cx.new(|_| gpui::Empty)
+                    }),
+            )
+            .into_any_element()
+    }
+
     fn render_commit_view_resize_handle(
         &self,
         _window: &mut Window,
@@ -2528,7 +2594,13 @@ impl Render for GitGraph {
                 .flex_row()
                 .child(
                     div()
-                        .w(self.graph_content_width())
+                        .flex_basis(DefiniteLength::Absolute(
+                            self.canvas_split_state
+                                .read(cx)
+                                .width()
+                                .unwrap_or(self.graph_content_width())
+                                .into(),
+                        ))
                         .h_full()
                         .flex()
                         .flex_col()
@@ -2545,19 +2617,29 @@ impl Render for GitGraph {
                         )
                         .child(
                             div()
-                                .id("graph-canvas")
-                                .flex_1()
-                                .overflow_hidden()
-                                .child(self.render_graph(window, cx))
-                                .on_scroll_wheel(cx.listener(Self::handle_graph_scroll))
-                                .on_mouse_move(cx.listener(Self::handle_graph_mouse_move))
-                                .on_click(cx.listener(Self::handle_graph_click))
-                                .on_hover(cx.listener(|this, &is_hovered: &bool, _, cx| {
-                                    if !is_hovered && this.hovered_entry_idx.is_some() {
-                                        this.hovered_entry_idx = None;
-                                        cx.notify();
-                                    }
-                                })),
+                                .size_full()
+                                .flex()
+                                .flex_row()
+                                .child(
+                                    div()
+                                        .id("graph-canvas")
+                                        .flex_1()
+                                        .flex_row()
+                                        .overflow_hidden()
+                                        .child(self.render_graph(window, cx))
+                                        .on_scroll_wheel(cx.listener(Self::handle_graph_scroll))
+                                        .on_mouse_move(cx.listener(Self::handle_graph_mouse_move))
+                                        .on_click(cx.listener(Self::handle_graph_click))
+                                        .on_hover(cx.listener(
+                                            |this, &is_hovered: &bool, _, cx| {
+                                                if !is_hovered && this.hovered_entry_idx.is_some() {
+                                                    this.hovered_entry_idx = None;
+                                                    cx.notify();
+                                                }
+                                            },
+                                        )),
+                                )
+                                .child(self.render_canvas_resize_handle(window, cx)),
                         ),
                 )
                 .child({
@@ -2644,6 +2726,13 @@ impl Render for GitGraph {
                         state.commit_ratio();
                     });
                 }))
+                .on_drag_move::<CanvasDraggedSplitHandle>(cx.listener(
+                    |this, event, window, cx| {
+                        this.canvas_split_state.update(cx, |state, cx| {
+                            state.on_drag_move(event, window, cx);
+                        });
+                    },
+                ))
                 .when(self.selected_entry_idx.is_some(), |this| {
                     this.child(self.render_commit_view_resize_handle(window, cx))
                         .child(self.render_commit_detail_panel(window, cx))

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -78,7 +78,10 @@ impl CopiedState {
     }
 }
 
-struct DraggedSplitHandle;
+enum DraggedSplitHandle {
+    CommitDetailPanel,
+    CanvasColumn,
+}
 
 #[derive(Clone)]
 struct ChangedFileEntry {
@@ -225,78 +228,61 @@ struct SearchState {
     pub selected_index: Option<usize>,
 }
 
-struct CanvasDraggedSplitHandle;
-
-struct CanvasSplitState {
-    width: Option<Pixels>,
-}
-
-impl CanvasSplitState {
-    pub fn new() -> Self {
-        Self { width: None }
-    }
-
-    pub fn width(&self) -> Option<Pixels> {
-        self.width
-    }
-
-    pub fn on_drag_move(
-        &mut self,
-        drag_event: &DragMoveEvent<CanvasDraggedSplitHandle>,
-        _window: &mut Window,
-        _cx: &mut Context<Self>,
-    ) {
-        let drag_position = drag_event.event.position;
-        let bounds = drag_event.bounds;
-        self.width = Some(drag_position.x - bounds.left());
-    }
-
-    fn on_double_click(&mut self) {
-        self.width = None
-    }
-}
-
 pub struct SplitState {
-    left_ratio: f32,
-    visible_left_ratio: f32,
+    commit_detail_panel_ratio: f32,
+    canvas_column_width: Option<Pixels>,
 }
 
 impl SplitState {
     pub fn new() -> Self {
         Self {
-            left_ratio: 1.0,
-            visible_left_ratio: 1.0,
+            commit_detail_panel_ratio: 0.0,
+            canvas_column_width: None,
         }
     }
 
-    pub fn right_ratio(&self) -> f32 {
-        1.0 - self.visible_left_ratio
+    pub fn canvas_column_width(&self) -> Option<Pixels> {
+        self.canvas_column_width
+    }
+
+    pub fn commit_detail_panel_ratio(&self) -> f32 {
+        self.commit_detail_panel_ratio
     }
 
     fn on_drag_move(
         &mut self,
         drag_event: &DragMoveEvent<DraggedSplitHandle>,
         _window: &mut Window,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         let drag_position = drag_event.event.position;
         let bounds = drag_event.bounds;
-        let bounds_width = bounds.right() - bounds.left();
+        let handle = drag_event.drag(cx);
+        match handle {
+            DraggedSplitHandle::CommitDetailPanel => {
+                let bounds_width = bounds.right() - bounds.left();
 
-        let min_ratio = 0.1;
-        let max_ratio = 0.9;
+                let min_ratio = 0.1;
+                let max_ratio = 0.9;
 
-        let new_ratio = (drag_position.x - bounds.left()) / bounds_width;
-        self.visible_left_ratio = new_ratio.clamp(min_ratio, max_ratio);
+                let new_ratio = (drag_position.x - bounds.left()) / bounds_width;
+                self.commit_detail_panel_ratio = 1.0 - new_ratio.clamp(min_ratio, max_ratio);
+            }
+            DraggedSplitHandle::CanvasColumn => {
+                self.canvas_column_width = Some(drag_position.x - bounds.left());
+            }
+        }
     }
 
-    fn commit_ratio(&mut self) {
-        self.left_ratio = self.visible_left_ratio;
-    }
-
-    fn on_double_click(&mut self) {
-        self.left_ratio = 1.0;
-        self.visible_left_ratio = 1.0;
+    fn on_double_click(&mut self, handle: DraggedSplitHandle) {
+        match handle {
+            DraggedSplitHandle::CommitDetailPanel => {
+                self.commit_detail_panel_ratio = 0.0;
+            }
+            DraggedSplitHandle::CanvasColumn => {
+                self.canvas_column_width = None;
+            }
+        }
     }
 }
 
@@ -943,9 +929,8 @@ pub struct GitGraph {
     selected_commit_diff: Option<CommitDiff>,
     selected_commit_diff_stats: Option<(usize, usize)>,
     _commit_diff_task: Option<Task<()>>,
-    commit_details_split_state: Entity<SplitState>,
+    split_state: Entity<SplitState>,
     repo_id: RepositoryId,
-    canvas_split_state: Entity<CanvasSplitState>,
     changed_files_scroll_handle: UniformListScrollHandle,
     pending_select_sha: Option<Oid>,
 }
@@ -1062,9 +1047,8 @@ impl GitGraph {
             selected_commit_diff_stats: None,
             log_source,
             log_order,
-            commit_details_split_state: cx.new(|_cx| SplitState::new()),
+            split_state: cx.new(|_cx| SplitState::new()),
             repo_id,
-            canvas_split_state: cx.new(|_cx| CanvasSplitState::new()),
             changed_files_scroll_handle: UniformListScrollHandle::new(),
             pending_select_sha: None,
         };
@@ -1840,7 +1824,7 @@ impl GitGraph {
             .h_full()
             .bg(cx.theme().colors().surface_background)
             .flex_basis(DefiniteLength::Fraction(
-                self.commit_details_split_state.read(cx).right_ratio(),
+                self.split_state.read(cx).commit_detail_panel_ratio(),
             ))
             .child(
                 v_flex()
@@ -2492,13 +2476,13 @@ impl GitGraph {
                     .on_hover(move |&was_hovered, _, cx| hovered.write(cx, was_hovered))
                     .on_click(cx.listener(|this, event: &ClickEvent, _window, cx| {
                         if event.click_count() >= 2 {
-                            this.canvas_split_state.update(cx, |state, _| {
-                                state.on_double_click();
+                            this.split_state.update(cx, |state, _| {
+                                state.on_double_click(DraggedSplitHandle::CanvasColumn);
                             });
                         }
                         cx.stop_propagation();
                     }))
-                    .on_drag(CanvasDraggedSplitHandle, |_, _, _, cx| {
+                    .on_drag(DraggedSplitHandle::CanvasColumn, |_, _, _, cx| {
                         cx.new(|_| gpui::Empty)
                     }),
             )
@@ -2528,13 +2512,15 @@ impl GitGraph {
                     .block_mouse_except_scroll()
                     .on_click(cx.listener(|this, event: &ClickEvent, _window, cx| {
                         if event.click_count() >= 2 {
-                            this.commit_details_split_state.update(cx, |state, _| {
-                                state.on_double_click();
+                            this.split_state.update(cx, |state, _| {
+                                state.on_double_click(DraggedSplitHandle::CommitDetailPanel);
                             });
                         }
                         cx.stop_propagation();
                     }))
-                    .on_drag(DraggedSplitHandle, |_, _, _, cx| cx.new(|_| gpui::Empty)),
+                    .on_drag(DraggedSplitHandle::CommitDetailPanel, |_, _, _, cx| {
+                        cx.new(|_| gpui::Empty)
+                    }),
             )
             .into_any_element()
     }
@@ -2602,9 +2588,9 @@ impl Render for GitGraph {
                 .child(
                     div()
                         .flex_basis(DefiniteLength::Absolute(
-                            self.canvas_split_state
+                            self.split_state
                                 .read(cx)
-                                .width()
+                                .canvas_column_width()
                                 .unwrap_or(self.graph_content_width())
                                 .into(),
                         ))
@@ -2724,17 +2710,7 @@ impl Render for GitGraph {
                     )
                 })
                 .on_drag_move::<DraggedSplitHandle>(cx.listener(|this, event, window, cx| {
-                    this.commit_details_split_state.update(cx, |state, cx| {
-                        state.on_drag_move(event, window, cx);
-                    });
-                }))
-                .on_drop::<DraggedSplitHandle>(cx.listener(|this, _event, _window, cx| {
-                    this.commit_details_split_state.update(cx, |state, _cx| {
-                        state.commit_ratio();
-                    });
-                }))
-                .on_drag_move::<CanvasDraggedSplitHandle>(cx.listener(|this, event, window, cx| {
-                    this.canvas_split_state.update(cx, |state, cx| {
+                    this.split_state.update(cx, |state, cx| {
                         state.on_drag_move(event, window, cx);
                     });
                 }))


### PR DESCRIPTION
Make git graph canvas column resizeable

[录屏 2026-03-05 09-46-10.webm](https://github.com/user-attachments/assets/329bff37-44ff-4d89-a39b-80e47cfa829d)


Before you mark this PR as ready for review, make sure that you have:
- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects
- [X] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
