### PR TITLE
Fix retain cycle in on_app_quit

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -744,9 +744,11 @@ impl App {
         }));
 
         platform.on_quit(Box::new({
-            let cx = app.clone();
+            let cx = Rc::downgrade(&app);
             move || {
-                cx.borrow_mut().shutdown();
+                if let Some(cx) = cx.upgrade() {
+                    cx.borrow_mut().shutdown();
+                }
             }
         }));
 


### PR DESCRIPTION
Updates #50970

While investigating the executor shutdown code, Claude noticed that we never
actually drop the app because of a reference cycle.

Release Notes:

- N/A
