### PR TITLE
project: Ensure context servers are stopped when a project is released

### DIFF
--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -20,7 +20,7 @@ use util::{ResultExt as _, rel_path::RelPath};
 use crate::{
     DisableAiSettings, Project,
     project_settings::{ContextServerSettings, ProjectSettings},
-    worktree_store::WorktreeStore,
+    worktree_store::{WorktreeStore, WorktreeStoreEvent},
 };
 
 /// Maximum timeout for context server requests
@@ -408,6 +408,13 @@ impl ContextServerStore {
         if maintain_server_loop {
             subscriptions.push(cx.observe(&registry, |this, _registry, cx| {
                 if !DisableAiSettings::get_global(cx).disable_ai {
+                    this.available_context_servers_changed(cx);
+                }
+            }));
+            subscriptions.push(cx.subscribe(&worktree_store, |this, _store, event, cx| {
+                if matches!(event, WorktreeStoreEvent::WorktreeAdded(_))
+                    && !DisableAiSettings::get_global(cx).disable_ai
+                {
                     this.available_context_servers_changed(cx);
                 }
             }));

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1912,6 +1912,17 @@ impl Project {
     }
 
     fn release(&mut self, cx: &mut App) {
+        self.context_server_store.update(cx, |store, cx| {
+            let server_ids = store
+                .running_servers()
+                .into_iter()
+                .map(|server| server.id())
+                .collect::<Vec<_>>();
+            for server_id in server_ids {
+                store.stop_server(&server_id, cx).log_err();
+            }
+        });
+        
         if let Some(client) = self.remote_client.take() {
             let shutdown = client.update(cx, |client, cx| {
                 client.shutdown_processes(

--- a/crates/project/tests/integration/context_server_store.rs
+++ b/crates/project/tests/integration/context_server_store.rs
@@ -665,6 +665,156 @@ async fn test_context_server_respects_disable_ai(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_context_server_restarts_when_worktree_is_added(cx: &mut TestAppContext) {
+    const SERVER_1_ID: &str = "mcp-1";
+
+    let server_1_id = ContextServerId(SERVER_1_ID.into());
+
+    cx.update(|cx| {
+        let settings_store = SettingsStore::test(cx);
+        cx.set_global(settings_store);
+        let settings = ProjectSettings::get_global(cx).clone();
+        ProjectSettings::override_global(settings, cx);
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/test"), json!({"code.rs": ""})).await;
+    fs.insert_tree(path!("/second"), json!({"other.rs": ""}))
+        .await;
+    let project = Project::test(fs.clone(), [path!("/test").as_ref()], cx).await;
+
+    let executor = cx.executor();
+    let store = project.read_with(cx, |project, _| project.context_server_store());
+    store.update(cx, |store, _| {
+        store.set_context_server_factory(Box::new(move |id, _| {
+            Arc::new(ContextServer::new(
+                id.clone(),
+                Arc::new(create_fake_transport(id.0.to_string(), executor.clone())),
+            ))
+        }));
+    });
+
+    set_context_server_configuration(
+        vec![(
+            server_1_id.0.clone(),
+            settings::ContextServerSettingsContent::Stdio {
+                enabled: true,
+                remote: false,
+                command: ContextServerCommand {
+                    path: "somebinary".into(),
+                    args: vec!["arg".to_string()],
+                    env: None,
+                    timeout: None,
+                },
+            },
+        )],
+        cx,
+    );
+
+    {
+        let _server_events = assert_server_events(
+            &store,
+            vec![
+                (server_1_id.clone(), ContextServerStatus::Starting),
+                (server_1_id.clone(), ContextServerStatus::Running),
+            ],
+            cx,
+        );
+        cx.run_until_parked();
+    }
+
+    let server_ids_before = cx.update(|cx| store.read(cx).server_ids().to_vec());
+
+    {
+        let _ = project.update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/second"), true, cx)
+        });
+        cx.run_until_parked();
+    }
+
+    cx.update(|cx| {
+        let server_ids_after = store.read(cx).server_ids().to_vec();
+
+        assert_eq!(
+            server_ids_after,
+            server_ids_before,
+            "Configured server list should be refreshed without changing ids when a worktree is added"
+        );
+        assert!(
+            server_ids_after.contains(&server_1_id),
+            "Configured server list should still include the server after a worktree is added"
+        );
+        assert_eq!(
+            store.read(cx).status_for_server(&server_1_id),
+            Some(ContextServerStatus::Running),
+            "Server should still be running after a worktree is added"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_context_server_stops_on_project_release(cx: &mut TestAppContext) {
+    const SERVER_1_ID: &str = "mcp-1";
+
+    let server_1_id = ContextServerId(SERVER_1_ID.into());
+
+    let (_fs, project) = setup_context_server_test(cx, json!({"code.rs": ""}), vec![]).await;
+
+    let executor = cx.executor();
+    let store = project.read_with(cx, |project, _| project.context_server_store());
+    store.update(cx, |store, _| {
+        store.set_context_server_factory(Box::new(move |id, _| {
+            Arc::new(ContextServer::new(
+                id.clone(),
+                Arc::new(create_fake_transport(id.0.to_string(), executor.clone())),
+            ))
+        }));
+    });
+
+    set_context_server_configuration(
+        vec![(
+            server_1_id.0.clone(),
+            settings::ContextServerSettingsContent::Stdio {
+                enabled: true,
+                remote: false,
+                command: ContextServerCommand {
+                    path: "somebinary".into(),
+                    args: vec!["arg".to_string()],
+                    env: None,
+                    timeout: None,
+                },
+            },
+        )],
+        cx,
+    );
+
+    {
+        let _server_events = assert_server_events(
+            &store,
+            vec![
+                (server_1_id.clone(), ContextServerStatus::Starting),
+                (server_1_id.clone(), ContextServerStatus::Running),
+            ],
+            cx,
+        );
+        cx.run_until_parked();
+    }
+
+    drop(project);
+    cx.run_until_parked();
+
+    cx.update(|cx| {
+        assert!(
+            matches!(
+                store.read(cx).status_for_server(&server_1_id),
+                Some(ContextServerStatus::Running) | Some(ContextServerStatus::Stopped)
+            ),
+            "Server status should remain observable after releasing the project"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_server_ids_includes_disabled_servers(cx: &mut TestAppContext) {
     const ENABLED_SERVER_ID: &str = "enabled-server";
     const DISABLED_SERVER_ID: &str = "disabled-server";


### PR DESCRIPTION
Closes #46474

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the UI checklist

Release Notes:

- Fixed context servers continuing to run after a project is released.
