### PR TITLE
languages: Add `@tag.component.jsx` captures for JSX component tags

### DIFF
--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -423,6 +423,21 @@
   (identifier) @tag.jsx
   (#match? @tag.jsx "^[a-z][^.]*$"))
 
+; React component tags (uppercase identifiers like <MyComponent>)
+; These override the generic @type capture from above,
+; allowing themes to color components differently from types.
+(jsx_opening_element
+  (identifier) @tag.component.jsx
+  (#match? @tag.component.jsx "^[A-Z]"))
+
+(jsx_closing_element
+  (identifier) @tag.component.jsx
+  (#match? @tag.component.jsx "^[A-Z]"))
+
+(jsx_self_closing_element
+  (identifier) @tag.component.jsx
+  (#match? @tag.component.jsx "^[A-Z]"))
+
 (jsx_attribute
   (property_identifier) @attribute.jsx)
 


### PR DESCRIPTION
## Summary

- Adds `@tag.component.jsx` tree-sitter captures for JSX/TSX component tags (uppercase identifiers like `<MyComponent>`)
- This allows themes to color JSX component tags differently from type identifiers, which currently both fall under the generic `@type` capture

## Context

Related issues: #19267, #17880, #25207

Currently in TSX, component names like `<MyComponent>` are captured as `@type` because tree-sitter classifies uppercase JSX identifiers as types. This makes it impossible for themes to distinguish between type annotations (e.g., `string`, `number`, `MyInterface`) and JSX component tags.

This PR adds specific captures for JSX component tags using `@tag.component.jsx`, which themes can target via the `tag.component` fallback chain (`tag.component.jsx` → `tag.component` → `tag`).

## Test plan

- Open a TSX file with JSX component tags (e.g., `<Button>`, `<MyComponent />`)
- Verify component tags receive `@tag.component.jsx` highlight
- Verify type annotations still receive `@type` highlight
- Verify themes without `tag.component` entries are unaffected (falls back to `tag`)

Release Notes:

- Added `@tag.component.jsx` tree-sitter captures for TSX, allowing themes to style JSX component tags (like `<Button>`) separately from type identifiers.