### PR TITLE
docs: Fix YAML syntax error in frontmatter

### DIFF
--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -1,6 +1,6 @@
 ---
 title: AI Agent Settings - Zed
-description: Customize Zed's AI agent: default models, temperature, tool approval, auto-run commands, notifications, and panel options.
+description: "Customize Zed's AI agent: default models, temperature, tool approval, auto-run commands, notifications, and panel options."
 ---
 
 # Agent Settings

--- a/docs/src/ai/privacy-and-security.md
+++ b/docs/src/ai/privacy-and-security.md
@@ -1,6 +1,6 @@
 ---
 title: AI Privacy and Security - Zed
-description: Zed's approach to AI privacy: opt-in data sharing by default, zero-data retention with providers, and full open-source transparency.
+description: "Zed's approach to AI privacy: opt-in data sharing by default, zero-data retention with providers, and full open-source transparency."
 ---
 
 # Privacy and Security

--- a/docs/src/development/glossary.md
+++ b/docs/src/development/glossary.md
@@ -1,5 +1,5 @@
 ---
-title: Zed Development: Glossary
+title: "Zed Development: Glossary"
 description: "Guide to zed development: glossary for Zed development."
 ---
 


### PR DESCRIPTION
The title in the YAML front matter contained a colon, which YAML interprets as a key-value separator, causing a parse error. Quoted the title value to fix it.

<img width="1087" height="248" alt="image" src="https://github.com/user-attachments/assets/f074af0e-937c-4289-80a9-83cde294fd23" />

Release Notes:

- N/A
