### PR TITLE
Fix active indent guide on closing block lines

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6459,6 +6459,19 @@ impl MultiBufferSnapshot {
             }
         }
 
+        // If the current row is at the end of an indented block (a closing line like `}` or `},`),
+        // we want to return the inner block as the enclosing indent, not the parent block.
+        if !target_indent.is_line_empty() && target_row.0 > 0 {
+            let prev_line_indent =
+                self.line_indent_for_row(MultiBufferRow(target_row.0 - 1));
+            if !prev_line_indent.is_line_empty()
+                && target_indent.raw_len() < prev_line_indent.raw_len()
+            {
+                target_indent = prev_line_indent;
+                target_row.0 -= 1;
+            }
+        }
+
         const SEARCH_ROW_LIMIT: u32 = 25000;
         const SEARCH_WHITESPACE_ROW_LIMIT: u32 = 2500;
         const YIELD_INTERVAL: u32 = 100;

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6462,8 +6462,7 @@ impl MultiBufferSnapshot {
         // If the current row is at the end of an indented block (a closing line like `}` or `},`),
         // we want to return the inner block as the enclosing indent, not the parent block.
         if !target_indent.is_line_empty() && target_row.0 > 0 {
-            let prev_line_indent =
-                self.line_indent_for_row(MultiBufferRow(target_row.0 - 1));
+            let prev_line_indent = self.line_indent_for_row(MultiBufferRow(target_row.0 - 1));
             if !prev_line_indent.is_line_empty()
                 && target_indent.raw_len() < prev_line_indent.raw_len()
             {

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -3715,6 +3715,85 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             }
         ))
     );
+
+    // Cursor on a closing bracket line should highlight the inner block, not the parent.
+    // This corresponds to GitHub issue #51068.
+    assert_eq!(
+        enclosing_indent(
+            indoc!(
+                "
+                fn b() {
+                    if c {
+                        let d = 2;
+                    }
+                }
+                "
+            ),
+            3,
+            cx,
+        )
+        .await,
+        Some((
+            1..2,
+            LineIndent {
+                tabs: 0,
+                spaces: 4,
+                line_blank: false,
+            }
+        ))
+    );
+
+    // Cursor on a closing bracket with trailing content (e.g. `},`)
+    assert_eq!(
+        enclosing_indent(
+            indoc!(
+                "
+                const foo = {
+                  a: {
+                    b: 1,
+                  },
+                };
+                "
+            ),
+            3,
+            cx,
+        )
+        .await,
+        Some((
+            1..2,
+            LineIndent {
+                tabs: 0,
+                spaces: 2,
+                line_blank: false,
+            }
+        ))
+    );
+
+    // Cursor on the outermost closing bracket should highlight the outer block.
+    assert_eq!(
+        enclosing_indent(
+            indoc!(
+                "
+                const foo = {
+                  a: {
+                    b: 1,
+                  },
+                };
+                "
+            ),
+            4,
+            cx,
+        )
+        .await,
+        Some((
+            0..3,
+            LineIndent {
+                tabs: 0,
+                spaces: 0,
+                line_blank: false,
+            }
+        ))
+    );
 }
 
 #[gpui::test]


### PR DESCRIPTION
Closes #51068

## Summary

- When the cursor is on a closing block line (e.g. `}`, `},`, `];`), the active indent guide now highlights the **inner block** being closed instead of the parent block, matching VSCode's behavior.
- Adds a block-end detection check in `enclosing_indent()`, symmetric to the existing block-start check: if the previous non-blank line has greater indent, adopt it as the target.

## Test plan

- [x] Added test cases to `test_enclosing_indent` covering:
  - Cursor on closing bracket `}` resolves to the inner block
  - Cursor on closing bracket with trailing content `},` (exact issue reproduction)
  - Cursor on outermost closing bracket `};` resolves correctly
- [x] CI passes all existing + new tests
- [x] Manual testing: open a `.ts` file with nested objects, place cursor on `},` line, verify the correct indent guide is highlighted


Release Notes:

- Fixed active indent guide highlighting the wrong indentation level when the cursor is on a closing block line (e.g. `}`, `},`).