### PR TITLE
Fix "Show Edit Predictions For This Buffer" button

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24199,6 +24199,7 @@ impl Editor {
                 }
                 jsx_tag_auto_close::refresh_enabled_in_any_buffer(self, multibuffer, cx);
                 cx.emit(EditorEvent::Reparsed(*buffer_id));
+                self.update_edit_prediction_settings(cx);
                 cx.notify();
             }
             multi_buffer::Event::DirtyChanged => cx.emit(EditorEvent::DirtyChanged),


### PR DESCRIPTION
Closes #48393

When switching the language of an unsaved buffer (e.g., from Plain Text to JavaScript), the editor's edit_prediction_settings were not recalculated. This caused the "This Buffer" toggle in the edit prediction menu to show a stale state, making the first click a no-op. I added a call to update_edit_prediction_settings in the LanguageChanged event handler so the editor immediately reflects the correct edit prediction state for the new language.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed the "Show Edit Predictions For This Buffer" toggle being a no-op in unsaved buffers after switching the buffer's language.
