### PR TITLE
nix: Coerce rel path to cargo wrapper script into abs path

### DIFF
--- a/nix/modules/devshells.nix
+++ b/nix/modules/devshells.nix
@@ -22,10 +22,14 @@
       # Cargo build timings wrapper script
       wrappedCargo = pkgs.writeShellApplication {
         name = "cargo";
-        runtimeInputs = [pkgs.nodejs];
-        text = ''
-          NIX_WRAPPER=1 CARGO=${rustToolchain}/bin/cargo ./script/cargo "$@"
-        '';
+        runtimeInputs = [ pkgs.nodejs ];
+        text =
+          let
+            pathToCargoScript = ./. + "/../../script/cargo";
+          in
+          ''
+            NIX_WRAPPER=1 CARGO=${rustToolchain}/bin/cargo ${pathToCargoScript} "$@"
+          '';
       };
     in
     {
@@ -34,7 +38,7 @@
         inputsFrom = [ zed-editor ];
 
         packages = with pkgs; [
-          wrappedCargo  # must be first, to shadow the `cargo` provided by `rustToolchain`
+          wrappedCargo # must be first, to shadow the `cargo` provided by `rustToolchain`
           rustToolchain # cargo, rustc, and rust-toolchain.toml components included
           cargo-nextest
           cargo-hakari


### PR DESCRIPTION
This allows you to now re-use our Zed flake in different side projects with cargo wrapper script having its path correctly resolved.

Say you have this dir structure:

```
$HOME/dev/zed
$HOME/dev/something
```

Then this now works:

```
$ cd $HOME/dev/something
$ nix develop ../zed
$ cargo version
cargo 1.93.0 (083ac5135 2025-12-15)
```

Release Notes:

- N/A
