### PR TITLE
editor: Show verbose rust-analyzer diagnostics in hover popover

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1026,9 +1026,38 @@ impl DiagnosticPopover {
                                 ),
                             ),
                     )
-                    .child(div().absolute().top_1().right_1().child({
-                        let message = self.local_diagnostic.diagnostic.message.clone();
+                    .child(div().absolute().top_1().right_1().flex().gap_1().child({
+                        let message = self.local_diagnostic.diagnostic.rendered
+                            .clone()
+                            .unwrap_or_else(|| self.local_diagnostic.diagnostic.message.clone());
                         CopyButton::new("copy-diagnostic", message).tooltip_label("Copy Diagnostic")
+                    }).when_some(self.local_diagnostic.diagnostic.rendered.clone(), |this, rendered| {
+                        this.child(
+                            IconButton::new("open-full-diagnostic", IconName::FileDoc)
+                                .icon_size(IconSize::Small)
+                                .tooltip(ui::Tooltip::text("Open Full Diagnostic"))
+                                .on_click(move |_, window, cx| {
+                                    let rendered = rendered.clone();
+                                    if let Some(workspace) = window.root::<Workspace>().flatten() {
+                                        workspace.update(cx, |workspace, cx| {
+                                            let project = workspace.project().clone();
+                                            let buffer = project.update(cx, |project, cx| {
+                                                project.create_local_buffer(&rendered, None, true, cx)
+                                            });
+                                            let editor = cx.new(|cx| {
+                                                Editor::for_buffer(buffer, Some(project), window, cx)
+                                            });
+                                            workspace.add_item_to_active_pane(
+                                                Box::new(editor),
+                                                None,
+                                                true,
+                                                window,
+                                                cx,
+                                            );
+                                        });
+                                    }
+                                }),
+                        )
                     }))
                     .custom_scrollbars(
                         Scrollbars::for_settings::<EditorSettings>()

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -290,6 +290,9 @@ pub struct Diagnostic {
     pub source_kind: DiagnosticSourceKind,
     /// Data from language server that produced this diagnostic. Passed back to the LS when we request code actions for this diagnostic.
     pub data: Option<Value>,
+    /// The full verbose rendered output from the compiler (e.g. rust-analyzer's `rendered` field),
+    /// including ASCII art spans and suggestions.
+    pub rendered: Option<String>,
     /// Whether to underline the corresponding text range in the editor.
     pub underline: bool,
 }
@@ -5723,6 +5726,7 @@ impl Default for Diagnostic {
             is_unnecessary: false,
             underline: true,
             data: None,
+            rendered: None,
             registration_id: None,
         }
     }

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -472,6 +472,7 @@ pub fn deserialize_diagnostics(
                         proto::diagnostic::SourceKind::Other => DiagnosticSourceKind::Other,
                     },
                     data,
+                    rendered: None,
                 },
             })
         })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11667,6 +11667,10 @@ impl LspStore {
                         is_unnecessary,
                         underline,
                         data: diagnostic.data.clone(),
+                        rendered: diagnostic.data.as_ref()
+                            .and_then(|d| d.get("rendered"))
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string()),
                         registration_id: registration_id.clone(),
                     },
                 });
@@ -11695,6 +11699,7 @@ impl LspStore {
                                     is_unnecessary: false,
                                     underline,
                                     data: diagnostic.data.clone(),
+                                    rendered: None,
                                     registration_id: registration_id.clone(),
                                 },
                             });


### PR DESCRIPTION
### Summary 

This is the first of two planned PRs for #21376. the follow-up PR will improve the project diagnostics view to display rendered diagnostics inline.

### Changes

- Store the `rendered` field from rust-analyzer's `diagnostic.data` in the internal `Diagnostic` struct
- Update the diagnostic popover copy button to copy the full verbose compiler output when available
- Add an "Open Full Diagnostic" button that opens the rendered output in a scratch buffer tab

### Result

**Before Fix**
<img width="609" height="312" alt="before_fix" src="https://github.com/user-attachments/assets/50b5a8aa-8b41-4320-a9da-4b086cfa7981" />

**After Fix**
<img width="564" height="318" alt="after_fix" src="https://github.com/user-attachments/assets/a53b713f-0dd0-4f54-a661-83f8ab9bd344" />

<img width="609" height="461" alt="after_fix_2" src="https://github.com/user-attachments/assets/e23ab644-165a-494d-b792-8544f8c206f5" />

Now we can see the "Open Full Diagnostic" clickable button and rendered compiler error output.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added "Open Full Diagnostic" button to the diagnostic popover that opens verbose rust-analyzer compiler output in a scratch buffer
- Improved "Copy Diagnostic" to copy the full rendered compiler output when available
