### PR TITLE
Add missing ctrl-shift-g binding for editor::UndoSelection to the JetBrains/IntelliJ keymap on macOS

### DIFF
--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -33,6 +33,7 @@
       "cmd-+": "editor::UnfoldLines",
       "alt-shift-g": "editor::SplitSelectionIntoLines",
       "ctrl-g": ["editor::SelectNext", { "replace_newest": false }],
+      "ctrl-shift-g": "editor::UndoSelection",
       "ctrl-cmd-g": ["editor::SelectPrevious", { "replace_newest": false }],
       "cmd-/": ["editor::ToggleComments", { "advance_downwards": true }],
       "alt-up": "editor::SelectLargerSyntaxNode",


### PR DESCRIPTION
## Description:

This PR adds the missing `ctrl-shift-g` binding for editor::UndoSelection to the JetBrains/IntelliJ keymap on macOS.

## Problem

In IntelliJ IDEA, when using multiple cursors:
- ctrl+g (macOS) adds the next occurrence to the selection
- ctrl+shift+g (macOS) removes the last added occurrence from the selection

The current Zed JetBrains keymap has `ctrl-g` for SelectNext but is missing the corresponding `ctrl-shift-g` for undoing/removing the last selection.

## Reference

- Press Ctrl+G (macOS) to find and select the next occurrence [link](https://www.jetbrains.com/help/idea/multicursor.html#multiple_words)

- To remove selection from the last selected occurrence, press Ctrl+Shift+G (macOS) [link](https://www.jetbrains.com/help/idea/multicursor.html#multiple_words)


This change improves parity with IntelliJ for users transitioning to Zed.


### Demo 
https://github.com/user-attachments/assets/0c7f699f-697d-4b81-a929-53f765d254d8

Closes #ISSUE




Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

-  JetBrains macOS bindings: added the missing `ctrl-shift-g` binding for `editor::UndoSelection`
