### PR TITLE
search: Add per-search context lines option to Project Search

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -81,6 +81,8 @@ pub struct MultiBuffer {
     excerpts_by_path: BTreeMap<PathKey, Vec<ExcerptId>>,
     /// Mapping from excerpt IDs to their path key.
     paths_by_excerpt: HashMap<ExcerptId, PathKey>,
+    /// Original anchored ranges per path, used to rebuild excerpts with different context line counts.
+    anchored_ranges_by_path: BTreeMap<PathKey, (Entity<Buffer>, Arc<[Range<text::Anchor>]>)>,
     /// Mapping from buffer IDs to their diff states
     diffs: HashMap<BufferId, DiffState>,
     subscriptions: Topic<MultiBufferOffset>,
@@ -1184,6 +1186,7 @@ impl MultiBuffer {
             title: None,
             excerpts_by_path: Default::default(),
             paths_by_excerpt: Default::default(),
+            anchored_ranges_by_path: Default::default(),
             buffer_changed_since_sync: Default::default(),
             history: History::default(),
         }
@@ -1221,6 +1224,7 @@ impl MultiBuffer {
             buffers,
             excerpts_by_path: Default::default(),
             paths_by_excerpt: Default::default(),
+            anchored_ranges_by_path: self.anchored_ranges_by_path.clone(),
             diffs: diff_bases,
             subscriptions: Default::default(),
             singleton: self.singleton,
@@ -1927,6 +1931,7 @@ impl MultiBuffer {
         let removed_buffer_ids = std::mem::take(&mut self.buffers).into_keys().collect();
         self.excerpts_by_path.clear();
         self.paths_by_excerpt.clear();
+        self.anchored_ranges_by_path.clear();
         let MultiBufferSnapshot {
             excerpts,
             buffer_locators,

--- a/crates/multi_buffer/src/path_key.rs
+++ b/crates/multi_buffer/src/path_key.rs
@@ -1,4 +1,4 @@
-use std::{mem, ops::Range, sync::Arc};
+use std::{mem, ops::Range, pin::Pin, sync::Arc};
 
 use collections::HashSet;
 use gpui::{App, AppContext, Context, Entity};
@@ -156,14 +156,28 @@ impl MultiBuffer {
         context_line_count: u32,
         cx: &Context<Self>,
     ) -> impl Future<Output = Vec<Range<Anchor>>> + use<> {
+        self.set_anchored_excerpts_for_path_arc(path_key, buffer, ranges.into(), context_line_count, cx)
+    }
+
+    fn set_anchored_excerpts_for_path_arc(
+        &self,
+        path_key: PathKey,
+        buffer: Entity<Buffer>,
+        ranges: Arc<[Range<text::Anchor>]>,
+        context_line_count: u32,
+        cx: &Context<Self>,
+    ) -> impl Future<Output = Vec<Range<Anchor>>> + use<> {
         let buffer_snapshot = buffer.read(cx).snapshot();
         let multi_buffer = cx.weak_entity();
         let mut app = cx.to_async();
+        let stored_path_key = path_key.clone();
+        let stored_buffer = buffer.clone();
+        let stored_ranges = ranges.clone();
         async move {
             let snapshot = buffer_snapshot.clone();
             let (excerpt_ranges, new, counts) = app
                 .background_spawn(async move {
-                    let ranges = ranges.into_iter().map(|range| range.to_point(&snapshot));
+                    let ranges = ranges.iter().map(|range| range.to_point(&snapshot));
                     let excerpt_ranges =
                         build_excerpt_ranges(ranges, context_line_count, &snapshot);
                     let (new, counts) = Self::merge_excerpt_ranges(&excerpt_ranges);
@@ -173,6 +187,10 @@ impl MultiBuffer {
 
             multi_buffer
                 .update(&mut app, move |multi_buffer, cx| {
+                    multi_buffer.anchored_ranges_by_path.insert(
+                        stored_path_key,
+                        (stored_buffer, stored_ranges),
+                    );
                     let (ranges, _) = multi_buffer.set_merged_excerpt_ranges_for_path(
                         path_key,
                         buffer,
@@ -187,6 +205,36 @@ impl MultiBuffer {
                 .ok()
                 .unwrap_or_default()
         }
+    }
+
+    pub fn rebuild_excerpts_with_context_lines(
+        &mut self,
+        context_line_count: u32,
+        cx: &mut Context<Self>,
+    ) -> Vec<Pin<Box<dyn Future<Output = Vec<Range<Anchor>>>>>> {
+        // Preserve anchored ranges across clear() so that has_anchored_ranges()
+        // remains true while the returned futures are still pending.
+        let preserved = mem::take(&mut self.anchored_ranges_by_path);
+        self.clear(cx);
+        self.anchored_ranges_by_path = preserved;
+
+        self.anchored_ranges_by_path
+            .iter()
+            .map(|(path_key, (buffer, ranges))| {
+                let future = self.set_anchored_excerpts_for_path_arc(
+                    path_key.clone(),
+                    buffer.clone(),
+                    ranges.clone(),
+                    context_line_count,
+                    cx,
+                );
+                Box::pin(future) as Pin<Box<dyn Future<Output = Vec<Range<Anchor>>>>>
+            })
+            .collect()
+    }
+
+    pub fn has_anchored_ranges(&self) -> bool {
+        !self.anchored_ranges_by_path.is_empty()
     }
 
     pub(super) fn expand_excerpts_with_paths(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -236,6 +236,8 @@ pub struct ProjectSearch {
     search_id: usize,
     no_results: Option<bool>,
     limit_reached: bool,
+    context_line_count: u32,
+    pending_rebuild: Option<Task<()>>,
     search_history_cursor: SearchHistoryCursor,
     search_included_history_cursor: SearchHistoryCursor,
     search_excluded_history_cursor: SearchHistoryCursor,
@@ -247,6 +249,7 @@ enum InputPanel {
     Replacement,
     Exclude,
     Include,
+    ContextLines,
 }
 
 pub struct ProjectSearchView {
@@ -262,6 +265,7 @@ pub struct ProjectSearchView {
     search_id: usize,
     included_files_editor: Entity<Editor>,
     excluded_files_editor: Entity<Editor>,
+    context_line_editor: Entity<Editor>,
     filters_enabled: bool,
     replace_enabled: bool,
     included_opened_only: bool,
@@ -294,6 +298,8 @@ impl ProjectSearch {
             search_id: 0,
             no_results: None,
             limit_reached: false,
+            context_line_count: multibuffer_context_lines(cx),
+            pending_rebuild: None,
             search_history_cursor: Default::default(),
             search_included_history_cursor: Default::default(),
             search_excluded_history_cursor: Default::default(),
@@ -313,6 +319,8 @@ impl ProjectSearch {
             search_id: self.search_id,
             no_results: self.no_results,
             limit_reached: self.limit_reached,
+            context_line_count: self.context_line_count,
+            pending_rebuild: None,
             search_history_cursor: self.search_history_cursor.clone(),
             search_included_history_cursor: self.search_included_history_cursor.clone(),
             search_excluded_history_cursor: self.search_excluded_history_cursor.clone(),
@@ -331,6 +339,41 @@ impl ProjectSearch {
             SearchInputKind::Include => &mut self.search_included_history_cursor,
             SearchInputKind::Exclude => &mut self.search_excluded_history_cursor,
         }
+    }
+
+    fn set_context_line_count(&mut self, count: u32, cx: &mut Context<Self>) {
+        if count == self.context_line_count {
+            return;
+        }
+        self.context_line_count = count;
+        if self.pending_search.is_some()
+            || !self.excerpts.read(cx).has_anchored_ranges()
+        {
+            return;
+        }
+        self.rebuild_excerpts(cx);
+    }
+
+    fn rebuild_excerpts(&mut self, cx: &mut Context<Self>) {
+        let context_line_count = self.context_line_count;
+
+        let futures = self.excerpts.update(cx, |excerpts, cx| {
+            excerpts.rebuild_excerpts_with_context_lines(context_line_count, cx)
+        });
+
+        self.match_ranges.clear();
+        let mut ordered_futures = futures.into_iter().collect::<FuturesOrdered<_>>();
+        self.pending_rebuild = Some(cx.spawn(async move |project_search, cx| {
+            while let Some(ranges) = ordered_futures.next().await {
+                smol::future::yield_now().await;
+                project_search
+                    .update(cx, |project_search, cx| {
+                        project_search.match_ranges.extend(ranges);
+                        cx.notify();
+                    })
+                    .log_err();
+            }
+        }));
     }
 
     fn search(&mut self, query: SearchQuery, cx: &mut Context<Self>) {
@@ -394,6 +437,7 @@ impl ProjectSearch {
                 limit_reached |= has_reached_limit;
                 let mut new_ranges = project_search
                     .update(cx, |project_search, cx| {
+                        let context_line_count = project_search.context_line_count;
                         project_search.excerpts.update(cx, |excerpts, cx| {
                             buffers_with_ranges
                                 .into_iter()
@@ -402,7 +446,7 @@ impl ProjectSearch {
                                         PathKey::for_buffer(&buffer, cx),
                                         buffer,
                                         ranges,
-                                        multibuffer_context_lines(cx),
+                                        context_line_count,
                                         cx,
                                     )
                                 })
@@ -936,6 +980,21 @@ impl ProjectSearchView {
             }),
         );
 
+        let initial_context_lines = entity.read(cx).context_line_count;
+        let context_line_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_text(initial_context_lines.to_string(), window, cx);
+            editor
+        });
+        subscriptions.push(cx.subscribe(
+            &context_line_editor,
+            |this, _editor, event: &EditorEvent, cx| {
+                if let EditorEvent::Blurred = event {
+                    this.apply_context_line_count(cx);
+                }
+            },
+        ));
+
         let focus_handle = cx.focus_handle();
         subscriptions.push(cx.on_focus(&focus_handle, window, |_, window, cx| {
             cx.on_next_frame(window, |this, window, cx| {
@@ -979,6 +1038,7 @@ impl ProjectSearchView {
             active_match_index: None,
             included_files_editor,
             excluded_files_editor,
+            context_line_editor,
             filters_enabled,
             replace_enabled: false,
             included_opened_only: false,
@@ -1221,6 +1281,22 @@ impl ProjectSearchView {
     }
 
     fn search(&mut self, cx: &mut Context<Self>) {
+        if self.panels_with_errors.remove(&InputPanel::ContextLines).is_some() {
+            let default_count = multibuffer_context_lines(cx);
+            self.entity.update(cx, |model, cx| {
+                model.set_context_line_count(default_count, cx);
+            });
+            self.context_line_editor.update(cx, |editor, cx| {
+                editor
+                    .buffer()
+                    .read(cx)
+                    .as_singleton()
+                    .expect("context line editor should be a singleton buffer")
+                    .update(cx, |buffer, cx| {
+                        buffer.set_text(default_count.to_string(), cx);
+                    });
+            });
+        }
         let open_buffers = if self.included_opened_only {
             self.workspace
                 .update(cx, |workspace, cx| self.open_buffers(cx, workspace))
@@ -1520,6 +1596,31 @@ impl ProjectSearchView {
         }
 
         cx.emit(ViewEvent::UpdateTab);
+        cx.notify();
+    }
+
+    fn apply_context_line_count(&mut self, cx: &mut Context<Self>) {
+        let text = self.context_line_editor.read(cx).text(cx);
+        match text.parse::<u32>() {
+            Ok(count) if count <= 32 => {
+                self.panels_with_errors.remove(&InputPanel::ContextLines);
+                self.entity.update(cx, |project_search, cx| {
+                    project_search.set_context_line_count(count, cx);
+                });
+            }
+            Ok(_) => {
+                self.panels_with_errors.insert(
+                    InputPanel::ContextLines,
+                    "Maximum context lines is 32".to_string(),
+                );
+            }
+            Err(_) => {
+                self.panels_with_errors.insert(
+                    InputPanel::ContextLines,
+                    "Invalid number".to_string(),
+                );
+            }
+        }
         cx.notify();
     }
 
@@ -2024,6 +2125,7 @@ impl ProjectSearchBar {
             })
         }
     }
+
 }
 
 impl Render for ProjectSearchBar {
@@ -2041,6 +2143,7 @@ impl Render for ProjectSearchBar {
             input_base_styles(search.border_color_for(panel, cx), |div| match panel {
                 InputPanel::Query | InputPanel::Replacement => div.w(input_width),
                 InputPanel::Include | InputPanel::Exclude => div.flex_grow(),
+                InputPanel::ContextLines => div,
             })
         };
         let theme_colors = cx.theme().colors();
@@ -2163,6 +2266,52 @@ impl Render for ProjectSearchBar {
                         this.tooltip(Tooltip::text(
                             "Search Limits Reached\nTry narrowing your search",
                         ))
+                    }),
+            )
+            .child(
+                h_flex()
+                    .id("project-search-context-lines")
+                    .ml_2()
+                    .gap_1()
+                    .tooltip(Tooltip::text(
+                        search
+                            .panels_with_errors
+                            .get(&InputPanel::ContextLines)
+                            .map_or("Context Lines".to_string(), |error| error.clone()),
+                    ))
+                    .child(
+                        Icon::new(IconName::Menu)
+                            .size(IconSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child({
+                        let search_view = self.active_project_search.clone();
+                        let context_line_border =
+                            search.border_color_for(InputPanel::ContextLines, cx);
+                        div()
+                            .w(rems_from_px(40.))
+                            .items_center()
+                            .border_1()
+                            .border_color(context_line_border)
+                            .rounded_sm()
+                            .px_0p5()
+                            .on_action(cx.listener(
+                                move |_this, _: &Confirm, window, cx| {
+                                    if let Some(search_view) = search_view.as_ref() {
+                                        search_view.update(cx, |view, cx| {
+                                            view.apply_context_line_count(cx);
+                                            view.results_editor
+                                                .focus_handle(cx)
+                                                .focus(window, cx);
+                                        });
+                                    }
+                                },
+                            ))
+                            .child(render_text_input(
+                                &search.context_line_editor,
+                                None,
+                                cx,
+                            ))
                     }),
             );
 


### PR DESCRIPTION
By default the context is two and I'm ok with that most of the times, however, from time to time the extra context comes in handy.

https://github.com/user-attachments/assets/b7c2461b-3055-4365-b931-bccedcbf53f3

Release Notes:

- Added a per-search context lines option to the Project Search 
