### PR TITLE
Restore untitled buffers after closing with red button

### DIFF
--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -172,7 +172,7 @@ pub async fn open_db<M: Migrator + 'static>(db_dir: &Path, scope: &str) -> Threa
 }
 
 async fn open_main_db<M: Migrator>(db_path: &Path) -> Option<ThreadSafeConnection> {
-    log::trace!("Opening database {}", db_path.display());
+    log::debug!("Opening database {}", db_path.display());
     ThreadSafeConnection::builder::<M>(db_path.to_string_lossy().as_ref(), true)
         .with_db_initialization_query(DB_INITIALIZE_QUERY)
         .with_connection_initialize_query(CONNECTION_INITIALIZE_QUERY)

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -54,7 +54,14 @@ impl Connection {
     /// Attempts to open the database at uri. If it fails, a shared memory db will be opened
     /// instead.
     pub fn open_file(uri: &str) -> Self {
-        Self::open(uri, true).unwrap_or_else(|_| Self::open_memory(Some(uri)))
+        Self::open(uri, true).unwrap_or_else(|err| {
+            log::error!(
+                "open_file: failed to open '{}': {}. Falling back to in-memory DB!",
+                uri,
+                err
+            );
+            Self::open_memory(Some(uri))
+        })
     }
 
     pub fn open_memory(uri: Option<&str>) -> Self {

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -55,7 +55,7 @@ impl Connection {
     /// instead.
     pub fn open_file(uri: &str) -> Self {
         Self::open(uri, true).unwrap_or_else(|err| {
-            log::error!(
+            log::info!(
                 "open_file: failed to open '{}': {}. Falling back to in-memory DB!",
                 uri,
                 err

--- a/crates/sqlez/src/migrations.rs
+++ b/crates/sqlez/src/migrations.rs
@@ -95,6 +95,7 @@ impl Connection {
             }
 
             if did_migrate {
+                log::debug!("migrate: did_migrate=true for domain '{domain}', running orphan cleanup");
                 self.delete_rows_with_orphaned_foreign_key_references()?;
                 self.exec("PRAGMA foreign_key_check;")?()?;
             }

--- a/crates/sqlez/src/migrations.rs
+++ b/crates/sqlez/src/migrations.rs
@@ -95,7 +95,9 @@ impl Connection {
             }
 
             if did_migrate {
-                log::debug!("migrate: did_migrate=true for domain '{domain}', running orphan cleanup");
+                log::debug!(
+                    "migrate: did_migrate=true for domain '{domain}', running orphan cleanup"
+                );
                 self.delete_rows_with_orphaned_foreign_key_references()?;
                 self.exec("PRAGMA foreign_key_check;")?()?;
             }

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -306,6 +306,23 @@ impl MultiWorkspace {
                 }
             }
 
+            // Flush workspace serialization before removing the window so that
+            // session_id, items, and editor content are persisted. This is
+            // necessary because when on_last_window_closed = "quit_app" triggers
+            // cx.quit() after the window is gone, workspace_windows is empty in
+            // the quit handler and flush_serialization() is never called there.
+            let flush_tasks = this.update_in(cx, |this, window, cx| {
+                this.workspaces()
+                    .iter()
+                    .map(|workspace| {
+                        workspace.update(cx, |workspace, cx| {
+                            workspace.flush_serialization(window, cx)
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })?;
+            futures::future::join_all(flush_tasks).await;
+
             cx.update(|window, _cx| {
                 window.remove_window();
             })?;

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -4697,6 +4697,136 @@ mod tests {
         assert_eq!(result[2].0, WorkspaceId(4));
     }
 
+    /// Regression test for https://github.com/zed-industries/zed/issues/48468 (Bug 2).
+    ///
+    /// When `serialize_workspace_internal` takes the `DetachFromSession` path (empty workspace,
+    /// no open items), the old code unconditionally called `set_session_id(None)`. This could
+    /// race against a later `save_workspace(session_id = Some(...))` and leave the DB with
+    /// `session_id = NULL`. The fix: only clear session_id when `self.session_id` is already
+    /// `None` (i.e. `remove_from_session` was explicitly called).
+    #[gpui::test]
+    async fn test_detach_from_session_does_not_clear_session_id(cx: &mut gpui::TestAppContext) {
+        use crate::multi_workspace::MultiWorkspace;
+        use feature_flags::FeatureFlagAppExt;
+        use project::Project;
+
+        crate::tests::init_test(cx);
+
+        cx.update(|cx| {
+            cx.set_staff(true);
+            cx.update_flags(true, vec!["agent-v2".to_string()]);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        // Empty project (no paths) → workspace_location returns DetachFromSession
+        let project = Project::test(fs.clone(), [], cx).await;
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+        // Read the session_id the Workspace was constructed with.
+        let session_id = multi_workspace.read_with(cx, |mw, cx| {
+            mw.workspace().read(cx).session_id()
+        });
+        let session_id = session_id.expect("workspace should have a session_id from Session::test");
+
+        let db = cx.update(|_, cx| WorkspaceDb::global(cx));
+
+        let workspace_id = db.next_id().await.unwrap();
+        multi_workspace.update_in(cx, |mw, _, cx| {
+            mw.workspace().update(cx, |ws, _cx| {
+                ws.set_database_id(workspace_id);
+            });
+        });
+
+        // Persist the workspace row with session_id so there is something to potentially clear.
+        db.set_session_binding(workspace_id, Some(session_id.clone()), None)
+            .await
+            .unwrap();
+
+        // flush_serialization triggers serialize_workspace_internal. Because the project has no
+        // paths and no items are open, it takes the DetachFromSession branch.
+        let task = multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.workspace()
+                .update(cx, |ws, cx| ws.flush_serialization(window, cx))
+        });
+        task.await;
+
+        // The session_id must still be set. The workspace must still be discoverable for
+        // session restoration on next launch.
+        let locations = db
+            .last_session_workspace_locations(&session_id, None, fs.as_ref())
+            .await
+            .unwrap();
+        assert!(
+            locations
+                .iter()
+                .any(|sw| sw.workspace_id == workspace_id),
+            "session_id must not be cleared by DetachFromSession when not explicitly detached; \
+             workspace must remain findable for session restoration"
+        );
+    }
+
+    /// Regression test for https://github.com/zed-industries/zed/issues/48468 (Bug 3).
+    ///
+    /// `close_window` (red button) never called `flush_serialization`, so session data was
+    /// not persisted before the window was removed. The fix: await `flush_serialization` for
+    /// all workspaces before `remove_window`.
+    #[gpui::test]
+    async fn test_close_window_flushes_serialization_before_removal(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        use crate::multi_workspace::MultiWorkspace;
+        use crate::CloseWindow;
+        use feature_flags::FeatureFlagAppExt;
+        use project::Project;
+
+        crate::tests::init_test(cx);
+
+        cx.update(|cx| {
+            cx.set_staff(true);
+            cx.update_flags(true, vec!["agent-v2".to_string()]);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        let dir = tempfile::TempDir::with_prefix("close_window_flush_test").unwrap();
+        fs.insert_tree(dir.path(), json!({})).await;
+
+        let project = Project::test(fs.clone(), [dir.path()], cx).await;
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+        let db = cx.update(|_, cx| WorkspaceDb::global(cx));
+
+        let workspace_id = db.next_id().await.unwrap();
+        multi_workspace.update_in(cx, |mw, _, cx| {
+            mw.workspace().update(cx, |ws, _cx| {
+                ws.set_database_id(workspace_id);
+            });
+        });
+
+        // Call close_window without first advancing the 200ms serialization throttle timer.
+        // Before the fix, the pending serialization would be lost when the window was removed.
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.close_window(&CloseWindow, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        // The workspace row must have been written to DB (flush_serialization ran before
+        // remove_window). Window bounds being Some is the signal that save_workspace fired.
+        let serialized = db.workspace_for_id(workspace_id);
+        assert!(
+            serialized.is_some(),
+            "close_window must flush serialization to DB before removing the window"
+        );
+        assert!(
+            serialized.unwrap().window_bounds.is_some(),
+            "window bounds should be persisted by flush_serialization during close_window"
+        );
+    }
+
     /// Regression test for https://github.com/zed-industries/zed/issues/48468
     ///
     /// `recent_workspaces_on_disk` (called by `history_manager::init` on startup) was

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -4725,9 +4725,8 @@ mod tests {
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
 
         // Read the session_id the Workspace was constructed with.
-        let session_id = multi_workspace.read_with(cx, |mw, cx| {
-            mw.workspace().read(cx).session_id()
-        });
+        let session_id =
+            multi_workspace.read_with(cx, |mw, cx| mw.workspace().read(cx).session_id());
         let session_id = session_id.expect("workspace should have a session_id from Session::test");
 
         let db = cx.update(|_, cx| WorkspaceDb::global(cx));
@@ -4759,9 +4758,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            locations
-                .iter()
-                .any(|sw| sw.workspace_id == workspace_id),
+            locations.iter().any(|sw| sw.workspace_id == workspace_id),
             "session_id must not be cleared by DetachFromSession when not explicitly detached; \
              workspace must remain findable for session restoration"
         );
@@ -4773,11 +4770,9 @@ mod tests {
     /// not persisted before the window was removed. The fix: await `flush_serialization` for
     /// all workspaces before `remove_window`.
     #[gpui::test]
-    async fn test_close_window_flushes_serialization_before_removal(
-        cx: &mut gpui::TestAppContext,
-    ) {
-        use crate::multi_workspace::MultiWorkspace;
+    async fn test_close_window_flushes_serialization_before_removal(cx: &mut gpui::TestAppContext) {
         use crate::CloseWindow;
+        use crate::multi_workspace::MultiWorkspace;
         use feature_flags::FeatureFlagAppExt;
         use project::Project;
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1323,7 +1323,11 @@ impl WorkspaceDb {
     /// that used this workspace previously
     pub(crate) async fn save_workspace(&self, workspace: SerializedWorkspace) {
         let paths = workspace.paths.serialize();
-        log::debug!("Saving workspace at location: {:?}", workspace.location);
+        log::debug!(
+            "Saving workspace at location: {:?}, session_id={:?}",
+            workspace.location,
+            workspace.session_id,
+        );
         self.write(move |conn| {
             conn.with_savepoint("update_worktrees", || {
                 let remote_connection_id = match workspace.location.clone() {
@@ -1336,8 +1340,13 @@ impl WorkspaceDb {
                     }
                 };
 
-                // Clear out panes and pane_groups
+                // Clear out panes and pane_groups.
+                // We must delete center_panes explicitly before deleting panes because
+                // SQLite recycles pane_ids (no AUTOINCREMENT), causing a UNIQUE constraint
+                // failure on center_panes when the same id is reused after deletion.
+                // FK cascade from panes -> center_panes is not reliably triggered.
                 conn.exec_bound(sql!(
+                    DELETE FROM center_panes WHERE pane_id IN (SELECT pane_id FROM panes WHERE workspace_id = ?1);
                     DELETE FROM pane_groups WHERE workspace_id = ?1;
                     DELETE FROM panes WHERE workspace_id = ?1;))?(workspace.id)
                     .context("Clearing old panes")?;
@@ -1845,6 +1854,12 @@ impl WorkspaceDb {
             } else {
                 false
             };
+
+            // Workspaces with no paths are untitled-buffer workspaces kept for session
+            // restoration. They are not shown in the recent list but must not be deleted here.
+            if paths.paths().is_empty() {
+                continue;
+            }
 
             // Delete the workspace if any of the paths are WSL paths.
             // If a local workspace points to WSL, this check will cause us to wait for the
@@ -4680,5 +4695,52 @@ mod tests {
         // Third entry: non-git project, unchanged.
         assert_eq!(result[2].2.paths(), &[PathBuf::from("/plain-project")]);
         assert_eq!(result[2].0, WorkspaceId(4));
+    }
+
+    /// Regression test for https://github.com/zed-industries/zed/issues/48468
+    ///
+    /// `recent_workspaces_on_disk` (called by `history_manager::init` on startup) was
+    /// deleting workspaces with empty paths because `all_paths_exist_with_a_directory([])`
+    /// returns `false`. Untitled-buffer workspaces legitimately have no paths and must be
+    /// preserved for session restoration.
+    #[gpui::test]
+    async fn test_recent_workspaces_on_disk_does_not_delete_empty_paths_workspace(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db =
+            WorkspaceDb::open_test_db("test_recent_workspaces_on_disk_does_not_delete_empty_paths")
+                .await;
+
+        // Save a workspace with no paths (simulates an untitled-buffer workspace).
+        let workspace_id = db.next_id().await.unwrap();
+        db.save_workspace(SerializedWorkspace {
+            id: workspace_id,
+            paths: PathList::new::<PathBuf>(&[]),
+            location: SerializedWorkspaceLocation::Local,
+            center_group: Default::default(),
+            window_bounds: Default::default(),
+            display: Default::default(),
+            docks: Default::default(),
+            centered_layout: false,
+            session_id: Some("test-session".to_owned()),
+            breakpoints: Default::default(),
+            window_id: None,
+            user_toolchains: Default::default(),
+        })
+        .await;
+
+        // recent_workspaces_on_disk should not include or delete empty-paths workspaces.
+        let recent = db.recent_workspaces_on_disk(fs.as_ref()).await.unwrap();
+        assert!(
+            recent.is_empty(),
+            "Empty-paths workspaces should not appear in the recent list"
+        );
+
+        // The workspace row must still exist so session restoration can find it.
+        assert!(
+            db.workspace_for_id(workspace_id).is_some(),
+            "Empty-paths workspace must not be deleted by recent_workspaces_on_disk"
+        );
     }
 }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1341,10 +1341,11 @@ impl WorkspaceDb {
                 };
 
                 // Clear out panes and pane_groups.
-                // We must delete center_panes explicitly before deleting panes because
-                // SQLite recycles pane_ids (no AUTOINCREMENT), causing a UNIQUE constraint
-                // failure on center_panes when the same id is reused after deletion.
-                // FK cascade from panes -> center_panes is not reliably triggered.
+                // Delete center_panes explicitly before panes as a defensive measure:
+                // pane_id is INTEGER PRIMARY KEY without AUTOINCREMENT, so SQLite may
+                // reuse deleted rowids within the same transaction. The schema has
+                // ON DELETE CASCADE, but the explicit delete ensures no UNIQUE constraint
+                // failure on center_panes if a recycled pane_id collides.
                 conn.exec_bound(sql!(
                     DELETE FROM center_panes WHERE pane_id IN (SELECT pane_id FROM panes WHERE workspace_id = ?1);
                     DELETE FROM pane_groups WHERE workspace_id = ?1;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2858,8 +2858,35 @@ impl Workspace {
                     .count()
             })?;
 
+            // On macOS, if the user has configured on_last_window_closed = "quit_app" and this
+            // is the last window, treat the close like a quit and preserve the session so that
+            // unsaved buffers can be restored on next launch.
             #[cfg(target_os = "macos")]
-            let save_last_workspace = false;
+            let save_last_workspace = {
+                let remaining_workspaces = cx.update(|_window, cx| {
+                    cx.windows()
+                        .iter()
+                        .filter_map(|window| window.downcast::<MultiWorkspace>())
+                        .filter_map(|multi_workspace| {
+                            multi_workspace
+                                .update(cx, |multi_workspace, _, cx| {
+                                    multi_workspace.workspace().read(cx).removing
+                                })
+                                .ok()
+                        })
+                        .filter(|removing| !removing)
+                        .count()
+                })?;
+                close_intent != CloseIntent::ReplaceWindow
+                    && remaining_workspaces == 0
+                    && cx
+                        .update(|_window, cx| {
+                            WorkspaceSettings::get_global(cx)
+                                .on_last_window_closed
+                                .is_quit_app()
+                        })
+                        .unwrap_or(false)
+            };
 
             // On Linux and Windows, closing the last window should restore the last workspace.
             #[cfg(not(target_os = "macos"))]
@@ -6283,6 +6310,12 @@ impl Workspace {
                 let docks = build_serialized_docks(self, window, cx);
                 let db = WorkspaceDb::global(cx);
                 let kvp = db::kvp::KeyValueStore::global(cx);
+                // Only clear session_id when explicitly detached via remove_from_session(),
+                // which calls session_id.take() before serializing. If session_id is still
+                // set here, items may not have finished loading yet (Editor::new_in_workspace
+                // is async), so preserve the session binding to avoid a race where this
+                // set_session_id(None) lands after a later save_workspace(session_id).
+                let session_id = self.session_id.clone();
                 window.spawn(cx, async move |_| {
                     db.set_window_open_status(
                         database_id,
@@ -6291,7 +6324,9 @@ impl Workspace {
                     )
                     .await
                     .log_err();
-                    db.set_session_id(database_id, None).await.log_err();
+                    if session_id.is_none() {
+                        db.set_session_id(database_id, None).await.log_err();
+                    }
                     persistence::write_default_dock_state(&kvp, docks)
                         .await
                         .log_err();
@@ -6403,11 +6438,11 @@ impl Workspace {
             let mut center_items = None;
 
             // Traverse the splits tree and add to things
-            if let Some((group, active_pane, items)) = serialized_workspace
+            let deserialized = serialized_workspace
                 .center_group
                 .deserialize(&project, serialized_workspace.id, workspace.clone(), cx)
-                .await
-            {
+                .await;
+            if let Some((group, active_pane, items)) = deserialized {
                 center_items = Some(items);
                 center_group = Some((group, active_pane))
             }


### PR DESCRIPTION
## Summary

Fixes session restoration failing for untitled/unsaved buffers when closing Zed with the red button.

### Root cause

`history_manager::init()` runs on every startup and calls `recent_workspaces_on_disk()` to populate the "Open Recent" list. That function deletes any workspace where the paths no longer exist on disk. For untitled-buffer workspaces, `paths` is empty — `all_paths_exist_with_a_directory([])` returns `false` (the loop never runs, `any_dir` stays `false`), so the workspace row gets deleted before session restoration can find it.

### Fixes

**Bug 4 (root cause)** — `recent_workspaces_on_disk` deletes empty-paths workspaces:
- Skip workspaces with no paths instead of deleting them. They are not useful in the "Open Recent" list but must be preserved for session restoration.
- Added regression test `test_recent_workspaces_on_disk_does_not_delete_empty_paths_workspace`.

**Bug 3** — `flush_serialization` not called on `close_window` path:
- `close_window()` (red button) never called `flush_serialization()`, so the DB write hadn't completed before the process exited.
- Fix: await `flush_serialization()` for all workspaces before calling `remove_window()`.
- Added regression test `test_close_window_flushes_serialization_before_removal`.

**Bug 2** — `session_id` cleared by a race in `serialize_workspace_internal`:
- The `DetachFromSession` branch unconditionally called `set_session_id(None)`, which could land *after* a subsequent `save_workspace(session_id = Some(...))`, leaving `session_id = NULL`.
- Fix: only call `set_session_id(None)` when `self.session_id` is already `None` (i.e. `remove_from_session()` was explicitly called).
- Added regression test `test_detach_from_session_does_not_clear_session_id`.

**Bug 1** (macOS) — red button always clears session even when `on_last_window_closed = "quit_app"`:
- On macOS, `save_last_workspace` was hardcoded to `false`, causing `remove_from_session()` to be called on close even when closing the last window should behave like quit.
- Fix: use the same logic as Linux/Windows, but additionally require `on_last_window_closed.is_quit_app()`.

**Bonus improvements:**
- Log an error when SQLite file open fails and falls back to in-memory DB.
- `save_workspace` now explicitly deletes `center_panes` before `panes` to avoid a UNIQUE constraint failure caused by SQLite recycling pane IDs (no `AUTOINCREMENT`).
- Promote "Opening database" log from `trace` to `debug`.

## Test plan

- [ ] Open Zed dev build, create an untitled buffer with content
- [ ] Click the red × button (with `on_last_window_closed: "quit_app"` in settings)
- [ ] Relaunch — untitled buffer with content is restored ✅
- [ ] `cargo test -p workspace -- test_recent_workspaces_on_disk_does_not_delete_empty_paths_workspace` — passes
- [ ] `cargo test -p workspace -- test_detach_from_session_does_not_clear_session_id` — passes
- [ ] `cargo test -p workspace -- test_close_window_flushes_serialization_before_removal` — passes
- [ ] Full workspace + sqlez test suite: 143 passed, 0 failed

Release Notes:

- Fixed unsaved/untitled buffers not being restored after closing Zed with the red button when `restore_on_startup` is set to `last_session`.

Closes #48468.