### PR TITLE
which_key: Add configurable key combo filter

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2392,6 +2392,34 @@
     "enabled": false,
     // Delay in milliseconds before showing the which-key popup.
     "delay_ms": 1000,
+    // Keystroke sequences to filter out from the which-key display.
+    "filtered_keystrokes": [
+      // Modifiers on normal vim commands
+      "g h",
+      "g j",
+      "g k",
+      "g l",
+      "g $",
+      "g ^",
+      // Duplicate keys with "ctrl" held, e.g. "ctrl-w ctrl-a" is duplicate of "ctrl-w a"
+      "ctrl-w ctrl-a",
+      "ctrl-w ctrl-c",
+      "ctrl-w ctrl-h",
+      "ctrl-w ctrl-j",
+      "ctrl-w ctrl-k",
+      "ctrl-w ctrl-l",
+      "ctrl-w ctrl-n",
+      "ctrl-w ctrl-o",
+      "ctrl-w ctrl-p",
+      "ctrl-w ctrl-q",
+      "ctrl-w ctrl-s",
+      "ctrl-w ctrl-v",
+      "ctrl-w ctrl-w",
+      "ctrl-w ctrl-]",
+      "ctrl-w ctrl-shift-w",
+      "ctrl-w ctrl-g t",
+      "ctrl-w ctrl-g shift-t"
+    ],
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2418,7 +2418,7 @@
       "ctrl-w ctrl-]",
       "ctrl-w ctrl-shift-w",
       "ctrl-w ctrl-g t",
-      "ctrl-w ctrl-g shift-t"
+      "ctrl-w ctrl-g shift-t",
     ],
   },
   // The server to connect to. If the environment variable

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1161,6 +1161,11 @@ pub struct WhichKeySettingsContent {
     ///
     /// Default: 700
     pub delay_ms: Option<u64>,
+    /// Keystroke sequences to filter out from the which-key display.
+    /// Each entry is a space-separated sequence of keystrokes, e.g. "ctrl-w ctrl-a".
+    ///
+    /// Default: includes vim modifier variants and ctrl-w duplicates
+    pub filtered_keystrokes: Option<Vec<String>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1436,7 +1436,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn which_key_section() -> [SettingsPageItem; 3] {
+    fn which_key_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("Which-key Menu"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -1472,6 +1472,30 @@ fn editor_page() -> SettingsPage {
                         settings_content.which_key.get_or_insert_default().delay_ms = value;
                     },
                 }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Filtered Keystrokes",
+                description: "Keystroke sequences to filter out from the which-key display.",
+                field: Box::new(
+                    SettingField {
+                        json_path: Some("which_key.filtered_keystrokes"),
+                        pick: |settings_content| {
+                            settings_content
+                                .which_key
+                                .as_ref()
+                                .and_then(|settings| settings.filtered_keystrokes.as_ref())
+                        },
+                        write: |settings_content, value| {
+                            settings_content
+                                .which_key
+                                .get_or_insert_default()
+                                .filtered_keystrokes = value;
+                        },
+                    }
+                    .unimplemented(),
+                ),
                 metadata: None,
                 files: USER,
             }),

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -1,11 +1,11 @@
 //! Which-key support for Zed.
 
 mod which_key_modal;
-mod which_key_settings;
+pub(crate) mod which_key_settings;
 
-use gpui::{App, Keystroke};
+use gpui::App;
 use settings::Settings;
-use std::{sync::LazyLock, time::Duration};
+use std::time::Duration;
 use util::ResultExt;
 use which_key_modal::WhichKeyModal;
 use which_key_settings::WhichKeySettings;
@@ -56,43 +56,3 @@ pub fn init(cx: &mut App) {
     })
     .detach();
 }
-
-// Hard-coded list of keystrokes to filter out from which-key display
-pub static FILTERED_KEYSTROKES: LazyLock<Vec<Vec<Keystroke>>> = LazyLock::new(|| {
-    [
-        // Modifiers on normal vim commands
-        "g h",
-        "g j",
-        "g k",
-        "g l",
-        "g $",
-        "g ^",
-        // Duplicate keys with "ctrl" held, e.g. "ctrl-w ctrl-a" is duplicate of "ctrl-w a"
-        "ctrl-w ctrl-a",
-        "ctrl-w ctrl-c",
-        "ctrl-w ctrl-h",
-        "ctrl-w ctrl-j",
-        "ctrl-w ctrl-k",
-        "ctrl-w ctrl-l",
-        "ctrl-w ctrl-n",
-        "ctrl-w ctrl-o",
-        "ctrl-w ctrl-p",
-        "ctrl-w ctrl-q",
-        "ctrl-w ctrl-s",
-        "ctrl-w ctrl-v",
-        "ctrl-w ctrl-w",
-        "ctrl-w ctrl-]",
-        "ctrl-w ctrl-shift-w",
-        "ctrl-w ctrl-g t",
-        "ctrl-w ctrl-g shift-t",
-    ]
-    .iter()
-    .filter_map(|s| {
-        let keystrokes: Result<Vec<_>, _> = s
-            .split(' ')
-            .map(|keystroke_str| Keystroke::parse(keystroke_str))
-            .collect();
-        keystrokes.ok()
-    })
-    .collect()
-});

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -14,7 +14,7 @@ use ui::{
 };
 use workspace::{ModalView, Workspace};
 
-use crate::FILTERED_KEYSTROKES;
+use crate::which_key_settings::WhichKeySettings;
 
 pub struct WhichKeyModal {
     _workspace: WeakEntity<Workspace>,
@@ -66,11 +66,11 @@ impl WhichKeyModal {
             return;
         };
         let bindings = window.possible_bindings_for_input(pending_keys);
+        let filtered = &WhichKeySettings::get_global(cx).filtered_keystrokes;
 
         let mut binding_data = bindings
             .iter()
             .map(|binding| {
-                // Map to keystrokes
                 (
                     binding
                         .keystrokes()
@@ -81,10 +81,8 @@ impl WhichKeyModal {
                 )
             })
             .filter(|(keystrokes, _action)| {
-                // Check if this binding matches any filtered keystroke pattern
-                !FILTERED_KEYSTROKES.iter().any(|filtered| {
-                    keystrokes.len() >= filtered.len()
-                        && keystrokes[..filtered.len()] == filtered[..]
+                !filtered.iter().any(|f| {
+                    keystrokes.len() >= f.len() && keystrokes[..f.len()] == f[..]
                 })
             })
             .map(|(keystrokes, action)| {

--- a/crates/which_key/src/which_key_settings.rs
+++ b/crates/which_key/src/which_key_settings.rs
@@ -1,18 +1,37 @@
+use gpui::Keystroke;
 use settings::{RegisterSetting, Settings, SettingsContent, WhichKeySettingsContent};
 
-#[derive(Debug, Clone, Copy, RegisterSetting)]
+#[derive(Debug, Clone, RegisterSetting)]
 pub struct WhichKeySettings {
     pub enabled: bool,
     pub delay_ms: u64,
+    pub filtered_keystrokes: Vec<Vec<Keystroke>>,
 }
 
 impl Settings for WhichKeySettings {
     fn from_settings(content: &SettingsContent) -> Self {
         let which_key: &WhichKeySettingsContent = content.which_key.as_ref().unwrap();
 
+        let filtered_keystrokes = which_key
+            .filtered_keystrokes
+            .as_ref()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|s| {
+                        s.split(' ')
+                            .map(|keystroke_str| Keystroke::parse(keystroke_str))
+                            .collect::<Result<Vec<_>, _>>()
+                            .ok()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Self {
             enabled: which_key.enabled.unwrap(),
             delay_ms: which_key.delay_ms.unwrap(),
+            filtered_keystrokes,
         }
     }
 }


### PR DESCRIPTION
Closes #49845 

Instead of having a hardcoded filter, make it a configurable option and carry over the hard coded option as the new defaults. Tested it and made sure it worked.

<img width="1888" height="2246" alt="image" src="https://github.com/user-attachments/assets/6c1bd2d3-9f18-4ab7-88cb-3e105d000399" />

Release Notes:

- whichkey: added a configurable filter for key combos for the whichkey display.
