### PR TITLE
danger: Add a check for changing Collab database schemas

### DIFF
--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -1,6 +1,8 @@
 -- This file is auto-generated. Do not modify it by hand.
 -- To regenerate, run `cargo xtask db dump-schema app --collab` from the Cloud repository.
 
+-- Test change.
+
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
 CREATE TABLE public.breakpoints (

--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -1,8 +1,6 @@
 -- This file is auto-generated. Do not modify it by hand.
 -- To regenerate, run `cargo xtask db dump-schema app --collab` from the Cloud repository.
 
--- Test change.
-
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
 CREATE TABLE public.breakpoints (

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -67,7 +67,7 @@ const MIGRATION_SCHEMA_FILES = [
 ];
 
 const modifiedSchemaFiles = danger.git.modified_files.filter((file) =>
-  MIGRATION_SCHEMA_FILES.some((migrationFile) => file.endsWith(migrationFile)),
+  MIGRATION_SCHEMA_FILES.some((schemaFilePath) => file.endsWith(schemaFilePath)),
 );
 
 if (modifiedSchemaFiles.length > 0) {

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -66,11 +66,11 @@ const MIGRATION_SCHEMA_FILES = [
   "crates/collab/migrations.sqlite/20221109000000_test_schema.sql",
 ];
 
-const modifiedMigrationFiles = danger.git.modified_files.filter((file) =>
+const modifiedSchemaFiles = danger.git.modified_files.filter((file) =>
   MIGRATION_SCHEMA_FILES.some((migrationFile) => file.endsWith(migrationFile)),
 );
 
-if (modifiedMigrationFiles.length > 0) {
+if (modifiedSchemaFiles.length > 0) {
   warn(
     [
       "This PR modifies database schema files.",

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -61,6 +61,25 @@ if (includesIssueUrl) {
   );
 }
 
+const MIGRATION_SCHEMA_FILES = [
+  "crates/collab/migrations/20251208000000_test_schema.sql",
+  "crates/collab/migrations.sqlite/20221109000000_test_schema.sql",
+];
+
+const modifiedMigrationFiles = danger.git.modified_files.filter((file) =>
+  MIGRATION_SCHEMA_FILES.some((migrationFile) => file.endsWith(migrationFile)),
+);
+
+if (modifiedMigrationFiles.length > 0) {
+  warn(
+    [
+      "This PR modifies database schema files.",
+      "",
+      "If you are making database changes, a migration needs to be added in the Cloud repository.",
+    ].join("\n"),
+  );
+}
+
 const FIXTURE_CHANGE_ATTESTATION = "Changes to test fixtures are intentional and necessary.";
 
 const FIXTURES_PATHS = ["crates/assistant_tools/src/edit_agent/evals/fixtures"];


### PR DESCRIPTION
This PR adds a Danger check to remind contributors that any database changes for Collab need to be done via a migration in the Cloud repo:

<img width="888" height="323" alt="Screenshot 2026-03-10 at 6 39 21 PM" src="https://github.com/user-attachments/assets/5b3bbc3d-1e9d-409a-837b-565e1ca36935" />

Release Notes:

- N/A
