### PR TITLE
git_ui: Disable Push/Fetch/Pull buttons while operation is in progress

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -653,7 +653,7 @@ pub struct GitPanel {
     local_committer_task: Option<Task<()>>,
     bulk_staging: Option<BulkStaging>,
     stash_entries: GitStash,
-
+    pending_remote_operation: Option<Task<()>>,
     _settings_subscription: Subscription,
 }
 
@@ -826,6 +826,7 @@ impl GitPanel {
                 entry_count: 0,
                 bulk_staging: None,
                 stash_entries: Default::default(),
+                pending_remote_operation: None,
                 _settings_subscription,
             };
 
@@ -2836,7 +2837,7 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.can_push_and_pull(cx) {
+        if !self.can_push_and_pull(cx) || self.pending_remote_operation.is_some() {
             return;
         }
 
@@ -2845,7 +2846,6 @@ impl GitPanel {
         };
         telemetry::event!("Git Fetched");
         let askpass = self.askpass_delegate("git fetch", window, cx);
-        let this = cx.weak_entity();
 
         let fetch_options = if is_fetch_all {
             Task::ready(Some(FetchOptions::All))
@@ -2853,8 +2853,8 @@ impl GitPanel {
             self.get_fetch_options(window, cx)
         };
 
-        window
-            .spawn(cx, async move |cx| {
+        self.pending_remote_operation = Some(cx.spawn(async move |this, cx| {
+            let result: anyhow::Result<()> = async {
                 let Some(fetch_options) = fetch_options.await else {
                     return Ok(());
                 };
@@ -2869,19 +2869,30 @@ impl GitPanel {
                         FetchOptions::Remote(remote) => RemoteAction::Fetch(Some(remote)),
                     };
                     match remote_message {
-                        Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                        Ok(remote_message) => {
+                            this.show_remote_output(action, remote_message, cx)
+                        }
                         Err(e) => {
                             log::error!("Error while fetching {:?}", e);
                             this.show_error_toast(action.name(), e, cx)
                         }
                     }
-
-                    anyhow::Ok(())
                 })
                 .ok();
-                anyhow::Ok(())
+                Ok(())
+            }
+            .await;
+
+            if let Err(e) = &result {
+                log::error!("{e:?}");
+            }
+            this.update(cx, |this, cx| {
+                this.pending_remote_operation = None;
+                cx.notify();
             })
-            .detach_and_log_err(cx);
+            .ok();
+        }));
+        cx.notify();
     }
 
     pub(crate) fn git_clone(&mut self, repo: String, window: &mut Window, cx: &mut Context<Self>) {
@@ -2979,7 +2990,7 @@ impl GitPanel {
     }
 
     pub(crate) fn pull(&mut self, rebase: bool, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.can_push_and_pull(cx) {
+        if !self.can_push_and_pull(cx) || self.pending_remote_operation.is_some() {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -2991,48 +3002,60 @@ impl GitPanel {
         telemetry::event!("Git Pulled");
         let branch = branch.clone();
         let remote = self.get_remote(false, false, window, cx);
-        cx.spawn_in(window, async move |this, cx| {
-            let remote = match remote.await {
-                Ok(Some(remote)) => remote,
-                Ok(None) => {
-                    return Ok(());
-                }
-                Err(e) => {
-                    log::error!("Failed to get current remote: {}", e);
-                    this.update(cx, |this, cx| this.show_error_toast("pull", e, cx))
-                        .ok();
-                    return Ok(());
-                }
-            };
+        self.pending_remote_operation = Some(cx.spawn_in(window, async move |this, cx| {
+            let result: anyhow::Result<()> = async {
+                let remote = match remote.await {
+                    Ok(Some(remote)) => remote,
+                    Ok(None) => {
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to get current remote: {}", e);
+                        this.update(cx, |this, cx| this.show_error_toast("pull", e, cx))
+                            .ok();
+                        return Ok(());
+                    }
+                };
 
-            let askpass = this.update_in(cx, |this, window, cx| {
-                this.askpass_delegate(format!("git pull {}", remote.name), window, cx)
-            })?;
+                let askpass = this.update_in(cx, |this, window, cx| {
+                    this.askpass_delegate(format!("git pull {}", remote.name), window, cx)
+                })?;
 
-            let branch_name = branch
-                .upstream
-                .is_none()
-                .then(|| branch.name().to_owned().into());
+                let branch_name = branch
+                    .upstream
+                    .is_none()
+                    .then(|| branch.name().to_owned().into());
 
-            let pull = repo.update(cx, |repo, cx| {
-                repo.pull(branch_name, remote.name.clone(), rebase, askpass, cx)
-            });
+                let pull = repo.update(cx, |repo, cx| {
+                    repo.pull(branch_name, remote.name.clone(), rebase, askpass, cx)
+                });
 
-            let remote_message = pull.await?;
+                let remote_message = pull.await?;
 
-            let action = RemoteAction::Pull(remote);
-            this.update(cx, |this, cx| match remote_message {
-                Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
-                Err(e) => {
-                    log::error!("Error while pulling {:?}", e);
-                    this.show_error_toast(action.name(), e, cx)
-                }
+                let action = RemoteAction::Pull(remote);
+                this.update(cx, |this, cx| match remote_message {
+                    Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                    Err(e) => {
+                        log::error!("Error while pulling {:?}", e);
+                        this.show_error_toast(action.name(), e, cx)
+                    }
+                })
+                .ok();
+
+                Ok(())
+            }
+            .await;
+
+            if let Err(e) = &result {
+                log::error!("{e:?}");
+            }
+            this.update(cx, |this, cx| {
+                this.pending_remote_operation = None;
+                cx.notify();
             })
             .ok();
-
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+        }));
+        cx.notify();
     }
 
     pub(crate) fn push(
@@ -3042,7 +3065,7 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.can_push_and_pull(cx) {
+        if !self.can_push_and_pull(cx) || self.pending_remote_operation.is_some() {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -3068,56 +3091,68 @@ impl GitPanel {
         };
         let remote = self.get_remote(select_remote, true, window, cx);
 
-        cx.spawn_in(window, async move |this, cx| {
-            let remote = match remote.await {
-                Ok(Some(remote)) => remote,
-                Ok(None) => {
-                    return Ok(());
-                }
-                Err(e) => {
-                    log::error!("Failed to get current remote: {}", e);
-                    this.update(cx, |this, cx| this.show_error_toast("push", e, cx))
-                        .ok();
-                    return Ok(());
-                }
-            };
+        self.pending_remote_operation = Some(cx.spawn_in(window, async move |this, cx| {
+            let result: anyhow::Result<()> = async {
+                let remote = match remote.await {
+                    Ok(Some(remote)) => remote,
+                    Ok(None) => {
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to get current remote: {}", e);
+                        this.update(cx, |this, cx| this.show_error_toast("push", e, cx))
+                            .ok();
+                        return Ok(());
+                    }
+                };
 
-            let askpass_delegate = this.update_in(cx, |this, window, cx| {
-                this.askpass_delegate(format!("git push {}", remote.name), window, cx)
-            })?;
+                let askpass_delegate = this.update_in(cx, |this, window, cx| {
+                    this.askpass_delegate(format!("git push {}", remote.name), window, cx)
+                })?;
 
-            let push = repo.update(cx, |repo, cx| {
-                repo.push(
-                    branch.name().to_owned().into(),
-                    branch
-                        .upstream
-                        .as_ref()
-                        .filter(|u| matches!(u.tracking, UpstreamTracking::Tracked(_)))
-                        .and_then(|u| u.branch_name())
-                        .unwrap_or_else(|| branch.name())
-                        .to_owned()
-                        .into(),
-                    remote.name.clone(),
-                    options,
-                    askpass_delegate,
-                    cx,
-                )
-            });
+                let push = repo.update(cx, |repo, cx| {
+                    repo.push(
+                        branch.name().to_owned().into(),
+                        branch
+                            .upstream
+                            .as_ref()
+                            .filter(|u| matches!(u.tracking, UpstreamTracking::Tracked(_)))
+                            .and_then(|u| u.branch_name())
+                            .unwrap_or_else(|| branch.name())
+                            .to_owned()
+                            .into(),
+                        remote.name.clone(),
+                        options,
+                        askpass_delegate,
+                        cx,
+                    )
+                });
 
-            let remote_output = push.await?;
+                let remote_output = push.await?;
 
-            let action = RemoteAction::Push(branch.name().to_owned().into(), remote);
-            this.update(cx, |this, cx| match remote_output {
-                Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
-                Err(e) => {
-                    log::error!("Error while pushing {:?}", e);
-                    this.show_error_toast(action.name(), e, cx)
-                }
-            })?;
+                let action = RemoteAction::Push(branch.name().to_owned().into(), remote);
+                this.update(cx, |this, cx| match remote_output {
+                    Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                    Err(e) => {
+                        log::error!("Error while pushing {:?}", e);
+                        this.show_error_toast(action.name(), e, cx)
+                    }
+                })?;
 
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+                Ok(())
+            }
+            .await;
+
+            if let Err(e) = &result {
+                log::error!("{e:?}");
+            }
+            this.update(cx, |this, cx| {
+                this.pending_remote_operation = None;
+                cx.notify();
+            })
+            .ok();
+        }));
+        cx.notify();
     }
 
     pub fn create_pull_request(&self, window: &mut Window, cx: &mut Context<Self>) {
@@ -4255,12 +4290,14 @@ impl GitPanel {
                 .flex_shrink_0()
                 .when_some(branch, |this, branch| {
                     let focus_handle = Some(self.focus_handle(cx));
+                    let disabled = self.pending_remote_operation.is_some();
 
                     this.children(render_remote_button(
                         "remote-button",
                         &branch,
                         focus_handle,
                         true,
+                        disabled,
                     ))
                 })
                 .into_any_element(),

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -653,7 +653,6 @@ pub struct GitPanel {
     local_committer_task: Option<Task<()>>,
     bulk_staging: Option<BulkStaging>,
     stash_entries: GitStash,
-    pending_remote_operation: Option<Task<()>>,
     _settings_subscription: Subscription,
 }
 
@@ -773,6 +772,9 @@ impl GitPanel {
                     | GitStoreEvent::ActiveRepositoryChanged(_) => {
                         this.schedule_update(window, cx);
                     }
+                    GitStoreEvent::JobsUpdated => {
+                        cx.notify();
+                    }
                     GitStoreEvent::IndexWriteError(error) => {
                         this.workspace
                             .update(cx, |workspace, cx| {
@@ -781,7 +783,7 @@ impl GitPanel {
                             .ok();
                     }
                     GitStoreEvent::RepositoryUpdated(_, _, _) => {}
-                    GitStoreEvent::JobsUpdated | GitStoreEvent::ConflictsUpdated => {}
+                    GitStoreEvent::ConflictsUpdated => {}
                 },
             )
             .detach();
@@ -826,7 +828,6 @@ impl GitPanel {
                 entry_count: 0,
                 bulk_staging: None,
                 stash_entries: Default::default(),
-                pending_remote_operation: None,
                 _settings_subscription,
             };
 
@@ -2837,7 +2838,7 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.can_push_and_pull(cx) || self.pending_remote_operation.is_some() {
+        if !self.can_push_and_pull(cx) || self.remote_operation_in_progress(cx) {
             return;
         }
 
@@ -2853,7 +2854,7 @@ impl GitPanel {
             self.get_fetch_options(window, cx)
         };
 
-        self.pending_remote_operation = Some(cx.spawn(async move |this, cx| {
+        cx.spawn(async move |this, cx| {
             let result: anyhow::Result<()> = async {
                 let Some(fetch_options) = fetch_options.await else {
                     return Ok(());
@@ -2869,9 +2870,7 @@ impl GitPanel {
                         FetchOptions::Remote(remote) => RemoteAction::Fetch(Some(remote)),
                     };
                     match remote_message {
-                        Ok(remote_message) => {
-                            this.show_remote_output(action, remote_message, cx)
-                        }
+                        Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
                         Err(e) => {
                             log::error!("Error while fetching {:?}", e);
                             this.show_error_toast(action.name(), e, cx)
@@ -2886,12 +2885,8 @@ impl GitPanel {
             if let Err(e) = &result {
                 log::error!("{e:?}");
             }
-            this.update(cx, |this, cx| {
-                this.pending_remote_operation = None;
-                cx.notify();
-            })
-            .ok();
-        }));
+        })
+        .detach();
         cx.notify();
     }
 
@@ -2990,7 +2985,7 @@ impl GitPanel {
     }
 
     pub(crate) fn pull(&mut self, rebase: bool, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.can_push_and_pull(cx) || self.pending_remote_operation.is_some() {
+        if !self.can_push_and_pull(cx) || self.remote_operation_in_progress(cx) {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -3002,7 +2997,7 @@ impl GitPanel {
         telemetry::event!("Git Pulled");
         let branch = branch.clone();
         let remote = self.get_remote(false, false, window, cx);
-        self.pending_remote_operation = Some(cx.spawn_in(window, async move |this, cx| {
+        cx.spawn_in(window, async move |this, cx| {
             let result: anyhow::Result<()> = async {
                 let remote = match remote.await {
                     Ok(Some(remote)) => remote,
@@ -3049,12 +3044,8 @@ impl GitPanel {
             if let Err(e) = &result {
                 log::error!("{e:?}");
             }
-            this.update(cx, |this, cx| {
-                this.pending_remote_operation = None;
-                cx.notify();
-            })
-            .ok();
-        }));
+        })
+        .detach();
         cx.notify();
     }
 
@@ -3065,7 +3056,7 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.can_push_and_pull(cx) || self.pending_remote_operation.is_some() {
+        if !self.can_push_and_pull(cx) || self.remote_operation_in_progress(cx) {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -3091,7 +3082,7 @@ impl GitPanel {
         };
         let remote = self.get_remote(select_remote, true, window, cx);
 
-        self.pending_remote_operation = Some(cx.spawn_in(window, async move |this, cx| {
+        cx.spawn_in(window, async move |this, cx| {
             let result: anyhow::Result<()> = async {
                 let remote = match remote.await {
                     Ok(Some(remote)) => remote,
@@ -3146,12 +3137,8 @@ impl GitPanel {
             if let Err(e) = &result {
                 log::error!("{e:?}");
             }
-            this.update(cx, |this, cx| {
-                this.pending_remote_operation = None;
-                cx.notify();
-            })
-            .ok();
-        }));
+        })
+        .detach();
         cx.notify();
     }
 
@@ -3241,6 +3228,14 @@ impl GitPanel {
 
     fn can_push_and_pull(&self, cx: &App) -> bool {
         !self.project.read(cx).is_via_collab()
+    }
+
+    fn remote_operation_in_progress(&self, cx: &App) -> bool {
+        let Some(repository) = self.active_repository.as_ref() else {
+            return false;
+        };
+
+        crate::remote_operation_in_progress(&repository.read(cx))
     }
 
     fn get_remote(
@@ -4284,20 +4279,20 @@ impl GitPanel {
         if !self.can_push_and_pull(cx) {
             return None;
         }
+        let in_progress = self.remote_operation_in_progress(cx);
         Some(
             h_flex()
                 .gap_1()
                 .flex_shrink_0()
                 .when_some(branch, |this, branch| {
                     let focus_handle = Some(self.focus_handle(cx));
-                    let disabled = self.pending_remote_operation.is_some();
 
                     this.children(render_remote_button(
                         "remote-button",
                         &branch,
                         focus_handle,
                         true,
-                        disabled,
+                        in_progress,
                     ))
                 })
                 .into_any_element(),

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -430,6 +430,7 @@ fn render_remote_button(
     branch: &Branch,
     keybinding_target: Option<FocusHandle>,
     show_fetch_button: bool,
+    disabled: bool,
 ) -> Option<impl IntoElement> {
     let id = id.into();
     let upstream = branch.upstream.as_ref();
@@ -438,20 +439,24 @@ fn render_remote_button(
             tracking: UpstreamTracking::Tracked(UpstreamTrackingStatus { ahead, behind }),
             ..
         }) => match (*ahead, *behind) {
-            (0, 0) if show_fetch_button => {
-                Some(remote_button::render_fetch_button(keybinding_target, id))
-            }
+            (0, 0) if show_fetch_button => Some(remote_button::render_fetch_button(
+                keybinding_target,
+                id,
+                disabled,
+            )),
             (0, 0) => None,
             (ahead, 0) => Some(remote_button::render_push_button(
                 keybinding_target,
                 id,
                 ahead,
+                disabled,
             )),
             (ahead, behind) => Some(remote_button::render_pull_button(
                 keybinding_target,
                 id,
                 ahead,
                 behind,
+                disabled,
             )),
         },
         Some(Upstream {
@@ -460,22 +465,29 @@ fn render_remote_button(
         }) => Some(remote_button::render_republish_button(
             keybinding_target,
             id,
+            disabled,
         )),
-        None => Some(remote_button::render_publish_button(keybinding_target, id)),
+        None => Some(remote_button::render_publish_button(
+            keybinding_target,
+            id,
+            disabled,
+        )),
     }
 }
 
 mod remote_button {
     use gpui::{Action, AnyView, ClickEvent, Corner, FocusHandle};
     use ui::{
-        App, ButtonCommon, Clickable, ContextMenu, ElementId, FluentBuilder, Icon, IconName,
-        IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle, ParentElement,
-        PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div, h_flex, rems,
+        App, ButtonCommon, Clickable, Color, CommonAnimationExt, ContextMenu, Disableable,
+        ElementId, FluentBuilder, Icon, IconName, IconSize, IntoElement, Label, LabelCommon,
+        LabelSize, LineHeightStyle, ParentElement, PopoverMenu, SharedString, SplitButton, Styled,
+        Tooltip, Window, div, h_flex, rems,
     };
 
     pub fn render_fetch_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -484,6 +496,7 @@ mod remote_button {
             0,
             Some(IconName::ArrowCircle),
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Fetch), cx);
             },
@@ -503,6 +516,7 @@ mod remote_button {
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
         ahead: u32,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -511,6 +525,7 @@ mod remote_button {
             0,
             None,
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -531,6 +546,7 @@ mod remote_button {
         id: SharedString,
         ahead: u32,
         behind: u32,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -539,6 +555,7 @@ mod remote_button {
             behind as usize,
             None,
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Pull), cx);
             },
@@ -557,6 +574,7 @@ mod remote_button {
     pub fn render_publish_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -565,6 +583,7 @@ mod remote_button {
             0,
             Some(IconName::ExpandUp),
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -583,6 +602,7 @@ mod remote_button {
     pub fn render_republish_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -591,6 +611,7 @@ mod remote_button {
             0,
             Some(IconName::ExpandUp),
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -665,6 +686,7 @@ mod remote_button {
         behind_count: usize,
         left_icon: Option<IconName>,
         keybinding_target: Option<FocusHandle>,
+        disabled: bool,
         left_on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
         tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
     ) -> SplitButton {
@@ -682,13 +704,25 @@ mod remote_button {
                 )
         }
 
-        let should_render_counts = left_icon.is_none() && (ahead_count > 0 || behind_count > 0);
+        let should_render_counts =
+            !disabled && left_icon.is_none() && (ahead_count > 0 || behind_count > 0);
 
         let left = ui::ButtonLike::new_rounded_left(ElementId::Name(
             format!("split-button-left-{}", id).into(),
         ))
         .layer(ui::ElevationIndex::ModalSurface)
         .size(ui::ButtonSize::Compact)
+        .when(disabled, |this| {
+            this.child(
+                h_flex()
+                    .ml_neg_0p5()
+                    .child(
+                        Icon::new(IconName::ArrowCircle)
+                            .size(IconSize::XSmall)
+                            .with_rotate_animation(3),
+                    ),
+            )
+        })
         .when(should_render_counts, |this| {
             this.child(
                 h_flex()
@@ -703,18 +737,25 @@ mod remote_button {
                     }),
             )
         })
-        .when_some(left_icon, |this, left_icon| {
-            this.child(
-                h_flex()
-                    .ml_neg_0p5()
-                    .child(Icon::new(left_icon).size(IconSize::XSmall)),
-            )
+        .when(!disabled, |this| {
+            this.when_some(left_icon, |this, left_icon| {
+                this.child(
+                    h_flex()
+                        .ml_neg_0p5()
+                        .child(Icon::new(left_icon).size(IconSize::XSmall)),
+                )
+            })
         })
         .child(
             div()
-                .child(Label::new(left_label).size(LabelSize::Small))
+                .child(
+                    Label::new(left_label)
+                        .size(LabelSize::Small)
+                        .when(disabled, |this| this.color(Color::Muted)),
+                )
                 .mr_0p5(),
         )
+        .disabled(disabled)
         .on_click(left_on_click)
         .tooltip(tooltip);
 

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -19,13 +19,21 @@ use gpui::{
     App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, SharedString, Window,
 };
 use menu::{Cancel, Confirm};
-use project::git_store::Repository;
+use project::git_store::{JobInfo, Repository};
 use project_diff::ProjectDiff;
 use ui::prelude::*;
 use workspace::{ModalView, Workspace, notifications::DetachAndPromptErr};
 use zed_actions;
 
 use crate::{git_panel::GitPanel, text_diff_view::TextDiffView};
+
+pub(crate) fn remote_operation_in_progress(repository: &Repository) -> bool {
+    remote_operation_in_progress_for_job(repository.current_job())
+}
+
+fn remote_operation_in_progress_for_job(current_job: Option<JobInfo>) -> bool {
+    current_job.is_some_and(|job| job.is_remote_operation)
+}
 
 mod askpass_modal;
 pub mod branch_picker;
@@ -430,7 +438,7 @@ fn render_remote_button(
     branch: &Branch,
     keybinding_target: Option<FocusHandle>,
     show_fetch_button: bool,
-    disabled: bool,
+    in_progress: bool,
 ) -> Option<impl IntoElement> {
     let id = id.into();
     let upstream = branch.upstream.as_ref();
@@ -442,21 +450,21 @@ fn render_remote_button(
             (0, 0) if show_fetch_button => Some(remote_button::render_fetch_button(
                 keybinding_target,
                 id,
-                disabled,
+                in_progress,
             )),
             (0, 0) => None,
             (ahead, 0) => Some(remote_button::render_push_button(
                 keybinding_target,
                 id,
                 ahead,
-                disabled,
+                in_progress,
             )),
             (ahead, behind) => Some(remote_button::render_pull_button(
                 keybinding_target,
                 id,
                 ahead,
                 behind,
-                disabled,
+                in_progress,
             )),
         },
         Some(Upstream {
@@ -465,12 +473,12 @@ fn render_remote_button(
         }) => Some(remote_button::render_republish_button(
             keybinding_target,
             id,
-            disabled,
+            in_progress,
         )),
         None => Some(remote_button::render_publish_button(
             keybinding_target,
             id,
-            disabled,
+            in_progress,
         )),
     }
 }
@@ -478,16 +486,38 @@ fn render_remote_button(
 mod remote_button {
     use gpui::{Action, AnyView, ClickEvent, Corner, FocusHandle};
     use ui::{
-        App, ButtonCommon, Clickable, Color, CommonAnimationExt, ContextMenu, Disableable,
-        ElementId, FluentBuilder, Icon, IconName, IconSize, IntoElement, Label, LabelCommon,
-        LabelSize, LineHeightStyle, ParentElement, PopoverMenu, SharedString, SplitButton, Styled,
-        Tooltip, Window, div, h_flex, rems,
+        App, ButtonCommon, Clickable, Color, ContextMenu, Disableable, ElementId, FluentBuilder,
+        Icon, IconName, IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle,
+        ParentElement, PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div,
+        h_flex, rems,
     };
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct SplitButtonPresentation {
+        show_counts: bool,
+        show_left_icon: bool,
+    }
+
+    fn split_button_presentation(
+        ahead_count: usize,
+        behind_count: usize,
+        left_icon: Option<IconName>,
+        in_progress: bool,
+    ) -> SplitButtonPresentation {
+        SplitButtonPresentation {
+            show_counts: left_icon.is_none() && (ahead_count > 0 || behind_count > 0),
+            show_left_icon: left_icon.is_some() && !in_progress,
+        }
+    }
+
+    fn in_progress_tooltip_label(left_label: &str) -> SharedString {
+        format!("{left_label} in progress").into()
+    }
 
     pub fn render_fetch_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
-        disabled: bool,
+        in_progress: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -496,7 +526,7 @@ mod remote_button {
             0,
             Some(IconName::ArrowCircle),
             keybinding_target.clone(),
-            disabled,
+            in_progress,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Fetch), cx);
             },
@@ -516,7 +546,7 @@ mod remote_button {
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
         ahead: u32,
-        disabled: bool,
+        in_progress: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -525,7 +555,7 @@ mod remote_button {
             0,
             None,
             keybinding_target.clone(),
-            disabled,
+            in_progress,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -546,7 +576,7 @@ mod remote_button {
         id: SharedString,
         ahead: u32,
         behind: u32,
-        disabled: bool,
+        in_progress: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -555,7 +585,7 @@ mod remote_button {
             behind as usize,
             None,
             keybinding_target.clone(),
-            disabled,
+            in_progress,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Pull), cx);
             },
@@ -574,7 +604,7 @@ mod remote_button {
     pub fn render_publish_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
-        disabled: bool,
+        in_progress: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -583,7 +613,7 @@ mod remote_button {
             0,
             Some(IconName::ExpandUp),
             keybinding_target.clone(),
-            disabled,
+            in_progress,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -602,7 +632,7 @@ mod remote_button {
     pub fn render_republish_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
-        disabled: bool,
+        in_progress: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -611,7 +641,7 @@ mod remote_button {
             0,
             Some(IconName::ExpandUp),
             keybinding_target.clone(),
-            disabled,
+            in_progress,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -686,7 +716,7 @@ mod remote_button {
         behind_count: usize,
         left_icon: Option<IconName>,
         keybinding_target: Option<FocusHandle>,
-        disabled: bool,
+        in_progress: bool,
         left_on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
         tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
     ) -> SplitButton {
@@ -704,25 +734,16 @@ mod remote_button {
                 )
         }
 
-        let should_render_counts =
-            !disabled && left_icon.is_none() && (ahead_count > 0 || behind_count > 0);
+        let left_label = left_label.into();
+        let presentation =
+            split_button_presentation(ahead_count, behind_count, left_icon, in_progress);
+        let should_render_counts = presentation.show_counts;
 
         let left = ui::ButtonLike::new_rounded_left(ElementId::Name(
             format!("split-button-left-{}", id).into(),
         ))
         .layer(ui::ElevationIndex::ModalSurface)
         .size(ui::ButtonSize::Compact)
-        .when(disabled, |this| {
-            this.child(
-                h_flex()
-                    .ml_neg_0p5()
-                    .child(
-                        Icon::new(IconName::ArrowCircle)
-                            .size(IconSize::XSmall)
-                            .with_rotate_animation(3),
-                    ),
-            )
-        })
         .when(should_render_counts, |this| {
             this.child(
                 h_flex()
@@ -737,7 +758,7 @@ mod remote_button {
                     }),
             )
         })
-        .when(!disabled, |this| {
+        .when(presentation.show_left_icon, |this| {
             this.when_some(left_icon, |this, left_icon| {
                 this.child(
                     h_flex()
@@ -749,15 +770,21 @@ mod remote_button {
         .child(
             div()
                 .child(
-                    Label::new(left_label)
+                    Label::new(left_label.clone())
                         .size(LabelSize::Small)
-                        .when(disabled, |this| this.color(Color::Muted)),
+                        .when(in_progress, |this| this.color(Color::Muted)),
                 )
                 .mr_0p5(),
         )
-        .disabled(disabled)
+        .disabled(in_progress)
         .on_click(left_on_click)
-        .tooltip(tooltip);
+        .tooltip(move |window, cx| {
+            if in_progress {
+                Tooltip::simple(in_progress_tooltip_label(&left_label), cx)
+            } else {
+                tooltip(window, cx)
+            }
+        });
 
         let right = render_git_action_menu(
             ElementId::Name(format!("split-button-right-{}", id).into()),
@@ -766,6 +793,52 @@ mod remote_button {
         .into_any_element();
 
         SplitButton::new(left, right)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::split_button_presentation;
+        use project::git_store::JobInfo;
+        use std::time::Instant;
+
+        #[test]
+        fn in_progress_remote_button_keeps_existing_counts() {
+            let presentation = split_button_presentation(2, 0, None, true);
+
+            assert!(presentation.show_counts);
+            assert!(!presentation.show_left_icon);
+        }
+
+        #[test]
+        fn in_progress_remote_button_uses_in_progress_tooltip() {
+            assert_eq!(
+                super::in_progress_tooltip_label("Pull").as_ref(),
+                "Pull in progress"
+            );
+        }
+
+        #[test]
+        fn remote_operation_in_progress_uses_job_flag() {
+            let current_job = Some(JobInfo {
+                start: Instant::now(),
+                message: "git status".into(),
+                is_remote_operation: true,
+            });
+
+            assert!(super::super::remote_operation_in_progress_for_job(
+                current_job
+            ));
+
+            let current_job = Some(JobInfo {
+                start: Instant::now(),
+                message: "git push".into(),
+                is_remote_operation: false,
+            });
+
+            assert!(!super::super::remote_operation_in_progress_for_job(
+                current_job
+            ));
+        }
     }
 }
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1793,6 +1793,7 @@ impl RenderOnce for ProjectDiffEmptyState {
                             self.focus_handle,
                             "push".into(),
                             ahead_count as u32,
+                            false,
                         )))
                     } else if branch_not_on_remote {
                         this.child(
@@ -1804,7 +1805,7 @@ impl RenderOnce for ProjectDiffEmptyState {
                                 ),
                         )
                         .child(
-                            div().child(render_publish_button(self.focus_handle, "publish".into())),
+                            div().child(render_publish_button(self.focus_handle, "publish".into(), false)),
                         )
                     } else {
                         this.child(Label::new("Remote status unknown").color(Color::Muted))

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -31,7 +31,7 @@ use multi_buffer::{MultiBuffer, PathKey};
 use project::{
     Project, ProjectPath,
     git_store::{
-        Repository,
+        GitStoreEvent, Repository,
         branch_diff::{self, BranchDiffEvent, DiffBase},
     },
 };
@@ -344,6 +344,7 @@ impl ProjectDiff {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let git_store = project.read(cx).git_store().clone();
         let focus_handle = cx.focus_handle();
         let multibuffer = cx.new(|cx| {
             let mut multibuffer = MultiBuffer::new(Capability::ReadWrite);
@@ -410,6 +411,15 @@ impl ProjectDiff {
                 }
             },
         );
+        let git_store_subscription = cx.subscribe_in(
+            &git_store,
+            window,
+            move |_this, _git_store, event, _window, cx| {
+                if matches!(event, GitStoreEvent::JobsUpdated) {
+                    cx.notify();
+                }
+            },
+        );
 
         let mut was_sort_by_path = GitPanelSettings::get_global(cx).sort_by_path;
         let mut was_collapse_untracked_diff =
@@ -450,8 +460,11 @@ impl ProjectDiff {
             review_comment_count: 0,
             _task: task,
             _subscription: Subscription::join(
-                branch_diff_subscription,
-                Subscription::join(editor_subscription, review_comment_subscription),
+                git_store_subscription,
+                Subscription::join(
+                    branch_diff_subscription,
+                    Subscription::join(editor_subscription, review_comment_subscription),
+                ),
             ),
         }
     }
@@ -1804,9 +1817,11 @@ impl RenderOnce for ProjectDiffEmptyState {
                                         .color(Color::Muted),
                                 ),
                         )
-                        .child(
-                            div().child(render_publish_button(self.focus_handle, "publish".into(), false)),
-                        )
+                        .child(div().child(render_publish_button(
+                            self.focus_handle,
+                            "publish".into(),
+                            false,
+                        )))
                     } else {
                         this.child(Label::new("Remote status unknown").color(Color::Muted))
                     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -301,6 +301,7 @@ type JobId = u64;
 pub struct JobInfo {
     pub start: Instant,
     pub message: SharedString,
+    pub is_remote_operation: bool,
 }
 
 struct GraphCommitDataHandler {
@@ -3933,6 +3934,7 @@ impl Repository {
         let _ = self.send_keyed_job(
             Some(GitJobKey::ReloadBufferDiffBases),
             None,
+            false,
             |state, mut cx| async move {
                 let RepositoryState::Local(LocalRepositoryState { backend, .. }) = state else {
                     log::error!("tried to recompute diffs for a non-local repository");
@@ -4097,13 +4099,27 @@ impl Repository {
         Fut: Future<Output = R> + 'static,
         R: Send + 'static,
     {
-        self.send_keyed_job(None, status, job)
+        self.send_keyed_job(None, status, false, job)
+    }
+
+    fn send_remote_job<F, Fut, R>(
+        &mut self,
+        status: Option<SharedString>,
+        job: F,
+    ) -> oneshot::Receiver<R>
+    where
+        F: FnOnce(RepositoryState, AsyncApp) -> Fut + 'static,
+        Fut: Future<Output = R> + 'static,
+        R: Send + 'static,
+    {
+        self.send_keyed_job(None, status, true, job)
     }
 
     fn send_keyed_job<F, Fut, R>(
         &mut self,
         key: Option<GitJobKey>,
         status: Option<SharedString>,
+        is_remote_operation: bool,
         job: F,
     ) -> oneshot::Receiver<R>
     where
@@ -4127,6 +4143,7 @@ impl Repository {
                                     JobInfo {
                                         start: Instant::now(),
                                         message: s.clone(),
+                                        is_remote_operation,
                                     },
                                 );
 
@@ -4823,6 +4840,7 @@ impl Repository {
                     this.send_keyed_job(
                         Some(job_key),
                         Some(status.into()),
+                        false,
                         move |git_repo, mut cx| async move {
                             let hunk_staging_operation_counts = weak_this
                                 .update(&mut cx, |this, cx| {
@@ -5263,7 +5281,7 @@ impl Repository {
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
         let id = self.id;
 
-        self.send_job(Some("git fetch".into()), move |git_repo, cx| async move {
+        self.send_remote_job(Some("git fetch".into()), move |git_repo, cx| async move {
             match git_repo {
                 RepositoryState::Local(LocalRepositoryState {
                     backend,
@@ -5325,7 +5343,7 @@ impl Repository {
             });
 
         let this = cx.weak_entity();
-        self.send_job(
+        self.send_remote_job(
             Some(format!("git push {} {} {}:{}", args, remote, branch, remote_branch).into()),
             move |git_repo, mut cx| async move {
                 match git_repo {
@@ -5418,7 +5436,7 @@ impl Repository {
             status.push_str(&format!(" {}", b));
         }
 
-        self.send_job(Some(status.into()), move |git_repo, cx| async move {
+        self.send_remote_job(Some(status.into()), move |git_repo, cx| async move {
             match git_repo {
                 RepositoryState::Local(LocalRepositoryState {
                     backend,
@@ -5476,6 +5494,7 @@ impl Repository {
         self.send_keyed_job(
             Some(GitJobKey::WriteIndex(vec![path.clone()])),
             None,
+            false,
             move |git_repo, mut cx| async move {
                 log::debug!(
                     "start updating index text for buffer {}",
@@ -6166,6 +6185,7 @@ impl Repository {
         let _ = self.send_keyed_job(
             Some(GitJobKey::ReloadGitState),
             None,
+            false,
             |state, mut cx| async move {
                 log::debug!("run scheduled git status scan");
 
@@ -6391,6 +6411,7 @@ impl Repository {
         let _ = self.send_keyed_job(
             Some(GitJobKey::RefreshStatuses),
             None,
+            false,
             |state, mut cx| async move {
                 let (prev_snapshot, changed_paths) = this.update(&mut cx, |this, _| {
                     (
@@ -6492,7 +6513,7 @@ impl Repository {
 
     /// currently running git command and when it started
     pub fn current_job(&self) -> Option<JobInfo> {
-        self.active_jobs.values().next().cloned()
+        current_job(&self.active_jobs)
     }
 
     pub fn barrier(&mut self) -> oneshot::Receiver<()> {
@@ -6881,6 +6902,14 @@ async fn compute_snapshot(
     Ok((snapshot, events))
 }
 
+fn current_job(active_jobs: &HashMap<JobId, JobInfo>) -> Option<JobInfo> {
+    active_jobs
+        .values()
+        .find(|job_info| job_info.is_remote_operation)
+        .cloned()
+        .or_else(|| active_jobs.values().next().cloned())
+}
+
 fn status_from_proto(
     simple_status: i32,
     status: Option<proto::GitFileStatus>,
@@ -7010,5 +7039,36 @@ fn tracked_status_to_proto(code: StatusCode) -> i32 {
         StatusCode::TypeChanged => proto::GitStatus::TypeChanged as _,
         StatusCode::Copied => proto::GitStatus::Copied as _,
         StatusCode::Unmodified => proto::GitStatus::Unmodified as _,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn current_job_prefers_remote_operations() {
+        let mut active_jobs = HashMap::default();
+        active_jobs.insert(
+            1,
+            JobInfo {
+                start: Instant::now(),
+                message: "local".into(),
+                is_remote_operation: false,
+            },
+        );
+        active_jobs.insert(
+            2,
+            JobInfo {
+                start: Instant::now(),
+                message: "remote".into(),
+                is_remote_operation: true,
+            },
+        );
+
+        let current_job = current_job(&active_jobs).unwrap();
+        assert!(current_job.is_remote_operation);
+        assert_eq!(current_job.message, "remote");
     }
 }


### PR DESCRIPTION
Closes #50779

- Track pending remote operations in `GitPanel` via a `pending_remote_operation` field so Push/Fetch/Pull buttons are disabled during execution
- Buttons show a spinning icon and muted label while an operation is running, preventing duplicate concurrent git operations
- Added early-return guards in `fetch()`, `pull()`, and `push()` to prevent duplicate invocations via keyboard shortcuts


https://github.com/user-attachments/assets/8858e807-6aae-434f-8c27-1a43653708c3



Release Notes:

- Fixed Push/Fetch/Pull buttons remaining clickable while their operation is in progress
