### PR TITLE
markdown_preview: Add support for `details` and `summary` tags

### DIFF
--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -19,6 +19,7 @@ pub enum ParsedMarkdownElement {
     Paragraph(MarkdownParagraph),
     HorizontalRule(Range<usize>),
     Image(Image),
+    Details(ParsedMarkdownDetails),
 }
 
 impl ParsedMarkdownElement {
@@ -36,6 +37,7 @@ impl ParsedMarkdownElement {
             },
             Self::HorizontalRule(range) => range.clone(),
             Self::Image(image) => image.source_range.clone(),
+            Self::Details(details) => details.source_range.clone(),
         })
     }
 
@@ -176,6 +178,27 @@ impl ParsedMarkdownTableRow {
 pub struct ParsedMarkdownBlockQuote {
     pub source_range: Range<usize>,
     pub children: Vec<ParsedMarkdownElement>,
+}
+
+/// The content model of a `<summary>` tag, per the HTML5.2 spec:
+/// either phrasing content (inline text, images) or exactly one heading element.
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum ParsedMarkdownSummaryContent {
+    Phrasing(MarkdownParagraph),
+    Heading(ParsedMarkdownHeading),
+}
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct ParsedMarkdownDetails {
+    pub source_range: Range<usize>,
+    /// The content of the `<summary>` child tag, if present.
+    pub summary: Option<ParsedMarkdownSummaryContent>,
+    /// All other children of the `<details>` tag.
+    pub body: Vec<ParsedMarkdownElement>,
+    /// Whether the `open` attribute is present, meaning the block starts expanded.
+    pub open: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -856,6 +856,29 @@ impl<'a> MarkdownParser<'a> {
         })
     }
 
+    /// Count the net number of unclosed `<details>` tags in `html`.
+    /// Returns a positive value when there are more opens than closes.
+    fn count_unclosed_details(html: &str) -> i32 {
+        let mut depth = 0i32;
+        let mut remaining = html;
+        while let Some(pos) = remaining.find('<') {
+            remaining = &remaining[pos..];
+            if remaining.starts_with("</details") {
+                let after = &remaining["</details".len()..];
+                if after.is_empty() || after.starts_with(|c: char| c == '>' || c.is_whitespace()) {
+                    depth -= 1;
+                }
+            } else if remaining.starts_with("<details") {
+                let after = &remaining["<details".len()..];
+                if after.is_empty() || after.starts_with(|c: char| c == '>' || c.is_whitespace()) {
+                    depth += 1;
+                }
+            }
+            remaining = &remaining[1..];
+        }
+        depth
+    }
+
     async fn parse_html_block(&mut self) -> Vec<ParsedMarkdownElement> {
         let mut elements = Vec::new();
         let Some((_event, _source_range)) = self.previous() else {
@@ -894,6 +917,23 @@ impl<'a> MarkdownParser<'a> {
             }
         }
 
+        // CommonMark type-6 HTML blocks (which include <details>) are terminated
+        // by blank lines. When a blank line appears inside a <details> block,
+        // pulldown-cmark ends the HTML block early and emits the body as separate
+        // markdown events (Paragraph, List, etc.). Detect this and parse those
+        // events as proper markdown elements rather than feeding raw source to html5ever.
+        if let Some(start) = html_source_range_start {
+            if Self::count_unclosed_details(&html_buffer) > 0 {
+                return self
+                    .parse_details_with_markdown_body(
+                        start,
+                        html_source_range_end,
+                        html_buffer,
+                    )
+                    .await;
+            }
+        }
+
         let bytes = cleanup_html(&html_buffer);
 
         let mut cursor = std::io::Cursor::new(bytes);
@@ -911,6 +951,98 @@ impl<'a> MarkdownParser<'a> {
         }
 
         elements
+    }
+
+    /// Handles `<details>` blocks split across multiple events by blank lines.
+    /// CommonMark type-6 HTML blocks end at blank lines, so pulldown-cmark emits
+    /// the body content as proper markdown events (Paragraph, List, etc.) rather
+    /// than as HTML. This method parses the `<summary>` from the initial HTML chunk,
+    /// then uses `parse_block` for the body, stopping at the closing `</details>`.
+    async fn parse_details_with_markdown_body(
+        &mut self,
+        range_start: usize,
+        initial_range_end: Option<usize>,
+        initial_html: String,
+    ) -> Vec<ParsedMarkdownElement> {
+        // Synthetically close the element so html5ever gets a complete tree from
+        // which we can extract the `open` attribute and `<summary>` content.
+        let mut synthetic_html = initial_html;
+        synthetic_html.push_str("</details>");
+
+        let partial_end = initial_range_end.unwrap_or(range_start);
+        let mut partial_elements = Vec::new();
+        let bytes = cleanup_html(&synthetic_html);
+        let mut io_cursor = std::io::Cursor::new(bytes);
+        if let Ok(dom) = parse_document(RcDom::default(), ParseOpts::default())
+            .from_utf8()
+            .read_from(&mut io_cursor)
+        {
+            self.parse_html_node(
+                range_start..partial_end,
+                &dom.document,
+                &mut partial_elements,
+                &ParseHtmlNodeContext::default(),
+            );
+        }
+
+        let (details_open, summary_content) = partial_elements
+            .into_iter()
+            .find_map(|e| {
+                if let ParsedMarkdownElement::Details(d) = e {
+                    Some((d.open, d.summary))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or((false, None));
+
+        // Parse remaining events as markdown body elements, stopping when we
+        // encounter an HtmlBlock that closes the <details>.
+        let mut body = Vec::new();
+        let mut range_end = partial_end;
+
+        while !self.eof() {
+            // Before calling parse_block, check if the upcoming HtmlBlock is the
+            // closing </details> (delta < 0 means net closing tags in that block).
+            if let Some((Event::Start(Tag::HtmlBlock), _)) = self.current() {
+                let closing_end = self.peek(1).and_then(|(e, r)| {
+                    if let Event::Html(html) = e {
+                        (Self::count_unclosed_details(html.as_ref()) < 0).then_some(r.end)
+                    } else {
+                        None
+                    }
+                });
+
+                if let Some(end) = closing_end {
+                    // Consume Start(HtmlBlock), Html(...), End(HtmlBlock)
+                    while !self.eof() {
+                        let is_end = matches!(
+                            self.current().map(|(e, _)| e),
+                            Some(Event::End(TagEnd::HtmlBlock))
+                        );
+                        self.cursor += 1;
+                        if is_end {
+                            break;
+                        }
+                    }
+                    range_end = end;
+                    break;
+                }
+            }
+
+            if let Some(block_elements) = self.parse_block().await {
+                body.extend(block_elements);
+            } else {
+                self.cursor += 1;
+            }
+        }
+
+        vec![ParsedMarkdownElement::Details(ParsedMarkdownDetails {
+            source_range: range_start..range_end,
+            summary: summary_content,
+            body,
+            open: details_open,
+        })]
     }
 
     fn parse_html_node(
@@ -3495,6 +3627,52 @@ fn main() {
             &details.summary,
             Some(ParsedMarkdownSummaryContent::Phrasing(_))
         ));
+    }
+
+    #[gpui::test]
+    async fn test_html_details_with_blank_lines_inside() {
+        // CommonMark type-6 HTML blocks are terminated by blank lines, so pulldown-cmark
+        // splits the block into multiple events when blank lines appear inside <details>.
+        // Verify the parser reassembles the full block so the body is hidden, not visible.
+        let parsed =
+            parse("<details>\n<summary>Click</summary>\n\nHidden content\n\n</details>").await;
+
+        assert_eq!(parsed.children.len(), 1);
+        let ParsedMarkdownElement::Details(details) = &parsed.children[0] else {
+            panic!("expected Details element, got {:?}", parsed.children[0]);
+        };
+        assert!(!details.open);
+        assert!(matches!(
+            &details.summary,
+            Some(ParsedMarkdownSummaryContent::Phrasing(_))
+        ));
+        assert!(
+            !details.body.is_empty(),
+            "body should contain 'Hidden content'"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_html_details_body_with_markdown_list() {
+        // Body uses markdown list syntax — pulldown-cmark parses it as a proper List
+        // (not plain text), so the rendered body should contain ListItem elements.
+        let parsed = parse(
+            "<details>\n<summary>Items</summary>\n\n- Item 1\n- Item 2\n\n</details>",
+        )
+        .await;
+
+        assert_eq!(parsed.children.len(), 1);
+        let ParsedMarkdownElement::Details(details) = &parsed.children[0] else {
+            panic!("expected Details element, got {:?}", parsed.children[0]);
+        };
+        assert!(
+            details
+                .body
+                .iter()
+                .any(|e| matches!(e, ParsedMarkdownElement::ListItem(_))),
+            "body should contain ListItem elements, got: {:?}",
+            details.body
+        );
     }
 
     impl PartialEq for ParsedMarkdownTable {

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -878,6 +878,12 @@ impl<'a> MarkdownParser<'a> {
                     html_buffer.push_str(html);
                     self.cursor += 1;
                 }
+                // pulldown_cmark emits a Text event (zero-length range) for any
+                // leading whitespace before the first HTML tag in an HTML block.
+                // Skip it so we don't bail out before collecting any HTML content.
+                Event::Text(_) if html_buffer.is_empty() => {
+                    self.cursor += 1;
+                }
                 Event::End(TagEnd::CodeBlock) => {
                     self.cursor += 1;
                     break;

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -3380,6 +3380,123 @@ fn main() {
         }
     }
 
+    fn details(
+        source_range: Range<usize>,
+        summary: Option<ParsedMarkdownSummaryContent>,
+        body: Vec<ParsedMarkdownElement>,
+        open: bool,
+    ) -> ParsedMarkdownElement {
+        ParsedMarkdownElement::Details(ParsedMarkdownDetails {
+            source_range,
+            summary,
+            body,
+            open,
+        })
+    }
+
+    #[gpui::test]
+    async fn test_html_details_collapsed() {
+        let parsed =
+            parse("<details>\n<summary>Click to expand</summary>\n<p>Body content</p>\n</details>")
+                .await;
+
+        assert_eq!(
+            parsed,
+            ParsedMarkdown {
+                children: vec![details(
+                    0..75,
+                    Some(ParsedMarkdownSummaryContent::Phrasing(text(
+                        "Click to expand",
+                        0..75
+                    ))),
+                    vec![p("Body content", 0..75)],
+                    false,
+                )]
+            }
+        );
+    }
+
+    #[gpui::test]
+    async fn test_html_details_open() {
+        let parsed =
+            parse("<details open>\n<summary>Open summary</summary>\n</details>").await;
+
+        assert_eq!(
+            parsed,
+            ParsedMarkdown {
+                children: vec![details(
+                    0..57,
+                    Some(ParsedMarkdownSummaryContent::Phrasing(text(
+                        "Open summary",
+                        0..57
+                    ))),
+                    vec![],
+                    true,
+                )]
+            }
+        );
+    }
+
+    #[gpui::test]
+    async fn test_html_details_without_summary() {
+        let parsed = parse("<details>\n<p>No summary</p>\n</details>").await;
+
+        assert_eq!(
+            parsed,
+            ParsedMarkdown {
+                children: vec![details(
+                    0..38,
+                    None,
+                    vec![p("No summary", 0..38)],
+                    false,
+                )]
+            }
+        );
+    }
+
+    #[gpui::test]
+    async fn test_html_details_heading_summary() {
+        let parsed = parse(
+            "<details>\n<summary><h2>Heading Summary</h2></summary>\n<p>Body</p>\n</details>",
+        )
+        .await;
+
+        assert_eq!(
+            parsed,
+            ParsedMarkdown {
+                children: vec![details(
+                    0..76,
+                    Some(ParsedMarkdownSummaryContent::Heading(
+                        ParsedMarkdownHeading {
+                            source_range: 0..76,
+                            level: HeadingLevel::H2,
+                            contents: text("Heading Summary", 0..76),
+                        }
+                    )),
+                    vec![p("Body", 0..76)],
+                    false,
+                )]
+            }
+        );
+    }
+
+    #[gpui::test]
+    async fn test_html_details_with_leading_space() {
+        // pulldown-cmark emits a leading Text event for HTML blocks with a leading space.
+        // Verify this does not prevent the block from being parsed.
+        let parsed = parse(" <details>\n<summary>Indented</summary>\n</details>").await;
+
+        assert_eq!(parsed.children.len(), 1);
+        let ParsedMarkdownElement::Details(details) = &parsed.children[0] else {
+            panic!("expected Details element");
+        };
+        assert!(!details.open);
+        assert!(matches!(
+            &details.summary,
+            Some(ParsedMarkdownSummaryContent::Phrasing(_))
+        ));
+    }
+
     impl PartialEq for ParsedMarkdownTable {
         fn eq(&self, other: &Self) -> bool {
             self.source_range == other.source_range

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -1005,6 +1005,10 @@ impl<'a> MarkdownParser<'a> {
                     if let Some(table) = self.extract_html_table(node, source_range) {
                         elements.push(ParsedMarkdownElement::Table(table));
                     }
+                } else if local_name!("details") == name.local {
+                    if let Some(details) = self.extract_html_details(node, source_range, attrs) {
+                        elements.push(ParsedMarkdownElement::Details(details));
+                    }
                 } else {
                     self.consume_children(source_range, node, elements, context);
                 }
@@ -1452,6 +1456,104 @@ impl<'a> MarkdownParser<'a> {
                 source_range,
             })
         }
+    }
+
+    fn extract_html_details(
+        &self,
+        node: &Rc<markup5ever_rcdom::Node>,
+        source_range: Range<usize>,
+        attrs: &RefCell<Vec<html5ever::Attribute>>,
+    ) -> Option<ParsedMarkdownDetails> {
+        let open = Self::attr_value(attrs, local_name!("open")).is_some();
+        let mut summary = None;
+        let mut body = Vec::new();
+
+        for child in node.children.borrow().iter() {
+            if let markup5ever_rcdom::NodeData::Element { name, .. } = &child.data {
+                if local_name!("summary") == name.local {
+                    if summary.is_none() {
+                        summary =
+                            Some(self.parse_summary_content(source_range.clone(), child));
+                    }
+                    continue;
+                }
+            }
+            self.parse_html_node(
+                source_range.clone(),
+                child,
+                &mut body,
+                &ParseHtmlNodeContext::default(),
+            );
+        }
+
+        Some(ParsedMarkdownDetails {
+            source_range,
+            summary,
+            body,
+            open,
+        })
+    }
+
+    fn parse_summary_content(
+        &self,
+        source_range: Range<usize>,
+        node: &Rc<markup5ever_rcdom::Node>,
+    ) -> ParsedMarkdownSummaryContent {
+        // Per HTML5.2, <summary> contains either phrasing content or exactly one heading.
+        // We check by looking for the first element child.
+        for child in node.children.borrow().iter() {
+            match &child.data {
+                markup5ever_rcdom::NodeData::Element { name, .. } => {
+                    if matches!(
+                        name.local,
+                        local_name!("h1")
+                            | local_name!("h2")
+                            | local_name!("h3")
+                            | local_name!("h4")
+                            | local_name!("h5")
+                            | local_name!("h6")
+                    ) {
+                        let mut paragraph = MarkdownParagraph::new();
+                        self.consume_paragraph(
+                            source_range.clone(),
+                            child,
+                            &mut paragraph,
+                            &mut Vec::new(),
+                            &mut Vec::new(),
+                        );
+                        let level = match name.local {
+                            local_name!("h1") => HeadingLevel::H1,
+                            local_name!("h2") => HeadingLevel::H2,
+                            local_name!("h3") => HeadingLevel::H3,
+                            local_name!("h4") => HeadingLevel::H4,
+                            local_name!("h5") => HeadingLevel::H5,
+                            local_name!("h6") => HeadingLevel::H6,
+                            _ => unreachable!(),
+                        };
+                        return ParsedMarkdownSummaryContent::Heading(ParsedMarkdownHeading {
+                            source_range,
+                            level,
+                            contents: paragraph,
+                        });
+                    }
+                    // First element child is not a heading — fall through to phrasing.
+                    break;
+                }
+                // Skip whitespace text nodes before the first element child.
+                markup5ever_rcdom::NodeData::Text { .. } => continue,
+                _ => break,
+            }
+        }
+
+        let mut paragraph = MarkdownParagraph::new();
+        self.consume_paragraph(
+            source_range,
+            node,
+            &mut paragraph,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        );
+        ParsedMarkdownSummaryContent::Phrasing(paragraph)
     }
 
     fn extract_html_table(

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -863,13 +863,11 @@ impl<'a> MarkdownParser<'a> {
         let mut remaining = html;
         while let Some(pos) = remaining.find('<') {
             remaining = &remaining[pos..];
-            if remaining.starts_with("</details") {
-                let after = &remaining["</details".len()..];
+            if let Some(after) = remaining.strip_prefix("</details") {
                 if after.is_empty() || after.starts_with(|c: char| c == '>' || c.is_whitespace()) {
                     depth -= 1;
                 }
-            } else if remaining.starts_with("<details") {
-                let after = &remaining["<details".len()..];
+            } else if let Some(after) = remaining.strip_prefix("<details") {
                 if after.is_empty() || after.starts_with(|c: char| c == '>' || c.is_whitespace()) {
                     depth += 1;
                 }
@@ -925,11 +923,7 @@ impl<'a> MarkdownParser<'a> {
         if let Some(start) = html_source_range_start {
             if Self::count_unclosed_details(&html_buffer) > 0 {
                 return self
-                    .parse_details_with_markdown_body(
-                        start,
-                        html_source_range_end,
-                        html_buffer,
-                    )
+                    .parse_details_with_markdown_body(start, html_source_range_end, html_buffer)
                     .await;
             }
         }
@@ -1610,8 +1604,7 @@ impl<'a> MarkdownParser<'a> {
             if let markup5ever_rcdom::NodeData::Element { name, .. } = &child.data {
                 if local_name!("summary") == name.local {
                     if summary.is_none() {
-                        summary =
-                            Some(self.parse_summary_content(source_range.clone(), child));
+                        summary = Some(self.parse_summary_content(source_range.clone(), child));
                     }
                     continue;
                 }
@@ -3550,8 +3543,7 @@ fn main() {
 
     #[gpui::test]
     async fn test_html_details_open() {
-        let parsed =
-            parse("<details open>\n<summary>Open summary</summary>\n</details>").await;
+        let parsed = parse("<details open>\n<summary>Open summary</summary>\n</details>").await;
 
         assert_eq!(
             parsed,
@@ -3576,12 +3568,7 @@ fn main() {
         assert_eq!(
             parsed,
             ParsedMarkdown {
-                children: vec![details(
-                    0..38,
-                    None,
-                    vec![p("No summary", 0..38)],
-                    false,
-                )]
+                children: vec![details(0..38, None, vec![p("No summary", 0..38)], false,)]
             }
         );
     }
@@ -3656,10 +3643,8 @@ fn main() {
     async fn test_html_details_body_with_markdown_list() {
         // Body uses markdown list syntax — pulldown-cmark parses it as a proper List
         // (not plain text), so the rendered body should contain ListItem elements.
-        let parsed = parse(
-            "<details>\n<summary>Items</summary>\n\n- Item 1\n- Item 2\n\n</details>",
-        )
-        .await;
+        let parsed =
+            parse("<details>\n<summary>Items</summary>\n\n- Item 1\n- Item 2\n\n</details>").await;
 
         assert_eq!(parsed.children.len(), 1);
         let ParsedMarkdownElement::Details(details) = &parsed.children[0] else {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -19,7 +19,8 @@ use workspace::item::{Item, ItemHandle};
 use workspace::{Pane, Workspace};
 
 use crate::markdown_elements::ParsedMarkdownElement;
-use crate::markdown_renderer::{CheckboxClickedEvent, MermaidState};
+use crate::markdown_renderer::{CheckboxClickedEvent, DetailsToggleEvent, MermaidState};
+use collections::HashMap;
 use crate::{
     OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
     markdown_elements::ParsedMarkdown,
@@ -40,6 +41,7 @@ pub struct MarkdownPreviewView {
     list_state: ListState,
     language_registry: Arc<LanguageRegistry>,
     mermaid_state: MermaidState,
+    expanded_details: Arc<HashMap<usize, bool>>,
     parsing_markdown_task: Option<Task<Result<()>>>,
     mode: MarkdownPreviewMode,
 }
@@ -216,6 +218,7 @@ impl MarkdownPreviewView {
                 list_state,
                 language_registry,
                 mermaid_state: Default::default(),
+                expanded_details: Arc::new(HashMap::default()),
                 parsing_markdown_task: None,
                 image_cache: RetainAllImageCache::new(cx),
                 mode,
@@ -575,12 +578,21 @@ impl Render for MarkdownPreviewView {
                                 return div().into_any();
                             };
 
+                            let expanded_details = this.expanded_details.clone();
                             let mut render_cx = RenderContext::new(
                                 Some(this.workspace.clone()),
                                 &this.mermaid_state,
                                 window,
                                 cx,
                             )
+                            .with_expanded_details(expanded_details)
+                            .with_details_toggle_callback(cx.listener(
+                                move |this, event: &DetailsToggleEvent, _window, cx| {
+                                    Arc::make_mut(&mut this.expanded_details)
+                                        .insert(event.source_range_start, event.expanded);
+                                    cx.notify();
+                                },
+                            ))
                             .with_checkbox_clicked_callback(cx.listener(
                                 move |this, e: &CheckboxClickedEvent, window, cx| {
                                     if let Some(editor) =

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -20,7 +20,6 @@ use workspace::{Pane, Workspace};
 
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::{CheckboxClickedEvent, DetailsToggleEvent, MermaidState};
-use collections::HashMap;
 use crate::{
     OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
     markdown_elements::ParsedMarkdown,
@@ -28,6 +27,7 @@ use crate::{
     markdown_renderer::{RenderContext, render_markdown_block},
 };
 use crate::{ScrollDown, ScrollDownByItem, ScrollUp, ScrollUpByItem};
+use collections::HashMap;
 
 const REPARSE_DEBOUNCE: Duration = Duration::from_millis(200);
 

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -1,9 +1,10 @@
 use crate::{
     markdown_elements::{
         HeadingLevel, Image, Link, MarkdownParagraph, MarkdownParagraphChunk, ParsedMarkdown,
-        ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock, ParsedMarkdownElement,
-        ParsedMarkdownHeading, ParsedMarkdownListItem, ParsedMarkdownListItemType,
-        ParsedMarkdownMermaidDiagram, ParsedMarkdownMermaidDiagramContents, ParsedMarkdownTable,
+        ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock, ParsedMarkdownDetails,
+        ParsedMarkdownElement, ParsedMarkdownHeading, ParsedMarkdownListItem,
+        ParsedMarkdownListItemType, ParsedMarkdownMermaidDiagram,
+        ParsedMarkdownMermaidDiagramContents, ParsedMarkdownSummaryContent, ParsedMarkdownTable,
         ParsedMarkdownTableAlignment, ParsedMarkdownTableRow,
     },
     markdown_preview_view::MarkdownPreviewView,
@@ -320,6 +321,7 @@ pub fn render_markdown_block(block: &ParsedMarkdownElement, cx: &mut RenderConte
         MermaidDiagram(mermaid) => render_mermaid_diagram(mermaid, cx),
         HorizontalRule(_) => render_markdown_rule(cx),
         Image(image) => render_markdown_image(image, cx),
+        Details(details) => render_markdown_details(details, cx),
     }
 }
 
@@ -741,6 +743,63 @@ fn render_markdown_block_quote(
                 .children(children),
         )
         .into_any()
+}
+
+fn render_markdown_details(
+    parsed: &ParsedMarkdownDetails,
+    cx: &mut RenderContext,
+) -> AnyElement {
+    let is_expanded = parsed.open;
+
+    let summary_content = match &parsed.summary {
+        Some(ParsedMarkdownSummaryContent::Phrasing(paragraph)) => {
+            render_markdown_paragraph(paragraph, cx)
+        }
+        Some(ParsedMarkdownSummaryContent::Heading(heading)) => {
+            render_markdown_heading(heading, cx)
+        }
+        None => div()
+            .child(SharedString::from("Details"))
+            .into_any(),
+    };
+
+    let chevron = if is_expanded {
+        ui::Icon::new(ui::IconName::ChevronDown)
+            .size(ui::IconSize::Small)
+            .color(ui::Color::Muted)
+    } else {
+        ui::Icon::new(ui::IconName::ChevronRight)
+            .size(ui::IconSize::Small)
+            .color(ui::Color::Muted)
+    };
+
+    let summary_row = h_flex()
+        .gap_1()
+        .items_start()
+        .child(div().mt(cx.scaled_rems(0.15)).child(chevron))
+        .child(summary_content);
+
+    if is_expanded {
+        cx.indent += 1;
+        let body_children: Vec<AnyElement> = parsed
+            .body
+            .iter()
+            .enumerate()
+            .map(|(ix, child)| {
+                cx.with_last_child(ix + 1 == parsed.body.len(), |cx| {
+                    render_markdown_block(child, cx)
+                })
+            })
+            .collect();
+        cx.indent -= 1;
+
+        cx.with_common_p(div())
+            .child(summary_row)
+            .child(div().pl(cx.scaled_rems(1.5)).children(body_children))
+            .into_any()
+    } else {
+        cx.with_common_p(div()).child(summary_row).into_any()
+    }
 }
 
 fn render_markdown_code_block(

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -15,7 +15,8 @@ use gpui::{
     AbsoluteLength, Animation, AnimationExt, AnyElement, App, AppContext as _, Context, Div,
     Element, ElementId, Entity, HighlightStyle, Hsla, ImageSource, InteractiveText, IntoElement,
     Keystroke, Modifiers, ParentElement, Render, RenderImage, Resource, SharedString, Styled,
-    StyledText, Task, TextStyle, WeakEntity, Window, div, img, pulsating_between, rems,
+    StyledText, Task, TextStyle, Transformation, WeakEntity, Window, div, img, pulsating_between,
+    radians, rems,
 };
 use settings::Settings;
 use std::{
@@ -790,15 +791,12 @@ fn render_markdown_details(
         None => div().child(SharedString::from("Details")).into_any(),
     };
 
-    let chevron = if is_expanded {
-        ui::Icon::new(ui::IconName::ChevronDown)
-            .size(ui::IconSize::Small)
-            .color(ui::Color::Muted)
-    } else {
-        ui::Icon::new(ui::IconName::ChevronRight)
-            .size(ui::IconSize::Small)
-            .color(ui::Color::Muted)
-    };
+    let triangle = ui::Icon::new(ui::IconName::TriangleRight)
+        .size(ui::IconSize::Medium)
+        .color(ui::Color::Muted)
+        .when(is_expanded, |icon| {
+            icon.transform(Transformation::rotate(radians(std::f32::consts::PI / 2.0)))
+        });
 
     let new_expanded = !is_expanded;
     let source_range_start = parsed.source_range.start;
@@ -807,7 +805,7 @@ fn render_markdown_details(
         .gap_1()
         .items_center()
         .cursor_pointer()
-        .child(chevron)
+        .child(triangle)
         .child(summary_content)
         .when_some(cx.details_toggle_callback.clone(), |this, callback| {
             this.on_click(move |_, window, cx| {

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -770,16 +770,26 @@ fn render_markdown_block_quote(
         .into_any()
 }
 
+fn details_is_expanded(
+    source_range_start: usize,
+    open: bool,
+    expanded_details: Option<&HashMap<usize, bool>>,
+) -> bool {
+    expanded_details
+        .and_then(|map| map.get(&source_range_start))
+        .copied()
+        .unwrap_or(open)
+}
+
 fn render_markdown_details(
     parsed: &ParsedMarkdownDetails,
     cx: &mut RenderContext,
 ) -> AnyElement {
-    let is_expanded = cx
-        .expanded_details
-        .as_ref()
-        .and_then(|map| map.get(&parsed.source_range.start))
-        .copied()
-        .unwrap_or(parsed.open);
+    let is_expanded = details_is_expanded(
+        parsed.source_range.start,
+        parsed.open,
+        cx.expanded_details.as_deref(),
+    );
 
     let summary_content = match &parsed.summary {
         Some(ParsedMarkdownSummaryContent::Phrasing(paragraph)) => {
@@ -1594,5 +1604,30 @@ mod tests {
             Arc::ptr_eq(&fallback.unwrap(), &svg_a),
             "Fallback should be the old duplicate diagram's image"
         );
+    }
+
+    #[test]
+    fn test_details_is_expanded_defaults_to_open_attribute() {
+        assert!(!details_is_expanded(0, false, None));
+        assert!(details_is_expanded(0, true, None));
+    }
+
+    #[test]
+    fn test_details_is_expanded_no_entry_falls_back_to_open_attribute() {
+        let map: HashMap<usize, bool> = HashMap::default();
+        assert!(!details_is_expanded(42, false, Some(&map)));
+        assert!(details_is_expanded(42, true, Some(&map)));
+    }
+
+    #[test]
+    fn test_details_is_expanded_explicit_toggle_overrides_open_attribute() {
+        let mut map: HashMap<usize, bool> = HashMap::default();
+        map.insert(10, false);
+        map.insert(20, true);
+
+        // open=true but user toggled closed
+        assert!(!details_is_expanded(10, true, Some(&map)));
+        // open=false but user toggled open
+        assert!(details_is_expanded(20, false, Some(&map)));
     }
 }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -805,9 +805,9 @@ fn render_markdown_details(
     let summary_row = h_flex()
         .id(cx.next_id(&parsed.source_range))
         .gap_1()
-        .items_start()
+        .items_center()
         .cursor_pointer()
-        .child(div().mt(cx.scaled_rems(0.15)).child(chevron))
+        .child(chevron)
         .child(summary_content)
         .when_some(cx.details_toggle_callback.clone(), |this, callback| {
             this.on_click(move |_, window, cx| {

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -781,10 +781,7 @@ fn details_is_expanded(
         .unwrap_or(open)
 }
 
-fn render_markdown_details(
-    parsed: &ParsedMarkdownDetails,
-    cx: &mut RenderContext,
-) -> AnyElement {
+fn render_markdown_details(parsed: &ParsedMarkdownDetails, cx: &mut RenderContext) -> AnyElement {
     let is_expanded = details_is_expanded(
         parsed.source_range.start,
         parsed.open,

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -45,6 +45,13 @@ impl CheckboxClickedEvent {
 
 type CheckboxClickedCallback = Arc<Box<dyn Fn(&CheckboxClickedEvent, &mut Window, &mut App)>>;
 
+pub struct DetailsToggleEvent {
+    pub source_range_start: usize,
+    pub expanded: bool,
+}
+
+type DetailsToggleCallback = Arc<Box<dyn Fn(&DetailsToggleEvent, &mut Window, &mut App)>>;
+
 type MermaidDiagramCache = HashMap<ParsedMarkdownMermaidDiagramContents, CachedMermaidDiagram>;
 
 #[derive(Default)]
@@ -190,6 +197,8 @@ pub struct RenderContext<'a> {
     syntax_theme: Arc<SyntaxTheme>,
     indent: usize,
     checkbox_clicked_callback: Option<CheckboxClickedCallback>,
+    expanded_details: Option<Arc<HashMap<usize, bool>>>,
+    details_toggle_callback: Option<DetailsToggleCallback>,
     is_last_child: bool,
     mermaid_state: &'a MermaidState,
 }
@@ -229,6 +238,8 @@ impl<'a> RenderContext<'a> {
             code_block_background_color: theme.colors().surface_background,
             code_span_background_color: theme.colors().editor_document_highlight_read_background,
             checkbox_clicked_callback: None,
+            expanded_details: None,
+            details_toggle_callback: None,
             is_last_child: false,
             mermaid_state,
         }
@@ -239,6 +250,19 @@ impl<'a> RenderContext<'a> {
         callback: impl Fn(&CheckboxClickedEvent, &mut Window, &mut App) + 'static,
     ) -> Self {
         self.checkbox_clicked_callback = Some(Arc::new(Box::new(callback)));
+        self
+    }
+
+    pub fn with_expanded_details(mut self, expanded: Arc<HashMap<usize, bool>>) -> Self {
+        self.expanded_details = Some(expanded);
+        self
+    }
+
+    pub fn with_details_toggle_callback(
+        mut self,
+        callback: impl Fn(&DetailsToggleEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.details_toggle_callback = Some(Arc::new(Box::new(callback)));
         self
     }
 
@@ -749,7 +773,12 @@ fn render_markdown_details(
     parsed: &ParsedMarkdownDetails,
     cx: &mut RenderContext,
 ) -> AnyElement {
-    let is_expanded = parsed.open;
+    let is_expanded = cx
+        .expanded_details
+        .as_ref()
+        .and_then(|map| map.get(&parsed.source_range.start))
+        .copied()
+        .unwrap_or(parsed.open);
 
     let summary_content = match &parsed.summary {
         Some(ParsedMarkdownSummaryContent::Phrasing(paragraph)) => {
@@ -758,9 +787,7 @@ fn render_markdown_details(
         Some(ParsedMarkdownSummaryContent::Heading(heading)) => {
             render_markdown_heading(heading, cx)
         }
-        None => div()
-            .child(SharedString::from("Details"))
-            .into_any(),
+        None => div().child(SharedString::from("Details")).into_any(),
     };
 
     let chevron = if is_expanded {
@@ -773,11 +800,27 @@ fn render_markdown_details(
             .color(ui::Color::Muted)
     };
 
+    let new_expanded = !is_expanded;
+    let source_range_start = parsed.source_range.start;
     let summary_row = h_flex()
+        .id(cx.next_id(&parsed.source_range))
         .gap_1()
         .items_start()
+        .cursor_pointer()
         .child(div().mt(cx.scaled_rems(0.15)).child(chevron))
-        .child(summary_content);
+        .child(summary_content)
+        .when_some(cx.details_toggle_callback.clone(), |this, callback| {
+            this.on_click(move |_, window, cx| {
+                callback(
+                    &DetailsToggleEvent {
+                        source_range_start,
+                        expanded: new_expanded,
+                    },
+                    window,
+                    cx,
+                )
+            })
+        });
 
     if is_expanded {
         cx.indent += 1;

--- a/crates/ui/src/prelude.rs
+++ b/crates/ui/src/prelude.rs
@@ -22,6 +22,7 @@ pub use crate::traits::disableable::*;
 pub use crate::traits::fixed::*;
 pub use crate::traits::styled_ext::*;
 pub use crate::traits::toggleable::*;
+pub use crate::traits::transformable::*;
 pub use crate::traits::visible_on_hover::*;
 pub use crate::{Button, ButtonSize, ButtonStyle, IconButton, SelectableButton};
 pub use crate::{ButtonCommon, Color};


### PR DESCRIPTION
Closes #49865 (also partially for #30275)

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added support for rendering `<details>` and `<summary>` tags in Markdown files, as collapsible blocks. 

Screenshots

Before:

<img width="3110" height="1952" alt="image" src="https://github.com/user-attachments/assets/713d8917-5960-4795-a7c2-fda2c2a8610a" />

After:

![after](https://github.com/user-attachments/assets/497a5a40-138e-490c-9938-19e26333ab25)


<details>
<summary>The .md file used in the screenshots</summary>

```
1. Plain text (most common)
<details>
    <summary>Click to expand</summary>
    Hidden content here
</details>

---

2. Bold inline
<details>
    <summary><strong>Bold</strong> summary</summary>
    Hidden content here
</details>

---

3. Mixed inline
<details>
    <summary>Expand <em>this</em> section</summary>
    Hidden content here
</details>

---

4. Heading (the other branch)
<details>
    <summary><h2>Section Title</h2></summary>
    Hidden content here
</details>

```
</details>

Known issue: 

1. Inline code blocks (e.g. `<code>`) should technically be allowed within the `<summary>` tags, as it is included in the "phrasing content". But with this PR it is not supported. It will just be rendered as ordinary text. It's a pre-existing limitation of `parse_paragraph` that affects all phrasing content contexts. Should be fixed in a separate PR. 
2. If you put list in the hidden content, you'll notice that the spacing between list items is larger than expected. This is also a pre-existing issue. You can reproduce this with blockquotes blocks (using `>`) too. Should be fixed in a separate PR. 
