### PR TITLE
Add more verbosity for panic inside `summaries_for_anchors_with_payloads`

### DIFF
--- a/crates/text/src/anchor.rs
+++ b/crates/text/src/anchor.rs
@@ -15,8 +15,8 @@ pub struct Anchor {
     // we store the replica id and sequence number of the timestamp inline
     // to avoid the alignment of our fields from increasing the size of this struct
     // This saves 8 bytes, by allowing replica id, value and bias to occupy the padding
-    timestamp_replica_id: clock::ReplicaId,
-    timestamp_value: clock::Seq,
+    pub(crate) timestamp_replica_id: clock::ReplicaId,
+    pub(crate) timestamp_value: clock::Seq,
 
     /// The byte offset into the text inserted in the operation
     /// at `timestamp`.

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2379,13 +2379,22 @@ impl BufferSnapshot {
                     anchor
                 );
             };
+            // TODO verbose debug because we are seeing is_max return false unexpectedly,
+            // remove this once that is understood and fixed
             assert_eq!(
                 insertion.timestamp,
                 anchor.timestamp(),
-                "invalid insertion for buffer {}@{:?} and anchor {:?}",
+                "invalid insertion for buffer {}@{:?}. anchor: {:?}, {:?}, {:?}, {:?}, {:?}. timestamp: {:?}, offset: {:?}, bias: {:?}",
                 self.remote_id(),
                 self.version,
-                anchor
+                anchor.timestamp_replica_id,
+                anchor.timestamp_value,
+                anchor.offset,
+                anchor.bias,
+                anchor.buffer_id,
+                anchor.timestamp() == clock::Lamport::MAX,
+                anchor.offset == u32::MAX,
+                anchor.bias == Bias::Right,
             );
 
             fragment_cursor.seek_forward(&Some(&insertion.fragment_id), Bias::Left);


### PR DESCRIPTION
We are seeing the timestamp comparison fail in an unexpected way, e.g. https://zed-dev.sentry.io/issues/7293482758/events/c7f7eab3f8f2463f879d4889a80d623e, where it seems like `text::Anchor::is_max` should be returning true but it apparently isn't. Add some more information when this panic happens to understand what's going on.

Release Notes:

- N/A