### PR TITLE
PR Review Assignment Workflow Round Two

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -26,7 +26,7 @@ permissions:
 # write access to request team reviewers with GITHUB_TOKEN.
 jobs:
   assign-reviewers:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout coordinator repo
@@ -58,6 +58,7 @@ jobs:
             --rules-file team-membership-rules.yml \
             --repo "$TARGET_REPO" \
             --org zed-industries \
+            --min-association member \
             2>&1 | tee /tmp/assign-reviewers-output.txt
 
       - name: Upload output

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -7,10 +7,9 @@
 # NOTE: This file is stored in the codeowner-coordinator repo but must be deployed to
 # the zed repo at .github/workflows/assign-reviewers.yml. See INSTALL.md.
 #
-# TOKEN NOTE: Uses GITHUB_TOKEN with pull-requests:write for team reviewer
-# requests. If this returns 422 errors, the org may require a PAT with
-# read:org scope — switch to secrets.ORG_ADMIN_TOKEN per other workflows.
-# Test with a non-critical PR before relying on this in production.
+# AUTH NOTE: Uses a GitHub App (COORDINATOR_APP_ID + COORDINATOR_APP_PRIVATE_KEY)
+# to generate an ephemeral token scoped to read-only on the coordinator repo.
+# PR operations (team review requests, assignee) use the default GITHUB_TOKEN.
 
 name: Assign Reviewers
 
@@ -29,12 +28,21 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      - name: Generate coordinator repo token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.2.1
+        with:
+          app-id: ${{ vars.COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.COORDINATOR_APP_PRIVATE_KEY }}
+          repositories: codeowner-coordinator
+
       - name: Checkout coordinator repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           repository: zed-industries/codeowner-coordinator
           ref: main
           path: codeowner-coordinator
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup Python

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,69 @@
+# Assign Reviewers — Smart team assignment based on diff weight
+#
+# Triggers on PR open and ready_for_review events. Checks out the coordinator
+# repo (zed-industries/codeowner-coordinator) to access the assignment script and rules,
+# then assigns the 1-2 most relevant teams as reviewers.
+#
+# NOTE: This file is stored in the codeowner-coordinator repo but must be deployed to
+# the zed repo at .github/workflows/assign-reviewers.yml. See INSTALL.md.
+#
+# TOKEN NOTE: Uses GITHUB_TOKEN with pull-requests:write for team reviewer
+# requests. If this returns 422 errors, the org may require a PAT with
+# read:org scope — switch to secrets.ORG_ADMIN_TOKEN per other workflows.
+# Test with a non-critical PR before relying on this in production.
+
+name: Assign Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+# Only run for PRs from within the org (not forks) — fork PRs don't have
+# write access to request team reviewers with GITHUB_TOKEN.
+jobs:
+  assign-reviewers:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout coordinator repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          repository: zed-industries/codeowner-coordinator
+          ref: main
+          path: codeowner-coordinator
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.3
+
+      - name: Assign reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          cd codeowner-coordinator
+          python .github/scripts/assign-reviewers.py \
+            --pr "$PR_URL" \
+            --apply \
+            --rules-file team-membership-rules.yml \
+            --repo "$TARGET_REPO" \
+            --org zed-industries \
+            2>&1 | tee /tmp/assign-reviewers-output.txt
+
+      - name: Upload output
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: assign-reviewers-output
+          path: /tmp/assign-reviewers-output.txt
+          retention-days: 30


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate reviewer assignment for pull requests. The workflow leverages the `codeowner-coordinator` repository to intelligently assign the most relevant teams as reviewers based on the changes in the PR. This should streamline the review process and ensure the right teams are notified.

**Automated Reviewer Assignment Workflow:**

* Introduced `.github/workflows/assign-reviewers.yml`, a workflow that triggers on PR open and ready-for-review events to assign 1-2 relevant teams as reviewers using a script from the `zed-industries/codeowner-coordinator` repository.
* The workflow checks out the coordinator repo, sets up Python, installs dependencies, and runs the assignment script with the necessary environment variables.
* Reviewer assignment is only performed for PRs originating from within the organization for now.
* The output of the reviewer assignment step is maintained as an Actions artifact for later inspection or debugging.

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] ~~Added a solid test coverage and/or screenshots from doing manual testing~~
- [x] Done a self-review taking into account security and performance aspects
- [ ] ~~Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)~~

Release Notes:

- N/A
