### PR TITLE
language: Skip runnables in Markdown code blocks

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -5095,6 +5095,10 @@ impl BufferSnapshot {
         iter::from_fn(move || {
             loop {
                 let mat = syntax_matches.peek()?;
+                if mat.depth > 0 {
+                    syntax_matches.advance();
+                    continue;
+                }
 
                 let test_range = test_configs[mat.grammar_index].and_then(|test_configs| {
                     let mut run_range = None;

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2891,6 +2891,56 @@ fn test_language_at_for_markdown_code_block(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_runnable_ranges_skip_markdown_code_blocks(cx: &mut App) {
+    init_settings(cx, |_| {});
+
+    cx.new(|cx| {
+        let rust_source = indoc! {r#"
+            #[test]
+            fn foo() {}
+        "#};
+        let rust_buffer = Buffer::local(rust_source, cx).with_language(rust_lang(), cx);
+        let rust_snapshot = rust_buffer.snapshot();
+        assert_eq!(
+            rust_snapshot.runnable_ranges(0..rust_source.len()).count(),
+            1
+        );
+
+        let markdown_source = indoc! {r#"
+            ```rust
+            #[test]
+            fn foo() {}
+            ```
+        "#};
+        let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+        language_registry.add(markdown_lang());
+        language_registry.add(Arc::new(markdown_inline_lang()));
+        language_registry.add(rust_lang());
+
+        let mut markdown_buffer = Buffer::local(markdown_source, cx);
+        markdown_buffer.set_language_registry(language_registry.clone());
+        markdown_buffer.set_language(
+            language_registry
+                .language_for_name("Markdown")
+                .now_or_never()
+                .unwrap()
+                .ok(),
+            cx,
+        );
+
+        let markdown_snapshot = markdown_buffer.snapshot();
+        assert_eq!(
+            markdown_snapshot
+                .runnable_ranges(0..markdown_source.len())
+                .count(),
+            0
+        );
+
+        markdown_buffer
+    });
+}
+
+#[gpui::test]
 fn test_syntax_layer_at_for_combined_injections(cx: &mut App) {
     init_settings(cx, |_| {});
 


### PR DESCRIPTION
Closes #50781

- Skip runnable detection for injected syntax layers so Markdown fenced code blocks do not show test gutter markers.
- Add a regression test covering Markdown fenced Rust code while preserving runnable detection in real Rust buffers.

| Before | After |
  | --- | --- |
  | <img width="424" height="399" alt="Screenshot 2026-03-07 at 9 56 54 AM" src="https://github.com/user-attachments/assets/7ab105ec-e597-4cf3-96de-b49a665c30c4" /> | <img width="437" height="396" alt="Screenshot2026-03-07 at 9 56 25 AM" src="https://github.com/user-attachments/assets/ebefe6d5-9c12-4a90-baf4-a38b77bdb8f1" /> |


  Release Notes:

  - Fixed test gutter markers appearing inside Markdown code blocks.