### PR TITLE
agent: Cleanup `StreamingEditFileTool`

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1452,6 +1452,7 @@ impl Thread {
         self.add_tool(StreamingEditFileTool::new(
             self.project.clone(),
             cx.weak_entity(),
+            self.action_log.clone(),
             language_registry,
         ));
         self.add_tool(FetchTool::new(self.project.read(cx).client().http_client()));

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -1115,43 +1115,17 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_create_file(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({"dir": {}})).await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(cx, json!({"dir": {}})).await;
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Create new file".into(),
-                    path: "root/dir/new_file.txt".into(),
-                    mode: StreamingEditFileMode::Write,
-                    content: Some("Hello, World!".into()),
-                    edits: None,
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Create new file".into(),
+                        path: "root/dir/new_file.txt".into(),
+                        mode: StreamingEditFileMode::Write,
+                        content: Some("Hello, World!".into()),
+                        edits: None,
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1167,44 +1141,18 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_overwrite_file(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({"file.txt": "old content"}))
-            .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "old content"})).await;
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Overwrite file".into(),
-                    path: "root/file.txt".into(),
-                    mode: StreamingEditFileMode::Write,
-                    content: Some("new content".into()),
-                    edits: None,
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Overwrite file".into(),
+                        path: "root/file.txt".into(),
+                        mode: StreamingEditFileMode::Write,
+                        content: Some("new content".into()),
+                        edits: None,
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1223,52 +1171,21 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_granular_edits(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "line 1\nline 2\nline 3\n"})).await;
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Edit lines".into(),
-                    path: "root/file.txt".into(),
-                    mode: StreamingEditFileMode::Edit,
-                    content: None,
-                    edits: Some(vec![Edit {
-                        old_text: "line 2".into(),
-                        new_text: "modified line 2".into(),
-                    }]),
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Edit lines".into(),
+                        path: "root/file.txt".into(),
+                        mode: StreamingEditFileMode::Edit,
+                        content: None,
+                        edits: Some(vec![Edit {
+                            old_text: "line 2".into(),
+                            new_text: "modified line 2".into(),
+                        }]),
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1283,58 +1200,30 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_multiple_edits(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"
-            }),
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Edit multiple lines".into(),
-                    path: "root/file.txt".into(),
-                    mode: StreamingEditFileMode::Edit,
-                    content: None,
-                    edits: Some(vec![
-                        Edit {
-                            old_text: "line 5".into(),
-                            new_text: "modified line 5".into(),
-                        },
-                        Edit {
-                            old_text: "line 1".into(),
-                            new_text: "modified line 1".into(),
-                        },
-                    ]),
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Edit multiple lines".into(),
+                        path: "root/file.txt".into(),
+                        mode: StreamingEditFileMode::Edit,
+                        content: None,
+                        edits: Some(vec![
+                            Edit {
+                                old_text: "line 5".into(),
+                                new_text: "modified line 5".into(),
+                            },
+                            Edit {
+                                old_text: "line 1".into(),
+                                new_text: "modified line 1".into(),
+                            },
+                        ]),
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1352,58 +1241,30 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_adjacent_edits(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"
-            }),
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Edit adjacent lines".into(),
-                    path: "root/file.txt".into(),
-                    mode: StreamingEditFileMode::Edit,
-                    content: None,
-                    edits: Some(vec![
-                        Edit {
-                            old_text: "line 2".into(),
-                            new_text: "modified line 2".into(),
-                        },
-                        Edit {
-                            old_text: "line 3".into(),
-                            new_text: "modified line 3".into(),
-                        },
-                    ]),
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Edit adjacent lines".into(),
+                        path: "root/file.txt".into(),
+                        mode: StreamingEditFileMode::Edit,
+                        content: None,
+                        edits: Some(vec![
+                            Edit {
+                                old_text: "line 2".into(),
+                                new_text: "modified line 2".into(),
+                            },
+                            Edit {
+                                old_text: "line 3".into(),
+                                new_text: "modified line 3".into(),
+                            },
+                        ]),
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1421,58 +1282,30 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_ascending_order_edits(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"
-            }),
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Edit multiple lines in ascending order".into(),
-                    path: "root/file.txt".into(),
-                    mode: StreamingEditFileMode::Edit,
-                    content: None,
-                    edits: Some(vec![
-                        Edit {
-                            old_text: "line 1".into(),
-                            new_text: "modified line 1".into(),
-                        },
-                        Edit {
-                            old_text: "line 5".into(),
-                            new_text: "modified line 5".into(),
-                        },
-                    ]),
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Edit multiple lines in ascending order".into(),
+                        path: "root/file.txt".into(),
+                        mode: StreamingEditFileMode::Edit,
+                        content: None,
+                        edits: Some(vec![
+                            Edit {
+                                old_text: "line 1".into(),
+                                new_text: "modified line 1".into(),
+                            },
+                            Edit {
+                                old_text: "line 5".into(),
+                                new_text: "modified line 5".into(),
+                            },
+                        ]),
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1490,46 +1323,20 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_nonexistent_file(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({})).await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(cx, json!({})).await;
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Some edit".into(),
-                    path: "root/nonexistent_file.txt".into(),
-                    mode: StreamingEditFileMode::Edit,
-                    content: None,
-                    edits: Some(vec![Edit {
-                        old_text: "foo".into(),
-                        new_text: "bar".into(),
-                    }]),
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project,
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Some edit".into(),
+                        path: "root/nonexistent_file.txt".into(),
+                        mode: StreamingEditFileMode::Edit,
+                        content: None,
+                        edits: Some(vec![Edit {
+                            old_text: "foo".into(),
+                            new_text: "bar".into(),
+                        }]),
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1544,47 +1351,21 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_failed_match(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({"file.txt": "hello world"}))
-            .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "hello world"})).await;
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Edit file".into(),
-                    path: "root/file.txt".into(),
-                    mode: StreamingEditFileMode::Edit,
-                    content: None,
-                    edits: Some(vec![Edit {
-                        old_text: "nonexistent text that is not in the file".into(),
-                        new_text: "replacement".into(),
-                    }]),
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project,
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Edit file".into(),
+                        path: "root/file.txt".into(),
+                        mode: StreamingEditFileMode::Edit,
+                        content: None,
+                        edits: Some(vec![Edit {
+                            old_text: "nonexistent text that is not in the file".into(),
+                            new_text: "replacement".into(),
+                        }]),
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -1602,44 +1383,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_early_buffer_open(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "line 1\nline 2\nline 3\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Send partials simulating LLM streaming: description first, then path, then mode
         sender.send_partial(json!({"display_description": "Edit lines"}));
@@ -1676,44 +1424,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_path_completeness_heuristic(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "hello world"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "hello world"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Send partial with path but NO mode — path should NOT be treated as complete
         sender.send_partial(json!({
@@ -1747,45 +1462,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_cancellation_during_partials(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "hello world"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "hello world"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver, mut cancellation_tx) =
             ToolCallEventStream::test_with_cancellation();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Send a partial
         sender.send_partial(json!({"display_description": "Edit"}));
@@ -1811,44 +1493,14 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_with_multiple_partials(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"
-            }),
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Simulate fine-grained streaming of the JSON
         sender.send_partial(json!({"display_description": "Edit multiple"}));
@@ -1909,38 +1561,10 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_create_file_with_partials(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({"dir": {}})).await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(cx, json!({"dir": {}})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Stream partials for create mode
         sender.send_partial(json!({"display_description": "Create new file"}));
@@ -1978,44 +1602,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_no_partials_direct_final(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "line 1\nline 2\nline 3\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Send final immediately with no partials (simulates non-streaming path)
         sender.send_final(json!({
@@ -2034,44 +1625,14 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_incremental_edit_application(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"
-            }),
+        let (tool, project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "line 1\nline 2\nline 3\nline 4\nline 5\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Stream description, path, mode
         sender.send_partial(json!({"display_description": "Edit multiple lines"}));
@@ -2165,44 +1726,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_incremental_three_edits(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "aaa\nbbb\nccc\nddd\neee\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "aaa\nbbb\nccc\nddd\neee\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Setup: description + path + mode
         sender.send_partial(json!({
@@ -2288,44 +1816,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_failure_mid_stream(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "line 1\nline 2\nline 3\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Setup
         sender.send_partial(json!({
@@ -2402,44 +1897,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_single_edit_no_incremental(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "hello world\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "hello world\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Setup + single edit that stays in-progress (no second edit to prove completion)
         sender.send_partial(json!({
@@ -2483,45 +1945,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_input_partials_then_final(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "line 1\nline 2\nline 3\n"})).await;
         let (sender, input): (ToolInputSender, ToolInput<StreamingEditFileToolInput>) =
             ToolInput::test();
-
         let (event_stream, _event_rx) = ToolCallEventStream::test();
-        let task = cx.update(|cx| {
-            Arc::new(StreamingEditFileTool::new(
-                project.clone(),
-                thread.downgrade(),
-                thread.read(cx).action_log().clone(),
-                language_registry,
-            ))
-            .run(input, event_stream, cx)
-        });
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Send progressively more complete partial snapshots, as the LLM would
         sender.send_partial(json!({
@@ -2561,45 +1990,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_input_sender_dropped_before_final(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "hello world\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "hello world\n"})).await;
         let (sender, input): (ToolInputSender, ToolInput<StreamingEditFileToolInput>) =
             ToolInput::test();
-
         let (event_stream, _event_rx) = ToolCallEventStream::test();
-        let task = cx.update(|cx| {
-            Arc::new(StreamingEditFileTool::new(
-                project.clone(),
-                thread.downgrade(),
-                thread.read(cx).action_log().clone(),
-                language_registry,
-            ))
-            .run(input, event_stream, cx)
-        });
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Send a partial then drop the sender without sending final
         sender.send_partial(json!({
@@ -2618,42 +2014,14 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_input_recv_drains_partials(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({"dir": {}})).await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(cx, json!({"dir": {}})).await;
         // Create a channel and send multiple partials before a final, then use
         // ToolInput::resolved-style immediate delivery to confirm recv() works
         // when partials are already buffered.
         let (sender, input): (ToolInputSender, ToolInput<StreamingEditFileToolInput>) =
             ToolInput::test();
-
         let (event_stream, _event_rx) = ToolCallEventStream::test();
-        let task = cx.update(|cx| {
-            Arc::new(StreamingEditFileTool::new(
-                project.clone(),
-                thread.downgrade(),
-                thread.read(cx).action_log().clone(),
-                language_registry,
-            ))
-            .run(input, event_stream, cx)
-        });
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Buffer several partials before sending the final
         sender.send_partial(json!({"display_description": "Create"}));
@@ -2767,8 +2135,8 @@ mod tests {
 
         let fs = project::FakeFs::new(cx.executor());
         fs.insert_tree("/root", json!({"src": {}})).await;
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+        let (tool, project, action_log, fs, thread) =
+            setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await;
 
         let rust_language = Arc::new(language::Language::new(
             language::LanguageConfig {
@@ -2817,9 +2185,10 @@ mod tests {
             project.register_buffer_with_language_servers(&buffer, cx)
         });
 
-        const UNFORMATTED_CONTENT: &str = "fn main() {println!(\"Hello!\");}\n";
-        const FORMATTED_CONTENT: &str =
-            "This file was formatted by the fake formatter in the test.\n";
+        const UNFORMATTED_CONTENT: &str = "fn main() {println!(\"Hello!\");}\
+";
+        const FORMATTED_CONTENT: &str = "This file was formatted by the fake formatter in the test.\
+";
 
         // Get the fake language server and set up formatting handler
         let fake_language_server = fake_language_servers.next().await.unwrap();
@@ -2830,20 +2199,6 @@ mod tests {
                     new_text: FORMATTED_CONTENT.to_string(),
                 }]))
             }
-        });
-
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
         });
 
         // Test with format_on_save enabled
@@ -2861,15 +2216,7 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry.clone(),
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         sender.send_partial(json!({
             "display_description": "Create main function",
@@ -2920,15 +2267,14 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
+        let tool2 = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
-            action_log,
+            action_log.clone(),
             language_registry,
         ));
 
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool2.run(input, event_stream, cx));
 
         sender.send_partial(json!({
             "display_description": "Update main function",
@@ -2963,7 +2309,6 @@ mod tests {
 
         let fs = project::FakeFs::new(cx.executor());
         fs.insert_tree("/root", json!({"src": {}})).await;
-
         fs.save(
             path!("/root/src/main.rs").as_ref(),
             &"initial content".into(),
@@ -2971,22 +2316,9 @@ mod tests {
         )
         .await
         .unwrap();
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
+        let (tool, project, action_log, fs, thread) =
+            setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await;
+        let language_registry = project.read_with(cx, |p, _cx| p.languages().clone());
 
         // Test with remove_trailing_whitespace_on_save enabled
         cx.update(|cx| {
@@ -3006,21 +2338,14 @@ mod tests {
 
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Create main function".into(),
-                    path: "root/src/main.rs".into(),
-                    mode: StreamingEditFileMode::Write,
-                    content: Some(CONTENT_WITH_TRAILING_WHITESPACE.into()),
-                    edits: None,
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry.clone(),
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool.clone().run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Create main function".into(),
+                        path: "root/src/main.rs".into(),
+                        mode: StreamingEditFileMode::Write,
+                        content: Some(CONTENT_WITH_TRAILING_WHITESPACE.into()),
+                        edits: None,
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -3052,23 +2377,23 @@ mod tests {
             });
         });
 
+        let tool2 = Arc::new(StreamingEditFileTool::new(
+            project.clone(),
+            thread.downgrade(),
+            action_log.clone(),
+            language_registry,
+        ));
+
         let result = cx
             .update(|cx| {
-                let input = StreamingEditFileToolInput {
-                    display_description: "Update main function".into(),
-                    path: "root/src/main.rs".into(),
-                    mode: StreamingEditFileMode::Write,
-                    content: Some(CONTENT_WITH_TRAILING_WHITESPACE.into()),
-                    edits: None,
-                };
-                Arc::new(StreamingEditFileTool::new(
-                    project.clone(),
-                    thread.downgrade(),
-                    thread.read(cx).action_log().clone(),
-                    language_registry,
-                ))
-                .run(
-                    ToolInput::resolved(input),
+                tool2.run(
+                    ToolInput::resolved(StreamingEditFileToolInput {
+                        display_description: "Update main function".into(),
+                        path: "root/src/main.rs".into(),
+                        mode: StreamingEditFileMode::Write,
+                        content: Some(CONTENT_WITH_TRAILING_WHITESPACE.into()),
+                        edits: None,
+                    }),
                     ToolCallEventStream::test().0,
                     cx,
                 )
@@ -3088,31 +2413,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_authorize(cx: &mut TestAppContext) {
-        init_test(cx);
-        let fs = project::FakeFs::new(cx.executor());
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-        fs.insert_tree("/root", json!({})).await;
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(cx, json!({})).await;
 
         // Test 1: Path with .zed component should require confirmation
         let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
@@ -3233,29 +2534,8 @@ mod tests {
         fs.insert_tree("/outside", json!({})).await;
         fs.insert_symlink("/root/link", PathBuf::from("/outside"))
             .await;
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project,
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await;
 
         cx.update(|cx| {
             let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
@@ -3318,31 +2598,8 @@ mod tests {
         )
         .await
         .unwrap();
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        cx.executor().run_until_parked();
-
-        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await;
 
         let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
         let _authorize_task = cx.update(|cx| {
@@ -3387,31 +2644,8 @@ mod tests {
         )
         .await
         .unwrap();
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        cx.executor().run_until_parked();
-
-        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await;
 
         let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
         let authorize_task = cx.update(|cx| {
@@ -3466,31 +2700,8 @@ mod tests {
         )
         .await
         .unwrap();
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        cx.executor().run_until_parked();
-
-        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await;
 
         let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
         let result = cx
@@ -3519,28 +2730,8 @@ mod tests {
         init_test(cx);
         let fs = project::FakeFs::new(cx.executor());
         fs.insert_tree("/project", json!({})).await;
-        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/project").as_ref()]).await;
 
         let test_cases = vec![
             (
@@ -3583,7 +2774,6 @@ mod tests {
     async fn test_streaming_needs_confirmation_with_multiple_worktrees(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = project::FakeFs::new(cx.executor());
-
         fs.insert_tree(
             "/workspace/frontend",
             json!({
@@ -3611,38 +2801,16 @@ mod tests {
             }),
         )
         .await;
-
-        let project = Project::test(
-            fs.clone(),
-            [
+        let (tool, _project, _action_log, _fs, _thread) = setup_test_with_fs(
+            cx,
+            fs,
+            &[
                 path!("/workspace/frontend").as_ref(),
                 path!("/workspace/backend").as_ref(),
                 path!("/workspace/shared").as_ref(),
             ],
-            cx,
         )
         .await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry.clone(),
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
 
         let test_cases = vec![
             ("frontend/src/main.js", false, "File in first worktree"),
@@ -3697,28 +2865,8 @@ mod tests {
             }),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry.clone(),
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/project").as_ref()]).await;
 
         let test_cases = vec![
             ("", false, "Empty path is treated as project root"),
@@ -3774,28 +2922,8 @@ mod tests {
             }),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry.clone(),
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/project").as_ref()]).await;
 
         let modes = vec![StreamingEditFileMode::Edit, StreamingEditFileMode::Write];
 
@@ -3846,28 +2974,9 @@ mod tests {
     async fn test_streaming_initial_title_with_partial_input(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = project::FakeFs::new(cx.executor());
-        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project,
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
+        fs.insert_tree("/project", json!({})).await;
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test_with_fs(cx, fs, &[path!("/project").as_ref()]).await;
 
         cx.update(|cx| {
             assert_eq!(
@@ -3922,35 +3031,15 @@ mod tests {
         init_test(cx);
         let fs = project::FakeFs::new(cx.executor());
         fs.insert_tree("/", json!({"main.rs": ""})).await;
+        let (tool, project, action_log, _fs, thread) =
+            setup_test_with_fs(cx, fs, &[path!("/").as_ref()]).await;
+        let language_registry = project.read_with(cx, |p, _cx| p.languages().clone());
 
-        let project = Project::test(fs.clone(), [path!("/").as_ref()], cx).await;
-        let languages = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry.clone(),
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         // Ensure the diff is finalized after the edit completes.
         {
-            let tool = Arc::new(StreamingEditFileTool::new(
-                project.clone(),
-                thread.downgrade(),
-                action_log.clone(),
-                languages.clone(),
-            ));
             let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
             let edit = cx.update(|cx| {
-                tool.run(
+                tool.clone().run(
                     ToolInput::resolved(StreamingEditFileToolInput {
                         display_description: "Edit file".into(),
                         path: path!("/main.rs").into(),
@@ -3976,7 +3065,7 @@ mod tests {
                 project.clone(),
                 thread.downgrade(),
                 action_log,
-                languages.clone(),
+                language_registry,
             ));
             let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
             let edit = cx.update(|cx| {
@@ -4003,43 +3092,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_consecutive_edits_work(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "test.txt": "original content"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let languages = project.read_with(cx, |project, _| project.languages().clone());
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-
+        let (tool, project, action_log, _fs, _thread) =
+            setup_test(cx, json!({"test.txt": "original content"})).await;
         let read_tool = Arc::new(crate::ReadFileTool::new(
             project.clone(),
             action_log.clone(),
             true,
-        ));
-        let edit_tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            languages,
         ));
 
         // Read the file first
@@ -4060,7 +3118,7 @@ mod tests {
         // First edit should work
         let edit_result = cx
             .update(|cx| {
-                edit_tool.clone().run(
+                tool.clone().run(
                     ToolInput::resolved(StreamingEditFileToolInput {
                         display_description: "First edit".into(),
                         path: "root/test.txt".into(),
@@ -4085,7 +3143,7 @@ mod tests {
         // Second edit should also work because the edit updated the recorded read time
         let edit_result = cx
             .update(|cx| {
-                edit_tool.clone().run(
+                tool.clone().run(
                     ToolInput::resolved(StreamingEditFileToolInput {
                         display_description: "Second edit".into(),
                         path: "root/test.txt".into(),
@@ -4110,43 +3168,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_external_modification_detected(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "test.txt": "original content"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let languages = project.read_with(cx, |project, _| project.languages().clone());
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-
+        let (tool, project, action_log, fs, _thread) =
+            setup_test(cx, json!({"test.txt": "original content"})).await;
         let read_tool = Arc::new(crate::ReadFileTool::new(
             project.clone(),
             action_log.clone(),
             true,
-        ));
-        let edit_tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            languages,
         ));
 
         // Read the file first
@@ -4195,7 +3222,7 @@ mod tests {
         // Try to edit - should fail because file was modified externally
         let result = cx
             .update(|cx| {
-                edit_tool.clone().run(
+                tool.clone().run(
                     ToolInput::resolved(StreamingEditFileToolInput {
                         display_description: "Edit after external change".into(),
                         path: "root/test.txt".into(),
@@ -4224,43 +3251,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_dirty_buffer_detected(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "test.txt": "original content"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model.clone()),
-                cx,
-            )
-        });
-        let languages = project.read_with(cx, |project, _| project.languages().clone());
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-
+        let (tool, project, action_log, _fs, _thread) =
+            setup_test(cx, json!({"test.txt": "original content"})).await;
         let read_tool = Arc::new(crate::ReadFileTool::new(
             project.clone(),
             action_log.clone(),
             true,
-        ));
-        let edit_tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            languages,
         ));
 
         // Read the file first
@@ -4300,7 +3296,7 @@ mod tests {
         // Try to edit - should fail because buffer has unsaved changes
         let result = cx
             .update(|cx| {
-                edit_tool.clone().run(
+                tool.clone().run(
                     ToolInput::resolved(StreamingEditFileToolInput {
                         display_description: "Edit with dirty buffer".into(),
                         path: "root/test.txt".into(),
@@ -4339,48 +3335,15 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_overlapping_edits_resolved_sequentially(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
         // Edit 1's replacement introduces text that contains edit 2's
         // old_text as a substring. Because edits resolve sequentially
         // against the current buffer, edit 2 finds a unique match in
         // the modified buffer and succeeds.
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "aaa\nbbb\nccc\nddd\neee\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "aaa\nbbb\nccc\nddd\neee\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Setup: resolve the buffer
         sender.send_partial(json!({
@@ -4428,38 +3391,10 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_create_content_streamed(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({"dir": {}})).await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, project, _action_log, _fs, _thread) = setup_test(cx, json!({"dir": {}})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Transition to BufferResolved
         sender.send_partial(json!({
@@ -4527,44 +3462,14 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_overwrite_diff_revealed_during_streaming(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "old line 1\nold line 2\nold line 3\n"
-            }),
+        let (tool, _project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "old line 1\nold line 2\nold line 3\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, mut receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Transition to BufferResolved
         sender.send_partial(json!({
@@ -4622,44 +3527,14 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_overwrite_content_streamed(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "old line 1\nold line 2\nold line 3\n"
-            }),
+        let (tool, project, _action_log, _fs, _thread) = setup_test(
+            cx,
+            json!({"file.txt": "old line 1\nold line 2\nold line 3\n"}),
         )
         .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         // Transition to BufferResolved
         sender.send_partial(json!({
@@ -4723,44 +3598,11 @@ mod tests {
 
     #[gpui::test]
     async fn test_streaming_edit_json_fixer_escape_corruption(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/root",
-            json!({
-                "file.txt": "hello\nworld\nfoo\n"
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let model = Arc::new(FakeLanguageModel::default());
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                Some(model),
-                cx,
-            )
-        });
-
+        let (tool, _project, _action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "hello\nworld\nfoo\n"})).await;
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
-
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log,
-            language_registry,
-        ));
-
-        let task = cx.update(|cx| tool.run(input, event_stream, cx));
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
 
         sender.send_partial(json!({
             "display_description": "Edit",
@@ -4810,48 +3652,17 @@ mod tests {
     // reports changed buffers so that the Accept All / Reject All review UI appears.
     #[gpui::test]
     async fn test_streaming_edit_file_tool_registers_changed_buffers(cx: &mut TestAppContext) {
-        init_test(cx);
+        let (tool, _project, action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "line 1\nline 2\nline 3\n"})).await;
         cx.update(|cx| {
             let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
             settings.tool_permissions.default = settings::ToolPermissionMode::Allow;
             agent_settings::AgentSettings::override_global(settings, cx);
         });
 
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            path!("/root"),
-            json!({
-                "file.txt": "line 1\nline 2\nline 3\n"
-            }),
-        )
-        .await;
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                None,
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log.clone(),
-            language_registry,
-        ));
         let (event_stream, _rx) = ToolCallEventStream::test();
-
         let task = cx.update(|cx| {
-            tool.run(
+            tool.clone().run(
                 ToolInput::resolved(StreamingEditFileToolInput {
                     display_description: "Edit lines".to_string(),
                     path: "root/file.txt".into(),
@@ -4875,7 +3686,7 @@ mod tests {
         let changed = action_log.read_with(cx, |log, cx| log.changed_buffers(cx));
         assert!(
             !changed.is_empty(),
-            "action_log.changed_buffers() should be non-empty after streaming edit, \
+            "action_log.changed_buffers() should be non-empty after streaming edit,
              but no changed buffers were found \u{2014} Accept All / Reject All will not appear"
         );
     }
@@ -4885,48 +3696,17 @@ mod tests {
     async fn test_streaming_edit_file_tool_write_mode_registers_changed_buffers(
         cx: &mut TestAppContext,
     ) {
-        init_test(cx);
+        let (tool, _project, action_log, _fs, _thread) =
+            setup_test(cx, json!({"file.txt": "original content"})).await;
         cx.update(|cx| {
             let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
             settings.tool_permissions.default = settings::ToolPermissionMode::Allow;
             agent_settings::AgentSettings::override_global(settings, cx);
         });
 
-        let fs = project::FakeFs::new(cx.executor());
-        fs.insert_tree(
-            path!("/root"),
-            json!({
-                "file.txt": "original content"
-            }),
-        )
-        .await;
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
-        let context_server_registry =
-            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-        let thread = cx.new(|cx| {
-            crate::Thread::new(
-                project.clone(),
-                cx.new(|_cx| ProjectContext::default()),
-                context_server_registry,
-                Templates::new(),
-                None,
-                cx,
-            )
-        });
-        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
-
-        let tool = Arc::new(StreamingEditFileTool::new(
-            project.clone(),
-            thread.downgrade(),
-            action_log.clone(),
-            language_registry,
-        ));
         let (event_stream, _rx) = ToolCallEventStream::test();
-
         let task = cx.update(|cx| {
-            tool.run(
+            tool.clone().run(
                 ToolInput::resolved(StreamingEditFileToolInput {
                     display_description: "Overwrite file".to_string(),
                     path: "root/file.txt".into(),
@@ -4950,6 +3730,58 @@ mod tests {
             "action_log.changed_buffers() should be non-empty after streaming write, \
              but no changed buffers were found \u{2014} Accept All / Reject All will not appear"
         );
+    }
+
+    async fn setup_test_with_fs(
+        cx: &mut TestAppContext,
+        fs: Arc<project::FakeFs>,
+        worktree_paths: &[&std::path::Path],
+    ) -> (
+        Arc<StreamingEditFileTool>,
+        Entity<Project>,
+        Entity<ActionLog>,
+        Arc<project::FakeFs>,
+        Entity<Thread>,
+    ) {
+        let project = Project::test(fs.clone(), worktree_paths.iter().copied(), cx).await;
+        let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            crate::Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
+        let tool = Arc::new(StreamingEditFileTool::new(
+            project.clone(),
+            thread.downgrade(),
+            action_log.clone(),
+            language_registry,
+        ));
+        (tool, project, action_log, fs, thread)
+    }
+
+    async fn setup_test(
+        cx: &mut TestAppContext,
+        initial_tree: serde_json::Value,
+    ) -> (
+        Arc<StreamingEditFileTool>,
+        Entity<Project>,
+        Entity<ActionLog>,
+        Arc<project::FakeFs>,
+        Entity<Thread>,
+    ) {
+        init_test(cx);
+        let fs = project::FakeFs::new(cx.executor());
+        fs.insert_tree("/root", initial_tree).await;
+        setup_test_with_fs(cx, fs, &[path!("/root").as_ref()]).await
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -2120,7 +2120,7 @@ mod tests {
         .await;
         let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
 
-        cx.update(|cx| resolve_path(mode.clone(), &PathBuf::from(path), &project, cx))
+        cx.update(|cx| resolve_path(*mode, &PathBuf::from(path), &project, cx))
     }
 
     #[track_caller]

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -677,18 +677,18 @@ impl EditSession {
         for event in events {
             match event {
                 ToolEditEvent::ContentChunk { chunk } => {
-                    let (buffer_id, insert_at) = self.buffer.read_with(cx, |buffer, _cx| {
-                        let insert_at = if !self.pipeline.content_written && buffer.len() > 0 {
-                            0..buffer.len()
-                        } else {
-                            let len = buffer.len();
-                            len..len
-                        };
-                        (buffer.remote_id(), insert_at)
-                    });
+                    let (buffer_id, buffer_len) = self
+                        .buffer
+                        .read_with(cx, |buffer, _cx| (buffer.remote_id(), buffer.len()));
+                    let edit_range = if self.pipeline.content_written {
+                        buffer_len..buffer_len
+                    } else {
+                        0..buffer_len
+                    };
+
                     agent_edit_buffer(
                         &self.buffer,
-                        [(insert_at, chunk.as_str())],
+                        [(edit_range, chunk.as_str())],
                         &tool.action_log,
                         cx,
                     );
@@ -824,7 +824,7 @@ impl EditSession {
                     }
 
                     let char_ops = streaming_diff.push_new(&reindented);
-                    Self::apply_char_operations(
+                    apply_char_operations(
                         &char_ops,
                         &self.buffer,
                         original_snapshot,
@@ -867,7 +867,7 @@ impl EditSession {
 
                     if !final_text.is_empty() {
                         let char_ops = streaming_diff.push_new(&final_text);
-                        Self::apply_char_operations(
+                        apply_char_operations(
                             &char_ops,
                             &self.buffer,
                             &original_snapshot,
@@ -878,7 +878,7 @@ impl EditSession {
                     }
 
                     let remaining_ops = streaming_diff.finish();
-                    Self::apply_char_operations(
+                    apply_char_operations(
                         &remaining_ops,
                         &self.buffer,
                         &original_snapshot,
@@ -896,30 +896,30 @@ impl EditSession {
         }
         Ok(())
     }
+}
 
-    fn apply_char_operations(
-        ops: &[CharOperation],
-        buffer: &Entity<Buffer>,
-        snapshot: &text::BufferSnapshot,
-        edit_cursor: &mut usize,
-        action_log: &Entity<ActionLog>,
-        cx: &mut AsyncApp,
-    ) {
-        for op in ops {
-            match op {
-                CharOperation::Insert { text } => {
-                    let anchor = snapshot.anchor_after(*edit_cursor);
-                    agent_edit_buffer(&buffer, [(anchor..anchor, text.as_str())], action_log, cx);
-                }
-                CharOperation::Delete { bytes } => {
-                    let delete_end = *edit_cursor + bytes;
-                    let anchor_range = snapshot.anchor_range_around(*edit_cursor..delete_end);
-                    agent_edit_buffer(&buffer, [(anchor_range, "")], action_log, cx);
-                    *edit_cursor = delete_end;
-                }
-                CharOperation::Keep { bytes } => {
-                    *edit_cursor += bytes;
-                }
+fn apply_char_operations(
+    ops: &[CharOperation],
+    buffer: &Entity<Buffer>,
+    snapshot: &text::BufferSnapshot,
+    edit_cursor: &mut usize,
+    action_log: &Entity<ActionLog>,
+    cx: &mut AsyncApp,
+) {
+    for op in ops {
+        match op {
+            CharOperation::Insert { text } => {
+                let anchor = snapshot.anchor_after(*edit_cursor);
+                agent_edit_buffer(&buffer, [(anchor..anchor, text.as_str())], action_log, cx);
+            }
+            CharOperation::Delete { bytes } => {
+                let delete_end = *edit_cursor + bytes;
+                let anchor_range = snapshot.anchor_range_around(*edit_cursor..delete_end);
+                agent_edit_buffer(&buffer, [(anchor_range, "")], action_log, cx);
+                *edit_cursor = delete_end;
+            }
+            CharOperation::Keep { bytes } => {
+                *edit_cursor += bytes;
             }
         }
     }

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -758,19 +758,18 @@ impl EditSession {
 
                     if let EditPipelineEntry::ResolvingOldText { matcher } =
                         &mut pipeline.edits[*edit_index]
+                        && !chunk.is_empty()
                     {
-                        if !chunk.is_empty() {
-                            if let Some(match_range) = matcher.push(chunk, None) {
-                                let anchor_range = buffer.read_with(cx, |buffer, _cx| {
-                                    buffer.anchor_range_between(match_range.clone())
-                                });
-                                diff.update(cx, |diff, cx| diff.reveal_range(anchor_range, cx));
+                        if let Some(match_range) = matcher.push(chunk, None) {
+                            let anchor_range = buffer.read_with(cx, |buffer, _cx| {
+                                buffer.anchor_range_between(match_range.clone())
+                            });
+                            diff.update(cx, |diff, cx| diff.reveal_range(anchor_range, cx));
 
-                                cx.update(|cx| {
-                                    let position = buffer.read(cx).anchor_before(match_range.end);
-                                    tool.set_agent_location(buffer.downgrade(), position, cx);
-                                });
-                            }
+                            cx.update(|cx| {
+                                let position = buffer.read(cx).anchor_before(match_range.end);
+                                tool.set_agent_location(buffer.downgrade(), position, cx);
+                            });
                         }
                     }
                 }
@@ -791,32 +790,7 @@ impl EditSession {
                     if !chunk.is_empty() {
                         matcher.push(chunk, None);
                     }
-                    let matches = matcher.finish();
-
-                    if matches.is_empty() {
-                        return Err(StreamingEditFileToolOutput::error(format!(
-                            "Could not find matching text for edit at index {}. \
-                                 The old_text did not match any content in the file. \
-                                 Please read the file again to get the current content.",
-                            edit_index,
-                        )));
-                    }
-                    if matches.len() > 1 {
-                        let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
-                        let lines = matches
-                            .iter()
-                            .map(|r| (snapshot.offset_to_point(r.start).row + 1).to_string())
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        return Err(StreamingEditFileToolOutput::error(format!(
-                            "Edit {} matched multiple locations in the file at lines: {}. \
-                                 Please provide more context in old_text to uniquely \
-                                 identify the location.",
-                            edit_index, lines
-                        )));
-                    }
-
-                    let range = matches.into_iter().next().expect("checked len above");
+                    let range = extract_match(matcher.finish(), buffer, edit_index, cx)?;
 
                     let anchor_range = buffer
                         .read_with(cx, |buffer, _cx| buffer.anchor_range_between(range.clone()));
@@ -979,6 +953,37 @@ impl EditSession {
                     *edit_cursor += bytes;
                 }
             }
+        }
+    }
+}
+
+fn extract_match(
+    matches: Vec<Range<usize>>,
+    buffer: &Entity<Buffer>,
+    edit_index: &usize,
+    cx: &mut AsyncApp,
+) -> Result<Range<usize>, StreamingEditFileToolOutput> {
+    match matches.len() {
+        0 => Err(StreamingEditFileToolOutput::error(format!(
+            "Could not find matching text for edit at index {}. \
+                The old_text did not match any content in the file. \
+                Please read the file again to get the current content.",
+            edit_index,
+        ))),
+        1 => Ok(matches.into_iter().next().unwrap()),
+        _ => {
+            let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
+            let lines = matches
+                .iter()
+                .map(|r| (snapshot.offset_to_point(r.start).row + 1).to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(StreamingEditFileToolOutput::error(format!(
+                "Edit {} matched multiple locations in the file at lines: {}. \
+                    Please provide more context in old_text to uniquely \
+                    identify the location.",
+                edit_index, lines
+            )))
         }
     }
 }

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -322,21 +322,29 @@ impl AgentTool for StreamingEditFileTool {
                                     ..
                                 } = &parsed
                             {
-                                    state = Some(
-                                        EditSession::new(
-                                            &PathBuf::from(path),
-                                            display_description,
-                                            *mode,
-                                            &self,
-                                            &event_stream,
-                                            cx,
-                                        )
-                                        .await?,
-                                    );
+                                match EditSession::new(
+                                    &PathBuf::from(path),
+                                    display_description,
+                                    *mode,
+                                    &self,
+                                    &event_stream,
+                                    cx,
+                                )
+                                .await
+                                {
+                                    Ok(session) => state = Some(session),
+                                    Err(e) => {
+                                        log::error!("Failed to create edit session: {}", e);
+                                        return Err(e);
+                                    }
+                                }
                             }
 
                             if let Some(state) = &mut state {
-                                state.process(parsed, &self, &event_stream, cx)?;
+                                if let Err(e) = state.process(parsed, &self, &event_stream, cx) {
+                                    log::error!("Failed to process edit: {}", e);
+                                    return Err(e);
+                                }
                             }
                         }
                     }
@@ -349,12 +357,16 @@ impl AgentTool for StreamingEditFileTool {
                 input
                     .recv()
                     .await
-                    .map_err(|e| StreamingEditFileToolOutput::error(format!("Failed to receive tool input: {e}")))?;
+                    .map_err(|e| {
+                        let err = StreamingEditFileToolOutput::error(format!("Failed to receive tool input: {e}"));
+                        log::error!("Failed to receive tool input: {e}");
+                        err
+                    })?;
 
             let mut state = if let Some(state) = state {
                 state
             } else {
-                EditSession::new(
+                match EditSession::new(
                     &full_input.path,
                     &full_input.display_description,
                     full_input.mode.clone(),
@@ -362,9 +374,22 @@ impl AgentTool for StreamingEditFileTool {
                     &event_stream,
                     cx,
                 )
-                .await?
+                .await
+                {
+                    Ok(session) => session,
+                    Err(e) => {
+                        log::error!("Failed to create edit session: {}", e);
+                        return Err(e);
+                    }
+                }
             };
-            state.finalize(full_input, &self, &event_stream, cx).await
+            match state.finalize(full_input, &self, &event_stream, cx).await {
+                Ok(output) => Ok(output),
+                Err(e) => {
+                    log::error!("Failed to finalize edit: {}", e);
+                    Err(e)
+                }
+            }
         })
     }
 

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -73,7 +73,7 @@ pub struct StreamingEditFileToolInput {
     /// <example>
     /// `frontend/db.js`
     /// </example>
-    pub path: String,
+    pub path: PathBuf,
 
     /// The mode of operation on the file. Possible values:
     /// - 'write': Replace the entire contents of the file. If the file doesn't exist, it will be created. Requires 'content' field.
@@ -93,7 +93,7 @@ pub struct StreamingEditFileToolInput {
     pub edits: Option<Vec<Edit>>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamingEditFileMode {
     /// Overwrite the file with new content (replacing any existing content).
@@ -264,11 +264,11 @@ impl AgentTool for StreamingEditFileTool {
                         .read(cx)
                         .short_full_path_for_project_path(&project_path, cx)
                 })
-                .unwrap_or(input.path)
+                .unwrap_or(input.path.to_string_lossy().into_owned())
                 .into(),
             Err(raw_input) => {
-                if let Some(input) =
-                    serde_json::from_value::<StreamingEditFileToolPartialInput>(raw_input).ok()
+                if let Ok(input) =
+                    serde_json::from_value::<StreamingEditFileToolPartialInput>(raw_input)
                 {
                     let path = input.path.unwrap_or_default();
                     let path = path.trim();
@@ -311,14 +311,19 @@ impl AgentTool for StreamingEditFileTool {
                     partial = input.recv_partial().fuse() => {
                         let Some(partial_value) = partial else { break };
                         if let Ok(parsed) = serde_json::from_value::<StreamingEditFileToolPartialInput>(partial_value) {
-                            if state.is_none() && let Some(path_str) = &parsed.path
-                                && let Some(display_description) = &parsed.display_description
-                                && let Some(mode) = parsed.mode.clone() {
+                            if state.is_none()
+                                && let StreamingEditFileToolPartialInput {
+                                    path: Some(path),
+                                    display_description: Some(display_description),
+                                    mode: Some(mode),
+                                    ..
+                                } = &parsed
+                            {
                                     state = Some(
                                         EditSession::new(
-                                            path_str,
+                                            &PathBuf::from(path),
                                             display_description,
-                                            mode,
+                                            *mode,
                                             &self,
                                             &event_stream,
                                             cx,
@@ -442,7 +447,6 @@ impl EditPipeline {
     }
 }
 
-/// Compute the `LineIndent` of the first line in a set of query lines.
 fn query_first_line_indent(query_lines: &[String]) -> text::LineIndent {
     let first_line = query_lines.first().map(|s| s.as_str()).unwrap_or("");
     text::LineIndent::from_iter(first_line.chars())
@@ -450,14 +454,13 @@ fn query_first_line_indent(query_lines: &[String]) -> text::LineIndent {
 
 impl EditSession {
     async fn new(
-        path_str: &str,
+        path: &PathBuf,
         display_description: &str,
         mode: StreamingEditFileMode,
         tool: &StreamingEditFileTool,
         event_stream: &ToolCallEventStream,
         cx: &mut AsyncApp,
     ) -> Result<Self, StreamingEditFileToolOutput> {
-        let path = PathBuf::from(path_str);
         let project_path = cx
             .update(|cx| resolve_path(mode.clone(), &path, &tool.project, cx))
             .map_err(|e| StreamingEditFileToolOutput::error(e.to_string()))?;
@@ -465,7 +468,8 @@ impl EditSession {
         let Some(abs_path) = cx.update(|cx| tool.project.read(cx).absolute_path(&project_path, cx))
         else {
             return Err(StreamingEditFileToolOutput::error(format!(
-                "Worktree at '{path_str}' does not exist"
+                "Worktree at '{}' does not exist",
+                path.to_string_lossy()
             )));
         };
 

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -369,7 +369,7 @@ impl AgentTool for StreamingEditFileTool {
                 match EditSession::new(
                     &full_input.path,
                     &full_input.display_description,
-                    full_input.mode.clone(),
+                    full_input.mode,
                     &self,
                     &event_stream,
                     cx,
@@ -485,7 +485,7 @@ impl EditSession {
         cx: &mut AsyncApp,
     ) -> Result<Self, StreamingEditFileToolOutput> {
         let project_path = cx
-            .update(|cx| resolve_path(mode.clone(), &path, &tool.project, cx))
+            .update(|cx| resolve_path(mode, &path, &tool.project, cx))
             .map_err(|e| StreamingEditFileToolOutput::error(e.to_string()))?;
 
         let Some(abs_path) = cx.update(|cx| tool.project.read(cx).absolute_path(&project_path, cx))
@@ -635,7 +635,7 @@ impl EditSession {
             .await;
 
         let output = StreamingEditFileToolOutput::Success {
-            input_path: PathBuf::from(input.path),
+            input_path: input.path,
             new_text,
             old_text: old_text.clone(),
             diff: unified_diff,

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -535,15 +535,7 @@ impl EditSession {
         event_stream: &ToolCallEventStream,
         cx: &mut AsyncApp,
     ) -> Result<StreamingEditFileToolOutput, StreamingEditFileToolOutput> {
-        let Self {
-            buffer,
-            old_text,
-            diff,
-            abs_path,
-            parser,
-            pipeline,
-            ..
-        } = self;
+        let old_text = self.old_text.clone();
 
         let action_log = tool
             .thread
@@ -552,52 +544,27 @@ impl EditSession {
 
         match input.mode {
             StreamingEditFileMode::Write => {
-                action_log.update(cx, |log, cx| {
-                    log.buffer_created(buffer.clone(), cx);
-                });
                 let content = input.content.ok_or_else(|| {
                     StreamingEditFileToolOutput::error("'content' field is required for write mode")
                 })?;
 
-                let events = parser.finalize_content(&content);
-                Self::process_events(
-                    &events,
-                    buffer,
-                    diff,
-                    pipeline,
-                    abs_path,
-                    tool,
-                    event_stream,
-                    cx,
-                )?;
+                let events = self.parser.finalize_content(&content);
+                self.process_events(&events, tool, event_stream, cx)?;
+
+                action_log.update(cx, |log, cx| {
+                    log.buffer_created(self.buffer.clone(), cx);
+                });
             }
             StreamingEditFileMode::Edit => {
                 let edits = input.edits.ok_or_else(|| {
                     StreamingEditFileToolOutput::error("'edits' field is required for edit mode")
                 })?;
-
-                let final_edits = edits
-                    .into_iter()
-                    .map(|e| Edit {
-                        old_text: e.old_text,
-                        new_text: e.new_text,
-                    })
-                    .collect::<Vec<_>>();
-                let events = parser.finalize_edits(&final_edits);
-                Self::process_events(
-                    &events,
-                    buffer,
-                    diff,
-                    pipeline,
-                    abs_path,
-                    tool,
-                    event_stream,
-                    cx,
-                )?;
+                let events = self.parser.finalize_edits(&edits);
+                self.process_events(&events, tool, event_stream, cx)?;
             }
         }
 
-        let format_on_save_enabled = buffer.read_with(cx, |buffer, cx| {
+        let format_on_save_enabled = self.buffer.read_with(cx, |buffer, cx| {
             let settings = language_settings::language_settings(
                 buffer.language().map(|l| l.name()),
                 buffer.file(),
@@ -608,12 +575,12 @@ impl EditSession {
 
         if format_on_save_enabled {
             action_log.update(cx, |log, cx| {
-                log.buffer_edited(buffer.clone(), cx);
+                log.buffer_edited(self.buffer.clone(), cx);
             });
 
             let format_task = tool.project.update(cx, |project, cx| {
                 project.format(
-                    HashSet::from_iter([buffer.clone()]),
+                    HashSet::from_iter([self.buffer.clone()]),
                     LspFormatTarget::Buffers,
                     false,
                     FormatTrigger::Save,
@@ -628,9 +595,9 @@ impl EditSession {
             };
         }
 
-        let save_task = tool
-            .project
-            .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx));
+        let save_task = tool.project.update(cx, |project, cx| {
+            project.save_buffer(self.buffer.clone(), cx)
+        });
         futures::select! {
             result = save_task.fuse() => { result.map_err(|e| StreamingEditFileToolOutput::error(e.to_string()))?; },
             _ = event_stream.cancelled_by_user().fuse() => {
@@ -639,10 +606,10 @@ impl EditSession {
         };
 
         action_log.update(cx, |log, cx| {
-            log.buffer_edited(buffer.clone(), cx);
+            log.buffer_edited(self.buffer.clone(), cx);
         });
 
-        let new_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
+        let new_snapshot = self.buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
         let (new_text, unified_diff) = cx
             .background_spawn({
                 let new_snapshot = new_snapshot.clone();
@@ -675,31 +642,13 @@ impl EditSession {
             StreamingEditFileMode::Write => {
                 if let Some(content) = &partial.content {
                     let events = self.parser.push_content(content);
-                    Self::process_events(
-                        &events,
-                        &self.buffer,
-                        &self.diff,
-                        &mut self.pipeline,
-                        &self.abs_path,
-                        tool,
-                        event_stream,
-                        cx,
-                    )?;
+                    self.process_events(&events, tool, event_stream, cx)?;
                 }
             }
             StreamingEditFileMode::Edit => {
                 if let Some(edits) = partial.edits {
                     let events = self.parser.push_edits(&edits);
-                    Self::process_events(
-                        &events,
-                        &self.buffer,
-                        &self.diff,
-                        &mut self.pipeline,
-                        &self.abs_path,
-                        tool,
-                        event_stream,
-                        cx,
-                    )?;
+                    self.process_events(&events, tool, event_stream, cx)?;
                 }
             }
         }
@@ -707,11 +656,8 @@ impl EditSession {
     }
 
     fn process_events(
+        &mut self,
         events: &[ToolEditEvent],
-        buffer: &Entity<Buffer>,
-        diff: &Entity<Diff>,
-        pipeline: &mut EditPipeline,
-        abs_path: &PathBuf,
         tool: &StreamingEditFileTool,
         event_stream: &ToolCallEventStream,
         cx: &mut AsyncApp,
@@ -724,8 +670,8 @@ impl EditSession {
         for event in events {
             match event {
                 ToolEditEvent::ContentChunk { chunk } => {
-                    let (buffer_id, insert_at) = buffer.read_with(cx, |buffer, _cx| {
-                        let insert_at = if !pipeline.content_written && buffer.len() > 0 {
+                    let (buffer_id, insert_at) = self.buffer.read_with(cx, |buffer, _cx| {
+                        let insert_at = if !self.pipeline.content_written && buffer.len() > 0 {
                             0..buffer.len()
                         } else {
                             let len = buffer.len();
@@ -734,19 +680,19 @@ impl EditSession {
                         (buffer.remote_id(), insert_at)
                     });
                     agent_edit_buffer(
-                        buffer,
+                        &self.buffer,
                         [(insert_at, chunk.as_str())],
                         action_log.as_ref(),
                         cx,
                     );
                     cx.update(|cx| {
                         tool.set_agent_location(
-                            buffer.downgrade(),
+                            self.buffer.downgrade(),
                             text::Anchor::max_for_buffer(buffer_id),
                             cx,
                         );
                     });
-                    pipeline.content_written = true;
+                    self.pipeline.content_written = true;
                 }
 
                 ToolEditEvent::OldTextChunk {
@@ -754,21 +700,23 @@ impl EditSession {
                     chunk,
                     done: false,
                 } => {
-                    pipeline.ensure_resolving_old_text(*edit_index, buffer, cx);
+                    self.pipeline
+                        .ensure_resolving_old_text(*edit_index, &self.buffer, cx);
 
                     if let EditPipelineEntry::ResolvingOldText { matcher } =
-                        &mut pipeline.edits[*edit_index]
+                        &mut self.pipeline.edits[*edit_index]
                         && !chunk.is_empty()
                     {
                         if let Some(match_range) = matcher.push(chunk, None) {
-                            let anchor_range = buffer.read_with(cx, |buffer, _cx| {
+                            let anchor_range = self.buffer.read_with(cx, |buffer, _cx| {
                                 buffer.anchor_range_between(match_range.clone())
                             });
-                            diff.update(cx, |diff, cx| diff.reveal_range(anchor_range, cx));
+                            self.diff
+                                .update(cx, |diff, cx| diff.reveal_range(anchor_range, cx));
 
                             cx.update(|cx| {
-                                let position = buffer.read(cx).anchor_before(match_range.end);
-                                tool.set_agent_location(buffer.downgrade(), position, cx);
+                                let position = self.buffer.read(cx).anchor_before(match_range.end);
+                                tool.set_agent_location(self.buffer.downgrade(), position, cx);
                             });
                         }
                     }
@@ -779,10 +727,11 @@ impl EditSession {
                     chunk,
                     done: true,
                 } => {
-                    pipeline.ensure_resolving_old_text(*edit_index, buffer, cx);
+                    self.pipeline
+                        .ensure_resolving_old_text(*edit_index, &self.buffer, cx);
 
                     let EditPipelineEntry::ResolvingOldText { matcher } =
-                        &mut pipeline.edits[*edit_index]
+                        &mut self.pipeline.edits[*edit_index]
                     else {
                         continue;
                     };
@@ -790,22 +739,25 @@ impl EditSession {
                     if !chunk.is_empty() {
                         matcher.push(chunk, None);
                     }
-                    let range = extract_match(matcher.finish(), buffer, edit_index, cx)?;
+                    let range = extract_match(matcher.finish(), &self.buffer, edit_index, cx)?;
 
-                    let anchor_range = buffer
+                    let anchor_range = self
+                        .buffer
                         .read_with(cx, |buffer, _cx| buffer.anchor_range_between(range.clone()));
-                    diff.update(cx, |diff, cx| diff.reveal_range(anchor_range, cx));
+                    self.diff
+                        .update(cx, |diff, cx| diff.reveal_range(anchor_range, cx));
 
-                    let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
+                    let snapshot = self.buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
 
                     let line = snapshot.offset_to_point(range.start).row;
                     event_stream.update_fields(
-                        ToolCallUpdateFields::new()
-                            .locations(vec![ToolCallLocation::new(abs_path).line(Some(line))]),
+                        ToolCallUpdateFields::new().locations(vec![
+                            ToolCallLocation::new(&self.abs_path).line(Some(line)),
+                        ]),
                     );
 
                     let EditPipelineEntry::ResolvingOldText { matcher } =
-                        &pipeline.edits[*edit_index]
+                        &self.pipeline.edits[*edit_index]
                     else {
                         continue;
                     };
@@ -817,8 +769,10 @@ impl EditSession {
                     let old_text_in_buffer =
                         snapshot.text_for_range(range.clone()).collect::<String>();
 
-                    let text_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.text_snapshot());
-                    pipeline.edits[*edit_index] = EditPipelineEntry::StreamingNewText {
+                    let text_snapshot = self
+                        .buffer
+                        .read_with(cx, |buffer, _cx| buffer.text_snapshot());
+                    self.pipeline.edits[*edit_index] = EditPipelineEntry::StreamingNewText {
                         streaming_diff: StreamingDiff::new(old_text_in_buffer),
                         edit_cursor: range.start,
                         reindenter: Reindenter::new(indent_delta),
@@ -826,8 +780,8 @@ impl EditSession {
                     };
 
                     cx.update(|cx| {
-                        let position = buffer.read(cx).anchor_before(range.end);
-                        tool.set_agent_location(buffer.downgrade(), position, cx);
+                        let position = self.buffer.read(cx).anchor_before(range.end);
+                        tool.set_agent_location(self.buffer.downgrade(), position, cx);
                     });
                 }
 
@@ -836,7 +790,7 @@ impl EditSession {
                     chunk,
                     done: false,
                 } => {
-                    if *edit_index >= pipeline.edits.len() {
+                    if *edit_index >= self.pipeline.edits.len() {
                         continue;
                     }
                     let EditPipelineEntry::StreamingNewText {
@@ -845,7 +799,7 @@ impl EditSession {
                         reindenter,
                         original_snapshot,
                         ..
-                    } = &mut pipeline.edits[*edit_index]
+                    } = &mut self.pipeline.edits[*edit_index]
                     else {
                         continue;
                     };
@@ -858,7 +812,7 @@ impl EditSession {
                     let char_ops = streaming_diff.push_new(&reindented);
                     Self::apply_char_operations(
                         &char_ops,
-                        buffer,
+                        &self.buffer,
                         original_snapshot,
                         edit_cursor,
                         action_log.as_ref(),
@@ -867,7 +821,7 @@ impl EditSession {
 
                     let position = original_snapshot.anchor_before(*edit_cursor);
                     cx.update(|cx| {
-                        tool.set_agent_location(buffer.downgrade(), position, cx);
+                        tool.set_agent_location(self.buffer.downgrade(), position, cx);
                     });
                 }
 
@@ -876,7 +830,7 @@ impl EditSession {
                     chunk,
                     done: true,
                 } => {
-                    if *edit_index >= pipeline.edits.len() {
+                    if *edit_index >= self.pipeline.edits.len() {
                         continue;
                     }
 
@@ -886,7 +840,7 @@ impl EditSession {
                         mut reindenter,
                         original_snapshot,
                     } = std::mem::replace(
-                        &mut pipeline.edits[*edit_index],
+                        &mut self.pipeline.edits[*edit_index],
                         EditPipelineEntry::Done,
                     )
                     else {
@@ -901,7 +855,7 @@ impl EditSession {
                         let char_ops = streaming_diff.push_new(&final_text);
                         Self::apply_char_operations(
                             &char_ops,
-                            buffer,
+                            &self.buffer,
                             &original_snapshot,
                             &mut edit_cursor,
                             action_log.as_ref(),
@@ -912,7 +866,7 @@ impl EditSession {
                     let remaining_ops = streaming_diff.finish();
                     Self::apply_char_operations(
                         &remaining_ops,
-                        buffer,
+                        &self.buffer,
                         &original_snapshot,
                         &mut edit_cursor,
                         action_log.as_ref(),
@@ -921,7 +875,7 @@ impl EditSession {
 
                     let position = original_snapshot.anchor_before(edit_cursor);
                     cx.update(|cx| {
-                        tool.set_agent_location(buffer.downgrade(), position, cx);
+                        tool.set_agent_location(self.buffer.downgrade(), position, cx);
                     });
                 }
             }

--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -187,20 +187,23 @@ impl From<StreamingEditFileToolOutput> for LanguageModelToolResultContent {
 }
 
 pub struct StreamingEditFileTool {
-    thread: WeakEntity<Thread>,
-    language_registry: Arc<LanguageRegistry>,
     project: Entity<Project>,
+    thread: WeakEntity<Thread>,
+    action_log: Entity<ActionLog>,
+    language_registry: Arc<LanguageRegistry>,
 }
 
 impl StreamingEditFileTool {
     pub fn new(
         project: Entity<Project>,
         thread: WeakEntity<Thread>,
+        action_log: Entity<ActionLog>,
         language_registry: Arc<LanguageRegistry>,
     ) -> Self {
         Self {
             project,
             thread,
+            action_log,
             language_registry,
         }
     }
@@ -447,11 +450,6 @@ impl EditPipeline {
     }
 }
 
-fn query_first_line_indent(query_lines: &[String]) -> text::LineIndent {
-    let first_line = query_lines.first().map(|s| s.as_str()).unwrap_or("");
-    text::LineIndent::from_iter(first_line.chars())
-}
-
 impl EditSession {
     async fn new(
         path: &PathBuf,
@@ -487,12 +485,7 @@ impl EditSession {
             .await
             .map_err(|e| StreamingEditFileToolOutput::error(e.to_string()))?;
 
-        let action_log = tool
-            .thread
-            .read_with(cx, |thread, _cx| thread.action_log().clone())
-            .ok();
-
-        ensure_buffer_saved(&buffer, &abs_path, tool, action_log.as_ref(), cx)?;
+        ensure_buffer_saved(&buffer, &abs_path, tool, cx)?;
 
         let diff = cx.new(|cx| Diff::new(buffer.clone(), cx));
         event_stream.update_diff(diff.clone());
@@ -504,9 +497,8 @@ impl EditSession {
             }
         }) as Box<dyn FnOnce()>);
 
-        if let Some(action_log) = &action_log {
-            action_log.update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
-        }
+        tool.action_log
+            .update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
 
         let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
         let old_text = cx
@@ -537,11 +529,6 @@ impl EditSession {
     ) -> Result<StreamingEditFileToolOutput, StreamingEditFileToolOutput> {
         let old_text = self.old_text.clone();
 
-        let action_log = tool
-            .thread
-            .read_with(cx, |thread, _cx| thread.action_log().clone())
-            .map_err(|e| StreamingEditFileToolOutput::error(e.to_string()))?;
-
         match input.mode {
             StreamingEditFileMode::Write => {
                 let content = input.content.ok_or_else(|| {
@@ -551,7 +538,7 @@ impl EditSession {
                 let events = self.parser.finalize_content(&content);
                 self.process_events(&events, tool, event_stream, cx)?;
 
-                action_log.update(cx, |log, cx| {
+                tool.action_log.update(cx, |log, cx| {
                     log.buffer_created(self.buffer.clone(), cx);
                 });
             }
@@ -574,7 +561,7 @@ impl EditSession {
         });
 
         if format_on_save_enabled {
-            action_log.update(cx, |log, cx| {
+            tool.action_log.update(cx, |log, cx| {
                 log.buffer_edited(self.buffer.clone(), cx);
             });
 
@@ -605,7 +592,7 @@ impl EditSession {
             }
         };
 
-        action_log.update(cx, |log, cx| {
+        tool.action_log.update(cx, |log, cx| {
             log.buffer_edited(self.buffer.clone(), cx);
         });
 
@@ -662,11 +649,6 @@ impl EditSession {
         event_stream: &ToolCallEventStream,
         cx: &mut AsyncApp,
     ) -> Result<(), StreamingEditFileToolOutput> {
-        let action_log = tool
-            .thread
-            .read_with(cx, |thread, _cx| thread.action_log().clone())
-            .ok();
-
         for event in events {
             match event {
                 ToolEditEvent::ContentChunk { chunk } => {
@@ -682,7 +664,7 @@ impl EditSession {
                     agent_edit_buffer(
                         &self.buffer,
                         [(insert_at, chunk.as_str())],
-                        action_log.as_ref(),
+                        &tool.action_log,
                         cx,
                     );
                     cx.update(|cx| {
@@ -763,7 +745,14 @@ impl EditSession {
                     };
                     let buffer_indent =
                         snapshot.line_indent_for_row(snapshot.offset_to_point(range.start).row);
-                    let query_indent = query_first_line_indent(matcher.query_lines());
+                    let query_indent = text::LineIndent::from_iter(
+                        matcher
+                            .query_lines()
+                            .first()
+                            .map(|s| s.as_str())
+                            .unwrap_or("")
+                            .chars(),
+                    );
                     let indent_delta = compute_indent_delta(buffer_indent, query_indent);
 
                     let old_text_in_buffer =
@@ -815,7 +804,7 @@ impl EditSession {
                         &self.buffer,
                         original_snapshot,
                         edit_cursor,
-                        action_log.as_ref(),
+                        &tool.action_log,
                         cx,
                     );
 
@@ -858,7 +847,7 @@ impl EditSession {
                             &self.buffer,
                             &original_snapshot,
                             &mut edit_cursor,
-                            action_log.as_ref(),
+                            &tool.action_log,
                             cx,
                         );
                     }
@@ -869,7 +858,7 @@ impl EditSession {
                         &self.buffer,
                         &original_snapshot,
                         &mut edit_cursor,
-                        action_log.as_ref(),
+                        &tool.action_log,
                         cx,
                     );
 
@@ -888,7 +877,7 @@ impl EditSession {
         buffer: &Entity<Buffer>,
         snapshot: &text::BufferSnapshot,
         edit_cursor: &mut usize,
-        action_log: Option<&Entity<ActionLog>>,
+        action_log: &Entity<ActionLog>,
         cx: &mut AsyncApp,
     ) {
         for op in ops {
@@ -949,7 +938,7 @@ fn extract_match(
 fn agent_edit_buffer<I, S, T>(
     buffer: &Entity<Buffer>,
     edits: I,
-    action_log: Option<&Entity<ActionLog>>,
+    action_log: &Entity<ActionLog>,
     cx: &mut AsyncApp,
 ) where
     I: IntoIterator<Item = (Range<S>, T)>,
@@ -960,9 +949,7 @@ fn agent_edit_buffer<I, S, T>(
         buffer.update(cx, |buffer, cx| {
             buffer.edit(edits, None, cx);
         });
-        if let Some(action_log) = action_log {
-            action_log.update(cx, |log, cx| log.buffer_edited(buffer.clone(), cx));
-        }
+        action_log.update(cx, |log, cx| log.buffer_edited(buffer.clone(), cx));
     });
 }
 
@@ -970,11 +957,11 @@ fn ensure_buffer_saved(
     buffer: &Entity<Buffer>,
     abs_path: &PathBuf,
     tool: &StreamingEditFileTool,
-    action_log: Option<&Entity<ActionLog>>,
     cx: &mut AsyncApp,
 ) -> Result<(), StreamingEditFileToolOutput> {
-    let last_read_mtime =
-        action_log.and_then(|log| log.read_with(cx, |log, _| log.file_read_time(abs_path)));
+    let last_read_mtime = tool
+        .action_log
+        .read_with(cx, |log, _| log.file_read_time(abs_path));
     let check_result = tool.thread.read_with(cx, |thread, cx| {
         let current = buffer
             .read(cx)
@@ -1135,6 +1122,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1187,6 +1175,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1250,6 +1239,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1315,6 +1305,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1383,6 +1374,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1451,6 +1443,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1507,6 +1500,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project,
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1561,6 +1555,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project,
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -1611,9 +1606,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -1683,9 +1680,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -1753,9 +1752,11 @@ mod tests {
         let (event_stream, _receiver, mut cancellation_tx) =
             ToolCallEventStream::test_with_cancellation();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -1814,9 +1815,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -1904,9 +1907,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -1977,9 +1982,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -2031,9 +2038,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -2160,9 +2169,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -2281,9 +2292,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -2393,9 +2406,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -2477,6 +2492,7 @@ mod tests {
             Arc::new(StreamingEditFileTool::new(
                 project.clone(),
                 thread.downgrade(),
+                thread.read(cx).action_log().clone(),
                 language_registry,
             ))
             .run(input, event_stream, cx)
@@ -2554,6 +2570,7 @@ mod tests {
             Arc::new(StreamingEditFileTool::new(
                 project.clone(),
                 thread.downgrade(),
+                thread.read(cx).action_log().clone(),
                 language_registry,
             ))
             .run(input, event_stream, cx)
@@ -2607,6 +2624,7 @@ mod tests {
             Arc::new(StreamingEditFileTool::new(
                 project.clone(),
                 thread.downgrade(),
+                thread.read(cx).action_log().clone(),
                 language_registry,
             ))
             .run(input, event_stream, cx)
@@ -2818,9 +2836,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry.clone(),
         ));
 
@@ -2875,9 +2895,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -2969,6 +2991,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry.clone(),
                 ))
                 .run(
@@ -3016,6 +3039,7 @@ mod tests {
                 Arc::new(StreamingEditFileTool::new(
                     project.clone(),
                     thread.downgrade(),
+                    thread.read(cx).action_log().clone(),
                     language_registry,
                 ))
                 .run(
@@ -3056,9 +3080,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
         fs.insert_tree("/root", json!({})).await;
@@ -3198,9 +3224,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project,
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3283,9 +3311,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3350,9 +3380,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3427,9 +3459,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3475,9 +3509,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3575,9 +3611,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3649,9 +3687,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3724,9 +3764,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3794,9 +3836,11 @@ mod tests {
                 cx,
             )
         });
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project,
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -3870,11 +3914,13 @@ mod tests {
             )
         });
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         // Ensure the diff is finalized after the edit completes.
         {
             let tool = Arc::new(StreamingEditFileTool::new(
                 project.clone(),
                 thread.downgrade(),
+                action_log.clone(),
                 languages.clone(),
             ));
             let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
@@ -3904,6 +3950,7 @@ mod tests {
             let tool = Arc::new(StreamingEditFileTool::new(
                 project.clone(),
                 thread.downgrade(),
+                action_log,
                 languages.clone(),
             ));
             let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
@@ -3958,10 +4005,15 @@ mod tests {
         let languages = project.read_with(cx, |project, _| project.languages().clone());
         let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
 
-        let read_tool = Arc::new(crate::ReadFileTool::new(project.clone(), action_log, true));
+        let read_tool = Arc::new(crate::ReadFileTool::new(
+            project.clone(),
+            action_log.clone(),
+            true,
+        ));
         let edit_tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             languages,
         ));
 
@@ -4060,10 +4112,15 @@ mod tests {
         let languages = project.read_with(cx, |project, _| project.languages().clone());
         let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
 
-        let read_tool = Arc::new(crate::ReadFileTool::new(project.clone(), action_log, true));
+        let read_tool = Arc::new(crate::ReadFileTool::new(
+            project.clone(),
+            action_log.clone(),
+            true,
+        ));
         let edit_tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             languages,
         ));
 
@@ -4169,10 +4226,15 @@ mod tests {
         let languages = project.read_with(cx, |project, _| project.languages().clone());
         let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
 
-        let read_tool = Arc::new(crate::ReadFileTool::new(project.clone(), action_log, true));
+        let read_tool = Arc::new(crate::ReadFileTool::new(
+            project.clone(),
+            action_log.clone(),
+            true,
+        ));
         let edit_tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             languages,
         ));
 
@@ -4285,9 +4347,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -4362,9 +4426,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -4465,9 +4531,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, mut receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -4558,9 +4626,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -4657,9 +4727,11 @@ mod tests {
         let (sender, input) = ToolInput::<StreamingEditFileToolInput>::test();
         let (event_stream, _receiver) = ToolCallEventStream::test();
 
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log,
             language_registry,
         ));
 
@@ -4748,6 +4820,7 @@ mod tests {
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log.clone(),
             language_registry,
         ));
         let (event_stream, _rx) = ToolCallEventStream::test();
@@ -4822,6 +4895,7 @@ mod tests {
         let tool = Arc::new(StreamingEditFileTool::new(
             project.clone(),
             thread.downgrade(),
+            action_log.clone(),
             language_registry,
         ));
         let (event_stream, _rx) = ToolCallEventStream::test();


### PR DESCRIPTION
- Adds logging if tool fails
- Reduces boilerplate in test 
- Simplified code in a bunch of places

Release Notes:

- N/A
