### PR TITLE
workspace: Avoid environment contamination when opening local settings from remote

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2693,6 +2693,7 @@ impl Workspace {
             cx.spawn_in(window, async move |_vh, cx| {
                 let (multi_workspace_window, _) = task.await?;
                 multi_workspace_window.update(cx, |multi_workspace, window, cx| {
+                    window.activate_window();
                     let workspace = multi_workspace.workspace().clone();
                     workspace.update(cx, |workspace, cx| callback(workspace, window, cx))
                 })
@@ -2718,12 +2719,11 @@ impl Workspace {
         if project.is_local() || project.is_via_wsl_with_host_interop(cx) {
             Task::ready(Ok(callback(self, window, cx)))
         } else {
-            let env = self.project.read(cx).cli_environment(cx);
             let task = Self::new_local(
                 Vec::new(),
                 self.app_state.clone(),
                 None,
-                env,
+                None,
                 None,
                 true,
                 cx,
@@ -2731,6 +2731,7 @@ impl Workspace {
             cx.spawn_in(window, async move |_vh, cx| {
                 let (multi_workspace_window, _) = task.await?;
                 multi_workspace_window.update(cx, |multi_workspace, window, cx| {
+                    window.activate_window();
                     let workspace = multi_workspace.workspace().clone();
                     workspace.update(cx, |workspace, cx| callback(workspace, window, cx))
                 })


### PR DESCRIPTION
Release Notes:

- Fixed settings file cannot be opened when accessing a remote directory


before:



https://github.com/user-attachments/assets/10595772-f085-424a-9e5e-b1630ed6396c



after:




https://github.com/user-attachments/assets/42e56254-d07a-4c20-946d-1d2e2ded2a2d



