### PR TITLE
Prevent underline and strikethrough artifacts on final glyph in text runs

### DIFF
--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -385,8 +385,12 @@ fn paint_line(
                             glyph_origin.x - underline_origin.x,
                             underline_style,
                         );
-                        underline_origin.x = origin.x;
-                        underline_origin.y += line_height;
+                        if glyph.index < run_end {
+                            underline_origin.x = origin.x;
+                            underline_origin.y += line_height;
+                        } else {
+                            current_underline = None;
+                        }
                     }
                     if let Some((strikethrough_origin, strikethrough_style)) =
                         current_strikethrough.as_mut()
@@ -399,8 +403,12 @@ fn paint_line(
                             glyph_origin.x - strikethrough_origin.x,
                             strikethrough_style,
                         );
-                        strikethrough_origin.x = origin.x;
-                        strikethrough_origin.y += line_height;
+                        if glyph.index < run_end {
+                            strikethrough_origin.x = origin.x;
+                            strikethrough_origin.y += line_height;
+                        } else {
+                            current_strikethrough = None;
+                        }
                     }
 
                     glyph_origin.x = aligned_origin_x(

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -626,8 +626,12 @@ fn paint_line_background(
                             },
                             *background_color,
                         ));
-                        background_origin.x = origin.x;
-                        background_origin.y += line_height;
+                        if glyph.index < run_end {
+                            background_origin.x = origin.x;
+                            background_origin.y += line_height;
+                        } else {
+                            current_background = None;
+                        }
                     }
 
                     glyph_origin.x = aligned_origin_x(


### PR DESCRIPTION
Closes #50587 

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:
- Fixed issue that showed underline and strikethrough when markdown preview screen was scaled to a smaller size


Previously:

<img width="741" height="457" alt="image" src="https://github.com/user-attachments/assets/f127cf44-c679-4140-b246-e0756c9fca32" />



Now:

<img width="742" height="592" alt="image" src="https://github.com/user-attachments/assets/a29fdc24-cac0-438f-8538-4e85c4df995a" />

