### PR TITLE
edit_prediction: Support self-hosted Sweep Next Edit models

### DIFF
--- a/crates/edit_prediction/src/cursor_excerpt.rs
+++ b/crates/edit_prediction/src/cursor_excerpt.rs
@@ -27,6 +27,17 @@ pub fn compute_cursor_excerpt(
     )
 }
 
+pub fn fixed_line_window_around_cursor(
+    snapshot: &BufferSnapshot,
+    cursor: Point,
+    above: u32,
+    below: u32,
+) -> Range<Point> {
+    let start_row = cursor.row.saturating_sub(above);
+    let end_row = (cursor.row + below).min(snapshot.max_point().row);
+    Point::new(start_row, 0)..Point::new(end_row, snapshot.line_len(end_row))
+}
+
 /// Expands symmetrically from cursor, one line at a time, alternating down then up.
 /// Returns (start_row, end_row, remaining_tokens).
 fn expand_symmetric_from_cursor(
@@ -565,5 +576,34 @@ mod tests {
                 buffer
             });
         }
+    }
+
+    #[gpui::test]
+    fn test_fixed_line_window_around_cursor_start_middle_and_end(cx: &mut App) {
+        cx.new(|cx| {
+            let text = (0..30)
+                .map(|row| format!("line {row}\n"))
+                .collect::<String>()
+                .trim_end_matches('\n')
+                .to_string();
+            let buffer = Buffer::local(&text, cx);
+            let snapshot = buffer.snapshot();
+
+            let start_window = fixed_line_window_around_cursor(&snapshot, Point::new(0, 0), 10, 10);
+            assert_eq!(start_window.start.row, 0);
+            assert_eq!(start_window.end.row, 10);
+
+            let middle_window =
+                fixed_line_window_around_cursor(&snapshot, Point::new(15, 2), 10, 10);
+            assert_eq!(middle_window.start.row, 5);
+            assert_eq!(middle_window.end.row, 25);
+
+            let end_window = fixed_line_window_around_cursor(&snapshot, Point::new(29, 1), 10, 10);
+            assert_eq!(end_window.start.row, 19);
+            assert_eq!(end_window.end.row, 29);
+            assert_eq!(end_window.end.column, snapshot.line_len(29));
+
+            buffer
+        });
     }
 }

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -83,6 +83,7 @@ pub mod ollama;
 mod onboarding_modal;
 pub mod open_ai_response;
 mod prediction;
+pub mod sweep_prompt;
 
 pub mod udiff;
 
@@ -188,6 +189,7 @@ pub(crate) struct EditPredictionRejectionPayload {
 pub enum EditPredictionModel {
     Zeta,
     Fim { format: EditPredictionPromptFormat },
+    SweepPrompt,
     Mercury,
 }
 
@@ -197,6 +199,7 @@ pub struct EditPredictionModelInput {
     snapshot: BufferSnapshot,
     position: Anchor,
     events: Vec<Arc<zeta_prompt::Event>>,
+    stored_events: Vec<StoredEvent>,
     related_files: Vec<RelatedFile>,
     editable_context: Option<Task<anyhow::Result<Vec<RelatedFile>>>>,
     mode: PredictEditsMode,
@@ -1187,7 +1190,7 @@ impl EditPredictionStore {
                     .with_down(IconName::ZedPredictDown)
                     .with_error(IconName::ZedPredictError)
             }
-            EditPredictionModel::Fim { .. } => {
+            EditPredictionModel::Fim { .. } | EditPredictionModel::SweepPrompt => {
                 let settings = &all_language_settings(None, cx).edit_predictions;
                 match settings.provider {
                     EditPredictionProvider::Ollama => {
@@ -1872,7 +1875,7 @@ impl EditPredictionStore {
                     zeta::edit_prediction_accepted(self, current_prediction, cx)
                 }
             }
-            EditPredictionModel::Fim { .. } => {}
+            EditPredictionModel::Fim { .. } | EditPredictionModel::SweepPrompt => {}
         }
     }
 
@@ -2283,7 +2286,7 @@ impl EditPredictionStore {
                     cx,
                 );
             }
-            EditPredictionModel::Fim { .. } => {}
+            EditPredictionModel::SweepPrompt | EditPredictionModel::Fim { .. } => {}
         }
     }
 
@@ -2846,6 +2849,7 @@ impl EditPredictionStore {
             snapshot,
             position,
             events,
+            stored_events: stored_events.clone(),
             related_files,
             editable_context,
             mode,
@@ -2891,6 +2895,7 @@ impl EditPredictionStore {
                 )
             }
             EditPredictionModel::Fim { format } => fim::request_prediction(inputs, format, cx),
+            EditPredictionModel::SweepPrompt => sweep_prompt::request_prediction(inputs, cx),
             EditPredictionModel::Mercury => {
                 self.mercury
                     .request_prediction(inputs, self.credentials_provider.clone(), cx)

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -3405,7 +3405,6 @@ async fn make_sweep_prompt_test_ep_store(
                                 model: Some("sweep-next-edit-1.5b".to_string()),
                                 prompt_format: Some(settings::EditPredictionPromptFormat::Sweep),
                                 max_output_tokens: Some(64),
-                                ..Default::default()
                             },
                         ),
                         ..Default::default()
@@ -3431,7 +3430,9 @@ async fn make_sweep_prompt_test_ep_store(
                 match (method, uri.as_str()) {
                     (Method::POST, "/v1/completions") => {
                         let mut body_bytes = Vec::new();
-                        body.read_to_end(&mut body_bytes).await.ok();
+                        body.read_to_end(&mut body_bytes)
+                            .await
+                            .expect("fake completion server should read request body");
                         let request: RawCompletionRequest =
                             serde_json::from_slice(&body_bytes).unwrap();
                         requests.lock().push(request);

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -3206,7 +3206,10 @@ async fn apply_edit_prediction(
     let buffer = cx.new(|cx| Buffer::local(buffer_content, cx));
     let (ep_store, response) = make_test_ep_store(&project, cx).await;
     *response.lock() = completion_response.to_string();
-    let edit_prediction = run_edit_prediction(&buffer, &project, &ep_store, cx).await;
+    let edit_prediction = run_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx)
+        .await
+        .expect("expected an edit prediction")
+        .prediction;
     buffer.update(cx, |buffer, cx| {
         buffer.edit(edit_prediction.edits.iter().cloned(), None, cx)
     });
@@ -3217,9 +3220,10 @@ async fn run_edit_prediction(
     buffer: &Entity<Buffer>,
     project: &Entity<Project>,
     ep_store: &Entity<EditPredictionStore>,
+    cursor: Point,
     cx: &mut TestAppContext,
-) -> EditPrediction {
-    let cursor = buffer.read_with(cx, |buffer, _| buffer.anchor_before(Point::new(1, 0)));
+) -> Option<EditPredictionResult> {
+    let cursor = buffer.read_with(cx, |buffer, _| buffer.anchor_before(cursor));
     ep_store.update(cx, |ep_store, cx| {
         ep_store.register_buffer(buffer, &project, cx)
     });
@@ -3233,31 +3237,7 @@ async fn run_edit_prediction(
             cx,
         )
     });
-    prediction_task.await.unwrap().unwrap().prediction
-}
-
-async fn request_edit_prediction(
-    buffer: &Entity<Buffer>,
-    project: &Entity<Project>,
-    ep_store: &Entity<EditPredictionStore>,
-    cursor: Point,
-    cx: &mut TestAppContext,
-) -> Result<Option<EditPredictionResult>, anyhow::Error> {
-    let anchor = buffer.read_with(cx, |buffer, _| buffer.anchor_before(cursor));
-    ep_store.update(cx, |ep_store, cx| {
-        ep_store.register_buffer(buffer, &project, cx)
-    });
-    cx.background_executor.run_until_parked();
-    let prediction_task = ep_store.update(cx, |ep_store, cx| {
-        ep_store.request_prediction(
-            &project,
-            buffer,
-            anchor,
-            PredictEditsRequestTrigger::Other,
-            cx,
-        )
-    });
-    prediction_task.await
+    prediction_task.await.unwrap()
 }
 
 async fn make_test_ep_store(
@@ -3623,9 +3603,8 @@ async fn test_sweep_prompt_request_prediction_diffs_rewritten_window_into_anchor
         make_sweep_prompt_test_ep_store(&project, cx).await;
     *completion_response.lock() = "line 0\nline 1 updated\nline 2\n".to_string();
 
-    let result = request_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx)
+    let result = run_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx)
         .await
-        .unwrap()
         .expect("expected a sweep prompt prediction");
     let prediction = result.prediction;
 
@@ -3680,9 +3659,7 @@ async fn test_sweep_prompt_request_prediction_returns_none_for_identical_rewrite
         make_sweep_prompt_test_ep_store(&project, cx).await;
     *completion_response.lock() = "line 0\nline 1\nline 2\n".to_string();
 
-    let result = request_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx)
-        .await
-        .unwrap();
+    let result = run_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx).await;
 
     assert!(
         result.is_none(),

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -9,7 +9,10 @@ use cloud_api_types::{
 use cloud_llm_client::{
     EditPredictionRejectReason, EditPredictionRejection, PredictEditsRequestTrigger,
     RejectEditPredictionsBody,
-    predict_edits_v3::{PredictEditsV3Request, PredictEditsV3Response},
+    predict_edits_v3::{
+        PredictEditsV3Request, PredictEditsV3Response, RawCompletionChoice, RawCompletionRequest,
+        RawCompletionResponse, RawCompletionUsage,
+    },
     predict_edits_v4::{PredictEditsV4Request, PredictEditsV4Response},
 };
 use db::AppDatabase;
@@ -3233,6 +3236,30 @@ async fn run_edit_prediction(
     prediction_task.await.unwrap().unwrap().prediction
 }
 
+async fn request_edit_prediction(
+    buffer: &Entity<Buffer>,
+    project: &Entity<Project>,
+    ep_store: &Entity<EditPredictionStore>,
+    cursor: Point,
+    cx: &mut TestAppContext,
+) -> Result<Option<EditPredictionResult>, anyhow::Error> {
+    let anchor = buffer.read_with(cx, |buffer, _| buffer.anchor_before(cursor));
+    ep_store.update(cx, |ep_store, cx| {
+        ep_store.register_buffer(buffer, &project, cx)
+    });
+    cx.background_executor.run_until_parked();
+    let prediction_task = ep_store.update(cx, |ep_store, cx| {
+        ep_store.request_prediction(
+            &project,
+            buffer,
+            anchor,
+            PredictEditsRequestTrigger::Other,
+            cx,
+        )
+    });
+    prediction_task.await
+}
+
 async fn make_test_ep_store(
     project: &Entity<Project>,
     cx: &mut TestAppContext,
@@ -3358,6 +3385,108 @@ async fn make_test_ep_store(
     (ep_store, completion_response)
 }
 
+async fn make_sweep_prompt_test_ep_store(
+    project: &Entity<Project>,
+    cx: &mut TestAppContext,
+) -> (
+    Entity<EditPredictionStore>,
+    Arc<Mutex<String>>,
+    Arc<Mutex<Vec<RawCompletionRequest>>>,
+) {
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.edit_predictions =
+                    Some(settings::EditPredictionSettingsContent {
+                        provider: Some(settings::EditPredictionProvider::OpenAiCompatibleApi),
+                        open_ai_compatible_api: Some(
+                            settings::CustomEditPredictionProviderSettingsContent {
+                                api_url: Some("http://localhost:8080/v1/completions".to_string()),
+                                model: Some("sweep-next-edit-1.5b".to_string()),
+                                prompt_format: Some(settings::EditPredictionPromptFormat::Sweep),
+                                max_output_tokens: Some(64),
+                                ..Default::default()
+                            },
+                        ),
+                        ..Default::default()
+                    });
+            });
+        });
+    });
+
+    let default_response = String::new();
+    let completion_response = Arc::new(Mutex::new(default_response));
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let http_client = FakeHttpClient::create({
+        let completion_response = completion_response.clone();
+        let requests = requests.clone();
+        let mut next_request_id = 0;
+        move |request| {
+            let completion_response = completion_response.clone();
+            let requests = requests.clone();
+            let method = request.method().clone();
+            let uri = request.uri().path().to_string();
+            let mut body = request.into_body();
+            async move {
+                match (method, uri.as_str()) {
+                    (Method::POST, "/v1/completions") => {
+                        let mut body_bytes = Vec::new();
+                        body.read_to_end(&mut body_bytes).await.ok();
+                        let request: RawCompletionRequest =
+                            serde_json::from_slice(&body_bytes).unwrap();
+                        requests.lock().push(request);
+
+                        next_request_id += 1;
+                        let response = RawCompletionResponse {
+                            id: format!("request-{next_request_id}"),
+                            object: "text_completion".to_string(),
+                            created: 0,
+                            model: "sweep-next-edit-1.5b".to_string(),
+                            choices: vec![RawCompletionChoice {
+                                text: completion_response.lock().clone(),
+                                finish_reason: Some("stop".to_string()),
+                            }],
+                            usage: RawCompletionUsage {
+                                prompt_tokens: 0,
+                                completion_tokens: 0,
+                                total_tokens: 0,
+                            },
+                        };
+
+                        Ok(http_client::Response::builder()
+                            .status(200)
+                            .body(serde_json::to_string(&response).unwrap().into())
+                            .unwrap())
+                    }
+                    _ => Ok(http_client::Response::builder()
+                        .status(404)
+                        .body("Not Found".to_string().into())
+                        .unwrap()),
+                }
+            }
+        }
+    });
+
+    cx.update(|cx| {
+        cx.set_http_client(http_client.clone());
+    });
+    let client =
+        cx.update(|cx| Client::new(Arc::new(FakeSystemClock::new()), http_client.clone(), cx));
+    let user_store = cx.update(|cx| cx.new(|cx| client::UserStore::new(client.clone(), cx)));
+    cx.update(|cx| {
+        RefreshLlmTokenListener::register(client.clone(), user_store.clone(), cx);
+    });
+    let _server = FakeServer::for_client(42, &client, cx).await;
+
+    let ep_store = cx.new(|cx| {
+        let mut ep_store = EditPredictionStore::new(client, project.read(cx).user_store(), cx);
+        ep_store.set_edit_prediction_model(EditPredictionModel::SweepPrompt);
+        ep_store
+    });
+
+    (ep_store, completion_response, requests)
+}
+
 fn to_completion_edits(
     iterator: impl IntoIterator<Item = (Range<usize>, Arc<str>)>,
     buffer: &Entity<Buffer>,
@@ -3459,6 +3588,110 @@ async fn test_unauthenticated_without_custom_url_blocks_prediction_impl(cx: &mut
 
     assert!(completion_task.await.unwrap().is_none());
     assert_eq!(request_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+}
+
+#[gpui::test]
+async fn test_sweep_prompt_request_prediction_diffs_rewritten_window_into_anchored_edits(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            "main.rs": "line 0\nline 1\nline 2\n"
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            let path = project
+                .find_project_path(path!("/project/main.rs"), cx)
+                .unwrap();
+            project.open_buffer(path, cx)
+        })
+        .await
+        .unwrap();
+
+    let (ep_store, completion_response, requests) =
+        make_sweep_prompt_test_ep_store(&project, cx).await;
+    *completion_response.lock() = "line 0\nline 1 updated\nline 2\n".to_string();
+
+    let result = request_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx)
+        .await
+        .unwrap()
+        .expect("expected a sweep prompt prediction");
+    let prediction = result.prediction.expect("expected prediction edits");
+
+    let edits = cx.update(|cx| from_completion_edits(&prediction.edits, &buffer, cx));
+    assert_eq!(edits, vec![(13..13, " updated".into())]);
+
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit(prediction.edits.iter().cloned(), None, cx)
+    });
+    assert_eq!(
+        buffer.read_with(cx, |buffer, _| buffer.text()),
+        "line 0\nline 1 updated\nline 2\n"
+    );
+
+    let requests = requests.lock();
+    assert_eq!(requests.len(), 1);
+    let stop_tokens = requests[0]
+        .stop
+        .iter()
+        .map(|token| token.as_ref())
+        .collect::<Vec<_>>();
+    assert_eq!(stop_tokens, vec!["<|file_sep|>", "</s>"]);
+}
+
+#[gpui::test]
+async fn test_sweep_prompt_request_prediction_returns_none_for_identical_rewrite(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            "main.rs": "line 0\nline 1\nline 2\n"
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            let path = project
+                .find_project_path(path!("/project/main.rs"), cx)
+                .unwrap();
+            project.open_buffer(path, cx)
+        })
+        .await
+        .unwrap();
+
+    let (ep_store, completion_response, requests) =
+        make_sweep_prompt_test_ep_store(&project, cx).await;
+    *completion_response.lock() = "line 0\nline 1\nline 2\n".to_string();
+
+    let result = request_edit_prediction(&buffer, &project, &ep_store, Point::new(1, 0), cx)
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_none(),
+        "identical rewrites should produce no prediction"
+    );
+
+    let requests = requests.lock();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].prompt.contains("<|file_sep|>updated/"),
+        "expected Sweep-style rewrite prompt"
+    );
 }
 
 #[gpui::test]

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -3403,7 +3403,9 @@ async fn make_sweep_prompt_test_ep_store(
                             settings::CustomEditPredictionProviderSettingsContent {
                                 api_url: Some("http://localhost:8080/v1/completions".to_string()),
                                 model: Some("sweep-next-edit-1.5b".to_string()),
-                                prompt_format: Some(settings::EditPredictionPromptFormat::Sweep),
+                                prompt_format: Some(
+                                    settings::EditPredictionPromptFormatContent::Sweep,
+                                ),
                                 max_output_tokens: Some(64),
                             },
                         ),
@@ -3625,7 +3627,7 @@ async fn test_sweep_prompt_request_prediction_diffs_rewritten_window_into_anchor
         .await
         .unwrap()
         .expect("expected a sweep prompt prediction");
-    let prediction = result.prediction.expect("expected prediction edits");
+    let prediction = result.prediction;
 
     let edits = cx.update(|cx| from_completion_edits(&prediction.edits, &buffer, cx));
     assert_eq!(edits, vec![(13..13, " updated".into())]);

--- a/crates/edit_prediction/src/open_ai_compatible.rs
+++ b/crates/edit_prediction/src/open_ai_compatible.rs
@@ -132,3 +132,23 @@ pub(crate) async fn send_custom_server_request(
         }
     }
 }
+
+pub(crate) async fn request_sweep_prompt_prediction(
+    provider: settings::EditPredictionProvider,
+    settings: &OpenAiCompatibleEditPredictionSettings,
+    prompt: String,
+    api_key: Option<Arc<str>>,
+    http_client: &Arc<dyn http_client::HttpClient>,
+) -> Result<(String, String)> {
+    send_custom_server_request(
+        provider,
+        settings,
+        prompt,
+        settings.max_output_tokens,
+        vec!["<|file_sep|>".to_string(), "</s>".to_string()],
+        api_key,
+        http_client,
+    )
+    .await
+    .context("sweep prompt request failed")
+}

--- a/crates/edit_prediction/src/open_ai_compatible.rs
+++ b/crates/edit_prediction/src/open_ai_compatible.rs
@@ -132,23 +132,3 @@ pub(crate) async fn send_custom_server_request(
         }
     }
 }
-
-pub(crate) async fn request_sweep_prompt_prediction(
-    provider: settings::EditPredictionProvider,
-    settings: &OpenAiCompatibleEditPredictionSettings,
-    prompt: String,
-    api_key: Option<Arc<str>>,
-    http_client: &Arc<dyn http_client::HttpClient>,
-) -> Result<(String, String)> {
-    send_custom_server_request(
-        provider,
-        settings,
-        prompt,
-        settings.max_output_tokens,
-        vec!["<|file_sep|>".to_string(), "</s>".to_string()],
-        api_key,
-        http_client,
-    )
-    .await
-    .context("sweep prompt request failed")
-}

--- a/crates/edit_prediction/src/sweep_prompt.rs
+++ b/crates/edit_prediction/src/sweep_prompt.rs
@@ -18,6 +18,7 @@ const WINDOW_LINES_ABOVE: u32 = 10;
 const WINDOW_LINES_BELOW: u32 = 10;
 const MAX_RECENT_CHANGE_BLOCKS: usize = 3;
 const MAX_RECENT_CHANGE_LINES: usize = 40;
+const RESERVED_SWEEP_TOKENS: [&str; 2] = ["<|file_sep|>", "</s>"];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SweepPromptInput {
@@ -94,6 +95,9 @@ pub fn request_prediction(
         &stored_events,
         filtered_related_files.clone(),
     );
+    if let Err(error) = validate_prompt_input(&prompt_input) {
+        return Task::ready(Err(error));
+    }
     let prompt = build_prompt(&prompt_input);
 
     if let Some(debug_tx) = &debug_tx {
@@ -109,7 +113,9 @@ pub fn request_prediction(
     }
 
     let window_start_offset = window_range.start.to_offset(&snapshot);
-    let cursor_offset_in_window = position.to_offset(&snapshot).saturating_sub(window_start_offset);
+    let cursor_offset_in_window = position
+        .to_offset(&snapshot)
+        .saturating_sub(window_start_offset);
     let zeta_input = ZetaPromptInput {
         events,
         related_files: filtered_related_files,
@@ -135,7 +141,11 @@ pub fn request_prediction(
         )
         .await?;
         let response_received_at = Instant::now();
-        Ok((request_id, clean_response_text(&response_text), response_received_at))
+        Ok((
+            request_id,
+            clean_response_text(&response_text),
+            response_received_at,
+        ))
     });
 
     cx.spawn(async move |cx| {
@@ -189,7 +199,11 @@ pub fn build_prompt(input: &SweepPromptInput) -> String {
     let mut prompt = String::new();
 
     for related_file in &input.related_files {
-        write_file_block(&mut prompt, related_file.file_path.as_ref(), &related_file.content);
+        write_file_block(
+            &mut prompt,
+            related_file.file_path.as_ref(),
+            &related_file.content,
+        );
     }
 
     for recent_change in &input.recent_changes {
@@ -206,7 +220,11 @@ pub fn build_prompt(input: &SweepPromptInput) -> String {
     }
 
     let original_path = format!("original/{}", input.file_path.display());
-    write_file_block(&mut prompt, Path::new(&original_path), &input.original_window);
+    write_file_block(
+        &mut prompt,
+        Path::new(&original_path),
+        &input.original_window,
+    );
 
     let current_path = format!("current/{}", input.file_path.display());
     write_file_block(&mut prompt, Path::new(&current_path), &input.current_window);
@@ -215,6 +233,42 @@ pub fn build_prompt(input: &SweepPromptInput) -> String {
     writeln!(&mut prompt, "<|file_sep|>{updated_path}").ok();
 
     prompt
+}
+
+fn validate_prompt_input(input: &SweepPromptInput) -> Result<()> {
+    validate_prompt_field("file path", &input.file_path.display().to_string())?;
+    validate_prompt_field("original window", &input.original_window)?;
+    validate_prompt_field("current window", &input.current_window)?;
+
+    for recent_change in &input.recent_changes {
+        validate_prompt_field(
+            "recent change path",
+            &recent_change.file_path.display().to_string(),
+        )?;
+        validate_prompt_field("recent change original", &recent_change.original)?;
+        validate_prompt_field("recent change updated", &recent_change.updated)?;
+    }
+
+    for related_file in &input.related_files {
+        validate_prompt_field(
+            "related file path",
+            &related_file.file_path.display().to_string(),
+        )?;
+        validate_prompt_field("related file content", &related_file.content)?;
+    }
+
+    Ok(())
+}
+
+fn validate_prompt_field(field_name: &str, value: &str) -> Result<()> {
+    if RESERVED_SWEEP_TOKENS
+        .iter()
+        .any(|reserved_token| value.contains(reserved_token))
+    {
+        anyhow::bail!("sweep prompt {field_name} contains reserved tokens");
+    }
+
+    Ok(())
 }
 
 pub(crate) fn original_window_for_current_window(
@@ -264,14 +318,15 @@ fn build_prompt_input(
     stored_events: &[StoredEvent],
     related_files: Vec<RelatedFile>,
 ) -> SweepPromptInput {
-    let current_window = snapshot.text_for_range(window_range.clone()).collect::<String>();
-    let original_window =
-        original_window_for_current_window(
-            window_range,
-            latest_active_buffer_event(stored_events, snapshot),
-            snapshot,
-        )
-        .unwrap_or_else(|| current_window.clone());
+    let current_window = snapshot
+        .text_for_range(window_range.clone())
+        .collect::<String>();
+    let original_window = original_window_for_current_window(
+        window_range,
+        latest_active_buffer_event(stored_events, snapshot),
+        snapshot,
+    )
+    .unwrap_or_else(|| current_window.clone());
 
     SweepPromptInput {
         file_path: file_path.clone(),
@@ -479,9 +534,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_original_window_for_current_window_returns_none_without_matching_history(
-        cx: &mut App,
-    ) {
+    fn test_original_window_for_current_window_returns_none_without_matching_history(cx: &mut App) {
         cx.new(|cx| {
             let buffer = Buffer::local("hello\nworld\n", cx);
             let current_snapshot = buffer.snapshot();
@@ -497,9 +550,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_recent_change_block_from_event_formats_original_and_updated_sections(
-        cx: &mut App,
-    ) {
+    fn test_recent_change_block_from_event_formats_original_and_updated_sections(cx: &mut App) {
         cx.new(|cx| {
             let buffer = Buffer::local("fn main() {\n    println!(\"old\");\n}\n", cx);
             let stored_event = StoredEvent {

--- a/crates/edit_prediction/src/sweep_prompt.rs
+++ b/crates/edit_prediction/src/sweep_prompt.rs
@@ -1,0 +1,561 @@
+use anyhow::{Result, anyhow};
+use gpui::{App, AppContext as _, Task};
+use language::{
+    BufferSnapshot, Point, ToOffset as _, ToPoint as _, language_settings::all_language_settings,
+};
+use std::{fmt::Write as _, ops::Range, path::Path, sync::Arc, time::Instant};
+use zeta_prompt::{RelatedFile, ZetaPromptInput, filter_redundant_excerpts};
+
+use crate::{
+    DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId, EditPredictionModelInput,
+    EditPredictionResult, EditPredictionStartedDebugEvent, StoredEvent,
+    cursor_excerpt::fixed_line_window_around_cursor,
+    open_ai_compatible::{self, load_open_ai_compatible_api_key_if_needed},
+    zeta,
+};
+
+const WINDOW_LINES_ABOVE: u32 = 10;
+const WINDOW_LINES_BELOW: u32 = 10;
+const MAX_RECENT_CHANGE_BLOCKS: usize = 3;
+const MAX_RECENT_CHANGE_LINES: usize = 40;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SweepPromptInput {
+    pub file_path: Arc<Path>,
+    pub original_window: String,
+    pub current_window: String,
+    pub recent_changes: Vec<RecentChangeBlock>,
+    pub related_files: Vec<RelatedFileBlock>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecentChangeBlock {
+    pub file_path: Arc<Path>,
+    pub original: String,
+    pub updated: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelatedFileBlock {
+    pub file_path: Arc<Path>,
+    pub content: String,
+}
+
+pub fn request_prediction(
+    input: EditPredictionModelInput,
+    cx: &mut App,
+) -> Task<Result<Option<EditPredictionResult>>> {
+    let settings = &all_language_settings(None, cx).edit_predictions;
+    let provider = settings.provider;
+    let Some(custom_settings) = (match provider {
+        settings::EditPredictionProvider::Ollama => settings.ollama.clone(),
+        settings::EditPredictionProvider::OpenAiCompatibleApi => {
+            settings.open_ai_compatible_api.clone()
+        }
+        _ => None,
+    }) else {
+        return Task::ready(Err(anyhow!(
+            "Unsupported edit prediction provider for Sweep prompt mode"
+        )));
+    };
+
+    let api_key = load_open_ai_compatible_api_key_if_needed(provider, cx);
+    let http_client = cx.http_client();
+    let buffer_snapshotted_at = Instant::now();
+
+    let EditPredictionModelInput {
+        buffer,
+        snapshot,
+        position,
+        events,
+        stored_events,
+        related_files,
+        debug_tx,
+        ..
+    } = input;
+
+    let cursor_point = position.to_point(&snapshot);
+    let window_range = fixed_line_window_around_cursor(
+        &snapshot,
+        cursor_point,
+        WINDOW_LINES_ABOVE,
+        WINDOW_LINES_BELOW,
+    );
+    let file_path = prompt_file_path(&snapshot);
+    let filtered_related_files = filter_redundant_excerpts(
+        related_files,
+        file_path.as_ref(),
+        window_range.start.row..window_range.end.row.saturating_add(1),
+    );
+    let prompt_input = build_prompt_input(
+        &file_path,
+        window_range.clone(),
+        &snapshot,
+        &stored_events,
+        filtered_related_files.clone(),
+    );
+    let prompt = build_prompt(&prompt_input);
+
+    if let Some(debug_tx) = &debug_tx {
+        debug_tx
+            .unbounded_send(DebugEvent::EditPredictionStarted(
+                EditPredictionStartedDebugEvent {
+                    buffer: buffer.downgrade(),
+                    prompt: Some(prompt.clone()),
+                    position,
+                },
+            ))
+            .ok();
+    }
+
+    let window_start_offset = window_range.start.to_offset(&snapshot);
+    let cursor_offset_in_window = position.to_offset(&snapshot).saturating_sub(window_start_offset);
+    let zeta_input = ZetaPromptInput {
+        events,
+        related_files: filtered_related_files,
+        cursor_path: file_path,
+        cursor_excerpt: prompt_input.current_window.clone().into(),
+        cursor_offset_in_excerpt: cursor_offset_in_window,
+        excerpt_start_row: Some(window_range.start.row),
+        excerpt_ranges: Default::default(),
+        experiment: None,
+        in_open_source_repo: false,
+        can_collect_data: false,
+        repo_url: None,
+    };
+
+    let current_window = prompt_input.current_window;
+    let request_task: Task<Result<(String, String, Instant)>> = cx.background_spawn(async move {
+        let (response_text, request_id) = open_ai_compatible::request_sweep_prompt_prediction(
+            provider,
+            &custom_settings,
+            prompt,
+            api_key,
+            &http_client,
+        )
+        .await?;
+        let response_received_at = Instant::now();
+        Ok((request_id, clean_response_text(&response_text), response_received_at))
+    });
+
+    cx.spawn(async move |cx| {
+        let (request_id, response_text, response_received_at) = request_task.await?;
+
+        if let Some(debug_tx) = &debug_tx {
+            debug_tx
+                .unbounded_send(DebugEvent::EditPredictionFinished(
+                    EditPredictionFinishedDebugEvent {
+                        buffer: buffer.downgrade(),
+                        position,
+                        model_output: Some(response_text.clone()),
+                    },
+                ))
+                .ok();
+        }
+
+        if response_text.is_empty() || response_text == current_window {
+            return Ok(None);
+        }
+
+        let edits = zeta::compute_edits(
+            current_window,
+            &response_text,
+            window_start_offset,
+            &snapshot,
+        );
+        if edits.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            EditPredictionResult::new(
+                EditPredictionId(request_id.into()),
+                &buffer,
+                &snapshot,
+                edits.into(),
+                None,
+                buffer_snapshotted_at,
+                response_received_at,
+                zeta_input,
+                None,
+                cx,
+            )
+            .await,
+        ))
+    })
+}
+
+pub fn build_prompt(input: &SweepPromptInput) -> String {
+    let mut prompt = String::new();
+
+    for related_file in &input.related_files {
+        write_file_block(&mut prompt, related_file.file_path.as_ref(), &related_file.content);
+    }
+
+    for recent_change in &input.recent_changes {
+        let diff_path = format!("{}.diff", recent_change.file_path.display());
+        let mut diff_body = String::new();
+        writeln!(&mut diff_body, "original:").ok();
+        diff_body.push_str(&recent_change.original);
+        if !recent_change.original.ends_with('\n') {
+            diff_body.push('\n');
+        }
+        writeln!(&mut diff_body, "updated:").ok();
+        diff_body.push_str(&recent_change.updated);
+        write_file_block(&mut prompt, Path::new(&diff_path), &diff_body);
+    }
+
+    let original_path = format!("original/{}", input.file_path.display());
+    write_file_block(&mut prompt, Path::new(&original_path), &input.original_window);
+
+    let current_path = format!("current/{}", input.file_path.display());
+    write_file_block(&mut prompt, Path::new(&current_path), &input.current_window);
+
+    let updated_path = format!("updated/{}", input.file_path.display());
+    writeln!(&mut prompt, "<|file_sep|>{updated_path}").ok();
+
+    prompt
+}
+
+pub(crate) fn original_window_for_current_window(
+    current_window: Range<Point>,
+    latest_event: Option<&StoredEvent>,
+    current_snapshot: &BufferSnapshot,
+) -> Option<String> {
+    let latest_event = latest_event?;
+    if latest_event.old_snapshot.remote_id() != current_snapshot.remote_id() {
+        return None;
+    }
+
+    let current_start = current_window.start.to_offset(current_snapshot);
+    let current_end = current_window.end.to_offset(current_snapshot);
+    let old_start =
+        map_current_offset_to_old_snapshot(current_start, latest_event, current_snapshot)?;
+    let old_end = map_current_offset_to_old_snapshot(current_end, latest_event, current_snapshot)?;
+    let (old_start, old_end) = if old_start <= old_end {
+        (old_start, old_end)
+    } else {
+        (old_end, old_start)
+    };
+
+    Some(
+        latest_event
+            .old_snapshot
+            .text_for_range(old_start..old_end)
+            .collect(),
+    )
+}
+
+pub(crate) fn latest_active_buffer_event<'a>(
+    stored_events: &'a [StoredEvent],
+    snapshot: &BufferSnapshot,
+) -> Option<&'a StoredEvent> {
+    let current_remote_id = snapshot.remote_id();
+    stored_events
+        .iter()
+        .rev()
+        .find(|stored_event| stored_event.old_snapshot.remote_id() == current_remote_id)
+}
+
+fn build_prompt_input(
+    file_path: &Arc<Path>,
+    window_range: Range<Point>,
+    snapshot: &BufferSnapshot,
+    stored_events: &[StoredEvent],
+    related_files: Vec<RelatedFile>,
+) -> SweepPromptInput {
+    let current_window = snapshot.text_for_range(window_range.clone()).collect::<String>();
+    let original_window =
+        original_window_for_current_window(
+            window_range,
+            latest_active_buffer_event(stored_events, snapshot),
+            snapshot,
+        )
+        .unwrap_or_else(|| current_window.clone());
+
+    SweepPromptInput {
+        file_path: file_path.clone(),
+        original_window,
+        current_window,
+        recent_changes: build_recent_change_blocks(stored_events),
+        related_files: build_related_file_blocks(related_files),
+    }
+}
+
+fn prompt_file_path(snapshot: &BufferSnapshot) -> Arc<Path> {
+    snapshot
+        .file()
+        .map(|file| Arc::<Path>::from(file.path().as_std_path()))
+        .unwrap_or_else(|| Path::new("untitled").into())
+}
+
+fn write_file_block(prompt: &mut String, path: &Path, content: &str) {
+    writeln!(prompt, "<|file_sep|>{}", path.display()).ok();
+    prompt.push_str(content);
+    if !content.ends_with('\n') {
+        prompt.push('\n');
+    }
+}
+
+fn map_current_offset_to_old_snapshot(
+    current_offset: usize,
+    latest_event: &StoredEvent,
+    current_snapshot: &BufferSnapshot,
+) -> Option<usize> {
+    if latest_event.old_snapshot.remote_id() != current_snapshot.remote_id() {
+        return None;
+    }
+
+    let old_snapshot = &latest_event.old_snapshot;
+    for edit in current_snapshot.edits_since::<usize>(old_snapshot.version()) {
+        if current_offset < edit.new.start {
+            break;
+        }
+
+        if current_offset <= edit.new.end {
+            let offset_in_edit = current_offset.saturating_sub(edit.new.start);
+            return Some(
+                (edit.old.start + offset_in_edit.min(edit.old.len())).min(old_snapshot.len()),
+            );
+        }
+    }
+
+    let old_offset = current_snapshot
+        .edits_since::<usize>(old_snapshot.version())
+        .take_while(|edit| current_offset > edit.new.end)
+        .fold(current_offset as isize, |old_offset, edit| {
+            old_offset + edit.old.len() as isize - edit.new.len() as isize
+        });
+
+    Some(old_offset.max(0) as usize)
+}
+
+fn build_related_file_blocks(related_files: Vec<RelatedFile>) -> Vec<RelatedFileBlock> {
+    related_files
+        .into_iter()
+        .map(|related_file| {
+            let mut excerpts = related_file.excerpts;
+            excerpts.sort_by_key(|excerpt| (excerpt.order, excerpt.row_range.start));
+            RelatedFileBlock {
+                file_path: related_file.path,
+                content: excerpts
+                    .into_iter()
+                    .map(|excerpt| excerpt.text.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            }
+        })
+        .collect()
+}
+
+fn build_recent_change_blocks(stored_events: &[StoredEvent]) -> Vec<RecentChangeBlock> {
+    stored_events
+        .iter()
+        .rev()
+        .filter_map(recent_change_block_from_event)
+        .take(MAX_RECENT_CHANGE_BLOCKS)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+fn recent_change_block_from_event(stored_event: &StoredEvent) -> Option<RecentChangeBlock> {
+    let zeta_prompt::Event::BufferChange {
+        old_path,
+        path,
+        diff,
+        ..
+    } = stored_event.event.as_ref();
+
+    let (mut original_lines, mut updated_lines) = parse_unified_diff(diff);
+    if original_lines.is_empty() && updated_lines.is_empty() {
+        if old_path != path {
+            original_lines.push(format!("path: {}", old_path.display()));
+            updated_lines.push(format!("path: {}", path.display()));
+        } else {
+            return None;
+        }
+    }
+
+    Some(RecentChangeBlock {
+        file_path: path.clone(),
+        original: limit_change_lines(original_lines, MAX_RECENT_CHANGE_LINES),
+        updated: limit_change_lines(updated_lines, MAX_RECENT_CHANGE_LINES),
+    })
+}
+
+fn parse_unified_diff(diff: &str) -> (Vec<String>, Vec<String>) {
+    let mut original_lines = Vec::new();
+    let mut updated_lines = Vec::new();
+
+    for line in diff.lines() {
+        if line.starts_with("@@") || line.starts_with("---") || line.starts_with("+++") {
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix('-') {
+            original_lines.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix('+') {
+            updated_lines.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix(' ') {
+            let shared_line = rest.to_string();
+            original_lines.push(shared_line.clone());
+            updated_lines.push(shared_line);
+        }
+    }
+
+    (original_lines, updated_lines)
+}
+
+fn limit_change_lines(lines: Vec<String>, max_lines: usize) -> String {
+    if lines.len() <= max_lines {
+        return lines.join("\n");
+    }
+
+    let head_count = max_lines / 2;
+    let tail_count = max_lines.saturating_sub(head_count + 1);
+    let mut trimmed = Vec::with_capacity(max_lines);
+    trimmed.extend(lines.iter().take(head_count).cloned());
+    trimmed.push("...".to_string());
+    trimmed.extend(
+        lines
+            .iter()
+            .rev()
+            .take(tail_count)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev(),
+    );
+    trimmed.join("\n")
+}
+
+fn clean_response_text(response_text: &str) -> String {
+    let mut cleaned = response_text.to_string();
+    for stop_token in ["<|file_sep|>", "</s>"] {
+        if let Some(position) = cleaned.find(stop_token) {
+            cleaned.truncate(position);
+        }
+    }
+    cleaned
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cursor_excerpt::fixed_line_window_around_cursor;
+    use gpui::{App, AppContext};
+    use language::Buffer;
+
+    #[gpui::test]
+    fn test_original_window_for_current_window_uses_latest_pre_edit_snapshot(cx: &mut App) {
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("zero\none\ntwo\nthree\n", cx);
+            let old_snapshot = buffer.text_snapshot();
+            buffer.edit([(5..8, "ONE")], None, cx);
+            let current_snapshot = buffer.snapshot();
+            let window = fixed_line_window_around_cursor(&current_snapshot, Point::new(1, 1), 1, 1);
+
+            let stored_event = StoredEvent {
+                event: Arc::new(zeta_prompt::Event::BufferChange {
+                    old_path: Arc::from(std::path::Path::new("test.txt")),
+                    path: Arc::from(std::path::Path::new("test.txt")),
+                    diff: String::new(),
+                    in_open_source_repo: false,
+                    predicted: false,
+                }),
+                old_snapshot,
+                edit_range: current_snapshot.anchor_before(5)..current_snapshot.anchor_before(8),
+            };
+
+            let original_window =
+                original_window_for_current_window(window, Some(&stored_event), &current_snapshot)
+                    .expect("expected original window");
+
+            assert_eq!(original_window, "zero\none\ntwo");
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    fn test_original_window_for_current_window_returns_none_without_matching_history(
+        cx: &mut App,
+    ) {
+        cx.new(|cx| {
+            let buffer = Buffer::local("hello\nworld\n", cx);
+            let current_snapshot = buffer.snapshot();
+            let window = fixed_line_window_around_cursor(&current_snapshot, Point::new(0, 0), 0, 1);
+
+            assert_eq!(
+                original_window_for_current_window(window, None, &current_snapshot),
+                None
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    fn test_recent_change_block_from_event_formats_original_and_updated_sections(
+        cx: &mut App,
+    ) {
+        cx.new(|cx| {
+            let buffer = Buffer::local("fn main() {\n    println!(\"old\");\n}\n", cx);
+            let stored_event = StoredEvent {
+                event: Arc::new(zeta_prompt::Event::BufferChange {
+                    old_path: Path::new("src/main.rs").into(),
+                    path: Path::new("src/main.rs").into(),
+                    diff: "@@ -1,3 +1,3 @@\n fn main() {\n-    println!(\"old\");\n+    println!(\"new\");\n }\n"
+                        .to_string(),
+                    in_open_source_repo: false,
+                    predicted: false,
+                }),
+                old_snapshot: buffer.text_snapshot(),
+                edit_range: language::Anchor::MIN..language::Anchor::MIN,
+            };
+
+            let block =
+                recent_change_block_from_event(&stored_event).expect("expected recent change block");
+            assert_eq!(block.original, "fn main() {\n    println!(\"old\");\n}");
+            assert_eq!(block.updated, "fn main() {\n    println!(\"new\");\n}");
+
+            buffer
+        });
+    }
+
+    #[test]
+    fn test_build_prompt_uses_run_model_ordering() {
+        let prompt = build_prompt(&SweepPromptInput {
+            file_path: Path::new("src/main.rs").into(),
+            original_window: "old window".to_string(),
+            current_window: "current window".to_string(),
+            recent_changes: vec![RecentChangeBlock {
+                file_path: Path::new("src/lib.rs").into(),
+                original: "old".to_string(),
+                updated: "new".to_string(),
+            }],
+            related_files: vec![RelatedFileBlock {
+                file_path: Path::new("src/context.rs").into(),
+                content: "context".to_string(),
+            }],
+        });
+
+        assert_eq!(
+            prompt,
+            "\
+<|file_sep|>src/context.rs\n\
+context\n\
+<|file_sep|>src/lib.rs.diff\n\
+original:\n\
+old\n\
+updated:\n\
+new\n\
+<|file_sep|>original/src/main.rs\n\
+old window\n\
+<|file_sep|>current/src/main.rs\n\
+current window\n\
+<|file_sep|>updated/src/main.rs\n"
+        );
+    }
+}

--- a/crates/edit_prediction/src/sweep_prompt.rs
+++ b/crates/edit_prediction/src/sweep_prompt.rs
@@ -367,7 +367,7 @@ fn map_current_offset_to_old_snapshot(
             break;
         }
 
-        if current_offset <= edit.new.end {
+        if current_offset < edit.new.end {
             let offset_in_edit = current_offset.saturating_sub(edit.new.start);
             return Some(
                 (edit.old.start + offset_in_edit.min(edit.old.len())).min(old_snapshot.len()),
@@ -377,7 +377,7 @@ fn map_current_offset_to_old_snapshot(
 
     let old_offset = current_snapshot
         .edits_since::<usize>(old_snapshot.version())
-        .take_while(|edit| current_offset > edit.new.end)
+        .take_while(|edit| current_offset >= edit.new.end)
         .fold(current_offset as isize, |old_offset, edit| {
             old_offset + edit.old.len() as isize - edit.new.len() as isize
         });
@@ -545,6 +545,43 @@ mod tests {
                 None
             );
 
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    fn test_original_window_for_current_window_treats_edit_end_as_post_edit_position(
+        cx: &mut App,
+    ) {
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("aaaaabbbbb", cx);
+            let old_snapshot = buffer.text_snapshot();
+            buffer.edit([(5..10, "b")], None, cx);
+            let current_snapshot = buffer.snapshot();
+            let window = Point::new(0, 0)..Point::new(0, current_snapshot.line_len(0));
+
+            let stored_event = StoredEvent {
+                event: Arc::new(zeta_prompt::Event::BufferChange {
+                    old_path: Arc::from(std::path::Path::new("test.txt")),
+                    path: Arc::from(std::path::Path::new("test.txt")),
+                    diff: String::new(),
+                    in_open_source_repo: false,
+                    predicted: false,
+                }),
+                old_snapshot,
+                edit_range: current_snapshot.anchor_before(5)..current_snapshot.anchor_before(6),
+            };
+
+            assert_eq!(
+                map_current_offset_to_old_snapshot(6, &stored_event, &current_snapshot),
+                Some(10)
+            );
+
+            let original_window =
+                original_window_for_current_window(window, Some(&stored_event), &current_snapshot)
+                    .expect("expected original window");
+
+            assert_eq!(original_window, "aaaaabbbbb");
             buffer
         });
     }

--- a/crates/edit_prediction/src/sweep_prompt.rs
+++ b/crates/edit_prediction/src/sweep_prompt.rs
@@ -1,14 +1,15 @@
 use anyhow::{Result, anyhow};
 use gpui::{App, AppContext as _, Task};
 use language::{
-    BufferSnapshot, Point, ToOffset as _, ToPoint as _, language_settings::all_language_settings,
+    BufferSnapshot, OffsetRangeExt as _, Point, ToOffset as _, ToPoint as _,
+    language_settings::all_language_settings,
 };
 use std::{fmt::Write as _, ops::Range, path::Path, sync::Arc, time::Instant};
-use zeta_prompt::{RelatedFile, ZetaPromptInput, filter_redundant_excerpts};
+use zeta_prompt::{RelatedFile, Zeta2PromptInput, filter_redundant_excerpts};
 
 use crate::{
-    DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId, EditPredictionModelInput,
-    EditPredictionResult, EditPredictionStartedDebugEvent, StoredEvent,
+    DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId, EditPredictionInputs,
+    EditPredictionModelInput, EditPredictionResult, EditPredictionStartedDebugEvent, StoredEvent,
     cursor_excerpt::fixed_line_window_around_cursor,
     open_ai_compatible::{self, load_open_ai_compatible_api_key_if_needed},
     zeta,
@@ -71,6 +72,7 @@ pub fn request_prediction(
         events,
         stored_events,
         related_files,
+        trigger,
         debug_tx,
         ..
     } = input;
@@ -112,19 +114,22 @@ pub fn request_prediction(
             .ok();
     }
 
-    let window_start_offset = window_range.start.to_offset(&snapshot);
+    let window_offset_range = window_range.to_offset(&snapshot);
+    let window_start_offset = window_offset_range.start;
+    let editable_range = snapshot.anchor_range_inside(window_offset_range);
     let cursor_offset_in_window = position
         .to_offset(&snapshot)
         .saturating_sub(window_start_offset);
-    let zeta_input = ZetaPromptInput {
+    let zeta_input = Zeta2PromptInput {
         events,
-        related_files: filtered_related_files,
+        related_files: Some(filtered_related_files),
+        active_buffer_diagnostics: Vec::new(),
         cursor_path: file_path,
         cursor_excerpt: prompt_input.current_window.clone().into(),
         cursor_offset_in_excerpt: cursor_offset_in_window,
         excerpt_start_row: Some(window_range.start.row),
         excerpt_ranges: Default::default(),
-        experiment: None,
+        syntax_ranges: None,
         in_open_source_repo: false,
         can_collect_data: false,
         repo_url: None,
@@ -184,10 +189,11 @@ pub fn request_prediction(
                 &snapshot,
                 edits.into(),
                 None,
-                buffer_snapshotted_at,
-                response_received_at,
-                zeta_input,
+                Some(editable_range),
+                EditPredictionInputs::V2(zeta_input),
                 None,
+                trigger,
+                response_received_at - buffer_snapshotted_at,
                 cx,
             )
             .await,
@@ -517,11 +523,16 @@ mod tests {
                     old_path: Arc::from(std::path::Path::new("test.txt")),
                     path: Arc::from(std::path::Path::new("test.txt")),
                     diff: String::new(),
+                    old_range: 5..8,
+                    new_range: 5..8,
                     in_open_source_repo: false,
                     predicted: false,
                 }),
                 old_snapshot,
-                edit_range: current_snapshot.anchor_before(5)..current_snapshot.anchor_before(8),
+                new_snapshot_version: current_snapshot.text.version.clone(),
+                total_edit_range: current_snapshot.anchor_before(5)
+                    ..current_snapshot.anchor_before(8),
+                file_context: None,
             };
 
             let original_window =
@@ -550,9 +561,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_original_window_for_current_window_treats_edit_end_as_post_edit_position(
-        cx: &mut App,
-    ) {
+    fn test_original_window_for_current_window_treats_edit_end_as_post_edit_position(cx: &mut App) {
         cx.new(|cx| {
             let mut buffer = Buffer::local("aaaaabbbbb", cx);
             let old_snapshot = buffer.text_snapshot();
@@ -565,11 +574,16 @@ mod tests {
                     old_path: Arc::from(std::path::Path::new("test.txt")),
                     path: Arc::from(std::path::Path::new("test.txt")),
                     diff: String::new(),
+                    old_range: 5..10,
+                    new_range: 5..6,
                     in_open_source_repo: false,
                     predicted: false,
                 }),
                 old_snapshot,
-                edit_range: current_snapshot.anchor_before(5)..current_snapshot.anchor_before(6),
+                new_snapshot_version: current_snapshot.text.version.clone(),
+                total_edit_range: current_snapshot.anchor_before(5)
+                    ..current_snapshot.anchor_before(6),
+                file_context: None,
             };
 
             assert_eq!(
@@ -590,17 +604,23 @@ mod tests {
     fn test_recent_change_block_from_event_formats_original_and_updated_sections(cx: &mut App) {
         cx.new(|cx| {
             let buffer = Buffer::local("fn main() {\n    println!(\"old\");\n}\n", cx);
+            let old_snapshot = buffer.text_snapshot();
+            let anchor = buffer.anchor_before(0);
             let stored_event = StoredEvent {
                 event: Arc::new(zeta_prompt::Event::BufferChange {
                     old_path: Path::new("src/main.rs").into(),
                     path: Path::new("src/main.rs").into(),
                     diff: "@@ -1,3 +1,3 @@\n fn main() {\n-    println!(\"old\");\n+    println!(\"new\");\n }\n"
                         .to_string(),
+                    old_range: 0..0,
+                    new_range: 0..0,
                     in_open_source_repo: false,
                     predicted: false,
                 }),
-                old_snapshot: buffer.text_snapshot(),
-                edit_range: language::Anchor::MIN..language::Anchor::MIN,
+                new_snapshot_version: old_snapshot.version.clone(),
+                old_snapshot,
+                total_edit_range: anchor..anchor,
+                file_context: None,
             };
 
             let block =

--- a/crates/edit_prediction/src/sweep_prompt.rs
+++ b/crates/edit_prediction/src/sweep_prompt.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use gpui::{App, AppContext as _, Task};
 use language::{
     BufferSnapshot, OffsetRangeExt as _, Point, ToOffset as _, ToPoint as _,
@@ -137,14 +137,17 @@ pub fn request_prediction(
 
     let current_window = prompt_input.current_window;
     let request_task: Task<Result<(String, String, Instant)>> = cx.background_spawn(async move {
-        let (response_text, request_id) = open_ai_compatible::request_sweep_prompt_prediction(
+        let (response_text, request_id) = open_ai_compatible::send_custom_server_request(
             provider,
             &custom_settings,
             prompt,
+            custom_settings.max_output_tokens,
+            RESERVED_SWEEP_TOKENS.map(str::to_string).to_vec(),
             api_key,
             &http_client,
         )
-        .await?;
+        .await
+        .context("sweep prompt request failed")?;
         let response_received_at = Instant::now();
         Ok((
             request_id,
@@ -287,34 +290,16 @@ pub(crate) fn original_window_for_current_window(
         return None;
     }
 
-    let current_start = current_window.start.to_offset(current_snapshot);
-    let current_end = current_window.end.to_offset(current_snapshot);
-    let old_start =
-        map_current_offset_to_old_snapshot(current_start, latest_event, current_snapshot)?;
-    let old_end = map_current_offset_to_old_snapshot(current_end, latest_event, current_snapshot)?;
-    let (old_start, old_end) = if old_start <= old_end {
-        (old_start, old_end)
-    } else {
-        (old_end, old_start)
-    };
-
+    let old_range = current_snapshot.range_to_version(
+        current_window.to_offset(current_snapshot),
+        latest_event.old_snapshot.version(),
+    );
     Some(
         latest_event
             .old_snapshot
-            .text_for_range(old_start..old_end)
+            .text_for_range(old_range)
             .collect(),
     )
-}
-
-pub(crate) fn latest_active_buffer_event<'a>(
-    stored_events: &'a [StoredEvent],
-    snapshot: &BufferSnapshot,
-) -> Option<&'a StoredEvent> {
-    let current_remote_id = snapshot.remote_id();
-    stored_events
-        .iter()
-        .rev()
-        .find(|stored_event| stored_event.old_snapshot.remote_id() == current_remote_id)
 }
 
 fn build_prompt_input(
@@ -327,12 +312,12 @@ fn build_prompt_input(
     let current_window = snapshot
         .text_for_range(window_range.clone())
         .collect::<String>();
-    let original_window = original_window_for_current_window(
-        window_range,
-        latest_active_buffer_event(stored_events, snapshot),
-        snapshot,
-    )
-    .unwrap_or_else(|| current_window.clone());
+    let latest_event = stored_events
+        .iter()
+        .rev()
+        .find(|event| event.old_snapshot.remote_id() == snapshot.remote_id());
+    let original_window = original_window_for_current_window(window_range, latest_event, snapshot)
+        .unwrap_or_else(|| current_window.clone());
 
     SweepPromptInput {
         file_path: file_path.clone(),
@@ -356,39 +341,6 @@ fn write_file_block(prompt: &mut String, path: &Path, content: &str) {
     if !content.ends_with('\n') {
         prompt.push('\n');
     }
-}
-
-fn map_current_offset_to_old_snapshot(
-    current_offset: usize,
-    latest_event: &StoredEvent,
-    current_snapshot: &BufferSnapshot,
-) -> Option<usize> {
-    if latest_event.old_snapshot.remote_id() != current_snapshot.remote_id() {
-        return None;
-    }
-
-    let old_snapshot = &latest_event.old_snapshot;
-    for edit in current_snapshot.edits_since::<usize>(old_snapshot.version()) {
-        if current_offset < edit.new.start {
-            break;
-        }
-
-        if current_offset < edit.new.end {
-            let offset_in_edit = current_offset.saturating_sub(edit.new.start);
-            return Some(
-                (edit.old.start + offset_in_edit.min(edit.old.len())).min(old_snapshot.len()),
-            );
-        }
-    }
-
-    let old_offset = current_snapshot
-        .edits_since::<usize>(old_snapshot.version())
-        .take_while(|edit| current_offset >= edit.new.end)
-        .fold(current_offset as isize, |old_offset, edit| {
-            old_offset + edit.old.len() as isize - edit.new.len() as isize
-        });
-
-    Some(old_offset.max(0) as usize)
 }
 
 fn build_related_file_blocks(related_files: Vec<RelatedFile>) -> Vec<RelatedFileBlock> {
@@ -469,27 +421,16 @@ fn parse_unified_diff(diff: &str) -> (Vec<String>, Vec<String>) {
     (original_lines, updated_lines)
 }
 
-fn limit_change_lines(lines: Vec<String>, max_lines: usize) -> String {
-    if lines.len() <= max_lines {
-        return lines.join("\n");
+fn limit_change_lines(mut lines: Vec<String>, max_lines: usize) -> String {
+    if lines.len() > max_lines {
+        let head_count = max_lines / 2;
+        let tail_count = max_lines.saturating_sub(head_count + 1);
+        lines.splice(
+            head_count..lines.len().saturating_sub(tail_count),
+            ["...".to_string()],
+        );
     }
-
-    let head_count = max_lines / 2;
-    let tail_count = max_lines.saturating_sub(head_count + 1);
-    let mut trimmed = Vec::with_capacity(max_lines);
-    trimmed.extend(lines.iter().take(head_count).cloned());
-    trimmed.push("...".to_string());
-    trimmed.extend(
-        lines
-            .iter()
-            .rev()
-            .take(tail_count)
-            .cloned()
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev(),
-    );
-    trimmed.join("\n")
+    lines.join("\n")
 }
 
 fn clean_response_text(response_text: &str) -> String {
@@ -560,76 +501,21 @@ mod tests {
         });
     }
 
-    #[gpui::test]
-    fn test_original_window_for_current_window_treats_edit_end_as_post_edit_position(cx: &mut App) {
-        cx.new(|cx| {
-            let mut buffer = Buffer::local("aaaaabbbbb", cx);
-            let old_snapshot = buffer.text_snapshot();
-            buffer.edit([(5..10, "b")], None, cx);
-            let current_snapshot = buffer.snapshot();
-            let window = Point::new(0, 0)..Point::new(0, current_snapshot.line_len(0));
-
-            let stored_event = StoredEvent {
-                event: Arc::new(zeta_prompt::Event::BufferChange {
-                    old_path: Arc::from(std::path::Path::new("test.txt")),
-                    path: Arc::from(std::path::Path::new("test.txt")),
-                    diff: String::new(),
-                    old_range: 5..10,
-                    new_range: 5..6,
-                    in_open_source_repo: false,
-                    predicted: false,
-                }),
-                old_snapshot,
-                new_snapshot_version: current_snapshot.text.version.clone(),
-                total_edit_range: current_snapshot.anchor_before(5)
-                    ..current_snapshot.anchor_before(6),
-                file_context: None,
-            };
-
-            assert_eq!(
-                map_current_offset_to_old_snapshot(6, &stored_event, &current_snapshot),
-                Some(10)
-            );
-
-            let original_window =
-                original_window_for_current_window(window, Some(&stored_event), &current_snapshot)
-                    .expect("expected original window");
-
-            assert_eq!(original_window, "aaaaabbbbb");
-            buffer
-        });
-    }
-
-    #[gpui::test]
-    fn test_recent_change_block_from_event_formats_original_and_updated_sections(cx: &mut App) {
-        cx.new(|cx| {
-            let buffer = Buffer::local("fn main() {\n    println!(\"old\");\n}\n", cx);
-            let old_snapshot = buffer.text_snapshot();
-            let anchor = buffer.anchor_before(0);
-            let stored_event = StoredEvent {
-                event: Arc::new(zeta_prompt::Event::BufferChange {
-                    old_path: Path::new("src/main.rs").into(),
-                    path: Path::new("src/main.rs").into(),
-                    diff: "@@ -1,3 +1,3 @@\n fn main() {\n-    println!(\"old\");\n+    println!(\"new\");\n }\n"
-                        .to_string(),
-                    old_range: 0..0,
-                    new_range: 0..0,
-                    in_open_source_repo: false,
-                    predicted: false,
-                }),
-                new_snapshot_version: old_snapshot.version.clone(),
-                old_snapshot,
-                total_edit_range: anchor..anchor,
-                file_context: None,
-            };
-
-            let block =
-                recent_change_block_from_event(&stored_event).expect("expected recent change block");
-            assert_eq!(block.original, "fn main() {\n    println!(\"old\");\n}");
-            assert_eq!(block.updated, "fn main() {\n    println!(\"new\");\n}");
-
-            buffer
-        });
+    #[test]
+    fn test_parse_unified_diff() {
+        assert_eq!(
+            parse_unified_diff(
+                "@@ -1,3 +1,3 @@\n fn main() {\n-    println!(\"old\");\n+    println!(\"new\");\n }\n"
+            ),
+            (
+                ["fn main() {", "    println!(\"old\");", "}"]
+                    .map(str::to_string)
+                    .to_vec(),
+                ["fn main() {", "    println!(\"new\");", "}"]
+                    .map(str::to_string)
+                    .to_vec(),
+            )
+        );
     }
 
     #[test]

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -553,6 +553,7 @@ pub enum EditPredictionPromptFormat {
     CodeGemma,
     Codestral,
     Glm,
+    Sweep,
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -577,6 +578,7 @@ impl From<EditPredictionPromptFormatContent> for EditPredictionPromptFormat {
             EditPredictionPromptFormatContent::CodeGemma => Self::CodeGemma,
             EditPredictionPromptFormatContent::Codestral => Self::Codestral,
             EditPredictionPromptFormatContent::Glm => Self::Glm,
+            EditPredictionPromptFormatContent::Sweep => Self::Sweep,
         }
     }
 }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -164,7 +164,7 @@ pub struct CustomEditPredictionProviderSettingsContent {
     ///
     /// Default: ""
     pub model: Option<String>,
-    /// Maximum tokens to generate.
+    /// Maximum tokens to generate for FIM models and self-hosted Sweep rewrite responses.
     ///
     /// Default: 256
     pub max_output_tokens: Option<u32>,
@@ -198,6 +198,7 @@ pub enum EditPredictionPromptFormatContent {
     CodeGemma,
     Codestral,
     Glm,
+    Sweep,
 }
 
 #[with_fallible_options]
@@ -269,7 +270,7 @@ pub struct OllamaEditPredictionSettingsContent {
     ///
     /// Default: none
     pub model: Option<OllamaModelName>,
-    /// Maximum tokens to generate for FIM models.
+    /// Maximum tokens to generate for FIM models and self-hosted Sweep rewrite responses.
     ///
     /// Default: 256
     pub max_output_tokens: Option<u32>,

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -319,7 +319,7 @@ mod tests {
     use super::*;
     use editor::MultiBuffer;
     use gpui::{BorrowAppContext, TestAppContext};
-    use settings::{EditPredictionPromptFormat, EditPredictionProvider, SettingsStore};
+    use settings::{EditPredictionPromptFormatContent, EditPredictionProvider, SettingsStore};
     use workspace::AppState;
 
     #[gpui::test]
@@ -327,7 +327,7 @@ mod tests {
         let app_state = cx.update(|cx| {
             let app_state = AppState::test(cx);
             client::init(&app_state.client, cx);
-            language_model::init(app_state.user_store.clone(), app_state.client.clone(), cx);
+            language_model::init(cx);
             app_state
         });
 
@@ -343,7 +343,7 @@ mod tests {
                                         "http://localhost:8080/v1/completions".to_string(),
                                     ),
                                     model: Some("sweep-next-edit-1.5b".to_string()),
-                                    prompt_format: Some(EditPredictionPromptFormat::Sweep),
+                                    prompt_format: Some(EditPredictionPromptFormatContent::Sweep),
                                     ..Default::default()
                                 },
                             ),

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -140,6 +140,10 @@ fn edit_prediction_provider_config_for_settings(cx: &App) -> Option<EditPredicti
 
             if matches!(format, EditPredictionPromptFormat::Zeta(_)) {
                 Some(EditPredictionProviderConfig::Zed(EditPredictionModel::Zeta))
+            } else if format == EditPredictionPromptFormat::Sweep {
+                Some(EditPredictionProviderConfig::Zed(
+                    EditPredictionModel::SweepPrompt,
+                ))
             } else {
                 Some(EditPredictionProviderConfig::Zed(
                     EditPredictionModel::Fim { format },
@@ -187,6 +191,7 @@ impl EditPredictionProviderConfig {
             EditPredictionProviderConfig::Zed(model) => match model {
                 EditPredictionModel::Zeta => "Zeta",
                 EditPredictionModel::Fim { .. } => "FIM",
+                EditPredictionModel::SweepPrompt => "Sweep Prompt",
                 EditPredictionModel::Mercury => "Mercury",
             },
         }
@@ -311,8 +316,56 @@ mod tests {
     use super::*;
     use editor::MultiBuffer;
     use gpui::{BorrowAppContext, TestAppContext};
-    use settings::{EditPredictionProvider, SettingsStore};
+    use settings::{EditPredictionPromptFormat, EditPredictionProvider, SettingsStore};
     use workspace::AppState;
+
+    #[gpui::test]
+    async fn test_sweep_prompt_format_routes_to_sweep_prompt_model(cx: &mut TestAppContext) {
+        let app_state = cx.update(|cx| {
+            let app_state = AppState::test(cx);
+            client::init(&app_state.client, cx);
+            language_model::init(app_state.user_store.clone(), app_state.client.clone(), cx);
+            app_state
+        });
+
+        cx.update(|cx| {
+            cx.update_global::<SettingsStore, _>(|store: &mut SettingsStore, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.project.all_languages.edit_predictions =
+                        Some(settings::EditPredictionSettingsContent {
+                            provider: Some(EditPredictionProvider::OpenAiCompatibleApi),
+                            open_ai_compatible_api: Some(
+                                settings::CustomEditPredictionProviderSettingsContent {
+                                    api_url: Some(
+                                        "http://localhost:8080/v1/completions".to_string(),
+                                    ),
+                                    model: Some("sweep-next-edit-1.5b".to_string()),
+                                    prompt_format: Some(EditPredictionPromptFormat::Sweep),
+                                    ..Default::default()
+                                },
+                            ),
+                            ..Default::default()
+                        });
+                });
+            });
+        });
+
+        let config = cx.update(|cx| edit_prediction_provider_config_for_settings(cx));
+        assert!(
+            matches!(
+                config,
+                Some(EditPredictionProviderConfig::Zed(
+                    EditPredictionModel::SweepPrompt,
+                ))
+            ),
+            "expected self-hosted sweep prompt format to route to SweepPrompt"
+        );
+
+        let provider_name = config.map(|config| config.name());
+        assert_eq!(provider_name, Some("Sweep Prompt"));
+
+        drop(app_state);
+    }
 
     #[gpui::test]
     async fn test_subscribe_uses_stale_provider_config_after_settings_change(

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -163,6 +163,9 @@ fn infer_prompt_format(model: &str) -> Option<EditPredictionPromptFormat> {
     Some(match model_base {
         "zeta2" => EditPredictionPromptFormat::Zeta(ZetaVersion::Zeta2),
         "zeta2.1" => EditPredictionPromptFormat::Zeta(ZetaVersion::Zeta2_1),
+        model_base if model_base.to_ascii_lowercase().contains("sweep-next-edit") => {
+            EditPredictionPromptFormat::Sweep
+        }
         "codellama" | "code-llama" => EditPredictionPromptFormat::CodeLlama,
         "starcoder" | "starcoder2" | "starcoderbase" => EditPredictionPromptFormat::StarCoder,
         "deepseek-coder" | "deepseek-coder-v2" => EditPredictionPromptFormat::DeepseekCoder,

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -342,6 +342,7 @@ The `prompt_format` setting controls how code context is formatted for the model
 - `code_gemma` - CodeGemma format: `<|fim_prefix|>prefix<|fim_suffix|>suffix<|fim_middle|>`
 - `codestral` - Codestral format: `[SUFFIX]suffix[PREFIX]prefix`
 - `glm` - GLM-4 format with code markers
+- `sweep` - Modified Qwen format for [Sweep rewrite-window](https://blog.sweep.dev/posts/oss-next-edit) around the cursor.
 - `infer` - Auto-detect from model name (default)
 
 With `"prompt_format": "infer"`, Zed automatically uses Zeta 2 format for models named `zeta2` and Zeta 2.1 format for models named `zeta2.1`.

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -342,7 +342,7 @@ The `prompt_format` setting controls how code context is formatted for the model
 - `code_gemma` - CodeGemma format: `<|fim_prefix|>prefix<|fim_suffix|>suffix<|fim_middle|>`
 - `codestral` - Codestral format: `[SUFFIX]suffix[PREFIX]prefix`
 - `glm` - GLM-4 format with code markers
-- `sweep` - Modified Qwen format for [Sweep rewrite-window](https://blog.sweep.dev/posts/oss-next-edit) around the cursor.
+- `sweep` - [Sweep rewrite-window](https://blog.sweep.dev/posts/oss-next-edit) format using `<|file_sep|>` file blocks for related files, `original/...`, `current/...`, and `updated/...`.
 - `infer` - Auto-detect from model name (default)
 
 With `"prompt_format": "infer"`, Zed automatically uses Zeta 2 format for models named `zeta2` and Zeta 2.1 format for models named `zeta2.1`.


### PR DESCRIPTION
This adds support for running self-hosted Sweep Next Edit edit prediction models through Zed's OpenAI-compatible provider. The target use case is a local deployment based on [sweepai/sweep-next-edit-1.5B](https://huggingface.co/sweepai/sweep-next-edit-1.5B), using the rewrite-window prompting approach described in [OSS Next Edit](https://blog.sweep.dev/posts/oss-next-edit). Personal user testing shows impressive quality from this small edit prediction model. 

This is valuable because it allows more flexibility for Zed users to self-host state of the art next edit prediction models! 

This PR addresses the self-hosted workflow discussed in https://github.com/zed-industries/zed/discussions/50929.
Note that the self-hosted model path needed more than just a new dropdown value. Zed has to build the rewrite-window prompt shape the model expects, map the rewritten window back into anchored edits, and make `prompt_format: "infer"` work with the filename-style model identifiers that llama-server local server reports.

The main changes are:
- add a `Sweep` prompt format for OpenAI-compatible edit prediction providers and route it to a dedicated `SweepPrompt` model path
- build Sweep rewrite-window prompts from the active cursor window, recent change history, and related file excerpts
- convert rewrite responses back into anchored edits and suppress no-op rewrites
- add fixed cursor-window extraction used by the Sweep rewrite prompt path
- recognize `sweep-next-edit` model names during `infer`, including filename-style identifiers such as `sweepai_sweep-next-edit-1.5B_sweep-next-edit-1.5b.q8_0.v2.gguf`
- reject reserved Sweep prompt tokens before sending malformed requests to a self-hosted server
- update the docs to describe the actual Sweep rewrite-window prompt format

Local setup used for manual verification:

```sh
llama-server \
  --hf-repo sweepai/sweep-next-edit-1.5B \
  --hf-file sweep-next-edit-1.5b.q8_0.v2.gguf \
  --ctx-size 8192 \
  --host 127.0.0.1 \
  --port 8080
```

```json
{
  "edit_predictions": {
    "provider": "open_ai_compatible_api",
    "open_ai_compatible_api": {
      "api_url": "http://127.0.0.1:8080/v1/completions",
      "model": "sweepai_sweep-next-edit-1.5B_sweep-next-edit-1.5b.q8_0.v2.gguf",
      "prompt_format": "infer",
      "max_output_tokens": 512
    }
  }
}
```

The request that produced this PR included screenshots of the OpenAI-compatible provider configuration and the prompt format dropdown with `Sweep` selected.

Tests added in this branch:
- `test_sweep_prompt_format_routes_to_sweep_prompt_model`
- `test_fixed_line_window_around_cursor_start_middle_and_end`
- `test_sweep_prompt_request_prediction_diffs_rewritten_window_into_anchored_edits`
- `test_sweep_prompt_request_prediction_returns_none_for_identical_rewrite`
- `test_original_window_for_current_window_uses_latest_pre_edit_snapshot`
- `test_original_window_for_current_window_returns_none_without_matching_history`
- `test_recent_change_block_from_event_formats_original_and_updated_sections`

Verification run locally:
- `cargo test -p zed sweep_prompt_format_routes`
- `cargo test -p zed subscribe_uses_stale_provider_config`
- `cargo test -p edit_prediction sweep_prompt`
- `cargo test -p edit_prediction fixed_line_window_around_cursor_start_middle_and_end`
- `cargo test -p edit_prediction test_sweep_prompt_request_prediction_diffs_rewritten_window_into_anchored_edits`
- `cargo test -p edit_prediction test_sweep_prompt_request_prediction_returns_none_for_identical_rewrite`
- `./script/clippy -p zed -p edit_prediction -p settings_content`

Release Notes:

- Added support for self-hosted Sweep Next Edit models in OpenAI-compatible edit predictions, including the `sweep` prompt format and `infer` detection for `sweep-next-edit` model names.
