### PR TITLE
Allow search/replace to span multiple lines

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -396,7 +396,17 @@
     "bindings": {
       "ctrl-enter": "editor::Newline",
       "shift-enter": "search::SelectPreviousMatch",
+    },
+  },
+  {
+    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && start_of_input",
+    "bindings": {
       "up": "search::PreviousHistoryQuery",
+    },
+  },
+  {
+    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && end_of_input",
+    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },
@@ -413,9 +423,21 @@
     },
   },
   {
-    "context": "ProjectSearchBar > Editor",
+    "context": "ProjectSearchBar > Editor && mode == single_line",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
+      "down": "search::NextHistoryQuery",
+    },
+  },
+  {
+    "context": "ProjectSearchBar > Editor && mode == auto_height && start_of_input",
+    "bindings": {
+      "up": "search::PreviousHistoryQuery",
+    },
+  },
+  {
+    "context": "ProjectSearchBar > Editor && mode == auto_height && end_of_input",
+    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -392,7 +392,10 @@
   },
   {
     "context": "BufferSearchBar && !in_replace > Editor",
+    "use_key_equivalents": true,
     "bindings": {
+      "ctrl-enter": "editor::Newline",
+      "shift-enter": "search::SelectPreviousMatch",
       "up": "search::PreviousHistoryQuery",
       "down": "search::NextHistoryQuery",
     },
@@ -421,6 +424,12 @@
     "bindings": {
       "enter": "search::ReplaceNext",
       "ctrl-alt-enter": "search::ReplaceAll",
+    },
+  },
+  {
+    "context": "ProjectSearchBar && !in_replace > Editor",
+    "bindings": {
+      "ctrl-enter": "editor::Newline",
     },
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -399,14 +399,9 @@
     },
   },
   {
-    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && start_of_input",
+    "context": "BufferSearchBar && !in_replace > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-    },
-  },
-  {
-    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && end_of_input",
-    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },
@@ -423,21 +418,9 @@
     },
   },
   {
-    "context": "ProjectSearchBar > Editor && mode == single_line",
+    "context": "ProjectSearchBar > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery",
-    },
-  },
-  {
-    "context": "ProjectSearchBar > Editor && mode == auto_height && start_of_input",
-    "bindings": {
-      "up": "search::PreviousHistoryQuery",
-    },
-  },
-  {
-    "context": "ProjectSearchBar > Editor && mode == auto_height && end_of_input",
-    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -446,6 +446,8 @@
     "context": "BufferSearchBar && !in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "ctrl-enter": "editor::Newline",
+      "shift-enter": "search::SelectPreviousMatch",
       "up": "search::PreviousHistoryQuery",
       "down": "search::NextHistoryQuery",
     },
@@ -484,6 +486,12 @@
     "bindings": {
       "enter": "search::ReplaceNext",
       "cmd-enter": "search::ReplaceAll",
+    },
+  },
+  {
+    "context": "ProjectSearchBar && !in_replace > Editor",
+    "bindings": {
+      "ctrl-enter": "editor::Newline",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -448,7 +448,17 @@
     "bindings": {
       "ctrl-enter": "editor::Newline",
       "shift-enter": "search::SelectPreviousMatch",
+    },
+  },
+  {
+    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && start_of_input",
+    "bindings": {
       "up": "search::PreviousHistoryQuery",
+    },
+  },
+  {
+    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && end_of_input",
+    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },
@@ -473,10 +483,22 @@
     },
   },
   {
-    "context": "ProjectSearchBar > Editor",
+    "context": "ProjectSearchBar > Editor && mode == single_line",
     "use_key_equivalents": true,
     "bindings": {
       "up": "search::PreviousHistoryQuery",
+      "down": "search::NextHistoryQuery",
+    },
+  },
+  {
+    "context": "ProjectSearchBar > Editor && mode == auto_height && start_of_input",
+    "bindings": {
+      "up": "search::PreviousHistoryQuery",
+    },
+  },
+  {
+    "context": "ProjectSearchBar > Editor && mode == auto_height && end_of_input",
+    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -451,14 +451,9 @@
     },
   },
   {
-    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && start_of_input",
+    "context": "BufferSearchBar && !in_replace > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-    },
-  },
-  {
-    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && end_of_input",
-    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },
@@ -483,22 +478,9 @@
     },
   },
   {
-    "context": "ProjectSearchBar > Editor && mode == single_line",
-    "use_key_equivalents": true,
+    "context": "ProjectSearchBar > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery",
-    },
-  },
-  {
-    "context": "ProjectSearchBar > Editor && mode == auto_height && start_of_input",
-    "bindings": {
-      "up": "search::PreviousHistoryQuery",
-    },
-  },
-  {
-    "context": "ProjectSearchBar > Editor && mode == auto_height && end_of_input",
-    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -400,7 +400,17 @@
     "bindings": {
       "ctrl-enter": "editor::Newline",
       "shift-enter": "search::SelectPreviousMatch",
+    },
+  },
+  {
+    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && start_of_input",
+    "bindings": {
       "up": "search::PreviousHistoryQuery",
+    },
+  },
+  {
+    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && end_of_input",
+    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },
@@ -415,10 +425,22 @@
     },
   },
   {
-    "context": "ProjectSearchBar > Editor",
+    "context": "ProjectSearchBar > Editor && mode == single_line",
     "use_key_equivalents": true,
     "bindings": {
       "up": "search::PreviousHistoryQuery",
+      "down": "search::NextHistoryQuery",
+    },
+  },
+  {
+    "context": "ProjectSearchBar > Editor && mode == auto_height && start_of_input",
+    "bindings": {
+      "up": "search::PreviousHistoryQuery",
+    },
+  },
+  {
+    "context": "ProjectSearchBar > Editor && mode == auto_height && end_of_input",
+    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -398,6 +398,8 @@
     "context": "BufferSearchBar && !in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "ctrl-enter": "editor::Newline",
+      "shift-enter": "search::SelectPreviousMatch",
       "up": "search::PreviousHistoryQuery",
       "down": "search::NextHistoryQuery",
     },
@@ -426,6 +428,12 @@
     "bindings": {
       "enter": "search::ReplaceNext",
       "ctrl-alt-enter": "search::ReplaceAll",
+    },
+  },
+  {
+    "context": "ProjectSearchBar && !in_replace > Editor",
+    "bindings": {
+      "ctrl-enter": "editor::Newline",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -403,14 +403,9 @@
     },
   },
   {
-    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && start_of_input",
+    "context": "BufferSearchBar && !in_replace > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-    },
-  },
-  {
-    "context": "BufferSearchBar && !in_replace > Editor && mode == auto_height && end_of_input",
-    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },
@@ -425,22 +420,9 @@
     },
   },
   {
-    "context": "ProjectSearchBar > Editor && mode == single_line",
-    "use_key_equivalents": true,
+    "context": "ProjectSearchBar > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery",
-    },
-  },
-  {
-    "context": "ProjectSearchBar > Editor && mode == auto_height && start_of_input",
-    "bindings": {
-      "up": "search::PreviousHistoryQuery",
-    },
-  },
-  {
-    "context": "ProjectSearchBar > Editor && mode == auto_height && end_of_input",
-    "bindings": {
       "down": "search::NextHistoryQuery",
     },
   },

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -303,7 +303,8 @@ impl Console {
     }
 
     fn previous_query(&mut self, _: &SelectPrevious, window: &mut Window, cx: &mut Context<Self>) {
-        let prev = self.history.previous(&mut self.cursor);
+        let current_query = self.query_bar.read(cx).text(cx);
+        let prev = self.history.previous(&mut self.cursor, &current_query);
         if let Some(prev) = prev {
             self.query_bar.update(cx, |editor, cx| {
                 editor.set_text(prev, window, cx);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2913,14 +2913,23 @@ impl Editor {
         }
 
         let disjoint = self.selections.disjoint_anchors();
-        let snapshot = self.snapshot(window, cx);
-        let snapshot = snapshot.buffer_snapshot();
-        if self.mode == EditorMode::SingleLine
-            && let [selection] = disjoint
+        if matches!(
+            &self.mode,
+            EditorMode::SingleLine | EditorMode::AutoHeight { .. }
+        ) && let [selection] = disjoint
             && selection.start == selection.end
-            && selection.end.to_offset(snapshot) == snapshot.len()
         {
-            key_context.add("end_of_input");
+            let snapshot = self.snapshot(window, cx);
+            let snapshot = snapshot.buffer_snapshot();
+            let caret_offset = selection.end.to_offset(snapshot);
+
+            if caret_offset == MultiBufferOffset(0) {
+                key_context.add("start_of_input");
+            }
+
+            if caret_offset == snapshot.len() {
+                key_context.add("end_of_input");
+            }
         }
 
         if self.has_any_expanded_diff_hunks(cx) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29839,14 +29839,47 @@ async fn test_end_of_editor_context(cx: &mut TestAppContext) {
     cx.set_state("line1\nline2ˇ");
     cx.update_editor(|e, window, cx| {
         e.set_mode(EditorMode::SingleLine);
+        assert!(!e.key_context(window, cx).contains("start_of_input"));
         assert!(e.key_context(window, cx).contains("end_of_input"));
     });
     cx.set_state("ˇline1\nline2");
     cx.update_editor(|e, window, cx| {
+        e.set_mode(EditorMode::SingleLine);
+        assert!(e.key_context(window, cx).contains("start_of_input"));
         assert!(!e.key_context(window, cx).contains("end_of_input"));
     });
     cx.set_state("line1ˇ\nline2");
     cx.update_editor(|e, window, cx| {
+        e.set_mode(EditorMode::SingleLine);
+        assert!(!e.key_context(window, cx).contains("start_of_input"));
+        assert!(!e.key_context(window, cx).contains("end_of_input"));
+    });
+
+    cx.set_state("line1\nline2ˇ");
+    cx.update_editor(|e, window, cx| {
+        e.set_mode(EditorMode::AutoHeight {
+            min_lines: 1,
+            max_lines: Some(4),
+        });
+        assert!(!e.key_context(window, cx).contains("start_of_input"));
+        assert!(e.key_context(window, cx).contains("end_of_input"));
+    });
+    cx.set_state("ˇline1\nline2");
+    cx.update_editor(|e, window, cx| {
+        e.set_mode(EditorMode::AutoHeight {
+            min_lines: 1,
+            max_lines: Some(4),
+        });
+        assert!(e.key_context(window, cx).contains("start_of_input"));
+        assert!(!e.key_context(window, cx).contains("end_of_input"));
+    });
+    cx.set_state("line1ˇ\nline2");
+    cx.update_editor(|e, window, cx| {
+        e.set_mode(EditorMode::AutoHeight {
+            min_lines: 1,
+            max_lines: Some(4),
+        });
+        assert!(!e.key_context(window, cx).contains("start_of_input"));
         assert!(!e.key_context(window, cx).contains("end_of_input"));
     });
 }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1649,14 +1649,9 @@ impl SearchableItem for Editor {
         match setting {
             SeedQuerySetting::Never => String::new(),
             SeedQuerySetting::Selection | SeedQuerySetting::Always if !selection.is_empty() => {
-                let text: String = buffer_snapshot
+                buffer_snapshot
                     .text_for_range(selection.start..selection.end)
-                    .collect();
-                if text.contains('\n') {
-                    String::new()
-                } else {
-                    text
-                }
+                    .collect()
             }
             SeedQuerySetting::Selection => String::new(),
             SeedQuerySetting::Always => {

--- a/crates/project/src/search_history.rs
+++ b/crates/project/src/search_history.rs
@@ -19,12 +19,19 @@ pub enum QueryInsertionBehavior {
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SearchHistoryCursor {
     selection: Option<usize>,
+    draft: Option<String>,
 }
 
 impl SearchHistoryCursor {
-    /// Resets the selection to `None`.
+    /// Resets the selection to `None` and clears the draft.
     pub fn reset(&mut self) {
         self.selection = None;
+        self.draft = None;
+    }
+
+    /// Takes the stored draft query, if any.
+    pub fn take_draft(&mut self) -> Option<String> {
+        self.draft.take()
     }
 }
 
@@ -45,6 +52,8 @@ impl SearchHistory {
     }
 
     pub fn add(&mut self, cursor: &mut SearchHistoryCursor, search_string: String) {
+        cursor.draft = None;
+
         if self.insertion_behavior == QueryInsertionBehavior::ReplacePreviousIfContains
             && let Some(previously_searched) = self.history.back_mut()
             && search_string.contains(previously_searched.as_str())
@@ -81,7 +90,23 @@ impl SearchHistory {
 
     /// Get the previous history entry using the given `SearchHistoryCursor`.
     /// Uses the last element in the history when there is no cursor.
-    pub fn previous(&mut self, cursor: &mut SearchHistoryCursor) -> Option<&str> {
+    ///
+    /// `current_query` is the current text in the search editor. If it differs
+    /// from the history entry at the cursor position (or if the cursor has no
+    /// selection), it is saved as a draft so it can be restored later.
+    pub fn previous(
+        &mut self,
+        cursor: &mut SearchHistoryCursor,
+        current_query: &str,
+    ) -> Option<&str> {
+        let matches_history = cursor
+            .selection
+            .and_then(|i| self.history.get(i))
+            .is_some_and(|entry| entry == current_query);
+        if !matches_history {
+            cursor.draft = Some(current_query.to_string());
+        }
+
         let prev_index = match cursor.selection {
             Some(index) => index.checked_sub(1)?,
             None => self.history.len().checked_sub(1)?,

--- a/crates/project/tests/integration/search_history.rs
+++ b/crates/project/tests/integration/search_history.rs
@@ -38,7 +38,7 @@ fn test_add() {
 
     // add item when it equals to current item if it's not the last one
     search_history.add(&mut cursor, "php".to_string());
-    search_history.previous(&mut cursor);
+    search_history.previous(&mut cursor, "");
     assert_eq!(search_history.current(&cursor), Some("rustlang"));
     search_history.add(&mut cursor, "rustlang".to_string());
     assert_eq!(search_history.len(), 3, "Should add item");
@@ -71,13 +71,13 @@ fn test_next_and_previous() {
 
     assert_eq!(search_history.current(&cursor), Some("TypeScript"));
 
-    assert_eq!(search_history.previous(&mut cursor), Some("JavaScript"));
+    assert_eq!(search_history.previous(&mut cursor, ""), Some("JavaScript"));
     assert_eq!(search_history.current(&cursor), Some("JavaScript"));
 
-    assert_eq!(search_history.previous(&mut cursor), Some("Rust"));
+    assert_eq!(search_history.previous(&mut cursor, ""), Some("Rust"));
     assert_eq!(search_history.current(&cursor), Some("Rust"));
 
-    assert_eq!(search_history.previous(&mut cursor), None);
+    assert_eq!(search_history.previous(&mut cursor, ""), None);
     assert_eq!(search_history.current(&cursor), Some("Rust"));
 
     assert_eq!(search_history.next(&mut cursor), Some("JavaScript"));
@@ -103,14 +103,14 @@ fn test_reset_selection() {
     cursor.reset();
     assert_eq!(search_history.current(&cursor), None);
     assert_eq!(
-        search_history.previous(&mut cursor),
+        search_history.previous(&mut cursor, ""),
         Some("TypeScript"),
         "Should start from the end after reset on previous item query"
     );
 
-    search_history.previous(&mut cursor);
+    search_history.previous(&mut cursor, "");
     assert_eq!(search_history.current(&cursor), Some("JavaScript"));
-    search_history.previous(&mut cursor);
+    search_history.previous(&mut cursor, "");
     assert_eq!(search_history.current(&cursor), Some("Rust"));
 
     cursor.reset();
@@ -134,8 +134,11 @@ fn test_multiple_cursors() {
     assert_eq!(search_history.current(&cursor1), Some("TypeScript"));
     assert_eq!(search_history.current(&cursor2), Some("C++"));
 
-    assert_eq!(search_history.previous(&mut cursor1), Some("JavaScript"));
-    assert_eq!(search_history.previous(&mut cursor2), Some("Java"));
+    assert_eq!(
+        search_history.previous(&mut cursor1, ""),
+        Some("JavaScript")
+    );
+    assert_eq!(search_history.previous(&mut cursor2, ""), Some("Java"));
 
     assert_eq!(search_history.next(&mut cursor1), Some("TypeScript"));
     assert_eq!(search_history.next(&mut cursor1), Some("Python"));

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -337,13 +337,11 @@ impl Render for BufferSearchBar {
         };
 
         let query_column = input_style
-            .child(
-                div()
-                    .flex_1()
-                    .min_w(px(0.))
-                    .overflow_hidden()
-                    .child(render_text_input(&self.query_editor, color_override, cx)),
-            )
+            .child(div().flex_1().min_w(px(0.)).child(render_text_input(
+                &self.query_editor,
+                color_override,
+                cx,
+            )))
             .child(
                 h_flex()
                     .flex_none()
@@ -484,39 +482,41 @@ impl Render for BufferSearchBar {
             .child(query_column)
             .child(mode_column);
 
-        let replace_line =
-            should_show_replace_input.then(|| {
-                let replace_column = input_base_styles(replacement_border)
-                    .child(render_text_input(&self.replacement_editor, None, cx));
-                let focus_handle = self.replacement_editor.read(cx).focus_handle(cx);
+        let replace_line = should_show_replace_input.then(|| {
+            let replace_column = input_base_styles(replacement_border).child(
+                div()
+                    .flex_1()
+                    .child(render_text_input(&self.replacement_editor, None, cx)),
+            );
+            let focus_handle = self.replacement_editor.read(cx).focus_handle(cx);
 
-                let replace_actions = h_flex()
-                    .min_w_64()
-                    .gap_1()
-                    .child(render_action_button(
-                        "buffer-search-replace-button",
-                        IconName::ReplaceNext,
-                        Default::default(),
-                        "Replace Next Match",
-                        &ReplaceNext,
-                        focus_handle.clone(),
-                    ))
-                    .child(render_action_button(
-                        "buffer-search-replace-button",
-                        IconName::ReplaceAll,
-                        Default::default(),
-                        "Replace All Matches",
-                        &ReplaceAll,
-                        focus_handle,
-                    ));
+            let replace_actions = h_flex()
+                .min_w_64()
+                .gap_1()
+                .child(render_action_button(
+                    "buffer-search-replace-button",
+                    IconName::ReplaceNext,
+                    Default::default(),
+                    "Replace Next Match",
+                    &ReplaceNext,
+                    focus_handle.clone(),
+                ))
+                .child(render_action_button(
+                    "buffer-search-replace-button",
+                    IconName::ReplaceAll,
+                    Default::default(),
+                    "Replace All Matches",
+                    &ReplaceAll,
+                    focus_handle,
+                ));
 
-                h_flex()
-                    .w_full()
-                    .gap_2()
-                    .when(has_collapse_button, |this| this.child(alignment_element()))
-                    .child(replace_column)
-                    .child(replace_actions)
-            });
+            h_flex()
+                .w_full()
+                .gap_2()
+                .when(has_collapse_button, |this| this.child(alignment_element()))
+                .child(replace_column)
+                .child(replace_actions)
+        });
 
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("BufferSearchBar");
@@ -831,13 +831,13 @@ impl BufferSearchBar {
         cx: &mut Context<Self>,
     ) -> Self {
         let query_editor = cx.new(|cx| {
-            let mut editor = Editor::single_line(window, cx);
+            let mut editor = Editor::auto_height(1, 4, window, cx);
             editor.set_use_autoclose(false);
             editor
         });
         cx.subscribe_in(&query_editor, window, Self::on_query_editor_event)
             .detach();
-        let replacement_editor = cx.new(|cx| Editor::single_line(window, cx));
+        let replacement_editor = cx.new(|cx| Editor::auto_height(1, 4, window, cx));
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -337,7 +337,7 @@ impl Render for BufferSearchBar {
         };
 
         let query_column = input_style
-            .child(div().flex_1().min_w(px(0.)).child(render_text_input(
+            .child(div().flex_1().min_w_0().py_1().child(render_text_input(
                 &self.query_editor,
                 color_override,
                 cx,
@@ -486,6 +486,7 @@ impl Render for BufferSearchBar {
             let replace_column = input_base_styles(replacement_border).child(
                 div()
                     .flex_1()
+                    .py_1()
                     .child(render_text_input(&self.replacement_editor, None, cx)),
             );
             let focus_handle = self.replacement_editor.read(cx).focus_handle(cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -6,8 +6,9 @@ use crate::{
     ToggleCaseSensitive, ToggleRegex, ToggleReplace, ToggleSelection, ToggleWholeWord,
     buffer_search::registrar::WithResultsOrExternalQuery,
     search_bar::{
-        ActionButtonState, alignment_element, filter_search_results_input, input_base_styles,
-        render_action_button, render_text_input,
+        ActionButtonState, HistoryNavigationDirection, alignment_element,
+        filter_search_results_input, input_base_styles, render_action_button, render_text_input,
+        should_navigate_history,
     },
 };
 use any_vec::AnyVec;
@@ -1705,15 +1706,19 @@ impl BufferSearchBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !should_navigate_history(&self.query_editor, HistoryNavigationDirection::Next, cx) {
+            cx.propagate();
+            return;
+        }
+
         if let Some(new_query) = self
             .search_history
             .next(&mut self.search_history_cursor)
             .map(str::to_string)
         {
             drop(self.search(&new_query, Some(self.search_options), false, window, cx));
-        } else {
-            self.search_history_cursor.reset();
-            drop(self.search("", Some(self.search_options), false, window, cx));
+        } else if let Some(draft) = self.search_history_cursor.take_draft() {
+            drop(self.search(&draft, Some(self.search_options), false, window, cx));
         }
     }
 
@@ -1723,6 +1728,11 @@ impl BufferSearchBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !should_navigate_history(&self.query_editor, HistoryNavigationDirection::Previous, cx) {
+            cx.propagate();
+            return;
+        }
+
         if self.query(cx).is_empty()
             && let Some(new_query) = self
                 .search_history
@@ -1733,9 +1743,10 @@ impl BufferSearchBar {
             return;
         }
 
+        let current_query = self.query(cx);
         if let Some(new_query) = self
             .search_history
-            .previous(&mut self.search_history_cursor)
+            .previous(&mut self.search_history_cursor, &current_query)
             .map(str::to_string)
         {
             drop(self.search(&new_query, Some(self.search_options), false, window, cx));
@@ -2717,13 +2728,13 @@ mod tests {
             assert_eq!(search_bar.search_options, SearchOptions::CASE_SENSITIVE);
         });
 
-        // Next history query after the latest should set the query to the empty string.
+        // Next history query after the latest should preserve the current query.
         search_bar.update_in(cx, |search_bar, window, cx| {
             search_bar.next_history_query(&NextHistoryQuery, window, cx);
         });
         cx.background_executor.run_until_parked();
         search_bar.update(cx, |search_bar, cx| {
-            assert_eq!(search_bar.query(cx), "");
+            assert_eq!(search_bar.query(cx), "c");
             assert_eq!(search_bar.search_options, SearchOptions::CASE_SENSITIVE);
         });
         search_bar.update_in(cx, |search_bar, window, cx| {
@@ -2731,17 +2742,17 @@ mod tests {
         });
         cx.background_executor.run_until_parked();
         search_bar.update(cx, |search_bar, cx| {
-            assert_eq!(search_bar.query(cx), "");
+            assert_eq!(search_bar.query(cx), "c");
             assert_eq!(search_bar.search_options, SearchOptions::CASE_SENSITIVE);
         });
 
-        // First previous query for empty current query should set the query to the latest.
+        // Previous query should navigate backwards through history.
         search_bar.update_in(cx, |search_bar, window, cx| {
             search_bar.previous_history_query(&PreviousHistoryQuery, window, cx);
         });
         cx.background_executor.run_until_parked();
         search_bar.update(cx, |search_bar, cx| {
-            assert_eq!(search_bar.query(cx), "c");
+            assert_eq!(search_bar.query(cx), "b");
             assert_eq!(search_bar.search_options, SearchOptions::CASE_SENSITIVE);
         });
 
@@ -2751,7 +2762,7 @@ mod tests {
         });
         cx.background_executor.run_until_parked();
         search_bar.update(cx, |search_bar, cx| {
-            assert_eq!(search_bar.query(cx), "b");
+            assert_eq!(search_bar.query(cx), "a");
             assert_eq!(search_bar.search_options, SearchOptions::CASE_SENSITIVE);
         });
 
@@ -2832,7 +2843,7 @@ mod tests {
         });
         cx.background_executor.run_until_parked();
         search_bar.update(cx, |search_bar, cx| {
-            assert_eq!(search_bar.query(cx), "");
+            assert_eq!(search_bar.query(cx), "ba");
             assert_eq!(search_bar.search_options, SearchOptions::NONE);
         });
     }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -16,6 +16,7 @@ use collections::HashMap;
 use editor::{
     Editor, EditorSettings, MultiBufferOffset, SplittableEditor, ToggleSplitDiff,
     actions::{Backtab, FoldAll, Tab, ToggleFoldAll, UnfoldAll},
+    scroll::Autoscroll,
 };
 use futures::channel::oneshot;
 use gpui::{
@@ -1188,6 +1189,7 @@ impl BufferSearchBar {
                     let len = query_buffer.len(cx);
                     query_buffer.edit([(MultiBufferOffset(0)..len, query)], None, cx);
                 });
+                query_editor.request_autoscroll(Autoscroll::fit(), cx);
             });
             self.set_search_options(options, cx);
             self.clear_matches(window, cx);
@@ -2845,6 +2847,66 @@ mod tests {
         search_bar.update(cx, |search_bar, cx| {
             assert_eq!(search_bar.query(cx), "ba");
             assert_eq!(search_bar.search_options, SearchOptions::NONE);
+        });
+    }
+
+    #[perf]
+    #[gpui::test]
+    async fn test_search_query_history_autoscroll(cx: &mut TestAppContext) {
+        let (_editor, search_bar, cx) = init_test(cx);
+
+        // Add a long multi-line query that exceeds the editor's max
+        // visible height (4 lines), then a short query.
+        let long_query = "line1\nline2\nline3\nline4\nline5\nline6";
+        search_bar
+            .update_in(cx, |search_bar, window, cx| {
+                search_bar.search(long_query, None, true, window, cx)
+            })
+            .await
+            .unwrap();
+        search_bar
+            .update_in(cx, |search_bar, window, cx| {
+                search_bar.search("short", None, true, window, cx)
+            })
+            .await
+            .unwrap();
+
+        // Navigate back to the long entry. Since "short" is single-line,
+        // the history navigation is allowed.
+        search_bar.update_in(cx, |search_bar, window, cx| {
+            search_bar.previous_history_query(&PreviousHistoryQuery, window, cx);
+        });
+        cx.background_executor.run_until_parked();
+        search_bar.update(cx, |search_bar, cx| {
+            assert_eq!(search_bar.query(cx), long_query);
+        });
+
+        // The cursor should be scrolled into view despite the content
+        // exceeding the editor's max visible height.
+        search_bar.update_in(cx, |search_bar, window, cx| {
+            let snapshot = search_bar
+                .query_editor
+                .update(cx, |editor, cx| editor.snapshot(window, cx));
+            let cursor_row = search_bar
+                .query_editor
+                .read(cx)
+                .selections
+                .newest_display(&snapshot)
+                .head()
+                .row();
+            let scroll_top = search_bar
+                .query_editor
+                .update(cx, |editor, cx| editor.scroll_position(cx).y);
+            let visible_lines = search_bar
+                .query_editor
+                .read(cx)
+                .visible_line_count()
+                .unwrap_or(0.0);
+            let scroll_bottom = scroll_top + visible_lines;
+            assert!(
+                (cursor_row.0 as f64) < scroll_bottom,
+                "cursor row {cursor_row:?} should be visible (scroll range {scroll_top}..{scroll_bottom})"
+            );
         });
     }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2086,7 +2086,7 @@ impl Render for ProjectSearchBar {
             .on_action(
                 cx.listener(|this, action, window, cx| this.next_history_query(action, window, cx)),
             )
-            .child(div().flex_1().child(render_text_input(
+            .child(div().flex_1().py_1().child(render_text_input(
                 &search.query_editor,
                 color_override,
                 cx,
@@ -2249,9 +2249,11 @@ impl Render for ProjectSearchBar {
 
         let replace_line = search.replace_enabled.then(|| {
             let replace_column = input_base_styles(InputPanel::Replacement).child(
-                div()
-                    .flex_1()
-                    .child(render_text_input(&search.replacement_editor, None, cx)),
+                div().flex_1().py_1().child(render_text_input(
+                    &search.replacement_editor,
+                    None,
+                    cx,
+                )),
             );
 
             let focus_handle = search.replacement_editor.read(cx).focus_handle(cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -858,7 +858,7 @@ impl ProjectSearchView {
         }));
 
         let query_editor = cx.new(|cx| {
-            let mut editor = Editor::single_line(window, cx);
+            let mut editor = Editor::auto_height(1, 4, window, cx);
             editor.set_placeholder_text("Search all files…", window, cx);
             editor.set_text(query_text, window, cx);
             editor
@@ -881,7 +881,7 @@ impl ProjectSearchView {
             }),
         );
         let replacement_editor = cx.new(|cx| {
-            let mut editor = Editor::single_line(window, cx);
+            let mut editor = Editor::auto_height(1, 4, window, cx);
             editor.set_placeholder_text("Replace in project…", window, cx);
             if let Some(text) = replacement_text {
                 editor.set_text(text, window, cx);
@@ -2086,7 +2086,11 @@ impl Render for ProjectSearchBar {
             .on_action(
                 cx.listener(|this, action, window, cx| this.next_history_query(action, window, cx)),
             )
-            .child(render_text_input(&search.query_editor, color_override, cx))
+            .child(div().flex_1().child(render_text_input(
+                &search.query_editor,
+                color_override,
+                cx,
+            )))
             .child(
                 h_flex()
                     .gap_1()
@@ -2244,8 +2248,11 @@ impl Render for ProjectSearchBar {
             .child(mode_column);
 
         let replace_line = search.replace_enabled.then(|| {
-            let replace_column = input_base_styles(InputPanel::Replacement)
-                .child(render_text_input(&search.replacement_editor, None, cx));
+            let replace_column = input_base_styles(InputPanel::Replacement).child(
+                div()
+                    .flex_1()
+                    .child(render_text_input(&search.replacement_editor, None, cx)),
+            );
 
             let focus_handle = search.replacement_editor.read(cx).focus_handle(cx);
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -4,8 +4,8 @@ use crate::{
     ToggleCaseSensitive, ToggleIncludeIgnored, ToggleRegex, ToggleReplace, ToggleWholeWord,
     buffer_search::Deploy,
     search_bar::{
-        ActionButtonState, alignment_element, input_base_styles, render_action_button,
-        render_text_input,
+        ActionButtonState, HistoryNavigationDirection, alignment_element, input_base_styles,
+        render_action_button, render_text_input, should_navigate_history,
     },
 };
 use anyhow::Context as _;
@@ -1926,6 +1926,11 @@ impl ProjectSearchBar {
                     ),
                 ] {
                     if editor.focus_handle(cx).is_focused(window) {
+                        if !should_navigate_history(&editor, HistoryNavigationDirection::Next, cx) {
+                            cx.propagate();
+                            return;
+                        }
+
                         let new_query = search_view.entity.update(cx, |model, cx| {
                             let project = model.project.clone();
 
@@ -1935,13 +1940,14 @@ impl ProjectSearchBar {
                                     .next(model.cursor_mut(kind))
                                     .map(str::to_string)
                             }) {
-                                new_query
+                                Some(new_query)
                             } else {
-                                model.cursor_mut(kind).reset();
-                                String::new()
+                                model.cursor_mut(kind).take_draft()
                             }
                         });
-                        search_view.set_search_editor(kind, &new_query, window, cx);
+                        if let Some(new_query) = new_query {
+                            search_view.set_search_editor(kind, &new_query, window, cx);
+                        }
                     }
                 }
             });
@@ -1968,6 +1974,15 @@ impl ProjectSearchBar {
                     ),
                 ] {
                     if editor.focus_handle(cx).is_focused(window) {
+                        if !should_navigate_history(
+                            &editor,
+                            HistoryNavigationDirection::Previous,
+                            cx,
+                        ) {
+                            cx.propagate();
+                            return;
+                        }
+
                         if editor.read(cx).text(cx).is_empty()
                             && let Some(new_query) = search_view
                                 .entity
@@ -1982,12 +1997,13 @@ impl ProjectSearchBar {
                             return;
                         }
 
+                        let current_query = editor.read(cx).text(cx);
                         if let Some(new_query) = search_view.entity.update(cx, |model, cx| {
                             let project = model.project.clone();
                             project.update(cx, |project, _| {
                                 project
                                     .search_history_mut(kind)
-                                    .previous(model.cursor_mut(kind))
+                                    .previous(model.cursor_mut(kind), &current_query)
                                     .map(str::to_string)
                             })
                         }) {
@@ -3854,7 +3870,7 @@ pub mod tests {
             })
             .unwrap();
 
-        // Next history query after the latest should set the query to the empty string.
+        // Next history query after the latest should preserve the current query.
         window
             .update(cx, |_, window, cx| {
                 search_bar.update(cx, |search_bar, cx| {
@@ -3866,7 +3882,10 @@ pub mod tests {
         window
             .update(cx, |_, _, cx| {
                 search_view.update(cx, |search_view, cx| {
-                    assert_eq!(search_view.query_editor.read(cx).text(cx), "");
+                    assert_eq!(
+                        search_view.query_editor.read(cx).text(cx),
+                        "JUST_TEXT_INPUT"
+                    );
                     assert_eq!(search_view.search_options, SearchOptions::CASE_SENSITIVE);
                 });
             })
@@ -3882,13 +3901,16 @@ pub mod tests {
         window
             .update(cx, |_, _, cx| {
                 search_view.update(cx, |search_view, cx| {
-                    assert_eq!(search_view.query_editor.read(cx).text(cx), "");
+                    assert_eq!(
+                        search_view.query_editor.read(cx).text(cx),
+                        "JUST_TEXT_INPUT"
+                    );
                     assert_eq!(search_view.search_options, SearchOptions::CASE_SENSITIVE);
                 });
             })
             .unwrap();
 
-        // First previous query for empty current query should set the query to the latest submitted one.
+        // Previous query should navigate backwards through history.
         window
             .update(cx, |_, window, cx| {
                 search_bar.update(cx, |search_bar, cx| {
@@ -3900,7 +3922,7 @@ pub mod tests {
         window
             .update(cx, |_, _, cx| {
                 search_view.update(cx, |search_view, cx| {
-                    assert_eq!(search_view.query_editor.read(cx).text(cx), "THREE");
+                    assert_eq!(search_view.query_editor.read(cx).text(cx), "TWO");
                     assert_eq!(search_view.search_options, SearchOptions::CASE_SENSITIVE);
                 });
             })
@@ -3918,7 +3940,7 @@ pub mod tests {
         window
             .update(cx, |_, _, cx| {
                 search_view.update(cx, |search_view, cx| {
-                    assert_eq!(search_view.query_editor.read(cx).text(cx), "TWO");
+                    assert_eq!(search_view.query_editor.read(cx).text(cx), "ONE");
                     assert_eq!(search_view.search_options, SearchOptions::CASE_SENSITIVE);
                 });
             })
@@ -4072,8 +4094,72 @@ pub mod tests {
         window
             .update(cx, |_, _, cx| {
                 search_view.update(cx, |search_view, cx| {
-                    assert_eq!(search_view.query_editor.read(cx).text(cx), "");
+                    assert_eq!(search_view.query_editor.read(cx).text(cx), "TWO_NEW");
                     assert_eq!(search_view.search_options, SearchOptions::CASE_SENSITIVE);
+                });
+            })
+            .unwrap();
+
+        // Typing text without running a search, then navigating history, should allow
+        // restoring the draft when pressing next past the end.
+        window
+            .update(cx, |_, window, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    search_view.query_editor.update(cx, |query_editor, cx| {
+                        query_editor.set_text("unsaved draft", window, cx)
+                    });
+                })
+            })
+            .unwrap();
+        cx.background_executor.run_until_parked();
+
+        // Navigate up into history — the draft should be stashed.
+        window
+            .update(cx, |_, window, cx| {
+                search_bar.update(cx, |search_bar, cx| {
+                    search_bar.focus_search(window, cx);
+                    search_bar.previous_history_query(&PreviousHistoryQuery, window, cx);
+                });
+            })
+            .unwrap();
+        window
+            .update(cx, |_, _, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    assert_eq!(search_view.query_editor.read(cx).text(cx), "THREE");
+                });
+            })
+            .unwrap();
+
+        // Navigate forward through history.
+        window
+            .update(cx, |_, window, cx| {
+                search_bar.update(cx, |search_bar, cx| {
+                    search_bar.focus_search(window, cx);
+                    search_bar.next_history_query(&NextHistoryQuery, window, cx);
+                });
+            })
+            .unwrap();
+        window
+            .update(cx, |_, _, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    assert_eq!(search_view.query_editor.read(cx).text(cx), "TWO_NEW");
+                });
+            })
+            .unwrap();
+
+        // Navigate past the end — the draft should be restored.
+        window
+            .update(cx, |_, window, cx| {
+                search_bar.update(cx, |search_bar, cx| {
+                    search_bar.focus_search(window, cx);
+                    search_bar.next_history_query(&NextHistoryQuery, window, cx);
+                });
+            })
+            .unwrap();
+        window
+            .update(cx, |_, _, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    assert_eq!(search_view.query_editor.read(cx).text(cx), "unsaved draft");
                 });
             })
             .unwrap();
@@ -4262,13 +4348,13 @@ pub mod tests {
         cx.background_executor.run_until_parked();
 
         select_next_history_item(&search_bar_2, cx);
-        assert_eq!(active_query(&search_view_2, cx), "");
-
-        select_prev_history_item(&search_bar_2, cx);
         assert_eq!(active_query(&search_view_2, cx), "THREE");
 
         select_prev_history_item(&search_bar_2, cx);
         assert_eq!(active_query(&search_view_2, cx), "TWO");
+
+        select_prev_history_item(&search_bar_2, cx);
+        assert_eq!(active_query(&search_view_2, cx), "ONE");
 
         select_prev_history_item(&search_bar_2, cx);
         assert_eq!(active_query(&search_view_2, cx), "ONE");
@@ -4287,7 +4373,7 @@ pub mod tests {
         assert_eq!(active_query(&search_view_2, cx), "THREE");
 
         select_next_history_item(&search_bar_2, cx);
-        assert_eq!(active_query(&search_view_2, cx), "");
+        assert_eq!(active_query(&search_view_2, cx), "THREE");
 
         select_next_history_item(&search_bar_1, cx);
         assert_eq!(active_query(&search_view_1, cx), "TWO");
@@ -4296,7 +4382,7 @@ pub mod tests {
         assert_eq!(active_query(&search_view_1, cx), "THREE");
 
         select_next_history_item(&search_bar_1, cx);
-        assert_eq!(active_query(&search_view_1, cx), "");
+        assert_eq!(active_query(&search_view_1, cx), "THREE");
     }
 
     #[perf]

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1474,8 +1474,9 @@ impl ProjectSearchView {
 
             SearchInputKind::Exclude => &self.excluded_files_editor,
         };
-        editor.update(cx, |included_editor, cx| {
-            included_editor.set_text(text, window, cx)
+        editor.update(cx, |editor, cx| {
+            editor.set_text(text, window, cx);
+            editor.request_autoscroll(Autoscroll::fit(), cx);
         });
     }
 

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -43,7 +43,7 @@ pub(crate) fn input_base_styles(border_color: Hsla, map: impl FnOnce(Div) -> Div
     h_flex()
         .map(map)
         .min_w_32()
-        .h_8()
+        .min_h_8()
         .pl_2()
         .pr_1()
         .border_1()

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -1,9 +1,36 @@
-use editor::{Editor, EditorElement, EditorStyle};
-use gpui::{Action, Entity, FocusHandle, Hsla, IntoElement, TextStyle};
+use editor::{Editor, EditorElement, EditorStyle, MultiBufferOffset, ToOffset};
+use gpui::{Action, App, Entity, FocusHandle, Hsla, IntoElement, TextStyle};
 use settings::Settings;
 use theme::ThemeSettings;
 use ui::{IconButton, IconButtonShape};
 use ui::{Tooltip, prelude::*};
+
+pub(super) enum HistoryNavigationDirection {
+    Previous,
+    Next,
+}
+
+pub(super) fn should_navigate_history(
+    editor: &Entity<Editor>,
+    direction: HistoryNavigationDirection,
+    cx: &App,
+) -> bool {
+    let editor_ref = editor.read(cx);
+    let snapshot = editor_ref.buffer().read(cx).snapshot(cx);
+    if snapshot.max_point().row == 0 {
+        return true;
+    }
+    let selections = editor_ref.selections.disjoint_anchors();
+    if let [selection] = selections {
+        let offset = selection.end.to_offset(&snapshot);
+        match direction {
+            HistoryNavigationDirection::Previous => offset == MultiBufferOffset(0),
+            HistoryNavigationDirection::Next => offset == snapshot.len(),
+        }
+    } else {
+        true
+    }
+}
 
 pub(super) enum ActionButtonState {
     Disabled,


### PR DESCRIPTION
Closes #49957 

Also adds `start_of_input` context, and modifies both `{start,end}_of_input` to work for both single line and auto height editor modes.

https://github.com/user-attachments/assets/e30f2b20-a96c-49d5-9eb6-3c95a485d14a

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added support for multi-line search and replace input in Buffer Search and Project Search
