### PR TITLE
git_ui: Auto-fold file diff on stage in Uncommitted Changes view

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1000,6 +1000,12 @@
     //
     // Default: 72
     "commit_title_max_length": 72,
+    // Controls whether file diffs automatically collapse/expand when
+    // staging or unstaging via the checkmark in the diff view.
+    //
+    // Choices: collapse_and_expand, collapse, none
+    // Default: collapse_and_expand
+    "stage_fold_behavior": "collapse_and_expand",
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -65,7 +65,9 @@ use project::{
 use prompt_store::{BuiltInPrompt, PromptId, PromptStore, RULES_FILE_NAMES};
 use proto::RpcError;
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsStore, StatusStyle, update_settings_file};
+use settings::{
+    Settings, SettingsStore, StageFoldBehavior, StatusStyle, update_settings_file,
+};
 use smallvec::SmallVec;
 use std::future::Future;
 use std::ops::Range;
@@ -5655,6 +5657,8 @@ impl GitPanel {
                 let git_panel = entity.downgrade();
                 let workspace = self.workspace.clone();
                 let will_stage = is_staging_or_staged != Some(true);
+                let fold_behavior =
+                    GitPanelSettings::get_global(cx).stage_fold_behavior;
                 move |_, window, cx| {
                     git_panel
                         .update(cx, |this, cx| {
@@ -5662,17 +5666,30 @@ impl GitPanel {
                             cx.stop_propagation();
                         })
                         .ok();
-                    if let Some(workspace) = workspace.upgrade() {
-                        if let Some(project_diff) =
-                            workspace.read(cx).item_of_type::<ProjectDiff>(cx)
-                        {
-                            project_diff.update(cx, |project_diff, cx| {
-                                if will_stage {
-                                    project_diff.fold_buffer(buffer_id, cx);
-                                } else {
-                                    project_diff.unfold_buffer(buffer_id, cx);
-                                }
-                            });
+                    let should_fold = will_stage
+                        && matches!(
+                            fold_behavior,
+                            StageFoldBehavior::CollapseAndExpand
+                                | StageFoldBehavior::Collapse
+                        );
+                    let should_unfold = !will_stage
+                        && matches!(
+                            fold_behavior,
+                            StageFoldBehavior::CollapseAndExpand
+                        );
+                    if should_fold || should_unfold {
+                        if let Some(workspace) = workspace.upgrade() {
+                            if let Some(project_diff) =
+                                workspace.read(cx).item_of_type::<ProjectDiff>(cx)
+                            {
+                                project_diff.update(cx, |project_diff, cx| {
+                                    if should_fold {
+                                        project_diff.fold_buffer(buffer_id, cx);
+                                    } else {
+                                        project_diff.unfold_buffer(buffer_id, cx);
+                                    }
+                                });
+                            }
                         }
                     }
                 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -45,7 +45,7 @@ use gpui::{
     UniformListScrollHandle, WeakEntity, actions, anchored, deferred, point, size, uniform_list,
 };
 use itertools::Itertools;
-use language::{Buffer, File};
+use language::{Buffer, BufferId, File};
 use language_model::{
     CompletionIntent, ConfiguredModel, LanguageModelRegistry, LanguageModelRequest,
     LanguageModelRequestMessage, Role,
@@ -5623,6 +5623,7 @@ impl GitPanel {
         &self,
         entity: &Entity<Self>,
         file: &Arc<dyn File>,
+        buffer_id: BufferId,
         _: &Window,
         cx: &App,
     ) -> Option<AnyElement> {
@@ -5652,6 +5653,8 @@ impl GitPanel {
             .on_click({
                 let entry = entry.clone();
                 let git_panel = entity.downgrade();
+                let workspace = self.workspace.clone();
+                let will_stage = is_staging_or_staged != Some(true);
                 move |_, window, cx| {
                     git_panel
                         .update(cx, |this, cx| {
@@ -5659,6 +5662,19 @@ impl GitPanel {
                             cx.stop_propagation();
                         })
                         .ok();
+                    if let Some(workspace) = workspace.upgrade() {
+                        if let Some(project_diff) =
+                            workspace.read(cx).item_of_type::<ProjectDiff>(cx)
+                        {
+                            project_diff.update(cx, |project_diff, cx| {
+                                if will_stage {
+                                    project_diff.fold_buffer(buffer_id, cx);
+                                } else {
+                                    project_diff.unfold_buffer(buffer_id, cx);
+                                }
+                            });
+                        }
+                    }
                 }
             });
         Some(
@@ -6758,7 +6774,7 @@ impl editor::Addon for GitPanelAddon {
 
     fn render_buffer_header_controls(
         &self,
-        _excerpt_info: &ExcerptBoundaryInfo,
+        excerpt_info: &ExcerptBoundaryInfo,
         buffer: &language::BufferSnapshot,
         window: &Window,
         cx: &App,
@@ -6768,7 +6784,7 @@ impl editor::Addon for GitPanelAddon {
 
         git_panel
             .read(cx)
-            .render_buffer_header_controls(&git_panel, file, window, cx)
+            .render_buffer_header_controls(&git_panel, file, excerpt_info.buffer_id(), window, cx)
     }
 }
 

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -2,7 +2,7 @@ use editor::{EditorSettings, ui_scrollbar_settings_from_raw};
 use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{RegisterSetting, Settings, StatusStyle};
+use settings::{RegisterSetting, Settings, StageFoldBehavior, StatusStyle};
 use ui::{
     px,
     scrollbars::{ScrollbarVisibility, ShowScrollbar},
@@ -31,6 +31,7 @@ pub struct GitPanelSettings {
     pub show_count_badge: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
+    pub stage_fold_behavior: StageFoldBehavior,
 }
 
 #[derive(Default)]
@@ -78,6 +79,7 @@ impl Settings for GitPanelSettings {
             show_count_badge: git_panel.show_count_badge.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
+            stage_fold_behavior: git_panel.stage_fold_behavior.unwrap(),
         }
     }
 }

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -503,6 +503,22 @@ impl ProjectDiff {
         self.branch_diff.read(cx).diff_base()
     }
 
+    pub fn fold_buffer(&self, buffer_id: BufferId, cx: &mut Context<Self>) {
+        self.editor.update(cx, |editor, cx| {
+            editor
+                .rhs_editor()
+                .update(cx, |editor, cx| editor.fold_buffers([buffer_id], cx));
+        });
+    }
+
+    pub fn unfold_buffer(&self, buffer_id: BufferId, cx: &mut Context<Self>) {
+        self.editor.update(cx, |editor, cx| {
+            editor
+                .rhs_editor()
+                .update(cx, |editor, cx| editor.unfold_buffer(buffer_id, cx));
+        });
+    }
+
     pub fn move_to_entry(
         &mut self,
         entry: GitStatusEntry,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -716,6 +716,12 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: 72
     pub commit_title_max_length: Option<usize>,
+
+    /// Controls whether file diffs automatically collapse/expand when
+    /// staging or unstaging via the checkmark in the diff view.
+    ///
+    /// Default: collapse_and_expand
+    pub stage_fold_behavior: Option<StageFoldBehavior>,
 }
 
 #[derive(
@@ -737,6 +743,28 @@ pub enum StatusStyle {
     #[default]
     Icon,
     LabelColor,
+}
+
+#[derive(
+    Default,
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum StageFoldBehavior {
+    #[default]
+    CollapseAndExpand,
+    Collapse,
+    None,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5499,7 +5499,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn git_panel_section() -> [SettingsPageItem; 15] {
+    fn git_panel_section() -> [SettingsPageItem; 16] {
         [
             SettingsPageItem::SectionHeader("Git Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5734,6 +5734,28 @@ fn panels_page() -> SettingsPage {
                             .git_panel
                             .get_or_insert_default()
                             .commit_title_max_length = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Stage Fold Behavior",
+                description: "Controls whether file diffs automatically collapse/expand when staging or unstaging via the checkmark in the diff view.",
+                field: Box::new(SettingField {
+                    json_path: Some("git_panel.stage_fold_behavior"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_panel
+                            .as_ref()?
+                            .stage_fold_behavior
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .stage_fold_behavior = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -537,6 +537,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ThinkingBlockDisplay>(render_dropdown)
         .add_basic_renderer::<settings::ImageFileSizeUnit>(render_dropdown)
         .add_basic_renderer::<settings::StatusStyle>(render_dropdown)
+        .add_basic_renderer::<settings::StageFoldBehavior>(render_dropdown)
         .add_basic_renderer::<settings::EncodingDisplayOptions>(render_dropdown)
         .add_basic_renderer::<settings::PaneSplitDirectionHorizontal>(render_dropdown)
         .add_basic_renderer::<settings::PaneSplitDirectionVertical>(render_dropdown)

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5324,6 +5324,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
     "fallback_branch_name": "main",
     "sort_by_path": false,
     "collapse_untracked_diff": false,
+    "stage_fold_behavior": "collapse_and_expand",
     "scrollbar": {
       "show": null
     },
@@ -5341,6 +5342,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `fallback_branch_name`: What branch name to use if `init.defaultBranch` is not set
 - `sort_by_path`: Whether to sort entries in the panel by path or by status (the default)
 - `collapse_untracked_diff`: Whether to collapse untracked files in the diff panel
+- `stage_fold_behavior`: Controls whether file diffs automatically collapse/expand when staging or unstaging. Can be `collapse_and_expand`, `collapse`, or `none`
 - `scrollbar`: When to show the scrollbar in the git panel
 - `starts_open`: Whether the git panel should open on startup
 


### PR DESCRIPTION
## Summary

When reviewing uncommitted changes, clicking the checkmark to stage a file leaves its diff expanded, requiring a manual collapse. This adds automatic fold/unfold behavior:

- Staging a file via the checkmark in the diff header automatically collapses its diff
- Unstaging unfolds it back so it can be reviewed again

This is controlled by a new `stage_fold_behavior` setting with three options:

| Value | Stage | Unstage |
|---|---|---|
| `collapse_and_expand` (default) | folds | unfolds |
| `collapse` | folds | no action |
| `none` | disabled | disabled |


Screenshot of the setting:

<img width="923" height="237" alt="settings sc" src="https://github.com/user-attachments/assets/fb9b7be2-6872-4245-948f-c8e417470ea8" />


Demo of the behavior:

![auto collapse-and-expand](https://github.com/user-attachments/assets/ac6f19ee-e29d-4a40-a24e-7ddaa567244b)

Settings panel:

<img width="717" height="304" alt="image" src="https://github.com/user-attachments/assets/0d635269-0cb8-4a48-b9b2-5fe0fd237511" />



Related discussion: https://github.com/zed-industries/zed/discussions/51052

## Test plan

- [ ] Open a repo with multiple changed files in the Uncommitted Changes view
- [ ] Click the checkmark to stage a file - its diff should collapse
- [ ] Click the checkmark again to unstage - its diff should expand
- [ ] Set `"stage_fold_behavior": "collapse"` - staging collapses, unstaging does nothing
- [ ] Set `"stage_fold_behavior": "none"` - no automatic fold/unfold (original behavior)
- [ ] Verify branch diff view is unaffected

Release Notes:

- Added `stage_fold_behavior` setting to auto-collapse file diffs when staging in the Uncommitted Changes view