### PR TITLE
Make ACP checkpoints work without truncate support

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1272,6 +1272,10 @@ impl AcpThread {
         }
     }
 
+    pub fn supports_rewind(&self, cx: &App) -> bool {
+        self.connection.truncate(&self.session_id, cx).is_some()
+    }
+
     pub fn had_error(&self) -> bool {
         self.had_error
     }
@@ -1918,11 +1922,7 @@ impl AcpThread {
         let request = acp::PromptRequest::new(self.session_id.clone(), message.clone());
         let git_store = self.project.read(cx).git_store().clone();
 
-        let message_id = if self.connection.truncate(&self.session_id, cx).is_some() {
-            Some(UserMessageId::new())
-        } else {
-            None
-        };
+        let message_id = Some(UserMessageId::new());
 
         self.run_turn(cx, async move |this, cx| {
             this.update(cx, |this, cx| {
@@ -2133,15 +2133,22 @@ impl AcpThread {
             .checkpoint
             .as_ref()
             .map(|c| c.git_checkpoint.clone());
+        let supports_rewind = self.supports_rewind(cx);
 
         // Cancel any in-progress generation before restoring
         let cancel_task = self.cancel(cx);
-        let rewind = self.rewind(id.clone(), cx);
+        let rewind = if supports_rewind {
+            Some(self.rewind(id.clone(), cx))
+        } else {
+            None
+        };
         let git_store = self.project.read(cx).git_store().clone();
 
         cx.spawn(async move |_, cx| {
             cancel_task.await;
-            rewind.await?;
+            if let Some(rewind) = rewind {
+                rewind.await?;
+            }
             if let Some(checkpoint) = checkpoint {
                 git_store
                     .update(cx, |git, cx| git.restore_checkpoint(checkpoint, cx))
@@ -3647,6 +3654,119 @@ mod tests {
         assert_eq!(fs.files(), vec![Path::new(path!("/test/file-0"))]);
     }
 
+    #[gpui::test(iterations = 10)]
+    async fn test_restore_checkpoint_without_truncate(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/test"),
+            json!({
+                ".git": {}
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/test").as_ref()], cx).await;
+
+        let next_filename = Arc::new(AtomicUsize::new(0));
+        let connection = Rc::new(
+            FakeAgentConnection::new()
+                .without_truncate()
+                .on_user_message({
+                    let fs = fs.clone();
+                    let next_filename = next_filename.clone();
+                    move |request, thread, mut cx| {
+                        let fs = fs.clone();
+                        let next_filename = next_filename.clone();
+                        async move {
+                            let filename =
+                                format!("/test/file-{}", next_filename.fetch_add(1, SeqCst));
+                            fs.write(Path::new(&filename), b"").await?;
+
+                            let acp::ContentBlock::Text(content) = &request.prompt[0] else {
+                                panic!("expected text content block");
+                            };
+
+                            thread.update(&mut cx, |thread, cx| {
+                                thread
+                                    .handle_session_update(
+                                        acp::SessionUpdate::AgentMessageChunk(
+                                            acp::ContentChunk::new(
+                                                content.text.to_uppercase().into(),
+                                            ),
+                                        ),
+                                        cx,
+                                    )
+                                    .unwrap();
+                            })?;
+
+                            Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
+                        }
+                        .boxed_local()
+                    }
+                }),
+        );
+
+        let thread = cx
+            .update(|cx| connection.new_session(project, Path::new(path!("/test")), cx))
+            .await
+            .unwrap();
+
+        cx.update(|cx| thread.update(cx, |thread, cx| thread.send(vec!["first".into()], cx)))
+            .await
+            .unwrap();
+        cx.update(|cx| thread.update(cx, |thread, cx| thread.send(vec!["second".into()], cx)))
+            .await
+            .unwrap();
+
+        let second_message_id = thread.read_with(cx, |thread, _cx| {
+            let AgentThreadEntry::UserMessage(first) = &thread.entries[0] else {
+                panic!("expected first entry to be a user message")
+            };
+            let AgentThreadEntry::UserMessage(second) = &thread.entries[2] else {
+                panic!("expected third entry to be a user message")
+            };
+            assert!(first.id.is_some());
+            second
+                .id
+                .clone()
+                .expect("checkpointed ACP messages should have an id")
+        });
+
+        thread
+            .update(cx, |thread, cx| {
+                thread.restore_checkpoint(second_message_id, cx)
+            })
+            .await
+            .unwrap();
+
+        thread.read_with(cx, |thread, cx| {
+            assert_eq!(thread.entries().len(), 4);
+            assert_eq!(
+                thread.to_markdown(cx),
+                indoc! {"
+                    ## User (checkpoint)
+
+                    first
+
+                    ## Assistant
+
+                    FIRST
+
+                    ## User (checkpoint)
+
+                    second
+
+                    ## Assistant
+
+                    SECOND
+
+                "}
+            );
+        });
+
+        assert_eq!(fs.files(), vec![Path::new(path!("/test/file-0"))]);
+    }
+
     #[gpui::test]
     async fn test_tool_result_refusal(cx: &mut TestAppContext) {
         use std::sync::atomic::AtomicUsize;
@@ -3916,6 +4036,7 @@ mod tests {
     struct FakeAgentConnection {
         auth_methods: Vec<acp::AuthMethod>,
         sessions: Arc<parking_lot::Mutex<HashMap<acp::SessionId, WeakEntity<AcpThread>>>>,
+        supports_truncate: bool,
         on_user_message: Option<
             Rc<
                 dyn Fn(
@@ -3934,6 +4055,7 @@ mod tests {
                 auth_methods: Vec::new(),
                 on_user_message: None,
                 sessions: Arc::default(),
+                supports_truncate: true,
             }
         }
 
@@ -3953,6 +4075,11 @@ mod tests {
             + 'static,
         ) -> Self {
             self.on_user_message.replace(Rc::new(handler));
+            self
+        }
+
+        fn without_truncate(mut self) -> Self {
+            self.supports_truncate = false;
             self
         }
     }
@@ -4033,9 +4160,11 @@ mod tests {
             session_id: &acp::SessionId,
             _cx: &App,
         ) -> Option<Rc<dyn AgentSessionTruncate>> {
-            Some(Rc::new(FakeAgentSessionEditor {
-                _session_id: session_id.clone(),
-            }))
+            self.supports_truncate.then(|| {
+                Rc::new(FakeAgentSessionEditor {
+                    _session_id: session_id.clone(),
+                }) as Rc<dyn AgentSessionTruncate>
+            })
         }
 
         fn into_any(self: Rc<Self>) -> Rc<dyn Any> {

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -650,6 +650,7 @@ impl ThreadView {
                 if let Some(AgentThreadEntry::UserMessage(user_message)) =
                     self.thread.read(cx).entries().get(event.entry_index)
                     && user_message.id.is_some()
+                    && self.thread.read(cx).supports_rewind(cx)
                 {
                     self.editing_message = Some(event.entry_index);
                     cx.notify();
@@ -659,6 +660,7 @@ impl ThreadView {
                 if let Some(AgentThreadEntry::UserMessage(user_message)) =
                     self.thread.read(cx).entries().get(event.entry_index)
                     && user_message.id.is_some()
+                    && self.thread.read(cx).supports_rewind(cx)
                 {
                     if editor.read(cx).text(cx).as_str() == user_message.content.to_markdown(cx) {
                         self.editing_message = None;
@@ -3723,6 +3725,8 @@ impl ThreadView {
                     .checkpoint
                     .as_ref()
                     .is_some_and(|checkpoint| checkpoint.show);
+                let message_can_be_edited =
+                    message.id.is_some() && self.thread.read(cx).supports_rewind(cx);
 
                 let agent_name = self.agent_name.clone();
                 let is_subagent = self.is_subagent();
@@ -3798,7 +3802,7 @@ impl ThreadView {
                                         if editing && !editor_focus {
                                             return this.border_dashed()
                                         }
-                                        if message.id.is_some() {
+                                        if message_can_be_edited {
                                             return this.shadow_md().hover(|s| {
                                                 s.border_color(focus_border.opacity(0.8))
                                             });
@@ -3834,7 +3838,7 @@ impl ThreadView {
                                             }),
                                         ),
                                     )
-                                } else if message.id.is_some() {
+                                } else if message_can_be_edited {
                                     this.child(
                                         base_container
                                             .child(

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -77,6 +77,7 @@ impl EntryViewState {
             AgentThreadEntry::UserMessage(message) => {
                 let has_id = message.id.is_some();
                 let is_subagent = thread.read(cx).parent_session_id().is_some();
+                let supports_rewind = thread.read(cx).supports_rewind(cx);
                 let chunks = message.chunks.clone();
                 if let Some(Entry::UserMessage(editor)) = self.entries.get_mut(index) {
                     if !editor.focus_handle(cx).is_focused(window) {
@@ -105,7 +106,7 @@ impl EntryViewState {
                             window,
                             cx,
                         );
-                        if !has_id || is_subagent {
+                        if !has_id || is_subagent || !supports_rewind {
                             editor.set_read_only(true, cx);
                         }
                         editor.set_message(chunks, window, cx);


### PR DESCRIPTION
This is a pure POC to show for the discussion I am planning to start

## Summary

- Decouples checkpoint creation from server-side truncate capability — all user messages now receive checkpoint IDs regardless of backend support
- `restore_checkpoint` conditionally skips the server-side rewind when `truncate` is unavailable, falling back to git-only restoration
- UI hides the edit/rewind affordance (hover, click-to-edit) when the connection doesn't support truncate
- Adds `test_restore_checkpoint_without_truncate` test and `FakeAgentConnection::without_truncate()` helper

## Test plan

- [ ] Verify checkpoints work end-to-end with a connection that supports truncate (existing behavior)
- [ ] Verify checkpoint restore works with a connection that does **not** support truncate (git files revert, no server rewind)
- [ ] Confirm user messages are not editable/clickable when truncate is unsupported
- [ ] Run `cargo test -p acp_thread` to validate the new test passes

Release Notes:

- N/A