### PR TITLE
 editor: Add Ctrl+scroll wheel zoom for buffer font size

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7644,6 +7644,31 @@ impl EditorElement {
                 .max(0.01);
 
             move |event: &ScrollWheelEvent, phase, window, cx| {
+                // Ctrl+scroll (Cmd+scroll on macOS) zooms the buffer font size.
+                if event.modifiers.control || event.modifiers.platform {
+                    if phase == DispatchPhase::Bubble && hitbox.should_handle_scroll(window) {
+                        let delta_y = match event.delta {
+                            ScrollDelta::Pixels(pixels) => pixels.y.into(),
+                            ScrollDelta::Lines(lines) => lines.y,
+                        };
+                        if delta_y > 0.0 {
+                            window.dispatch_action(
+                                Box::new(zed_actions::IncreaseBufferFontSize { persist: false }),
+                                cx,
+                            );
+                        } else if delta_y < 0.0 {
+                            window.dispatch_action(
+                                Box::new(zed_actions::DecreaseBufferFontSize { persist: false }),
+                                cx,
+                            );
+                        }
+                        if delta_y != 0.0 {
+                            cx.stop_propagation();
+                            return;
+                        }
+                    }
+                }
+
                 let scroll_sensitivity = {
                     if event.modifiers.alt {
                         fast_scroll_sensitivity


### PR DESCRIPTION
When Ctrl (or Cmd on macOS) is held, scrolling over the editor changes the buffer font size instead of scrolling: scroll up to increase, scroll
  down to decrease. Uses the same non-persistent zoom as the Ctrl+/Ctrl- shortcuts.