### PR TITLE
workspace: Avoid environment contamination when opening local settings from remote

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2680,12 +2680,11 @@ impl Workspace {
         if self.project.read(cx).is_local() {
             Task::ready(Ok(callback(self, window, cx)))
         } else {
-            let env = self.project.read(cx).cli_environment(cx);
             let task = Self::new_local(
                 Vec::new(),
                 self.app_state.clone(),
                 None,
-                env,
+                None,
                 None,
                 true,
                 cx,
@@ -2718,12 +2717,11 @@ impl Workspace {
         if project.is_local() || project.is_via_wsl_with_host_interop(cx) {
             Task::ready(Ok(callback(self, window, cx)))
         } else {
-            let env = self.project.read(cx).cli_environment(cx);
             let task = Self::new_local(
                 Vec::new(),
                 self.app_state.clone(),
                 None,
-                env,
+                None,
                 None,
                 true,
                 cx,


### PR DESCRIPTION
Release Notes:

- Fixed Avoid environment contamination when opening local settings from remote

When connected to a remote project (e.g., via SSH or WSL), executing commands
that open local windows (like "Open Settings File") would pass the remote
project's environment variables to the new local window.

Remote-specific variables (such as `DISPLAY`, `ZED_IPC_PIPE`, or
`WAYLAND_DISPLAY`) could interfere with GPUI's local window initialization,
causing the window creation to fail silently or hang.

This change ensures that `with_local_workspace` and
`with_local_or_wsl_workspace` use a clean local environment when spawning
the new local workspace window.
