### PR TITLE
fs: Map EventKind::Other to Changed instead of None

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -238,7 +238,8 @@ fn path_event_kind(event_kind: &EventKind) -> Option<PathEventKind> {
         EventKind::Create(_) => Some(PathEventKind::Created),
         EventKind::Modify(_) => Some(PathEventKind::Changed),
         EventKind::Remove(_) => Some(PathEventKind::Removed),
-        _ => Some(PathEventKind::Changed),
+        EventKind::Other | EventKind::Any => Some(PathEventKind::Changed),
+        _ => None,
     }
 }
 
@@ -312,5 +313,6 @@ mod tests {
             path_event_kind(&EventKind::Any),
             Some(PathEventKind::Changed),
         );
+        assert_eq!(path_event_kind(&EventKind::Access(AccessKind::Any)), None,);
     }
 }


### PR DESCRIPTION
Closes #48694
Supersedes #48695
Related to #38109

## Problem

When the OS event queue overflows, the `notify` crate emits `EventKind::Other` as a rescan signal (e.g. macOS `MustScanSubDirs`, Linux `IN_Q_OVERFLOW`). The catch-all in `fs_watcher.rs` maps this to `None`.

Three downstream consumers silently drop events with `kind: None`:
- BackgroundScanner initial scan filters them out (worktree.rs)
- Settings file watcher ignores them (settings_file.rs)
- LSP `didChangeWatchedFiles` notifications skip them (lsp_store.rs)

The original `_ => None` predates these consumers. When it was written, `process_events()` stripped the kind and only used paths, so `None` was harmless. The settings watcher and LSP path were added later and assumed `kind` would always be set.

This is an uncommon trigger (requires event queue overflow from heavy filesystem activity) and the failure is silent, which makes it hard to link to specific user reports. But the fix is simple and the current behavior is clearly wrong.

## Fix

Map `EventKind::Other` and `EventKind::Any` to `Some(PathEventKind::Changed)`. "Something changed, re-read from disk" is the correct semantic for both variants. Other unknown variants (like `EventKind::Access`) remain mapped to `None`.

Extracted the mapping into a standalone `path_event_kind()` function with unit tests.

## Test plan

- New: `test_path_event_kind_mapping` covers all `EventKind` variants
- All existing fs tests pass
- clippy clean

Release Notes:

- Fixed an issue where filesystem events could be silently dropped after OS event queue overflow, potentially causing stale settings and missing LSP notifications.