### PR TITLE
docs: Remove outdated reference to simple-completion-language-server

### DIFF
--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -42,24 +42,4 @@ To create JSX snippets you have to use `javascript.json` snippets file, instead 
 ## Known Limitations
 
 - Only the first prefix is used when a list of prefixes is passed in.
-- Currently only the `json` snippet file format is supported, even though the `simple-completion-language-server` supports both `json` and `toml` file formats.
-
-## See also
-
-The `feature_paths` option in `simple-completion-language-server` is disabled by default.
-
-If you want to enable it you can add the following to your `settings.json`:
-
-```json [settings]
-{
-  "lsp": {
-    "snippet-completion-server": {
-      "settings": {
-        "feature_paths": true
-      }
-    }
-  }
-}
-```
-
-For more configuration information, see the [`simple-completion-language-server` instructions](https://github.com/zed-industries/simple-completion-language-server/tree/main).
+- Currently only the `json` snippet file format is supported.


### PR DESCRIPTION
Closes #46811

Release Notes:

- N/A
