### PR TITLE
dap: Interpolate variables in DAP error response messages

### DIFF
--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -375,7 +375,19 @@ impl TransportDelegate {
                 .body
                 .clone()
                 .and_then(|body| serde_json::from_value::<ErrorResponse>(body).ok())
-                .and_then(|response| response.error.map(|msg| msg.format))
+                .and_then(|response| {
+                    response.error.map(|msg| {
+                        let mut result = msg.format;
+                        if let Some(serde_json::Value::Object(variables)) = msg.variables {
+                            for (key, value) in variables {
+                                if let serde_json::Value::String(substitution) = value {
+                                    result = result.replace(&format!("{{{key}}}"), &substitution);
+                                }
+                            }
+                        }
+                        result
+                    })
+                })
                 .or_else(|| response.message.clone())
             {
                 anyhow::bail!(error_message);
@@ -1016,5 +1028,108 @@ impl Transport for FakeTransport {
     #[cfg(any(test, feature = "test-support"))]
     fn as_fake(&self) -> &FakeTransport {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_error_response(body: Option<serde_json::Value>) -> Response {
+        Response {
+            seq: 1,
+            request_seq: 1,
+            success: false,
+            command: "launch".to_string(),
+            message: Some("Failed".to_string()),
+            body,
+        }
+    }
+
+    #[test]
+    fn test_process_response_interpolates_variables() {
+        let response = make_error_response(Some(json!({
+            "error": {
+                "id": 1,
+                "format": "{response_message}",
+                "variables": {
+                    "response_message": "Please use the `program-binary` option to specify an executable"
+                }
+            }
+        })));
+
+        let err = TransportDelegate::process_response(response).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Please use the `program-binary` option"),
+            "Expected interpolated message, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_process_response_interpolates_multiple_variables() {
+        let response = make_error_response(Some(json!({
+            "error": {
+                "id": 1,
+                "format": "Error in {module}: {detail}",
+                "variables": {
+                    "module": "probe-rs",
+                    "detail": "connection failed"
+                }
+            }
+        })));
+
+        let err = TransportDelegate::process_response(response).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Error in probe-rs: connection failed"),
+            "Expected interpolated message, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_process_response_without_variables() {
+        let response = make_error_response(Some(json!({
+            "error": {
+                "id": 1,
+                "format": "A plain error message"
+            }
+        })));
+
+        let err = TransportDelegate::process_response(response).unwrap_err();
+        assert!(
+            err.to_string().contains("A plain error message"),
+            "Expected plain format string, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_process_response_falls_back_to_response_message() {
+        let response = make_error_response(None);
+
+        let err = TransportDelegate::process_response(response).unwrap_err();
+        assert!(
+            err.to_string().contains("Failed"),
+            "Expected fallback message, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_process_response_success() {
+        let response = Response {
+            seq: 1,
+            request_seq: 1,
+            success: true,
+            command: "launch".to_string(),
+            message: None,
+            body: None,
+        };
+
+        assert!(TransportDelegate::process_response(response).is_ok());
     }
 }

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -376,17 +376,9 @@ impl TransportDelegate {
                 .clone()
                 .and_then(|body| serde_json::from_value::<ErrorResponse>(body).ok())
                 .and_then(|response| {
-                    response.error.map(|msg| {
-                        let mut result = msg.format;
-                        if let Some(serde_json::Value::Object(variables)) = msg.variables {
-                            for (key, value) in variables {
-                                if let serde_json::Value::String(substitution) = value {
-                                    result = result.replace(&format!("{{{key}}}"), &substitution);
-                                }
-                            }
-                        }
-                        result
-                    })
+                    response
+                        .error
+                        .map(|msg| interpolate_dap_format(&msg.format, &msg.variables))
                 })
                 .or_else(|| response.message.clone())
             {
@@ -1031,6 +1023,30 @@ impl Transport for FakeTransport {
     }
 }
 
+fn interpolate_dap_format(format: &str, variables: &Option<serde_json::Value>) -> String {
+    let Some(serde_json::Value::Object(vars)) = variables else {
+        return format.to_string();
+    };
+
+    let mut result = String::with_capacity(format.len());
+    let mut rest = format;
+    while let Some(start) = rest.find('{') {
+        result.push_str(&rest[..start]);
+        let after = &rest[start + 1..];
+        if let Some((key, tail)) = after.split_once('}')
+            && let Some(value) = vars.get(key).and_then(serde_json::Value::as_str)
+        {
+            result.push_str(value);
+            rest = tail;
+        } else {
+            result.push('{');
+            rest = after;
+        }
+    }
+    result.push_str(rest);
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1131,5 +1147,54 @@ mod tests {
         };
 
         assert!(TransportDelegate::process_response(response).is_ok());
+    }
+
+    #[test]
+    fn test_interpolate_does_not_double_substitute() {
+        let format = "{a} and {b}";
+        let variables = Some(json!({
+            "a": "{b}",
+            "b": "oops"
+        }));
+        let result = interpolate_dap_format(format, &variables);
+        assert_eq!(result, "{b} and oops");
+    }
+
+    #[test]
+    fn test_interpolate_no_variables() {
+        let result = interpolate_dap_format("plain message", &None);
+        assert_eq!(result, "plain message");
+    }
+
+    #[test]
+    fn test_interpolate_unknown_placeholder_kept() {
+        let format = "{known} and {unknown}";
+        let variables = Some(json!({ "known": "value" }));
+        let result = interpolate_dap_format(format, &variables);
+        assert_eq!(result, "value and {unknown}");
+    }
+
+    #[test]
+    fn test_interpolate_multibyte_key_does_not_drop_trailing_chars() {
+        let format = "{ñ}x";
+        let variables = Some(json!({ "ñ": "v" }));
+        let result = interpolate_dap_format(format, &variables);
+        assert_eq!(result, "vx");
+    }
+
+    #[test]
+    fn test_interpolate_unclosed_brace_kept_verbatim() {
+        let format = "{foo";
+        let variables = Some(json!({ "foo": "x" }));
+        let result = interpolate_dap_format(format, &variables);
+        assert_eq!(result, "{foo");
+    }
+
+    #[test]
+    fn test_interpolate_non_string_value_kept_verbatim() {
+        let format = "code {n}";
+        let variables = Some(json!({ "n": 42 }));
+        let result = interpolate_dap_format(format, &variables);
+        assert_eq!(result, "code {n}");
     }
 }

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -2107,6 +2107,155 @@ async fn test_remote_agent_fs_tool_calls(cx: &mut TestAppContext, server_cx: &mu
 }
 
 #[gpui::test]
+async fn test_remote_registry_npx_agent_fails_without_working_node(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(path!("/project"), json!({})).await;
+
+    let (project, _headless_project) = init_test(&fs, cx, server_cx).await;
+    project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/project"), true, cx)
+        })
+        .await
+        .unwrap();
+
+    // Configure a registry agent with a CLAUDE_CODE_EXECUTABLE override on the
+    // client side. This simulates what a NixOS user would do: they set the env
+    // override hoping it bypasses npm, but the registry agent's get_command()
+    // calls npm_command() first, which fails when Node.js is unavailable.
+    cx.update_global::<SettingsStore, _>(|settings_store, cx| {
+        settings_store
+            .set_user_settings(
+                &json!({
+                    "agent_servers": {
+                        "claude-acp": {
+                            "type": "registry",
+                            "env": {
+                                "CLAUDE_CODE_EXECUTABLE": "/nix/store/some-hash/bin/claude"
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+                cx,
+            )
+            .unwrap();
+    });
+
+    cx.run_until_parked();
+    server_cx.run_until_parked();
+
+    // The registry agent doesn't appear because NodeRuntime is unavailable in the
+    // test (init_test uses NodeRuntime::unavailable()), and registry agents require
+    // the AgentRegistryStore to have loaded the agent metadata. On NixOS, even if
+    // the agent metadata were present, get_command() would fail at the npm_command()
+    // call because the Zed-managed Node.js binary can't execute.
+    //
+    // This mirrors the real bug: the CLAUDE_CODE_EXECUTABLE env override is only
+    // applied AFTER npm_command() succeeds (in LocalRegistryNpxAgent::get_command),
+    // so it can't help when Node.js itself is broken.
+    let names = project.update(cx, |project, cx| {
+        project
+            .agent_server_store()
+            .read(cx)
+            .external_agents()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>()
+    });
+    pretty_assertions::assert_eq!(names, Vec::<String>::new());
+}
+
+#[gpui::test]
+async fn test_remote_custom_agent_settings_forwarded_to_server(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(path!("/project"), json!({})).await;
+
+    let (project, _headless_project) = init_test(&fs, cx, server_cx).await;
+    project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/project"), true, cx)
+        })
+        .await
+        .unwrap();
+
+    // Verify no agents exist initially.
+    let names = project.update(cx, |project, cx| {
+        project
+            .agent_server_store()
+            .read(cx)
+            .external_agents()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>()
+    });
+    pretty_assertions::assert_eq!(names, Vec::<String>::new());
+
+    // Set a custom agent on the CLIENT side. User settings are forwarded to the
+    // remote server via UpdateUserSettings, so the remote's AgentServerStore
+    // picks them up and registers the agent.
+    cx.update_global::<SettingsStore, _>(|settings_store, cx| {
+        settings_store
+            .set_user_settings(
+                &json!({
+                    "agent_servers": {
+                        "my-agent": {
+                            "type": "custom",
+                            "command": "/usr/bin/my-agent",
+                            "args": ["--serve"],
+                            "env": {
+                                "MY_VAR": "my-val"
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+                cx,
+            )
+            .unwrap();
+    });
+
+    cx.run_until_parked();
+    server_cx.run_until_parked();
+
+    // Custom agents ARE forwarded and visible on the client.
+    let names = project.update(cx, |project, cx| {
+        project
+            .agent_server_store()
+            .read(cx)
+            .external_agents()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>()
+    });
+    pretty_assertions::assert_eq!(names, ["my-agent"]);
+
+    // Verify the command includes the env vars from client settings.
+    let command = project
+        .update(cx, |project, cx| {
+            project.agent_server_store().update(cx, |store, cx| {
+                store
+                    .get_external_agent(&"my-agent".into())
+                    .unwrap()
+                    .get_command(
+                        HashMap::default(),
+                        None,
+                        None,
+                        &mut cx.to_async(),
+                    )
+            })
+        })
+        .await
+        .unwrap();
+    assert_eq!(command.args, vec!["/usr/bin/my-agent".to_string(), "--serve".to_string()]);
+    let env = command.env.unwrap();
+    assert_eq!(env.get("MY_VAR").map(|s| s.as_str()), Some("my-val"));
+}
+
+#[gpui::test]
 async fn test_remote_external_agent_server(
     cx: &mut TestAppContext,
     server_cx: &mut TestAppContext,

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -2240,17 +2240,15 @@ async fn test_remote_custom_agent_settings_forwarded_to_server(
                 store
                     .get_external_agent(&"my-agent".into())
                     .unwrap()
-                    .get_command(
-                        HashMap::default(),
-                        None,
-                        None,
-                        &mut cx.to_async(),
-                    )
+                    .get_command(HashMap::default(), None, None, &mut cx.to_async())
             })
         })
         .await
         .unwrap();
-    assert_eq!(command.args, vec!["/usr/bin/my-agent".to_string(), "--serve".to_string()]);
+    assert_eq!(
+        command.args,
+        vec!["/usr/bin/my-agent".to_string(), "--serve".to_string()]
+    );
     let env = command.env.unwrap();
     assert_eq!(env.get("MY_VAR").map(|s| s.as_str()), Some("my-val"));
 }


### PR DESCRIPTION
Closes #50354

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed DAP error messages showing raw template placeholders (e.g., `{response_message}`) instead of the actual error text.

Notes:
- UI checklist is left unchecked since this is a backend-only change with no UI modifications.
- The release note uses "Fixed" since it's a bug fix with user-facing impact.