### PR TITLE
Allow renaming task terminals via tab context menu

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1574,14 +1574,9 @@ impl Item for TerminalView {
     fn tab_extra_context_menu_actions(
         &self,
         _window: &mut Window,
-        cx: &mut Context<Self>,
+        _cx: &mut Context<Self>,
     ) -> Vec<(SharedString, Box<dyn gpui::Action>)> {
-        let terminal = self.terminal.read(cx);
-        if terminal.task().is_none() {
-            vec![("Rename".into(), Box::new(RenameTerminal))]
-        } else {
-            Vec::new()
-        }
+        vec![("Rename".into(), Box::new(RenameTerminal))]
     }
 
     fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {


### PR DESCRIPTION
## Problem

The **Rename** option in the terminal tab context menu is currently restricted to interactive terminals only. Task-spawned terminals (opened via `task::Spawn`, including those with `reveal_target: "center"`) do not offer this option.

This creates a frustrating workflow gap: users who run long-lived tools as tasks — such as `claude`, `lazygit`, `npm run dev`, or other dev servers — in the editor area cannot rename those tabs to reflect their session context.

### Concrete scenario

A developer has a `tasks.json` with a `claude` task:

```json
{
  "label": "Claude Code",
  "command": "claude",
  "use_new_terminal": true,
  "allow_concurrent_runs": true,
  "reveal": "always"
}
```

They bind `ctrl-shift-t` to:
```json
["task::Spawn", { "task_name": "Claude Code", "reveal_target": "center" }]
```

Each keypress opens a new Claude Code session in a center pane tab. They may have several such tabs open simultaneously across different projects or tasks. Without rename, all tabs are labeled identically as `Claude Code`, making it impossible to distinguish which session is working on what.

The same problem affects any long-lived task: a dev server, a REPL, an AI assistant, a database shell.

## Solution

Remove the `task().is_none()` guard from `tab_extra_context_menu_actions`. All terminal tabs — interactive or task-spawned — now offer the Rename action.

The rename mechanism itself (`RenameTerminal` action, inline editing, persistence) already works correctly. The only change is lifting the restriction that prevented task terminals from accessing it.

## Change

```diff
 fn tab_extra_context_menu_actions(
     &self,
     _window: &mut Window,
-    cx: &mut Context<Self>,
+    _cx: &mut Context<Self>,
 ) -> Vec<(SharedString, Box<dyn gpui::Action>)> {
-    let terminal = self.terminal.read(cx);
-    if terminal.task().is_none() {
-        vec![("Rename".into(), Box::new(RenameTerminal))]
-    } else {
-        Vec::new()
-    }
+    vec![("Rename".into(), Box::new(RenameTerminal))]
 }
```