### PR TITLE
agent_ui: Group together pending permissions above AI chat input

### DIFF
--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -161,14 +161,6 @@ pub(crate) struct Conversation {
 }
 
 impl Conversation {
-    pub fn thread(
-        &self,
-        session_id: &acp::SessionId,
-        _cx: &App,
-    ) -> Option<&Entity<AcpThread>> {
-        self.threads.get(session_id)
-    }
-
     pub fn register_thread(&mut self, thread: Entity<AcpThread>, cx: &mut Context<Self>) {
         let session_id = thread.read(cx).session_id().clone();
         let subscription = cx.subscribe(&thread, move |this, _thread, event, _cx| match event {
@@ -262,7 +254,7 @@ impl Conversation {
         &'a self,
         session_id: &acp::SessionId,
         cx: &'a App,
-    ) -> Vec<(acp::SessionId, acp::ToolCallId, &'a PermissionOptions)> {
+    ) -> Vec<(acp::SessionId, acp::ToolCallId, &'a ToolCall, &'a PermissionOptions)> {
         let thread = self.threads.get(session_id);
         let is_subagent = thread
             .map(|t| t.read(cx).parent_session_id().is_some())
@@ -295,6 +287,7 @@ impl Conversation {
                 result.push((
                     thread.read(cx).session_id().clone(),
                     tool_id.clone(),
+                    tool_call,
                     options,
                 ));
             }

--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -161,6 +161,14 @@ pub(crate) struct Conversation {
 }
 
 impl Conversation {
+    pub fn thread(
+        &self,
+        session_id: &acp::SessionId,
+        _cx: &App,
+    ) -> Option<&Entity<AcpThread>> {
+        self.threads.get(session_id)
+    }
+
     pub fn register_thread(&mut self, thread: Entity<AcpThread>, cx: &mut Context<Self>) {
         let session_id = thread.read(cx).session_id().clone();
         let subscription = cx.subscribe(&thread, move |this, _thread, event, _cx| match event {
@@ -248,6 +256,50 @@ impl Conversation {
             tool_id.clone(),
             options,
         ))
+    }
+
+    pub fn all_pending_tool_calls<'a>(
+        &'a self,
+        session_id: &acp::SessionId,
+        cx: &'a App,
+    ) -> Vec<(acp::SessionId, acp::ToolCallId, &'a PermissionOptions)> {
+        let thread = self.threads.get(session_id);
+        let is_subagent = thread
+            .map(|t| t.read(cx).parent_session_id().is_some())
+            .unwrap_or(false);
+
+        let iter: Box<dyn Iterator<Item = (&acp::SessionId, &Vec<acp::ToolCallId>)>> =
+            if is_subagent {
+                if let Some(tool_calls) = self.permission_requests.get(session_id) {
+                    Box::new(std::iter::once((session_id, tool_calls)))
+                } else {
+                    return Vec::new();
+                }
+            } else {
+                Box::new(self.permission_requests.iter())
+            };
+
+        let mut result = Vec::new();
+        for (sid, tool_call_ids) in iter {
+            let Some(thread) = self.threads.get(sid) else {
+                continue;
+            };
+            for tool_id in tool_call_ids {
+                let Some((_, tool_call)) = thread.read(cx).tool_call(tool_id) else {
+                    continue;
+                };
+                let ToolCallStatus::WaitingForConfirmation { options, .. } = &tool_call.status
+                else {
+                    continue;
+                };
+                result.push((
+                    thread.read(cx).session_id().clone(),
+                    tool_id.clone(),
+                    options,
+                ));
+            }
+        }
+        result
     }
 
     pub fn authorize_pending_tool_call(

--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -254,7 +254,12 @@ impl Conversation {
         &'a self,
         session_id: &acp::SessionId,
         cx: &'a App,
-    ) -> Vec<(acp::SessionId, acp::ToolCallId, &'a ToolCall, &'a PermissionOptions)> {
+    ) -> Vec<(
+        acp::SessionId,
+        acp::ToolCallId,
+        &'a ToolCall,
+        &'a PermissionOptions,
+    )> {
         let thread = self.threads.get(session_id);
         let is_subagent = thread
             .map(|t| t.read(cx).parent_session_id().is_some())

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -5966,18 +5966,11 @@ impl ThreadView {
                 .border_t_1()
                 .border_color(self.tool_card_border_color(cx))
                 .child(
-                    h_flex()
-                        .px_2()
-                        .py_1()
-                        .justify_between()
-                        .child(
-                            Label::new(format!(
-                                "Pending Permissions ({})",
-                                total_count
-                            ))
+                    h_flex().px_2().py_1().justify_between().child(
+                        Label::new(format!("Pending Permissions ({})", total_count))
                             .size(LabelSize::Small)
                             .color(Color::Muted),
-                        ),
+                    ),
                 )
                 .children(pending.into_iter().enumerate().map(
                     |(index, (session_id, tool_call_id, tool_call, options))| {
@@ -5987,17 +5980,11 @@ impl ThreadView {
                             .border_t_1()
                             .border_color(self.tool_card_border_color(cx))
                             .child(
-                                h_flex()
-                                    .px_2()
-                                    .pt_1()
-                                    .overflow_hidden()
-                                    .child(
-                                        Label::new(
-                                            tool_call.label.read(cx).source().to_string(),
-                                        )
+                                h_flex().px_2().pt_1().overflow_hidden().child(
+                                    Label::new(tool_call.label.read(cx).source().to_string())
                                         .size(LabelSize::Small)
                                         .color(Color::Muted),
-                                    ),
+                                ),
                             )
                             .child(self.render_permission_buttons(
                                 session_id,

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -5950,6 +5950,70 @@ impl ThreadView {
             }))
     }
 
+    fn render_pending_permissions(&self, cx: &Context<Self>) -> Option<AnyElement> {
+        let conversation = self.conversation.read(cx);
+        let pending = conversation.all_pending_tool_calls(&self.id, cx);
+        if pending.is_empty() {
+            return None;
+        }
+
+        let total_count = pending.len();
+        let focus_handle = self.focus_handle.clone();
+
+        Some(
+            v_flex()
+                .bg(cx.theme().colors().editor_background)
+                .border_t_1()
+                .border_color(self.tool_card_border_color(cx))
+                .child(
+                    h_flex()
+                        .px_2()
+                        .py_1()
+                        .justify_between()
+                        .child(
+                            Label::new(format!(
+                                "Pending Permissions ({})",
+                                total_count
+                            ))
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                        ),
+                )
+                .children(pending.into_iter().enumerate().map(
+                    |(index, (session_id, tool_call_id, tool_call, options))| {
+                        let is_first = index == 0;
+
+                        v_flex()
+                            .border_t_1()
+                            .border_color(self.tool_card_border_color(cx))
+                            .child(
+                                h_flex()
+                                    .px_2()
+                                    .pt_1()
+                                    .overflow_hidden()
+                                    .child(
+                                        Label::new(
+                                            tool_call.label.read(cx).source().to_string(),
+                                        )
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                    ),
+                            )
+                            .child(self.render_permission_buttons(
+                                session_id,
+                                is_first,
+                                options,
+                                index,
+                                tool_call_id,
+                                &focus_handle,
+                                cx,
+                            ))
+                    },
+                ))
+                .into_any_element(),
+        )
+    }
+
     fn render_diff_loading(&self, cx: &Context<Self>) -> AnyElement {
         let bar = |n: u64, width_class: &str| {
             let bg_color = cx.theme().colors().element_active;
@@ -7815,6 +7879,7 @@ impl Render for ThreadView {
                 |this, version| this.child(self.render_new_version_callout(&version, cx)),
             )
             .children(self.render_token_limit_callout(cx))
+            .children(self.render_pending_permissions(cx))
             .child(self.render_message_editor(window, cx))
     }
 }


### PR DESCRIPTION
I have no idea how many times i have thought that my Claude Code agent was buggy and hanging, before i realised that it was because i hadn't provided an answer to a permission that was drowned in the chat. This PR improves the interaction IMO by having a "Pending permissions" section right above the chat input, so that you can easily see the permissions you have to interact it.

Here's how it looks like in a normal chat. Note that the existing pending approvals are not removed inline in the chat, i think that they should also be there:

<img width="1308" height="1660" alt="image" src="https://github.com/user-attachments/assets/b5253667-4d04-45fd-9a8a-186aebcace02" />

And here's how it looks like when you have a pending message:

<img width="1316" height="1806" alt="image" src="https://github.com/user-attachments/assets/81461ec5-cd55-4e9f-9849-bb29847cdba2" />



### Changes

- Added `all_pending_tool_calls()` to `Conversation` to collect all pending permission requests across threads
- Added `render_pending_permissions()` to `ThreadView` that groups all pending tool call permission requests in a section between the chat and the input area
- Styled to match native tool cards with editor background and border colors, showing a "Pending Permissions (N)" header with the total count and each tool call's label


### Release Notes:

- Improved permission prompts in the agent panel to be grouped above the chat input instead of inline