### PR TITLE
docs: Remove Preview callouts for stable release

### DIFF
--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -406,8 +406,6 @@ After adding your API key, Codestral will appear in the provider dropdown in the
 
 ### Self-Hosted OpenAI-compatible servers
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 You can use any self-hosted server that implements the OpenAI completion API format. This works with vLLM, llama.cpp server, LocalAI, and other compatible servers.
 
 #### Configuration

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -152,8 +152,6 @@ For the most up-to-date supported regions and models, refer to the [Supported Mo
 
 #### Extended Context Window {#bedrock-extended-context}
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 Anthropic models on Bedrock support a 1M token extended context window through the `anthropic_beta` API parameter. To enable this feature, set `"allow_extended_context": true` in your Bedrock configuration:
 
 ```json [settings]
@@ -172,8 +170,6 @@ Anthropic models on Bedrock support a 1M token extended context window through t
 Zed enables extended context for supported models (Claude Sonnet 4.5 and Claude Opus 4.6). Extended context usage may increase API costs—refer to AWS Bedrock pricing for details.
 
 #### Image Support {#bedrock-image-support}
-
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
 
 Bedrock models that support vision (Claude 3 and later, Amazon Nova Pro and Lite, Meta Llama 3.2 Vision models, Mistral Pixtral) can receive images in conversations and tool results.
 
@@ -629,8 +625,6 @@ OpenRouter provides access to multiple AI models through a single API. It suppor
 The OpenRouter API key will be saved in your keychain.
 
 Zed will also use the `OPENROUTER_API_KEY` environment variable if it's defined.
-
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
 
 When using OpenRouter as your assistant provider, you must explicitly select a model in your settings. OpenRouter no longer provides a default model selection.
 

--- a/docs/src/collaboration/overview.md
+++ b/docs/src/collaboration/overview.md
@@ -24,8 +24,6 @@ See the [Data and Privacy FAQs](https://zed.dev/faq#data-and-privacy) for more d
 
 ### Selecting Audio Devices
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 You can select specific input and output audio devices instead of using system defaults. To configure audio devices:
 
 1. Open {#kb zed::OpenSettings}

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -165,8 +165,6 @@ Not all languages in Zed support toolchain discovery and selection, but for thos
 
 ### Configuring Language Servers
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 When configuring language servers in your `settings.json`, autocomplete suggestions include all available LSP adapters recognized by Zed, not only those currently active for loaded languages. This helps you discover and configure language servers before opening files that use them.
 
 Many language servers accept custom configuration options. You can set these in the `lsp` section of your `settings.json`:

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -165,8 +165,6 @@ The debug adapter will then stop whenever an exception of a given kind occurs. W
 
 ## Working with Split Panes
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 When debugging with multiple split panes open, Zed shows the active debug line in one pane and preserves your layout in others. If you have the same file open in multiple panes, the debugger picks a pane where the file is already the active tab—it won't switch tabs in panes where the file is inactive.
 
 Once the debugger picks a pane, it continues using that pane for subsequent breakpoints during the session. If you drag the tab with the active debug line to a different split, the debugger tracks the move and uses the new pane.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -13,8 +13,6 @@ This guide covers the essential commands, environment setup, and navigation basi
 
 ### Welcome Page
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 When you open Zed without a folder, you see the welcome page in the main editor area. The welcome page offers quick actions to open a folder, clone a repository, or view documentation. Once you open a folder or file, the welcome page disappears. If you split the editor into multiple panes, the welcome page appears only in the center pane when empty—other panes show a standard empty state.
 
 To reopen the welcome page, close all items in the center pane or use the command palette to search for "Welcome".

--- a/docs/src/outline-panel.md
+++ b/docs/src/outline-panel.md
@@ -7,8 +7,6 @@ description: Navigate code structure with Zed's outline panel. View symbols, jum
 
 In addition to the modal outline (`cmd-shift-o`), Zed offers an outline panel. The outline panel can be deployed via `cmd-shift-b` (`outline panel: toggle focus` via the command palette), or by clicking the `Outline Panel` button in the status bar.
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 When viewing a "singleton" buffer (i.e., a single file on a tab), the outline panel works similarly to that of the outline modal－it displays the outline of the current buffer's symbols. Each symbol entry shows its type prefix (such as "struct", "fn", "mod", "impl") along with the symbol name, helping you quickly identify what kind of symbol you're looking at. Clicking on an entry allows you to jump to the associated section in the file. The outline view will also automatically scroll to the section associated with the current cursor position within the file.
 
 ![Using the outline panel in a singleton buffer](https://zed.dev/img/outline-panel/singleton.png)

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -225,8 +225,6 @@ This could be useful for launching a terminal application that you want to use i
 
 ## VS Code Task Format
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 When importing VS Code tasks from `.vscode/tasks.json`, you can omit the `label` field. Zed automatically generates labels based on the task type:
 
 - **npm tasks**: `npm: <script>` (e.g., `npm: start`)

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -88,8 +88,6 @@ If you're experiencing language-server related issues, such as stale diagnostics
 
 ### "Max tokens reached"
 
-> **Preview:** This error handling is available in Zed Preview. It will be included in the next Stable release.
-
 You see this error when the agent's response exceeds the model's maximum token limit. This happens when:
 
 - The agent generates an extremely long response


### PR DESCRIPTION
This PR removes Preview callouts from documentation for features that are now in Stable.

## Files Updated

• docs/src/collaboration/overview.md
• docs/src/debugger.md
• docs/src/configuring-languages.md
• docs/src/troubleshooting.md
• docs/src/outline-panel.md
• docs/src/getting-started.md
• docs/src/tasks.md
• docs/src/ai/edit-prediction.md
• docs/src/ai/llm-providers.md

## What This Does

Removes callouts like:
```markdown
> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
```

And:
```markdown
> **Changed in Preview (v0.XXX).** See [release notes](/releases#0.XXX).
```

These features are now in Stable, so the callouts are no longer needed.

Release Notes:

- N/A