### PR TITLE
keymap_editor: Remove redundant parentheses when displaying keymap context

### DIFF
--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -202,10 +202,35 @@ impl fmt::Display for KeyBindingContextPredicate {
             Self::Identifier(name) => write!(f, "{}", name),
             Self::Equal(left, right) => write!(f, "{} == {}", left, right),
             Self::NotEqual(left, right) => write!(f, "{} != {}", left, right),
-            Self::Not(pred) => write!(f, "!{}", pred),
             Self::Descendant(parent, child) => write!(f, "{} > {}", parent, child),
-            Self::And(left, right) => write!(f, "({} && {})", left, right),
-            Self::Or(left, right) => write!(f, "({} || {})", left, right),
+            Self::Not(pred) => match pred.as_ref() {
+                Self::Identifier(name) => write!(f, "!{}", name),
+                _ => write!(f, "!({})", pred),
+            },
+            Self::And(..) => {
+                let nodes = self
+                    .collect_and_nodes()
+                    .iter()
+                    .map(|node| match node {
+                        Self::Or(..) => format!("({})", node),
+                        _ => format!("{}", node),
+                    })
+                    .collect::<Vec<String>>();
+
+                write!(f, "{}", nodes.join(" && "))
+            }
+            Self::Or(..) => {
+                let nodes = self
+                    .collect_or_nodes()
+                    .iter()
+                    .map(|node| match node {
+                        Self::And(..) => format!("({})", node),
+                        _ => format!("{}", node),
+                    })
+                    .collect::<Vec<String>>();
+
+                write!(f, "{}", nodes.join(" || "))
+            }
         }
     }
 }
@@ -434,6 +459,28 @@ impl KeyBindingContextPredicate {
             Ok(Self::NotEqual(left, right))
         } else {
             anyhow::bail!("operands of != must be identifiers");
+        }
+    }
+
+    fn collect_and_nodes(&self) -> Vec<&Self> {
+        match self {
+            Self::And(left, right) => {
+                let mut nodes = left.collect_and_nodes();
+                nodes.extend(right.collect_and_nodes());
+                nodes
+            }
+            _ => vec![self],
+        }
+    }
+
+    fn collect_or_nodes(&self) -> Vec<&Self> {
+        match self {
+            Self::Or(left, right) => {
+                let mut nodes = left.collect_or_nodes();
+                nodes.extend(right.collect_or_nodes());
+                nodes
+            }
+            _ => vec![self],
         }
     }
 }

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -804,4 +804,223 @@ mod tests {
         assert!(not_workspace.eval(slice::from_ref(&editor_context)));
         assert!(!not_workspace.eval(&workspace_pane_editor));
     }
+
+    // MARK: - Display
+
+    #[test]
+    fn test_display_identifier() {
+        assert_eq!(Identifier("a".into()).to_string(), "a")
+    }
+
+    #[test]
+    fn test_display_equal() {
+        assert_eq!(Equal("a".into(), "b".into()).to_string(), "a == b")
+    }
+
+    #[test]
+    fn test_display_not_equal() {
+        assert_eq!(NotEqual("a".into(), "b".into()).to_string(), "a != b")
+    }
+
+    #[test]
+    fn test_display_descendant() {
+        assert_eq!(
+            Descendant(
+                Box::new(Identifier("a".into())),
+                Box::new(Identifier("b".into()))
+            )
+            .to_string(),
+            "a > b"
+        )
+    }
+
+    #[test]
+    fn test_display_not_identifier() {
+        assert_eq!(Not(Box::new(Identifier("a".into()))).to_string(), "!a");
+    }
+
+    #[test]
+    fn test_display_not_with_equal() {
+        assert_eq!(
+            Not(Box::new(Equal("a".into(), "b".into()))).to_string(),
+            "!(a == b)"
+        );
+    }
+
+    #[test]
+    fn test_display_not_with_descendant() {
+        assert_eq!(
+            Not(Box::new(Descendant(
+                Box::new(Identifier("a".into())),
+                Box::new(Identifier("b".into()))
+            )))
+            .to_string(),
+            "!(a > b)"
+        );
+    }
+
+    #[test]
+    fn test_display_not_with_and() {
+        assert_eq!(
+            Not(Box::new(And(
+                Box::new(Identifier("a".into())),
+                Box::new(Identifier("b".into()))
+            )))
+            .to_string(),
+            "!(a && b)"
+        );
+    }
+
+    #[test]
+    fn test_display_not_with_or() {
+        assert_eq!(
+            Not(Box::new(Or(
+                Box::new(Identifier("a".into())),
+                Box::new(Identifier("b".into()))
+            )))
+            .to_string(),
+            "!(a || b)"
+        );
+    }
+
+    #[test]
+    fn test_display_and() {
+        assert_eq!(
+            And(
+                Box::new(Identifier("a".into())),
+                Box::new(Identifier("b".into()))
+            )
+            .to_string(),
+            "a && b"
+        );
+    }
+
+    #[test]
+    fn test_display_and_chained() {
+        assert_eq!(
+            And(
+                Box::new(And(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Identifier("b".into()))
+                )),
+                Box::new(Identifier("c".into()))
+            )
+            .to_string(),
+            "a && b && c"
+        );
+    }
+
+    #[test]
+    fn test_display_and_with_nested_or() {
+        assert_eq!(
+            And(
+                Box::new(Identifier("a".into())),
+                Box::new(Or(
+                    Box::new(Identifier("b".into())),
+                    Box::new(Identifier("c".into()))
+                ))
+            )
+            .to_string(),
+            "a && (b || c)"
+        );
+    }
+
+    #[test]
+    fn test_display_or() {
+        assert_eq!(
+            Or(
+                Box::new(Identifier("a".into())),
+                Box::new(Identifier("b".into()))
+            )
+            .to_string(),
+            "a || b"
+        );
+    }
+
+    #[test]
+    fn test_display_or_chained() {
+        assert_eq!(
+            Or(
+                Box::new(Or(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Identifier("b".into()))
+                )),
+                Box::new(Identifier("c".into()))
+            )
+            .to_string(),
+            "a || b || c"
+        );
+    }
+
+    #[test]
+    fn test_display_or_with_nested_and() {
+        assert_eq!(
+            Or(
+                Box::new(Identifier("a".into())),
+                Box::new(And(
+                    Box::new(Identifier("b".into())),
+                    Box::new(Identifier("c".into()))
+                ))
+            )
+            .to_string(),
+            "a || (b && c)"
+        );
+    }
+
+    #[test]
+    fn test_display_mixed() {
+        assert_eq!(
+            And(
+                Box::new(And(
+                    Box::new(And(
+                        Box::new(Identifier("a".into())),
+                        Box::new(Equal("b".into(), "c".into())),
+                    )),
+                    Box::new(Not(Box::new(Descendant(
+                        Box::new(Identifier("d".into())),
+                        Box::new(Identifier("e".into()))
+                    ))))
+                )),
+                Box::new(Equal("f".into(), "g".into()))
+            )
+            .to_string(),
+            "a && b == c && !(d > e) && f == g"
+        );
+    }
+
+    #[test]
+    fn test_display_or_inside_and_chain() {
+        assert_eq!(
+            And(
+                Box::new(And(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Or(
+                        Box::new(Identifier("b".into())),
+                        Box::new(Identifier("c".into()))
+                    ))
+                )),
+                Box::new(Identifier("d".into()))
+            )
+            .to_string(),
+            "a && (b || c) && d"
+        );
+    }
+
+    #[test]
+    fn test_display_and_inside_or_chain() {
+        assert_eq!(
+            Or(
+                Box::new(Or(
+                    Box::new(Identifier("a".into())),
+                    Box::new(And(
+                        Box::new(Identifier("b".into())),
+                        Box::new(Identifier("c".into()))
+                    ))
+                )),
+                Box::new(Identifier("d".into()))
+            )
+            .to_string(),
+            "a || (b && c) || d"
+        );
+    }
 }

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -199,38 +199,20 @@ pub enum KeyBindingContextPredicate {
 impl fmt::Display for KeyBindingContextPredicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Identifier(name) => write!(f, "{}", name),
-            Self::Equal(left, right) => write!(f, "{} == {}", left, right),
-            Self::NotEqual(left, right) => write!(f, "{} != {}", left, right),
-            Self::Descendant(parent, child) => write!(f, "{} > {}", parent, child),
+            Self::Identifier(name) => write!(f, "{name}"),
+            Self::Equal(left, right) => write!(f, "{left} == {right}"),
+            Self::NotEqual(left, right) => write!(f, "{left} != {right}"),
+            Self::Descendant(parent, child) => write!(f, "{parent} > {child}"),
             Self::Not(pred) => match pred.as_ref() {
-                Self::Identifier(name) => write!(f, "!{}", name),
-                _ => write!(f, "!({})", pred),
+                Self::Identifier(name) => write!(f, "!{name}"),
+                _ => write!(f, "!({pred})"),
             },
-            Self::And(..) => {
-                let nodes = self
-                    .collect_and_nodes()
-                    .iter()
-                    .map(|node| match node {
-                        Self::Or(..) => format!("({})", node),
-                        _ => format!("{}", node),
-                    })
-                    .collect::<Vec<String>>();
-
-                write!(f, "{}", nodes.join(" && "))
-            }
-            Self::Or(..) => {
-                let nodes = self
-                    .collect_or_nodes()
-                    .iter()
-                    .map(|node| match node {
-                        Self::And(..) => format!("({})", node),
-                        _ => format!("{}", node),
-                    })
-                    .collect::<Vec<String>>();
-
-                write!(f, "{}", nodes.join(" || "))
-            }
+            Self::And(..) => self.fmt_joined(f, " && ", LogicalOperator::And, |node| {
+                matches!(node, Self::Or(..))
+            }),
+            Self::Or(..) => self.fmt_joined(f, " || ", LogicalOperator::Or, |node| {
+                matches!(node, Self::And(..))
+            }),
         }
     }
 }
@@ -462,27 +444,51 @@ impl KeyBindingContextPredicate {
         }
     }
 
-    fn collect_and_nodes(&self) -> Vec<&Self> {
-        match self {
-            Self::And(left, right) => {
-                let mut nodes = left.collect_and_nodes();
-                nodes.extend(right.collect_and_nodes());
-                nodes
-            }
-            _ => vec![self],
-        }
+    fn fmt_joined(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        separator: &str,
+        operator: LogicalOperator,
+        needs_parens: impl Fn(&Self) -> bool + Copy,
+    ) -> fmt::Result {
+        let mut first = true;
+        self.fmt_joined_inner(f, separator, operator, needs_parens, &mut first)
     }
 
-    fn collect_or_nodes(&self) -> Vec<&Self> {
-        match self {
-            Self::Or(left, right) => {
-                let mut nodes = left.collect_or_nodes();
-                nodes.extend(right.collect_or_nodes());
-                nodes
+    fn fmt_joined_inner(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        separator: &str,
+        operator: LogicalOperator,
+        needs_parens: impl Fn(&Self) -> bool + Copy,
+        first: &mut bool,
+    ) -> fmt::Result {
+        match (operator, self) {
+            (LogicalOperator::And, Self::And(left, right))
+            | (LogicalOperator::Or, Self::Or(left, right)) => {
+                left.fmt_joined_inner(f, separator, operator, needs_parens, first)?;
+                right.fmt_joined_inner(f, separator, operator, needs_parens, first)
             }
-            _ => vec![self],
+            (_, node) => {
+                if !*first {
+                    f.write_str(separator)?;
+                }
+                *first = false;
+
+                if needs_parens(node) {
+                    write!(f, "({node})")
+                } else {
+                    write!(f, "{node}")
+                }
+            }
         }
     }
+}
+
+#[derive(Clone, Copy)]
+enum LogicalOperator {
+    And,
+    Or,
 }
 
 const PRECEDENCE_CHILD: u32 = 1;
@@ -808,219 +814,141 @@ mod tests {
     // MARK: - Display
 
     #[test]
-    fn test_display_identifier() {
-        assert_eq!(Identifier("a".into()).to_string(), "a")
-    }
-
-    #[test]
-    fn test_display_equal() {
-        assert_eq!(Equal("a".into(), "b".into()).to_string(), "a == b")
-    }
-
-    #[test]
-    fn test_display_not_equal() {
-        assert_eq!(NotEqual("a".into(), "b".into()).to_string(), "a != b")
-    }
-
-    #[test]
-    fn test_display_descendant() {
-        assert_eq!(
-            Descendant(
-                Box::new(Identifier("a".into())),
-                Box::new(Identifier("b".into()))
-            )
-            .to_string(),
-            "a > b"
-        )
-    }
-
-    #[test]
-    fn test_display_not_identifier() {
-        assert_eq!(Not(Box::new(Identifier("a".into()))).to_string(), "!a");
-    }
-
-    #[test]
-    fn test_display_not_with_equal() {
-        assert_eq!(
-            Not(Box::new(Equal("a".into(), "b".into()))).to_string(),
-            "!(a == b)"
-        );
-    }
-
-    #[test]
-    fn test_display_not_with_descendant() {
-        assert_eq!(
-            Not(Box::new(Descendant(
-                Box::new(Identifier("a".into())),
-                Box::new(Identifier("b".into()))
-            )))
-            .to_string(),
-            "!(a > b)"
-        );
-    }
-
-    #[test]
-    fn test_display_not_with_and() {
-        assert_eq!(
-            Not(Box::new(And(
-                Box::new(Identifier("a".into())),
-                Box::new(Identifier("b".into()))
-            )))
-            .to_string(),
-            "!(a && b)"
-        );
-    }
-
-    #[test]
-    fn test_display_not_with_or() {
-        assert_eq!(
-            Not(Box::new(Or(
-                Box::new(Identifier("a".into())),
-                Box::new(Identifier("b".into()))
-            )))
-            .to_string(),
-            "!(a || b)"
-        );
-    }
-
-    #[test]
-    fn test_display_and() {
-        assert_eq!(
-            And(
-                Box::new(Identifier("a".into())),
-                Box::new(Identifier("b".into()))
-            )
-            .to_string(),
-            "a && b"
-        );
-    }
-
-    #[test]
-    fn test_display_and_chained() {
-        assert_eq!(
-            And(
-                Box::new(And(
+    fn test_context_display() {
+        let test_cases = [
+            (Identifier("a".into()), "a"),
+            (Equal("a".into(), "b".into()), "a == b"),
+            (NotEqual("a".into(), "b".into()), "a != b"),
+            (
+                Descendant(
                     Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into()))
-                )),
-                Box::new(Identifier("c".into()))
-            )
-            .to_string(),
-            "a && b && c"
-        );
-    }
-
-    #[test]
-    fn test_display_and_with_nested_or() {
-        assert_eq!(
-            And(
-                Box::new(Identifier("a".into())),
-                Box::new(Or(
                     Box::new(Identifier("b".into())),
-                    Box::new(Identifier("c".into()))
-                ))
-            )
-            .to_string(),
-            "a && (b || c)"
-        );
-    }
-
-    #[test]
-    fn test_display_or() {
-        assert_eq!(
-            Or(
-                Box::new(Identifier("a".into())),
-                Box::new(Identifier("b".into()))
-            )
-            .to_string(),
-            "a || b"
-        );
-    }
-
-    #[test]
-    fn test_display_or_chained() {
-        assert_eq!(
-            Or(
-                Box::new(Or(
+                ),
+                "a > b",
+            ),
+            (Not(Box::new(Identifier("a".into()))), "!a"),
+            (Not(Box::new(Equal("a".into(), "b".into()))), "!(a == b)"),
+            (
+                Not(Box::new(Descendant(
                     Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into()))
-                )),
-                Box::new(Identifier("c".into()))
-            )
-            .to_string(),
-            "a || b || c"
-        );
-    }
-
-    #[test]
-    fn test_display_or_with_nested_and() {
-        assert_eq!(
-            Or(
-                Box::new(Identifier("a".into())),
-                Box::new(And(
                     Box::new(Identifier("b".into())),
-                    Box::new(Identifier("c".into()))
-                ))
-            )
-            .to_string(),
-            "a || (b && c)"
-        );
-    }
-
-    #[test]
-    fn test_display_mixed() {
-        assert_eq!(
-            And(
-                Box::new(And(
+                ))),
+                "!(a > b)",
+            ),
+            (
+                Not(Box::new(And(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Identifier("b".into())),
+                ))),
+                "!(a && b)",
+            ),
+            (
+                Not(Box::new(Or(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Identifier("b".into())),
+                ))),
+                "!(a || b)",
+            ),
+            (
+                And(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Identifier("b".into())),
+                ),
+                "a && b",
+            ),
+            (
+                And(
                     Box::new(And(
                         Box::new(Identifier("a".into())),
-                        Box::new(Equal("b".into(), "c".into())),
+                        Box::new(Identifier("b".into())),
                     )),
-                    Box::new(Not(Box::new(Descendant(
-                        Box::new(Identifier("d".into())),
-                        Box::new(Identifier("e".into()))
-                    ))))
-                )),
-                Box::new(Equal("f".into(), "g".into()))
-            )
-            .to_string(),
-            "a && b == c && !(d > e) && f == g"
-        );
-    }
-
-    #[test]
-    fn test_display_or_inside_and_chain() {
-        assert_eq!(
-            And(
-                Box::new(And(
+                    Box::new(Identifier("c".into())),
+                ),
+                "a && b && c",
+            ),
+            (
+                And(
                     Box::new(Identifier("a".into())),
                     Box::new(Or(
                         Box::new(Identifier("b".into())),
-                        Box::new(Identifier("c".into()))
-                    ))
-                )),
-                Box::new(Identifier("d".into()))
-            )
-            .to_string(),
-            "a && (b || c) && d"
-        );
-    }
-
-    #[test]
-    fn test_display_and_inside_or_chain() {
-        assert_eq!(
-            Or(
-                Box::new(Or(
+                        Box::new(Identifier("c".into())),
+                    )),
+                ),
+                "a && (b || c)",
+            ),
+            (
+                Or(
+                    Box::new(Identifier("a".into())),
+                    Box::new(Identifier("b".into())),
+                ),
+                "a || b",
+            ),
+            (
+                Or(
+                    Box::new(Or(
+                        Box::new(Identifier("a".into())),
+                        Box::new(Identifier("b".into())),
+                    )),
+                    Box::new(Identifier("c".into())),
+                ),
+                "a || b || c",
+            ),
+            (
+                Or(
                     Box::new(Identifier("a".into())),
                     Box::new(And(
                         Box::new(Identifier("b".into())),
-                        Box::new(Identifier("c".into()))
-                    ))
-                )),
-                Box::new(Identifier("d".into()))
-            )
-            .to_string(),
-            "a || (b && c) || d"
-        );
+                        Box::new(Identifier("c".into())),
+                    )),
+                ),
+                "a || (b && c)",
+            ),
+            (
+                And(
+                    Box::new(And(
+                        Box::new(And(
+                            Box::new(Identifier("a".into())),
+                            Box::new(Equal("b".into(), "c".into())),
+                        )),
+                        Box::new(Not(Box::new(Descendant(
+                            Box::new(Identifier("d".into())),
+                            Box::new(Identifier("e".into())),
+                        )))),
+                    )),
+                    Box::new(Equal("f".into(), "g".into())),
+                ),
+                "a && b == c && !(d > e) && f == g",
+            ),
+            (
+                And(
+                    Box::new(And(
+                        Box::new(Identifier("a".into())),
+                        Box::new(Or(
+                            Box::new(Identifier("b".into())),
+                            Box::new(Identifier("c".into())),
+                        )),
+                    )),
+                    Box::new(Identifier("d".into())),
+                ),
+                "a && (b || c) && d",
+            ),
+            (
+                Or(
+                    Box::new(Or(
+                        Box::new(Identifier("a".into())),
+                        Box::new(And(
+                            Box::new(Identifier("b".into())),
+                            Box::new(Identifier("c".into())),
+                        )),
+                    )),
+                    Box::new(Identifier("d".into())),
+                ),
+                "a || (b && c) || d",
+            ),
+        ];
+
+        for (predicate, expected) in test_cases {
+            assert_eq!(predicate.to_string(), expected);
+        }
     }
 }

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -815,140 +815,77 @@ mod tests {
 
     #[test]
     fn test_context_display() {
+        fn ident(s: &str) -> Box<KeyBindingContextPredicate> {
+            Box::new(Identifier(SharedString::new(s)))
+        }
+        fn eq(a: &str, b: &str) -> Box<KeyBindingContextPredicate> {
+            Box::new(Equal(SharedString::new(a), SharedString::new(b)))
+        }
+        fn not_eq(a: &str, b: &str) -> Box<KeyBindingContextPredicate> {
+            Box::new(NotEqual(SharedString::new(a), SharedString::new(b)))
+        }
+        fn and(
+            a: Box<KeyBindingContextPredicate>,
+            b: Box<KeyBindingContextPredicate>,
+        ) -> Box<KeyBindingContextPredicate> {
+            Box::new(And(a, b))
+        }
+        fn or(
+            a: Box<KeyBindingContextPredicate>,
+            b: Box<KeyBindingContextPredicate>,
+        ) -> Box<KeyBindingContextPredicate> {
+            Box::new(Or(a, b))
+        }
+        fn descendant(
+            a: Box<KeyBindingContextPredicate>,
+            b: Box<KeyBindingContextPredicate>,
+        ) -> Box<KeyBindingContextPredicate> {
+            Box::new(Descendant(a, b))
+        }
+        fn not(a: Box<KeyBindingContextPredicate>) -> Box<KeyBindingContextPredicate> {
+            Box::new(Not(a))
+        }
+
         let test_cases = [
-            (Identifier("a".into()), "a"),
-            (Equal("a".into(), "b".into()), "a == b"),
-            (NotEqual("a".into(), "b".into()), "a != b"),
+            (ident("a"), "a"),
+            (eq("a", "b"), "a == b"),
+            (not_eq("a", "b"), "a != b"),
+            (descendant(ident("a"), ident("b")), "a > b"),
+            (not(ident("a")), "!a"),
+            (not_eq("a", "b"), "a != b"),
+            (descendant(ident("a"), ident("b")), "a > b"),
+            (not(and(ident("a"), ident("b"))), "!(a && b)"),
+            (not(or(ident("a"), ident("b"))), "!(a || b)"),
+            (and(ident("a"), ident("b")), "a && b"),
+            (and(and(ident("a"), ident("b")), ident("c")), "a && b && c"),
+            (or(ident("a"), ident("b")), "a || b"),
+            (or(or(ident("a"), ident("b")), ident("c")), "a || b || c"),
+            (or(ident("a"), and(ident("b"), ident("c"))), "a || (b && c)"),
             (
-                Descendant(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into())),
-                ),
-                "a > b",
-            ),
-            (Not(Box::new(Identifier("a".into()))), "!a"),
-            (Not(Box::new(Equal("a".into(), "b".into()))), "!(a == b)"),
-            (
-                Not(Box::new(Descendant(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into())),
-                ))),
-                "!(a > b)",
-            ),
-            (
-                Not(Box::new(And(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into())),
-                ))),
-                "!(a && b)",
-            ),
-            (
-                Not(Box::new(Or(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into())),
-                ))),
-                "!(a || b)",
-            ),
-            (
-                And(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into())),
-                ),
-                "a && b",
-            ),
-            (
-                And(
-                    Box::new(And(
-                        Box::new(Identifier("a".into())),
-                        Box::new(Identifier("b".into())),
-                    )),
-                    Box::new(Identifier("c".into())),
-                ),
-                "a && b && c",
-            ),
-            (
-                And(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Or(
-                        Box::new(Identifier("b".into())),
-                        Box::new(Identifier("c".into())),
-                    )),
-                ),
-                "a && (b || c)",
-            ),
-            (
-                Or(
-                    Box::new(Identifier("a".into())),
-                    Box::new(Identifier("b".into())),
-                ),
-                "a || b",
-            ),
-            (
-                Or(
-                    Box::new(Or(
-                        Box::new(Identifier("a".into())),
-                        Box::new(Identifier("b".into())),
-                    )),
-                    Box::new(Identifier("c".into())),
-                ),
-                "a || b || c",
-            ),
-            (
-                Or(
-                    Box::new(Identifier("a".into())),
-                    Box::new(And(
-                        Box::new(Identifier("b".into())),
-                        Box::new(Identifier("c".into())),
-                    )),
-                ),
-                "a || (b && c)",
-            ),
-            (
-                And(
-                    Box::new(And(
-                        Box::new(And(
-                            Box::new(Identifier("a".into())),
-                            Box::new(Equal("b".into(), "c".into())),
-                        )),
-                        Box::new(Not(Box::new(Descendant(
-                            Box::new(Identifier("d".into())),
-                            Box::new(Identifier("e".into())),
-                        )))),
-                    )),
-                    Box::new(Equal("f".into(), "g".into())),
+                and(
+                    and(
+                        and(ident("a"), eq("b", "c")),
+                        not(descendant(ident("d"), ident("e"))),
+                    ),
+                    eq("f", "g"),
                 ),
                 "a && b == c && !(d > e) && f == g",
             ),
             (
-                And(
-                    Box::new(And(
-                        Box::new(Identifier("a".into())),
-                        Box::new(Or(
-                            Box::new(Identifier("b".into())),
-                            Box::new(Identifier("c".into())),
-                        )),
-                    )),
-                    Box::new(Identifier("d".into())),
-                ),
+                and(and(ident("a"), or(ident("b"), ident("c"))), ident("d")),
                 "a && (b || c) && d",
             ),
             (
-                Or(
-                    Box::new(Or(
-                        Box::new(Identifier("a".into())),
-                        Box::new(And(
-                            Box::new(Identifier("b".into())),
-                            Box::new(Identifier("c".into())),
-                        )),
-                    )),
-                    Box::new(Identifier("d".into())),
-                ),
+                or(or(ident("a"), and(ident("b"), ident("c"))), ident("d")),
                 "a || (b && c) || d",
             ),
         ];
 
         for (predicate, expected) in test_cases {
-            assert_eq!(predicate.to_string(), expected);
+            let actual = predicate.to_string();
+            assert_eq!(actual, expected);
+            let parsed = KeyBindingContextPredicate::parse(&actual).unwrap();
+            assert_eq!(parsed, *predicate);
         }
     }
 }


### PR DESCRIPTION
Closes #34976

## Root Cause

The current implementation of `fmt::Display` in `KeyBindingContextPredicate` hardcodes a parentheses around `And` and `Or` cases. Causing the text displayed on the keymap editor to have nested parentheses.

This PR refactors the display logic and make the parentheses added only when there's nested operator.

## As is/ To be

As is | To be
--- | ---	
<img width="800" height="1101" alt="Screenshot 2026-03-06 at 15 07 10" src="https://github.com/user-attachments/assets/33b4366d-4d16-48db-9cc6-b79d6cc7ddc7" /> | <img width="800" height="977" alt="Screenshot 2026-03-06 at 14 54 57" src="https://github.com/user-attachments/assets/3d5ed38d-949d-4265-8fad-e29250c3a285" />

## Test coverage

<img width="800" height="916" alt="Screenshot 2026-03-06 at 15 00 42" src="https://github.com/user-attachments/assets/5846b908-5c86-48a7-919e-a7ae198484a8" />



Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- keymap_editor: Remove redundant parentheses when displaying keymap context
