### PR TITLE
Add PDF viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,6 +3349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "color"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6189,6 +6198,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fast_image_resize"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "num-traits",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6241,6 +6262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -6363,6 +6393,7 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -8068,6 +8099,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "hayro"
+version = "0.5.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "bytemuck",
+ "fast_image_resize",
+ "hayro-interpret",
+ "image",
+ "kurbo 0.13.0",
+ "vello_cpu",
+]
+
+[[package]]
+name = "hayro-ccitt"
+version = "0.2.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+
+[[package]]
+name = "hayro-cmap"
+version = "0.1.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "hayro-postscript",
+]
+
+[[package]]
+name = "hayro-font"
+version = "0.4.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "log",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.5.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "bitflags 2.10.0",
+ "hayro-cmap",
+ "hayro-font",
+ "hayro-syntax",
+ "kurbo 0.13.0",
+ "log",
+ "moxcms",
+ "phf 0.13.1",
+ "rustc-hash 2.1.1",
+ "siphasher 1.0.1",
+ "skrifa 0.40.0",
+ "smallvec",
+ "yoke 0.8.0",
+]
+
+[[package]]
+name = "hayro-jbig2"
+version = "0.1.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "hayro-ccitt",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.3.3"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "fearless_simd",
+]
+
+[[package]]
+name = "hayro-postscript"
+version = "0.1.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+
+[[package]]
+name = "hayro-syntax"
+version = "0.5.0"
+source = "git+https://github.com/dsturnbull/hayro?rev=58de31aebb3bc89de5184a392e164247800c2844#58de31aebb3bc89de5184a392e164247800c2844"
+dependencies = [
+ "flate2",
+ "hayro-ccitt",
+ "hayro-jbig2",
+ "hayro-jpeg2000",
+ "log",
+ "rustc-hash 2.1.1",
+ "smallvec",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8662,8 +8784,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core",
- "zune-jpeg",
+ "zune-core 0.4.12",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -9300,6 +9422,17 @@ name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -10691,9 +10824,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c588e11a3082784af229e23e8e4ecf5bcc6fbe4f69101e0421ce8d79da7f0b40"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -12014,6 +12147,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0008e816fcdaf229cdd540e9b6ca2dc4a10d65c31624abb546c6420a02846e61"
 
 [[package]]
+name = "pdf_viewer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "db",
+ "file_icons",
+ "gpui",
+ "hayro",
+ "image",
+ "kurbo 0.13.0",
+ "log",
+ "project",
+ "serde",
+ "settings",
+ "smallvec",
+ "smol",
+ "theme",
+ "ui",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "peg"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12057,6 +12213,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
+]
+
+[[package]]
+name = "peniko"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo 0.13.0",
+ "linebender_resource_handle",
+ "smallvec",
 ]
 
 [[package]]
@@ -12544,6 +12713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12574,6 +12753,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand 2.3.0",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12600,6 +12789,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12613,6 +12815,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -16745,7 +16956,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
  "siphasher 1.0.1",
 ]
 
@@ -17539,7 +17750,7 @@ dependencies = [
  "half",
  "quick-error 2.0.1",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -18808,7 +19019,7 @@ dependencies = [
  "flate2",
  "fontdb 0.23.0",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -18983,6 +19194,33 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vello_common"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.16.1",
+ "log",
+ "peniko",
+ "png 0.17.16",
+ "skrifa 0.40.0",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "vello_common",
+]
 
 [[package]]
 name = "vercel"
@@ -21896,6 +22134,7 @@ dependencies = [
  "outline_panel",
  "parking_lot",
  "paths",
+ "pdf_viewer",
  "picker",
  "pkg-config",
  "pretty_assertions",
@@ -22319,6 +22558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
 name = "zlog"
 version = "0.1.0"
 dependencies = [
@@ -22391,6 +22636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22405,7 +22656,16 @@ version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ members = [
     "crates/http_client_tls",
     "crates/icons",
     "crates/image_viewer",
+    "crates/pdf_viewer",
     "crates/inspector_ui",
     "crates/install_cli",
     "crates/journal",
@@ -343,6 +344,7 @@ http_client = { path = "crates/http_client" }
 http_client_tls = { path = "crates/http_client_tls" }
 icons = { path = "crates/icons" }
 image_viewer = { path = "crates/image_viewer" }
+pdf_viewer = { path = "crates/pdf_viewer" }
 edit_prediction_types = { path = "crates/edit_prediction_types" }
 edit_prediction_ui = { path = "crates/edit_prediction_ui" }
 edit_prediction_context = { path = "crates/edit_prediction_context" }
@@ -847,6 +849,13 @@ windows-capture = { git = "https://github.com/zed-industries/windows-capture.git
 calloop = { git = "https://github.com/zed-industries/calloop" }
 livekit = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "cf4375b244ebb51702968df7fc36e192d0f45ad5" }
 libwebrtc = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "cf4375b244ebb51702968df7fc36e192d0f45ad5" }
+hayro = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
+hayro-interpret = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
+hayro-syntax = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
+hayro-font = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
+hayro-ccitt = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
+hayro-jbig2 = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
+hayro-jpeg2000 = { git = "https://github.com/dsturnbull/hayro", rev = "58de31aebb3bc89de5184a392e164247800c2844" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1428,6 +1428,18 @@
     },
   },
   {
+    "context": "PdfViewer",
+    "bindings": {
+      "ctrl-c": "pdf_viewer::CopyDocumentText",
+      "ctrl-=": "pdf_viewer::ZoomIn",
+      "ctrl-+": "pdf_viewer::ZoomIn",
+      "ctrl--": "pdf_viewer::ZoomOut",
+      "ctrl-0": "pdf_viewer::ResetZoom",
+      "ctrl-1": "pdf_viewer::ZoomToActualSize",
+      "ctrl-shift-0": "pdf_viewer::FitToView",
+    },
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "alt-1": "new_process_modal::ActivateTaskTab",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1506,6 +1506,19 @@
     },
   },
   {
+    "context": "PdfViewer",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-c": "pdf_viewer::CopyDocumentText",
+      "cmd-=": "pdf_viewer::ZoomIn",
+      "cmd-+": "pdf_viewer::ZoomIn",
+      "cmd--": "pdf_viewer::ZoomOut",
+      "cmd-0": "pdf_viewer::ResetZoom",
+      "cmd-1": "pdf_viewer::ZoomToActualSize",
+      "cmd-shift-0": "pdf_viewer::FitToView",
+    },
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "cmd-1": "new_process_modal::ActivateTaskTab",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1421,6 +1421,18 @@
     },
   },
   {
+    "context": "PdfViewer",
+    "bindings": {
+      "ctrl-c": "pdf_viewer::CopyDocumentText",
+      "ctrl-=": "pdf_viewer::ZoomIn",
+      "ctrl-+": "pdf_viewer::ZoomIn",
+      "ctrl--": "pdf_viewer::ZoomOut",
+      "ctrl-0": "pdf_viewer::ResetZoom",
+      "ctrl-1": "pdf_viewer::ZoomToActualSize",
+      "ctrl-shift-0": "pdf_viewer::FitToView",
+    },
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "alt-1": "new_process_modal::ActivateTaskTab",

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -189,6 +189,10 @@ unsafe fn build_classes() {
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );
                 decl.add_method(
+                    sel!(magnifyWithEvent:),
+                    handle_view_event as extern "C" fn(&Object, Sel, id),
+                );
+                decl.add_method(
                     sel!(flagsChanged:),
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );

--- a/crates/pdf_viewer/Cargo.toml
+++ b/crates/pdf_viewer/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "pdf_viewer"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "Apache-2.0"
+
+[features]
+test-bench = []
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/pdf_viewer.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+db.workspace = true
+file_icons.workspace = true
+gpui.workspace = true
+image = { workspace = true }
+log.workspace = true
+project.workspace = true
+serde.workspace = true
+settings.workspace = true
+smallvec.workspace = true
+smol.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+hayro = { version = "0.5", default-features = false, features = ["embed-fonts"] }
+kurbo = "0.13"

--- a/crates/pdf_viewer/src/pdf_item.rs
+++ b/crates/pdf_viewer/src/pdf_item.rs
@@ -1,0 +1,98 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use gpui::{App, AppContext as _, BackgroundExecutor, Entity, EventEmitter, Task};
+use project::{Project, ProjectEntryId, ProjectItem, ProjectPath};
+
+pub struct PdfItem {
+    project_path: ProjectPath,
+    abs_path: PathBuf,
+    pdf_bytes: Arc<[u8]>,
+}
+
+pub enum PdfItemEvent {
+    Reloaded,
+}
+
+impl EventEmitter<PdfItemEvent> for PdfItem {}
+
+impl PdfItem {
+    pub fn abs_path(&self) -> &Path {
+        &self.abs_path
+    }
+
+    pub fn file_name(&self) -> &str {
+        self.abs_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("document.pdf")
+    }
+
+    pub fn pdf_bytes(&self) -> &Arc<[u8]> {
+        &self.pdf_bytes
+    }
+
+    pub fn project_path(&self) -> &ProjectPath {
+        &self.project_path
+    }
+}
+
+pub fn is_pdf_file(path: &ProjectPath) -> bool {
+    path.path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
+}
+
+fn load_pdf_bytes(abs_path: PathBuf, background: BackgroundExecutor) -> Task<Result<Arc<[u8]>>> {
+    background.spawn(async move {
+        let bytes = std::fs::read(&abs_path)
+            .with_context(|| format!("Failed to read PDF: {}", abs_path.display()))?;
+        Ok(Arc::from(bytes))
+    })
+}
+
+impl ProjectItem for PdfItem {
+    fn try_open(
+        project: &Entity<Project>,
+        path: &ProjectPath,
+        cx: &mut App,
+    ) -> Option<Task<Result<Entity<Self>>>> {
+        if !is_pdf_file(path) {
+            return None;
+        }
+
+        let worktree = project.read(cx).worktree_for_id(path.worktree_id, cx)?;
+        let abs_path = worktree
+            .read(cx)
+            .abs_path()
+            .join(path.path.as_std_path());
+        let project_path = path.clone();
+        let background = cx.background_executor().clone();
+
+        Some(cx.spawn(async move |cx| {
+            let pdf_bytes = load_pdf_bytes(abs_path.clone(), background).await?;
+
+            let entity = cx.update(|cx| {
+                cx.new(|_| PdfItem {
+                    project_path,
+                    abs_path,
+                    pdf_bytes,
+                })
+            });
+            Ok(entity)
+        }))
+    }
+
+    fn entry_id(&self, _cx: &App) -> Option<ProjectEntryId> {
+        None
+    }
+
+    fn project_path(&self, _cx: &App) -> Option<ProjectPath> {
+        Some(self.project_path.clone())
+    }
+
+    fn is_dirty(&self) -> bool {
+        false
+    }
+}

--- a/crates/pdf_viewer/src/pdf_renderer.rs
+++ b/crates/pdf_viewer/src/pdf_renderer.rs
@@ -1,0 +1,505 @@
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use gpui::RenderImage;
+use hayro::hayro_interpret::InterpreterSettings;
+use hayro::hayro_syntax::Pdf;
+use hayro::text::extract_text;
+use hayro::vello_cpu::color::AlphaColor;
+use hayro::vello_cpu::color::Srgb;
+
+use hayro::RenderSettings;
+use image::Frame;
+use smallvec::SmallVec;
+
+// Font-size-relative threshold for same-line detection in hit testing.
+// Glyphs with a vertical gap smaller than this fraction of font size are
+// considered part of the same visual line.
+const SAME_LINE_THRESHOLD: f32 = 0.8;
+
+// Horizontal gap (as fraction of font size) beyond which a synthetic
+// space is inserted between consecutive same-line glyphs.  Handles PDFs
+// that position words without explicit space glyphs.
+const SPACE_DIST: f32 = 0.15;
+
+
+/// Dimensions of a single PDF page in PDF points (1/72 inch).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PageDimensions {
+    pub width: f32,
+    pub height: f32,
+}
+
+/// Lightweight metadata extracted from a PDF without rendering any pages.
+#[derive(Clone, Debug)]
+pub struct PdfMetadata {
+    pub page_count: usize,
+    pub page_dimensions: Vec<PageDimensions>,
+}
+
+pub struct RenderedPage {
+    pub image: Arc<RenderImage>,
+    pub page_width: u32,
+    pub page_height: u32,
+}
+
+pub fn open_pdf(pdf_bytes: &[u8]) -> Result<Pdf> {
+    Pdf::new(pdf_bytes.to_vec()).map_err(|err| anyhow!("Failed to parse PDF document: {err:?}"))
+}
+
+/// Parse the PDF and extract page count + dimensions without rendering.
+/// This is fast (~6ms for a 98-page document).
+pub fn parse_metadata(pdf_bytes: &[u8]) -> Result<PdfMetadata> {
+    let pdf = open_pdf(pdf_bytes)?;
+    let pages = pdf.pages();
+
+    let mut page_dimensions = Vec::new();
+    for page in pages.iter() {
+        let (width, height) = page.render_dimensions();
+        page_dimensions.push(PageDimensions { width, height });
+    }
+
+    Ok(PdfMetadata {
+        page_count: page_dimensions.len(),
+        page_dimensions,
+    })
+}
+
+fn pixmap_to_render_image(pixmap: &hayro::vello_cpu::Pixmap) -> Result<Arc<RenderImage>> {
+    let width = pixmap.width() as u32;
+    let height = pixmap.height() as u32;
+
+    // hayro's Pixmap pixel data is premultiplied RGBA.
+    // GPUI expects BGRA with premultiplied alpha, so swap R and B.
+    let raw_pixels = pixmap.data();
+    let mut bgra_pixels: Vec<u8> = Vec::with_capacity(raw_pixels.len() * 4);
+    for pixel in raw_pixels {
+        bgra_pixels.push(pixel.b);
+        bgra_pixels.push(pixel.g);
+        bgra_pixels.push(pixel.r);
+        bgra_pixels.push(pixel.a);
+    }
+
+    let image_buffer =
+        image::ImageBuffer::<image::Rgba<u8>, Vec<u8>>::from_raw(width, height, bgra_pixels)
+            .ok_or_else(|| anyhow!("Failed to create image buffer from rendered PDF page"))?;
+
+    let render_image = Arc::new(RenderImage::new(SmallVec::from_elem(
+        Frame::new(image_buffer),
+        1,
+    )));
+
+    Ok(render_image)
+}
+
+#[derive(Clone)]
+pub struct TextGlyph {
+    pub character: String,
+    /// Position in PDF points, top-left origin.
+    pub x: f32,
+    pub y: f32,
+    /// Advance width from the PDF text state.
+    pub width: f32,
+    /// Visual font size in device-space units, accounting for all transforms.
+    pub font_size: f32,
+    /// `true` when this glyph is the first inside a new block-level
+    /// PDF structure element (heading, paragraph, list item, etc.).
+    /// Derived from marked-content tags in the PDF content stream.
+    pub is_block_start: bool,
+}
+
+#[derive(Clone)]
+pub struct PageTextLayout {
+    /// Glyphs sorted in reading order (top-to-bottom, left-to-right).
+    pub glyphs: Vec<TextGlyph>,
+}
+
+impl PageTextLayout {
+    pub fn full_text(&self) -> String {
+        self.merge_glyphs(0, self.glyphs.len())
+    }
+
+    pub fn selected_text(&self, start_index: usize, end_index: usize) -> String {
+        let (start, end) = if start_index > end_index {
+            (end_index, start_index)
+        } else {
+            (start_index, end_index)
+        };
+        let clamped_start = start.min(self.glyphs.len());
+        let clamped_end = end.min(self.glyphs.len());
+        self.merge_glyphs(clamped_start, clamped_end)
+    }
+
+    pub fn glyph_index_at_point(&self, x: f32, y: f32) -> Option<usize> {
+        if self.glyphs.is_empty() {
+            return None;
+        }
+
+        let mut lines: Vec<(f32, f32, Vec<usize>)> = Vec::new();
+        for (index, glyph) in self.glyphs.iter().enumerate() {
+            let threshold = glyph.font_size * SAME_LINE_THRESHOLD;
+            let found = lines
+                .iter_mut()
+                .find(|(line_y, _, _)| (glyph.y - *line_y).abs() < threshold);
+            if let Some((running_y, max_font_size, indices)) = found {
+                *max_font_size = max_font_size.max(glyph.font_size);
+                let count = indices.len() as f32;
+                *running_y = (*running_y * count + glyph.y) / (count + 1.0);
+                indices.push(index);
+            } else {
+                lines.push((glyph.y, glyph.font_size, vec![index]));
+            }
+        }
+
+        let mut closest_line_index = 0;
+        let mut closest_distance = f32::MAX;
+        for (line_index, (average_y, _, _)) in lines.iter().enumerate() {
+            let distance = (*average_y - y).abs();
+            if distance < closest_distance {
+                closest_distance = distance;
+                closest_line_index = line_index;
+            }
+        }
+
+        let (_, _, ref line_indices) = lines[closest_line_index];
+
+        let mut nearest_index = line_indices[0];
+        let mut nearest_distance = f32::MAX;
+        for &glyph_index in line_indices {
+            let glyph = &self.glyphs[glyph_index];
+            if x >= glyph.x && x <= glyph.x + glyph.width {
+                return Some(glyph_index);
+            }
+            let center_x = glyph.x + glyph.width / 2.0;
+            let distance = (center_x - x).abs();
+            if distance < nearest_distance {
+                nearest_distance = distance;
+                nearest_index = glyph_index;
+            }
+        }
+
+        Some(nearest_index)
+    }
+
+    fn merge_glyphs(&self, start: usize, end: usize) -> String {
+        if start >= end || start >= self.glyphs.len() {
+            return String::new();
+        }
+        let end = end.min(self.glyphs.len());
+        let slice = &self.glyphs[start..end];
+        let mut result = String::new();
+        let has_structure_tags = slice.iter().any(|g| g.is_block_start);
+
+        for (index, glyph) in slice.iter().enumerate() {
+            if index > 0 {
+                let previous = &slice[index - 1];
+                let size = previous.font_size.max(glyph.font_size).max(1.0);
+                let same_line =
+                    (glyph.y - previous.y).abs() / size < SAME_LINE_THRESHOLD;
+
+                if same_line {
+                    // Same line — insert a synthetic space for large
+                    // horizontal gaps (PDFs without explicit space glyphs).
+                    let expected_x = previous.x + previous.width;
+                    let spacing = (glyph.x - expected_x) / size;
+                    if spacing > SPACE_DIST && !result.ends_with(' ') {
+                        result.push(' ');
+                    }
+                } else if has_structure_tags && glyph.is_block_start {
+                    // New block-level element (heading, paragraph, list
+                    // item) — insert a paragraph break.
+                    result.push('\n');
+                } else {
+                    // Different line, no structural signal — soft line
+                    // wrap within a paragraph; join with a space.
+                    if !result.ends_with(' ') {
+                        result.push(' ');
+                    }
+                }
+            }
+
+            // Append the glyph text, collapsing runs of whitespace.
+            for ch in glyph.character.chars() {
+                if ch.is_whitespace() {
+                    if !result.ends_with(' ') && !result.ends_with('\n') {
+                        result.push(' ');
+                    }
+                } else {
+                    result.push(ch);
+                }
+            }
+        }
+
+        result.trim_end().to_string()
+    }
+}
+
+pub fn extract_page_text(pdf: &Pdf, page_index: usize) -> Result<PageTextLayout> {
+    let pages = pdf.pages();
+    let page = pages
+        .get(page_index)
+        .ok_or_else(|| anyhow!("Page index {page_index} out of range"))?;
+
+    let settings = InterpreterSettings::default();
+    let spans = extract_text(page, &settings);
+
+    let mut glyphs: Vec<TextGlyph> = spans
+        .iter()
+        .filter(|span| !span.is_artifact)
+        .flat_map(|span| {
+            let mut first = true;
+            span.glyphs.iter().map(move |glyph_position| {
+                let is_block_start = first && span.is_block_start;
+                first = false;
+                TextGlyph {
+                    character: glyph_position.text.clone(),
+                    x: glyph_position.x as f32,
+                    y: glyph_position.y as f32,
+                    width: (glyph_position.advance_x as f32).max(0.0),
+                    font_size: span.font_size_device,
+                    is_block_start,
+                }
+            })
+        })
+        .collect();
+
+    glyphs.sort_by(|a, b| {
+        a.y.partial_cmp(&b.y)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
+    });
+
+    Ok(PageTextLayout { glyphs })
+}
+
+pub fn render_single_page(
+    pdf: &Pdf,
+    page_index: usize,
+    scale_factor: f32,
+    bg_color: AlphaColor<Srgb>,
+) -> Result<RenderedPage> {
+    let pages = pdf.pages();
+    let all_pages: Vec<_> = pages.iter().collect();
+    let page = all_pages
+        .get(page_index)
+        .ok_or_else(|| anyhow!("Page index {page_index} out of range"))?;
+
+    let interpreter_settings = InterpreterSettings::default();
+    let render_settings = RenderSettings {
+        x_scale: scale_factor,
+        y_scale: scale_factor,
+        bg_color,
+        ..Default::default()
+    };
+
+    let pixmap = hayro::render(page, &interpreter_settings, &render_settings);
+    let width = pixmap.width() as u32;
+    let height = pixmap.height() as u32;
+    let image = pixmap_to_render_image(&pixmap)?;
+
+    Ok(RenderedPage {
+        image,
+        page_width: width,
+        page_height: height,
+    })
+}
+
+
+
+#[cfg(all(test, feature = "test-bench"))]
+#[path = "pdf_renderer_bench.rs"]
+mod pdf_renderer_bench;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal valid PDF with the given text content.
+    /// Each entry in `lines` is a `(x, y, text)` tuple in PDF coordinates
+    /// (origin at bottom-left, Y increases upward).
+    fn build_pdf(lines: &[(f32, f32, &str)]) -> Vec<u8> {
+        let mut stream = String::new();
+        stream.push_str("BT\n/F1 12 Tf\n");
+        for (x, y, text) in lines {
+            // Move to absolute position via Td from origin each time.
+            // We reset by ending and restarting the text object.
+            stream.push_str(&format!("{x} {y} Td\n({text}) Tj\n"));
+            // Return to origin so next Td is absolute.
+            stream.push_str(&format!("{} {} Td\n", -x, -y));
+        }
+        stream.push_str("ET\n");
+
+        let stream_bytes = stream.as_bytes();
+        let stream_length = stream_bytes.len();
+
+        // Hand-craft a minimal PDF. Object offsets don't need to be
+        // precise — hayro's parser is tolerant of linearisation gaps.
+        let mut pdf = Vec::new();
+        let header = b"%PDF-1.4\n";
+        pdf.extend_from_slice(header);
+
+        let obj1_offset = pdf.len();
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+        let obj2_offset = pdf.len();
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+        let obj3_offset = pdf.len();
+        pdf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n   \
+              /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n\n",
+        );
+
+        let obj4_offset = pdf.len();
+        pdf.extend_from_slice(format!("4 0 obj\n<< /Length {stream_length} >>\nstream\n").as_bytes());
+        pdf.extend_from_slice(stream_bytes);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+        let obj5_offset = pdf.len();
+        pdf.extend_from_slice(
+            b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n\n",
+        );
+
+        let xref_offset = pdf.len();
+        pdf.extend_from_slice(b"xref\n0 6\n");
+        pdf.extend_from_slice(format!("{:010} 65535 f \n", 0).as_bytes());
+        for offset in [obj1_offset, obj2_offset, obj3_offset, obj4_offset, obj5_offset] {
+            pdf.extend_from_slice(format!("{:010} 00000 n \n", offset).as_bytes());
+        }
+
+        pdf.extend_from_slice(b"\ntrailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n");
+        pdf.extend_from_slice(format!("{xref_offset}\n").as_bytes());
+        pdf.extend_from_slice(b"%%EOF\n");
+
+        pdf
+    }
+
+    #[test]
+    fn text_extraction_single_line() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "Hello World")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        let text = layout.full_text();
+        assert_eq!(text, "Hello World");
+    }
+
+    #[test]
+    fn text_extraction_multiple_lines() {
+        let pdf_bytes = build_pdf(&[
+            (72.0, 720.0, "First line"),
+            (72.0, 706.0, "Second line"),
+        ]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        let text = layout.full_text();
+        // Lines at normal leading (14pt gap at 12pt font) without structure
+        // tags are joined with a space.
+        assert_eq!(text, "First line Second line");
+    }
+
+    #[test]
+    fn text_extraction_preserves_spaces() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "one two  three")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        let text = layout.full_text();
+        assert!(
+            text.contains("one") && text.contains("two") && text.contains("three"),
+            "Expected words 'one', 'two', 'three' in extracted text, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn text_extraction_font_size_nonzero() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "Test")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        for glyph in &layout.glyphs {
+            assert!(
+                glyph.font_size > 1.0,
+                "Glyph '{}' has font_size {}, expected > 1.0 (UNITS_PER_EM correction missing?)",
+                glyph.character,
+                glyph.font_size,
+            );
+        }
+    }
+
+    #[test]
+    fn text_extraction_glyph_widths_nonzero() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "Hello")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        for glyph in &layout.glyphs {
+            if glyph.character != " " {
+                assert!(
+                    glyph.width > 0.1,
+                    "Glyph '{}' has width {}, expected > 0.1",
+                    glyph.character,
+                    glyph.width,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn selected_text_subset() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "ABCDEF")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        assert_eq!(layout.glyphs.len(), 6);
+        // Select glyphs 1..4 → "BCD"
+        let selected = layout.selected_text(1, 4);
+        assert_eq!(selected, "BCD");
+    }
+
+    #[test]
+    fn selected_text_reversed_range() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "ABCDEF")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        // Reversed selection (drag upward) should produce the same text.
+        let forward = layout.selected_text(1, 4);
+        let reversed = layout.selected_text(4, 1);
+        assert_eq!(forward, reversed);
+    }
+
+    #[test]
+    fn untagged_pdf_joins_lines() {
+        // Without structure tags, different lines are joined with spaces
+        // regardless of gap size (no heuristic paragraph detection).
+        let pdf_bytes = build_pdf(&[
+            (72.0, 720.0, "Heading"),
+            (72.0, 690.0, "Body text"),
+        ]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        let text = layout.full_text();
+        assert_eq!(text, "Heading Body text");
+    }
+
+    #[test]
+    fn glyph_hit_test_finds_correct_glyph() {
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "ABC")]);
+        let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+        let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+        assert_eq!(layout.glyphs.len(), 3);
+
+        // Hit the center of glyph 'B' (index 1).
+        let b_glyph = &layout.glyphs[1];
+        let hit_x = b_glyph.x + b_glyph.width / 2.0;
+        let hit_y = b_glyph.y;
+        let index = layout.glyph_index_at_point(hit_x, hit_y);
+        assert_eq!(index, Some(1), "Expected to hit glyph 'B' at index 1");
+    }
+
+
+}

--- a/crates/pdf_viewer/src/pdf_renderer_bench.rs
+++ b/crates/pdf_viewer/src/pdf_renderer_bench.rs
@@ -1,0 +1,150 @@
+use super::*;
+use hayro::vello_cpu::color::palette::css::WHITE;
+use std::time::Instant;
+
+#[test]
+fn dump_real_pdf_glyphs() {
+    let pdf_path =
+        std::env::var("PDF_DUMP_PATH").expect("set PDF_DUMP_PATH to a PDF file path");
+    let pdf_bytes = std::fs::read(&pdf_path).expect("Failed to read PDF file");
+    let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+    let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
+
+    eprintln!("--- Page 1: {} glyphs ---", layout.glyphs.len());
+    let mut prev_y: Option<f32> = None;
+    for (i, g) in layout.glyphs.iter().enumerate() {
+        let line_break = prev_y
+            .map(|py| (g.y - py).abs() > g.font_size * SAME_LINE_THRESHOLD)
+            .unwrap_or(false);
+        if line_break {
+            let py = prev_y.unwrap_or(0.0);
+            let gap = (g.y - py).abs();
+            let size = g.font_size;
+            eprintln!(
+                "  ---- line break: y_gap={:.1} fs={:.1} base_offset={:.2} ----",
+                gap,
+                size,
+                gap / size.max(1.0)
+            );
+        }
+        if i < 300 || line_break {
+            eprintln!(
+                "  [{:>4}] '{}' x={:.1} y={:.1} w={:.1} fs={:.1}",
+                i,
+                g.character.escape_debug(),
+                g.x,
+                g.y,
+                g.width,
+                g.font_size
+            );
+        }
+        prev_y = Some(g.y);
+    }
+
+    eprintln!("\n--- full_text (first 2000 chars) ---");
+    let text = layout.full_text();
+    eprintln!("{}", &text[..text.len().min(2000)]);
+}
+
+#[test]
+fn bench_render_phases() {
+    let pdf_path =
+        std::env::var("PDF_BENCH_PATH").expect("set PDF_BENCH_PATH to a PDF file path");
+    let scale = std::env::var("PDF_BENCH_SCALE")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(2.0);
+
+    let t0 = Instant::now();
+    let pdf_bytes = std::fs::read(&pdf_path).expect("Failed to read PDF file");
+    let read_elapsed = t0.elapsed();
+    eprintln!(
+        "Phase 1 — Read file:      {:>8.2?}  ({} bytes)",
+        read_elapsed,
+        pdf_bytes.len()
+    );
+
+    let t1 = Instant::now();
+    let metadata = parse_metadata(&pdf_bytes).expect("Failed to parse PDF");
+    let parse_elapsed = t1.elapsed();
+    eprintln!(
+        "Phase 2 — Parse metadata: {:>8.2?}  ({} pages)",
+        parse_elapsed, metadata.page_count
+    );
+
+    let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
+    let pages = pdf.pages();
+    let interpreter_settings = InterpreterSettings::default();
+
+    let mut render_times = Vec::with_capacity(metadata.page_count);
+    let mut convert_times = Vec::with_capacity(metadata.page_count);
+
+    for (index, page) in pages.iter().enumerate() {
+        let render_settings = RenderSettings {
+            x_scale: scale,
+            y_scale: scale,
+            bg_color: WHITE,
+            ..Default::default()
+        };
+
+        let t_render = Instant::now();
+        let pixmap = hayro::render(&page, &interpreter_settings, &render_settings);
+        let render_elapsed = t_render.elapsed();
+        render_times.push(render_elapsed);
+
+        let t_convert = Instant::now();
+        let _image = pixmap_to_render_image(&pixmap).expect("Failed to convert pixmap");
+        let convert_elapsed = t_convert.elapsed();
+        convert_times.push(convert_elapsed);
+
+        if index < 5 || index == metadata.page_count - 1 {
+            eprintln!(
+                "  Page {:>3}: render {:>8.2?}, convert {:>8.2?}  ({}×{})",
+                index + 1,
+                render_elapsed,
+                convert_elapsed,
+                pixmap.width(),
+                pixmap.height()
+            );
+        } else if index == 5 {
+            eprintln!("  ...");
+        }
+    }
+
+    let total_render: std::time::Duration = render_times.iter().sum();
+    let total_convert: std::time::Duration = convert_times.iter().sum();
+    let avg_render = total_render / metadata.page_count as u32;
+    let avg_convert = total_convert / metadata.page_count as u32;
+
+    eprintln!();
+    eprintln!(
+        "Phase 3 — Render pages:   {:>8.2?}  (avg {:>8.2?}/page)",
+        total_render, avg_render
+    );
+    eprintln!(
+        "Phase 4 — Convert pixmaps:{:>8.2?}  (avg {:>8.2?}/page)",
+        total_convert, avg_convert
+    );
+    eprintln!();
+
+    let total = read_elapsed + parse_elapsed + total_render + total_convert;
+    eprintln!("Total:                    {:>8.2?}", total);
+    eprintln!();
+    eprintln!("Breakdown:");
+    eprintln!(
+        "  Read:    {:>5.1}%",
+        read_elapsed.as_secs_f64() / total.as_secs_f64() * 100.0
+    );
+    eprintln!(
+        "  Parse:   {:>5.1}%",
+        parse_elapsed.as_secs_f64() / total.as_secs_f64() * 100.0
+    );
+    eprintln!(
+        "  Render:  {:>5.1}%",
+        total_render.as_secs_f64() / total.as_secs_f64() * 100.0
+    );
+    eprintln!(
+        "  Convert: {:>5.1}%",
+        total_convert.as_secs_f64() / total.as_secs_f64() * 100.0
+    );
+}

--- a/crates/pdf_viewer/src/pdf_viewer.rs
+++ b/crates/pdf_viewer/src/pdf_viewer.rs
@@ -1,0 +1,854 @@
+mod pdf_item;
+mod pdf_renderer;
+mod selection;
+mod toolbar;
+
+use hayro::vello_cpu::color::palette::css::WHITE;
+
+pub use pdf_item::{PdfItem, is_pdf_file};
+pub use toolbar::PdfViewToolbarControls;
+
+use std::collections::{HashMap, HashSet};
+use std::ops::Range;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use file_icons::FileIcons;
+use gpui::{
+    actions, div, img, point, px, AnyElement, App, Context, CursorStyle, Entity,
+    EventEmitter, FocusHandle, Focusable, Font, IntoElement, MouseButton,
+    ParentElement, Pixels, Point, RenderImage, Render, ScrollDelta,
+    ScrollHandle, ScrollWheelEvent, SharedString, Styled, Task, Window,
+};
+use project::Project;
+use ui::prelude::*;
+use ui::WithScrollbar;
+use workspace::{
+    Pane, ToolbarItemLocation,
+    WorkspaceId,
+    invalid_item_view::InvalidItemView,
+    item::{HighlightedText, Item, ProjectItem, TabContentParams},
+};
+
+use pdf_renderer::{PageDimensions, PageTextLayout, PdfMetadata};
+
+const PAGE_GAP_PX: f32 = 20.0;
+const RENDER_BUFFER_PAGES: usize = 2;
+const SCREEN_SCALE_FACTOR: f32 = 2.0;
+// Metal texture atlas tiles cannot exceed 16384px in either dimension.
+const MAX_GPU_TILE_PX: f32 = 16384.0;
+
+const MIN_ZOOM: f32 = 0.1;
+const MAX_ZOOM: f32 = 20.0;
+const ZOOM_STEP: f32 = 1.1;
+const SCROLL_LINE_MULTIPLIER: f32 = 20.0;
+const SCROLL_ZOOM_SENSITIVITY: f32 = 0.01;
+
+const RENDER_DEBOUNCE: Duration = Duration::from_millis(200);
+
+actions!(
+    pdf_viewer,
+    [
+        /// Zoom in the PDF.
+        ZoomIn,
+        /// Zoom out the PDF.
+        ZoomOut,
+        /// Reset zoom to 100%.
+        ResetZoom,
+        /// Fit the PDF to the view width.
+        FitToView,
+        /// Zoom to actual size (100%).
+        ZoomToActualSize,
+        /// Copy all document text to the clipboard.
+        CopyDocumentText,
+    ]
+);
+
+pub enum PdfViewEvent {
+    TitleChanged,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct TextPosition {
+    page: usize,
+    glyph_index: usize,
+}
+
+pub struct PdfViewer {
+    pdf_item: Entity<PdfItem>,
+    project: Entity<Project>,
+    focus_handle: FocusHandle,
+    scroll_handle: ScrollHandle,
+    metadata: Option<PdfMetadata>,
+    rendered_pages: HashMap<usize, (f32, Arc<RenderImage>)>,
+    pages_in_flight: HashSet<usize>,
+    cancel_token: Arc<AtomicBool>,
+    render_task: Task<()>,
+    render_debounce: Task<()>,
+    render_error: Option<SharedString>,
+    zoom_level: f32,
+    render_scale: f32,
+    pan_x: Pixels,
+    text_layouts: HashMap<usize, PageTextLayout>,
+    text_extraction_task: Task<()>,
+    selection_start: Option<TextPosition>,
+    selection_end: Option<TextPosition>,
+    is_selecting: bool,
+}
+
+impl PdfViewer {
+    pub fn new(
+        pdf_item: Entity<PdfItem>,
+        project: Entity<Project>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut this = Self {
+            pdf_item,
+            project,
+            focus_handle: cx.focus_handle(),
+            scroll_handle: ScrollHandle::new(),
+            metadata: None,
+            rendered_pages: HashMap::new(),
+            pages_in_flight: HashSet::new(),
+            cancel_token: Arc::new(AtomicBool::new(false)),
+            render_task: Task::ready(()),
+            render_debounce: Task::ready(()),
+            render_error: None,
+            zoom_level: 1.0,
+            render_scale: SCREEN_SCALE_FACTOR,
+            pan_x: px(0.0),
+            text_layouts: HashMap::new(),
+            text_extraction_task: Task::ready(()),
+            selection_start: None,
+            selection_end: None,
+            is_selecting: false,
+        };
+        this.load_metadata(cx);
+        this
+    }
+
+    fn load_metadata(&mut self, cx: &mut Context<Self>) {
+        let pdf_bytes = self.pdf_item.read(cx).pdf_bytes().clone();
+
+        let background_task =
+            cx.background_spawn(async move { pdf_renderer::parse_metadata(&pdf_bytes) });
+
+        self.render_task = cx.spawn(async move |this, cx| {
+            let result = background_task.await;
+            this.update(cx, |this, cx| match result {
+                Ok(metadata) => {
+                    log::debug!(
+                        "pdf_viewer: loaded metadata — {} pages",
+                        metadata.page_count
+                    );
+                    this.metadata = Some(metadata);
+                    this.render_error = None;
+                    log::debug!("pdf_viewer: kicking off text extraction");
+                    this.extract_all_text(cx);
+                    cx.notify();
+                }
+                Err(error) => {
+                    log::error!("pdf_viewer: failed to load metadata: {error:#}");
+                    this.render_error = Some(format!("{error:#}").into());
+                }
+            })
+            .ok();
+        });
+    }
+
+    fn page_count(&self) -> usize {
+        self.metadata
+            .as_ref()
+            .map_or(0, |metadata| metadata.page_count)
+    }
+
+    fn page_dimensions(&self) -> &[PageDimensions] {
+        self.metadata
+            .as_ref()
+            .map_or(&[], |metadata| &metadata.page_dimensions)
+    }
+
+    fn display_height(dim: &PageDimensions, container_width: f32, zoom: f32) -> f32 {
+        if dim.width <= 0.0 {
+            return dim.height * zoom;
+        }
+        let fit_scale = container_width / dim.width;
+        dim.height * fit_scale * zoom
+    }
+
+    fn total_content_height(&self, container_width: f32) -> f32 {
+        let dimensions = self.page_dimensions();
+        let pages_height: f32 = dimensions
+            .iter()
+            .map(|dim| Self::display_height(dim, container_width, self.zoom_level))
+            .sum();
+        let gaps = dimensions.len().saturating_sub(1) as f32 * PAGE_GAP_PX;
+        pages_height + gaps
+    }
+
+    /// Clamp horizontal pan so content edges never retreat past the viewport
+    /// edges, matching macOS Preview behaviour. When content fits within the
+    /// viewport pan is forced to zero (centered). When content overflows, pan
+    /// is bounded so neither edge can slide past its corresponding viewport
+    /// edge.
+    fn clamp_pan(&mut self) {
+        let viewport_width: f32 = self.scroll_handle.bounds().size.width.into();
+        if viewport_width <= 0.0 {
+            return;
+        }
+        // At any zoom, every page has display_width = viewport_width * zoom
+        // (fit-to-view normalizes all pages to viewport_width at zoom 1.0).
+        let content_width = viewport_width * self.zoom_level;
+        let overflow = (content_width - viewport_width).max(0.0);
+        let half_overflow = overflow / 2.0;
+        self.pan_x = self.pan_x.clamp(px(-half_overflow), px(half_overflow));
+    }
+
+    fn visible_page_range(&self, viewport_height: f32, viewport_width: f32) -> Range<usize> {
+        let dimensions = self.page_dimensions();
+        if dimensions.is_empty() {
+            return 0..0;
+        }
+
+        let scroll_y: f32 = self.scroll_handle.offset().y.into();
+        let scroll_offset = scroll_y.abs();
+
+        let mut y = 0.0_f32;
+        let mut first_visible = None;
+        let mut last_visible = 0;
+
+        for (index, dim) in dimensions.iter().enumerate() {
+            let page_height = Self::display_height(dim, viewport_width, self.zoom_level);
+            let page_top = y;
+            let page_bottom = y + page_height;
+
+            if page_bottom > scroll_offset && first_visible.is_none() {
+                first_visible = Some(index);
+            }
+            if page_top < scroll_offset + viewport_height {
+                last_visible = index;
+            }
+            if page_top > scroll_offset + viewport_height {
+                break;
+            }
+
+            y = page_bottom + PAGE_GAP_PX;
+        }
+
+        let first = first_visible.unwrap_or(0);
+        let last = (last_visible + 1).min(dimensions.len());
+        first..last
+    }
+
+    fn buffered_range(&self, visible: Range<usize>) -> Range<usize> {
+        let start = visible.start.saturating_sub(RENDER_BUFFER_PAGES);
+        let end = (visible.end + RENDER_BUFFER_PAGES).min(self.page_count());
+        start..end
+    }
+
+    fn schedule_render_after_zoom(&mut self, cx: &mut Context<Self>) {
+        self.render_debounce = cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(RENDER_DEBOUNCE).await;
+            this.update(cx, |this, cx| {
+                this.update_render_scale_if_needed();
+                this.request_visible_pages(cx);
+            })
+            .ok();
+        });
+    }
+
+    fn update_render_scale_if_needed(&mut self) {
+        let ideal_scale = self.zoom_level * SCREEN_SCALE_FACTOR;
+        // Cap so the largest page dimension never exceeds the Metal atlas limit.
+        let max_dim = self
+            .page_dimensions()
+            .iter()
+            .map(|d| d.width.max(d.height))
+            .fold(0.0_f32, f32::max);
+        let needed_scale = if max_dim > 0.0 {
+            ideal_scale.min(MAX_GPU_TILE_PX / max_dim)
+        } else {
+            ideal_scale
+        };
+        let scale_too_low = needed_scale > self.render_scale;
+        let scale_wasteful = needed_scale < self.render_scale * 0.25;
+        if scale_too_low || scale_wasteful {
+            log::debug!(
+                "pdf_viewer: render scale change {:.1} -> {:.1} (zoom={:.2})",
+                self.render_scale,
+                needed_scale,
+                self.zoom_level
+            );
+            self.render_scale = needed_scale;
+            self.cancel_token.store(true, Ordering::Relaxed);
+            self.cancel_token = Arc::new(AtomicBool::new(false));
+            self.pages_in_flight.clear();
+        }
+    }
+
+    fn request_visible_pages(&mut self, cx: &mut Context<Self>) {
+        if self.metadata.is_none() {
+            return;
+        }
+
+        let bounds = self.scroll_handle.bounds();
+        let viewport_height = {
+            let h: f32 = bounds.size.height.into();
+            if h > 0.0 { h } else { 800.0 }
+        };
+        let viewport_width = {
+            let w: f32 = bounds.size.width.into();
+            if w > 0.0 { w } else { 600.0 }
+        };
+
+        let visible = self.visible_page_range(viewport_height, viewport_width);
+        let target_range = self.buffered_range(visible.clone());
+
+        let current_scale = self.render_scale;
+        let needs_render = |index: &usize| -> bool {
+            !self.pages_in_flight.contains(index)
+                && self
+                    .rendered_pages
+                    .get(index)
+                    .map_or(true, |(scale, _)| *scale != current_scale)
+        };
+
+        let mut needed: Vec<usize> = visible.clone().filter(&needs_render).collect();
+        let buffer_pages: Vec<usize> = target_range
+            .filter(|index| !visible.contains(index) && needs_render(index))
+            .collect();
+        needed.extend(buffer_pages);
+
+        if needed.is_empty() {
+            return;
+        }
+
+        for &index in &needed {
+            self.pages_in_flight.insert(index);
+        }
+
+        let needed_display: Vec<usize> = needed.iter().map(|i| i + 1).collect();
+        log::debug!(
+            "pdf_viewer: rendering pages {:?} at scale {:.1}",
+            needed_display,
+            self.render_scale
+        );
+
+        let pdf_bytes = self.pdf_item.read(cx).pdf_bytes().clone();
+        let render_scale = self.render_scale;
+        let cancel_token = self.cancel_token.clone();
+
+        let (sender, receiver) = smol::channel::unbounded::<(usize, Arc<RenderImage>)>();
+
+        if let Err(error) = std::thread::Builder::new()
+            .name("pdf-renderer".into())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                let pdf = match pdf_renderer::open_pdf(&pdf_bytes) {
+                    Ok(pdf) => pdf,
+                    Err(error) => {
+                        log::error!(
+                            "pdf_viewer: failed to open PDF for rendering: {error:#}"
+                        );
+                        return;
+                    }
+                };
+                for page_index in needed {
+                    if cancel_token.load(Ordering::Relaxed) {
+                        log::debug!("pdf_viewer: render cancelled");
+                        break;
+                    }
+                    log::debug!("pdf_viewer: rendering page {}...", page_index + 1);
+                    match pdf_renderer::render_single_page(
+                        &pdf,
+                        page_index,
+                        render_scale,
+                        WHITE,
+                    ) {
+                        Ok(rendered) => {
+                            log::debug!(
+                                "pdf_viewer: page {} rendered ({}x{})",
+                                page_index + 1,
+                                rendered.page_width,
+                                rendered.page_height
+                            );
+                            if sender.send_blocking((page_index, rendered.image)).is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            log::error!(
+                                "pdf_viewer: failed to render page {}: {error:#}",
+                                page_index + 1
+                            );
+                            break;
+                        }
+                    }
+                }
+            })
+        {
+            log::error!("pdf_viewer: failed to spawn render thread: {error:#}");
+        }
+
+        self.render_task = cx.spawn(async move |this, cx| {
+            while let Ok((page_index, image)) = receiver.recv().await {
+                let scale = render_scale;
+                this.update(cx, |this, cx| {
+                    this.pages_in_flight.remove(&page_index);
+                    this.rendered_pages.insert(page_index, (scale, image));
+                    cx.notify();
+                })
+                .ok();
+            }
+            this.update(cx, |this, _cx| {
+                this.pages_in_flight.clear();
+            })
+            .ok();
+        });
+    }
+
+    fn render_page_element(
+        &self,
+        index: usize,
+        dimensions: &PageDimensions,
+        container_width: f32,
+    ) -> AnyElement {
+        let fit_scale = if dimensions.width > 0.0 {
+            container_width / dimensions.width
+        } else {
+            1.0
+        };
+        let scale = fit_scale * self.zoom_level;
+        let display_width = px(dimensions.width * scale);
+        let display_height = px(dimensions.height * scale);
+
+        let page_content = if let Some((_scale, image)) = self.rendered_pages.get(&index) {
+            img(image.clone())
+                .id(("pdf-page", index))
+                .w(display_width)
+                .h(display_height)
+                .into_any_element()
+        } else {
+            div()
+                .id(("pdf-page-placeholder", index))
+                .w(display_width)
+                .h(display_height)
+                .bg(gpui::rgb(0xf0f0f0))
+                .border_1()
+                .border_color(gpui::rgb(0xe0e0e0))
+                .flex()
+                .justify_center()
+                .items_center()
+                .child(Label::new(format!("Page {}", index + 1)).color(Color::Muted))
+                .into_any_element()
+        };
+
+        let highlights = self.selection_highlights_for_page(index, fit_scale);
+
+        div()
+            .relative()
+            .w(display_width)
+            .h(display_height)
+            .child(page_content)
+            .children(highlights)
+            .into_any_element()
+    }
+
+    // -- Zoom --
+
+    fn set_zoom(
+        &mut self,
+        new_zoom: f32,
+        zoom_center: Option<Point<Pixels>>,
+        cx: &mut Context<Self>,
+    ) {
+        let old_zoom = self.zoom_level;
+        self.zoom_level = new_zoom.clamp(MIN_ZOOM, MAX_ZOOM);
+        if (self.zoom_level - old_zoom).abs() > f32::EPSILON {
+            if old_zoom > 0.0 {
+                let ratio = self.zoom_level / old_zoom;
+                self.pan_x *= ratio;
+            }
+            self.clamp_pan();
+
+            if let Some(cursor) = zoom_center {
+                let bounds = self.scroll_handle.bounds();
+                let offset = self.scroll_handle.offset();
+
+                let cursor_in_container = point(
+                    cursor.x - bounds.origin.x,
+                    cursor.y - bounds.origin.y,
+                );
+
+                let content_x = cursor_in_container.x - offset.x;
+                let content_y = cursor_in_container.y - offset.y;
+
+                let zoom_ratio = self.zoom_level / old_zoom;
+                let new_content_x = content_x * zoom_ratio;
+                let new_content_y = content_y * zoom_ratio;
+
+                let new_offset = point(
+                    cursor_in_container.x - new_content_x,
+                    cursor_in_container.y - new_content_y,
+                );
+                self.scroll_handle.set_offset(new_offset);
+            }
+
+            cx.notify();
+            self.schedule_render_after_zoom(cx);
+        }
+    }
+
+    fn zoom_in(&mut self, _: &ZoomIn, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(self.zoom_level * ZOOM_STEP, None, cx);
+    }
+
+    fn zoom_out(&mut self, _: &ZoomOut, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(self.zoom_level / ZOOM_STEP, None, cx);
+    }
+
+    fn reset_zoom(&mut self, _: &ResetZoom, _window: &mut Window, cx: &mut Context<Self>) {
+        self.pan_x = px(0.0);
+        self.set_zoom(1.0, None, cx);
+    }
+
+    fn fit_to_view(&mut self, _: &FitToView, _window: &mut Window, cx: &mut Context<Self>) {
+        self.pan_x = px(0.0);
+        self.set_zoom(1.0, None, cx);
+    }
+
+    fn zoom_to_actual_size(
+        &mut self,
+        _: &ZoomToActualSize,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_zoom(1.0, None, cx);
+    }
+
+    // Handle horizontal scroll manually here because GPUI's ScrollHandler
+    // only deals with vertical scrolling — horizontal delta from the
+    // trackpad / scroll wheel is not forwarded through the scroll container.
+    fn handle_scroll_wheel(
+        &mut self,
+        event: &ScrollWheelEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.modifiers.control || event.modifiers.platform {
+            let delta: f32 = match event.delta {
+                ScrollDelta::Pixels(pixels) => pixels.y.into(),
+                ScrollDelta::Lines(lines) => lines.y * SCROLL_LINE_MULTIPLIER,
+            };
+            let zoom_factor = if delta > 0.0 {
+                1.0 + delta.abs() * SCROLL_ZOOM_SENSITIVITY
+            } else {
+                1.0 / (1.0 + delta.abs() * SCROLL_ZOOM_SENSITIVITY)
+            };
+            self.set_zoom(self.zoom_level * zoom_factor, Some(event.position), cx);
+        } else {
+            let delta_x = match event.delta {
+                ScrollDelta::Pixels(pixels) => pixels.x,
+                ScrollDelta::Lines(lines) => px(lines.x * SCROLL_LINE_MULTIPLIER),
+            };
+            if delta_x != px(0.0) {
+                self.pan_x += delta_x;
+                self.clamp_pan();
+            }
+            self.request_visible_pages(cx);
+            cx.notify();
+        }
+    }
+}
+
+impl EventEmitter<PdfViewEvent> for PdfViewer {}
+impl EventEmitter<()> for PdfViewer {}
+
+impl Focusable for PdfViewer {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for PdfViewer {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.request_visible_pages(cx);
+
+        let content = if let Some(error) = &self.render_error {
+            v_flex()
+                .p_4()
+                .gap_2()
+                .child(Label::new("Failed to render PDF").color(Color::Error))
+                .child(Label::new(error.clone()).size(LabelSize::Small))
+                .into_any_element()
+        } else if self.metadata.is_none() {
+            v_flex()
+                .p_4()
+                .child(Label::new("Loading..."))
+                .into_any_element()
+        } else {
+            let dimensions = self.page_dimensions().to_vec();
+            let bounds = self.scroll_handle.bounds();
+            let container_width: f32 = bounds.size.width.into();
+            let container_width = if container_width > 0.0 {
+                container_width
+            } else {
+                dimensions
+                    .iter()
+                    .map(|d| d.width)
+                    .fold(0.0_f32, f32::max)
+            };
+
+            // When all pages fit inside the viewport, centre them vertically
+            // with equal padding so they float in the middle. When content
+            // exceeds the viewport, no padding is added and GPUI's scroll
+            // container naturally bounds scrolling to the content height —
+            // matching macOS Preview's behaviour.
+            let total_content_h = self.total_content_height(container_width);
+            let viewport_h: f32 = {
+                let h: f32 = self.scroll_handle.bounds().size.height.into();
+                if h > 0.0 { h } else { 800.0 }
+            };
+
+            let centering_pad = if total_content_h < viewport_h {
+                (viewport_h - total_content_h) / 2.0
+            } else {
+                0.0
+            };
+
+            let mut pages_column = v_flex().gap(px(PAGE_GAP_PX)).items_center();
+            if centering_pad > 0.0 {
+                pages_column = pages_column.child(div().h(px(centering_pad)));
+            }
+            for (index, dim) in dimensions.iter().enumerate() {
+                pages_column =
+                    pages_column.child(self.render_page_element(index, dim, container_width));
+            }
+            if centering_pad > 0.0 {
+                pages_column = pages_column.child(div().h(px(centering_pad)));
+            }
+
+            if self.pan_x != px(0.0) {
+                div()
+                    .relative()
+                    .left(self.pan_x)
+                    .child(pages_column)
+                    .into_any_element()
+            } else {
+                pages_column.into_any_element()
+            }
+        };
+
+        let bounds = self.scroll_handle.bounds();
+        let vp_h: f32 = bounds.size.height.into();
+        let vp_w: f32 = bounds.size.width.into();
+        let vp_h = if vp_h > 0.0 { vp_h } else { 800.0 };
+        let vp_w = if vp_w > 0.0 { vp_w } else { 600.0 };
+
+        let zoom_percent = (self.zoom_level * 100.0).round() as u32;
+        let page_info = if self.page_count() > 0 {
+            let visible = self.visible_page_range(vp_h, vp_w);
+            let first = visible.start + 1;
+            let last = if visible.end > 0 { visible.end } else { 1 };
+            if first == last || visible.end - visible.start <= 1 {
+                format!(
+                    "Page {} of {}  ·  {}%",
+                    first,
+                    self.page_count(),
+                    zoom_percent,
+                )
+            } else {
+                format!(
+                    "Pages {}-{} of {}  ·  {}%",
+                    first,
+                    last,
+                    self.page_count(),
+                    zoom_percent,
+                )
+            }
+        } else {
+            "Loading...".to_string()
+        };
+
+        v_flex()
+            .id("PdfViewer")
+            .key_context("PdfViewer")
+            .track_focus(&self.focus_handle(cx))
+            .on_action(cx.listener(Self::zoom_in))
+            .on_action(cx.listener(Self::zoom_out))
+            .on_action(cx.listener(Self::reset_zoom))
+            .on_action(cx.listener(Self::fit_to_view))
+            .on_action(cx.listener(Self::zoom_to_actual_size))
+            .on_action(cx.listener(Self::copy_document_text))
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .child(
+                h_flex()
+                    .px_3()
+                    .py_1()
+                    .border_b_1()
+                    .border_color(cx.theme().colors().border)
+                    .child(Label::new(page_info).size(LabelSize::Small)),
+            )
+            .child(
+                div()
+                    .id("pdf-scroll-container")
+                    .flex_1()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.scroll_handle)
+                    .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(Self::handle_mouse_down),
+                    )
+                    .on_mouse_move(cx.listener(Self::handle_mouse_move))
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(Self::handle_mouse_up),
+                    )
+                    .cursor(CursorStyle::IBeam)
+                    .child(content)
+                    .vertical_scrollbar_for(&self.scroll_handle, window, cx),
+            )
+    }
+}
+
+impl Item for PdfViewer {
+    type Event = PdfViewEvent;
+
+    fn to_item_events(event: &Self::Event, f: &mut dyn FnMut(workspace::item::ItemEvent)) {
+        match event {
+            PdfViewEvent::TitleChanged => {
+                f(workspace::item::ItemEvent::UpdateTab);
+                f(workspace::item::ItemEvent::UpdateBreadcrumbs);
+            }
+        }
+    }
+
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        self.pdf_item.read(cx).file_name().to_string().into()
+    }
+
+    fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
+        Label::new(self.tab_content_text(params.detail.unwrap_or_default(), cx))
+            .single_line()
+            .color(params.text_color())
+            .into_any_element()
+    }
+
+    fn tab_icon(&self, _window: &Window, cx: &App) -> Option<Icon> {
+        let path = self.pdf_item.read(cx).abs_path();
+        FileIcons::get_icon(path, cx).map(Icon::from_path)
+    }
+
+    fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
+        Some(
+            self.pdf_item
+                .read(cx)
+                .abs_path()
+                .display()
+                .to_string()
+                .into(),
+        )
+    }
+
+    fn for_each_project_item(
+        &self,
+        cx: &App,
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
+    ) {
+        f(self.pdf_item.entity_id(), self.pdf_item.read(cx))
+    }
+
+    fn breadcrumb_location(&self, _cx: &App) -> ToolbarItemLocation {
+        ToolbarItemLocation::PrimaryLeft
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<(Vec<HighlightedText>, Option<Font>)> {
+        let text = self.pdf_item.read(cx).file_name().to_string();
+        Some((
+            vec![HighlightedText {
+                text,
+                highlights: None,
+            }],
+            None,
+        ))
+    }
+
+    fn can_split(&self) -> bool {
+        true
+    }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: Option<WorkspaceId>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<Entity<Self>>>
+    where
+        Self: Sized,
+    {
+        Task::ready(Some(cx.new(|cx| Self {
+            pdf_item: self.pdf_item.clone(),
+            project: self.project.clone(),
+            focus_handle: cx.focus_handle(),
+            scroll_handle: ScrollHandle::new(),
+            metadata: self.metadata.clone(),
+            rendered_pages: self.rendered_pages.clone(),
+            pages_in_flight: HashSet::new(),
+            cancel_token: Arc::new(AtomicBool::new(false)),
+            render_task: Task::ready(()),
+            render_debounce: Task::ready(()),
+            render_error: self.render_error.clone(),
+            zoom_level: self.zoom_level,
+            render_scale: self.render_scale,
+            pan_x: self.pan_x,
+            text_layouts: self.text_layouts.clone(),
+            text_extraction_task: Task::ready(()),
+            selection_start: None,
+            selection_end: None,
+            is_selecting: false,
+        })))
+    }
+
+    fn buffer_kind(&self, _cx: &App) -> workspace::item::ItemBufferKind {
+        workspace::item::ItemBufferKind::Singleton
+    }
+}
+
+impl ProjectItem for PdfViewer {
+    type Item = PdfItem;
+
+    fn for_project_item(
+        project: Entity<Project>,
+        _pane: Option<&Pane>,
+        item: Entity<Self::Item>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        Self::new(item, project, window, cx)
+    }
+
+    fn for_broken_project_item(
+        abs_path: &Path,
+        is_local: bool,
+        error: &anyhow::Error,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<InvalidItemView>
+    where
+        Self: Sized,
+    {
+        Some(InvalidItemView::new(abs_path, is_local, error, window, cx))
+    }
+}
+
+pub fn init(cx: &mut App) {
+    workspace::register_project_item::<PdfViewer>(cx);
+}

--- a/crates/pdf_viewer/src/selection.rs
+++ b/crates/pdf_viewer/src/selection.rs
@@ -1,0 +1,510 @@
+use gpui::{
+    div, px, AnyElement, ClipboardItem, Context, IntoElement, MouseButton, MouseDownEvent,
+    MouseMoveEvent, MouseUpEvent, Pixels, Point, Styled, Window,
+};
+
+use super::pdf_renderer;
+use super::{CopyDocumentText, PdfViewer, TextPosition, PAGE_GAP_PX};
+
+impl PdfViewer {
+    pub(crate) fn extract_all_text(&mut self, cx: &mut Context<Self>) {
+        let page_count = self.page_count();
+        if page_count == 0 {
+            log::debug!("pdf_viewer: extract_all_text called but page_count=0");
+            return;
+        }
+        if self.text_layouts.len() >= page_count {
+            log::debug!(
+                "pdf_viewer: extract_all_text skipped, already have {}/{} layouts",
+                self.text_layouts.len(),
+                page_count
+            );
+            return;
+        }
+        log::debug!(
+            "pdf_viewer: starting text extraction for {} pages (have {} so far)",
+            page_count,
+            self.text_layouts.len()
+        );
+
+        let pdf_bytes = self.pdf_item.read(cx).pdf_bytes().clone();
+
+        let (sender, receiver) = smol::channel::unbounded::<(usize, pdf_renderer::PageTextLayout)>();
+
+        if let Err(error) = std::thread::Builder::new()
+            .name("pdf-text-extractor".into())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                let pdf = match pdf_renderer::open_pdf(&pdf_bytes) {
+                    Ok(pdf) => pdf,
+                    Err(error) => {
+                        log::error!(
+                            "pdf_viewer: failed to open PDF for text extraction: {error:#}"
+                        );
+                        return;
+                    }
+                };
+                for page_index in 0..page_count {
+                    match pdf_renderer::extract_page_text(&pdf, page_index) {
+                        Ok(layout) => {
+                            log::debug!(
+                                "pdf_viewer: extracted {} glyphs from page {}",
+                                layout.glyphs.len(),
+                                page_index + 1
+                            );
+                            if sender.send_blocking((page_index, layout)).is_err() {
+                                log::error!("pdf_viewer: channel closed, aborting text extraction");
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            log::error!(
+                                "pdf_viewer: failed to extract text from page {}: {error:#}",
+                                page_index + 1
+                            );
+                        }
+                    }
+                }
+            })
+        {
+            log::error!("pdf_viewer: failed to spawn text extractor thread: {error:#}");
+        }
+
+        self.text_extraction_task = cx.spawn(async move |this, cx| {
+            while let Ok((page_index, layout)) = receiver.recv().await {
+                let glyph_count = layout.glyphs.len();
+                this.update(cx, |this, cx| {
+                    log::debug!(
+                        "pdf_viewer: stored text layout for page {} ({} glyphs, {}/{} pages done)",
+                        page_index + 1,
+                        glyph_count,
+                        this.text_layouts.len() + 1,
+                        this.page_count()
+                    );
+                    this.text_layouts.insert(page_index, layout);
+                    cx.notify();
+                })
+                .ok();
+            }
+            log::debug!("pdf_viewer: text extraction channel closed, all pages done");
+        });
+    }
+
+    pub(crate) fn copy_document_text(
+        &mut self,
+        _: &CopyDocumentText,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let page_count = self.page_count();
+        if page_count == 0 {
+            return;
+        }
+
+        if let (Some(start), Some(end)) = (self.selection_start, self.selection_end) {
+            if start != end {
+                let (start, end) = if start > end {
+                    (end, start)
+                } else {
+                    (start, end)
+                };
+
+                let mut selected_text = String::new();
+                for page_index in start.page..=end.page {
+                    if let Some(layout) = self.text_layouts.get(&page_index) {
+                        let page_start = if page_index == start.page {
+                            start.glyph_index
+                        } else {
+                            0
+                        };
+                        let page_end = if page_index == end.page {
+                            end.glyph_index
+                        } else {
+                            layout.glyphs.len().saturating_sub(1)
+                        };
+                        if !selected_text.is_empty() {
+                            selected_text.push('\n');
+                        }
+                        selected_text.push_str(&layout.selected_text(page_start, page_end));
+                    }
+                }
+                cx.write_to_clipboard(ClipboardItem::new_string(selected_text));
+                log::debug!(
+                    "pdf_viewer: copied selected text (pages {}-{}) to clipboard",
+                    start.page + 1,
+                    end.page + 1
+                );
+                return;
+            }
+        }
+
+        if self.text_layouts.len() >= page_count {
+            let mut full_text = String::new();
+            for page_index in 0..page_count {
+                if !full_text.is_empty() {
+                    full_text.push_str("\n\n");
+                }
+                if let Some(layout) = self.text_layouts.get(&page_index) {
+                    full_text.push_str(&layout.full_text());
+                }
+            }
+            cx.write_to_clipboard(ClipboardItem::new_string(full_text));
+            log::debug!(
+                "pdf_viewer: copied text from {} pages to clipboard",
+                page_count
+            );
+        } else {
+            log::debug!(
+                "pdf_viewer: text extraction in progress ({}/{}), starting extraction",
+                self.text_layouts.len(),
+                page_count
+            );
+            self.extract_all_text(cx);
+        }
+    }
+
+    pub(crate) fn point_to_text_position(
+        &self,
+        window_position: Point<Pixels>,
+    ) -> Option<TextPosition> {
+        let dimensions = self.page_dimensions();
+        if dimensions.is_empty() {
+            log::debug!("pdf_viewer: hit test — no page dimensions");
+            return None;
+        }
+
+        let bounds = self.scroll_handle.bounds();
+        let scroll_offset = self.scroll_handle.offset();
+
+        let container_width: f32 = {
+            let w: f32 = bounds.size.width.into();
+            if w > 0.0 { w } else {
+                log::debug!("pdf_viewer: hit test — container_width=0");
+                return None;
+            }
+        };
+        let viewport_height: f32 = {
+            let h: f32 = bounds.size.height.into();
+            if h > 0.0 { h } else { 800.0 }
+        };
+
+        let window_x: f32 = window_position.x.into();
+        let window_y: f32 = window_position.y.into();
+        let bounds_origin_x: f32 = bounds.origin.x.into();
+        let bounds_origin_y: f32 = bounds.origin.y.into();
+        let scroll_offset_y: f32 = scroll_offset.y.into();
+
+        let content_y = (window_y - bounds_origin_y) + scroll_offset_y.abs();
+
+        let total_content_h = self.total_content_height(container_width);
+        let centering_pad = if total_content_h < viewport_height {
+            (viewport_height - total_content_h) / 2.0
+        } else {
+            0.0
+        };
+
+        let content_y_adjusted = content_y - centering_pad;
+
+        log::debug!(
+            "pdf_viewer: hit test — window=({:.0},{:.0}) bounds_origin=({:.0},{:.0}) \
+             scroll_y={:.0} content_y={:.0} centering_pad={:.0} content_y_adjusted={:.0} \
+             container_width={:.0} viewport_height={:.0} total_content_h={:.0} \
+             text_layouts_count={} zoom={:.2}",
+            window_x, window_y,
+            bounds_origin_x, bounds_origin_y,
+            scroll_offset_y,
+            content_y,
+            centering_pad,
+            content_y_adjusted,
+            container_width, viewport_height, total_content_h,
+            self.text_layouts.len(),
+            self.zoom_level,
+        );
+
+        if content_y_adjusted < 0.0 {
+            log::debug!("pdf_viewer: hit test — above content (content_y_adjusted < 0)");
+            return None;
+        }
+
+        let mut accumulated_y = 0.0_f32;
+        let mut target_page = None;
+
+        for (index, dim) in dimensions.iter().enumerate() {
+            let page_height = Self::display_height(dim, container_width, self.zoom_level);
+            let page_top = accumulated_y;
+            let page_bottom = accumulated_y + page_height;
+
+            if content_y_adjusted >= page_top && content_y_adjusted < page_bottom {
+                target_page = Some((index, dim, page_top));
+                break;
+            }
+
+            accumulated_y = page_bottom + PAGE_GAP_PX;
+
+            if content_y_adjusted < accumulated_y {
+                log::debug!(
+                    "pdf_viewer: hit test — in gap between pages {} and {}",
+                    index + 1, index + 2
+                );
+                return None;
+            }
+        }
+
+        let (page_index, page_dim, page_top_y) = match target_page {
+            Some(t) => t,
+            None => {
+                log::debug!("pdf_viewer: hit test — below all pages");
+                return None;
+            }
+        };
+
+        let page_local_y = content_y_adjusted - page_top_y;
+
+        let fit_scale = if page_dim.width > 0.0 {
+            container_width / page_dim.width
+        } else {
+            1.0
+        };
+        let scale = fit_scale * self.zoom_level;
+        let page_display_width = page_dim.width * scale;
+
+        let page_left_in_container = (container_width - page_display_width) / 2.0;
+        let pan_x_f32: f32 = self.pan_x.into();
+        let content_x = (window_x - bounds_origin_x) - page_left_in_container - pan_x_f32;
+
+        log::debug!(
+            "pdf_viewer: hit test — page {} (dim={:.0}x{:.0}) fit_scale={:.3} scale={:.3} \
+             page_display_width={:.0} page_left={:.0} pan_x={:.0} content_x={:.0} page_local_y={:.0}",
+            page_index + 1,
+            page_dim.width, page_dim.height,
+            fit_scale, scale,
+            page_display_width, page_left_in_container,
+            pan_x_f32,
+            content_x, page_local_y,
+        );
+
+        if content_x < 0.0 || content_x > page_display_width {
+            log::debug!(
+                "pdf_viewer: hit test — outside page horizontally (content_x={:.0}, page_width={:.0})",
+                content_x, page_display_width
+            );
+            return None;
+        }
+
+        let pdf_x = content_x / scale;
+        let pdf_y = page_local_y / scale;
+
+        log::debug!(
+            "pdf_viewer: hit test — pdf coords ({:.1}, {:.1})",
+            pdf_x, pdf_y
+        );
+
+        let layout = match self.text_layouts.get(&page_index) {
+            Some(l) => l,
+            None => {
+                log::debug!(
+                    "pdf_viewer: hit test — no text layout for page {} (have layouts for pages: {:?})",
+                    page_index + 1,
+                    self.text_layouts.keys().map(|k| k + 1).collect::<Vec<_>>()
+                );
+                return None;
+            }
+        };
+
+        log::debug!(
+            "pdf_viewer: hit test — page {} has {} glyphs",
+            page_index + 1,
+            layout.glyphs.len()
+        );
+
+        let glyph_index = match layout.glyph_index_at_point(pdf_x, pdf_y) {
+            Some(idx) => {
+                if let Some(glyph) = layout.glyphs.get(idx) {
+                    log::debug!(
+                        "pdf_viewer: hit test — matched glyph {} '{}' at ({:.1},{:.1}) w={:.1} fs={:.1}",
+                        idx, glyph.character, glyph.x, glyph.y, glyph.width, glyph.font_size
+                    );
+                }
+                idx
+            }
+            None => {
+                log::debug!("pdf_viewer: hit test — glyph_index_at_point returned None");
+                return None;
+            }
+        };
+
+        Some(TextPosition {
+            page: page_index,
+            glyph_index,
+        })
+    }
+
+    pub(crate) fn handle_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.button != MouseButton::Left {
+            return;
+        }
+
+        log::debug!(
+            "pdf_viewer: mouse_down at ({:.0},{:.0})",
+            f32::from(event.position.x),
+            f32::from(event.position.y),
+        );
+
+        if let Some(position) = self.point_to_text_position(event.position) {
+            log::debug!(
+                "pdf_viewer: selection start — page {} glyph {}",
+                position.page + 1,
+                position.glyph_index
+            );
+            self.selection_start = Some(position);
+            self.selection_end = Some(position);
+            self.is_selecting = true;
+        } else {
+            log::debug!("pdf_viewer: mouse_down — no text position found, clearing selection");
+            self.selection_start = None;
+            self.selection_end = None;
+            self.is_selecting = false;
+        }
+        cx.notify();
+    }
+
+    pub(crate) fn handle_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.is_selecting {
+            return;
+        }
+
+        if event.pressed_button != Some(MouseButton::Left) {
+            log::debug!("pdf_viewer: mouse_move — left button released, stopping selection");
+            self.is_selecting = false;
+            return;
+        }
+
+        if let Some(position) = self.point_to_text_position(event.position) {
+            log::debug!(
+                "pdf_viewer: selection drag — page {} glyph {}",
+                position.page + 1,
+                position.glyph_index
+            );
+            self.selection_end = Some(position);
+        }
+        cx.notify();
+    }
+
+    pub(crate) fn handle_mouse_up(
+        &mut self,
+        _event: &MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.is_selecting = false;
+
+        if self.selection_start == self.selection_end {
+            log::debug!("pdf_viewer: mouse_up — click without drag, clearing selection");
+            self.selection_start = None;
+            self.selection_end = None;
+        } else {
+            log::debug!(
+                "pdf_viewer: mouse_up — selection: {:?} to {:?}",
+                self.selection_start,
+                self.selection_end
+            );
+        }
+        cx.notify();
+    }
+
+    pub(crate) fn selection_highlights_for_page(
+        &self,
+        page_index: usize,
+        fit_scale: f32,
+    ) -> Vec<AnyElement> {
+        let (start, end) = match (self.selection_start, self.selection_end) {
+            (Some(start), Some(end)) if start != end => {
+                if start > end {
+                    (end, start)
+                } else {
+                    (start, end)
+                }
+            }
+            _ => return Vec::new(),
+        };
+
+        let layout = match self.text_layouts.get(&page_index) {
+            Some(layout) => layout,
+            None => return Vec::new(),
+        };
+
+        if page_index < start.page || page_index > end.page {
+            return Vec::new();
+        }
+
+        let glyph_start = if page_index == start.page {
+            start.glyph_index
+        } else {
+            0
+        };
+        let glyph_end = if page_index == end.page {
+            end.glyph_index
+        } else {
+            layout.glyphs.len().saturating_sub(1)
+        };
+
+        let scale = fit_scale * self.zoom_level;
+        let mut highlights = Vec::new();
+
+        if glyph_start <= glyph_end {
+            log::debug!(
+                "pdf_viewer: rendering {} highlights for page {} (glyphs {}..={}, scale={:.3})",
+                glyph_end - glyph_start + 1,
+                page_index + 1,
+                glyph_start,
+                glyph_end,
+                scale,
+            );
+        }
+
+        for glyph_idx in glyph_start..=glyph_end {
+            if let Some(glyph) = layout.glyphs.get(glyph_idx) {
+                let display_x = glyph.x * scale;
+                let display_width = glyph.width * scale;
+                let display_height = glyph.font_size * scale;
+                // glyph.y is the baseline; text ascenders extend above it
+                // (smaller Y in top-down coords). Shift up by ~80% of
+                // font_size to cover the main glyph body.
+                let display_y = (glyph.y - glyph.font_size * 0.8) * scale;
+
+                if glyph_idx == glyph_start {
+                    log::debug!(
+                        "pdf_viewer: first highlight glyph '{}' — pdf({:.1},{:.1}) display({:.0},{:.0}) size({:.0}x{:.0})",
+                        glyph.character,
+                        glyph.x, glyph.y,
+                        display_x, display_y,
+                        display_width, display_height,
+                    );
+                }
+
+                highlights.push(
+                    div()
+                        .absolute()
+                        .left(px(display_x))
+                        .top(px(display_y))
+                        .w(px(display_width))
+                        .h(px(display_height))
+                        .bg(gpui::rgba(0x3584e430))
+                        .into_any_element(),
+                );
+            }
+        }
+
+        highlights
+    }
+}

--- a/crates/pdf_viewer/src/toolbar.rs
+++ b/crates/pdf_viewer/src/toolbar.rs
@@ -1,0 +1,139 @@
+use gpui::{Context, EventEmitter, IntoElement, Subscription, WeakEntity, Window};
+use ui::prelude::*;
+use ui::{IconButton, IconName, IconSize, Tooltip};
+use workspace::{ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, item::ItemHandle};
+
+use super::{
+    CopyDocumentText, FitToView, PdfViewer, ResetZoom, ZoomIn, ZoomOut,
+};
+
+pub struct PdfViewToolbarControls {
+    pdf_view: Option<WeakEntity<PdfViewer>>,
+    _subscription: Option<Subscription>,
+}
+
+impl PdfViewToolbarControls {
+    pub fn new() -> Self {
+        Self {
+            pdf_view: None,
+            _subscription: None,
+        }
+    }
+}
+
+impl Render for PdfViewToolbarControls {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(pdf_view) = self.pdf_view.as_ref().and_then(|v| v.upgrade()) else {
+            return div().into_any_element();
+        };
+
+        let zoom_level = pdf_view.read(cx).zoom_level;
+        let zoom_percentage = format!("{}%", (zoom_level * 100.0).round() as i32);
+
+        h_flex()
+            .gap_1()
+            .child(
+                IconButton::new("zoom-out", IconName::Dash)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Zoom Out", &ZoomOut, cx))
+                    .on_click({
+                        let pdf_view = pdf_view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = pdf_view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.zoom_out(&ZoomOut, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                Button::new("zoom-level", zoom_percentage)
+                    .label_size(LabelSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Reset Zoom", &ResetZoom, cx))
+                    .on_click({
+                        let pdf_view = pdf_view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = pdf_view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.reset_zoom(&ResetZoom, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                IconButton::new("zoom-in", IconName::Plus)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Zoom In", &ZoomIn, cx))
+                    .on_click({
+                        let pdf_view = pdf_view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = pdf_view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.zoom_in(&ZoomIn, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                IconButton::new("fit-to-view", IconName::Maximize)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Fit to View", &FitToView, cx))
+                    .on_click({
+                        let pdf_view = pdf_view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = pdf_view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.fit_to_view(&FitToView, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                IconButton::new("copy-text", IconName::Copy)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Copy Document Text", &CopyDocumentText, cx)
+                    })
+                    .on_click({
+                        let pdf_view = pdf_view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = pdf_view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.copy_document_text(&CopyDocumentText, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .into_any_element()
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for PdfViewToolbarControls {}
+
+impl ToolbarItemView for PdfViewToolbarControls {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        self.pdf_view = None;
+        self._subscription = None;
+
+        if let Some(item) = active_pane_item.and_then(|i| i.downcast::<PdfViewer>()) {
+            self._subscription = Some(cx.observe(&item, |_, _, cx| {
+                cx.notify();
+            }));
+            self.pdf_view = Some(item.downgrade());
+            cx.notify();
+            return ToolbarItemLocation::PrimaryRight;
+        }
+
+        ToolbarItemLocation::Hidden
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -131,6 +131,7 @@ edit_prediction.workspace = true
 edit_prediction_ui.workspace = true
 http_client.workspace = true
 image_viewer.workspace = true
+pdf_viewer.workspace = true
 inspector_ui.workspace = true
 install_cli.workspace = true
 journal.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -690,6 +690,7 @@ fn main() {
 
         editor::init(cx);
         image_viewer::init(cx);
+        pdf_viewer::init(cx);
         repl::notebook::init(cx);
         diagnostics::init(cx);
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1231,6 +1231,8 @@ fn initialize_pane(
             toolbar.add_item(basedpyright_banner, window, cx);
             let image_view_toolbar = cx.new(|_| image_viewer::ImageViewToolbarControls::new());
             toolbar.add_item(image_view_toolbar, window, cx);
+            let pdf_view_toolbar = cx.new(|_| pdf_viewer::PdfViewToolbarControls::new());
+            toolbar.add_item(pdf_view_toolbar, window, cx);
         })
     });
 }


### PR DESCRIPTION
Related: https://github.com/LaurenzV/hayro/pull/1049

Adds a `pdf_viewer` crate that renders PDF files in Zed with text selection
and copy support, built on the hayro PDF library.

<img width="1115" height="1212" alt="Screenshot 2026-03-08 at 3 45 03 pm" src="https://github.com/user-attachments/assets/836e7c51-67e3-4297-b48a-99ad988be871" />

### Summary

- Opens PDF files as workspace items with page rendering, zoom, scroll, and pinch-to-zoom.
- Extracts structured text from each page using hayro's text extraction API (font size, glyph positions, Unicode mappings — no heuristic reconstruction).
- Click-and-drag text selection with per-glyph highlight rendering.
- Cmd+C copies selected text, or the full document if nothing is selected.
- Toolbar with zoom controls and a copy button.

### Crate structure

| File | Concern |
|------|---------|
| `pdf_viewer.rs` | Core viewer: loading, layout, rendering, zoom, scroll, workspace trait impls |
| `selection.rs` | Text selection: extraction, hit-testing, mouse handlers, highlights |
| `toolbar.rs` | `PdfViewToolbarControls` and its impls |
| `pdf_renderer.rs` | Hayro integration: metadata parsing, page rendering, text extraction |
| `pdf_renderer_bench.rs` | Diagnostic tests behind `test-bench` feature flag |
| `pdf_item.rs` | `ProjectItem` wrapper for PDF files |

### Notes

- The `NSEventTypeMagnify` handler in `gpui_macos/src/events.rs` (pinch-to-zoom translated to scroll events) could be split into its own PR.


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added built-in PDF viewer with text selection and copy support.
