### PR TITLE
vim: Fix visual block Shift-I jumping to original cursor after Ctrl-D scroll

### DIFF
--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -97,13 +97,14 @@ impl Vim {
         let mode = self.mode;
         Vim::take_forced_motion(cx);
         self.exit_temporary_normal(window, cx);
-        self.update_editor(cx, |_, editor, cx| {
-            scroll_editor(editor, mode, move_cursor, amount, window, cx)
+        self.update_editor(cx, |vim, editor, cx| {
+            scroll_editor(vim, editor, mode, move_cursor, amount, window, cx)
         });
     }
 }
 
 fn scroll_editor(
+    vim: &mut Vim,
     editor: &mut Editor,
     mode: Mode,
     preserve_cursor_position: bool,
@@ -152,124 +153,133 @@ fn scroll_editor(
         .scroll_top_display_point(&display_snapshot, cx);
     let vertical_scroll_margin = EditorSettings::get_global(cx).vertical_scroll_margin;
 
-    editor.change_selections(
-        SelectionEffects::no_scroll().nav_history(false),
-        window,
-        cx,
-        |s| {
-            s.move_with(&mut |map, selection| {
-                // TODO: Improve the logic and function calls below to be dependent on
-                // the `amount`. If the amount is vertical, we don't care about
-                // columns, while if it's horizontal, we don't care about rows,
-                // so we don't need to calculate both and deal with logic for
-                // both.
-                let mut head = selection.head();
-                let max_point = map.max_point();
-                let starting_column = head.column();
+    let mut move_cursor = |map: &editor::display_map::DisplaySnapshot, mut head: DisplayPoint, goal: SelectionGoal| {
+        // TODO: Improve the logic and function calls below to be dependent on
+        // the `amount`. If the amount is vertical, we don't care about
+        // columns, while if it's horizontal, we don't care about rows,
+        // so we don't need to calculate both and deal with logic for
+        // both.
+        let max_point = map.max_point();
+        let starting_column = head.column();
 
-                let vertical_scroll_margin =
-                    (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
+        let vertical_scroll_margin =
+            (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
 
-                if preserve_cursor_position {
-                    let new_row = if old_top.row() == top.row() {
-                        DisplayRow(
-                            head.row()
-                                .0
-                                .saturating_add_signed(amount.lines(visible_line_count) as i32),
-                        )
-                    } else {
-                        DisplayRow(top.row().0.saturating_add_signed(
-                            selection.head().row().0 as i32 - old_top.row().0 as i32,
-                        ))
-                    };
-                    head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
-                }
-
-                let min_row = if top.row().0 == 0 {
-                    DisplayRow(0)
-                } else {
-                    DisplayRow(top.row().0 + vertical_scroll_margin)
-                };
-
-                let max_visible_row = top.row().0.saturating_add(
-                    (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
-                );
-                // scroll off the end.
-                let max_row = if top.row().0 + visible_line_count as u32 >= max_point.row().0 {
-                    max_point.row()
-                } else {
-                    DisplayRow(
-                        (top.row().0 + visible_line_count as u32)
-                            .saturating_sub(1 + vertical_scroll_margin),
-                    )
-                };
-
-                let new_row = if full_page_up {
-                    // Special-casing ctrl-b/page-up, which is special-cased by Vim, it seems
-                    // to always put the cursor on the last line of the page, even if the cursor
-                    // was before that.
-                    DisplayRow(max_visible_row)
-                } else if head.row() < min_row {
-                    min_row
-                } else if head.row() > max_row {
-                    max_row
-                } else {
+        if preserve_cursor_position {
+            let new_row = if old_top.row() == top.row() {
+                DisplayRow(
                     head.row()
-                };
+                        .0
+                        .saturating_add_signed(amount.lines(visible_line_count) as i32),
+                )
+            } else {
+                DisplayRow(top.row().0.saturating_add_signed(
+                    head.row().0 as i32 - old_top.row().0 as i32,
+                ))
+            };
+            head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
+        }
 
-                // The minimum column position that the cursor position can be
-                // at is either the scroll manager's anchor column, which is the
-                // left-most column in the visible area, or the scroll manager's
-                // old anchor column, in case the cursor position is being
-                // preserved. This is necessary for motions like `ctrl-d` in
-                // case there's not enough content to scroll half page down, in
-                // which case the scroll manager's anchor column will be the
-                // maximum column for the current line, so the minimum column
-                // would end up being the same as the maximum column.
-                let min_column = match preserve_cursor_position {
-                    true => old_top.column(),
-                    false => top.column(),
-                };
+        let min_row = if top.row().0 == 0 {
+            DisplayRow(0)
+        } else {
+            DisplayRow(top.row().0 + vertical_scroll_margin)
+        };
 
-                // As for the maximum column position, that should be either the
-                // right-most column in the visible area, which we can easily
-                // calculate by adding the visible column count to the minimum
-                // column position, or the right-most column in the current
-                // line, seeing as the cursor might be in a short line, in which
-                // case we don't want to go past its last column.
-                let max_row_column = if new_row <= map.max_point().row() {
-                    map.line_len(new_row)
-                } else {
-                    0
-                };
-                let max_column = match min_column + visible_column_count as u32 {
-                    max_column if max_column >= max_row_column => max_row_column,
-                    max_column => max_column,
-                };
+        let max_visible_row = top.row().0.saturating_add(
+            (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
+        );
+        // scroll off the end.
+        let max_row = if top.row().0 + visible_line_count as u32 >= max_point.row().0 {
+            max_point.row()
+        } else {
+            DisplayRow(
+                (top.row().0 + visible_line_count as u32)
+                    .saturating_sub(1 + vertical_scroll_margin),
+            )
+        };
 
-                // Ensure that the cursor's column stays within the visible
-                // area, otherwise clip it at either the left or right edge of
-                // the visible area.
-                let new_column = match (min_column, max_column) {
-                    (min_column, _) if starting_column < min_column => min_column,
-                    (_, max_column) if starting_column > max_column => max_column,
-                    _ => starting_column,
-                };
+        let new_row = if full_page_up {
+            // Special-casing ctrl-b/page-up, which is special-cased by Vim, it seems
+            // to always put the cursor on the last line of the page, even if the cursor
+            // was before that.
+            DisplayRow(max_visible_row)
+        } else if head.row() < min_row {
+            min_row
+        } else if head.row() > max_row {
+            max_row
+        } else {
+            head.row()
+        };
 
-                let new_head = map.clip_point(DisplayPoint::new(new_row, new_column), Bias::Left);
-                let goal = match amount {
-                    ScrollAmount::Column(_) | ScrollAmount::PageWidth(_) => SelectionGoal::None,
-                    _ => selection.goal,
-                };
+        // The minimum column position that the cursor position can be
+        // at is either the scroll manager's anchor column, which is the
+        // left-most column in the visible area, or the scroll manager's
+        // old anchor column, in case the cursor position is being
+        // preserved. This is necessary for motions like `ctrl-d` in
+        // case there's not enough content to scroll half page down, in
+        // which case the scroll manager's anchor column will be the
+        // maximum column for the current line, so the minimum column
+        // would end up being the same as the maximum column.
+        let min_column = match preserve_cursor_position {
+            true => old_top.column(),
+            false => top.column(),
+        };
 
-                if selection.is_empty() || !mode.is_visual() {
-                    selection.collapse_to(new_head, goal)
-                } else {
-                    selection.set_head(new_head, goal)
-                };
-            })
-        },
-    );
+        // As for the maximum column position, that should be either the
+        // right-most column in the visible area, which we can easily
+        // calculate by adding the visible column count to the minimum
+        // column position, or the right-most column in the current
+        // line, seeing as the cursor might be in a short line, in which
+        // case we don't want to go past its last column.
+        let max_row_column = if new_row <= map.max_point().row() {
+            map.line_len(new_row)
+        } else {
+            0
+        };
+        let max_column = match min_column + visible_column_count as u32 {
+            max_column if max_column >= max_row_column => max_row_column,
+            max_column => max_column,
+        };
+
+        // Ensure that the cursor's column stays within the visible
+        // area, otherwise clip it at either the left or right edge of
+        // the visible area.
+        let new_column = match (min_column, max_column) {
+            (min_column, _) if starting_column < min_column => min_column,
+            (_, max_column) if starting_column > max_column => max_column,
+            _ => starting_column,
+        };
+
+        let new_head = map.clip_point(DisplayPoint::new(new_row, new_column), Bias::Left);
+        let goal = match amount {
+            ScrollAmount::Column(_) | ScrollAmount::PageWidth(_) => SelectionGoal::None,
+            _ => goal,
+        };
+
+        Some((new_head, goal))
+    };
+
+    if mode == Mode::VisualBlock {
+        vim.visual_block_motion(false, editor, window, cx, &mut move_cursor);
+    } else {
+        editor.change_selections(
+            SelectionEffects::no_scroll().nav_history(false),
+            window,
+            cx,
+            |s| {
+                s.move_with(&mut |map, selection| {
+                    if let Some((new_head, goal)) = move_cursor(map, selection.head(), selection.goal) {
+                        if selection.is_empty() || !mode.is_visual() {
+                            selection.collapse_to(new_head, goal)
+                        } else {
+                            selection.set_head(new_head, goal)
+                        }
+                    }
+                })
+            },
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -261,7 +261,7 @@ fn scroll_editor(
     };
 
     if mode == Mode::VisualBlock {
-        vim.visual_block_motion(false, editor, window, cx, &mut move_cursor);
+        vim.visual_block_motion(true, editor, window, cx, &mut move_cursor);
     } else {
         editor.change_selections(
             SelectionEffects::no_scroll().nav_history(false),

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -88,197 +88,199 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 impl Vim {
     fn scroll(
         &mut self,
-        move_cursor: bool,
+        preserve_cursor_position: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
         by: fn(c: Option<f32>) -> ScrollAmount,
     ) {
         let amount = by(Vim::take_count(cx).map(|c| c as f32));
-        let mode = self.mode;
         Vim::take_forced_motion(cx);
         self.exit_temporary_normal(window, cx);
+        self.scroll_editor(preserve_cursor_position, amount, window, cx);
+    }
+
+    fn scroll_editor(
+        &mut self,
+        preserve_cursor_position: bool,
+        amount: ScrollAmount,
+        window: &mut Window,
+        cx: &mut Context<Vim>,
+    ) {
         self.update_editor(cx, |vim, editor, cx| {
-            scroll_editor(vim, editor, mode, move_cursor, amount, window, cx)
-        });
-    }
-}
+            let should_move_cursor = editor.newest_selection_on_screen(cx).is_eq();
+            let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let old_top = editor
+                .scroll_manager
+                .scroll_top_display_point(&display_snapshot, cx);
 
-fn scroll_editor(
-    vim: &mut Vim,
-    editor: &mut Editor,
-    mode: Mode,
-    preserve_cursor_position: bool,
-    amount: ScrollAmount,
-    window: &mut Window,
-    cx: &mut Context<Editor>,
-) {
-    let should_move_cursor = editor.newest_selection_on_screen(cx).is_eq();
-    let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
-    let old_top = editor
-        .scroll_manager
-        .scroll_top_display_point(&display_snapshot, cx);
-
-    if editor.scroll_hover(amount, window, cx) {
-        return;
-    }
-
-    let full_page_up = amount.is_full_page() && amount.direction().is_upwards();
-    let amount = match (amount.is_full_page(), editor.visible_line_count()) {
-        (true, Some(visible_line_count)) => {
-            if amount.direction().is_upwards() {
-                ScrollAmount::Line((amount.lines(visible_line_count) + 1.0) as f32)
-            } else {
-                ScrollAmount::Line((amount.lines(visible_line_count) - 1.0) as f32)
+            if editor.scroll_hover(amount, window, cx) {
+                return;
             }
-        }
-        _ => amount,
-    };
 
-    editor.scroll_screen(&amount, window, cx);
-    if !should_move_cursor {
-        return;
-    }
-
-    let Some(visible_line_count) = editor.visible_line_count() else {
-        return;
-    };
-
-    let Some(visible_column_count) = editor.visible_column_count() else {
-        return;
-    };
-
-    let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
-    let top = editor
-        .scroll_manager
-        .scroll_top_display_point(&display_snapshot, cx);
-    let vertical_scroll_margin = EditorSettings::get_global(cx).vertical_scroll_margin;
-
-    let mut move_cursor = |map: &editor::display_map::DisplaySnapshot, mut head: DisplayPoint, goal: SelectionGoal| {
-        // TODO: Improve the logic and function calls below to be dependent on
-        // the `amount`. If the amount is vertical, we don't care about
-        // columns, while if it's horizontal, we don't care about rows,
-        // so we don't need to calculate both and deal with logic for
-        // both.
-        let max_point = map.max_point();
-        let starting_column = head.column();
-
-        let vertical_scroll_margin =
-            (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
-
-        if preserve_cursor_position {
-            let new_row = if old_top.row() == top.row() {
-                DisplayRow(
-                    head.row()
-                        .0
-                        .saturating_add_signed(amount.lines(visible_line_count) as i32),
-                )
-            } else {
-                DisplayRow(top.row().0.saturating_add_signed(
-                    head.row().0 as i32 - old_top.row().0 as i32,
-                ))
-            };
-            head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
-        }
-
-        let min_row = if top.row().0 == 0 {
-            DisplayRow(0)
-        } else {
-            DisplayRow(top.row().0 + vertical_scroll_margin)
-        };
-
-        let max_visible_row = top.row().0.saturating_add(
-            (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
-        );
-        // scroll off the end.
-        let max_row = if top.row().0 + visible_line_count as u32 >= max_point.row().0 {
-            max_point.row()
-        } else {
-            DisplayRow(
-                (top.row().0 + visible_line_count as u32)
-                    .saturating_sub(1 + vertical_scroll_margin),
-            )
-        };
-
-        let new_row = if full_page_up {
-            // Special-casing ctrl-b/page-up, which is special-cased by Vim, it seems
-            // to always put the cursor on the last line of the page, even if the cursor
-            // was before that.
-            DisplayRow(max_visible_row)
-        } else if head.row() < min_row {
-            min_row
-        } else if head.row() > max_row {
-            max_row
-        } else {
-            head.row()
-        };
-
-        // The minimum column position that the cursor position can be
-        // at is either the scroll manager's anchor column, which is the
-        // left-most column in the visible area, or the scroll manager's
-        // old anchor column, in case the cursor position is being
-        // preserved. This is necessary for motions like `ctrl-d` in
-        // case there's not enough content to scroll half page down, in
-        // which case the scroll manager's anchor column will be the
-        // maximum column for the current line, so the minimum column
-        // would end up being the same as the maximum column.
-        let min_column = match preserve_cursor_position {
-            true => old_top.column(),
-            false => top.column(),
-        };
-
-        // As for the maximum column position, that should be either the
-        // right-most column in the visible area, which we can easily
-        // calculate by adding the visible column count to the minimum
-        // column position, or the right-most column in the current
-        // line, seeing as the cursor might be in a short line, in which
-        // case we don't want to go past its last column.
-        let max_row_column = if new_row <= map.max_point().row() {
-            map.line_len(new_row)
-        } else {
-            0
-        };
-        let max_column = match min_column + visible_column_count as u32 {
-            max_column if max_column >= max_row_column => max_row_column,
-            max_column => max_column,
-        };
-
-        // Ensure that the cursor's column stays within the visible
-        // area, otherwise clip it at either the left or right edge of
-        // the visible area.
-        let new_column = match (min_column, max_column) {
-            (min_column, _) if starting_column < min_column => min_column,
-            (_, max_column) if starting_column > max_column => max_column,
-            _ => starting_column,
-        };
-
-        let new_head = map.clip_point(DisplayPoint::new(new_row, new_column), Bias::Left);
-        let goal = match amount {
-            ScrollAmount::Column(_) | ScrollAmount::PageWidth(_) => SelectionGoal::None,
-            _ => goal,
-        };
-
-        Some((new_head, goal))
-    };
-
-    if mode == Mode::VisualBlock {
-        vim.visual_block_motion(true, editor, window, cx, &mut move_cursor);
-    } else {
-        editor.change_selections(
-            SelectionEffects::no_scroll().nav_history(false),
-            window,
-            cx,
-            |s| {
-                s.move_with(&mut |map, selection| {
-                    if let Some((new_head, goal)) = move_cursor(map, selection.head(), selection.goal) {
-                        if selection.is_empty() || !mode.is_visual() {
-                            selection.collapse_to(new_head, goal)
-                        } else {
-                            selection.set_head(new_head, goal)
-                        }
+            let full_page_up = amount.is_full_page() && amount.direction().is_upwards();
+            let amount = match (amount.is_full_page(), editor.visible_line_count()) {
+                (true, Some(visible_line_count)) => {
+                    if amount.direction().is_upwards() {
+                        ScrollAmount::Line((amount.lines(visible_line_count) + 1.0) as f32)
+                    } else {
+                        ScrollAmount::Line((amount.lines(visible_line_count) - 1.0) as f32)
                     }
-                })
-            },
-        );
+                }
+                _ => amount,
+            };
+
+            editor.scroll_screen(&amount, window, cx);
+            if !should_move_cursor {
+                return;
+            }
+
+            let Some(visible_line_count) = editor.visible_line_count() else {
+                return;
+            };
+
+            let Some(visible_column_count) = editor.visible_column_count() else {
+                return;
+            };
+
+            let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let top = editor
+                .scroll_manager
+                .scroll_top_display_point(&display_snapshot, cx);
+            let vertical_scroll_margin = EditorSettings::get_global(cx).vertical_scroll_margin;
+
+            let mut move_cursor = |map: &editor::display_map::DisplaySnapshot,
+                                   mut head: DisplayPoint,
+                                   goal: SelectionGoal| {
+                // TODO: Improve the logic and function calls below to be dependent on
+                // the `amount`. If the amount is vertical, we don't care about
+                // columns, while if it's horizontal, we don't care about rows,
+                // so we don't need to calculate both and deal with logic for
+                // both.
+                let max_point = map.max_point();
+                let starting_column = head.column();
+
+                let vertical_scroll_margin =
+                    (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
+
+                if preserve_cursor_position {
+                    let new_row =
+                        if old_top.row() == top.row() {
+                            DisplayRow(
+                                head.row()
+                                    .0
+                                    .saturating_add_signed(amount.lines(visible_line_count) as i32),
+                            )
+                        } else {
+                            DisplayRow(top.row().0.saturating_add_signed(
+                                head.row().0 as i32 - old_top.row().0 as i32,
+                            ))
+                        };
+                    head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
+                }
+
+                let min_row = if top.row().0 == 0 {
+                    DisplayRow(0)
+                } else {
+                    DisplayRow(top.row().0 + vertical_scroll_margin)
+                };
+
+                let max_visible_row = top.row().0.saturating_add(
+                    (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
+                );
+                // scroll off the end.
+                let max_row = if top.row().0 + visible_line_count as u32 >= max_point.row().0 {
+                    max_point.row()
+                } else {
+                    DisplayRow(
+                        (top.row().0 + visible_line_count as u32)
+                            .saturating_sub(1 + vertical_scroll_margin),
+                    )
+                };
+
+                let new_row = if full_page_up {
+                    // Special-casing ctrl-b/page-up, which is special-cased by Vim, it seems
+                    // to always put the cursor on the last line of the page, even if the cursor
+                    // was before that.
+                    DisplayRow(max_visible_row)
+                } else if head.row() < min_row {
+                    min_row
+                } else if head.row() > max_row {
+                    max_row
+                } else {
+                    head.row()
+                };
+
+                // The minimum column position that the cursor position can be
+                // at is either the scroll manager's anchor column, which is the
+                // left-most column in the visible area, or the scroll manager's
+                // old anchor column, in case the cursor position is being
+                // preserved. This is necessary for motions like `ctrl-d` in
+                // case there's not enough content to scroll half page down, in
+                // which case the scroll manager's anchor column will be the
+                // maximum column for the current line, so the minimum column
+                // would end up being the same as the maximum column.
+                let min_column = match preserve_cursor_position {
+                    true => old_top.column(),
+                    false => top.column(),
+                };
+
+                // As for the maximum column position, that should be either the
+                // right-most column in the visible area, which we can easily
+                // calculate by adding the visible column count to the minimum
+                // column position, or the right-most column in the current
+                // line, seeing as the cursor might be in a short line, in which
+                // case we don't want to go past its last column.
+                let max_row_column = if new_row <= map.max_point().row() {
+                    map.line_len(new_row)
+                } else {
+                    0
+                };
+                let max_column = match min_column + visible_column_count as u32 {
+                    max_column if max_column >= max_row_column => max_row_column,
+                    max_column => max_column,
+                };
+
+                // Ensure that the cursor's column stays within the visible
+                // area, otherwise clip it at either the left or right edge of
+                // the visible area.
+                let new_column = match (min_column, max_column) {
+                    (min_column, _) if starting_column < min_column => min_column,
+                    (_, max_column) if starting_column > max_column => max_column,
+                    _ => starting_column,
+                };
+
+                let new_head = map.clip_point(DisplayPoint::new(new_row, new_column), Bias::Left);
+                let goal = match amount {
+                    ScrollAmount::Column(_) | ScrollAmount::PageWidth(_) => SelectionGoal::None,
+                    _ => goal,
+                };
+
+                Some((new_head, goal))
+            };
+
+            if vim.mode == Mode::VisualBlock {
+                vim.visual_block_motion(true, editor, window, cx, &mut move_cursor);
+            } else {
+                editor.change_selections(
+                    SelectionEffects::no_scroll().nav_history(false),
+                    window,
+                    cx,
+                    |s| {
+                        s.move_with(&mut |map, selection| {
+                            if let Some((new_head, goal)) =
+                                move_cursor(map, selection.head(), selection.goal)
+                            {
+                                if selection.is_empty() || !vim.mode.is_visual() {
+                                    selection.collapse_to(new_head, goal)
+                                } else {
+                                    selection.set_head(new_head, goal)
+                                }
+                            }
+                        })
+                    },
+                );
+            }
+        });
     }
 }
 

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -1564,30 +1564,14 @@ mod test {
     #[gpui::test]
     async fn test_visual_block_insert_after_ctrl_d_scroll(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
+        let shared_state_lines = (1..=60)
+            .map(|line_number| format!("alpha {line_number:02}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let shared_state = format!("ˇ{shared_state_lines}\n");
 
         cx.set_scroll_height(10).await;
-        cx.set_shared_state(indoc! {
-            "ˇalpha 01
-            alpha 02
-            alpha 03
-            alpha 04
-            alpha 05
-            alpha 06
-            alpha 07
-            alpha 08
-            alpha 09
-            alpha 10
-            alpha 11
-            alpha 12
-            alpha 13
-            alpha 14
-            alpha 15
-            alpha 16
-            alpha 17
-            alpha 18
-            "
-        })
-        .await;
+        cx.set_shared_state(&shared_state).await;
 
         cx.simulate_shared_keystrokes("ctrl-v 5 j ctrl-d").await;
         cx.shared_state().await.assert_matches();

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -1562,6 +1562,41 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_visual_block_insert_after_ctrl_d_scroll(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_scroll_height(10).await;
+        cx.set_shared_state(indoc! {
+            "ˇalpha 01
+            alpha 02
+            alpha 03
+            alpha 04
+            alpha 05
+            alpha 06
+            alpha 07
+            alpha 08
+            alpha 09
+            alpha 10
+            alpha 11
+            alpha 12
+            alpha 13
+            alpha 14
+            alpha 15
+            alpha 16
+            alpha 17
+            alpha 18
+            "
+        })
+        .await;
+
+        cx.simulate_shared_keystrokes("ctrl-v 5 j ctrl-d").await;
+        cx.shared_state().await.assert_matches();
+
+        cx.simulate_shared_keystrokes("shift-i x escape").await;
+        cx.shared_state().await.assert_matches();
+    }
+
+    #[gpui::test]
     async fn test_visual_block_wrapping_selection(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
 

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -1564,20 +1564,33 @@ mod test {
     #[gpui::test]
     async fn test_visual_block_insert_after_ctrl_d_scroll(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
-        let shared_state_lines = (1..=60)
-            .map(|line_number| format!("alpha {line_number:02}"))
+        let shared_state_lines = (1..=10)
+            .map(|line_number| format!("{line_number:02}"))
             .collect::<Vec<_>>()
             .join("\n");
         let shared_state = format!("ˇ{shared_state_lines}\n");
 
-        cx.set_scroll_height(10).await;
+        cx.set_scroll_height(5).await;
         cx.set_shared_state(&shared_state).await;
 
-        cx.simulate_shared_keystrokes("ctrl-v 5 j ctrl-d").await;
+        cx.simulate_shared_keystrokes("ctrl-v ctrl-d").await;
         cx.shared_state().await.assert_matches();
 
         cx.simulate_shared_keystrokes("shift-i x escape").await;
-        cx.shared_state().await.assert_matches();
+        cx.shared_state().await.assert_eq(indoc! {
+            "
+            ˇx01
+            x02
+            x03
+            x04
+            x05
+            06
+            07
+            08
+            09
+            10
+            "
+        });
     }
 
     #[gpui::test]

--- a/crates/vim/test_data/test_visual_block_insert_after_ctrl_d_scroll.json
+++ b/crates/vim/test_data/test_visual_block_insert_after_ctrl_d_scroll.json
@@ -1,0 +1,12 @@
+{"SetOption":{"value":"scrolloff=3"}}
+{"SetOption":{"value":"lines=12"}}
+{"Put":{"state":"ˇalpha 01\nalpha 02\nalpha 03\nalpha 04\nalpha 05\nalpha 06\nalpha 07\nalpha 08\nalpha 09\nalpha 10\nalpha 11\nalpha 12\nalpha 13\nalpha 14\nalpha 15\nalpha 16\nalpha 17\nalpha 18\nalpha 19\nalpha 20\nalpha 21\nalpha 22\nalpha 23\nalpha 24\nalpha 25\nalpha 26\nalpha 27\nalpha 28\nalpha 29\nalpha 30\nalpha 31\nalpha 32\nalpha 33\nalpha 34\nalpha 35\nalpha 36\nalpha 37\nalpha 38\nalpha 39\nalpha 40\nalpha 41\nalpha 42\nalpha 43\nalpha 44\nalpha 45\nalpha 46\nalpha 47\nalpha 48\nalpha 49\nalpha 50\nalpha 51\nalpha 52\nalpha 53\nalpha 54\nalpha 55\nalpha 56\nalpha 57\nalpha 58\nalpha 59\nalpha 60\n"}}
+{"Key":"ctrl-v"}
+{"Key":"5"}
+{"Key":"j"}
+{"Key":"ctrl-d"}
+{"Get":{"state":"«aˇ»lpha 01\n«aˇ»lpha 02\n«aˇ»lpha 03\n«aˇ»lpha 04\n«aˇ»lpha 05\n«aˇ»lpha 06\n«aˇ»lpha 07\n«aˇ»lpha 08\n«aˇ»lpha 09\n«aˇ»lpha 10\n«aˇ»lpha 11\nalpha 12\nalpha 13\nalpha 14\nalpha 15\nalpha 16\nalpha 17\nalpha 18\nalpha 19\nalpha 20\nalpha 21\nalpha 22\nalpha 23\nalpha 24\nalpha 25\nalpha 26\nalpha 27\nalpha 28\nalpha 29\nalpha 30\nalpha 31\nalpha 32\nalpha 33\nalpha 34\nalpha 35\nalpha 36\nalpha 37\nalpha 38\nalpha 39\nalpha 40\nalpha 41\nalpha 42\nalpha 43\nalpha 44\nalpha 45\nalpha 46\nalpha 47\nalpha 48\nalpha 49\nalpha 50\nalpha 51\nalpha 52\nalpha 53\nalpha 54\nalpha 55\nalpha 56\nalpha 57\nalpha 58\nalpha 59\nalpha 60\n","mode":"VisualBlock"}}
+{"Key":"shift-i"}
+{"Key":"x"}
+{"Key":"escape"}
+{"Get":{"state":"ˇxalpha 01\nxalpha 02\nxalpha 03\nxalpha 04\nxalpha 05\nxalpha 06\nxalpha 07\nxalpha 08\nxalpha 09\nxalpha 10\nxalpha 11\nalpha 12\nalpha 13\nalpha 14\nalpha 15\nalpha 16\nalpha 17\nalpha 18\nalpha 19\nalpha 20\nalpha 21\nalpha 22\nalpha 23\nalpha 24\nalpha 25\nalpha 26\nalpha 27\nalpha 28\nalpha 29\nalpha 30\nalpha 31\nalpha 32\nalpha 33\nalpha 34\nalpha 35\nalpha 36\nalpha 37\nalpha 38\nalpha 39\nalpha 40\nalpha 41\nalpha 42\nalpha 43\nalpha 44\nalpha 45\nalpha 46\nalpha 47\nalpha 48\nalpha 49\nalpha 50\nalpha 51\nalpha 52\nalpha 53\nalpha 54\nalpha 55\nalpha 56\nalpha 57\nalpha 58\nalpha 59\nalpha 60\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_visual_block_insert_after_ctrl_d_scroll.json
+++ b/crates/vim/test_data/test_visual_block_insert_after_ctrl_d_scroll.json
@@ -1,12 +1,10 @@
 {"SetOption":{"value":"scrolloff=3"}}
-{"SetOption":{"value":"lines=12"}}
-{"Put":{"state":"ˇalpha 01\nalpha 02\nalpha 03\nalpha 04\nalpha 05\nalpha 06\nalpha 07\nalpha 08\nalpha 09\nalpha 10\nalpha 11\nalpha 12\nalpha 13\nalpha 14\nalpha 15\nalpha 16\nalpha 17\nalpha 18\nalpha 19\nalpha 20\nalpha 21\nalpha 22\nalpha 23\nalpha 24\nalpha 25\nalpha 26\nalpha 27\nalpha 28\nalpha 29\nalpha 30\nalpha 31\nalpha 32\nalpha 33\nalpha 34\nalpha 35\nalpha 36\nalpha 37\nalpha 38\nalpha 39\nalpha 40\nalpha 41\nalpha 42\nalpha 43\nalpha 44\nalpha 45\nalpha 46\nalpha 47\nalpha 48\nalpha 49\nalpha 50\nalpha 51\nalpha 52\nalpha 53\nalpha 54\nalpha 55\nalpha 56\nalpha 57\nalpha 58\nalpha 59\nalpha 60\n"}}
+{"SetOption":{"value":"lines=7"}}
+{"Put":{"state":"ˇ01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n"}}
 {"Key":"ctrl-v"}
-{"Key":"5"}
-{"Key":"j"}
 {"Key":"ctrl-d"}
-{"Get":{"state":"«aˇ»lpha 01\n«aˇ»lpha 02\n«aˇ»lpha 03\n«aˇ»lpha 04\n«aˇ»lpha 05\n«aˇ»lpha 06\n«aˇ»lpha 07\n«aˇ»lpha 08\n«aˇ»lpha 09\n«aˇ»lpha 10\n«aˇ»lpha 11\nalpha 12\nalpha 13\nalpha 14\nalpha 15\nalpha 16\nalpha 17\nalpha 18\nalpha 19\nalpha 20\nalpha 21\nalpha 22\nalpha 23\nalpha 24\nalpha 25\nalpha 26\nalpha 27\nalpha 28\nalpha 29\nalpha 30\nalpha 31\nalpha 32\nalpha 33\nalpha 34\nalpha 35\nalpha 36\nalpha 37\nalpha 38\nalpha 39\nalpha 40\nalpha 41\nalpha 42\nalpha 43\nalpha 44\nalpha 45\nalpha 46\nalpha 47\nalpha 48\nalpha 49\nalpha 50\nalpha 51\nalpha 52\nalpha 53\nalpha 54\nalpha 55\nalpha 56\nalpha 57\nalpha 58\nalpha 59\nalpha 60\n","mode":"VisualBlock"}}
+{"Get":{"state":"«0ˇ»1\n«0ˇ»2\n«0ˇ»3\n«0ˇ»4\n«0ˇ»5\n06\n07\n08\n09\n10\n","mode":"VisualBlock"}}
 {"Key":"shift-i"}
 {"Key":"x"}
 {"Key":"escape"}
-{"Get":{"state":"ˇxalpha 01\nxalpha 02\nxalpha 03\nxalpha 04\nxalpha 05\nxalpha 06\nxalpha 07\nxalpha 08\nxalpha 09\nxalpha 10\nxalpha 11\nalpha 12\nalpha 13\nalpha 14\nalpha 15\nalpha 16\nalpha 17\nalpha 18\nalpha 19\nalpha 20\nalpha 21\nalpha 22\nalpha 23\nalpha 24\nalpha 25\nalpha 26\nalpha 27\nalpha 28\nalpha 29\nalpha 30\nalpha 31\nalpha 32\nalpha 33\nalpha 34\nalpha 35\nalpha 36\nalpha 37\nalpha 38\nalpha 39\nalpha 40\nalpha 41\nalpha 42\nalpha 43\nalpha 44\nalpha 45\nalpha 46\nalpha 47\nalpha 48\nalpha 49\nalpha 50\nalpha 51\nalpha 52\nalpha 53\nalpha 54\nalpha 55\nalpha 56\nalpha 57\nalpha 58\nalpha 59\nalpha 60\n","mode":"Normal"}}
+{"Get":{"state":"ˇx01\nx02\nx03\nx04\nx05\n06\n07\n08\n09\n10\n","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:

- Fixed visual block `shift-i` jumping to the initial cursor position after scrolling with `ctrl-d`/`ctrl-u`


In Vim mode, press Ctrl+V to enter line selection, press Ctrl+D to start scrolling, then press Shift+I to insert into the newly selected multiple lines.

Current: Jump to the beginning
Expected: Enter multi-line insert mode

before:


https://github.com/user-attachments/assets/3cf6489c-828d-44d8-b575-239b68e50c2b



after:


https://github.com/user-attachments/assets/a086f6d1-abeb-464d-8e09-5a3c1173840c


vim behaviour:



https://github.com/user-attachments/assets/900cb540-9cca-4e90-9796-dcc56874c8b7




