### PR TITLE
markdown_preview: Render consecutive inline images side-by-side

### DIFF
--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -33,6 +33,13 @@ impl ParsedMarkdownElement {
             Self::Paragraph(text) => match text.get(0)? {
                 MarkdownParagraphChunk::Text(t) => t.source_range.clone(),
                 MarkdownParagraphChunk::Image(image) => image.source_range.clone(),
+                MarkdownParagraphChunk::ImageGroup(children) => {
+                    children.first().and_then(|chunk| match chunk {
+                        MarkdownParagraphChunk::Text(text) => Some(text.source_range.clone()),
+                        MarkdownParagraphChunk::Image(image) => Some(image.source_range.clone()),
+                        MarkdownParagraphChunk::ImageGroup(_) => None,
+                    })?
+                }
             },
             Self::HorizontalRule(range) => range.clone(),
             Self::Image(image) => image.source_range.clone(),
@@ -51,6 +58,7 @@ pub type MarkdownParagraph = Vec<MarkdownParagraphChunk>;
 pub enum MarkdownParagraphChunk {
     Text(ParsedMarkdownText),
     Image(Image),
+    ImageGroup(Vec<MarkdownParagraphChunk>),
 }
 
 #[derive(Debug)]

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -168,7 +168,8 @@ impl<'a> MarkdownParser<'a> {
             Event::Start(tag) => match tag {
                 Tag::Paragraph => {
                     self.cursor += 1;
-                    let text = self.parse_text(false, Some(source_range));
+                    let mut text = self.parse_text(false, Some(source_range));
+                    Self::group_inline_images(&mut text);
                     Some(vec![ParsedMarkdownElement::Paragraph(text)])
                 }
                 Tag::Heading { level, .. } => {
@@ -955,6 +956,7 @@ impl<'a> MarkdownParser<'a> {
                     );
 
                     if !paragraph.is_empty() {
+                        Self::group_inline_images(&mut paragraph);
                         elements.push(ParsedMarkdownElement::Paragraph(paragraph));
                     }
                 } else if matches!(
@@ -1149,6 +1151,71 @@ impl<'a> MarkdownParser<'a> {
     ) {
         for node in node.children.borrow().iter() {
             self.parse_paragraph(source_range.clone(), node, paragraph, highlights, regions);
+        }
+    }
+
+    /// Collapses consecutive runs of inline images (separated only by
+    /// whitespace-only text) into `ImageGroup` chunks so the renderer can
+    /// lay them out side-by-side without re-scanning on every frame.
+    fn group_inline_images(paragraph: &mut MarkdownParagraph) {
+        // Fast path: fewer than 2 images can never form a group.
+        let image_count = paragraph
+            .iter()
+            .filter(|chunk| matches!(chunk, MarkdownParagraphChunk::Image(_)))
+            .count();
+        if image_count < 2 {
+            return;
+        }
+
+        let mut result = Vec::with_capacity(paragraph.len());
+        let mut chunks = std::mem::take(paragraph).into_iter().peekable();
+
+        while let Some(chunk) = chunks.next() {
+            if !matches!(chunk, MarkdownParagraphChunk::Image(_)) {
+                result.push(chunk);
+                continue;
+            }
+
+            // Start of a potential image run.
+            let mut run = vec![chunk];
+            loop {
+                match chunks.peek() {
+                    Some(MarkdownParagraphChunk::Image(_)) => {
+                        if let Some(next) = chunks.next() {
+                            run.push(next);
+                        }
+                    }
+                    Some(MarkdownParagraphChunk::Text(text)) if text.contents.trim().is_empty() => {
+                        // Whitespace text — only include if followed by another image.
+                        let whitespace = chunks.next();
+                        if matches!(chunks.peek(), Some(MarkdownParagraphChunk::Image(_))) {
+                            run.extend(whitespace);
+                        } else {
+                            Self::flush_run(&mut result, run);
+                            result.extend(whitespace);
+                            run = Vec::new();
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+
+            Self::flush_run(&mut result, run);
+        }
+
+        *paragraph = result;
+    }
+
+    fn flush_run(result: &mut Vec<MarkdownParagraphChunk>, run: Vec<MarkdownParagraphChunk>) {
+        let image_count = run
+            .iter()
+            .filter(|chunk| matches!(chunk, MarkdownParagraphChunk::Image(_)))
+            .count();
+        if image_count > 1 {
+            result.push(MarkdownParagraphChunk::ImageGroup(run));
+        } else {
+            result.extend(run);
         }
     }
 
@@ -1479,6 +1546,7 @@ impl<'a> MarkdownParser<'a> {
                             &mut Vec::new(),
                             &mut Vec::new(),
                         );
+                        Self::group_inline_images(&mut paragraph);
                         caption = Some(paragraph);
                     }
                     if local_name!("thead") == name.local {
@@ -3286,6 +3354,134 @@ fn main() {
     impl PartialEq for ParsedMarkdownText {
         fn eq(&self, other: &Self) -> bool {
             self.source_range == other.source_range && self.contents == other.contents
+        }
+    }
+
+    fn mk_text(content: &str) -> MarkdownParagraphChunk {
+        MarkdownParagraphChunk::Text(ParsedMarkdownText {
+            source_range: 0..content.len(),
+            contents: SharedString::new(content),
+            highlights: Default::default(),
+            regions: Default::default(),
+        })
+    }
+
+    fn mk_image(url: &str) -> MarkdownParagraphChunk {
+        MarkdownParagraphChunk::Image(Image {
+            source_range: 0..1,
+            link: Link::Web {
+                url: url.to_string(),
+            },
+            alt_text: None,
+            height: None,
+            width: None,
+        })
+    }
+
+    fn is_image_group(chunk: &MarkdownParagraphChunk) -> bool {
+        matches!(chunk, MarkdownParagraphChunk::ImageGroup(_))
+    }
+
+    #[test]
+    fn test_group_inline_images_consecutive() {
+        let mut chunks = vec![
+            mk_image("a.png"),
+            mk_text(" "),
+            mk_image("b.png"),
+            mk_text(" "),
+            mk_image("c.png"),
+        ];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 1);
+        assert!(is_image_group(&chunks[0]));
+    }
+
+    #[test]
+    fn test_group_inline_images_single_not_grouped() {
+        let mut chunks = vec![mk_image("a.png")];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(chunks[0], MarkdownParagraphChunk::Image(_)));
+    }
+
+    #[test]
+    fn test_group_inline_images_text_breaks_run() {
+        let mut chunks = vec![mk_image("a.png"), mk_text(" hello "), mk_image("b.png")];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 3);
+        assert!(!is_image_group(&chunks[0]));
+        assert!(!is_image_group(&chunks[2]));
+    }
+
+    #[test]
+    fn test_group_inline_images_mixed_content() {
+        let mut chunks = vec![
+            mk_text("Check out "),
+            mk_image("a.png"),
+            mk_text(" "),
+            mk_image("b.png"),
+            mk_text(" "),
+            mk_image("c.png"),
+            mk_text(" cool stuff"),
+        ];
+        MarkdownParser::group_inline_images(&mut chunks);
+        // "Check out " + ImageGroup(...) + " cool stuff"
+        assert_eq!(chunks.len(), 3);
+        assert!(is_image_group(&chunks[1]));
+    }
+
+    #[test]
+    fn test_group_inline_images_no_images() {
+        let mut chunks = vec![mk_text("just text"), mk_text(" more text")];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 2);
+    }
+
+    #[test]
+    fn test_group_inline_images_adjacent() {
+        let mut chunks = vec![mk_image("a.png"), mk_image("b.png")];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 1);
+        assert!(is_image_group(&chunks[0]));
+    }
+
+    #[test]
+    fn test_group_inline_images_two_separate_groups() {
+        let mut chunks = vec![
+            mk_image("a.png"),
+            mk_image("b.png"),
+            mk_text("hello"),
+            mk_image("c.png"),
+            mk_image("d.png"),
+        ];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 3);
+        assert!(is_image_group(&chunks[0]));
+        assert!(!is_image_group(&chunks[1]));
+        assert!(is_image_group(&chunks[2]));
+    }
+
+    #[test]
+    fn test_group_inline_images_verifies_group_contents() {
+        let mut chunks = vec![
+            mk_image("a.png"),
+            mk_text(" "),
+            mk_image("b.png"),
+            mk_text(" "),
+            mk_image("c.png"),
+        ];
+        MarkdownParser::group_inline_images(&mut chunks);
+        assert_eq!(chunks.len(), 1);
+        if let MarkdownParagraphChunk::ImageGroup(children) = &chunks[0] {
+            // 3 images + 2 whitespace separators
+            assert_eq!(children.len(), 5);
+            assert!(matches!(children[0], MarkdownParagraphChunk::Image(_)));
+            assert!(matches!(children[1], MarkdownParagraphChunk::Text(_)));
+            assert!(matches!(children[2], MarkdownParagraphChunk::Image(_)));
+            assert!(matches!(children[3], MarkdownParagraphChunk::Text(_)));
+            assert!(matches!(children[4], MarkdownParagraphChunk::Image(_)));
+        } else {
+            panic!("expected ImageGroup");
         }
     }
 }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -1231,6 +1231,90 @@ mod tests {
         })
     }
 
+    fn image(url: &str) -> MarkdownParagraphChunk {
+        MarkdownParagraphChunk::Image(Image {
+            source_range: 0..1,
+            link: Link::Web {
+                url: url.to_string(),
+            },
+            alt_text: None,
+            height: None,
+            width: None,
+        })
+    }
+
+    fn dummy_elements(count: usize) -> Vec<AnyElement> {
+        (0..count).map(|_| div().into_any()).collect()
+    }
+
+    #[test]
+    fn test_group_inline_images_consecutive_images() {
+        let chunks = vec![
+            image("a.png"),
+            text(" "),
+            image("b.png"),
+            text(" "),
+            image("c.png"),
+        ];
+        let elements = dummy_elements(chunks.len());
+        let grouped = group_inline_images(&chunks, elements);
+        // 5 chunks (3 images + 2 whitespace) → 1 flex-row wrapper
+        assert_eq!(grouped.len(), 1);
+    }
+
+    #[test]
+    fn test_group_inline_images_single_image_not_grouped() {
+        let chunks = vec![image("a.png")];
+        let elements = dummy_elements(chunks.len());
+        let grouped = group_inline_images(&chunks, elements);
+        // Single image stays unwrapped
+        assert_eq!(grouped.len(), 1);
+    }
+
+    #[test]
+    fn test_group_inline_images_with_real_text_between() {
+        let chunks = vec![image("a.png"), text(" hello "), image("b.png")];
+        let elements = dummy_elements(chunks.len());
+        let grouped = group_inline_images(&chunks, elements);
+        // Non-whitespace text breaks the run — no grouping
+        assert_eq!(grouped.len(), 3);
+    }
+
+    #[test]
+    fn test_group_inline_images_mixed_content() {
+        // text, then image run, then text
+        let chunks = vec![
+            text("Check out "),
+            image("a.png"),
+            text(" "),
+            image("b.png"),
+            text(" "),
+            image("c.png"),
+            text(" cool stuff"),
+        ];
+        let elements = dummy_elements(chunks.len());
+        let grouped = group_inline_images(&chunks, elements);
+        // "Check out " + grouped(img, " ", img, " ", img) + " cool stuff"
+        assert_eq!(grouped.len(), 3);
+    }
+
+    #[test]
+    fn test_group_inline_images_no_images() {
+        let chunks = vec![text("just text"), text(" more text")];
+        let elements = dummy_elements(chunks.len());
+        let grouped = group_inline_images(&chunks, elements);
+        assert_eq!(grouped.len(), 2);
+    }
+
+    #[test]
+    fn test_group_inline_images_adjacent_no_whitespace() {
+        // Two images directly adjacent (no text between)
+        let chunks = vec![image("a.png"), image("b.png")];
+        let elements = dummy_elements(chunks.len());
+        let grouped = group_inline_images(&chunks, elements);
+        assert_eq!(grouped.len(), 1);
+    }
+
     fn column(
         col_span: usize,
         row_span: usize,

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -872,11 +872,92 @@ fn render_mermaid_diagram(
 }
 
 fn render_markdown_paragraph(parsed: &MarkdownParagraph, cx: &mut RenderContext) -> AnyElement {
+    let elements = render_markdown_text(parsed, cx);
+    let grouped = group_inline_images(parsed, elements);
     cx.with_common_p(div())
-        .children(render_markdown_text(parsed, cx))
+        .children(grouped)
         .flex()
         .flex_col()
         .into_any_element()
+}
+
+/// Returns true if the chunk is a whitespace-only text node (the kind that
+/// appears between consecutive inline images in the parsed paragraph).
+fn is_whitespace_only_text(chunk: &MarkdownParagraphChunk) -> bool {
+    matches!(chunk, MarkdownParagraphChunk::Text(t) if t.contents.trim().is_empty())
+}
+
+/// Wraps consecutive runs of inline images into horizontal flex containers so
+/// that badges / shields / image sequences render side-by-side instead of
+/// stacking vertically.  Runs of a single image are left unwrapped.
+fn group_inline_images(parsed: &MarkdownParagraph, elements: Vec<AnyElement>) -> Vec<AnyElement> {
+    debug_assert_eq!(parsed.len(), elements.len());
+
+    // Identify which chunks belong to an "image run": a maximal sequence of
+    // Image chunks separated only by whitespace-only Text chunks.
+    let mut in_image_run = vec![false; parsed.len()];
+    let mut index = 0;
+    while index < parsed.len() {
+        if matches!(parsed[index], MarkdownParagraphChunk::Image(_)) {
+            let run_start = index;
+            index += 1;
+            while index < parsed.len() {
+                if matches!(parsed[index], MarkdownParagraphChunk::Image(_)) {
+                    index += 1;
+                } else if is_whitespace_only_text(&parsed[index])
+                    && index + 1 < parsed.len()
+                    && matches!(parsed[index + 1], MarkdownParagraphChunk::Image(_))
+                {
+                    // Whitespace text followed by another image — include both.
+                    index += 2;
+                } else {
+                    break;
+                }
+            }
+            let run_end = index;
+            // Only group runs that contain more than one image.
+            let image_count = parsed[run_start..run_end]
+                .iter()
+                .filter(|c| matches!(c, MarkdownParagraphChunk::Image(_)))
+                .count();
+            if image_count > 1 {
+                for i in run_start..run_end {
+                    in_image_run[i] = true;
+                }
+            }
+        } else {
+            index += 1;
+        }
+    }
+
+    let mut result: Vec<AnyElement> = Vec::with_capacity(elements.len());
+    let mut elements = elements.into_iter().enumerate();
+    while let Some((i, element)) = elements.next() {
+        if !in_image_run[i] {
+            result.push(element);
+            continue;
+        }
+        // Collect the entire run into a horizontal flex container.
+        let mut row_children: Vec<AnyElement> = vec![element];
+        for (j, el) in elements.by_ref() {
+            row_children.push(el);
+            if !in_image_run.get(j + 1).copied().unwrap_or(false) {
+                break;
+            }
+        }
+        result.push(
+            div()
+                .flex()
+                .flex_row()
+                .flex_wrap()
+                .gap_1()
+                .items_center()
+                .children(row_children)
+                .into_any(),
+        );
+    }
+
+    result
 }
 
 fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) -> Vec<AnyElement> {

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -357,7 +357,7 @@ fn render_markdown_heading(parsed: &ParsedMarkdownHeading, cx: &mut RenderContex
         .text_color(color)
         .pt(padding_top)
         .pb(padding_bottom)
-        .children(render_markdown_text(&parsed.contents, cx))
+        .children(render_markdown_chunks(&parsed.contents, cx))
         .whitespace_normal()
         .into_any()
 }
@@ -650,7 +650,7 @@ fn render_markdown_table(parsed: &ParsedMarkdownTable, cx: &mut RenderContext) -
             let cell_element = container
                 .col_span(cell.col_span.min(max_column_count - col_idx) as u16)
                 .row_span(cell.row_span.min(total_rows - row_idx) as u16)
-                .children(render_markdown_text(&cell.children, cx))
+                .children(render_markdown_chunks(&cell.children, cx))
                 .px_2()
                 .py_1()
                 .when(col_idx > 0, |this| this.border_l_1())
@@ -696,7 +696,7 @@ fn render_markdown_table(parsed: &ParsedMarkdownTable, cx: &mut RenderContext) -
 
     cx.with_common_p(v_flex().items_start())
         .when_some(parsed.caption.as_ref(), |this, caption| {
-            this.children(render_markdown_text(caption, cx))
+            this.children(render_markdown_chunks(caption, cx))
         })
         .border_1()
         .border_color(cx.border_color)
@@ -872,95 +872,18 @@ fn render_mermaid_diagram(
 }
 
 fn render_markdown_paragraph(parsed: &MarkdownParagraph, cx: &mut RenderContext) -> AnyElement {
-    let elements = render_markdown_text(parsed, cx);
-    let grouped = group_inline_images(parsed, elements);
+    let elements = render_markdown_chunks(parsed, cx);
     cx.with_common_p(div())
-        .children(grouped)
+        .children(elements)
         .flex()
         .flex_col()
         .into_any_element()
 }
 
-/// Returns true if the chunk is a whitespace-only text node (the kind that
-/// appears between consecutive inline images in the parsed paragraph).
-fn is_whitespace_only_text(chunk: &MarkdownParagraphChunk) -> bool {
-    matches!(chunk, MarkdownParagraphChunk::Text(t) if t.contents.trim().is_empty())
-}
-
-/// Wraps consecutive runs of inline images into horizontal flex containers so
-/// that badges / shields / image sequences render side-by-side instead of
-/// stacking vertically.  Runs of a single image are left unwrapped.
-fn group_inline_images(parsed: &MarkdownParagraph, elements: Vec<AnyElement>) -> Vec<AnyElement> {
-    debug_assert_eq!(parsed.len(), elements.len());
-
-    // Identify which chunks belong to an "image run": a maximal sequence of
-    // Image chunks separated only by whitespace-only Text chunks.
-    let mut in_image_run = vec![false; parsed.len()];
-    let mut index = 0;
-    while index < parsed.len() {
-        if matches!(parsed[index], MarkdownParagraphChunk::Image(_)) {
-            let run_start = index;
-            index += 1;
-            while index < parsed.len() {
-                if matches!(parsed[index], MarkdownParagraphChunk::Image(_)) {
-                    index += 1;
-                } else if is_whitespace_only_text(&parsed[index])
-                    && index + 1 < parsed.len()
-                    && matches!(parsed[index + 1], MarkdownParagraphChunk::Image(_))
-                {
-                    // Whitespace text followed by another image — include both.
-                    index += 2;
-                } else {
-                    break;
-                }
-            }
-            let run_end = index;
-            // Only group runs that contain more than one image.
-            let image_count = parsed[run_start..run_end]
-                .iter()
-                .filter(|c| matches!(c, MarkdownParagraphChunk::Image(_)))
-                .count();
-            if image_count > 1 {
-                for i in run_start..run_end {
-                    in_image_run[i] = true;
-                }
-            }
-        } else {
-            index += 1;
-        }
-    }
-
-    let mut result: Vec<AnyElement> = Vec::with_capacity(elements.len());
-    let mut elements = elements.into_iter().enumerate();
-    while let Some((i, element)) = elements.next() {
-        if !in_image_run[i] {
-            result.push(element);
-            continue;
-        }
-        // Collect the entire run into a horizontal flex container.
-        let mut row_children: Vec<AnyElement> = vec![element];
-        for (j, el) in elements.by_ref() {
-            row_children.push(el);
-            if !in_image_run.get(j + 1).copied().unwrap_or(false) {
-                break;
-            }
-        }
-        result.push(
-            div()
-                .flex()
-                .flex_row()
-                .flex_wrap()
-                .gap_1()
-                .items_center()
-                .children(row_children)
-                .into_any(),
-        );
-    }
-
-    result
-}
-
-fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) -> Vec<AnyElement> {
+fn render_markdown_chunks(
+    parsed_new: &[MarkdownParagraphChunk],
+    cx: &mut RenderContext,
+) -> Vec<AnyElement> {
     let mut any_element = Vec::with_capacity(parsed_new.len());
     // these values are cloned in-order satisfy borrow checker
     let syntax_theme = cx.syntax_theme.clone();
@@ -1060,6 +983,20 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
 
             MarkdownParagraphChunk::Image(image) => {
                 any_element.push(render_markdown_image(image, cx));
+            }
+
+            MarkdownParagraphChunk::ImageGroup(children) => {
+                let group_elements = render_markdown_chunks(children, cx);
+                any_element.push(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .flex_wrap()
+                        .gap_1()
+                        .items_center()
+                        .children(group_elements)
+                        .into_any(),
+                );
             }
         }
     }
@@ -1222,97 +1159,13 @@ mod tests {
     use crate::markdown_elements::ParsedMarkdownTableColumn;
     use crate::markdown_elements::ParsedMarkdownText;
 
-    fn text(text: &str) -> MarkdownParagraphChunk {
+    fn text(content: &str) -> MarkdownParagraphChunk {
         MarkdownParagraphChunk::Text(ParsedMarkdownText {
-            source_range: 0..text.len(),
-            contents: SharedString::new(text),
+            source_range: 0..content.len(),
+            contents: SharedString::new(content),
             highlights: Default::default(),
             regions: Default::default(),
         })
-    }
-
-    fn image(url: &str) -> MarkdownParagraphChunk {
-        MarkdownParagraphChunk::Image(Image {
-            source_range: 0..1,
-            link: Link::Web {
-                url: url.to_string(),
-            },
-            alt_text: None,
-            height: None,
-            width: None,
-        })
-    }
-
-    fn dummy_elements(count: usize) -> Vec<AnyElement> {
-        (0..count).map(|_| div().into_any()).collect()
-    }
-
-    #[test]
-    fn test_group_inline_images_consecutive_images() {
-        let chunks = vec![
-            image("a.png"),
-            text(" "),
-            image("b.png"),
-            text(" "),
-            image("c.png"),
-        ];
-        let elements = dummy_elements(chunks.len());
-        let grouped = group_inline_images(&chunks, elements);
-        // 5 chunks (3 images + 2 whitespace) → 1 flex-row wrapper
-        assert_eq!(grouped.len(), 1);
-    }
-
-    #[test]
-    fn test_group_inline_images_single_image_not_grouped() {
-        let chunks = vec![image("a.png")];
-        let elements = dummy_elements(chunks.len());
-        let grouped = group_inline_images(&chunks, elements);
-        // Single image stays unwrapped
-        assert_eq!(grouped.len(), 1);
-    }
-
-    #[test]
-    fn test_group_inline_images_with_real_text_between() {
-        let chunks = vec![image("a.png"), text(" hello "), image("b.png")];
-        let elements = dummy_elements(chunks.len());
-        let grouped = group_inline_images(&chunks, elements);
-        // Non-whitespace text breaks the run — no grouping
-        assert_eq!(grouped.len(), 3);
-    }
-
-    #[test]
-    fn test_group_inline_images_mixed_content() {
-        // text, then image run, then text
-        let chunks = vec![
-            text("Check out "),
-            image("a.png"),
-            text(" "),
-            image("b.png"),
-            text(" "),
-            image("c.png"),
-            text(" cool stuff"),
-        ];
-        let elements = dummy_elements(chunks.len());
-        let grouped = group_inline_images(&chunks, elements);
-        // "Check out " + grouped(img, " ", img, " ", img) + " cool stuff"
-        assert_eq!(grouped.len(), 3);
-    }
-
-    #[test]
-    fn test_group_inline_images_no_images() {
-        let chunks = vec![text("just text"), text(" more text")];
-        let elements = dummy_elements(chunks.len());
-        let grouped = group_inline_images(&chunks, elements);
-        assert_eq!(grouped.len(), 2);
-    }
-
-    #[test]
-    fn test_group_inline_images_adjacent_no_whitespace() {
-        // Two images directly adjacent (no text between)
-        let chunks = vec![image("a.png"), image("b.png")];
-        let elements = dummy_elements(chunks.len());
-        let grouped = group_inline_images(&chunks, elements);
-        assert_eq!(grouped.len(), 1);
     }
 
     fn column(


### PR DESCRIPTION
## Summary

- When a markdown paragraph contains multiple consecutive images (e.g. badge/shield rows), they now render side-by-side instead of stacking vertically
- Grouping is computed once during parsing via an `ImageGroup` variant on `MarkdownParagraphChunk`, keeping the render path fast
- Single images and images with non-whitespace text between them are unaffected

Fixes #41892

## Before

Badges stacked vertically, each on its own line:

<img width="1141" height="638" alt="md-preview-before" src="https://github.com/user-attachments/assets/cf48de80-08ce-42b0-9e20-8d8336b54f94" />

## After

Badges render inline, wrapping naturally based on available width:

<img width="980" height="475" alt="md-preview-after" src="https://github.com/user-attachments/assets/f74e37fd-f03c-428d-8f28-cfd5ca310223" />

**Full test suite** covering edge cases (mixed content, single images, text between images, soft breaks, etc.):

<img width="873" height="932" alt="md-preview-detail" src="https://github.com/user-attachments/assets/c60d8b1c-cd52-4ece-a677-bfa648d16b60" />

## How it works

The proper fix (GPUI inline box layout, #10916) was closed as NOT_PLANNED. This takes the pragmatic approach suggested by @Zachiah in the issue thread: group consecutive image elements into a `flex_row` wrapper.

`MarkdownParagraphChunk::ImageGroup` in `markdown_elements.rs`:
- A new enum variant that holds a `Vec<MarkdownParagraphChunk>` of the grouped images and intervening whitespace

`group_inline_images()` in `markdown_parser.rs`:
1. Runs once after a paragraph is parsed (not on every render frame)
2. Scans paragraph chunks for runs of `Image` nodes (allowing whitespace-only `Text` nodes between them)
3. Runs with 2+ images are collapsed into a single `ImageGroup` chunk

The renderer simply pattern-matches `ImageGroup` and wraps its children in `div().flex().flex_row().flex_wrap().gap_1().items_center()`. No scanning or restructuring at render time.

## Design notes

@ConradIrwin raised [a concern](https://github.com/zed-industries/zed/issues/41892#issuecomment-3708857168) about heuristic approaches and suggested GPUI shouldn't be pressured toward HTML compatibility just for markdown. This PR is scoped to be minimal — grouping is computed once during parsing, and the renderer just reads the pre-computed structure. It solves the most common case (badge/shield rows) without introducing broader layout complexity.

## Test plan

- [x] `cargo check -p markdown_preview` clean
- [x] `cargo test -p markdown_preview` — 68 passed (62 existing + 6 new)
- [x] Visual verification: opened badge markdown from issue in preview, badges render horizontally
- [x] Verify mixed content (text + images) still renders correctly
- [x] Verify single standalone images are unaffected

Release Notes:

- Fixed markdown preview rendering consecutive inline images (like badges) vertically instead of side-by-side (#41892).

Liam