### PR TITLE
Fix Node.js language servers failing with `--user-data-dir` on Windows

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, OnceLock};
 
+use util::paths::SanitizedPath;
 pub use util::paths::home_dir;
 use util::rel_path::RelPath;
 
@@ -71,8 +72,10 @@ pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
     CUSTOM_DATA_DIR.get_or_init(|| {
         let path = PathBuf::from(dir);
         std::fs::create_dir_all(&path).expect("failed to create custom data directory");
-        path.canonicalize()
-            .expect("failed to canonicalize custom data directory's path to an absolute path")
+        let canonicalized = path
+            .canonicalize()
+            .expect("failed to canonicalize custom data directory's path to an absolute path");
+        SanitizedPath::new(&canonicalized).as_path().to_path_buf()
     })
 }
 

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -75,6 +75,10 @@ pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
         let canonicalized = path
             .canonicalize()
             .expect("failed to canonicalize custom data directory's path to an absolute path");
+        // On Windows, `canonicalize` produces extended-length paths prefixed
+        // with `\\?\`. Strip that prefix so downstream consumers (e.g.
+        // Node.js language servers) that receive derived paths as arguments
+        // don't choke on the verbatim syntax.
         SanitizedPath::new(&canonicalized).as_path().to_path_buf()
     })
 }


### PR DESCRIPTION
Closes #50677.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed Node.js language servers failing with `--user-data-dir` on Windows
