### PR TITLE
Fix ctrl+enter inserting newline in Recent Projects search

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5092,6 +5092,11 @@ impl Editor {
             return;
         }
 
+        if self.mode.is_single_line() {
+            cx.propagate();
+            return;
+        }
+
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
         self.transact(window, cx, |this, window, cx| {
             let (edits_with_flags, selection_info): (Vec<_>, Vec<_>) = {
@@ -5317,6 +5322,11 @@ impl Editor {
             return;
         }
 
+        if self.mode.is_single_line() {
+            cx.propagate();
+            return;
+        }
+
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
 
         let buffer = self.buffer.read(cx);
@@ -5385,6 +5395,11 @@ impl Editor {
 
     pub fn newline_below(&mut self, _: &NewlineBelow, window: &mut Window, cx: &mut Context<Self>) {
         if self.read_only(cx) {
+            return;
+        }
+
+        if self.mode.is_single_line() {
+            cx.propagate();
             return;
         }
 


### PR DESCRIPTION
Closes #51005

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:
- Fixed Ctrl+Enter inserting newline in Recent Projects search instead of opening project in new window (#51005)
