### PR TITLE
Normalize `line_comments` strings to have a trailing space

### DIFF
--- a/crates/languages/src/gitcommit/config.toml
+++ b/crates/languages/src/gitcommit/config.toml
@@ -7,7 +7,7 @@ path_suffixes = [
   "NOTES_EDITMSG",
   "EDIT_DESCRIPTION",
 ]
-line_comments = ["#"]
+line_comments = ["# "]
 brackets = [
   { start = "(", end = ")", close = true, newline = false },
   { start = "`", end = "`", close = true, newline = false },

--- a/crates/languages/src/gomod/config.toml
+++ b/crates/languages/src/gomod/config.toml
@@ -2,7 +2,7 @@ name = "Go Mod"
 code_fence_block_name = "go.mod"
 grammar = "gomod"
 path_suffixes = ["mod"]
-line_comments = ["//"]
+line_comments = ["// "]
 autoclose_before = ")"
 brackets = [
     { start = "(", end = ")", close = true, newline = true}

--- a/crates/languages/src/gowork/config.toml
+++ b/crates/languages/src/gowork/config.toml
@@ -2,7 +2,7 @@ name = "Go Work"
 code_fence_block_name = "gowork"
 grammar = "gowork"
 path_suffixes = ["work"]
-line_comments = ["//"]
+line_comments = ["// "]
 autoclose_before = ")"
 brackets = [
     { start = "(", end = ")", close = true, newline = true}


### PR DESCRIPTION
I did a search for `/^line_comments = .*[^\s\[]"/` to identify these 3 languages:

- Git Commit
- Go Mod
- Go Work

that don't add/remove a trailing space for inline comments. I couldn't find any indication that the absence of the trailing space is due to any peculiarity specific to these languages.

---

For Git Commit, I should note that (strictly speaking) the comment character is a single `#` without a trailing space, as Git removes any line starting with the default comment character (`#`) (see https://git-scm.com/docs/git-config#Documentation/git-config.txt-corecommentChar).

But I believe this change only affects whether `editor::ToggleComments` adds/removes the space, and not how the file is syntax highlighted. So for aesthetics and consistency, it should be better to add/remove the trailing space.

---

Before you mark this PR as ready for review, make sure that you have:

- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Add/remove a space when toggling inline comments in Git Commit and Go Mod/Work languages