### PR TITLE
workspace: Fix opening closed projects randomly when Zed restarts

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6047,7 +6047,7 @@ impl Workspace {
         }
     }
 
-    fn remove_from_session(&mut self, window: &mut Window, cx: &mut App) -> Task<()> {
+    pub fn remove_from_session(&mut self, window: &mut Window, cx: &mut App) -> Task<()> {
         self.session_id.take();
         self.serialize_workspace_internal(window, cx)
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6047,7 +6047,7 @@ impl Workspace {
         }
     }
 
-    pub fn remove_from_session(&mut self, window: &mut Window, cx: &mut App) -> Task<()> {
+    fn remove_from_session(&mut self, window: &mut Window, cx: &mut App) -> Task<()> {
         self.session_id.take();
         self.serialize_workspace_internal(window, cx)
     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1071,38 +1071,48 @@ fn register_actions(
                     return;
                 };
                 if let Some(app_state) = app_state.upgrade() {
-                    let remove_task = workspace.remove_from_session(window, cx);
-                    cx.spawn_in(window, async move |_, cx| {
-                        remove_task.await;
-                        let task = cx.update(|_window, cx| {
-                            open_new(
-                                workspace::OpenOptions {
-                                    replace_window: Some(window_handle),
-                                    ..Default::default()
-                                },
-                                app_state,
-                                cx,
-                                |workspace, window, cx| {
-                                    cx.activate(true);
-                                    // Create buffer synchronously to avoid flicker
-                                    let project = workspace.project().clone();
-                                    let buffer = project.update(cx, |project, cx| {
-                                        project.create_local_buffer("", None, true, cx)
-                                    });
-                                    let editor = cx.new(|cx| {
-                                        Editor::for_buffer(buffer, Some(project), window, cx)
-                                    });
-                                    workspace.add_item_to_active_pane(
-                                        Box::new(editor),
-                                        None,
-                                        true,
-                                        window,
-                                        cx,
-                                    );
-                                },
-                            )
-                        })?;
-                        task.await
+                    cx.spawn_in(window, async move |this, cx| {
+                        let should_continue = this
+                            .update_in(cx, |workspace, window, cx| {
+                                workspace.prepare_to_close(
+                                    CloseIntent::ReplaceWindow,
+                                    window,
+                                    cx,
+                                )
+                            })?
+                            .await?;
+                        if should_continue {
+                            let task = cx.update(|_window, cx| {
+                                open_new(
+                                    workspace::OpenOptions {
+                                        replace_window: Some(window_handle),
+                                        ..Default::default()
+                                    },
+                                    app_state,
+                                    cx,
+                                    |workspace, window, cx| {
+                                        cx.activate(true);
+                                        let project = workspace.project().clone();
+                                        let buffer = project.update(cx, |project, cx| {
+                                            project.create_local_buffer("", None, true, cx)
+                                        });
+                                        let editor = cx.new(|cx| {
+                                            Editor::for_buffer(buffer, Some(project), window, cx)
+                                        });
+                                        workspace.add_item_to_active_pane(
+                                            Box::new(editor),
+                                            None,
+                                            true,
+                                            window,
+                                            cx,
+                                        );
+                                    },
+                                )
+                            })?;
+                            task.await
+                        } else {
+                            Ok(())
+                        }
                     })
                     .detach_and_log_err(cx);
                 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1066,7 +1066,7 @@ fn register_actions(
         })
         .register_action({
             let app_state = Arc::downgrade(&app_state);
-            move |workspace, _: &CloseProject, window, cx| {
+            move |_workspace, _: &CloseProject, window, cx| {
                 let Some(window_handle) = window.window_handle().downcast::<MultiWorkspace>() else {
                     return;
                 };

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1066,37 +1066,44 @@ fn register_actions(
         })
         .register_action({
             let app_state = Arc::downgrade(&app_state);
-            move |_, _: &CloseProject, window, cx| {
+            move |workspace, _: &CloseProject, window, cx| {
                 let Some(window_handle) = window.window_handle().downcast::<MultiWorkspace>() else {
                     return;
                 };
                 if let Some(app_state) = app_state.upgrade() {
-                    open_new(
-                        workspace::OpenOptions {
-                            replace_window: Some(window_handle),
-                            ..Default::default()
-                        },
-                        app_state,
-                        cx,
-                        |workspace, window, cx| {
-                            cx.activate(true);
-                            // Create buffer synchronously to avoid flicker
-                            let project = workspace.project().clone();
-                            let buffer = project.update(cx, |project, cx| {
-                                project.create_local_buffer("", None, true, cx)
-                            });
-                            let editor = cx.new(|cx| {
-                                Editor::for_buffer(buffer, Some(project), window, cx)
-                            });
-                            workspace.add_item_to_active_pane(
-                                Box::new(editor),
-                                None,
-                                true,
-                                window,
+                    let remove_task = workspace.remove_from_session(window, cx);
+                    cx.spawn_in(window, async move |_, cx| {
+                        remove_task.await;
+                        let task = cx.update(|_window, cx| {
+                            open_new(
+                                workspace::OpenOptions {
+                                    replace_window: Some(window_handle),
+                                    ..Default::default()
+                                },
+                                app_state,
                                 cx,
-                            );
-                        },
-                    )
+                                |workspace, window, cx| {
+                                    cx.activate(true);
+                                    // Create buffer synchronously to avoid flicker
+                                    let project = workspace.project().clone();
+                                    let buffer = project.update(cx, |project, cx| {
+                                        project.create_local_buffer("", None, true, cx)
+                                    });
+                                    let editor = cx.new(|cx| {
+                                        Editor::for_buffer(buffer, Some(project), window, cx)
+                                    });
+                                    workspace.add_item_to_active_pane(
+                                        Box::new(editor),
+                                        None,
+                                        true,
+                                        window,
+                                        cx,
+                                    );
+                                },
+                            )
+                        })?;
+                        task.await
+                    })
                     .detach_and_log_err(cx);
                 }
             }


### PR DESCRIPTION
Closes #49854 

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] No UI changes

Video for the fix: 
in the video i open a project -> close the project -> quit out of zed -> reopen zed -> zed opens to  an empty workspace which was not the case before

https://github.com/user-attachments/assets/1afb44a1-932b-4dab-8228-9d9d65750b6e



Release Notes:
 - Fixed closed projects re-opening erroneously