### PR TITLE
markdown: Fix code block scrollbars flashing on vertical scroll

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -1053,8 +1053,6 @@ impl PartialEq for ScrollbarLayout {
 
         thumb_offset == other_thumb_offset
             && self.thumb_bounds.size.along(axis) == other.thumb_bounds.size.along(axis)
-            && self.track_bounds.size.along(axis) == other.track_bounds.size.along(axis)
-            && self.reserved_space == other.reserved_space
     }
 }
 

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -1041,7 +1041,20 @@ impl ScrollbarLayout {
 
 impl PartialEq for ScrollbarLayout {
     fn eq(&self, other: &Self) -> bool {
-        self.axis == other.axis && self.thumb_bounds == other.thumb_bounds
+        if self.axis != other.axis {
+            return false;
+        }
+
+        let axis = self.axis;
+        let thumb_offset =
+            self.thumb_bounds.origin.along(axis) - self.track_bounds.origin.along(axis);
+        let other_thumb_offset =
+            other.thumb_bounds.origin.along(axis) - other.track_bounds.origin.along(axis);
+
+        thumb_offset == other_thumb_offset
+            && self.thumb_bounds.size.along(axis) == other.thumb_bounds.size.along(axis)
+            && self.track_bounds.size.along(axis) == other.track_bounds.size.along(axis)
+            && self.reserved_space == other.reserved_space
     }
 }
 


### PR DESCRIPTION
Release Notes:

- Fixed code block scrollbars flashing on vertical scroll


before:

When there are many code blocks, scrolling through markdown will display a horizontal scrollbar (when the mouse is not inside a code block).

https://github.com/user-attachments/assets/1fae36ec-5a3f-4283-b54f-e5cb4f45646b




after:

When scrolling markdown, do not display the horizontal scrollbar when the mouse is not in a code block.

https://github.com/user-attachments/assets/0c0f2016-9b18-4055-87a6-4f508dbfd193

