### PR TITLE
language_models: Avoid debug formatting in Copilot Chat, OpenAI errors

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -748,7 +748,7 @@ impl CopilotResponsesEventMapper {
             }
 
             copilot_responses::StreamEvent::GenericError { error } => vec![Err(
-                LanguageModelCompletionError::Other(anyhow!(format!("{error:?}"))),
+                LanguageModelCompletionError::Other(anyhow!(error.message)),
             )],
 
             copilot_responses::StreamEvent::Created { .. }

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -1069,9 +1069,9 @@ impl OpenAiResponseEventMapper {
             }
             ResponsesStreamEvent::Error { error }
             | ResponsesStreamEvent::GenericError { error } => {
-                vec![Err(LanguageModelCompletionError::Other(anyhow!(format!(
-                    "{error:?}"
-                ))))]
+                vec![Err(LanguageModelCompletionError::Other(anyhow!(
+                    error.message
+                )))]
             }
             ResponsesStreamEvent::OutputTextDone { .. } => Vec::new(),
             ResponsesStreamEvent::OutputItemDone { .. }


### PR DESCRIPTION
See these screenshots:

<img width="832" height="564" alt="image" src="https://github.com/user-attachments/assets/64d04fe7-4be7-4fbf-8536-b4b7a2ea62ed" />

<img width="836" height="1094" alt="image" src="https://github.com/user-attachments/assets/247b215c-8e7e-4eff-8e08-b1b9ee8894b9" />

Release Notes:

- Fixed some error messages in OpenAI/Copilot Chat conversations that were using the Debug representation.
