### PR TITLE
git: Fix hardcoded .git/ paths in GitBinary for linked worktrees

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -608,6 +608,10 @@ impl GitExcludeOverride {
         content.push_str(self.added_excludes.as_ref().unwrap());
         content.push_str(Self::END_BLOCK_MARKER);
 
+        if let Some(parent) = self.git_exclude_path.parent() {
+            smol::fs::create_dir_all(parent).await?;
+        }
+
         smol::fs::write(&self.git_exclude_path, content).await?;
         Ok(())
     }
@@ -1023,10 +1027,19 @@ impl RealGitRepository {
     }
 
     fn git_binary(&self) -> Result<GitBinary> {
+        let repository = self.repository.lock();
+        let git_dir = repository.path().to_path_buf();
+        let working_directory = repository
+            .workdir()
+            .context("Can't run git commands without a working directory")?
+            .to_path_buf();
+
+        drop(repository);
+
         Ok(GitBinary::new(
             self.any_git_binary_path.clone(),
-            self.working_directory()
-                .with_context(|| "Can't run git commands without a working directory")?,
+            working_directory,
+            Some(git_dir),
             self.executor.clone(),
             self.is_trusted(),
         ))
@@ -1081,6 +1094,7 @@ pub async fn get_git_committer(cx: &AsyncApp) -> GitCommitter {
     let git = GitBinary::new(
         git_binary_path.unwrap_or(PathBuf::from("git")),
         paths::home_dir().clone(),
+        None,
         cx.background_executor().clone(),
         true,
     );
@@ -2245,6 +2259,7 @@ impl GitRepository for RealGitRepository {
             let git = GitBinary::new(
                 git_binary_path,
                 working_directory,
+                None,
                 executor.clone(),
                 is_trusted,
             );
@@ -2287,6 +2302,7 @@ impl GitRepository for RealGitRepository {
             let git = GitBinary::new(
                 git_binary_path,
                 working_directory,
+                None,
                 executor.clone(),
                 is_trusted,
             );
@@ -2328,6 +2344,7 @@ impl GitRepository for RealGitRepository {
             let git = GitBinary::new(
                 git_binary_path,
                 working_directory,
+                None,
                 executor.clone(),
                 is_trusted,
             );
@@ -2980,6 +2997,7 @@ async fn exclude_files(git: &GitBinary) -> Result<GitExcludeOverride> {
 pub(crate) struct GitBinary {
     git_binary_path: PathBuf,
     working_directory: PathBuf,
+    git_dir: Option<PathBuf>,
     executor: BackgroundExecutor,
     index_file_path: Option<PathBuf>,
     envs: HashMap<String, String>,
@@ -2990,17 +3008,25 @@ impl GitBinary {
     pub(crate) fn new(
         git_binary_path: PathBuf,
         working_directory: PathBuf,
+        git_dir: Option<PathBuf>,
         executor: BackgroundExecutor,
         is_trusted: bool,
     ) -> Self {
         Self {
             git_binary_path,
             working_directory,
+            git_dir,
             executor,
             index_file_path: None,
             envs: HashMap::default(),
             is_trusted,
         }
+    }
+
+    fn git_dir(&self) -> PathBuf {
+        self.git_dir
+            .clone()
+            .unwrap_or_else(|| self.working_directory.join(".git"))
     }
 
     async fn list_untracked_files(&self) -> Result<Vec<PathBuf>> {
@@ -3041,12 +3067,9 @@ impl GitBinary {
 
         // Copy the default index file so that Git doesn't have to rebuild the
         // whole index from scratch. This might fail if this is an empty repository.
-        smol::fs::copy(
-            self.working_directory.join(".git").join("index"),
-            &index_file_path,
-        )
-        .await
-        .ok();
+        smol::fs::copy(self.git_dir().join("index"), &index_file_path)
+            .await
+            .ok();
 
         self.index_file_path = Some(index_file_path.clone());
         let result = f(self).await;
@@ -3060,19 +3083,13 @@ impl GitBinary {
     }
 
     pub async fn with_exclude_overrides(&self) -> Result<GitExcludeOverride> {
-        let path = self
-            .working_directory
-            .join(".git")
-            .join("info")
-            .join("exclude");
+        let path = self.git_dir().join("info").join("exclude");
 
         GitExcludeOverride::new(path).await
     }
 
     fn path_for_index_id(&self, id: Uuid) -> PathBuf {
-        self.working_directory
-            .join(".git")
-            .join(format!("index-{}.tmp", id))
+        self.git_dir().join(format!("index-{}.tmp", id))
     }
 
     pub async fn run<S>(&self, args: impl IntoIterator<Item = S>) -> Result<String>
@@ -3390,6 +3407,7 @@ mod tests {
         let git = GitBinary::new(
             PathBuf::from("git"),
             dir.path().to_path_buf(),
+            None,
             cx.executor(),
             false,
         );
@@ -3403,6 +3421,7 @@ mod tests {
         let git = GitBinary::new(
             PathBuf::from("git"),
             dir.path().to_path_buf(),
+            None,
             cx.executor(),
             false,
         );
@@ -3422,6 +3441,7 @@ mod tests {
         let git = GitBinary::new(
             PathBuf::from("git"),
             dir.path().to_path_buf(),
+            None,
             cx.executor(),
             false,
         );
@@ -3447,6 +3467,7 @@ mod tests {
         let git = GitBinary::new(
             PathBuf::from("git"),
             dir.path().to_path_buf(),
+            None,
             cx.executor(),
             true,
         );
@@ -3465,6 +3486,7 @@ mod tests {
         let git = GitBinary::new(
             PathBuf::from("git"),
             dir.path().to_path_buf(),
+            None,
             cx.executor(),
             true,
         );
@@ -3567,6 +3589,89 @@ mod tests {
         //         .ok(),
         //     None
         // );
+    }
+
+    #[gpui::test]
+    async fn test_checkpoint_in_linked_worktree(cx: &mut TestAppContext) {
+        disable_git_global_config();
+
+        cx.executor().allow_parking();
+
+        let main_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(main_dir.path()).unwrap();
+
+        let file_path = main_dir.path().join("file");
+        smol::fs::write(&file_path, "initial").await.unwrap();
+
+        let main_repo = RealGitRepository::new(
+            &main_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        main_repo
+            .stage_paths(vec![repo_path("file")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+
+        main_repo
+            .commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
+            .await
+            .unwrap();
+
+        // Create a linked worktree using the repository API.
+        let worktree_parent = tempfile::tempdir().unwrap();
+        main_repo
+            .create_worktree(
+                "feature-branch".to_string(),
+                worktree_parent.path().to_path_buf(),
+                Some("HEAD".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let worktree_path = worktree_parent.path().join("feature-branch");
+
+        // The linked worktree's .git is a file, not a directory.
+        let worktree_dot_git = worktree_path.join(".git");
+        assert!(
+            worktree_dot_git.is_file(),
+            ".git in linked worktree should be a file"
+        );
+
+        let worktree_repo =
+            RealGitRepository::new(&worktree_dot_git, None, Some("git".into()), cx.executor())
+                .unwrap();
+
+        // Modify a file in the worktree and create a checkpoint.
+        let worktree_file = worktree_path.join("file");
+        smol::fs::write(&worktree_file, "modified in worktree")
+            .await
+            .unwrap();
+
+        let checkpoint = worktree_repo.checkpoint().await.unwrap();
+
+        // Make further changes after the checkpoint.
+        smol::fs::write(&worktree_file, "after checkpoint")
+            .await
+            .unwrap();
+
+        // Restore the checkpoint — this exercises with_temp_index and
+        // with_exclude_overrides which previously used hardcoded .git/ paths.
+        worktree_repo.restore_checkpoint(checkpoint).await.unwrap();
+
+        assert_eq!(
+            smol::fs::read_to_string(&worktree_file).await.unwrap(),
+            "modified in worktree"
+        );
     }
 
     #[gpui::test]
@@ -4371,7 +4476,8 @@ mod tests {
                 .spawn(async move {
                     let git_binary_path = git_binary_path.clone();
                     let working_directory = working_directory?;
-                    let git = GitBinary::new(git_binary_path, working_directory, executor, true);
+                    let git =
+                        GitBinary::new(git_binary_path, working_directory, None, executor, true);
                     git.run(&["gc", "--prune"]).await?;
                     Ok(())
                 })


### PR DESCRIPTION
Linked worktrees use a `.git` **file** (not directory) that points to the actual git directory (e.g. `.git/worktrees/feature-x/`). Three `GitBinary` methods hardcoded `working_directory.join(".git")`, which silently failed for linked worktrees — breaking checkpoint/restore used by the AI assistant.

**The bug:** `with_temp_index` copies from `working_dir/.git/index`, but for a linked worktree `.git` is a plain file, so the copy silently fails (`.ok()`). The temp index starts empty, `write-tree` captures nothing useful, and `path_for_index_id` tries to write inside a file path. Similarly, `with_exclude_overrides` reads from a nonexistent `.git/info/exclude`.

**Verified manually:** In production Zed, opening a linked worktree and using the Claude Agent to edit a file does not show the "Restore Checkpoint" button (checkpoint creation fails silently). With this fix applied, the button appears and checkpoint/restore works correctly.

**The fix:** Add a `git_dir: Option<PathBuf>` field to `GitBinary`. When provided (via `RealGitRepository::git_binary()` using `repo.path()`), the three methods resolve paths through the actual worktree-specific git directory. Other callers (push/pull/fetch/gc) pass `None` and retain the existing fallback behavior.

Also ensures the `info/` parent directory is created before writing exclude overrides, since linked worktree git dirs don't have it by default.

~~Part of #33764~~ (the core symptoms described in #33764 are no longer reproducible on current stable Zed — this PR fixes a separate worktree bug)

Related:
- #50763 (fix detached-HEAD worktrees + ignore stack)
- #50179 (sidebar labels for worktrees)

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed checkpoint/restore failing silently in git linked worktrees (the "Restore Checkpoint" button was missing in the AI assistant when working in a linked worktree)