### PR TITLE
Fix threads database locking errors

### DIFF
--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -382,6 +382,9 @@ impl ThreadsDatabase {
             Connection::open_file(&sqlite_path.to_string_lossy())
         };
 
+        connection.exec("PRAGMA journal_mode=WAL;")?()?;
+        connection.exec("PRAGMA busy_timeout=1000;")?()?;
+
         connection.exec(indoc! {"
             CREATE TABLE IF NOT EXISTS threads (
                 id TEXT PRIMARY KEY,


### PR DESCRIPTION
The threads SQLite database (`threads.db`) was opened without setting `journal_mode` or `busy_timeout` pragmas. This caused a flood of "database is locked" errors (SQLite error code 5) in the logs.

**Root cause:** Without WAL mode, SQLite uses the default rollback journal where readers block writers and vice versa. Without `busy_timeout`, SQLite returns `SQLITE_BUSY` immediately instead of retrying when it encounters a lock. This is triggered when `save_thread` and `list_threads` (from `reload`) overlap, or when multiple Zed windows share the same `threads.db` file.

**Fix:** Set `PRAGMA journal_mode=WAL` so readers and writers can proceed concurrently, and `PRAGMA busy_timeout=1000` so SQLite retries for up to one second before giving up.

Release Notes:

- Fixed occasional "database is locked" errors when saving agent threads.