### PR TITLE
agent: Serialize terminal tool executions and support custom timeouts

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1,3 +1,4 @@
+pub mod command_queue;
 mod db;
 mod edit_agent;
 mod legacy_thread;
@@ -12,6 +13,7 @@ mod thread_store;
 mod tool_permissions;
 mod tools;
 
+pub use command_queue::{CommandQueue, configured_command_timeout};
 use context_server::ContextServerId;
 pub use db::*;
 use itertools::Itertools;

--- a/crates/agent/src/command_queue.rs
+++ b/crates/agent/src/command_queue.rs
@@ -1,0 +1,133 @@
+use agent_settings::AgentSettings;
+use anyhow::Result;
+use gpui::{App, AsyncApp, Global, Task};
+use settings::Settings;
+use smol::channel;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use crate::{TerminalHandle, ThreadEnvironment};
+
+struct GlobalCommandQueue(CommandQueue);
+
+impl Global for GlobalCommandQueue {}
+
+/// A single-worker serialization gate for agent terminal commands.
+///
+/// Commands are executed one at a time: the next command does not begin until
+/// the previous caller drops its [`CommandGuard`]. This replaces
+/// fire-and-forget process spawning with a disciplined, sequential model.
+///
+/// The queue is stored as a GPUI `Global` so it survives terminal UI
+/// closure/recycling and lives for the lifetime of the application.
+///
+/// Implementation: a bounded channel of capacity 1 is pre-filled with a single
+/// permit. [`CommandQueue::acquire`] receives the permit (blocking if another
+/// caller already holds it) and returns a [`CommandGuard`]. Dropping the guard
+/// sends the permit back, unblocking the next waiter.
+#[derive(Clone)]
+pub struct CommandQueue {
+    permit_tx: channel::Sender<()>,
+    permit_rx: channel::Receiver<()>,
+}
+
+/// RAII guard returned by [`CommandQueue::acquire`].
+///
+/// While this guard is alive the serialization permit is held, preventing the
+/// next queued command from starting. Drop (or explicitly call
+/// [`CommandGuard::release`]) when the current command is finished.
+pub struct CommandGuard {
+    permit_tx: Option<channel::Sender<()>>,
+}
+
+impl CommandGuard {
+    /// Explicitly release the serialization permit.
+    pub fn release(self) {
+        drop(self);
+    }
+}
+
+impl Drop for CommandGuard {
+    fn drop(&mut self) {
+        if let Some(tx) = self.permit_tx.take() {
+            tx.try_send(()).ok();
+        }
+    }
+}
+
+impl CommandQueue {
+    /// Initialize the global `CommandQueue`. Must be called once during app
+    /// startup. Subsequent calls are no-ops if the global is already set.
+    pub fn init(cx: &mut App) {
+        if cx.has_global::<GlobalCommandQueue>() {
+            return;
+        }
+        let (permit_tx, permit_rx) = channel::bounded(1);
+        // Seed with one permit so the first `acquire` succeeds immediately.
+        permit_tx.try_send(()).ok();
+        let queue = Self {
+            permit_tx,
+            permit_rx,
+        };
+        cx.set_global(GlobalCommandQueue(queue));
+    }
+
+    /// Returns a clone of the global `CommandQueue`.
+    pub fn global(cx: &App) -> CommandQueue {
+        cx.global::<GlobalCommandQueue>().0.clone()
+    }
+
+    /// Try to get the global `CommandQueue`, returning `None` if it hasn't
+    /// been initialized yet.
+    pub fn try_global(cx: &App) -> Option<CommandQueue> {
+        cx.try_global::<GlobalCommandQueue>().map(|g| g.0.clone())
+    }
+
+    /// Wait for the serialization permit and return a guard.
+    ///
+    /// The returned [`CommandGuard`] holds the permit. While it is alive no
+    /// other call to `acquire` will complete. Drop the guard when the
+    /// command's child process has exited (or timed out) to let the next
+    /// queued command proceed.
+    pub async fn acquire(&self) -> CommandGuard {
+        // The channel is FIFO, so callers are served in order.
+        self.permit_rx.recv().await.ok();
+        CommandGuard {
+            permit_tx: Some(self.permit_tx.clone()),
+        }
+    }
+
+    /// Convenience: acquire the gate, create a terminal, and return both the
+    /// terminal handle and the guard.
+    ///
+    /// The caller is responsible for waiting on the child process and dropping
+    /// the guard afterwards (this is intentional — the caller may need to
+    /// handle user-cancellation, custom timeouts, etc.).
+    pub fn create_terminal_serialized(
+        &self,
+        environment: &Rc<dyn ThreadEnvironment>,
+        command: String,
+        cwd: Option<PathBuf>,
+        output_byte_limit: Option<u64>,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<(Rc<dyn TerminalHandle>, CommandGuard)>> {
+        let queue = self.clone();
+        let environment = environment.clone();
+
+        cx.spawn(async move |cx| {
+            let guard = queue.acquire().await;
+
+            let terminal = environment
+                .create_terminal(command, cwd, output_byte_limit, cx)
+                .await?;
+
+            Ok((terminal, guard))
+        })
+    }
+}
+
+/// Read the `agent.command_timeout` setting.
+pub fn configured_command_timeout(cx: &App) -> agent_settings::CommandTimeout {
+    let settings = AgentSettings::get_global(cx);
+    settings.command_timeout
+}

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -560,6 +560,7 @@ mod tests {
             message_editor_min_lines: 1,
             tool_permissions,
             show_turn_stats: false,
+            command_timeout: agent_settings::CommandTimeout::Auto,
         }
     }
 

--- a/crates/agent/src/tools/terminal_tool.rs
+++ b/crates/agent/src/tools/terminal_tool.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use crate::{
-    AgentTool, ThreadEnvironment, ToolCallEventStream, ToolInput, ToolPermissionDecision,
-    decide_permission_from_settings,
+    AgentTool, CommandQueue, ThreadEnvironment, ToolCallEventStream, ToolInput,
+    ToolPermissionDecision, configured_command_timeout, decide_permission_from_settings,
 };
 
 const COMMAND_OUTPUT_LIMIT: u64 = 16 * 1024;
@@ -89,6 +89,9 @@ impl AgentTool for TerminalTool {
         event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<Self::Output, Self::Output>> {
+        let queue = CommandQueue::try_global(cx);
+        let global_timeout = configured_command_timeout(cx);
+
         cx.spawn(async move |cx| {
             let input = input
                 .recv()
@@ -128,6 +131,15 @@ impl AgentTool for TerminalTool {
                 authorize.await.map_err(|e| e.to_string())?;
             }
 
+            // Acquire the serialization gate so only one command runs at a
+            // time. The guard is held until the child process exits (or times
+            // out / is cancelled), preventing the next queued command from
+            // starting prematurely.
+            let _command_guard = match &queue {
+                Some(queue) => Some(queue.acquire().await),
+                None => None,
+            };
+
             let terminal = self
                 .environment
                 .create_terminal(
@@ -144,7 +156,15 @@ impl AgentTool for TerminalTool {
                 acp::ToolCallContent::Terminal(acp::Terminal::new(terminal_id)),
             ]));
 
-            let timeout = input.timeout_ms.map(Duration::from_millis);
+            // The global `agent.command_timeout` setting determines precedence:
+            // - "never": override any model-provided timeout_ms and wait indefinitely.
+            // - "seconds(x)": override any model-provided timeout_ms and wait x seconds.
+            // - "auto": use the model's timeout_ms, and wait indefinitely if it isn't set.
+            let timeout = match global_timeout {
+                agent_settings::CommandTimeout::Never => None,
+                agent_settings::CommandTimeout::Seconds(s) => Some(Duration::from_secs_f64(s)),
+                agent_settings::CommandTimeout::Auto => input.timeout_ms.map(Duration::from_millis),
+            };
 
             let mut timed_out = false;
             let mut user_stopped_via_signal = false;
@@ -179,6 +199,9 @@ impl AgentTool for TerminalTool {
                     }
                 }
             };
+
+            // _command_guard is dropped here (end of scope), releasing the
+            // serialization lock so the next queued command can proceed.
 
             // Check if user stopped - we check both:
             // 1. The cancellation signal from RunningTurn::cancel (e.g. user pressed main Stop button)

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -51,6 +51,14 @@ pub struct AgentSettings {
     pub message_editor_min_lines: usize,
     pub show_turn_stats: bool,
     pub tool_permissions: ToolPermissions,
+    pub command_timeout: CommandTimeout,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CommandTimeout {
+    Seconds(f64),
+    Auto,
+    Never,
 }
 
 impl AgentSettings {
@@ -438,6 +446,13 @@ impl Settings for AgentSettings {
             message_editor_min_lines: agent.message_editor_min_lines.unwrap(),
             show_turn_stats: agent.show_turn_stats.unwrap(),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
+            command_timeout: match agent.command_timeout {
+                Some(settings::CommandTimeoutContent::Seconds(s)) => CommandTimeout::Seconds(s),
+                Some(settings::CommandTimeoutContent::Mode(
+                    settings::CommandTimeoutModeContent::Never,
+                )) => CommandTimeout::Never,
+                _ => CommandTimeout::Auto,
+            },
         }
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -287,6 +287,7 @@ pub fn init(
     cx: &mut App,
 ) {
     agent::ThreadStore::init_global(cx);
+    agent::CommandQueue::init(cx);
     assistant_text_thread::init(client, cx);
     rules_library::init(cx);
     if !is_eval {
@@ -576,6 +577,7 @@ mod tests {
             message_editor_min_lines: 1,
             tool_permissions: Default::default(),
             show_turn_stats: false,
+            command_timeout: agent_settings::CommandTimeout::Auto,
         };
 
         cx.update(|cx| {

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -122,6 +122,41 @@ pub struct AgentSettingsContent {
     /// `always_confirm`) match against the tool's text input (command, path,
     /// URL, etc.).
     pub tool_permissions: Option<ToolPermissionsContent>,
+    /// How long to wait for an agent terminal command to complete before killing it.
+    /// - `"auto"`: Use the timeout provided by the model (default)
+    /// - `"never"`: Never timeout, allow commands to run indefinitely
+    /// - `<number>`: Force a specific timeout in seconds, ignoring the model's timeout
+    ///
+    /// Default: auto
+    pub command_timeout: Option<CommandTimeoutContent>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(untagged)]
+pub enum CommandTimeoutContent {
+    /// Force a specific timeout in seconds
+    Seconds(f64),
+    /// "auto" or "never"
+    Mode(CommandTimeoutModeContent),
+}
+
+impl crate::merge_from::MergeFrom for CommandTimeoutContent {
+    fn merge_from(&mut self, other: &Self) {
+        *self = other.clone();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandTimeoutModeContent {
+    Auto,
+    Never,
+}
+
+impl crate::merge_from::MergeFrom for CommandTimeoutModeContent {
+    fn merge_from(&mut self, other: &Self) {
+        *self = *other;
+    }
 }
 
 impl AgentSettingsContent {


### PR DESCRIPTION
Currently, the TerminalTool spawns processes in a "fire-and-forget" manner. If an agent executes multiple terminal commands in quick succession, they run concurrently. Furthermore, the terminal timeouts were solely dependent on the model's output (via timeout_ms), which is often overly short or incorrect.
This PR introduces a CommandQueue acting as a single-worker serialization gate. It prevents concurrent execution of terminal commands invoked by the agent, ensuring they run strictly sequentially.
Additionally, it adds a new command_timeout setting under agent to control timeouts globally:

"auto": Rely on the timeout_ms provided by the model (default behavior).
"never": Allow commands to run indefinitely, ignoring the model's timeout.
<number>: Force a specific timeout in seconds, overriding the model's timeout.