### PR TITLE
workspace: Allow disabling tab cycles when using keyboard navigation

### DIFF
--- a/crates/tab_switcher/src/tab_switcher_tests.rs
+++ b/crates/tab_switcher/src/tab_switcher_tests.rs
@@ -223,8 +223,8 @@ async fn test_close_selected_item(cx: &mut gpui::TestAppContext) {
     // 1.txt | [3.txt] | 2.txt | 4.txt
     //
     // With 3.txt being the active item in the pane.
-    cx.dispatch_action(ActivatePreviousItem);
-    cx.dispatch_action(ActivatePreviousItem);
+    cx.dispatch_action(ActivatePreviousItem::default());
+    cx.dispatch_action(ActivatePreviousItem::default());
     cx.run_until_parked();
 
     cx.simulate_modifiers_change(Modifiers::control());

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1659,9 +1659,9 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
             action.range.replace(range.clone());
             Some(Box::new(action))
         }),
-        VimCommand::new(("bn", "ext"), workspace::ActivateNextItem).count(),
-        VimCommand::new(("bN", "ext"), workspace::ActivatePreviousItem).count(),
-        VimCommand::new(("bp", "revious"), workspace::ActivatePreviousItem).count(),
+        VimCommand::new(("bn", "ext"), workspace::ActivateNextItem::default()).count(),
+        VimCommand::new(("bN", "ext"), workspace::ActivatePreviousItem::default()).count(),
+        VimCommand::new(("bp", "revious"), workspace::ActivatePreviousItem::default()).count(),
         VimCommand::new(("bf", "irst"), workspace::ActivateItem(0)),
         VimCommand::new(("br", "ewind"), workspace::ActivateItem(0)),
         VimCommand::new(("bl", "ast"), workspace::ActivateLastItem),
@@ -1669,9 +1669,9 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::str(("ls", ""), "tab_switcher::ToggleAll"),
         VimCommand::new(("new", ""), workspace::NewFileSplitHorizontal),
         VimCommand::new(("vne", "w"), workspace::NewFileSplitVertical),
-        VimCommand::new(("tabn", "ext"), workspace::ActivateNextItem).count(),
-        VimCommand::new(("tabp", "revious"), workspace::ActivatePreviousItem).count(),
-        VimCommand::new(("tabN", "ext"), workspace::ActivatePreviousItem).count(),
+        VimCommand::new(("tabn", "ext"), workspace::ActivateNextItem::default()).count(),
+        VimCommand::new(("tabp", "revious"), workspace::ActivatePreviousItem::default()).count(),
+        VimCommand::new(("tabN", "ext"), workspace::ActivatePreviousItem::default()).count(),
         VimCommand::new(
             ("tabc", "lose"),
             workspace::CloseActiveItem {

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1661,7 +1661,11 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         }),
         VimCommand::new(("bn", "ext"), workspace::ActivateNextItem::default()).count(),
         VimCommand::new(("bN", "ext"), workspace::ActivatePreviousItem::default()).count(),
-        VimCommand::new(("bp", "revious"), workspace::ActivatePreviousItem::default()).count(),
+        VimCommand::new(
+            ("bp", "revious"),
+            workspace::ActivatePreviousItem::default(),
+        )
+        .count(),
         VimCommand::new(("bf", "irst"), workspace::ActivateItem(0)),
         VimCommand::new(("br", "ewind"), workspace::ActivateItem(0)),
         VimCommand::new(("bl", "ast"), workspace::ActivateLastItem),
@@ -1670,7 +1674,11 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("new", ""), workspace::NewFileSplitHorizontal),
         VimCommand::new(("vne", "w"), workspace::NewFileSplitVertical),
         VimCommand::new(("tabn", "ext"), workspace::ActivateNextItem::default()).count(),
-        VimCommand::new(("tabp", "revious"), workspace::ActivatePreviousItem::default()).count(),
+        VimCommand::new(
+            ("tabp", "revious"),
+            workspace::ActivatePreviousItem::default(),
+        )
+        .count(),
         VimCommand::new(("tabN", "ext"), workspace::ActivatePreviousItem::default()).count(),
         VimCommand::new(
             ("tabc", "lose"),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -449,7 +449,7 @@ pub fn init(cx: &mut App) {
                 );
             } else {
                 // If no count is provided, go to the next tab.
-                window.dispatch_action(workspace::pane::ActivateNextItem.boxed_clone(), cx);
+                window.dispatch_action(workspace::pane::ActivateNextItem::default().boxed_clone(), cx);
             }
         });
 
@@ -473,7 +473,7 @@ pub fn init(cx: &mut App) {
                 }
             } else {
                 // No count provided, go to the previous tab.
-                window.dispatch_action(workspace::pane::ActivatePreviousItem.boxed_clone(), cx);
+                window.dispatch_action(workspace::pane::ActivatePreviousItem::default().boxed_clone(), cx);
             }
         });
     })

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -449,7 +449,10 @@ pub fn init(cx: &mut App) {
                 );
             } else {
                 // If no count is provided, go to the next tab.
-                window.dispatch_action(workspace::pane::ActivateNextItem::default().boxed_clone(), cx);
+                window.dispatch_action(
+                    workspace::pane::ActivateNextItem::default().boxed_clone(),
+                    cx,
+                );
             }
         });
 
@@ -473,7 +476,10 @@ pub fn init(cx: &mut App) {
                 }
             } else {
                 // No count provided, go to the previous tab.
-                window.dispatch_action(workspace::pane::ActivatePreviousItem::default().boxed_clone(), cx);
+                window.dispatch_action(
+                    workspace::pane::ActivatePreviousItem::default().boxed_clone(),
+                    cx,
+                );
             }
         });
     })

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -229,13 +229,27 @@ split_structs!(
     SplitVertical => "Splits the pane vertically."
 );
 
+/// Activates the previous item in the pane.
+#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
+#[action(namespace = pane)]
+#[serde(deny_unknown_fields, default)]
+pub struct ActivatePreviousItem {
+    #[serde(default)]
+    pub clamp: bool,
+}
+
+/// Activates the next item in the pane.
+#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
+#[action(namespace = pane)]
+#[serde(deny_unknown_fields, default)]
+pub struct ActivateNextItem {
+    #[serde(default)]
+    pub clamp: bool,
+}
+
 actions!(
     pane,
     [
-        /// Activates the previous item in the pane.
-        ActivatePreviousItem,
-        /// Activates the next item in the pane.
-        ActivateNextItem,
         /// Activates the last item in the pane.
         ActivateLastItem,
         /// Switches to the alternate file.
@@ -1474,14 +1488,14 @@ impl Pane {
 
     pub fn activate_previous_item(
         &mut self,
-        _: &ActivatePreviousItem,
+        action: &ActivatePreviousItem,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let mut index = self.active_item_index;
         if index > 0 {
             index -= 1;
-        } else if !self.items.is_empty() {
+        } else if !action.clamp && !self.items.is_empty() {
             index = self.items.len() - 1;
         }
         self.activate_item(index, true, true, window, cx);
@@ -1489,14 +1503,14 @@ impl Pane {
 
     pub fn activate_next_item(
         &mut self,
-        _: &ActivateNextItem,
+        action: &ActivateNextItem,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let mut index = self.active_item_index;
         if index + 1 < self.items.len() {
             index += 1;
-        } else {
+        } else if !action.clamp {
             index = 0;
         }
         self.activate_item(index, true, true, window, cx);
@@ -8452,6 +8466,56 @@ mod tests {
             has_closed_items,
             "closed item should be in closed_stack and reopenable"
         );
+    }
+
+    #[gpui::test]
+    async fn test_activate_item_with_clamp(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        add_labeled_item(&pane, "A", false, cx);
+        add_labeled_item(&pane, "B", false, cx);
+        add_labeled_item(&pane, "C", false, cx);
+        assert_item_labels(&pane, ["A", "B", "C*"], cx);
+
+        // clamp: true on last item should stay on last item
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_next_item(&ActivateNextItem { clamp: true }, window, cx);
+        });
+        assert_item_labels(&pane, ["A", "B", "C*"], cx);
+
+        // clamp: false (default) on last item should wrap to first
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_next_item(&ActivateNextItem::default(), window, cx);
+        });
+        assert_item_labels(&pane, ["A*", "B", "C"], cx);
+
+        // clamp: true on first item should stay on first item
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_previous_item(&ActivatePreviousItem { clamp: true }, window, cx);
+        });
+        assert_item_labels(&pane, ["A*", "B", "C"], cx);
+
+        // clamp: false (default) on first item should wrap to last
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_previous_item(&ActivatePreviousItem::default(), window, cx);
+        });
+        assert_item_labels(&pane, ["A", "B", "C*"], cx);
+
+        // normal navigation still works with clamp
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_previous_item(&ActivatePreviousItem { clamp: true }, window, cx);
+        });
+        assert_item_labels(&pane, ["A", "B*", "C"], cx);
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_next_item(&ActivateNextItem { clamp: true }, window, cx);
+        });
+        assert_item_labels(&pane, ["A", "B", "C*"], cx);
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -48,7 +48,9 @@ use ui::{
     IconDecorationKind, Indicator, PopoverMenu, PopoverMenuHandle, Tab, TabBar, TabPosition,
     Tooltip, prelude::*, right_click_menu,
 };
-use util::{ResultExt, debug_panic, maybe, paths::PathStyle, truncate_and_remove_front};
+use util::{
+    ResultExt, debug_panic, maybe, paths::PathStyle, serde::default_true, truncate_and_remove_front,
+};
 
 /// A selected entry in e.g. project panel.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -230,21 +232,35 @@ split_structs!(
 );
 
 /// Activates the previous item in the pane.
-#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
+#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields, default)]
 pub struct ActivatePreviousItem {
-    #[serde(default)]
-    pub clamp: bool,
+    /// Whether to wrap from the first item to the last item.
+    #[serde(default = "default_true")]
+    pub wrap_around: bool,
+}
+
+impl Default for ActivatePreviousItem {
+    fn default() -> Self {
+        Self { wrap_around: true }
+    }
 }
 
 /// Activates the next item in the pane.
-#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
+#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields, default)]
 pub struct ActivateNextItem {
-    #[serde(default)]
-    pub clamp: bool,
+    /// Whether to wrap from the last item to the first item.
+    #[serde(default = "default_true")]
+    pub wrap_around: bool,
+}
+
+impl Default for ActivateNextItem {
+    fn default() -> Self {
+        Self { wrap_around: true }
+    }
 }
 
 actions!(
@@ -1495,7 +1511,7 @@ impl Pane {
         let mut index = self.active_item_index;
         if index > 0 {
             index -= 1;
-        } else if !action.clamp && !self.items.is_empty() {
+        } else if action.wrap_around && !self.items.is_empty() {
             index = self.items.len() - 1;
         }
         self.activate_item(index, true, true, window, cx);
@@ -1510,7 +1526,7 @@ impl Pane {
         let mut index = self.active_item_index;
         if index + 1 < self.items.len() {
             index += 1;
-        } else if !action.clamp {
+        } else if action.wrap_around {
             index = 0;
         }
         self.activate_item(index, true, true, window, cx);
@@ -8469,7 +8485,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_activate_item_with_clamp(cx: &mut TestAppContext) {
+    async fn test_activate_item_with_wrap_around(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, None, cx).await;
@@ -8482,38 +8498,33 @@ mod tests {
         add_labeled_item(&pane, "C", false, cx);
         assert_item_labels(&pane, ["A", "B", "C*"], cx);
 
-        // clamp: true on last item should stay on last item
         pane.update_in(cx, |pane, window, cx| {
-            pane.activate_next_item(&ActivateNextItem { clamp: true }, window, cx);
+            pane.activate_next_item(&ActivateNextItem { wrap_around: false }, window, cx);
         });
         assert_item_labels(&pane, ["A", "B", "C*"], cx);
 
-        // clamp: false (default) on last item should wrap to first
         pane.update_in(cx, |pane, window, cx| {
             pane.activate_next_item(&ActivateNextItem::default(), window, cx);
         });
         assert_item_labels(&pane, ["A*", "B", "C"], cx);
 
-        // clamp: true on first item should stay on first item
         pane.update_in(cx, |pane, window, cx| {
-            pane.activate_previous_item(&ActivatePreviousItem { clamp: true }, window, cx);
+            pane.activate_previous_item(&ActivatePreviousItem { wrap_around: false }, window, cx);
         });
         assert_item_labels(&pane, ["A*", "B", "C"], cx);
 
-        // clamp: false (default) on first item should wrap to last
         pane.update_in(cx, |pane, window, cx| {
             pane.activate_previous_item(&ActivatePreviousItem::default(), window, cx);
         });
         assert_item_labels(&pane, ["A", "B", "C*"], cx);
 
-        // normal navigation still works with clamp
         pane.update_in(cx, |pane, window, cx| {
-            pane.activate_previous_item(&ActivatePreviousItem { clamp: true }, window, cx);
+            pane.activate_previous_item(&ActivatePreviousItem { wrap_around: false }, window, cx);
         });
         assert_item_labels(&pane, ["A", "B*", "C"], cx);
 
         pane.update_in(cx, |pane, window, cx| {
-            pane.activate_next_item(&ActivateNextItem { clamp: true }, window, cx);
+            pane.activate_next_item(&ActivateNextItem { wrap_around: false }, window, cx);
         });
         assert_item_labels(&pane, ["A", "B", "C*"], cx);
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6738,7 +6738,7 @@ impl Workspace {
             ))
             .on_action(cx.listener(Workspace::toggle_centered_layout))
             .on_action(cx.listener(
-                |workspace: &mut Workspace, _action: &pane::ActivateNextItem, window, cx| {
+                |workspace: &mut Workspace, action: &pane::ActivateNextItem, window, cx| {
                     if let Some(active_dock) = workspace.active_dock(window, cx) {
                         let dock = active_dock.read(cx);
                         if let Some(active_panel) = dock.active_panel() {
@@ -6756,14 +6756,17 @@ impl Workspace {
                                 }
 
                                 if let Some(pane) = recent_pane {
+                                    let clamp = action.clamp;
                                     pane.update(cx, |pane, cx| {
                                         let current_index = pane.active_item_index();
                                         let items_len = pane.items_len();
                                         if items_len > 0 {
                                             let next_index = if current_index + 1 < items_len {
                                                 current_index + 1
-                                            } else {
+                                            } else if !clamp {
                                                 0
+                                            } else {
+                                                return;
                                             };
                                             pane.activate_item(
                                                 next_index, false, false, window, cx,
@@ -6779,7 +6782,7 @@ impl Workspace {
                 },
             ))
             .on_action(cx.listener(
-                |workspace: &mut Workspace, _action: &pane::ActivatePreviousItem, window, cx| {
+                |workspace: &mut Workspace, action: &pane::ActivatePreviousItem, window, cx| {
                     if let Some(active_dock) = workspace.active_dock(window, cx) {
                         let dock = active_dock.read(cx);
                         if let Some(active_panel) = dock.active_panel() {
@@ -6797,14 +6800,17 @@ impl Workspace {
                                 }
 
                                 if let Some(pane) = recent_pane {
+                                    let clamp = action.clamp;
                                     pane.update(cx, |pane, cx| {
                                         let current_index = pane.active_item_index();
                                         let items_len = pane.items_len();
                                         if items_len > 0 {
                                             let prev_index = if current_index > 0 {
                                                 current_index - 1
-                                            } else {
+                                            } else if !clamp {
                                                 items_len.saturating_sub(1)
+                                            } else {
+                                                return;
                                             };
                                             pane.activate_item(
                                                 prev_index, false, false, window, cx,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6756,14 +6756,14 @@ impl Workspace {
                                 }
 
                                 if let Some(pane) = recent_pane {
-                                    let clamp = action.clamp;
+                                    let wrap_around = action.wrap_around;
                                     pane.update(cx, |pane, cx| {
                                         let current_index = pane.active_item_index();
                                         let items_len = pane.items_len();
                                         if items_len > 0 {
                                             let next_index = if current_index + 1 < items_len {
                                                 current_index + 1
-                                            } else if !clamp {
+                                            } else if wrap_around {
                                                 0
                                             } else {
                                                 return;
@@ -6800,14 +6800,14 @@ impl Workspace {
                                 }
 
                                 if let Some(pane) = recent_pane {
-                                    let clamp = action.clamp;
+                                    let wrap_around = action.wrap_around;
                                     pane.update(cx, |pane, cx| {
                                         let current_index = pane.active_item_index();
                                         let items_len = pane.items_len();
                                         if items_len > 0 {
                                             let prev_index = if current_index > 0 {
                                                 current_index - 1
-                                            } else if !clamp {
+                                            } else if wrap_around {
                                                 items_len.saturating_sub(1)
                                             } else {
                                                 return;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4639,7 +4639,7 @@ mod tests {
         assert_key_bindings_for(
             window.into(),
             cx,
-            vec![("backspace", &ActionB), ("{", &ActivatePreviousItem)],
+            vec![("backspace", &ActionB), ("{", &ActivatePreviousItem::default())],
             line!(),
         );
     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4639,7 +4639,10 @@ mod tests {
         assert_key_bindings_for(
             window.into(),
             cx,
-            vec![("backspace", &ActionB), ("{", &ActivatePreviousItem::default())],
+            vec![
+                ("backspace", &ActionB),
+                ("{", &ActivatePreviousItem::default()),
+            ],
             line!(),
         );
     }


### PR DESCRIPTION
Hi I've wanted this feature and looked through most open issues and pull request and couldn't find an implementation! Currently keymap of  `pane::ActivatePreviousItem` or `pane::ActivateNextItem` will cycle through the tab when it reaches the end (either the start or the beginning). This PR allows the user to set whether they want to "clamp" it so that it doesn't cycle. 

Heres a video of before and after when the keyboard short cut has been set. Let me know if this needs more clarifying.

https://github.com/user-attachments/assets/883b49b3-8721-419c-94dd-8268a450a7d8

## Summary

- Adds an optional `wrap_around` field to `ActivatePreviousItem` and `ActivateNextItem` pane actions
- When `wrap_around: false`, tab navigation stops at the first/last tab instead of wrapping circularly
- Defaults to `true`, fully preserving existing behavior

### Usage

Taking the current default macOS keymap, one could update the current behavior with the following bindings:

```json
{
    "context": "Pane",
    "use_key_equivalents": true,
    "bindings": {
      "alt-cmd-left": ["pane::ActivatePreviousItem", { "wrap_around": false }],
      "cmd-{": ["pane::ActivatePreviousItem", { "wrap_around": false }],
      "alt-cmd-right": ["pane::ActivateNextItem", { "wrap_around": false }],
      "cmd-}": ["pane::ActivateNextItem", { "wrap_around": false }],
    },
  }
```

## Test plan

- [x] Added `test_activate_item_with_clamp` in `crates/workspace/src/pane.rs` covering:
  - `clamp: true` at last tab stays on last tab
  - `clamp: true` at first tab stays on first tab
  - Default behavior (wrapping) unchanged
  - Normal mid-list navigation works with clamp
- [x] Existing tests pass (`cargo test -p workspace`, `cargo test -p tab_switcher`)
- [x] Tested locally: default keybindings still wrap, custom `clamp: true` bindings stop at boundaries

Release Notes:

- Added a `wrap_around` option to both `pane::ActivatePreviousItem` and `pane::ActivateNextItem` actions to optionally disable wrapping when cycling past the first or last tab.