### PR TITLE
git_ui: Fix `git_panel::ToggleFocus` to update the context stack properly

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8441,6 +8441,76 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_focus_panel_handle_focuses_changes_list_context(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "tracked": "tracked\n",
+            }),
+        )
+        .await;
+
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("tracked", "old tracked\n".into())],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+        cx.simulate_resize(gpui::size(px(800.), px(600.)));
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.focus_editor(&FocusEditor, window, cx);
+        });
+        cx.executor().run_until_parked();
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.focus_handle.focus(window, cx);
+        });
+        cx.simulate_resize(gpui::size(px(800.), px(600.)));
+
+        panel.update_in(cx, |panel, window, cx| {
+            assert!(
+                panel.focus_handle.contains_focused(window, cx),
+                "panel/list focus handle should contain focused after FocusChanges"
+            );
+            assert!(
+                !panel.commit_editor.read(cx).is_focused(window),
+                "commit editor should not be focused after FocusChanges"
+            );
+            let context = panel.dispatch_context(window, cx);
+            assert!(
+                context.contains("menu"),
+                "should contain menu context after FocusChanges"
+            );
+            assert!(
+                context.contains("ChangesList"),
+                "should contain ChangesList context after FocusChanges"
+            );
+            assert!(
+                !context.contains("CommitEditor"),
+                "should not contain CommitEditor context after FocusChanges"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_fill_commit_editor_toggle(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.background_executor.clone());

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -237,7 +237,20 @@ const TREE_INDENT: f32 = 16.0;
 
 pub fn register(workspace: &mut Workspace) {
     workspace.register_action(|workspace, _: &ToggleFocus, window, cx| {
-        workspace.toggle_panel_focus::<GitPanel>(window, cx);
+        if workspace.toggle_panel_focus::<GitPanel>(window, cx) {
+            if let Some(panel) = workspace.panel::<GitPanel>(cx) {
+                let commit_editor_focus_handle = panel
+                    .read(cx)
+                    .commit_editor
+                    .read(cx)
+                    .focus_handle(cx)
+                    .clone();
+                panel.update(cx, |_panel, cx| {
+                    window.focus(&commit_editor_focus_handle, cx);
+                    cx.notify();
+                });
+            }
+        }
     });
     workspace.register_action(|workspace, _: &Toggle, window, cx| {
         if !workspace.toggle_panel_focus::<GitPanel>(window, cx) {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8379,6 +8379,68 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_focus_editor_action_focuses_commit_editor_handle(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "tracked": "tracked\n",
+            }),
+        )
+        .await;
+
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("tracked", "old tracked\n".into())],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+        cx.simulate_resize(gpui::size(px(800.), px(600.)));
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.focus_editor(&FocusEditor, window, cx);
+            assert!(
+                panel.commit_editor.read(cx).is_focused(window),
+                "commit editor handle should be focused after FocusEditor"
+            );
+            let context = panel.dispatch_context(window, cx);
+            assert!(
+                context.contains("GitPanel"),
+                "should always have GitPanel context"
+            );
+            assert!(
+                context.contains("CommitEditor"),
+                "should contain CommitEditor context after FocusEditor"
+            );
+            assert!(
+                !context.contains("menu"),
+                "should not contain menu context while commit editor is focused"
+            );
+            assert!(
+                !context.contains("ChangesList"),
+                "should not contain ChangesList context while commit editor is focused"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_fill_commit_editor_toggle(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.background_executor.clone());

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5966,7 +5966,7 @@ impl Render for GitPanel {
         v_flex()
             .id("git_panel")
             .key_context(self.dispatch_context(window, cx))
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .when(has_write_access && !project.is_read_only(cx), |this| {
                 this.on_action(cx.listener(Self::toggle_staged_for_selected))
                     .on_action(cx.listener(Self::stage_range))

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8319,6 +8319,10 @@ mod tests {
         cx.simulate_resize(gpui::size(px(800.), px(600.)));
 
         panel.update_in(cx, |panel, window, cx| {
+            assert!(
+                !panel.commit_editor.read(cx).is_focused(window),
+                "commit editor should not be focused when changes list is focused"
+            );
             let context = panel.dispatch_context(window, cx);
             assert!(
                 context.contains("GitPanel"),

--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -668,6 +668,24 @@ impl<'a, T: 'static> Context<'a, T> {
         subscription
     }
 
+    // Register a listener to be called whenever focus changes anywhere in the window.
+    /// This fires on every focus change regardless of which element was focused or blurred.
+    /// Returns a subscription and persists until the subscription is dropped.
+    pub fn on_focus_changed(
+        &mut self,
+        window: &mut Window,
+        mut listener: impl FnMut(&mut T, &mut Window, &mut Context<T>) + 'static,
+    ) -> Subscription {
+        let view = self.weak_entity();
+        let (subscription, activate) =
+            window.new_focus_listener(Box::new(move |_event, window, cx| {
+                view.update(cx, |view, cx| listener(view, window, cx))
+                    .is_ok()
+            }));
+        self.defer(|_| activate());
+        subscription
+    }
+
     /// Schedule a future to be run asynchronously.
     /// The given callback is invoked with a [`WeakEntity<V>`] to avoid leaking the entity for a long-running process.
     /// It's also given an [`AsyncWindowContext`], which can be used to access the state of the entity across await points.

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -42,7 +42,7 @@ struct KeyContextView {
     last_possibilities: Vec<(SharedString, SharedString, Option<bool>)>,
     context_stack: Vec<KeyContext>,
     focus_handle: FocusHandle,
-    _subscriptions: [Subscription; 2],
+    _subscriptions: [Subscription; 3],
 }
 
 impl KeyContextView {
@@ -102,6 +102,9 @@ impl KeyContextView {
             }
             cx.notify();
         });
+        let sub3 = cx.on_focus_changed(window, |this, window, cx| {
+            this.set_context_stack(window.context_stack(), cx);
+        });
 
         Self {
             context_stack: Vec::new(),
@@ -109,7 +112,7 @@ impl KeyContextView {
             last_keystrokes: None,
             last_possibilities: Vec::new(),
             focus_handle: cx.focus_handle(),
-            _subscriptions: [sub1, sub2],
+            _subscriptions: [sub1, sub2, sub3],
         }
     }
 }


### PR DESCRIPTION
Closes #48275 

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x]  No UI Changes

Release Notes:

video of the fix: 
p.s. not sure what the weird stutter in the recording is, was using cap which is probably why

https://github.com/user-attachments/assets/28669189-58ae-4c39-a831-7819b99e1660


- added GitPanel to use focus_handle for dynamic focus 
- added on_focus_changed api that uses new_focus_listener to fire any focus change (now we can use it outside gpui crate)
- update key context to subcsribe to on_focused_change


### Question: 
currently this solves issue #48275 when a git repo is not initialized but when a git repo is already initialized and the cmd palette is used to toggle focus to the git panel, this fix currently doesnt make commit editor active, its a tab away. Should it make commit_editor active when a git repo is initialized? please lmk 