### PR TITLE
docs: Fix typo in consent banner hide check

### DIFF
--- a/docs/theme/analytics.js
+++ b/docs/theme/analytics.js
@@ -55,7 +55,7 @@ document.addEventListener("DOMContentLoaded", () => {
   consentStore.subscribe((state) => {
     const hideBanner =
       state.activeUI === "none" ||
-      (state.activeUI === "banner" && state.mode === "opt-out");
+      (state.activeUI === "banner" && state.model === "opt-out");
     banner.style.display = hideBanner ? "none" : "block";
 
     if (state.activeUI === "dialog" && previousActiveUI !== "dialog") {


### PR DESCRIPTION
Fixes a typo in the consent banner check on docs pages, which makes the opt-out logic work correctly.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
