### PR TITLE
dap_adapters: Improve JavaScript debug adapter error on network failure

### DIFF
--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -6,7 +6,7 @@ use gpui::AsyncApp;
 use serde_json::Value;
 use std::{path::PathBuf, sync::OnceLock};
 use task::DebugRequest;
-use util::{ResultExt, maybe, shell::ShellKind};
+use util::{maybe, shell::ShellKind};
 
 use crate::*;
 
@@ -141,7 +141,13 @@ impl JsDebugAdapter {
                 file_name.starts_with(&file_name_prefix)
             })
             .await
-            .context("Couldn't find JavaScript dap directory")?
+            .with_context(|| {
+                format!(
+                    "JavaScript debug adapter not found in {}. \
+                     It may need to be downloaded — check your network connection and try again.",
+                    adapter_path.display()
+                )
+            })?
             .join(Self::ADAPTER_PATH)
         };
 
@@ -510,16 +516,39 @@ impl DebugAdapter for JsDebugAdapter {
     ) -> Result<DebugAdapterBinary> {
         if self.checked.set(()).is_ok() {
             delegate.output_to_console(format!("Checking latest version of {}...", self.name()));
-            if let Some(version) = self.fetch_latest_adapter_version(delegate).await.log_err() {
-                adapters::download_adapter_from_github(
-                    self.name(),
-                    version,
-                    adapters::DownloadedFileType::GzipTar,
-                    delegate.as_ref(),
-                )
-                .await?;
-            } else {
-                delegate.output_to_console(format!("{} debug adapter is up to date", self.name()));
+            match self.fetch_latest_adapter_version(delegate).await {
+                Ok(version) => {
+                    adapters::download_adapter_from_github(
+                        self.name(),
+                        version,
+                        adapters::DownloadedFileType::GzipTar,
+                        delegate.as_ref(),
+                    )
+                    .await?;
+                }
+                Err(error) => {
+                    let adapter_path =
+                        paths::debug_adapters_dir().join(self.name().as_ref());
+                    let file_name_prefix = format!("{}_", self.name());
+                    let has_cached_adapter =
+                        util::fs::find_file_name_in_dir(adapter_path.as_path(), |file_name| {
+                            file_name.starts_with(&file_name_prefix)
+                        })
+                        .await
+                        .is_some();
+
+                    if has_cached_adapter {
+                        delegate.output_to_console(format!(
+                            "Failed to fetch latest version, using cached adapter: {error}"
+                        ));
+                    } else {
+                        return Err(error).context(
+                            "Failed to download JavaScript debug adapter \
+                             (no cached version available). \
+                             Check your network connection and try again.",
+                        );
+                    }
+                }
             }
         }
 
@@ -549,6 +578,69 @@ impl DebugAdapter for JsDebugAdapter {
 
     fn prefer_thread_name(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_get_installed_binary_error_contains_path_and_guidance() {
+        // Use a path that definitely doesn't exist to simulate a missing adapter
+        let adapter_path = PathBuf::from("/tmp/nonexistent_debug_adapters/JavaScript");
+        let file_name_prefix = format!("{}_", JsDebugAdapter::ADAPTER_NAME);
+
+        let result = smol::block_on(util::fs::find_file_name_in_dir(
+            adapter_path.as_path(),
+            |file_name| file_name.starts_with(&file_name_prefix),
+        ));
+
+        assert!(result.is_none());
+
+        // Verify our error formatting matches what get_installed_binary produces
+        let error = result
+            .with_context(|| {
+                format!(
+                    "JavaScript debug adapter not found in {}. \
+                     It may need to be downloaded — check your network connection and try again.",
+                    adapter_path.display()
+                )
+            })
+            .unwrap_err();
+
+        let error_message = format!("{:#}", error);
+        assert!(
+            error_message.contains("debug_adapters"),
+            "Error should include the adapter path, got: {error_message}"
+        );
+        assert!(
+            error_message.contains("network connection"),
+            "Error should include actionable guidance, got: {error_message}"
+        );
+    }
+
+    #[test]
+    fn test_normalize_task_type() {
+        let cases = vec![
+            ("node", "pwa-node"),
+            ("pwa-node", "pwa-node"),
+            ("node-terminal", "pwa-node"),
+            ("chrome", "pwa-chrome"),
+            ("pwa-chrome", "pwa-chrome"),
+            ("edge", "pwa-msedge"),
+            ("msedge", "pwa-msedge"),
+            ("pwa-edge", "pwa-msedge"),
+            ("pwa-msedge", "pwa-msedge"),
+            ("unknown", "unknown"),
+        ];
+
+        for (input, expected) in cases {
+            let mut value = json!(input);
+            normalize_task_type(&mut value);
+            assert_eq!(value, json!(expected), "normalize_task_type({input:?})");
+        }
     }
 }
 

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -46,6 +46,15 @@ impl JsDebugAdapter {
         })
     }
 
+    async fn find_cached_adapter(&self) -> Option<PathBuf> {
+        let adapter_path = paths::debug_adapters_dir().join(self.name().as_ref());
+        let file_name_prefix = format!("{}_", self.name());
+        util::fs::find_file_name_in_dir(adapter_path.as_path(), |file_name| {
+            file_name.starts_with(&file_name_prefix)
+        })
+        .await
+    }
+
     async fn get_installed_binary(
         &self,
         delegate: &Arc<dyn DapDelegate>,
@@ -133,23 +142,17 @@ impl JsDebugAdapter {
         let adapter_path = if let Some(user_installed_path) = user_installed_path {
             user_installed_path
         } else {
-            let adapter_path = paths::debug_adapters_dir().join(self.name().as_ref());
-
-            let file_name_prefix = format!("{}_", self.name());
-
-            util::fs::find_file_name_in_dir(adapter_path.as_path(), |file_name| {
-                file_name.starts_with(&file_name_prefix)
-            })
-            .await
-            .with_context(|| {
-                format!(
-                    "{} debug adapter not found in {}. \
-                     It may need to be downloaded — check your network connection and try again.",
-                    self.name(),
-                    adapter_path.display()
-                )
-            })?
-            .join(Self::ADAPTER_PATH)
+            self.find_cached_adapter()
+                .await
+                .with_context(|| {
+                    format!(
+                        "{} debug adapter not found in {}. \
+                         It may need to be downloaded, check your network connection and try again.",
+                        self.name(),
+                        paths::debug_adapters_dir().join(self.name().as_ref()).display()
+                    )
+                })?
+                .join(Self::ADAPTER_PATH)
         };
 
         let arguments = if let Some(mut args) = user_args {
@@ -528,25 +531,14 @@ impl DebugAdapter for JsDebugAdapter {
                     .await?;
                 }
                 Err(error) => {
-                    let adapter_path =
-                        paths::debug_adapters_dir().join(self.name().as_ref());
-                    let file_name_prefix = format!("{}_", self.name());
-                    let has_cached_adapter =
-                        util::fs::find_file_name_in_dir(adapter_path.as_path(), |file_name| {
-                            file_name.starts_with(&file_name_prefix)
-                        })
-                        .await
-                        .is_some();
-
-                    if has_cached_adapter {
+                    if self.find_cached_adapter().await.is_some() {
                         delegate.output_to_console(format!(
-                            "Failed to fetch latest version, using cached adapter: {error}"
+                            "Failed to fetch latest version, using cached adapter: {error:#}"
                         ));
                     } else {
                         return Err(error).context(format!(
-                            "Failed to download {} debug adapter \
-                             (no cached version available). \
-                             Check your network connection and try again.",
+                            "Failed to download {} debug adapter and no cached version is available. \
+                             Check your network connection, or reinstall the adapter, and try again.",
                             self.name(),
                         ));
                     }

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -143,8 +143,9 @@ impl JsDebugAdapter {
             .await
             .with_context(|| {
                 format!(
-                    "JavaScript debug adapter not found in {}. \
+                    "{} debug adapter not found in {}. \
                      It may need to be downloaded — check your network connection and try again.",
+                    self.name(),
                     adapter_path.display()
                 )
             })?
@@ -542,11 +543,12 @@ impl DebugAdapter for JsDebugAdapter {
                             "Failed to fetch latest version, using cached adapter: {error}"
                         ));
                     } else {
-                        return Err(error).context(
-                            "Failed to download JavaScript debug adapter \
+                        return Err(error).context(format!(
+                            "Failed to download {} debug adapter \
                              (no cached version available). \
                              Check your network connection and try again.",
-                        );
+                            self.name(),
+                        ));
                     }
                 }
             }
@@ -585,41 +587,6 @@ impl DebugAdapter for JsDebugAdapter {
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn test_get_installed_binary_error_contains_path_and_guidance() {
-        // Use a path that definitely doesn't exist to simulate a missing adapter
-        let adapter_path = PathBuf::from("/tmp/nonexistent_debug_adapters/JavaScript");
-        let file_name_prefix = format!("{}_", JsDebugAdapter::ADAPTER_NAME);
-
-        let result = smol::block_on(util::fs::find_file_name_in_dir(
-            adapter_path.as_path(),
-            |file_name| file_name.starts_with(&file_name_prefix),
-        ));
-
-        assert!(result.is_none());
-
-        // Verify our error formatting matches what get_installed_binary produces
-        let error = result
-            .with_context(|| {
-                format!(
-                    "JavaScript debug adapter not found in {}. \
-                     It may need to be downloaded — check your network connection and try again.",
-                    adapter_path.display()
-                )
-            })
-            .unwrap_err();
-
-        let error_message = format!("{:#}", error);
-        assert!(
-            error_message.contains("debug_adapters"),
-            "Error should include the adapter path, got: {error_message}"
-        );
-        assert!(
-            error_message.contains("network connection"),
-            "Error should include actionable guidance, got: {error_message}"
-        );
-    }
 
     #[test]
     fn test_normalize_task_type() {


### PR DESCRIPTION
Closes #49269

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed JavaScript debug adapter silently failing on network errors, now falls back to cached adapter or shows a clear error message