### PR TITLE
python: Fix conda environment not auto-activated in remote terminal

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1378,12 +1378,9 @@ impl ToolchainLister for PythonToolchainProvider {
 
             match toolchain.environment.kind {
                 Some(PythonEnvironmentKind::Conda) => {
-                    let Some(manager_info) = &toolchain.environment.manager else {
+                    let Some(_) = &toolchain.environment.manager else {
                         return vec![];
                     };
-                    if smol::fs::metadata(&manager_info.executable).await.is_err() {
-                        return vec![];
-                    }
 
                     let manager = match conda_manager {
                         settings::CondaManager::Conda => "conda",

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1378,7 +1378,7 @@ impl ToolchainLister for PythonToolchainProvider {
 
             match toolchain.environment.kind {
                 Some(PythonEnvironmentKind::Conda) => {
-                    let Some(_) = &toolchain.environment.manager else {
+                    if toolchain.environment.manager.is_none() {
                         return vec![];
                     };
 


### PR DESCRIPTION
Closes #50619

In the conda activation script building procedure, Zed currently performs a file check for the conda executable on the client side. When in remote development, this check always fails because the file exists on the remote host, not the local machine. Since `pet` already handles existence checks, removing this redundant check allows the activation to proceed. It is also better to let any potential issues (like permissions) show up in the terminal rather than silently skipping the activation.

This addresses the root cause for remote development, which is different from the approach in #50715 that focuses on shell hooks.

**The video recording**

https://github.com/user-attachments/assets/62967351-e3c5-4814-aec4-b2332940e7e3

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed conda environment not auto-activating in the terminal during remote development sessions.
