### PR TITLE
db: Isolate default test databases per test case

### DIFF
--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -15,10 +15,16 @@ pub use release_channel::RELEASE_CHANNEL;
 use sqlez::domain::Migrator;
 use sqlez::thread_safe_connection::ThreadSafeConnection;
 use sqlez_macros::sql;
+#[cfg(any(test, feature = "test-support"))]
+use std::collections::HashMap;
 use std::future::Future;
 use std::path::Path;
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::{LazyLock, atomic::Ordering};
+#[cfg(any(test, feature = "test-support"))]
+use std::{borrow::Cow, ops::Deref};
 use util::{ResultExt, maybe};
 use zed_env_vars::ZED_STATELESS;
 
@@ -97,7 +103,8 @@ async fn open_fallback_db<M: Migrator>() -> ThreadSafeConnection {
 pub async fn open_test_db<M: Migrator>(db_name: &str) -> ThreadSafeConnection {
     use sqlez::thread_safe_connection::locking_queue;
 
-    ThreadSafeConnection::builder::<M>(db_name, false)
+    let db_name = scoped_test_db_name(db_name);
+    ThreadSafeConnection::builder::<M>(&db_name, false)
         .with_db_initialization_query(DB_INITIALIZE_QUERY)
         .with_connection_initialize_query(CONNECTION_INITIALIZE_QUERY)
         // Serialize queued writes via a mutex and run them synchronously
@@ -105,6 +112,69 @@ pub async fn open_test_db<M: Migrator>(db_name: &str) -> ThreadSafeConnection {
         .build()
         .await
         .unwrap()
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn scoped_test_db_name(db_name: &str) -> Cow<'_, str> {
+    let Some(test_name) = current_test_scope_name() else {
+        return Cow::Borrowed(db_name);
+    };
+
+    let mut scoped_name = String::with_capacity(db_name.len() + test_name.len() + 2);
+    scoped_name.push_str(db_name);
+    scoped_name.push('@');
+    for ch in test_name.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+            scoped_name.push(ch);
+        } else {
+            scoped_name.push('_');
+        }
+    }
+
+    Cow::Owned(scoped_name)
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn current_test_scope_name() -> Option<String> {
+    if let Some(test_name) = gpui::current_test_name() {
+        return Some(test_name.to_string());
+    }
+
+    let current_thread = std::thread::current();
+    if let Some(test_name) = current_thread.name() {
+        return Some(test_name.to_string());
+    }
+
+    Some(format!("thread_{:?}", current_thread.id()))
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub struct TestScopedStatic<T: Send + Sync + 'static> {
+    initializer: fn() -> T,
+    values: Mutex<HashMap<String, &'static T>>,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl<T: Send + Sync + 'static> TestScopedStatic<T> {
+    pub fn new(initializer: fn() -> T) -> Self {
+        Self {
+            initializer,
+            values: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl<T: Send + Sync + 'static> Deref for TestScopedStatic<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        let scope_name = current_test_scope_name().unwrap_or_else(|| "default".to_string());
+        let mut values = self.values.lock().unwrap();
+        *values
+            .entry(scope_name)
+            .or_insert_with(|| Box::leak(Box::new((self.initializer)())))
+    }
 }
 
 /// Implements a basic DB wrapper for a given domain
@@ -126,16 +196,23 @@ macro_rules! static_connection {
 
         impl $t {
             #[cfg(any(test, feature = "test-support"))]
-            pub async fn open_test_db(name: &'static str) -> Self {
+            pub async fn open_test_db(name: &str) -> Self {
                 $t($crate::open_test_db::<$t>(name).await)
             }
         }
 
         #[cfg(any(test, feature = "test-support"))]
-        pub static $id: std::sync::LazyLock<$t> = std::sync::LazyLock::new(|| {
-            #[allow(unused_parens)]
-            $t($crate::smol::block_on($crate::open_test_db::<($($d,)* $t)>(stringify!($id))))
-        });
+        pub static $id: std::sync::LazyLock<$crate::TestScopedStatic<$t>> =
+            std::sync::LazyLock::new(|| {
+                fn initializer() -> $t {
+                    #[allow(unused_parens)]
+                    $t($crate::smol::block_on(
+                        $crate::open_test_db::<($($d,)* $t)>(stringify!($id))
+                    ))
+                }
+
+                $crate::TestScopedStatic::new(initializer)
+            });
 
         #[cfg(not(any(test, feature = "test-support")))]
         pub static $id: std::sync::LazyLock<$t> = std::sync::LazyLock::new(|| {
@@ -161,9 +238,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use std::thread;
 
-    use sqlez::domain::Domain;
+    use sqlez::{domain::Domain, thread_safe_connection::ThreadSafeConnection};
     use sqlez_macros::sql;
 
     use crate::open_db;
@@ -294,5 +372,70 @@ mod tests {
         for guard in guards.into_iter() {
             assert!(guard.join().is_ok());
         }
+    }
+
+    pub struct ScopedStaticDb(ThreadSafeConnection);
+
+    impl Domain for ScopedStaticDb {
+        const NAME: &str = "test_scoped_static_db";
+        const MIGRATIONS: &[&str] = &[sql!(
+            CREATE TABLE IF NOT EXISTS scoped_values(
+                value INTEGER NOT NULL
+            ) STRICT;
+        )];
+    }
+
+    crate::static_connection!(SCOPED_STATIC_DB, ScopedStaticDb, []);
+
+    impl ScopedStaticDb {
+        fn replace_value(&self, value: i64) -> Result<()> {
+            smol::block_on(self.write(move |connection| {
+                connection.exec("DELETE FROM scoped_values")?()?;
+                connection.exec_bound("INSERT INTO scoped_values(value) VALUES (?)")?(value)?;
+                anyhow::Ok(())
+            }))
+        }
+
+        fn read_value(&self) -> Result<Option<i64>> {
+            self.select_row::<i64>("SELECT value FROM scoped_values")
+                .unwrap()()
+        }
+    }
+
+    #[test]
+    fn static_test_connections_are_scoped_by_test_name() {
+        gpui::with_test_name(
+            Some("static_test_connections_are_scoped_by_test_name_a"),
+            || {
+                assert_eq!(SCOPED_STATIC_DB.read_value().unwrap(), None);
+                SCOPED_STATIC_DB.replace_value(7).unwrap();
+                assert_eq!(SCOPED_STATIC_DB.read_value().unwrap(), Some(7));
+            },
+        );
+
+        gpui::with_test_name(
+            Some("static_test_connections_are_scoped_by_test_name_b"),
+            || {
+                assert_eq!(SCOPED_STATIC_DB.read_value().unwrap(), None);
+                SCOPED_STATIC_DB.replace_value(11).unwrap();
+                assert_eq!(SCOPED_STATIC_DB.read_value().unwrap(), Some(11));
+            },
+        );
+    }
+
+    #[test]
+    fn static_test_connections_share_state_across_threads_with_same_test_name() {
+        gpui::with_test_name(
+            Some("static_test_connections_share_state_across_threads_with_same_test_name"),
+            || {
+                SCOPED_STATIC_DB.replace_value(13).unwrap();
+
+                let test_name = gpui::current_test_name();
+                let thread = thread::spawn(move || {
+                    gpui::with_test_name(test_name, || SCOPED_STATIC_DB.read_value().unwrap())
+                });
+                assert_eq!(thread.join().unwrap(), Some(13));
+            },
+        );
     }
 }

--- a/crates/gpui/src/platform/test/dispatcher.rs
+++ b/crates/gpui/src/platform/test/dispatcher.rs
@@ -146,8 +146,9 @@ impl PlatformDispatcher for TestDispatcher {
     }
 
     fn spawn_realtime(&self, f: Box<dyn FnOnce() + Send>) {
+        let test_name = crate::current_test_name();
         std::thread::spawn(move || {
-            f();
+            crate::with_test_name(test_name, f);
         });
     }
 }

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -29,6 +29,7 @@ use crate::{Entity, Subscription, TestAppContext, TestDispatcher};
 use futures::StreamExt as _;
 use proptest::prelude::{Just, Strategy, any};
 use std::{
+    cell::Cell,
     env,
     panic::{self, RefUnwindSafe, UnwindSafe},
     pin::Pin,
@@ -62,6 +63,38 @@ pub fn run_test_once(seed: u64, test_fn: Box<dyn UnwindSafe + FnOnce(TestDispatc
         Ok(()) => {}
         Err(e) => panic::resume_unwind(e),
     }
+}
+
+thread_local! {
+    static CURRENT_TEST_NAME: Cell<Option<&'static str>> = const { Cell::new(None) };
+}
+
+/// Returns the test name currently associated with this thread, if any.
+pub fn current_test_name() -> Option<&'static str> {
+    CURRENT_TEST_NAME.with(Cell::get)
+}
+
+/// Runs the closure with the given test name installed for the current thread.
+pub fn with_test_name<R>(name: Option<&'static str>, f: impl FnOnce() -> R) -> R {
+    CURRENT_TEST_NAME.with(|current_name| {
+        struct RestoreTestName<'a> {
+            current_name: &'a Cell<Option<&'static str>>,
+            previous_name: Option<&'static str>,
+        }
+
+        impl Drop for RestoreTestName<'_> {
+            fn drop(&mut self) {
+                self.current_name.set(self.previous_name);
+            }
+        }
+
+        let previous_name = current_name.replace(name);
+        let _restore = RestoreTestName {
+            current_name,
+            previous_name,
+        };
+        f()
+    })
 }
 
 /// Run the given test function with the configured parameters.

--- a/crates/gpui_macros/src/test.rs
+++ b/crates/gpui_macros/src/test.rs
@@ -192,17 +192,19 @@ fn generate_test_function(
                     &[#seeds],
                     #max_retries,
                     &mut |dispatcher, _seed| {
-                        let exec = std::sync::Arc::new(dispatcher.clone());
-                        #cx_vars
-                        gpui::ForegroundExecutor::new(exec.clone()).block_test(#inner_fn_name(#inner_fn_args));
-                        drop(exec);
-                        #cx_teardowns
-                        // Ideally we would only drop cancelled tasks, that way we could detect leaks due to task <-> entity
-                        // cycles as cancelled tasks will be dropped properly once the runnable gets run again
-                        //
-                        // async-task does not give us the power to do this just yet though
-                        dispatcher.drain_tasks();
-                        drop(dispatcher);
+                        gpui::with_test_name(Some(stringify!(#outer_fn_name)), || {
+                            let exec = std::sync::Arc::new(dispatcher.clone());
+                            #cx_vars
+                            gpui::ForegroundExecutor::new(exec.clone()).block_test(#inner_fn_name(#inner_fn_args));
+                            drop(exec);
+                            #cx_teardowns
+                            // Ideally we would only drop cancelled tasks, that way we could detect leaks due to task <-> entity
+                            // cycles as cancelled tasks will be dropped properly once the runnable gets run again
+                            //
+                            // async-task does not give us the power to do this just yet though
+                            dispatcher.drain_tasks();
+                            drop(dispatcher);
+                        })
                     },
                     #on_failure_fn_name
                 );
@@ -285,15 +287,17 @@ fn generate_test_function(
                     &[#seeds],
                     #max_retries,
                     &mut |dispatcher, _seed| {
-                        #cx_vars
-                        #inner_fn_name(#inner_fn_args);
-                        #cx_teardowns
-                        // Ideally we would only drop cancelled tasks, that way we could detect leaks due to task <-> entity
-                        // cycles as cancelled tasks will be dropped properly once they runnable gets run again
-                        //
-                        // async-task does not give us the power to do this just yet though
-                        dispatcher.drain_tasks();
-                        drop(dispatcher);
+                        gpui::with_test_name(Some(stringify!(#outer_fn_name)), || {
+                            #cx_vars
+                            #inner_fn_name(#inner_fn_args);
+                            #cx_teardowns
+                            // Ideally we would only drop cancelled tasks, that way we could detect leaks due to task <-> entity
+                            // cycles as cancelled tasks will be dropped properly once they runnable gets run again
+                            //
+                            // async-task does not give us the power to do this just yet though
+                            dispatcher.drain_tasks();
+                            drop(dispatcher);
+                        })
                     },
                     #on_failure_fn_name,
                 );


### PR DESCRIPTION
In test mode, db::static_connection! created one process-global database wrapper per static id, such as DB or KEY_VALUE_STORE. That allowed unrelated tests running in the same test process to silently share the same named test database and leak persisted state into each other.

This change scopes default test databases to the current test case instead of the whole process. It propagates the current test name through the gpui test harness and its realtime worker threads, and uses that scope when resolving the default test database wrapper.

This preserves sharing across threads that belong to the same test while preventing unrelated tests from reusing the same default database.

Closes #51010

Before you mark this PR as ready for review, make sure that you have:
- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects
- [X] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
