### PR TITLE
Change behavior of search with vim mode enabled

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -648,6 +648,8 @@ impl Vim {
                     self.search = SearchState {
                         direction: searchable::Direction::Next,
                         count: 1,
+                        vim_mode_search: true,
+                        show_match_highlights: false,
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
                         prior_mode: self.mode,

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -649,7 +649,6 @@ impl Vim {
                         direction: searchable::Direction::Next,
                         count: 1,
                         vim_mode_search: true,
-                        show_match_highlights: false,
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
                         prior_mode: self.mode,

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -648,7 +648,7 @@ impl Vim {
                     self.search = SearchState {
                         direction: searchable::Direction::Next,
                         count: 1,
-                        vim_mode_search: true,
+                        cmd_f_search: false,
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
                         prior_mode: self.mode,

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -331,14 +331,8 @@ impl Vim {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;
-                // If search was initiated with vim shortcut '/', focus on editor, else if initiated
-                // via standard search shortcut, keep search bar focused (and always move by count=1).
-                if self.search.vim_mode_search {
-                    search_bar.select_match(direction, count, window, cx);
-                    search_bar.focus_editor(&Default::default(), window, cx);
-                } else {
-                    search_bar.select_match(direction, 1, window, cx);
-                }
+                search_bar.select_match(direction, count, window, cx);
+                search_bar.focus_editor(&Default::default(), window, cx);
 
                 let prior_selections: Vec<_> = self.search.prior_selections.drain(..).collect();
                 let prior_mode = self.search.prior_mode;

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -285,6 +285,7 @@ impl Vim {
             direction,
             count,
             vim_mode_search: true,
+            show_match_highlights: false,
             prior_selections,
             prior_operator: self.operator_stack.last().cloned(),
             prior_mode,
@@ -299,6 +300,7 @@ impl Vim {
         let current_mode = self.mode;
         self.search = Default::default();
         self.search.prior_mode = current_mode;
+        self.search.show_match_highlights = true;
         cx.propagate();
     }
 
@@ -956,6 +958,45 @@ mod test {
         cx.assert_editor_state("one «oneˇ» one one");
         cx.simulate_keystrokes("shift-enter");
         cx.assert_editor_state("«oneˇ» one one one");
+    }
+
+    #[gpui::test]
+    async fn test_non_vim_search_in_vim_mode(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.cx.set_state("ˇone one one one");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("cmd-f");
+        cx.run_until_parked();
+
+        cx.assert_state("«oneˇ» one one one", Mode::Visual);
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        cx.assert_state("one «oneˇ» one one", Mode::Visual);
+        cx.simulate_keystrokes("shift-enter");
+        cx.run_until_parked();
+        cx.assert_state("«oneˇ» one one one", Mode::Visual);
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+        cx.assert_state("«oneˇ» one one one", Mode::Visual);
+    }
+
+    #[gpui::test]
+    async fn test_non_vim_search_in_vim_insert_mode(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.set_state("ˇone one one one", Mode::Insert);
+        cx.run_until_parked();
+        cx.simulate_keystrokes("cmd-f");
+        cx.run_until_parked();
+
+        cx.assert_state("«oneˇ» one one one", Mode::Insert);
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        cx.assert_state("one «oneˇ» one one", Mode::Insert);
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+        cx.assert_state("one «oneˇ» one one", Mode::Insert);
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -285,7 +285,6 @@ impl Vim {
             direction,
             count,
             vim_mode_search: true,
-            show_match_highlights: false,
             prior_selections,
             prior_operator: self.operator_stack.last().cloned(),
             prior_mode,
@@ -300,7 +299,6 @@ impl Vim {
         let current_mode = self.mode;
         self.search = Default::default();
         self.search.prior_mode = current_mode;
-        self.search.show_match_highlights = true;
         cx.propagate();
     }
 

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -284,6 +284,7 @@ impl Vim {
         self.search = SearchState {
             direction,
             count,
+            vim_mode_search: true,
             prior_selections,
             prior_operator: self.operator_stack.last().cloned(),
             prior_mode,
@@ -330,8 +331,14 @@ impl Vim {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;
-                search_bar.select_match(direction, count, window, cx);
-                search_bar.focus_editor(&Default::default(), window, cx);
+                // If search was initiated with vim shortcut '/', focus on editor, else if initiated
+                // via standard search shortcut, keep search bar focused (and always move by count=1).
+                if self.search.vim_mode_search {
+                    search_bar.select_match(direction, count, window, cx);
+                    search_bar.focus_editor(&Default::default(), window, cx);
+                } else {
+                    search_bar.select_match(direction, 1, window, cx);
+                }
 
                 let prior_selections: Vec<_> = self.search.prior_selections.drain(..).collect();
                 let prior_mode = self.search.prior_mode;

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -284,7 +284,7 @@ impl Vim {
         self.search = SearchState {
             direction,
             count,
-            vim_mode_search: true,
+            cmd_f_search: false,
             prior_selections,
             prior_operator: self.operator_stack.last().cloned(),
             prior_mode,
@@ -299,6 +299,7 @@ impl Vim {
         let current_mode = self.mode;
         self.search = Default::default();
         self.search.prior_mode = current_mode;
+        self.search.cmd_f_search = true;
         cx.propagate();
     }
 

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1022,6 +1022,7 @@ impl Clone for ReplayableAction {
 pub struct SearchState {
     pub direction: Direction,
     pub count: usize,
+    pub vim_mode_search: bool,
 
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1022,7 +1022,7 @@ impl Clone for ReplayableAction {
 pub struct SearchState {
     pub direction: Direction,
     pub count: usize,
-    pub vim_mode_search: bool,
+    pub cmd_f_search: bool,
 
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1023,7 +1023,6 @@ pub struct SearchState {
     pub direction: Direction,
     pub count: usize,
     pub vim_mode_search: bool,
-    pub show_match_highlights: bool,
 
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1023,6 +1023,7 @@ pub struct SearchState {
     pub direction: Direction,
     pub count: usize,
     pub vim_mode_search: bool,
+    pub show_match_highlights: bool,
 
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -432,8 +432,12 @@ pub fn init(cx: &mut App) {
                 .and_then(|item| item.act_as::<Editor>(cx))
                 .and_then(|editor| editor.read(cx).addon::<VimAddon>().cloned());
             let Some(vim) = vim else { return };
-            vim.entity.update(cx, |_, cx| {
-                cx.defer_in(window, |vim, window, cx| vim.search_submit(window, cx))
+            vim.entity.update(cx, |vim, cx| {
+                if vim.search.vim_mode_search {
+                    cx.defer_in(window, |vim, window, cx| vim.search_submit(window, cx))
+                } else {
+                    cx.propagate()
+                }
             })
         });
         workspace.register_action(|_, _: &GoToTab, window, cx| {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2085,7 +2085,7 @@ impl Vim {
             cursor_shape: self.cursor_shape(cx),
             clip_at_line_ends: self.clip_at_line_ends(),
             collapse_matches: !HelixModeSetting::get_global(cx).0
-                && !self.search.show_match_highlights,
+                && self.search.vim_mode_search,
             input_enabled: self.editor_input_enabled(),
             expects_character_input: self.expects_character_input(),
             autoindent: self.should_autoindent(),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2084,8 +2084,7 @@ impl Vim {
         VimEditorSettingsState {
             cursor_shape: self.cursor_shape(cx),
             clip_at_line_ends: self.clip_at_line_ends(),
-            collapse_matches: !HelixModeSetting::get_global(cx).0
-                && self.search.vim_mode_search,
+            collapse_matches: !HelixModeSetting::get_global(cx).0 && self.search.vim_mode_search,
             input_enabled: self.editor_input_enabled(),
             expects_character_input: self.expects_character_input(),
             autoindent: self.should_autoindent(),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2084,7 +2084,8 @@ impl Vim {
         VimEditorSettingsState {
             cursor_shape: self.cursor_shape(cx),
             clip_at_line_ends: self.clip_at_line_ends(),
-            collapse_matches: !HelixModeSetting::get_global(cx).0,
+            collapse_matches: !HelixModeSetting::get_global(cx).0
+                && !self.search.show_match_highlights,
             input_enabled: self.editor_input_enabled(),
             expects_character_input: self.expects_character_input(),
             autoindent: self.should_autoindent(),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -433,7 +433,7 @@ pub fn init(cx: &mut App) {
                 .and_then(|editor| editor.read(cx).addon::<VimAddon>().cloned());
             let Some(vim) = vim else { return };
             vim.entity.update(cx, |vim, cx| {
-                if vim.search.vim_mode_search {
+                if !vim.search.cmd_f_search {
                     cx.defer_in(window, |vim, window, cx| vim.search_submit(window, cx))
                 } else {
                     cx.propagate()
@@ -2084,7 +2084,7 @@ impl Vim {
         VimEditorSettingsState {
             cursor_shape: self.cursor_shape(cx),
             clip_at_line_ends: self.clip_at_line_ends(),
-            collapse_matches: !HelixModeSetting::get_global(cx).0 && self.search.vim_mode_search,
+            collapse_matches: !HelixModeSetting::get_global(cx).0 && !self.search.cmd_f_search,
             input_enabled: self.editor_input_enabled(),
             expects_character_input: self.expects_character_input(),
             autoindent: self.should_autoindent(),


### PR DESCRIPTION
When vim mode is enabled, previously if Cmd-F (or platform equivalent) was pressed, enter will go to the editor's first match, and then hitting enter again goes to the next line rather than next match. This PR changes it to make enter go to the next match, which matches the convention in most other programs. The behavior when search is initiated with / is left unchanged.

This is a reopen of #35157, rebased and fixed.
Closes #7692

Release Notes:

- In vim mode, when search is triggered by the non-vim mode shortcut (cmd-f by default) enter will now behave as it does outside of vim mode.