### PR TITLE
search: Fix cmd-up/down in Find bar on macOS

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -435,7 +435,7 @@
     },
   },
   {
-    "context": "BufferSearchBar > Editor",
+    "context": "(BufferSearchBar || ProjectSearchBar) > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-up": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -435,14 +435,6 @@
     },
   },
   {
-    "context": "(BufferSearchBar || ProjectSearchBar) > Editor",
-    "use_key_equivalents": true,
-    "bindings": {
-      "cmd-up": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
-      "cmd-down": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": true }],
-    },
-  },
-  {
     "context": "BufferSearchBar && in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -435,6 +435,14 @@
     },
   },
   {
+    "context": "BufferSearchBar > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-up": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
+      "cmd-down": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": true }],
+    },
+  },
+  {
     "context": "BufferSearchBar && in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15245,10 +15245,6 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if matches!(self.mode, EditorMode::SingleLine) {
-            cx.propagate();
-            return;
-        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.change_selections(Default::default(), window, cx, |s| {
             s.select_ranges(vec![Anchor::min()..Anchor::min()]);
@@ -15270,10 +15266,6 @@ impl Editor {
     }
 
     pub fn move_to_end(&mut self, _: &MoveToEnd, window: &mut Window, cx: &mut Context<Self>) {
-        if matches!(self.mode, EditorMode::SingleLine) {
-            cx.propagate();
-            return;
-        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         let cursor = self.buffer.read(cx).read(cx).len();
         self.change_selections(Default::default(), window, cx, |s| {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29699,6 +29699,24 @@ async fn test_end_of_editor_context(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_move_to_beginning_and_end_in_single_line_mode(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("abcˇdef");
+    cx.update_editor(|editor, window, cx| {
+        editor.set_mode(EditorMode::SingleLine);
+        editor.move_to_beginning(&MoveToBeginning, window, cx);
+    });
+    cx.assert_editor_state("ˇabcdef");
+
+    cx.update_editor(|editor, window, cx| {
+        editor.move_to_end(&MoveToEnd, window, cx);
+    });
+    cx.assert_editor_state("abcdefˇ");
+}
+
+#[gpui::test]
 async fn test_sticky_scroll(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;


### PR DESCRIPTION
Closes #50635

## Summary
 - Fix the root cause in editor actions: `editor::MoveToBeginning` and `editor::MoveToEnd` now work in `EditorMode::SingleLine` instead of propagating/no-op.
 - Remove the temporary keymap workaround from this PR.
 - Add regression test coverage for single line behavior:
    - `editor_tests::test_move_to_beginning_and_end_in_single_line_mode`

## Verification
 - `./script/check-keymaps`
 - `./script/clippy -p editor`
 - `cargo test -p editor test_move_to_beginning_and_end_in_single_line_mode -- --nocapture`
 - `cargo test -p editor -- --nocapture`
 - `cargo test -p search -- --nocapture`
 - Manually:
   - Find bar and Project Search inputs: `cmd-up/down` move caret to start/end.
   - `up/down` history behavior unchanged.
   - File Finder / Command Palette `cmd-up/down` behavior unchanged.

 - [x] Added a solid test coverage and/or screenshots from doing manual testing
 - [x] Done a self-review taking into account security and performance aspects
 - [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:
 - Fixed `cmd-up` and `cmd-down` in single line search inputs on macOS.