### PR TITLE
editor: Fix inlay hint highlighting

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1752,15 +1752,14 @@ impl DisplaySnapshot {
     }
 
     /// Converts a buffer offset range into one or more `DisplayPoint` ranges
-    /// that cover only actual buffer text, excluding any inlay hint text that
-    /// falls within the range.
-    pub fn isomorphic_display_point_ranges_for_buffer_range(
+    /// that cover the actual buffer text, including any logically selected inlay hint text.
+    pub fn display_point_ranges_for_buffer_range(
         &self,
         range: Range<MultiBufferOffset>,
     ) -> SmallVec<[Range<DisplayPoint>; 1]> {
         let inlay_snapshot = self.inlay_snapshot();
         inlay_snapshot
-            .buffer_offset_to_inlay_ranges(range)
+            .display_ranges_for_buffer_range(range)
             .map(|inlay_range| {
                 let inlay_point_to_display_point = |inlay_point: InlayPoint, bias: Bias| {
                     let fold_point = self.fold_snapshot().to_fold_point(inlay_point, bias);
@@ -4050,7 +4049,7 @@ pub mod tests {
     }
 
     #[gpui::test]
-    fn test_isomorphic_display_point_ranges_for_buffer_range(cx: &mut gpui::TestAppContext) {
+    fn test_display_point_ranges_for_buffer_range(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| init_test(cx, &|_| {}));
 
         let buffer = cx.new(|cx| Buffer::local("let x = 5;\n", cx));
@@ -4074,7 +4073,7 @@ pub mod tests {
 
         // Without inlays, a buffer range maps to a single display range.
         let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
-        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+        let ranges = snapshot.display_point_ranges_for_buffer_range(
             MultiBufferOffset(4)..MultiBufferOffset(9),
         );
         assert_eq!(ranges.len(), 1);
@@ -4098,34 +4097,32 @@ pub mod tests {
         assert_eq!(snapshot.text(), "let x: i32 = 5;\n");
 
         // A buffer range [4..9] ("x = 5") now spans across the inlay.
-        // It should be split into two display ranges that skip the inlay text.
-        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+        // It successfully merges both pieces and the inlay since it's fully covered.
+        let ranges = snapshot.display_point_ranges_for_buffer_range(
             MultiBufferOffset(4)..MultiBufferOffset(9),
         );
         assert_eq!(
             ranges.len(),
-            2,
-            "expected the range to be split around the inlay, got: {:?}",
-            ranges,
+            1,
+            "Range should NOT be split around the inlay hint because it is selected."
         );
-        // First sub-range: buffer [4, 5) → "x" at display columns 4..5
         assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 4));
-        assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 5));
-        // Second sub-range: buffer [5, 9) → " = 5" at display columns 10..14
-        // (shifted right by the 5-char ": i32" inlay)
-        assert_eq!(ranges[1].start, DisplayPoint::new(DisplayRow(0), 10));
-        assert_eq!(ranges[1].end, DisplayPoint::new(DisplayRow(0), 14));
+        assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 14));
 
-        // A range entirely before the inlay is not split.
-        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+        // A range ending immediately at the inlay.
+        let ranges = snapshot.display_point_ranges_for_buffer_range(
             MultiBufferOffset(0)..MultiBufferOffset(5),
         );
-        assert_eq!(ranges.len(), 1);
+        // The inlay WILL be included because its anchor is Bias::Right.
+        assert_eq!(ranges.len(), 2);
         assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 0));
         assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 5));
+        assert_eq!(ranges[1].start, DisplayPoint::new(DisplayRow(0), 5));
+        assert_eq!(ranges[1].end, DisplayPoint::new(DisplayRow(0), 10));
 
-        // A range entirely after the inlay is not split.
-        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+        // A range entirely after the inlay is not split. Bias::Right matches <= range.end and > range.start
+        // 5 is NOT > 5, so it is NOT included.
+        let ranges = snapshot.display_point_ranges_for_buffer_range(
             MultiBufferOffset(5)..MultiBufferOffset(9),
         );
         assert_eq!(ranges.len(), 1);

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -948,22 +948,26 @@ impl InlaySnapshot {
         self.inlay_point_cursor().map(point, Bias::Left)
     }
 
-    /// Converts a buffer offset range into one or more `InlayOffset` ranges that
-    /// cover only the actual buffer text, skipping any inlay hint text that falls
-    /// within the range. When there are no inlays the returned vec contains a
-    /// single element identical to the input mapped into inlay-offset space.
-    pub fn buffer_offset_to_inlay_ranges(
+    /// Converts a buffer offset range into one or more `InlayOffset` ranges.
+    /// Inlay hints are included if they logically fall within the selected text.
+    pub fn display_ranges_for_buffer_range(
         &self,
         range: Range<MultiBufferOffset>,
     ) -> impl Iterator<Item = Range<InlayOffset>> {
         let mut cursor = self
             .transforms
             .cursor::<Dimensions<MultiBufferOffset, InlayOffset>>(());
-        cursor.seek(&range.start, Bias::Right);
+        cursor.seek(&range.start, Bias::Left);
+
+        let mut current_range: Option<Range<InlayOffset>> = None;
 
         std::iter::from_fn(move || {
             loop {
-                match cursor.item()? {
+                let item = cursor.item();
+                if item.is_none() {
+                    return current_range.take();
+                }
+                match item.unwrap() {
                     Transform::Isomorphic(_) => {
                         let seg_buffer_start = cursor.start().0;
                         let seg_buffer_end = cursor.end().0;
@@ -980,14 +984,50 @@ impl InlaySnapshot {
                                 InlayOffset(seg_inlay_start.0 + (overlap_start - seg_buffer_start));
                             let inlay_end =
                                 InlayOffset(seg_inlay_start.0 + (overlap_end - seg_buffer_start));
-                            return Some(inlay_start..inlay_end);
+                            
+                            if let Some(r) = &mut current_range {
+                                if r.end == inlay_start {
+                                    r.end = inlay_end;
+                                } else {
+                                    let old_range = current_range.replace(inlay_start..inlay_end);
+                                    return old_range;
+                                }
+                            } else {
+                                current_range = Some(inlay_start..inlay_end);
+                            }
                         }
 
                         if past_end {
-                            return None;
+                            return current_range.take();
                         }
                     }
-                    Transform::Inlay(_) => cursor.next(),
+                    Transform::Inlay(inlay) => {
+                        let inlay_buffer_offset = cursor.start().0;
+                        let inlay_inlay_start = cursor.start().1;
+                        let inlay_inlay_end = cursor.end().1;
+                        
+                        let is_included = if inlay.position.bias() == Bias::Left {
+                            inlay_buffer_offset >= range.start && inlay_buffer_offset < range.end
+                        } else {
+                            inlay_buffer_offset > range.start && inlay_buffer_offset <= range.end
+                        };
+
+                        cursor.next();
+                        if is_included {
+                            if let Some(r) = &mut current_range {
+                                if r.end == inlay_inlay_start {
+                                    r.end = inlay_inlay_end;
+                                } else {
+                                    let old_range = current_range.replace(inlay_inlay_start..inlay_inlay_end);
+                                    return old_range;
+                                }
+                            } else {
+                                current_range = Some(inlay_inlay_start..inlay_inlay_end);
+                            }
+                        } else if current_range.is_some() {
+                            return current_range.take();
+                        }
+                    }
                 }
             }
         })

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -115,7 +115,7 @@ struct SelectionLayout {
     cursor_shape: CursorShape,
     is_newest: bool,
     is_local: bool,
-    range: Range<DisplayPoint>,
+    ranges: SmallVec<[Range<DisplayPoint>; 1]>,
     active_rows: Range<DisplayRow>,
     user_name: Option<SharedString>,
 }
@@ -128,7 +128,7 @@ struct InlineBlameLayout {
 }
 
 impl SelectionLayout {
-    fn new<T: ToPoint + ToDisplayPoint + Clone>(
+    fn new<T: ToPoint + ToDisplayPoint + Copy>(
         selection: Selection<T>,
         line_mode: bool,
         cursor_offset: bool,
@@ -139,20 +139,22 @@ impl SelectionLayout {
         user_name: Option<SharedString>,
     ) -> Self {
         let point_selection = selection.map(|p| p.to_point(map.buffer_snapshot()));
-        let display_selection = point_selection.map(|p| p.to_display_point(map));
-        let mut range = display_selection.range();
-        let mut head = display_selection.head();
+        let mut point_range = point_selection.range();
+        let mut head = point_selection.head().to_display_point(map);
         let mut active_rows = map.prev_line_boundary(point_selection.start).1.row()
             ..map.next_line_boundary(point_selection.end).1.row();
 
         // vim visual line mode
         if line_mode {
-            let point_range = map.expand_to_line(point_selection.range());
-            range = point_range.start.to_display_point(map)..point_range.end.to_display_point(map);
+            point_range = map.expand_to_line(point_range);
         }
 
+        let start_offset = map.buffer_snapshot().point_to_offset(point_range.start);
+        let end_offset = map.buffer_snapshot().point_to_offset(point_range.end);
+        let mut ranges = map.display_point_ranges_for_buffer_range(start_offset..end_offset);
+
         // any vim visual mode (including line mode)
-        if cursor_offset && !range.is_empty() && !selection.reversed {
+        if cursor_offset && !ranges.is_empty() && !selection.reversed {
             if head.column() > 0 {
                 head = map.clip_point(DisplayPoint::new(head.row(), head.column() - 1), Bias::Left);
             } else if head.row().0 > 0 && head != map.max_point() {
@@ -167,7 +169,9 @@ impl SelectionLayout {
                 // on the newline containing a multi-buffer divider
                 // in which case the clip_point may have moved the head up
                 // an additional row.
-                range.end = DisplayPoint::new(head.row().next_row(), 0);
+                if let Some(last_range) = ranges.last_mut() {
+                    last_range.end = DisplayPoint::new(head.row().next_row(), 0);
+                }
                 active_rows.end = head.row();
             }
         }
@@ -177,7 +181,7 @@ impl SelectionLayout {
             cursor_shape,
             is_newest,
             is_local,
-            range,
+            ranges,
             active_rows,
             user_name,
         }
@@ -3622,12 +3626,14 @@ impl EditorElement {
         let highlight_iter = highlight_ranges.iter().cloned();
         let selection_iter = selections.iter().flat_map(|(player_color, layouts)| {
             let color = player_color.selection;
-            layouts.iter().filter_map(move |selection_layout| {
-                if selection_layout.range.start != selection_layout.range.end {
-                    Some((selection_layout.range.clone(), color))
-                } else {
-                    None
-                }
+            layouts.iter().flat_map(move |selection_layout| {
+                selection_layout.ranges.iter().filter_map(move |range| {
+                    if range.start != range.end {
+                        Some((range.clone(), color))
+                    } else {
+                        None
+                    }
+                })
             })
         });
         let mut per_row_map = vec![Vec::new(); rows.len()];
@@ -5611,7 +5617,7 @@ impl EditorElement {
             .flat_map(|word_diff| {
                 let display_ranges = snapshot
                     .display_snapshot
-                    .isomorphic_display_point_ranges_for_buffer_range(
+                    .display_point_ranges_for_buffer_range(
                         word_diff.start..word_diff.end,
                     );
 
@@ -6606,18 +6612,20 @@ impl EditorElement {
 
             for (player_color, selections) in &layout.selections {
                 for selection in selections.iter() {
-                    self.paint_highlighted_range(
-                        selection.range.clone(),
-                        true,
-                        player_color.selection,
-                        corner_radius,
-                        corner_radius * 2.,
-                        layout,
-                        window,
-                    );
+                    for range in &selection.ranges {
+                        self.paint_highlighted_range(
+                            range.clone(),
+                            true,
+                            player_color.selection,
+                            corner_radius,
+                            corner_radius * 2.,
+                            layout,
+                            window,
+                        );
 
-                    if selection.is_local && !selection.range.is_empty() {
-                        invisible_display_ranges.push(selection.range.clone());
+                        if selection.is_local && !range.is_empty() {
+                            invisible_display_ranges.push(range.clone());
+                        }
                     }
                 }
             }
@@ -7894,7 +7902,7 @@ impl EditorElement {
                         let end = range.end.to_display_point(display_snapshot);
                         let selection_layout = SelectionLayout {
                             head: start,
-                            range: start..end,
+                            ranges: smallvec![start..end],
                             cursor_shape: CursorShape::Bar,
                             is_newest: false,
                             is_local: false,
@@ -12897,14 +12905,14 @@ mod tests {
             DisplayPoint::new(DisplayRow(0), 6)
         );
         assert_eq!(
-            local_selections[0].range,
-            DisplayPoint::new(DisplayRow(0), 0)..DisplayPoint::new(DisplayRow(1), 0)
+            local_selections[0].ranges.as_slice(),
+            &[(DisplayPoint::new(DisplayRow(0), 0)..DisplayPoint::new(DisplayRow(1), 0))]
         );
 
         // moves cursor back one column
         assert_eq!(
-            local_selections[1].range,
-            DisplayPoint::new(DisplayRow(3), 2)..DisplayPoint::new(DisplayRow(3), 3)
+            local_selections[1].ranges.as_slice(),
+            &[(DisplayPoint::new(DisplayRow(3), 2)..DisplayPoint::new(DisplayRow(3), 3))]
         );
         assert_eq!(
             local_selections[1].head,
@@ -12913,8 +12921,8 @@ mod tests {
 
         // leaves cursor on the max point
         assert_eq!(
-            local_selections[2].range,
-            DisplayPoint::new(DisplayRow(5), 6)..DisplayPoint::new(DisplayRow(6), 0)
+            local_selections[2].ranges.as_slice(),
+            &[(DisplayPoint::new(DisplayRow(5), 6)..DisplayPoint::new(DisplayRow(6), 0))]
         );
         assert_eq!(
             local_selections[2].head,
@@ -13293,7 +13301,7 @@ mod tests {
                 cursor_shape: CursorShape::Bar,
                 is_newest: true,
                 is_local: true,
-                range: DisplayPoint::new(DisplayRow(1), 5)..DisplayPoint::new(DisplayRow(3), 7),
+                ranges: smallvec![DisplayPoint::new(DisplayRow(1), 5)..DisplayPoint::new(DisplayRow(3), 7)],
                 active_rows: DisplayRow(1)..DisplayRow(4),
                 user_name: None,
             };
@@ -13342,7 +13350,7 @@ mod tests {
                 cursor_shape: CursorShape::Bar,
                 is_newest: true,
                 is_local: true,
-                range: DisplayPoint::new(DisplayRow(1), 5)..DisplayPoint::new(DisplayRow(3), 0),
+                ranges: smallvec![DisplayPoint::new(DisplayRow(1), 5)..DisplayPoint::new(DisplayRow(3), 0)],
                 active_rows: DisplayRow(1)..DisplayRow(3),
                 user_name: None,
             };


### PR DESCRIPTION
Closes #48141

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed an issue where selecting text immediately before an inlay hint (e.g. the opening `(` in a function call) would incorrectly select the first inlay hint. Now, inlay hints are correctly selected only when the token they are attached to is selected.
