### PR TITLE
repl: Add notebook cell delete button

### DIFF
--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -62,6 +62,8 @@ actions!(
         AddMarkdownBlock,
         /// Adds a new code cell.
         AddCodeBlock,
+        /// Delete current cell.
+        DeleteCurrentCell,
         /// Restarts the kernel.
         RestartKernel,
         /// Interrupts the current execution.
@@ -784,6 +786,25 @@ impl NotebookEditor {
         cx.notify();
     }
 
+    fn delete_current_cell(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.cell_order.is_empty() {
+            return;
+        }
+
+        let cell_id = self.cell_order.remove(self.selected_cell_index);
+        self.cell_map.remove(&cell_id);
+
+        if !self.cell_order.is_empty() {
+            self.selected_cell_index =
+                self.selected_cell_index.min(self.cell_order.len() - 1);
+        } else {
+            self.selected_cell_index = 0;
+        }
+
+        self.cell_list.reset(self.cell_order.len());
+        cx.notify();
+    }
+
     fn cell_count(&self) -> usize {
         self.cell_map.len()
     }
@@ -1006,6 +1027,21 @@ impl NotebookEditor {
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(AddCodeBlock), cx);
+                                }),
+                            )
+                            .child(
+                                Self::render_notebook_control(
+                                    "delete-current-cell",
+                                    IconName::Trash,
+                                    window,
+                                    cx,
+                                )
+                                .disabled(self.cell_order.is_empty())
+                                .tooltip(move |window, cx| {
+                                    Tooltip::for_action("Delete current cell", &DeleteCurrentCell, cx)
+                                })
+                                .on_click(|_, window, cx| {
+                                    window.dispatch_action(Box::new(DeleteCurrentCell), cx);
                                 }),
                             ),
                     ),
@@ -1240,6 +1276,9 @@ impl Render for NotebookEditor {
             }))
             .on_action(
                 cx.listener(|this, _: &AddCodeBlock, window, cx| this.add_code_block(window, cx)),
+            )
+            .on_action(
+                cx.listener(|this, _: &DeleteCurrentCell, window, cx| this.delete_current_cell(window, cx)),
             )
             .on_action(cx.listener(|this, _: &MoveUp, window, cx| {
                 this.select_previous(&menu::SelectPrevious, window, cx);

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -795,8 +795,7 @@ impl NotebookEditor {
         self.cell_map.remove(&cell_id);
 
         if !self.cell_order.is_empty() {
-            self.selected_cell_index =
-                self.selected_cell_index.min(self.cell_order.len() - 1);
+            self.selected_cell_index = self.selected_cell_index.min(self.cell_order.len() - 1);
         } else {
             self.selected_cell_index = 0;
         }
@@ -1038,7 +1037,11 @@ impl NotebookEditor {
                                 )
                                 .disabled(self.cell_order.is_empty())
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action("Delete current cell", &DeleteCurrentCell, cx)
+                                    Tooltip::for_action(
+                                        "Delete current cell",
+                                        &DeleteCurrentCell,
+                                        cx,
+                                    )
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(DeleteCurrentCell), cx);
@@ -1277,9 +1280,9 @@ impl Render for NotebookEditor {
             .on_action(
                 cx.listener(|this, _: &AddCodeBlock, window, cx| this.add_code_block(window, cx)),
             )
-            .on_action(
-                cx.listener(|this, _: &DeleteCurrentCell, window, cx| this.delete_current_cell(window, cx)),
-            )
+            .on_action(cx.listener(|this, _: &DeleteCurrentCell, window, cx| {
+                this.delete_current_cell(window, cx)
+            }))
             .on_action(cx.listener(|this, _: &MoveUp, window, cx| {
                 this.select_previous(&menu::SelectPrevious, window, cx);
                 if let Some(cell_id) = this.cell_order.get(this.selected_cell_index) {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -11,7 +11,7 @@ use futures::FutureExt;
 use futures::future::Shared;
 use gpui::{
     AnyElement, App, Entity, EventEmitter, FocusHandle, Focusable, ListScrollEvent, ListState,
-    Point, Task, actions, list, prelude::*,
+    Point, PromptLevel, Task, actions, list, prelude::*,
 };
 use jupyter_protocol::JupyterKernelspec;
 use language::{Language, LanguageRegistry};
@@ -20,6 +20,7 @@ use project::{Project, ProjectEntryId, ProjectPath};
 use settings::Settings as _;
 use ui::{CommonAnimationExt, Tooltip, prelude::*};
 use workspace::item::{ItemEvent, SaveOptions, TabContentParams};
+use workspace::notifications::DetachAndPromptErr;
 use workspace::searchable::SearchableItemHandle;
 use workspace::{Item, ItemHandle, Pane, ProjectItem, ToolbarItemLocation};
 
@@ -786,7 +787,37 @@ impl NotebookEditor {
         cx.notify();
     }
 
-    fn delete_current_cell(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+    fn delete_current_cell(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.cell_order.is_empty() {
+            return;
+        }
+
+        let prompt = window.prompt(
+            PromptLevel::Warning,
+            "Delete current cell?",
+            None,
+            &["Delete", "Cancel"],
+            cx,
+        );
+
+        cx.spawn_in(window, async move |this, cx| {
+            let answer = prompt.await?;
+            if answer != 0 {
+                return Ok(());
+            }
+
+            this.update_in(cx, |this, window, cx| {
+                this.delete_current_cell_confirmed(window, cx);
+            })?;
+
+            Ok(())
+        })
+        .detach_and_prompt_err("Failed to delete cell", window, cx, |e, _, _| {
+            Some(format!("{e}"))
+        });
+    }
+
+    fn delete_current_cell_confirmed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         if self.cell_order.is_empty() {
             return;
         }

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1058,26 +1058,24 @@ impl NotebookEditor {
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(AddCodeBlock), cx);
                                 }),
-                            )
-                            .child(
-                                Self::render_notebook_control(
-                                    "delete-current-cell",
-                                    IconName::Trash,
-                                    window,
-                                    cx,
-                                )
-                                .disabled(self.cell_order.is_empty())
-                                .tooltip(move |window, cx| {
-                                    Tooltip::for_action(
-                                        "Delete current cell",
-                                        &DeleteCurrentCell,
-                                        cx,
-                                    )
-                                })
-                                .on_click(|_, window, cx| {
-                                    window.dispatch_action(Box::new(DeleteCurrentCell), cx);
-                                }),
                             ),
+                    )
+                    .child(
+                        Self::button_group(window, cx).child(
+                            Self::render_notebook_control(
+                                "delete-current-cell",
+                                IconName::Trash,
+                                window,
+                                cx,
+                            )
+                            .disabled(self.cell_order.is_empty())
+                            .tooltip(move |window, cx| {
+                                Tooltip::for_action("Delete current cell", &DeleteCurrentCell, cx)
+                            })
+                            .on_click(|_, window, cx| {
+                                window.dispatch_action(Box::new(DeleteCurrentCell), cx);
+                            }),
+                        ),
                     ),
             )
             .child(


### PR DESCRIPTION
Closes #51267

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Before:
<img width="1700" height="1105" alt="image" src="https://github.com/user-attachments/assets/65aa39d2-4b02-4dbb-8acd-0c89bcfed805" />

After:
<img width="1700" height="1105" alt="image" src="https://github.com/user-attachments/assets/6386f603-fc8d-4ea7-9a49-42dbe74ffb82" />

Release Notes:

- Added a delete current cell button.
