### PR TITLE
agent: Fail faster in case streaming tool call fails

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -6510,14 +6510,14 @@ async fn test_streaming_tool_error_waits_for_prior_tools_to_complete(cx: &mut Te
                 content: vec![
                     language_model::MessageContent::ToolResult(LanguageModelToolResult {
                         tool_use_id: second_tool_use.id.clone(),
-                        tool_name: second_tool_use.name.clone(),
+                        tool_name: second_tool_use.name,
                         is_error: true,
                         content: "failed".into(),
                         output: Some("failed".into()),
                     }),
                     language_model::MessageContent::ToolResult(LanguageModelToolResult {
                         tool_use_id: first_tool_use.id.clone(),
-                        tool_name: first_tool_use.name.clone(),
+                        tool_name: first_tool_use.name,
                         is_error: false,
                         content: "hello world".into(),
                         output: Some("hello world".into()),

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3616,7 +3616,7 @@ async fn test_streaming_tool_completes_when_llm_stream_ends_without_final_input(
     let fake_model = model.as_fake();
 
     thread.update(cx, |thread, _cx| {
-        thread.add_tool(StreamingEchoTool);
+        thread.add_tool(StreamingEchoTool::new());
     });
 
     let _events = thread
@@ -6338,7 +6338,7 @@ async fn test_queued_message_ends_turn_at_boundary(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext) {
+async fn test_streaming_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext) {
     init_test(cx);
     always_allow_tools(cx);
 
@@ -6353,7 +6353,11 @@ async fn test_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext)
 
     let _events = thread
         .update(cx, |thread, cx| {
-            thread.send(UserMessageId::new(), ["Use the streaming_echo tool"], cx)
+            thread.send(
+                UserMessageId::new(),
+                ["Use the streaming_failing_echo tool"],
+                cx,
+            )
         })
         .unwrap();
     cx.run_until_parked();
@@ -6380,7 +6384,7 @@ async fn test_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext)
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
-                content: vec!["Use the streaming_echo tool".into()],
+                content: vec!["Use the streaming_failing_echo tool".into()],
                 cache: false,
                 reasoning_details: None,
             },
@@ -6401,6 +6405,124 @@ async fn test_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext)
                         output: Some("failed".into()),
                     }
                 )],
+                cache: true,
+                reasoning_details: None,
+            },
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_streaming_tool_error_waits_for_prior_tools_to_complete(cx: &mut TestAppContext) {
+    init_test(cx);
+    always_allow_tools(cx);
+
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let (complete_streaming_echo_tool_call_tx, complete_streaming_echo_tool_call_rx) =
+        oneshot::channel();
+
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(
+            StreamingEchoTool::new().with_wait_until_complete(complete_streaming_echo_tool_call_rx),
+        );
+        thread.add_tool(StreamingFailingEchoTool {
+            receive_chunks_until_failure: 1,
+        });
+    });
+
+    let _events = thread
+        .update(cx, |thread, cx| {
+            thread.send(
+                UserMessageId::new(),
+                ["Use the streaming_echo tool and the streaming_failing_echo tool"],
+                cx,
+            )
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_1".into(),
+            name: StreamingEchoTool::NAME.into(),
+            raw_input: "hello".into(),
+            input: json!({ "text": "hello" }),
+            is_input_complete: false,
+            thought_signature: None,
+        },
+    ));
+    let first_tool_use = LanguageModelToolUse {
+        id: "call_1".into(),
+        name: StreamingEchoTool::NAME.into(),
+        raw_input: "hello world".into(),
+        input: json!({ "text": "hello world" }),
+        is_input_complete: true,
+        thought_signature: None,
+    };
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        first_tool_use.clone(),
+    ));
+    let second_tool_use = LanguageModelToolUse {
+        name: StreamingFailingEchoTool::NAME.into(),
+        raw_input: "hello".into(),
+        input: json!({ "text": "hello" }),
+        is_input_complete: false,
+        thought_signature: None,
+        id: "call_2".into(),
+    };
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        second_tool_use.clone(),
+    ));
+
+    cx.run_until_parked();
+
+    complete_streaming_echo_tool_call_tx.send(()).unwrap();
+
+    cx.run_until_parked();
+
+    let completions = fake_model.pending_completions();
+    let last_completion = completions.last().unwrap();
+
+    assert_eq!(
+        last_completion.messages[1..],
+        vec![
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![
+                    "Use the streaming_echo tool and the streaming_failing_echo tool".into()
+                ],
+                cache: false,
+                reasoning_details: None,
+            },
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    language_model::MessageContent::ToolUse(first_tool_use.clone()),
+                    language_model::MessageContent::ToolUse(second_tool_use.clone())
+                ],
+                cache: false,
+                reasoning_details: None,
+            },
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![
+                    language_model::MessageContent::ToolResult(LanguageModelToolResult {
+                        tool_use_id: second_tool_use.id.clone(),
+                        tool_name: second_tool_use.name.clone(),
+                        is_error: true,
+                        content: "failed".into(),
+                        output: Some("failed".into()),
+                    }),
+                    language_model::MessageContent::ToolResult(LanguageModelToolResult {
+                        tool_use_id: first_tool_use.id.clone(),
+                        tool_name: first_tool_use.name.clone(),
+                        is_error: false,
+                        content: "hello world".into(),
+                        output: Some("hello world".into()),
+                    }),
+                ],
                 cache: true,
                 reasoning_details: None,
             },

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3768,7 +3768,8 @@ async fn setup(cx: &mut TestAppContext, model: TestModel) -> ThreadTest {
                             InfiniteTool::NAME: true,
                             CancellationAwareTool::NAME: true,
                             StreamingEchoTool::NAME: true,
-                            (TerminalTool::NAME): true,
+                            StreamingFailingEchoTool::NAME: true,
+                            TerminalTool::NAME: true,
                         }
                     }
                 }
@@ -6344,80 +6345,65 @@ async fn test_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext)
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();
 
-    // Start a turn by sending a message
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(StreamingFailingEchoTool {
+            receive_chunks_until_failure: 1,
+        });
+    });
+
     let _events = thread
         .update(cx, |thread, cx| {
-            thread.send(UserMessageId::new(), ["Do something"], cx)
+            thread.send(UserMessageId::new(), ["Use the streaming_echo tool"], cx)
         })
         .unwrap();
     cx.run_until_parked();
 
-    // The model should have received one completion request.
-    assert_eq!(fake_model.completion_count(), 1);
-    let first_request = fake_model.pending_completions().into_iter().next().unwrap();
+    let tool_use = LanguageModelToolUse {
+        id: "call_1".into(),
+        name: StreamingFailingEchoTool::NAME.into(),
+        raw_input: "hello".into(),
+        input: json!({}),
+        is_input_complete: false,
+        thought_signature: None,
+    };
 
-    // Send a ToolUse for a tool that doesn't exist. This produces a
-    // Task::ready error result immediately. With the fix, the select
-    // loop detects this completed result and breaks out of the stream
-    // loop without waiting for the LLM stream to finish.
-    fake_model.send_completion_stream_event(
-        &first_request,
-        LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
-            id: "call_1".into(),
-            name: "nonexistent_tool".into(),
-            raw_input: "{}".into(),
-            input: json!({}),
-            is_input_complete: true,
-            thought_signature: None,
-        }),
-    );
-    fake_model.send_completion_stream_event(
-        &first_request,
-        LanguageModelCompletionEvent::Stop(StopReason::ToolUse),
-    );
-    // Importantly, we do NOT end the first stream — it stays open.
-
-    cx.run_until_parked();
-
-    // The turn should have processed the tool error and moved on to a
-    // second completion request (to send the error result back to the
-    // LLM) even though the first stream was never closed.
-    assert_eq!(
-        fake_model.completion_count(),
-        2,
-        "A second completion request should have been made after the tool error, \
-         proving the error was detected during streaming"
-    );
-
-    // Verify the second request contains the tool error result sent
-    // back to the LLM.
-    let second_request = fake_model.pending_completions().into_iter().last().unwrap();
-    let has_tool_error_result = second_request.messages.iter().any(|message| {
-        message.content.iter().any(|content| {
-            matches!(
-                content,
-                MessageContent::ToolResult(result) if result.is_error
-            )
-        })
-    });
-    assert!(
-        has_tool_error_result,
-        "The second completion request should include the tool error result"
-    );
-
-    // End the second stream so the turn finishes cleanly.
-    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::Text(
-        "Recovered from the error".into(),
-    ));
     fake_model
-        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
-    fake_model.end_last_completion_stream();
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(tool_use.clone()));
+
     cx.run_until_parked();
 
-    thread.read_with(cx, |thread, _cx| {
-        assert!(
-            thread.is_turn_complete(),
-            "Thread should be idle after the turn completes"
-        );
-    });
+    let completions = fake_model.pending_completions();
+    let last_completion = completions.last().unwrap();
+
+    assert_eq!(
+        last_completion.messages[1..],
+        vec![
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec!["Use the streaming_echo tool".into()],
+                cache: false,
+                reasoning_details: None,
+            },
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![language_model::MessageContent::ToolUse(tool_use.clone())],
+                cache: false,
+                reasoning_details: None,
+            },
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![language_model::MessageContent::ToolResult(
+                    LanguageModelToolResult {
+                        tool_use_id: tool_use.id.clone(),
+                        tool_name: tool_use.name,
+                        is_error: true,
+                        content: "failed".into(),
+                        output: Some("failed".into()),
+                    }
+                )],
+                cache: true,
+                reasoning_details: None,
+            },
+        ]
+    );
 }

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -6335,3 +6335,89 @@ async fn test_queued_message_ends_turn_at_boundary(cx: &mut TestAppContext) {
         );
     });
 }
+
+#[gpui::test]
+async fn test_tool_error_breaks_stream_loop_immediately(cx: &mut TestAppContext) {
+    init_test(cx);
+    always_allow_tools(cx);
+
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    // Start a turn by sending a message
+    let _events = thread
+        .update(cx, |thread, cx| {
+            thread.send(UserMessageId::new(), ["Do something"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // The model should have received one completion request.
+    assert_eq!(fake_model.completion_count(), 1);
+    let first_request = fake_model.pending_completions().into_iter().next().unwrap();
+
+    // Send a ToolUse for a tool that doesn't exist. This produces a
+    // Task::ready error result immediately. With the fix, the select
+    // loop detects this completed result and breaks out of the stream
+    // loop without waiting for the LLM stream to finish.
+    fake_model.send_completion_stream_event(
+        &first_request,
+        LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
+            id: "call_1".into(),
+            name: "nonexistent_tool".into(),
+            raw_input: "{}".into(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        }),
+    );
+    fake_model.send_completion_stream_event(
+        &first_request,
+        LanguageModelCompletionEvent::Stop(StopReason::ToolUse),
+    );
+    // Importantly, we do NOT end the first stream — it stays open.
+
+    cx.run_until_parked();
+
+    // The turn should have processed the tool error and moved on to a
+    // second completion request (to send the error result back to the
+    // LLM) even though the first stream was never closed.
+    assert_eq!(
+        fake_model.completion_count(),
+        2,
+        "A second completion request should have been made after the tool error, \
+         proving the error was detected during streaming"
+    );
+
+    // Verify the second request contains the tool error result sent
+    // back to the LLM.
+    let second_request = fake_model.pending_completions().into_iter().last().unwrap();
+    let has_tool_error_result = second_request.messages.iter().any(|message| {
+        message.content.iter().any(|content| {
+            matches!(
+                content,
+                MessageContent::ToolResult(result) if result.is_error
+            )
+        })
+    });
+    assert!(
+        has_tool_error_result,
+        "The second completion request should include the tool error result"
+    );
+
+    // End the second stream so the turn finishes cleanly.
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::Text(
+        "Recovered from the error".into(),
+    ));
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    thread.read_with(cx, |thread, _cx| {
+        assert!(
+            thread.is_turn_complete(),
+            "Thread should be idle after the turn completes"
+        );
+    });
+}

--- a/crates/agent/src/tests/test_tools.rs
+++ b/crates/agent/src/tests/test_tools.rs
@@ -2,6 +2,7 @@ use super::*;
 use agent_settings::AgentSettings;
 use gpui::{App, SharedString, Task};
 use std::future;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -14,7 +15,22 @@ pub struct StreamingEchoToolInput {
     pub text: String,
 }
 
-pub struct StreamingEchoTool;
+pub struct StreamingEchoTool {
+    wait_until_complete_rx: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+impl StreamingEchoTool {
+    pub fn new() -> Self {
+        Self {
+            wait_until_complete_rx: Mutex::new(None),
+        }
+    }
+
+    pub fn with_wait_until_complete(mut self, receiver: oneshot::Receiver<()>) -> Self {
+        self.wait_until_complete_rx = Mutex::new(Some(receiver));
+        self
+    }
+}
 
 impl AgentTool for StreamingEchoTool {
     type Input = StreamingEchoToolInput;
@@ -44,12 +60,16 @@ impl AgentTool for StreamingEchoTool {
         _event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<String, String>> {
+        let wait_until_complete_rx = self.wait_until_complete_rx.lock().unwrap().take();
         cx.spawn(async move |_cx| {
             while input.recv_partial().await.is_some() {}
             let input = input
                 .recv()
                 .await
                 .map_err(|e| format!("Failed to receive tool input: {e}"))?;
+            if let Some(rx) = wait_until_complete_rx {
+                rx.await.ok();
+            }
             Ok(input.text)
         })
     }

--- a/crates/agent/src/tests/test_tools.rs
+++ b/crates/agent/src/tests/test_tools.rs
@@ -55,6 +55,57 @@ impl AgentTool for StreamingEchoTool {
     }
 }
 
+/// A streaming tool that echoes its input, used to test streaming tool
+/// lifecycle (e.g. partial delivery and cleanup when the LLM stream ends
+/// before `is_input_complete`).
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub struct StreamingFailingEchoToolInput {
+    /// The text to echo.
+    pub text: String,
+}
+
+pub struct StreamingFailingEchoTool {
+    pub receive_chunks_until_failure: usize,
+}
+
+impl AgentTool for StreamingFailingEchoTool {
+    type Input = StreamingFailingEchoToolInput;
+
+    type Output = String;
+
+    const NAME: &'static str = "streaming_failing_echo";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn supports_input_streaming() -> bool {
+        true
+    }
+
+    fn initial_title(
+        &self,
+        _input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        "echo".into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        mut input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        cx.spawn(async move |_cx| {
+            for _ in 0..self.receive_chunks_until_failure {
+                let _ = input.recv_partial().await;
+            }
+            Err("failed".into())
+        })
+    }
+}
+
 /// A tool that echoes its input
 #[derive(JsonSchema, Serialize, Deserialize)]
 pub struct EchoToolInput {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2234,7 +2234,6 @@ impl Thread {
         self.send_or_update_tool_use(&tool_use, title, kind, event_stream);
 
         let Some(tool) = tool else {
-            dbg!(&tool_use);
             let content = format!("No tool named {} exists", tool_use.name);
             return Some(Task::ready(LanguageModelToolResult {
                 content: LanguageModelToolResultContent::Text(Arc::from(content)),
@@ -2245,7 +2244,6 @@ impl Thread {
             }));
         };
 
-        dbg!(&tool_use);
         if !tool_use.is_input_complete {
             if tool.supports_input_streaming() {
                 let running_turn = self.running_turn.as_mut()?;
@@ -2256,7 +2254,6 @@ impl Thread {
 
                 let (sender, tool_input) = ToolInputSender::channel();
                 sender.send_partial(tool_use.input);
-                dbg!("Insertting tool input for {}", &tool_use.id);
                 running_turn
                     .streaming_tool_inputs
                     .insert(tool_use.id.clone(), sender);

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1854,10 +1854,7 @@ impl Thread {
                 // Race between getting the first event, tool completion, and cancellation.
                 // Including tool_results here ensures that tool errors cause us to
                 // break out of the stream loop immediately rather than waiting for
-                // the LLM stream to finish. Completed results are stashed in
-                // `early_tool_results` and processed in the post-loop along with
-                // any remaining results, preserving the flow that returns them
-                // to the LLM.
+                // the LLM stream to finish.
                 let first_event = futures::select! {
                     event = events.next().fuse() => event,
                     tool_result = futures::StreamExt::select_next_some(&mut tool_results) => {
@@ -1949,9 +1946,6 @@ impl Thread {
 
             let end_turn = tool_results.is_empty() && early_tool_results.is_empty();
 
-            // Process tool results that completed while the stream was still
-            // running (stashed earlier to avoid being consumed from the
-            // FuturesUnordered before the end_turn check).
             for tool_result in early_tool_results {
                 Self::process_tool_result(this, event_stream, cx, tool_result)?;
             }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1852,15 +1852,27 @@ impl Thread {
             let mut cancelled = false;
             loop {
                 // Race between getting the first event, tool completion, and cancellation.
-                // Including tool_results here ensures that tool errors cause us to
-                // break out of the stream loop immediately rather than waiting for
-                // the LLM stream to finish.
                 let first_event = futures::select! {
                     event = events.next().fuse() => event,
                     tool_result = futures::StreamExt::select_next_some(&mut tool_results) => {
                         let is_error = tool_result.is_error;
+                        let is_still_streaming = this
+                            .read_with(cx, |this, _cx| {
+                                this.running_turn
+                                    .as_ref()
+                                    .and_then(|turn| turn.streaming_tool_inputs.get(&tool_result.tool_use_id))
+                                    .map_or(false, |inputs| !inputs.has_received_final())
+                            })
+                            .unwrap_or(false);
+
                         early_tool_results.push(tool_result);
-                        if is_error {
+
+                        // Only break if the tool errored and we are still
+                        // streaming the input of the tool. If the tool errored
+                        // but we are no longer streaming its input (i.e. there
+                        // are parallel tool calls) we want to continue
+                        // processing those tool inputs.
+                        if is_error && is_still_streaming {
                             break;
                         }
                         continue;
@@ -2222,6 +2234,7 @@ impl Thread {
         self.send_or_update_tool_use(&tool_use, title, kind, event_stream);
 
         let Some(tool) = tool else {
+            dbg!(&tool_use);
             let content = format!("No tool named {} exists", tool_use.name);
             return Some(Task::ready(LanguageModelToolResult {
                 content: LanguageModelToolResultContent::Text(Arc::from(content)),
@@ -2232,6 +2245,7 @@ impl Thread {
             }));
         };
 
+        dbg!(&tool_use);
         if !tool_use.is_input_complete {
             if tool.supports_input_streaming() {
                 let running_turn = self.running_turn.as_mut()?;
@@ -2242,6 +2256,7 @@ impl Thread {
 
                 let (sender, tool_input) = ToolInputSender::channel();
                 sender.send_partial(tool_use.input);
+                dbg!("Insertting tool input for {}", &tool_use.id);
                 running_turn
                     .streaming_tool_inputs
                     .insert(tool_use.id.clone(), sender);
@@ -3097,6 +3112,10 @@ impl ToolInputSender {
             _phantom: PhantomData,
         };
         (sender, input)
+    }
+
+    pub(crate) fn has_received_final(&self) -> bool {
+        self.final_tx.is_none()
     }
 
     pub(crate) fn send_partial(&self, value: serde_json::Value) {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1846,12 +1846,28 @@ impl Thread {
                 Ok(events) => (events.fuse(), None),
                 Err(err) => (stream::empty().boxed().fuse(), Some(err)),
             };
-            let mut tool_results = FuturesUnordered::new();
+            let mut tool_results: FuturesUnordered<Task<LanguageModelToolResult>> =
+                FuturesUnordered::new();
+            let mut early_tool_results: Vec<LanguageModelToolResult> = Vec::new();
             let mut cancelled = false;
             loop {
-                // Race between getting the first event and cancellation
+                // Race between getting the first event, tool completion, and cancellation.
+                // Including tool_results here ensures that tool errors cause us to
+                // break out of the stream loop immediately rather than waiting for
+                // the LLM stream to finish. Completed results are stashed in
+                // `early_tool_results` and processed in the post-loop along with
+                // any remaining results, preserving the flow that returns them
+                // to the LLM.
                 let first_event = futures::select! {
                     event = events.next().fuse() => event,
+                    tool_result = futures::StreamExt::select_next_some(&mut tool_results) => {
+                        let is_error = tool_result.is_error;
+                        early_tool_results.push(tool_result);
+                        if is_error {
+                            break;
+                        }
+                        continue;
+                    }
                     _ = cancellation_rx.changed().fuse() => {
                         if *cancellation_rx.borrow() {
                             cancelled = true;
@@ -1931,26 +1947,16 @@ impl Thread {
                 }
             })?;
 
-            let end_turn = tool_results.is_empty();
-            while let Some(tool_result) = tool_results.next().await {
-                log::debug!("Tool finished {:?}", tool_result);
+            let end_turn = tool_results.is_empty() && early_tool_results.is_empty();
 
-                event_stream.update_tool_call_fields(
-                    &tool_result.tool_use_id,
-                    acp::ToolCallUpdateFields::new()
-                        .status(if tool_result.is_error {
-                            acp::ToolCallStatus::Failed
-                        } else {
-                            acp::ToolCallStatus::Completed
-                        })
-                        .raw_output(tool_result.output.clone()),
-                    None,
-                );
-                this.update(cx, |this, _cx| {
-                    this.pending_message()
-                        .tool_results
-                        .insert(tool_result.tool_use_id.clone(), tool_result);
-                })?;
+            // Process tool results that completed while the stream was still
+            // running (stashed earlier to avoid being consumed from the
+            // FuturesUnordered before the end_turn check).
+            for tool_result in early_tool_results {
+                Self::process_tool_result(this, event_stream, cx, tool_result)?;
+            }
+            while let Some(tool_result) = tool_results.next().await {
+                Self::process_tool_result(this, event_stream, cx, tool_result)?;
             }
 
             this.update(cx, |this, cx| {
@@ -2002,6 +2008,33 @@ impl Thread {
                 attempt = 0;
             }
         }
+    }
+
+    fn process_tool_result(
+        this: &WeakEntity<Thread>,
+        event_stream: &ThreadEventStream,
+        cx: &mut AsyncApp,
+        tool_result: LanguageModelToolResult,
+    ) -> Result<(), anyhow::Error> {
+        log::debug!("Tool finished {:?}", tool_result);
+
+        event_stream.update_tool_call_fields(
+            &tool_result.tool_use_id,
+            acp::ToolCallUpdateFields::new()
+                .status(if tool_result.is_error {
+                    acp::ToolCallStatus::Failed
+                } else {
+                    acp::ToolCallStatus::Completed
+                })
+                .raw_output(tool_result.output.clone()),
+            None,
+        );
+        this.update(cx, |this, _cx| {
+            this.pending_message()
+                .tool_results
+                .insert(tool_result.tool_use_id.clone(), tool_result);
+        })?;
+        Ok(())
     }
 
     fn handle_completion_error(


### PR DESCRIPTION
If a streaming tool call (e.g. edit file) returns an error during streaming, we would wait until we received the whole input.

Release Notes:

- N/A
