### PR TITLE
agent_ui: Fix button to copy the command from terminal calls not appearing

### DIFF
--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -4844,6 +4844,7 @@ impl ThreadView {
         cx: &Context<Self>,
     ) -> Div {
         v_flex()
+            .group(group.clone())
             .p_1p5()
             .bg(self.tool_card_header_bg(cx))
             .when(is_preview, |this| {


### PR DESCRIPTION
Fixes #51048

The "Copy Command" button uses `.visible_on_hover(group)` from GPUI to only appear when the user hovers over its parent container. In `render_collapsible_command` (used to render the code blocks for terminal tool calls like "Run Command"), the parent `v_flex()` container was missing the `.group()` assignment. This caused the copy button to never become visible, which became apparent when an agent session was restored from history.

This commit adds `.group(group.clone())` to the root `v_flex()` container in `render_collapsible_command` to restore the hover visibility for the "Copy Command" button.

Video :
[Screencast from 2026-03-10 18-06-57.webm](https://github.com/user-attachments/assets/ae931ac3-c7f1-4044-a3d8-a91a93d9c3bb)
[Screencast from 2026-03-10 18-06-01.webm](https://github.com/user-attachments/assets/5ddb8085-bafe-4e9a-bb02-74e3d860ae1a)

Release Notes:

- Agent: Fixed an issue where the "Copy Command" button would not appear on hover for terminal tool calls.