### PR TITLE
extensions_ui: Fix extension author list overflow

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -874,6 +874,8 @@ impl ExtensionsPage {
                     .child(
                         h_flex()
                             .gap_1()
+                            .flex_1()
+                            .min_w_0()
                             .child(
                                 Icon::new(IconName::Person)
                                     .size(IconSize::XSmall)
@@ -889,6 +891,7 @@ impl ExtensionsPage {
                     .child(
                         h_flex()
                             .gap_1()
+                            .flex_shrink_0()
                             .child({
                                 let repo_url_for_tooltip = repository_url.clone();
 

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -870,12 +870,13 @@ impl ExtensionsPage {
             )
             .child(
                 h_flex()
+                    .min_w_0()
+                    .w_full()
                     .justify_between()
                     .child(
                         h_flex()
-                            .gap_1()
-                            .flex_1()
                             .min_w_0()
+                            .gap_1()
                             .child(
                                 Icon::new(IconName::Person)
                                     .size(IconSize::XSmall)


### PR DESCRIPTION
Closes #50995 

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed extension author's list overflow

<img width="1326" height="369" alt="image" src="https://github.com/user-attachments/assets/4b2cf9cb-d3c3-4d71-a4fd-9436fb7b1469" />

