### PR TITLE
ep: Fix infinite loop of EP requests in some cases

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -1800,12 +1800,7 @@ impl EditPredictionStore {
         };
 
         // Prefer predictions from buffer
-        let has_pending_predictions = project_state.current_prediction.is_some()
-            || project_state
-                .pending_predictions
-                .iter()
-                .any(|p| !project_state.cancelled_predictions.contains(&p.id));
-        if has_pending_predictions {
+        if project_state.current_prediction.is_some() {
             log::debug!(
                 "edit_prediction: diagnostic refresh skipped, current prediction already exists"
             );

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -1800,7 +1800,15 @@ impl EditPredictionStore {
         };
 
         // Prefer predictions from buffer
-        if project_state.current_prediction.is_some() {
+        let has_pending_predictions = project_state.current_prediction.is_some()
+            || project_state
+                .pending_predictions
+                .iter()
+                .any(|p| !project_state.cancelled_predictions.contains(&p.id));
+        if has_pending_predictions {
+            log::debug!(
+                "edit_prediction: diagnostic refresh skipped, current prediction already exists"
+            );
             return;
         }
 
@@ -2262,7 +2270,13 @@ impl EditPredictionStore {
         cx.spawn(async move |this, cx| {
             let prediction = task.await?;
 
-            if prediction.is_none() && allow_jump && has_events {
+            // Only fall back to diagnostics-based prediction if we got a
+            // the model had nothing to suggest for the buffer
+            if prediction.is_none()
+                && allow_jump
+                && has_events
+                && !matches!(trigger, PredictEditsRequestTrigger::Diagnostics)
+            {
                 this.update(cx, |this, cx| {
                     this.refresh_prediction_from_diagnostics(
                         project,


### PR DESCRIPTION
When a diagnostic-triggered prediction returns no edits, don't fall back to requesting another diagnostic prediction. This was causing an infinite loop that burned through the API rate limit until hitting 429 errors.


Release Notes:

- N/A 
