### PR TITLE
markdown_preview: Add more navigation options

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1241,6 +1241,17 @@
     // If `enable_preview_file_from_code_navigation` or `enable_preview_multibuffer_from_code_navigation` is also true, the new tab may replace the existing one.
     "enable_keep_preview_on_code_navigation": false,
   },
+  // Settings for the markdown preview.
+  "markdown_preview": {
+    // Controls what happens when clicking a local markdown file link in the markdown preview.
+    //
+    // Options:
+    //   "ignore"   - Do nothing
+    //   "open"     - Open the linked file in the editor
+    //   "preview"  - Open the linked file as a new markdown preview tab
+    //   "navigate" - Navigate the current preview to the linked file (supports back/forward)
+    "link_click_behavior": "open"
+  },
   // Settings related to the file finder.
   "file_finder": {
     // Whether to show file icons in the file finder.

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -1,5 +1,22 @@
 use gpui::{App, actions};
+use settings::{MarkdownPreviewLinkClickBehavior, RegisterSetting, Settings};
 use workspace::Workspace;
+
+#[derive(RegisterSetting)]
+pub struct MarkdownPreviewSettings {
+    pub link_click_behavior: MarkdownPreviewLinkClickBehavior,
+}
+
+impl Settings for MarkdownPreviewSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let markdown_preview = content.markdown_preview.as_ref();
+        Self {
+            link_click_behavior: markdown_preview
+                .and_then(|mp| mp.link_click_behavior)
+                .unwrap_or_default(),
+        }
+    }
+}
 
 pub mod markdown_elements;
 mod markdown_minifier;
@@ -32,6 +49,7 @@ actions!(
 );
 
 pub fn init(cx: &mut App) {
+    MarkdownPreviewSettings::register(cx);
     cx.observe_new(|workspace: &mut Workspace, window, cx| {
         let Some(window) = window else {
             return;

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -668,6 +668,15 @@ impl Item for MarkdownPreviewView {
             .unwrap_or_else(|| SharedString::from("Markdown Preview"))
     }
 
+    fn deactivated(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let path = self.current_displayed_path(cx);
+        if let Some(nav_history) = &mut self.nav_history {
+            if let Some(path) = path {
+                nav_history.push(Some(MarkdownPreviewNavigationData { path }), cx);
+            }
+        }
+    }
+
     fn set_nav_history(
         &mut self,
         history: ItemNavHistory,

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -1,22 +1,25 @@
 use std::cmp::min;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{ops::Range, path::PathBuf};
+use std::{any::Any, ops::Range, path::PathBuf};
 
 use anyhow::Result;
 use editor::scroll::Autoscroll;
 use editor::{Editor, EditorEvent, MultiBufferOffset, SelectionEffects};
+use fs::normalize_path;
 use gpui::{
     App, ClickEvent, Context, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
     IntoElement, IsZero, ListState, ParentElement, Render, RetainAllImageCache, Styled,
     Subscription, Task, WeakEntity, Window, list,
 };
 use language::LanguageRegistry;
-use settings::Settings;
+use settings::{MarkdownPreviewLinkClickBehavior, Settings};
 use theme::ThemeSettings;
 use ui::{WithScrollbar, prelude::*};
 use workspace::item::{Item, ItemHandle};
-use workspace::{Pane, Workspace};
+use workspace::{ItemNavHistory, OpenOptions, OpenVisible, Pane, Workspace};
+
+use crate::MarkdownPreviewSettings;
 
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::{CheckboxClickedEvent, MermaidState};
@@ -42,6 +45,13 @@ pub struct MarkdownPreviewView {
     mermaid_state: MermaidState,
     parsing_markdown_task: Option<Task<Result<()>>>,
     mode: MarkdownPreviewMode,
+    nav_history: Option<ItemNavHistory>,
+    navigated_path: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+struct MarkdownPreviewNavigationData {
+    path: PathBuf,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -219,6 +229,8 @@ impl MarkdownPreviewView {
                 parsing_markdown_task: None,
                 image_cache: RetainAllImageCache::new(cx),
                 mode,
+                nav_history: None,
+                navigated_path: None,
             };
 
             this.set_editor(active_editor, window, cx);
@@ -270,6 +282,8 @@ impl MarkdownPreviewView {
         {
             return;
         }
+
+        self.navigated_path = None;
 
         let subscription = cx.subscribe_in(
             &editor,
@@ -510,6 +524,115 @@ impl MarkdownPreviewView {
         }
         cx.notify();
     }
+
+    fn current_displayed_path(&self, cx: &App) -> Option<PathBuf> {
+        if let Some(path) = &self.navigated_path {
+            return Some(path.clone());
+        }
+        if let Some(state) = &self.active_editor {
+            let editor = state.editor.read(cx);
+            if let Some(file) = editor.file_at(MultiBufferOffset(0), cx) {
+                if let Some(local) = file.as_local() {
+                    return Some(local.abs_path(cx).to_path_buf());
+                }
+            }
+        }
+        None
+    }
+
+    fn open_markdown_preview_for_path(
+        &self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let workspace_weak = self.workspace.clone();
+        workspace.update(cx, |workspace, cx| {
+            let task = workspace.open_abs_path(
+                path,
+                OpenOptions {
+                    visible: Some(OpenVisible::None),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            );
+            cx.spawn_in(window, async move |_, cx| {
+                let item = task.await?;
+                cx.update(|window, cx| {
+                    if let Some(editor) = item.act_as::<Editor>(cx) {
+                        if let Some(workspace) = workspace_weak.upgrade() {
+                            workspace.update(cx, |workspace, cx| {
+                                let view = MarkdownPreviewView::create_markdown_view(
+                                    workspace, editor, window, cx,
+                                );
+                                workspace.active_pane().update(cx, |pane, cx| {
+                                    pane.add_item(Box::new(view), true, true, None, window, cx);
+                                });
+                            });
+                        }
+                    }
+                })
+            })
+            .detach_and_log_err(cx);
+        });
+    }
+
+    fn navigate_to_markdown_file(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Push current state to nav history before navigating
+        let current_path = self.current_displayed_path(cx);
+        if let Some(nav_history) = &mut self.nav_history {
+            if let Some(current_path) = current_path {
+                nav_history.push(
+                    Some(MarkdownPreviewNavigationData {
+                        path: current_path,
+                    }),
+                    cx,
+                );
+            }
+        }
+
+        self.navigated_path = Some(path.clone());
+        self.load_and_display_markdown_file(path, window, cx);
+        cx.notify();
+    }
+
+    fn load_and_display_markdown_file(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let language_registry = self.language_registry.clone();
+        let file_location = path.parent().map(|p| p.to_path_buf());
+
+        self.parsing_markdown_task = Some(cx.spawn_in(window, async move |view, cx| {
+            let contents = cx
+                .background_spawn(async move {
+                    let text = std::fs::read_to_string(&path)?;
+                    Ok::<_, anyhow::Error>(
+                        parse_markdown(&text, file_location, Some(language_registry)).await,
+                    )
+                })
+                .await?;
+
+            view.update(cx, move |view, cx| {
+                view.mermaid_state.update(&contents, cx);
+                let markdown_blocks_count = contents.children.len();
+                view.contents = Some(contents);
+                view.list_state.reset(markdown_blocks_count);
+                cx.notify();
+            })
+        }));
+    }
 }
 
 impl Focusable for MarkdownPreviewView {
@@ -528,6 +651,13 @@ impl Item for MarkdownPreviewView {
     }
 
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        if let Some(path) = &self.navigated_path {
+            let file_name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "Markdown Preview".to_string());
+            return format!("Preview {}", file_name).into();
+        }
         self.active_editor
             .as_ref()
             .map(|editor_state| {
@@ -536,6 +666,30 @@ impl Item for MarkdownPreviewView {
                 format!("Preview {}", title).into()
             })
             .unwrap_or_else(|| SharedString::from("Markdown Preview"))
+    }
+
+    fn set_nav_history(
+        &mut self,
+        history: ItemNavHistory,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        self.nav_history = Some(history);
+    }
+
+    fn navigate(
+        &mut self,
+        data: Arc<dyn Any + Send>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if let Some(nav_data) = data.downcast_ref::<MarkdownPreviewNavigationData>() {
+            self.navigated_path = Some(nav_data.path.clone());
+            self.load_and_display_markdown_file(nav_data.path.clone(), window, cx);
+            true
+        } else {
+            false
+        }
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {
@@ -601,6 +755,46 @@ impl Render for MarkdownPreviewView {
                                         });
                                         this.parse_markdown_from_active_editor(false, window, cx);
                                         cx.notify();
+                                    }
+                                },
+                            ))
+                            .with_link_clicked_callback(cx.listener(
+                                |this, link: &crate::markdown_elements::Link, window, cx| {
+                                    let crate::markdown_elements::Link::Path { path, .. } = link
+                                    else {
+                                        return;
+                                    };
+                                    let path = normalize_path(path.as_path());
+                                    let behavior = MarkdownPreviewSettings::get_global(cx)
+                                        .link_click_behavior;
+
+                                    match behavior {
+                                        MarkdownPreviewLinkClickBehavior::Ignore => {}
+                                        MarkdownPreviewLinkClickBehavior::Open => {
+                                            if let Some(workspace) = this.workspace.upgrade() {
+                                                workspace.update(cx, |workspace, cx| {
+                                                    workspace
+                                                        .open_abs_path(
+                                                            path,
+                                                            OpenOptions {
+                                                                visible: Some(OpenVisible::None),
+                                                                ..Default::default()
+                                                            },
+                                                            window,
+                                                            cx,
+                                                        )
+                                                        .detach();
+                                                });
+                                            }
+                                        }
+                                        MarkdownPreviewLinkClickBehavior::Preview => {
+                                            this.open_markdown_preview_for_path(
+                                                path, window, cx,
+                                            );
+                                        }
+                                        MarkdownPreviewLinkClickBehavior::Navigate => {
+                                            this.navigate_to_markdown_file(path, window, cx);
+                                        }
                                     }
                                 },
                             ));

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -43,6 +43,7 @@ impl CheckboxClickedEvent {
 }
 
 type CheckboxClickedCallback = Arc<Box<dyn Fn(&CheckboxClickedEvent, &mut Window, &mut App)>>;
+type LinkClickedCallback = Arc<Box<dyn Fn(&Link, &mut Window, &mut App)>>;
 
 type MermaidDiagramCache = HashMap<ParsedMarkdownMermaidDiagramContents, CachedMermaidDiagram>;
 
@@ -189,6 +190,7 @@ pub struct RenderContext<'a> {
     syntax_theme: Arc<SyntaxTheme>,
     indent: usize,
     checkbox_clicked_callback: Option<CheckboxClickedCallback>,
+    link_clicked_callback: Option<LinkClickedCallback>,
     is_last_child: bool,
     mermaid_state: &'a MermaidState,
 }
@@ -228,9 +230,18 @@ impl<'a> RenderContext<'a> {
             code_block_background_color: theme.colors().surface_background,
             code_span_background_color: theme.colors().editor_document_highlight_read_background,
             checkbox_clicked_callback: None,
+            link_clicked_callback: None,
             is_last_child: false,
             mermaid_state,
         }
+    }
+
+    pub fn with_link_clicked_callback(
+        mut self,
+        callback: impl Fn(&Link, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.link_clicked_callback = Some(Arc::new(Box::new(callback)));
+        self
     }
 
     pub fn with_checkbox_clicked_callback(
@@ -930,6 +941,7 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                     }
                 }
                 let workspace = workspace_clone.clone();
+                let link_clicked_callback = cx.link_clicked_callback.clone();
                 let element = div()
                     .child(
                         InteractiveText::new(
@@ -953,7 +965,19 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                             link_ranges,
                             move |clicked_range_ix, window, cx| match &links[clicked_range_ix] {
                                 Link::Web { url } => cx.open_url(url),
-                                Link::Path { path, .. } => {
+                                link @ Link::Path { path, .. } => {
+                                    let is_markdown = path
+                                        .extension()
+                                        .map(|ext| ext == "md" || ext == "markdown")
+                                        .unwrap_or(false);
+
+                                    if is_markdown {
+                                        if let Some(callback) = &link_clicked_callback {
+                                            callback(link, window, cx);
+                                            return;
+                                        }
+                                    }
+
                                     if let Some(workspace) = &workspace {
                                         _ = workspace.update(cx, |workspace, cx| {
                                             workspace

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -200,6 +200,7 @@ impl VsCodeSettings {
             node: self.node_binary_settings(),
             notification_panel: None,
             outline_panel: self.outline_panel_settings_content(),
+            markdown_preview: None,
             preview_tabs: self.preview_tabs_settings_content(),
             project: self.project_settings_content(),
             project_panel: self.project_panel_settings_content(),

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -107,6 +107,9 @@ pub struct SettingsContent {
 
     pub preview_tabs: Option<PreviewTabsSettingsContent>,
 
+    /// Settings for the markdown preview.
+    pub markdown_preview: Option<MarkdownPreviewSettingsContent>,
+
     pub agent: Option<AgentSettingsContent>,
     pub agent_servers: Option<AllAgentServersSettings>,
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -256,6 +256,42 @@ pub enum ShowDiagnostics {
     Copy,
     Clone,
     Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum MarkdownPreviewLinkClickBehavior {
+    /// Do nothing when a local markdown link is clicked.
+    Ignore,
+    /// Open the linked markdown file in the editor.
+    #[default]
+    Open,
+    /// Open the linked markdown file as a new markdown preview tab.
+    Preview,
+    /// Navigate the current preview to show the linked file, with back/forward support.
+    Navigate,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct MarkdownPreviewSettingsContent {
+    /// Controls what happens when clicking a local markdown file link in the markdown preview.
+    ///
+    /// Default: open
+    pub link_click_behavior: Option<MarkdownPreviewLinkClickBehavior>,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
     PartialEq,
     Default,
     Serialize,


### PR DESCRIPTION
Closes #51056

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

https://github.com/user-attachments/assets/abe2da27-f2e0-407e-8280-286ec49a813d


Release Notes:

- Adds markdown preview settings enum for how links should be handled
- Allows navigation of markdown files without leaving preview mode
- User configurable in case some people don't like the way this is handled
- Defaults to opening the markdown file as current behaviour, making this entirely opt in
