### PR TITLE
terminal_view: Add right-click copy/paste behavior setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1708,6 +1708,13 @@
     "copy_on_select": false,
     // Whether to keep the text selection after copying it to the clipboard.
     "keep_selection_on_copy": true,
+    // What happens on right-click in the terminal.
+    // May take 2 values:
+    //  1. Show the context menu:
+    //         "context_menu"
+    //  2. Copy selected text, or paste if no selection:
+    //         "copy_paste"
+    "right_click_behavior": "context_menu",
     // Whether to show the terminal button in the status bar
     "button": true,
     // Any key-value pairs added to this list will be added to the terminal's

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -869,6 +869,7 @@ impl VsCodeSettings {
             minimum_contrast: None,
             option_as_meta: self.read_bool("terminal.integrated.macOptionIsMeta"),
             project: self.project_terminal_settings_content(),
+            right_click_behavior: None,
             scrollbar: None,
             scroll_multiplier: None,
             toolbar: None,

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -124,6 +124,12 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: true
     pub keep_selection_on_copy: Option<bool>,
+    /// What happens on right-click in the terminal. "context_menu" shows the
+    /// context menu (default). "copy_paste" copies the selection if there is
+    /// one, otherwise pastes from the clipboard (no menu).
+    ///
+    /// Default: context_menu
+    pub right_click_behavior: Option<RightClickBehavior>,
     /// Whether to show the terminal button in the status bar.
     ///
     /// Default: true
@@ -171,6 +177,30 @@ pub struct TerminalSettingsContent {
     /// Default: 45
     #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
     pub minimum_contrast: Option<f32>,
+}
+
+/// Behavior on right-click in the terminal.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum RightClickBehavior {
+    /// Show the context menu on right click.
+    #[default]
+    ContextMenu,
+    /// Copy selection if any, otherwise paste from clipboard (no menu).
+    CopyPaste,
 }
 
 /// Shell configuration to open the terminal with.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6139,7 +6139,7 @@ fn terminal_page() -> SettingsPage {
         ]
     }
 
-    fn behavior_settings_section() -> [SettingsPageItem; 4] {
+    fn behavior_settings_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("Behavior Settings"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -6195,6 +6195,28 @@ fn terminal_page() -> SettingsPage {
                             .terminal
                             .get_or_insert_default()
                             .keep_selection_on_copy = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Right Click Behavior",
+                description: "What happens on right-click in the terminal. \"Context Menu\" shows the menu (default). \"Copy Paste\" copies selection or pastes from clipboard.",
+                field: Box::new(SettingField {
+                    json_path: Some("terminal.right_click_behavior"),
+                    pick: |settings_content| {
+                        settings_content
+                            .terminal
+                            .as_ref()?
+                            .right_click_behavior
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .terminal
+                            .get_or_insert_default()
+                            .right_click_behavior = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -504,6 +504,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::CompletionDetailAlignment>(render_dropdown)
         .add_basic_renderer::<settings::DiffViewStyle>(render_dropdown)
         .add_basic_renderer::<settings::AlternateScroll>(render_dropdown)
+        .add_basic_renderer::<settings::RightClickBehavior>(render_dropdown)
         .add_basic_renderer::<settings::TerminalBlink>(render_dropdown)
         .add_basic_renderer::<settings::CursorShapeContent>(render_dropdown)
         .add_basic_renderer::<settings::EditPredictionPromptFormat>(render_dropdown)

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub use settings::AlternateScroll;
 
 use settings::{
-    IntoGpui, PathHyperlinkRegex, RegisterSetting, ShowScrollbar, TerminalBlink,
+    IntoGpui, PathHyperlinkRegex, RegisterSetting, RightClickBehavior, ShowScrollbar, TerminalBlink,
     TerminalDockPosition, TerminalLineHeight, VenvSettings, WorkingDirectory,
     merge_from::MergeFrom,
 };
@@ -38,6 +38,7 @@ pub struct TerminalSettings {
     pub option_as_meta: bool,
     pub copy_on_select: bool,
     pub keep_selection_on_copy: bool,
+    pub right_click_behavior: RightClickBehavior,
     pub button: bool,
     pub dock: TerminalDockPosition,
     pub default_width: Pixels,
@@ -105,6 +106,7 @@ impl settings::Settings for TerminalSettings {
             option_as_meta: user_content.option_as_meta.unwrap(),
             copy_on_select: user_content.copy_on_select.unwrap(),
             keep_selection_on_copy: user_content.keep_selection_on_copy.unwrap(),
+            right_click_behavior: user_content.right_click_behavior.unwrap_or_default(),
             button: user_content.button.unwrap(),
             dock: user_content.dock.unwrap(),
             default_width: px(user_content.default_width.unwrap()),

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -19,7 +19,7 @@ use persistence::TERMINAL_DB;
 use project::{Project, ProjectEntryId, search::SearchQuery};
 use schemars::JsonSchema;
 use serde::Deserialize;
-use settings::{Settings, SettingsStore, TerminalBlink, WorkingDirectory};
+use settings::{RightClickBehavior, Settings, SettingsStore, TerminalBlink, WorkingDirectory};
 use std::{
     any::Any,
     cmp,
@@ -1241,12 +1241,34 @@ impl Render for TerminalView {
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseDownEvent, window, cx| {
                     if !this.terminal.read(cx).mouse_mode(event.modifiers.shift) {
-                        if this.terminal.read(cx).last_content.selection.is_none() {
-                            this.terminal.update(cx, |terminal, _| {
-                                terminal.select_word_at_event_position(event);
-                            });
-                        };
-                        this.deploy_context_menu(event.position, window, cx);
+                        let right_click_behavior =
+                            TerminalSettings::get_global(cx).right_click_behavior;
+                        match right_click_behavior {
+                            RightClickBehavior::CopyPaste => {
+                                let has_selection = this
+                                    .terminal
+                                    .read(cx)
+                                    .last_content
+                                    .selection_text
+                                    .as_ref()
+                                    .is_some_and(|text| !text.is_empty());
+                                if has_selection {
+                                    this.terminal.update(cx, |terminal, _| {
+                                        terminal.copy(Some(false));
+                                    });
+                                } else {
+                                    window.dispatch_action(Box::new(Paste), cx);
+                                }
+                            }
+                            RightClickBehavior::ContextMenu => {
+                                if this.terminal.read(cx).last_content.selection.is_none() {
+                                    this.terminal.update(cx, |terminal, _| {
+                                        terminal.select_word_at_event_position(event);
+                                    });
+                                };
+                                this.deploy_context_menu(event.position, window, cx);
+                            }
+                        }
                         cx.notify();
                     }
                 }),


### PR DESCRIPTION
**Description:**
Add a new configuration setting to allow binding right-click in the terminal to "copy selection and paste from clipboard" without showing the context menu.
**Details:**
Default behavior remains unchanged (context menu on right-click).
New mode is enabled via the right_click_behavior: "copy_paste" option in terminal settings.
This mimics the classic terminal behavior (like Putty or X11) where:
If text is selected: right-click copies it.
If no text is selected: right-click pastes from the clipboard.