### PR TITLE
Fix parsing of filenames like main (1).log

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -595,10 +595,6 @@ const ROW_COL_CAPTURE_REGEX: &str = r"(?xs)
         |
         \((\d+)\)()     # filename:(row)
     )
-    (?:
-        -\(\d+(?:[,:]\d+)?\) # filename:(row,column)-(row,column), filename:(row,column)-(row)
-    )?
-    \:*$
     |
     ([^\(]+)(?:
         \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column)

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -595,12 +595,17 @@ const ROW_COL_CAPTURE_REGEX: &str = r"(?xs)
         |
         \((\d+)\)()     # filename:(row)
     )
+    (?:
+        -\(\d+(?:[,:]\d+)?\) # filename:(row,column)-(row,column), filename:(row,column)-(row)
+    )?
+    \:*$
     |
     ([^\(]+)(?:
         \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column)
         |
         \((\d+)\)()     # filename(row)
     )
+    \:*$
     |
     (.+?)(?:
         \:+(\d+)\:(\d+)\:*$  # filename:row:column
@@ -2097,6 +2102,15 @@ mod tests {
                 column: Some(9),
             }
         );
+
+        assert_eq!(
+            PathWithPosition::parse_str("main (1).log"),
+            PathWithPosition {
+                path: PathBuf::from("main (1).log"),
+                row: None,
+                column: None
+            }
+        );
     }
 
     #[perf]
@@ -2171,6 +2185,15 @@ mod tests {
             PathWithPosition::parse_str("C:\\Users\\someone\\test_file.rs"),
             PathWithPosition {
                 path: PathBuf::from("C:\\Users\\someone\\test_file.rs"),
+                row: None,
+                column: None
+            }
+        );
+
+        assert_eq!(
+            PathWithPosition::parse_str("C:\\Users\\someone\\main (1).log"),
+            PathWithPosition {
+                path: PathBuf::from("C:\\Users\\someone\\main (1).log"),
                 row: None,
                 column: None
             }


### PR DESCRIPTION
## Summary
Fixes Windows file-open parsing for names like `main (1).log`.

`PathWithPosition::parse_str` could treat `(1)` in a normal filename as a position suffix and drop the extension/path tail. The regex is now anchored so parenthesized row/column parsing only applies at the end of the filename (with optional trailing `:` and optional range suffix).

## Testing
- `cargo test -p util path_with_position_parse_`

Closes #50597

Release Notes:

- Fixed opening files with names like `main (1).log` on Windows.