### PR TITLE
Fix hidden files in remote Open Folder dialog

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -390,7 +390,7 @@ impl ProjectPicker {
     ) -> Entity<Self> {
         let (tx, rx) = oneshot::channel();
         let lister = project::DirectoryLister::Project(project.clone());
-        let delegate = open_path_prompt::OpenPathDelegate::new(tx, lister, false, cx);
+        let delegate = open_path_prompt::OpenPathDelegate::new(tx, lister, false, cx).show_hidden();
 
         let picker = cx.new(|cx| {
             let picker = Picker::uniform_list(delegate, window, cx)


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/48457

Hidden files (like .config, .ssh, etc.) were not showing in the Open Folder dialog when browsing remote servers via SSH. This was because the `OpenPathDelegate` was not configured to show hidden files.

This fix adds .show_hidden() when creating the delegate for remote project picker.


Release Notes:

- Fixed the hidden files not showing in remote project's open folder action