### PR TITLE
helix: Tentatively fix line selection cursor rendering bug

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1225,6 +1225,10 @@ pub struct Editor {
     /// Whether the cursor is offset one character to the left when something is
     /// selected (needed for vim visual mode)
     cursor_offset_on_selection: bool,
+    /// Whether to apply cursor offset even when the head is at the buffer's
+    /// max_point (needed for helix normal mode where line selections can end
+    /// on an empty trailing line)
+    cursor_offset_at_max_point: bool,
     current_line_highlight: Option<CurrentLineHighlight>,
     /// Whether to collapse search match ranges to just their start position.
     /// When true, navigating to a match positions the cursor at the match
@@ -2458,6 +2462,7 @@ impl Editor {
                 .cursor_shape
                 .unwrap_or_default(),
             cursor_offset_on_selection: false,
+            cursor_offset_at_max_point: false,
             current_line_highlight: None,
             autoindent_mode: Some(AutoindentMode::EachLine),
             collapse_matches: false,
@@ -3453,6 +3458,10 @@ impl Editor {
 
     pub fn set_cursor_offset_on_selection(&mut self, set_cursor_offset_on_selection: bool) {
         self.cursor_offset_on_selection = set_cursor_offset_on_selection;
+    }
+
+    pub fn set_cursor_offset_at_max_point(&mut self, value: bool) {
+        self.cursor_offset_at_max_point = value;
     }
 
     pub fn set_current_line_highlight(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -155,6 +155,9 @@ impl SelectionLayout {
             if head.column() > 0 {
                 head = map.clip_point(DisplayPoint::new(head.row(), head.column() - 1), Bias::Left);
             } else if head.row().0 > 0 && (head != map.max_point() || cursor_offset_at_max_point) {
+                // cursor_offset_at_max_point case handles helix line selection
+                // removing head != map.max_point() would be the correct behavior in helix mode
+                // but causes a mismatch in vim mode.
                 head = map.clip_point(
                     DisplayPoint::new(
                         head.row().previous_row(),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -130,6 +130,7 @@ impl SelectionLayout {
         selection: Selection<T>,
         line_mode: bool,
         cursor_offset: bool,
+        cursor_offset_at_max_point: bool,
         cursor_shape: CursorShape,
         map: &DisplaySnapshot,
         is_newest: bool,
@@ -153,7 +154,7 @@ impl SelectionLayout {
         if cursor_offset && !range.is_empty() && !selection.reversed {
             if head.column() > 0 {
                 head = map.clip_point(DisplayPoint::new(head.row(), head.column() - 1), Bias::Left);
-            } else if head.row().0 > 0 && head != map.max_point() {
+            } else if head.row().0 > 0 && (head != map.max_point() || cursor_offset_at_max_point) {
                 head = map.clip_point(
                     DisplayPoint::new(
                         head.row().previous_row(),
@@ -1581,6 +1582,7 @@ impl EditorElement {
                         selection,
                         editor.selections.line_mode(),
                         editor.cursor_offset_on_selection,
+                        editor.cursor_offset_at_max_point,
                         editor.cursor_shape,
                         &snapshot.display_snapshot,
                         is_newest,
@@ -1628,6 +1630,7 @@ impl EditorElement {
                         drop_cursor.clone(),
                         false,
                         editor.cursor_offset_on_selection,
+                        editor.cursor_offset_at_max_point,
                         CursorShape::Bar,
                         &snapshot.display_snapshot,
                         false,
@@ -1692,6 +1695,7 @@ impl EditorElement {
                             selection.selection,
                             selection.line_mode,
                             editor.cursor_offset_on_selection,
+                            false,
                             selection.cursor_shape,
                             &snapshot.display_snapshot,
                             false,
@@ -1712,6 +1716,7 @@ impl EditorElement {
                             selection,
                             line_mode,
                             cursor_offset_on_selection,
+                            false,
                             cursor_shape,
                             &snapshot.display_snapshot,
                             false,
@@ -10094,6 +10099,7 @@ impl Element for EditorElement {
                                 newest,
                                 editor.selections.line_mode(),
                                 editor.cursor_offset_on_selection,
+                                editor.cursor_offset_at_max_point,
                                 editor.cursor_shape,
                                 &snapshot,
                                 true,

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -973,6 +973,7 @@ mod test {
     use workspace::{DeploySearch, MultiWorkspace};
 
     use crate::{VimAddon, state::Mode, test::VimTestContext};
+    use workspace::Item;
 
     #[gpui::test]
     async fn test_word_motions(cx: &mut gpui::TestAppContext) {
@@ -1981,6 +1982,23 @@ mod test {
         );
         cx.simulate_keystrokes("o");
         cx.assert_state("line one\nline two\nline three\nˇ\nline four", Mode::Insert);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_line_at_end_of_file(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // Selecting the last content line before trailing newline.
+        // The cursor should render on "two", not on the empty trailing line.
+        cx.set_state("one\nˇtwo\n", Mode::HelixNormal);
+        let cursor_y_before =
+            cx.update_editor(|editor, _, cx| editor.pixel_position_of_cursor(cx).map(|p| p.y));
+        cx.simulate_keystrokes("x");
+        cx.assert_state("one\n«two\nˇ»", Mode::HelixNormal);
+        let cursor_y_after =
+            cx.update_editor(|editor, _, cx| editor.pixel_position_of_cursor(cx).map(|p| p.y));
+        assert_eq!(cursor_y_before, cursor_y_after);
     }
 
     #[gpui::test]

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2085,6 +2085,7 @@ impl Vim {
             expects_character_input: self.expects_character_input(),
             autoindent: self.should_autoindent(),
             cursor_offset_on_selection: self.mode.is_visual() || self.mode.is_helix(),
+            cursor_offset_at_max_point: matches!(self.mode, Mode::HelixNormal | Mode::HelixSelect),
             line_mode: matches!(self.mode, Mode::VisualLine),
             hide_edit_predictions: !matches!(self.mode, Mode::Insert | Mode::Replace),
         }
@@ -2103,6 +2104,7 @@ impl Vim {
         editor.set_expects_character_input(state.expects_character_input);
         editor.set_autoindent(state.autoindent);
         editor.set_cursor_offset_on_selection(state.cursor_offset_on_selection);
+        editor.set_cursor_offset_at_max_point(state.cursor_offset_at_max_point);
         editor.selections.set_line_mode(state.line_mode);
         editor.set_edit_predictions_hidden_for_vim_mode(state.hide_edit_predictions, window, cx);
     }
@@ -2121,6 +2123,7 @@ struct VimEditorSettingsState {
     expects_character_input: bool,
     autoindent: bool,
     cursor_offset_on_selection: bool,
+    cursor_offset_at_max_point: bool,
     line_mode: bool,
     hide_edit_predictions: bool,
 }


### PR DESCRIPTION
Closes #50893

The issue is ultimately not really with the selection but just the cursor rendering, because of that we have to get a bit creative to avoid stepping on vim's feet here. Maybe in the future it will make sense to separate helix's selection handling from vim's more. I say that because through exploring this bug there are lots of subtle ways that vim and helix handle the selections and cursor rendering differently, and fixing them all like this maybe isn't ideal. Idk maybe this is the right way though.

an example of this:
```
# vim
test\n
# execute "V r 1" to select the line and replace everything with 1s you get
1111\n
# helix
test\n
# execute "x r 1" to select the line and replace everything with 1s
11111
```

There were some solutions I found that were contained in helix_select_lines that fixed the behavior of the cursor rendering on the next line, but accomplished it by changing the bounds of the actual selection s.t. they no longer matched helix. My proposed solution doesn't change any selection behavior, only cursor rendering to better match helix.

added a new helix test to test this behavior and both via automated tests and lots of manual experimentation that nothing was broken.

Would love to improve this solution though.

Release Notes:

- Helix: brought `x` line selection command behavior inline 
