### PR TITLE
auto_update: Always display update progress when requesting manual update

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -380,6 +380,10 @@ impl AutoUpdater {
 
     pub fn poll(&mut self, check_type: UpdateCheckType, cx: &mut Context<Self>) {
         if self.pending_poll.is_some() {
+            if self.update_check_type == UpdateCheckType::Automatic {
+                self.update_check_type = check_type;
+                cx.notify();
+            }
             return;
         }
         self.update_check_type = check_type;
@@ -549,7 +553,7 @@ impl AutoUpdater {
                 asset,
                 metrics_id: metrics_id.as_deref(),
                 system_id: system_id.as_deref(),
-                is_staff: is_staff,
+                is_staff,
             },
         )?;
 


### PR DESCRIPTION



Before if a user requested a manual update check while an automatic one was going we were not showing the update status as automatic ones force hide them. Now requesting a manual check while an automatic one is already going will instead make it visible.


Release Notes:

- N/A *or* Added/Fixed/Improved ...
