### PR TITLE
recent_projects: Don't panic when attempting to delete SSH server out of bounds

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1656,7 +1656,9 @@ impl RemoteServerProjects {
 
     fn delete_ssh_server(&mut self, server: SshServerIndex, cx: &mut Context<Self>) {
         self.update_settings_file(cx, move |setting, _| {
-            if let Some(connections) = setting.ssh_connections.as_mut() {
+            if let Some(connections) = setting.ssh_connections.as_mut()
+                && connections.get(server.0).is_some()
+            {
                 connections.remove(server.0);
             }
         });


### PR DESCRIPTION
Fixes ZED-517

Can be reproed by:

    Going into server options of the last server on your list.
    selecting "Remove server".
    Clicking on the button AND issuing menu::Confirm action at the same time (well, roughly the same time).

The result: OS pop-up is issued twice; if the user does confirm twice, that's when that panic is hit.

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed a potential crash when deleting SSH servers too eagerly.
