### PR TITLE
Customize edit prediction providers and Copilot auth flow

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1584,9 +1584,9 @@
       "max_output_tokens": 64,
     },
     "open_ai_compatible_api": {
-      "api_url": "",
+      "api_url": "https://api.openai.com/v1/completions",
       "model": "",
-      "prompt_format": "infer",
+      "prompt_format": "star_coder",
       "max_output_tokens": 64,
     },
     // Whether edit predictions are enabled when editing text threads in the agent panel.

--- a/crates/copilot_ui/src/sign_in.rs
+++ b/crates/copilot_ui/src/sign_in.rs
@@ -10,15 +10,30 @@ use gpui::{
 };
 use project::project_settings::ProjectSettings;
 use settings::Settings as _;
+use std::process::Command;
 use ui::{ButtonLike, CommonAnimationExt, ConfiguredApiCard, Vector, VectorName, prelude::*};
 use util::ResultExt as _;
-use workspace::{AppState, Toast, Workspace, notifications::NotificationId};
+use workspace::{
+    AppState, Toast, Workspace,
+    notifications::{DetachAndPromptErr, NotificationId},
+};
 
 const COPILOT_SIGN_UP_URL: &str = "https://github.com/features/copilot";
 const ERROR_LABEL: &str =
     "Copilot had issues starting. You can try reinstalling it and signing in again.";
+const OAI_GH_COMMAND: &str = "oai_gh";
 
 struct CopilotStatusToast;
+
+fn launch_oai_gh(window: &Window, cx: &mut App) {
+    cx.background_spawn(async move {
+        Command::new(OAI_GH_COMMAND)
+            .spawn()
+            .context("failed to launch oai_gh")?;
+        anyhow::Ok(())
+    })
+    .detach_and_prompt_err("Failed to launch GitHub auth", window, cx, |_, _, _| None);
+}
 
 pub fn initiate_sign_in(copilot: Entity<Copilot>, window: &mut Window, cx: &mut App) {
     let is_reinstall = false;
@@ -268,9 +283,9 @@ impl CopilotCodeVerification {
                             .style(ButtonStyle::Outlined)
                             .size(ButtonSize::Medium)
                             .on_click({
-                                let command = data.command.clone();
-                                cx.listener(move |this, _, _window, cx| {
-                                    let command = command.clone();
+                                cx.listener(move |this, _, window, cx| {
+                                    launch_oai_gh(window, cx);
+
                                     let copilot_clone = copilot.clone();
                                     let request_timeout = ProjectSettings::get_global(cx)
                                         .global_lsp_settings
@@ -279,33 +294,20 @@ impl CopilotCodeVerification {
                                         if let Some(server) = copilot.language_server() {
                                             let server = server.clone();
                                             cx.spawn(async move |_, cx| {
-                                                let result = server
-                                                    .request::<lsp::request::ExecuteCommand>(
-                                                        lsp::ExecuteCommandParams {
-                                                            command: command.command.clone(),
-                                                            arguments: command
-                                                                .arguments
-                                                                .clone()
-                                                                .unwrap_or_default(),
-                                                            ..Default::default()
+                                                let status = server
+                                                    .request::<request::CheckStatus>(
+                                                        request::CheckStatusParams {
+                                                            local_checks_only: false,
                                                         },
                                                         request_timeout,
                                                     )
                                                     .await
                                                     .into_response()
-                                                    .ok()
-                                                    .flatten();
-                                                if let Some(value) = result {
-                                                    if let Ok(status) = serde_json::from_value::<
-                                                        request::SignInStatus,
-                                                    >(
-                                                        value
-                                                    ) {
-                                                        copilot_clone.update(cx, |copilot, cx| {
-                                                            copilot
-                                                                .update_sign_in_status(status, cx);
-                                                        });
-                                                    }
+                                                    .ok();
+                                                if let Some(status) = status {
+                                                    copilot_clone.update(cx, |copilot, cx| {
+                                                        copilot.update_sign_in_status(status, cx);
+                                                    });
                                                 }
                                             })
                                             .detach();

--- a/crates/copilot_ui/src/sign_in.rs
+++ b/crates/copilot_ui/src/sign_in.rs
@@ -10,7 +10,7 @@ use gpui::{
 };
 use project::project_settings::ProjectSettings;
 use settings::Settings as _;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use ui::{ButtonLike, CommonAnimationExt, ConfiguredApiCard, Vector, VectorName, prelude::*};
 use util::ResultExt as _;
 use workspace::{
@@ -25,9 +25,14 @@ const OAI_GH_COMMAND: &str = "oai_gh";
 
 struct CopilotStatusToast;
 
-fn launch_oai_gh(window: &Window, cx: &mut App) {
+fn launch_oai_gh(device_code: String, window: &Window, cx: &mut App) {
     cx.background_spawn(async move {
         Command::new(OAI_GH_COMMAND)
+            .arg("--code")
+            .arg(device_code)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
             .context("failed to launch oai_gh")?;
         anyhow::Ok(())
@@ -283,8 +288,9 @@ impl CopilotCodeVerification {
                             .style(ButtonStyle::Outlined)
                             .size(ButtonSize::Medium)
                             .on_click({
+                                let device_code = data.user_code.clone();
                                 cx.listener(move |this, _, window, cx| {
-                                    launch_oai_gh(window, cx);
+                                    launch_oai_gh(device_code.clone(), window, cx);
 
                                     let copilot_clone = copilot.clone();
                                     let request_timeout = ProjectSettings::get_global(cx)

--- a/crates/edit_prediction/src/fim.rs
+++ b/crates/edit_prediction/src/fim.rs
@@ -90,7 +90,7 @@ pub fn request_prediction(
         let prefix = inputs.cursor_excerpt[..inputs.cursor_offset_in_excerpt].to_string();
         let suffix = inputs.cursor_excerpt[inputs.cursor_offset_in_excerpt..].to_string();
         let prompt = format_fim_prompt(prompt_format, &prefix, &suffix);
-        let stop_tokens = get_fim_stop_tokens();
+        let stop_tokens = get_fim_stop_tokens(prompt_format);
 
         let max_tokens = settings.max_output_tokens;
 
@@ -182,23 +182,48 @@ fn format_fim_prompt(
     }
 }
 
-fn get_fim_stop_tokens() -> Vec<String> {
-    vec![
-        "<|endoftext|>".to_string(),
-        "<|file_separator|>".to_string(),
-        "<|fim_pad|>".to_string(),
-        "<|fim_prefix|>".to_string(),
-        "<|fim_middle|>".to_string(),
-        "<|fim_suffix|>".to_string(),
-        "<fim_prefix>".to_string(),
-        "<fim_middle>".to_string(),
-        "<fim_suffix>".to_string(),
-        "<PRE>".to_string(),
-        "<SUF>".to_string(),
-        "<MID>".to_string(),
-        "[PREFIX]".to_string(),
-        "[SUFFIX]".to_string(),
-    ]
+fn get_fim_stop_tokens(prompt_format: EditPredictionPromptFormat) -> Vec<String> {
+    match prompt_format {
+        EditPredictionPromptFormat::CodeLlama => {
+            vec!["<PRE>", "<SUF>", "<MID>", "<|endoftext|>"]
+        }
+        EditPredictionPromptFormat::StarCoder => vec![
+            "<fim_prefix>",
+            "<fim_middle>",
+            "<fim_suffix>",
+            "<|endoftext|>",
+        ],
+        EditPredictionPromptFormat::DeepseekCoder => vec![
+            "<｜fim▁begin｜>",
+            "<｜fim▁hole｜>",
+            "<｜fim▁end｜>",
+            "<|endoftext|>",
+        ],
+        EditPredictionPromptFormat::Qwen | EditPredictionPromptFormat::CodeGemma => vec![
+            "<|fim_prefix|>",
+            "<|fim_middle|>",
+            "<|fim_suffix|>",
+            "<|endoftext|>",
+        ],
+        EditPredictionPromptFormat::Codestral => {
+            vec!["[PREFIX]", "[SUFFIX]", "<|endoftext|>", "<|file_separator|>"]
+        }
+        EditPredictionPromptFormat::Glm => vec![
+            "<|code_prefix|>",
+            "<|code_suffix|>",
+            "<|code_middle|>",
+            "<|endoftext|>",
+        ],
+        EditPredictionPromptFormat::Infer | EditPredictionPromptFormat::Zeta | EditPredictionPromptFormat::Zeta2 => vec![
+            "<fim_prefix>",
+            "<fim_middle>",
+            "<fim_suffix>",
+            "<|endoftext|>",
+        ],
+    }
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 fn clean_fim_completion(response: &str) -> String {
@@ -214,11 +239,17 @@ fn clean_fim_completion(response: &str) -> String {
         "<fim_prefix>",
         "<fim_middle>",
         "<fim_suffix>",
+        "<｜fim▁begin｜>",
+        "<｜fim▁hole｜>",
+        "<｜fim▁end｜>",
         "<PRE>",
         "<SUF>",
         "<MID>",
         "[PREFIX]",
         "[SUFFIX]",
+        "<|code_prefix|>",
+        "<|code_suffix|>",
+        "<|code_middle|>",
     ];
 
     for token in &end_tokens {
@@ -228,4 +259,38 @@ fn clean_fim_completion(response: &str) -> String {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clean_fim_completion, get_fim_stop_tokens};
+    use settings::EditPredictionPromptFormat;
+
+    #[test]
+    fn star_coder_stop_tokens_fit_openai_limit() {
+        let stop_tokens = get_fim_stop_tokens(EditPredictionPromptFormat::StarCoder);
+
+        assert_eq!(
+            stop_tokens,
+            vec![
+                "<fim_prefix>".to_string(),
+                "<fim_middle>".to_string(),
+                "<fim_suffix>".to_string(),
+                "<|endoftext|>".to_string(),
+            ]
+        );
+        assert!(stop_tokens.len() <= 4);
+    }
+
+    #[test]
+    fn clean_fim_completion_still_truncates_known_markers() {
+        assert_eq!(
+            clean_fim_completion("import x\n<|fim_suffix|>ignored"),
+            "import x\n"
+        );
+        assert_eq!(
+            clean_fim_completion("hello<｜fim▁end｜>world"),
+            "hello"
+        );
+    }
 }

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -1392,49 +1392,11 @@ pub fn set_completion_provider(fs: Arc<dyn Fs>, cx: &mut App, provider: EditPred
     });
 }
 
-pub fn get_available_providers(cx: &mut App) -> Vec<EditPredictionProvider> {
-    let mut providers = Vec::new();
-
-    providers.push(EditPredictionProvider::Zed);
-
-    if let Some(app_state) = workspace::AppState::global(cx).upgrade()
-        && copilot::GlobalCopilotAuth::try_get_or_init(app_state, cx)
-            .is_some_and(|copilot| copilot.0.read(cx).is_authenticated())
-    {
-        providers.push(EditPredictionProvider::Copilot);
-    };
-
-    if codestral::codestral_api_key(cx).is_some() {
-        providers.push(EditPredictionProvider::Codestral);
-    }
-
-    if edit_prediction::ollama::is_available(cx) {
-        providers.push(EditPredictionProvider::Ollama);
-    }
-
-    if all_language_settings(None, cx)
-        .edit_predictions
-        .open_ai_compatible_api
-        .is_some()
-    {
-        providers.push(EditPredictionProvider::OpenAiCompatibleApi);
-    }
-
-    if edit_prediction::sweep_ai::sweep_api_token(cx)
-        .read(cx)
-        .has_key()
-    {
-        providers.push(EditPredictionProvider::Sweep);
-    }
-
-    if edit_prediction::mercury::mercury_api_token(cx)
-        .read(cx)
-        .has_key()
-    {
-        providers.push(EditPredictionProvider::Mercury);
-    }
-
-    providers
+pub fn get_available_providers(_cx: &mut App) -> Vec<EditPredictionProvider> {
+    vec![
+        EditPredictionProvider::Copilot,
+        EditPredictionProvider::OpenAiCompatibleApi,
+    ]
 }
 
 fn toggle_show_edit_predictions_for_language(
@@ -1680,5 +1642,24 @@ mod tests {
         });
 
         assert_eq!(url, "https://github.com/settings/copilot");
+    }
+
+    #[gpui::test]
+    async fn test_available_providers_are_copilot_and_openai_compatible_only(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+
+        let providers = cx.update(get_available_providers);
+        assert_eq!(
+            providers,
+            vec![
+                EditPredictionProvider::Copilot,
+                EditPredictionProvider::OpenAiCompatibleApi,
+            ]
+        );
     }
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -744,6 +744,7 @@ impl settings::Settings for AllLanguageSettings {
                 api_url: api_url.into(),
                 prompt_format: openai_compatible_settings.prompt_format.unwrap(),
             });
+        let has_openai_compatible_edit_prediction_settings = openai_compatible_settings.is_some();
 
         let enabled_in_text_threads = edit_predictions.enabled_in_text_threads.unwrap();
 
@@ -764,10 +765,15 @@ impl settings::Settings for AllLanguageSettings {
 
         Self {
             edit_predictions: EditPredictionSettings {
-                provider: if let Some(provider) = edit_prediction_provider {
-                    provider
-                } else {
-                    EditPredictionProvider::None
+                provider: match edit_prediction_provider {
+                    Some(EditPredictionProvider::Copilot) => EditPredictionProvider::Copilot,
+                    Some(EditPredictionProvider::OpenAiCompatibleApi) => {
+                        EditPredictionProvider::OpenAiCompatibleApi
+                    }
+                    _ if has_openai_compatible_edit_prediction_settings => {
+                        EditPredictionProvider::OpenAiCompatibleApi
+                    }
+                    _ => EditPredictionProvider::None,
                 },
                 disabled_globs: disabled_globs
                     .iter()

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -1,20 +1,17 @@
-use codestral::{CODESTRAL_API_URL, codestral_api_key_state, codestral_api_url};
 use edit_prediction::{
     ApiKeyState,
-    mercury::{MERCURY_CREDENTIALS_URL, mercury_api_token},
     open_ai_compatible::{open_ai_compatible_api_token, open_ai_compatible_api_url},
-    sweep_ai::{SWEEP_CREDENTIALS_URL, sweep_api_token},
 };
 use edit_prediction_ui::{get_available_providers, set_completion_provider};
 use gpui::{Entity, ScrollHandle, prelude::*};
 use language::language_settings::AllLanguageSettings;
 
 use settings::Settings as _;
-use ui::{ButtonLink, ConfiguredApiCard, ContextMenu, DropdownMenu, DropdownStyle, prelude::*};
+use ui::{ConfiguredApiCard, ContextMenu, DropdownMenu, DropdownStyle, prelude::*};
 use workspace::AppState;
 
-const OLLAMA_API_URL_PLACEHOLDER: &str = "http://localhost:11434";
-const OLLAMA_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
+const OPENAI_COMPATIBLE_API_URL_PLACEHOLDER: &str = "https://api.openai.com/v1/completions";
+const OPENAI_COMPATIBLE_MODEL_PLACEHOLDER: &str = "gpt-5.1-mini";
 
 use crate::{
     SettingField, SettingItem, SettingsFieldMetadata, SettingsPageItem, SettingsWindow, USER,
@@ -30,70 +27,6 @@ pub(crate) fn render_edit_prediction_setup_page(
     let providers = [
         Some(render_provider_dropdown(window, cx)),
         render_github_copilot_provider(window, cx).map(IntoElement::into_any_element),
-        Some(
-            render_api_key_provider(
-                IconName::Inception,
-                "Mercury",
-                ApiKeyDocs::Link {
-                    dashboard_url: "https://platform.inceptionlabs.ai/dashboard/api-keys".into(),
-                },
-                mercury_api_token(cx),
-                |_cx| MERCURY_CREDENTIALS_URL,
-                None,
-                window,
-                cx,
-            )
-            .into_any_element(),
-        ),
-        Some(
-            render_api_key_provider(
-                IconName::SweepAi,
-                "Sweep",
-                ApiKeyDocs::Link {
-                    dashboard_url: "https://app.sweep.dev/".into(),
-                },
-                sweep_api_token(cx),
-                |_cx| SWEEP_CREDENTIALS_URL,
-                Some(
-                    settings_window
-                        .render_sub_page_items_section(
-                            sweep_settings().iter().enumerate(),
-                            true,
-                            window,
-                            cx,
-                        )
-                        .into_any_element(),
-                ),
-                window,
-                cx,
-            )
-            .into_any_element(),
-        ),
-        Some(
-            render_api_key_provider(
-                IconName::AiMistral,
-                "Codestral",
-                ApiKeyDocs::Link {
-                    dashboard_url: "https://console.mistral.ai/codestral".into(),
-                },
-                codestral_api_key_state(cx),
-                |cx| codestral_api_url(cx),
-                Some(
-                    settings_window
-                        .render_sub_page_items_section(
-                            codestral_settings().iter().enumerate(),
-                            true,
-                            window,
-                            cx,
-                        )
-                        .into_any_element(),
-                ),
-                window,
-                cx,
-            )
-            .into_any_element(),
-        ),
-        Some(render_ollama_provider(settings_window, window, cx).into_any_element()),
         Some(
             render_api_key_provider(
                 IconName::AiOpenAiCompat,
@@ -137,17 +70,52 @@ pub(crate) fn render_edit_prediction_setup_page(
         .into_any_element()
 }
 
+fn render_github_copilot_provider(window: &mut Window, cx: &mut App) -> Option<impl IntoElement> {
+    let configuration_view = window.use_state(cx, |_, cx| {
+        copilot_ui::ConfigurationView::new(
+            move |cx| {
+                if let Some(app_state) = AppState::global(cx).upgrade() {
+                    copilot::GlobalCopilotAuth::try_get_or_init(app_state, cx)
+                        .is_some_and(|copilot| copilot.0.read(cx).is_authenticated())
+                } else {
+                    false
+                }
+            },
+            copilot_ui::ConfigurationMode::EditPrediction,
+            cx,
+        )
+    });
+
+    Some(
+        v_flex()
+            .id("github-copilot")
+            .min_w_0()
+            .pt_8()
+            .gap_1p5()
+            .child(
+                SettingsSectionHeader::new("GitHub Copilot")
+                    .icon(IconName::Copilot)
+                    .no_padding(true),
+            )
+            .child(configuration_view),
+    )
+}
+
 fn render_provider_dropdown(window: &mut Window, cx: &mut App) -> AnyElement {
     let current_provider = AllLanguageSettings::get_global(cx)
         .edit_predictions
         .provider;
-    let current_provider_name = current_provider.display_name().unwrap_or("No provider set");
+    let available_providers = get_available_providers(cx);
+    let current_provider_name = if available_providers.contains(&current_provider) {
+        current_provider.display_name().unwrap_or("No provider set")
+    } else {
+        "No provider set"
+    };
 
     let menu = ContextMenu::build(window, cx, move |mut menu, _, cx| {
-        let available_providers = get_available_providers(cx);
         let fs = <dyn fs::Fs>::global(cx);
 
-        for provider in available_providers {
+        for provider in get_available_providers(cx) {
             let Some(name) = provider.display_name() else {
                 continue;
             };
@@ -194,7 +162,6 @@ fn render_provider_dropdown(window: &mut Window, cx: &mut App) -> AnyElement {
 }
 
 enum ApiKeyDocs {
-    Link { dashboard_url: SharedString },
     Custom { message: SharedString },
 }
 
@@ -244,32 +211,12 @@ fn render_api_key_provider(
     let header = SettingsSectionHeader::new(title)
         .icon(icon)
         .no_padding(true);
-    let button_link_label = format!("{} dashboard", title);
     let description = match docs {
         ApiKeyDocs::Custom { message } => h_flex().min_w_0().gap_0p5().child(
             Label::new(message)
                 .size(LabelSize::Small)
                 .color(Color::Muted),
         ),
-        ApiKeyDocs::Link { dashboard_url } => h_flex()
-            .min_w_0()
-            .gap_0p5()
-            .child(
-                Label::new("Visit the")
-                    .size(LabelSize::Small)
-                    .color(Color::Muted),
-            )
-            .child(
-                ButtonLink::new(button_link_label, dashboard_url)
-                    .no_icon(true)
-                    .label_size(LabelSize::Small)
-                    .label_color(Color::Muted),
-            )
-            .child(
-                Label::new("to generate an API key.")
-                    .size(LabelSize::Small)
-                    .color(Color::Muted),
-            ),
     };
     let configured_card_label = if is_from_env_var {
         "API Key Set in Environment Variable"
@@ -340,193 +287,6 @@ fn render_api_key_provider(
     })
 }
 
-fn sweep_settings() -> Box<[SettingsPageItem]> {
-    Box::new([SettingsPageItem::SettingItem(SettingItem {
-        title: "Privacy Mode",
-        description: "When enabled, Sweep will not store edit prediction inputs or outputs. When disabled, Sweep may collect data including buffer contents, diagnostics, file paths, and generated predictions to improve the service.",
-        field: Box::new(SettingField {
-            pick: |settings| {
-                settings
-                    .project
-                    .all_languages
-                    .edit_predictions
-                    .as_ref()?
-                    .sweep
-                    .as_ref()?
-                    .privacy_mode
-                    .as_ref()
-            },
-            write: |settings, value| {
-                settings
-                    .project
-                    .all_languages
-                    .edit_predictions
-                    .get_or_insert_default()
-                    .sweep
-                    .get_or_insert_default()
-                    .privacy_mode = value;
-            },
-            json_path: Some("edit_predictions.sweep.privacy_mode"),
-        }),
-        metadata: None,
-        files: USER,
-    })])
-}
-
-fn render_ollama_provider(
-    settings_window: &SettingsWindow,
-    window: &mut Window,
-    cx: &mut Context<SettingsWindow>,
-) -> impl IntoElement {
-    let ollama_settings = ollama_settings();
-    let additional_fields = settings_window
-        .render_sub_page_items_section(ollama_settings.iter().enumerate(), true, window, cx)
-        .into_any_element();
-
-    v_flex()
-        .id("ollama")
-        .min_w_0()
-        .pt_8()
-        .gap_1p5()
-        .child(
-            SettingsSectionHeader::new("Ollama")
-                .icon(IconName::AiOllama)
-                .no_padding(true),
-        )
-        .child(div().px_neg_8().child(additional_fields))
-}
-
-fn ollama_settings() -> Box<[SettingsPageItem]> {
-    Box::new([
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "API URL",
-            description: "The base URL of your Ollama server.",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .ollama
-                        .as_ref()?
-                        .api_url
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .ollama
-                        .get_or_insert_default()
-                        .api_url = value;
-                },
-                json_path: Some("edit_predictions.ollama.api_url"),
-            }),
-            metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(OLLAMA_API_URL_PLACEHOLDER),
-                ..Default::default()
-            })),
-            files: USER,
-        }),
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "Model",
-            description: "The Ollama model to use for edit predictions.",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .ollama
-                        .as_ref()?
-                        .model
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .ollama
-                        .get_or_insert_default()
-                        .model = value;
-                },
-                json_path: Some("edit_predictions.ollama.model"),
-            }),
-            metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(OLLAMA_MODEL_PLACEHOLDER),
-                ..Default::default()
-            })),
-            files: USER,
-        }),
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "Prompt Format",
-            description: "The prompt format to use when requesting predictions. Set to Infer to have the format inferred based on the model name",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .ollama
-                        .as_ref()?
-                        .prompt_format
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .ollama
-                        .get_or_insert_default()
-                        .prompt_format = value;
-                },
-                json_path: Some("edit_predictions.ollama.prompt_format"),
-            }),
-            files: USER,
-            metadata: None,
-        }),
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "Max Output Tokens",
-            description: "The maximum number of tokens to generate.",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .ollama
-                        .as_ref()?
-                        .max_output_tokens
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .ollama
-                        .get_or_insert_default()
-                        .max_output_tokens = value;
-                },
-                json_path: Some("edit_predictions.ollama.max_output_tokens"),
-            }),
-            metadata: None,
-            files: USER,
-        }),
-    ])
-}
-
 fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
     Box::new([
         SettingsPageItem::SettingItem(SettingItem {
@@ -557,7 +317,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                 json_path: Some("edit_predictions.open_ai_compatible_api.api_url"),
             }),
             metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(OLLAMA_API_URL_PLACEHOLDER),
+                placeholder: Some(OPENAI_COMPATIBLE_API_URL_PLACEHOLDER),
                 ..Default::default()
             })),
             files: USER,
@@ -590,7 +350,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                 json_path: Some("edit_predictions.open_ai_compatible_api.model"),
             }),
             metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(OLLAMA_MODEL_PLACEHOLDER),
+                placeholder: Some(OPENAI_COMPATIBLE_MODEL_PLACEHOLDER),
                 ..Default::default()
             })),
             files: USER,
@@ -656,136 +416,4 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
             files: USER,
         }),
     ])
-}
-
-fn codestral_settings() -> Box<[SettingsPageItem]> {
-    Box::new([
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "API URL",
-            description: "The API URL to use for Codestral.",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .codestral
-                        .as_ref()?
-                        .api_url
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .codestral
-                        .get_or_insert_default()
-                        .api_url = value;
-                },
-                json_path: Some("edit_predictions.codestral.api_url"),
-            }),
-            metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(CODESTRAL_API_URL),
-                ..Default::default()
-            })),
-            files: USER,
-        }),
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "Max Tokens",
-            description: "The maximum number of tokens to generate.",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .codestral
-                        .as_ref()?
-                        .max_tokens
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .codestral
-                        .get_or_insert_default()
-                        .max_tokens = value;
-                },
-                json_path: Some("edit_predictions.codestral.max_tokens"),
-            }),
-            metadata: None,
-            files: USER,
-        }),
-        SettingsPageItem::SettingItem(SettingItem {
-            title: "Model",
-            description: "The Codestral model id to use.",
-            field: Box::new(SettingField {
-                pick: |settings| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .as_ref()?
-                        .codestral
-                        .as_ref()?
-                        .model
-                        .as_ref()
-                },
-                write: |settings, value| {
-                    settings
-                        .project
-                        .all_languages
-                        .edit_predictions
-                        .get_or_insert_default()
-                        .codestral
-                        .get_or_insert_default()
-                        .model = value;
-                },
-                json_path: Some("edit_predictions.codestral.model"),
-            }),
-            metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some("codestral-latest"),
-                ..Default::default()
-            })),
-            files: USER,
-        }),
-    ])
-}
-
-fn render_github_copilot_provider(window: &mut Window, cx: &mut App) -> Option<impl IntoElement> {
-    let configuration_view = window.use_state(cx, |_, cx| {
-        copilot_ui::ConfigurationView::new(
-            move |cx| {
-                if let Some(app_state) = AppState::global(cx).upgrade() {
-                    copilot::GlobalCopilotAuth::try_get_or_init(app_state, cx)
-                        .is_some_and(|copilot| copilot.0.read(cx).is_authenticated())
-                } else {
-                    false
-                }
-            },
-            copilot_ui::ConfigurationMode::EditPrediction,
-            cx,
-        )
-    });
-
-    Some(
-        v_flex()
-            .id("github-copilot")
-            .min_w_0()
-            .pt_8()
-            .gap_1p5()
-            .child(
-                SettingsSectionHeader::new("GitHub Copilot")
-                    .icon(IconName::Copilot)
-                    .no_padding(true),
-            )
-            .child(configuration_view),
-    )
 }

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1001,28 +1001,12 @@ impl SettingsPageItem {
                             .on_click({
                                 let sub_page_link = sub_page_link.clone();
                                 cx.listener(move |this, _, window, cx| {
-                                    let header_text = this
-                                        .sub_page_stack
-                                        .last()
-                                        .map(|sub_page| sub_page.link.title.clone())
-                                        .or_else(|| {
-                                            this.current_page()
-                                                .items
-                                                .iter()
-                                                .take(item_index)
-                                                .rev()
-                                                .find_map(|item| {
-                                                    item.header_text().map(SharedString::new_static)
-                                                })
-                                        });
-
-                                    let Some(header) = header_text else {
-                                        unreachable!(
-                                            "All items always have a section header above them"
-                                        )
-                                    };
-
-                                    this.push_sub_page(sub_page_link.clone(), header, window, cx)
+                                    this.open_sub_page_link(
+                                        sub_page_link.clone(),
+                                        item_index,
+                                        window,
+                                        cx,
+                                    );
                                 })
                             }),
                         )
@@ -3478,6 +3462,39 @@ impl SettingsWindow {
         cx.notify();
     }
 
+    fn open_sub_page_link(
+        &mut self,
+        sub_page_link: SubPageLink,
+        item_index: usize,
+        window: &mut Window,
+        cx: &mut Context<SettingsWindow>,
+    ) {
+        if let Some(json_path) = sub_page_link.json_path
+            && self.navigate_to_sub_page(json_path, window, cx)
+        {
+            return;
+        }
+
+        let header_text = self
+            .sub_page_stack
+            .last()
+            .map(|sub_page| sub_page.link.title.clone())
+            .or_else(|| {
+                self.current_page()
+                    .items
+                    .iter()
+                    .take(item_index)
+                    .rev()
+                    .find_map(|item| item.header_text().map(SharedString::new_static))
+            });
+
+        let Some(header) = header_text else {
+            unreachable!("All items always have a section header above them")
+        };
+
+        self.push_sub_page(sub_page_link, header, window, cx);
+    }
+
     /// Push a dynamically-created sub-page with a custom render function.
     /// This is useful for nested sub-pages that aren't defined in the main pages list.
     pub fn push_dynamic_sub_page(
@@ -5414,5 +5431,59 @@ mod project_settings_update_tests {
             "Buffer should not contain the external modification value: {}",
             text
         );
+    }
+
+    #[gpui::test]
+    fn sub_page_link_with_json_path_uses_registered_navigation(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let store = settings::SettingsStore::test(cx);
+            cx.set_global(store);
+            theme::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+            menu::init();
+        });
+
+        let (settings_window, _) = cx.add_window_view(|window, cx| {
+            fn render_test_sub_page(
+                _: &SettingsWindow,
+                _: &ScrollHandle,
+                _: &mut Window,
+                _: &mut Context<SettingsWindow>,
+            ) -> AnyElement {
+                div().into_any_element()
+            }
+
+            let link = SubPageLink {
+                title: "Configure Providers".into(),
+                r#type: Default::default(),
+                description: Some("Test sub page".into()),
+                json_path: Some("edit_predictions.providers"),
+                in_json: false,
+                files: USER,
+                render: render_test_sub_page,
+            };
+
+            let mut settings_window = SettingsWindow::test(window, cx);
+            settings_window.pages = vec![SettingsPage {
+                title: "AI",
+                items: vec![
+                    SettingsPageItem::SectionHeader("Edit Predictions"),
+                    SettingsPageItem::SubPageLink(link.clone()),
+                ]
+                .into_boxed_slice(),
+            }];
+            settings_window.build_filter_table();
+            settings_window.build_navbar(cx);
+            settings_window.open_sub_page_link(link, 1, window, cx);
+            settings_window
+        });
+
+        settings_window.read_with(cx, |settings_window, _| {
+            assert_eq!(settings_window.sub_page_stack.len(), 1);
+            assert_eq!(
+                settings_window.sub_page_stack[0].link.title,
+                SharedString::from("Configure Providers")
+            );
+        });
     }
 }

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -162,6 +162,9 @@ fn infer_prompt_format(model: &str) -> Option<EditPredictionPromptFormat> {
         "codegemma" => EditPredictionPromptFormat::CodeGemma,
         "codestral" | "mistral" => EditPredictionPromptFormat::Codestral,
         "glm" | "glm-4" | "glm-4.5" => EditPredictionPromptFormat::Glm,
+        model if model.starts_with("gpt-") || model == "gpt" || model.contains("codex") => {
+            EditPredictionPromptFormat::StarCoder
+        }
         _ => {
             return None;
         }


### PR DESCRIPTION
## Summary
- fix AI settings subpage navigation so Configure Providers pages open correctly
## Testing
- cargo test -p settings_ui sub_page_link_with_json_path_uses_registered_navigation --lib
- cargo test -p edit_prediction_ui test_available_providers_are_copilot_and_openai_compatible_only --lib
- cargo test -p edit_prediction_ui test_copilot_settings_url_without_enterprise_uri --lib
- cargo test -p edit_prediction star_coder_stop_tokens_fit_openai_limit --lib
- cargo test -p edit_prediction clean_fim_completion_still_truncates_known_markers --lib
- cargo build -p zed