### PR TITLE
Truncate long diagnostic messages in the status bar

### DIFF
--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -28,7 +28,7 @@ pub struct DiagnosticIndicator {
 
 impl Render for DiagnosticIndicator {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let indicator = h_flex().gap_2();
+        let indicator = h_flex().gap_2().min_w_0().overflow_x_hidden();
         if !ProjectSettings::get_global(cx).diagnostics.button {
             return indicator.hidden();
         }
@@ -67,6 +67,7 @@ impl Render for DiagnosticIndicator {
             Some(
                 Button::new("diagnostic_message", SharedString::new(message))
                     .label_size(LabelSize::Small)
+                    .truncate(true)
                     .tooltip(|_window, cx| {
                         Tooltip::for_action(
                             "Next Diagnostic",

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -70,12 +70,14 @@ impl StatusBar {
     fn render_left_tools(&self) -> impl IntoElement {
         h_flex()
             .gap_1()
+            .min_w_0()
             .overflow_x_hidden()
             .children(self.left_items.iter().map(|item| item.to_any()))
     }
 
     fn render_right_tools(&self) -> impl IntoElement {
         h_flex()
+            .flex_shrink_0()
             .gap_1()
             .overflow_x_hidden()
             .children(self.right_items.iter().rev().map(|item| item.to_any()))


### PR DESCRIPTION
Closes #50186

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

## Screenshots:
### Before:
<img width="2543" height="39" alt="image" src="https://github.com/user-attachments/assets/5e9fb7c5-0ba6-44b5-a0f6-1f63b35550f6" />

### After:
<img width="1165" height="581" alt="image" src="https://github.com/user-attachments/assets/903bc637-7d38-48c5-9207-30e12eaa40de" />

Release Notes:

- Fixed long diagnostic messages in the status bar pushing right-side buttons (terminal, agent, etc.) off screen