### PR TITLE
Fix crash in `start_display_link`

### DIFF
--- a/crates/gpui_macos/src/display_link.rs
+++ b/crates/gpui_macos/src/display_link.rs
@@ -41,6 +41,7 @@ impl DisplayLink {
             );
             frame_requests.set_context(data);
             frame_requests.set_event_handler_f(callback);
+            frame_requests.resume();
 
             let display_link = sys::DisplayLink::new(
                 display_id,
@@ -57,7 +58,6 @@ impl DisplayLink {
 
     pub fn start(&mut self) -> Result<()> {
         unsafe {
-            self.frame_requests.resume();
             self.display_link.as_mut().unwrap().start()?;
         }
         Ok(())
@@ -65,7 +65,6 @@ impl DisplayLink {
 
     pub fn stop(&mut self) -> Result<()> {
         unsafe {
-            self.frame_requests.suspend();
             self.display_link.as_mut().unwrap().stop()?;
         }
         Ok(())
@@ -84,8 +83,6 @@ impl Drop for DisplayLink {
         // We might also want to upgrade to CADisplayLink, but that requires dropping old macOS support.
         std::mem::forget(self.display_link.take());
         self.frame_requests.cancel();
-        // A suspended DispatchSource cannot be destroyed.
-        self.frame_requests.resume();
     }
 }
 


### PR DESCRIPTION
Fixes ZED-5G8

If `DisplayLink::new` fails, `frame_requests` is dropped . It is not valid to destroy a DispatchSource that is not `resume()`d. So, ensure we call `resume()` before there's a chance for anything to fail. 

Release Notes:

- (preview only) Fixed a crash that could occur on macOS when changing monitor configurations
