### PR TITLE
Increase timeout for `test_random_blocks`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -42,3 +42,7 @@ slow-timeout = { period = "300s", terminate-after = 1 }
 [[profile.default.overrides]]
 filter =  'package(editor) and test(test_random_split_editor)'
 slow-timeout = { period = "300s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter =  'package(editor) and test(test_random_blocks)'
+slow-timeout = { period = "300s", terminate-after = 1 }


### PR DESCRIPTION
See https://github.com/zed-industries/zed/actions/runs/22679055818

Release Notes:

- N/A