### PR TITLE
docs: Fix incorrect binary name for `visual_test_runner`

### DIFF
--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -89,7 +89,7 @@ Before making any UI changes, generate baseline images from a known-good state:
 
 ```sh
 git checkout origin/main
-UPDATE_BASELINE=1 cargo run -p zed --bin visual_test_runner --features visual-tests
+UPDATE_BASELINE=1 cargo run -p zed --bin zed_visual_test_runner --features visual-tests
 git checkout -
 ```
 


### PR DESCRIPTION
The correct binary name is zed_visual_test_runner, not visual_test_runner. Fixes #51151

Closes #51151

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
