### PR TITLE
languages: Support more JSON configuration files

### DIFF
--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 grammar = "json"
-path_suffixes = ["json", "flake.lock", "geojson", "prettierrc"]
+path_suffixes = ["json", "flake.lock", "geojson", "prettierrc", "babelrc", "eslintrc", "stylelintrc", "swcrc"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 grammar = "json"
-path_suffixes = ["json", "flake.lock", "geojson", "prettierrc", "babelrc", "eslintrc", "stylelintrc", "swcrc"]
+path_suffixes = ["json", "flake.lock", "geojson", "prettierrc"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [

--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -1,6 +1,6 @@
 name = "JSONC"
 grammar = "jsonc"
-path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "luaurc"]
+path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "luaurc", "swcrc", "babelrc", "eslintrc", "stylelintrc"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
Several widely used configuration files are JSON but have no `.json` extension,
such as `.babelrc` or `.eslintrc`.

Editors like VS Code detect these as JSON automatically, but Zed currently
treats them as plain text.

This change adds common JSON config suffixes so they get proper JSON syntax
highlighting.

Added:
- [`.babelrc`](https://babeljs.io/docs/config-files)
- [`.eslintrc`](https://archive.eslint.org/docs/user-guide/configuring/configuration-files)
- [`.stylelintrc`](https://stylelint.io/user-guide/configure/)
- [`.swcrc`](https://github.com/swc-project/swc/pull/4236)

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Support more JSON configuration files
