### PR TITLE
Refresh context servers when a worktree is added

### DIFF
--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -20,7 +20,7 @@ use util::{ResultExt as _, rel_path::RelPath};
 use crate::{
     DisableAiSettings, Project,
     project_settings::{ContextServerSettings, ProjectSettings},
-    worktree_store::WorktreeStore,
+    worktree_store::{WorktreeStore, WorktreeStoreEvent},
 };
 
 /// Maximum timeout for context server requests
@@ -408,6 +408,13 @@ impl ContextServerStore {
         if maintain_server_loop {
             subscriptions.push(cx.observe(&registry, |this, _registry, cx| {
                 if !DisableAiSettings::get_global(cx).disable_ai {
+                    this.available_context_servers_changed(cx);
+                }
+            }));
+            subscriptions.push(cx.subscribe(&worktree_store, |this, _store, event, cx| {
+                if matches!(event, WorktreeStoreEvent::WorktreeAdded(_))
+                    && !DisableAiSettings::get_global(cx).disable_ai
+                {
                     this.available_context_servers_changed(cx);
                 }
             }));

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1912,6 +1912,17 @@ impl Project {
     }
 
     fn release(&mut self, cx: &mut App) {
+        self.context_server_store.update(cx, |store, cx| {
+            let server_ids = store
+                .running_servers()
+                .into_iter()
+                .map(|server| server.id())
+                .collect::<Vec<_>>();
+            for server_id in server_ids {
+                store.stop_server(&server_id, cx).log_err();
+            }
+        });
+        
         if let Some(client) = self.remote_client.take() {
             let shutdown = client.update(cx, |client, cx| {
                 client.shutdown_processes(


### PR DESCRIPTION
Refresh context servers when a worktree is added so `ContextServerStore` re-resolves the project root after worktrees become available.

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing  
  - Manual testing: opened a local project and confirmed the context server re-resolves the working directory after worktree add.
- [x] Done a self-review taking into account security and performance aspects  
  - Self-review: no new I/O, network calls, or heavy computation paths added.
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)  
  - UI checklist: N/A (no UI changes).

Release Notes:

- Fixed context server startup to re-evaluate the working directory after worktrees are added
