### PR TITLE
editor: Fix indentation of parent numberings

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11115,7 +11115,7 @@ impl Editor {
         }
 
         let mut delta_for_end_row = 0;
-        let mut next_ordered_list_number = 1;
+        let mut next_ordered_list_number: Option<u32> = None;
         let has_multiple_rows = start_row + 1 != end_row;
         let mut trailing_renumber_anchor_row: Option<u32> = None;
         let mut trailing_renumber_indent_len: Option<u32> = None;
@@ -11144,11 +11144,15 @@ impl Editor {
 
             if let Some(language) = snapshot.language_scope_at(Point::new(row, current_indent.len))
             {
-                let renumber_to = if has_multiple_rows {
-                    next_ordered_list_number
-                } else {
-                    1
-                };
+                let renumber_to = *next_ordered_list_number.get_or_insert_with(|| {
+                    let target_indent_len = current_indent.len + indent_delta.len;
+                    previous_ordered_list_number_at_indent(
+                        row,
+                        target_indent_len,
+                        snapshot,
+                        &language,
+                    ) + 1
+                });
                 if let Some((marker_start_col, marker_end_col, marker_text)) =
                     ordered_list_indent_renumber(
                         row,
@@ -11162,7 +11166,10 @@ impl Editor {
                         Point::new(row, marker_start_col)..Point::new(row, marker_end_col),
                         marker_text,
                     ));
-                    next_ordered_list_number += 1;
+                    if has_multiple_rows {
+                        next_ordered_list_number =
+                            Some(renumber_to.saturating_add(1));
+                    }
 
                     if let Some(indent_len) = trailing_renumber_indent_len {
                         if current_indent.len == indent_len {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11167,8 +11167,7 @@ impl Editor {
                         marker_text,
                     ));
                     if has_multiple_rows {
-                        next_ordered_list_number =
-                            Some(renumber_to.saturating_add(1));
+                        next_ordered_list_number = Some(renumber_to.saturating_add(1));
                     }
 
                     if let Some(indent_len) = trailing_renumber_indent_len {
@@ -11197,14 +11196,12 @@ impl Editor {
             if let (Some(anchor_row), Some(indent_len)) =
                 (trailing_renumber_anchor_row, trailing_renumber_indent_len)
             {
-                if let Some(language) = snapshot.language_scope_at(Point::new(anchor_row, indent_len))
+                if let Some(language) =
+                    snapshot.language_scope_at(Point::new(anchor_row, indent_len))
                 {
                     renumber_following_ordered_list_siblings_after_indent(
                         previous_ordered_list_number_at_indent(
-                            anchor_row,
-                            indent_len,
-                            snapshot,
-                            &language,
+                            anchor_row, indent_len, snapshot, &language,
                         ) + 1,
                         end_row,
                         indent_len,
@@ -11254,8 +11251,7 @@ impl Editor {
                 }
 
                 let has_multiple_rows = rows.len() > 1;
-                let original_indent_len =
-                    snapshot.indent_size_for_line(rows.start).len;
+                let original_indent_len = snapshot.indent_size_for_line(rows.start).len;
 
                 let mut next_outdent_number = 0u32;
                 let mut moved_ordered_items_at_original_indent = 0u32;
@@ -11290,25 +11286,20 @@ impl Editor {
                         if let Some(language) =
                             snapshot.language_scope_at(Point::new(row.0, indent_size.len))
                         {
-                            if let Some(marker) = ordered_list_marker(
-                                row.0,
-                                indent_size.len,
-                                &snapshot,
-                                &language,
-                            ) {
-                                let target_indent =
-                                    indent_size.len.saturating_sub(deletion_len);
+                            if let Some(marker) =
+                                ordered_list_marker(row.0, indent_size.len, &snapshot, &language)
+                            {
+                                let target_indent = indent_size.len.saturating_sub(deletion_len);
 
                                 // Lazy-initialize the counter on the first ordered item
                                 // we encounter in this selection.
                                 if next_outdent_number == 0 {
-                                    next_outdent_number =
-                                        previous_ordered_list_number_at_indent(
-                                            row.0,
-                                            target_indent,
-                                            &snapshot,
-                                            &language,
-                                        ) + 1;
+                                    next_outdent_number = previous_ordered_list_number_at_indent(
+                                        row.0,
+                                        target_indent,
+                                        &snapshot,
+                                        &language,
+                                    ) + 1;
                                     first_target_indent = Some(target_indent);
                                 }
 
@@ -11337,10 +11328,9 @@ impl Editor {
                 // Renumber the siblings that were left behind at the original (deeper)
                 // indent level to fill the gap created by the outdented items.
                 if moved_ordered_items_at_original_indent > 0 {
-                    let following_row =
-                        last_outdent.map_or(rows.start.0, |r| r.next_row().0);
-                    if let Some(language) = snapshot
-                        .language_scope_at(Point::new(rows.start.0, original_indent_len))
+                    let following_row = last_outdent.map_or(rows.start.0, |r| r.next_row().0);
+                    if let Some(language) =
+                        snapshot.language_scope_at(Point::new(rows.start.0, original_indent_len))
                     {
                         renumber_following_ordered_list_siblings_after_indent(
                             previous_ordered_list_number_at_indent(
@@ -11362,10 +11352,9 @@ impl Editor {
                 // after the outdented block — they are displaced forward since new
                 // items were inserted before them at that level.
                 if let Some(target_indent) = first_target_indent {
-                    let following_row =
-                        last_outdent.map_or(rows.start.0, |r| r.next_row().0);
-                    if let Some(language) = snapshot
-                        .language_scope_at(Point::new(rows.start.0, target_indent))
+                    let following_row = last_outdent.map_or(rows.start.0, |r| r.next_row().0);
+                    if let Some(language) =
+                        snapshot.language_scope_at(Point::new(rows.start.0, target_indent))
                     {
                         renumber_following_ordered_list_siblings_after_indent(
                             next_outdent_number,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11138,6 +11138,25 @@ impl Editor {
                 indent_delta.chars().collect::<String>(),
             ));
 
+            // When indenting a single ordered list item, reset its number to 1
+            // since it starts a new sub-list at the deeper indentation level.
+            // For multi-row selections we skip this because the user is moving
+            // an existing list block and the relative ordering must be preserved.
+            if !has_multiple_rows {
+                if let Some(language) =
+                    snapshot.language_scope_at(Point::new(row, current_indent.len))
+                {
+                    if let Some((marker_start_col, marker_end_col, reset_marker)) =
+                        ordered_list_indent_reset(row, &current_indent, snapshot, &language)
+                    {
+                        edits.push((
+                            Point::new(row, marker_start_col)..Point::new(row, marker_end_col),
+                            reset_marker,
+                        ));
+                    }
+                }
+            }
+
             // Update this selection's endpoints to reflect the indentation.
             if row == selection.start.row {
                 selection.start.column += indent_delta.len;
@@ -26262,6 +26281,62 @@ fn list_delimiter_for_newline(
             }
 
             return None;
+        }
+    }
+
+    None
+}
+
+/// Returns `(marker_start_col, marker_end_col, reset_text)` for an ordered list item
+/// on `row` that has content after the marker, so the caller can replace the marker
+/// with `reset_text` (which always formats the number as `1`) when indenting.
+///
+/// Returns `None` if the row is not an ordered list item with content, or if the
+/// marker would not change (i.e., it is already `1`).
+fn ordered_list_indent_reset(
+    row: u32,
+    current_indent: &IndentSize,
+    snapshot: &MultiBufferSnapshot,
+    language: &LanguageScope,
+) -> Option<(u32, u32, String)> {
+    let (buffer_snapshot, range) = snapshot.buffer_line_for_row(MultiBufferRow(row))?;
+    let indent_len = current_indent.len as usize;
+
+    let candidate: String = buffer_snapshot
+        .chars_for_range(range.clone())
+        .skip(indent_len)
+        .take(ORDERED_LIST_MAX_MARKER_LEN)
+        .collect();
+
+    for ordered_config in language.ordered_list() {
+        let regex = match Regex::new(&ordered_config.pattern) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        if let Some(captures) = regex.captures(&candidate) {
+            let full_match = captures.get(0)?;
+            let marker_len = full_match.len();
+            let end_of_marker = indent_len + marker_len;
+
+            let has_content = buffer_snapshot
+                .chars_for_range(range)
+                .skip(end_of_marker)
+                .any(|c| !c.is_whitespace());
+
+            if !has_content {
+                return None;
+            }
+
+            let current_number: u32 = captures.get(1)?.as_str().parse().ok()?;
+            if current_number == 1 {
+                return None;
+            }
+
+            let reset_marker = ordered_config.format.replace("{1}", "1");
+            let marker_start_col = indent_len as u32;
+            let marker_end_col = end_of_marker as u32;
+            return Some((marker_start_col, marker_end_col, reset_marker));
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11115,7 +11115,12 @@ impl Editor {
         }
 
         let mut delta_for_end_row = 0;
+        let mut next_ordered_list_number = 1;
         let has_multiple_rows = start_row + 1 != end_row;
+        let original_indent_len = snapshot
+            .indent_size_for_line(MultiBufferRow(start_row))
+            .len;
+        let mut moved_ordered_items_at_original_indent = 0u32;
         for row in start_row..end_row {
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(row));
             let indent_delta = match (current_indent.kind, indent_kind) {
@@ -11138,21 +11143,31 @@ impl Editor {
                 indent_delta.chars().collect::<String>(),
             ));
 
-            // When indenting a single ordered list item, reset its number to 1
-            // since it starts a new sub-list at the deeper indentation level.
-            // For multi-row selections we skip this because the user is moving
-            // an existing list block and the relative ordering must be preserved.
-            if !has_multiple_rows {
-                if let Some(language) =
-                    snapshot.language_scope_at(Point::new(row, current_indent.len))
+            if let Some(language) = snapshot.language_scope_at(Point::new(row, current_indent.len))
+            {
+                let renumber_to = if has_multiple_rows {
+                    next_ordered_list_number
+                } else {
+                    1
+                };
+                if let Some((marker_start_col, marker_end_col, marker_text)) =
+                    ordered_list_indent_renumber(
+                        row,
+                        &current_indent,
+                        snapshot,
+                        &language,
+                        renumber_to,
+                    )
                 {
-                    if let Some((marker_start_col, marker_end_col, reset_marker)) =
-                        ordered_list_indent_reset(row, &current_indent, snapshot, &language)
-                    {
-                        edits.push((
-                            Point::new(row, marker_start_col)..Point::new(row, marker_end_col),
-                            reset_marker,
-                        ));
+                    edits.push((
+                        Point::new(row, marker_start_col)..Point::new(row, marker_end_col),
+                        marker_text,
+                    ));
+                    if has_multiple_rows {
+                        next_ordered_list_number += 1;
+                        if current_indent.len == original_indent_len {
+                            moved_ordered_items_at_original_indent += 1;
+                        }
                     }
                 }
             }
@@ -11164,6 +11179,21 @@ impl Editor {
             if row == selection.end.row {
                 selection.end.column += indent_delta.len;
                 delta_for_end_row = indent_delta.len;
+            }
+        }
+
+        if has_multiple_rows && moved_ordered_items_at_original_indent > 0 {
+            if let Some(language) =
+                snapshot.language_scope_at(Point::new(start_row, original_indent_len))
+            {
+                renumber_following_ordered_list_siblings_after_indent(
+                    start_row,
+                    end_row,
+                    original_indent_len,
+                    snapshot,
+                    &language,
+                    edits,
+                );
             }
         }
 
@@ -26287,23 +26317,39 @@ fn list_delimiter_for_newline(
     None
 }
 
-/// Returns `(marker_start_col, marker_end_col, reset_text)` for an ordered list item
-/// on `row` that has content after the marker, so the caller can replace the marker
-/// with `reset_text` (which always formats the number as `1`) when indenting.
-///
-/// Returns `None` if the row is not an ordered list item with content, or if the
-/// marker would not change (i.e., it is already `1`).
-fn ordered_list_indent_reset(
+/// Returns `(marker_start_col, marker_end_col, marker_text)` for an ordered list item
+/// on `row`, allowing the caller to replace the marker while indenting.
+fn ordered_list_indent_renumber(
     row: u32,
     current_indent: &IndentSize,
     snapshot: &MultiBufferSnapshot,
     language: &LanguageScope,
+    renumber_to: u32,
 ) -> Option<(u32, u32, String)> {
+    let marker = ordered_list_marker(row, current_indent.len, snapshot, language)?;
+    let marker_text = marker.format.replace("{1}", &renumber_to.to_string());
+    Some((marker.start_col, marker.end_col, marker_text))
+}
+
+#[derive(Clone)]
+struct OrderedListMarker {
+    start_col: u32,
+    end_col: u32,
+    number: u32,
+    format: String,
+}
+
+fn ordered_list_marker(
+    row: u32,
+    indent_len: u32,
+    snapshot: &MultiBufferSnapshot,
+    language: &LanguageScope,
+) -> Option<OrderedListMarker> {
     let (buffer_snapshot, range) = snapshot.buffer_line_for_row(MultiBufferRow(row))?;
-    let indent_len = current_indent.len as usize;
+    let indent_len = indent_len as usize;
 
     let candidate: String = buffer_snapshot
-        .chars_for_range(range.clone())
+        .chars_for_range(range)
         .skip(indent_len)
         .take(ORDERED_LIST_MAX_MARKER_LEN)
         .collect();
@@ -26316,31 +26362,88 @@ fn ordered_list_indent_reset(
 
         if let Some(captures) = regex.captures(&candidate) {
             let full_match = captures.get(0)?;
-            let marker_len = full_match.len();
-            let end_of_marker = indent_len + marker_len;
-
-            let has_content = buffer_snapshot
-                .chars_for_range(range)
-                .skip(end_of_marker)
-                .any(|c| !c.is_whitespace());
-
-            if !has_content {
-                return None;
-            }
-
-            let current_number: u32 = captures.get(1)?.as_str().parse().ok()?;
-            if current_number == 1 {
-                return None;
-            }
-
-            let reset_marker = ordered_config.format.replace("{1}", "1");
-            let marker_start_col = indent_len as u32;
-            let marker_end_col = end_of_marker as u32;
-            return Some((marker_start_col, marker_end_col, reset_marker));
+            let number = captures.get(1)?.as_str().parse().ok()?;
+            return Some(OrderedListMarker {
+                start_col: indent_len as u32,
+                end_col: (indent_len + full_match.len()) as u32,
+                number,
+                format: ordered_config.format.to_string(),
+            });
         }
     }
 
     None
+}
+
+fn previous_ordered_list_number_at_indent(
+    before_row: u32,
+    indent_len: u32,
+    snapshot: &MultiBufferSnapshot,
+    language: &LanguageScope,
+) -> u32 {
+    for row in (0..before_row).rev() {
+        let row = MultiBufferRow(row);
+        if snapshot.is_line_blank(row) {
+            return 0;
+        }
+
+        let row_indent_len = snapshot.indent_size_for_line(row).len;
+        if row_indent_len < indent_len {
+            return 0;
+        }
+
+        if row_indent_len == indent_len {
+            if let Some(marker) = ordered_list_marker(row.0, indent_len, snapshot, language) {
+                return marker.number;
+            }
+            return 0;
+        }
+    }
+
+    0
+}
+
+fn renumber_following_ordered_list_siblings_after_indent(
+    moved_start_row: u32,
+    following_start_row: u32,
+    indent_len: u32,
+    snapshot: &MultiBufferSnapshot,
+    language: &LanguageScope,
+    edits: &mut Vec<(Range<Point>, String)>,
+) {
+    let mut next_number =
+        previous_ordered_list_number_at_indent(moved_start_row, indent_len, snapshot, language) + 1;
+    let max_row = snapshot.max_point().row;
+
+    for row in following_start_row..=max_row {
+        let row = MultiBufferRow(row);
+        if snapshot.is_line_blank(row) {
+            break;
+        }
+
+        let row_indent_len = snapshot.indent_size_for_line(row).len;
+        if row_indent_len < indent_len {
+            break;
+        }
+
+        if row_indent_len > indent_len {
+            continue;
+        }
+
+        let Some(marker) = ordered_list_marker(row.0, indent_len, snapshot, language) else {
+            break;
+        };
+
+        if marker.number != next_number {
+            let marker_text = marker.format.replace("{1}", &next_number.to_string());
+            edits.push((
+                Point::new(row.0, marker.start_col)..Point::new(row.0, marker.end_col),
+                marker_text,
+            ));
+        }
+
+        next_number += 1;
+    }
 }
 
 fn is_list_prefix_row(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11117,10 +11117,9 @@ impl Editor {
         let mut delta_for_end_row = 0;
         let mut next_ordered_list_number = 1;
         let has_multiple_rows = start_row + 1 != end_row;
-        let original_indent_len = snapshot
-            .indent_size_for_line(MultiBufferRow(start_row))
-            .len;
-        let mut moved_ordered_items_at_original_indent = 0u32;
+        let mut trailing_renumber_anchor_row: Option<u32> = None;
+        let mut trailing_renumber_indent_len: Option<u32> = None;
+        let mut moved_ordered_items_at_trailing_indent = 0u32;
         for row in start_row..end_row {
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(row));
             let indent_delta = match (current_indent.kind, indent_kind) {
@@ -11163,11 +11162,16 @@ impl Editor {
                         Point::new(row, marker_start_col)..Point::new(row, marker_end_col),
                         marker_text,
                     ));
-                    if has_multiple_rows {
-                        next_ordered_list_number += 1;
-                        if current_indent.len == original_indent_len {
-                            moved_ordered_items_at_original_indent += 1;
+                    next_ordered_list_number += 1;
+
+                    if let Some(indent_len) = trailing_renumber_indent_len {
+                        if current_indent.len == indent_len {
+                            moved_ordered_items_at_trailing_indent += 1;
                         }
+                    } else {
+                        trailing_renumber_anchor_row = Some(row);
+                        trailing_renumber_indent_len = Some(current_indent.len);
+                        moved_ordered_items_at_trailing_indent = 1;
                     }
                 }
             }
@@ -11182,18 +11186,26 @@ impl Editor {
             }
         }
 
-        if has_multiple_rows && moved_ordered_items_at_original_indent > 0 {
-            if let Some(language) =
-                snapshot.language_scope_at(Point::new(start_row, original_indent_len))
+        if moved_ordered_items_at_trailing_indent > 0 {
+            if let (Some(anchor_row), Some(indent_len)) =
+                (trailing_renumber_anchor_row, trailing_renumber_indent_len)
             {
-                renumber_following_ordered_list_siblings_after_indent(
-                    start_row,
-                    end_row,
-                    original_indent_len,
-                    snapshot,
-                    &language,
-                    edits,
-                );
+                if let Some(language) = snapshot.language_scope_at(Point::new(anchor_row, indent_len))
+                {
+                    renumber_following_ordered_list_siblings_after_indent(
+                        previous_ordered_list_number_at_indent(
+                            anchor_row,
+                            indent_len,
+                            snapshot,
+                            &language,
+                        ) + 1,
+                        end_row,
+                        indent_len,
+                        snapshot,
+                        &language,
+                        edits,
+                    );
+                }
             }
         }
 
@@ -11216,7 +11228,7 @@ impl Editor {
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(&display_map);
-        let mut deletion_ranges = Vec::new();
+        let mut edits: Vec<(Range<Point>, String)> = Vec::new();
         let mut last_outdent = None;
         {
             let buffer = self.buffer.read(cx);
@@ -11233,7 +11245,15 @@ impl Editor {
                 {
                     rows.start = rows.start.next_row();
                 }
+
                 let has_multiple_rows = rows.len() > 1;
+                let original_indent_len =
+                    snapshot.indent_size_for_line(rows.start).len;
+
+                let mut next_outdent_number = 0u32;
+                let mut moved_ordered_items_at_original_indent = 0u32;
+                let mut first_target_indent: Option<u32> = None;
+
                 for row in rows.iter_rows() {
                     let indent_size = snapshot.indent_size_for_line(row);
                     if indent_size.len > 0 {
@@ -11256,10 +11276,98 @@ impl Editor {
                         } else {
                             selection.start.column - deletion_len
                         };
-                        deletion_ranges.push(
-                            Point::new(row.0, start)..Point::new(row.0, start + deletion_len),
-                        );
+                        let deletion_range =
+                            Point::new(row.0, start)..Point::new(row.0, start + deletion_len);
+                        edits.push((deletion_range, String::new()));
+
+                        if let Some(language) =
+                            snapshot.language_scope_at(Point::new(row.0, indent_size.len))
+                        {
+                            if let Some(marker) = ordered_list_marker(
+                                row.0,
+                                indent_size.len,
+                                &snapshot,
+                                &language,
+                            ) {
+                                let target_indent =
+                                    indent_size.len.saturating_sub(deletion_len);
+
+                                // Lazy-initialize the counter on the first ordered item
+                                // we encounter in this selection.
+                                if next_outdent_number == 0 {
+                                    next_outdent_number =
+                                        previous_ordered_list_number_at_indent(
+                                            row.0,
+                                            target_indent,
+                                            &snapshot,
+                                            &language,
+                                        ) + 1;
+                                    first_target_indent = Some(target_indent);
+                                }
+
+                                if marker.number != next_outdent_number {
+                                    let new_marker = marker
+                                        .format
+                                        .replace("{1}", &next_outdent_number.to_string());
+                                    edits.push((
+                                        Point::new(row.0, marker.start_col)
+                                            ..Point::new(row.0, marker.end_col),
+                                        new_marker,
+                                    ));
+                                }
+
+                                next_outdent_number += 1;
+                                if indent_size.len == original_indent_len {
+                                    moved_ordered_items_at_original_indent += 1;
+                                }
+                            }
+                        }
+
                         last_outdent = Some(row);
+                    }
+                }
+
+                // Renumber the siblings that were left behind at the original (deeper)
+                // indent level to fill the gap created by the outdented items.
+                if moved_ordered_items_at_original_indent > 0 {
+                    let following_row =
+                        last_outdent.map_or(rows.start.0, |r| r.next_row().0);
+                    if let Some(language) = snapshot
+                        .language_scope_at(Point::new(rows.start.0, original_indent_len))
+                    {
+                        renumber_following_ordered_list_siblings_after_indent(
+                            previous_ordered_list_number_at_indent(
+                                rows.start.0,
+                                original_indent_len,
+                                &snapshot,
+                                &language,
+                            ) + 1,
+                            following_row,
+                            original_indent_len,
+                            &snapshot,
+                            &language,
+                            &mut edits,
+                        );
+                    }
+                }
+
+                // Renumber the siblings at the target (shallower) indent that come
+                // after the outdented block — they are displaced forward since new
+                // items were inserted before them at that level.
+                if let Some(target_indent) = first_target_indent {
+                    let following_row =
+                        last_outdent.map_or(rows.start.0, |r| r.next_row().0);
+                    if let Some(language) = snapshot
+                        .language_scope_at(Point::new(rows.start.0, target_indent))
+                    {
+                        renumber_following_ordered_list_siblings_after_indent(
+                            next_outdent_number,
+                            following_row,
+                            target_indent,
+                            &snapshot,
+                            &language,
+                            &mut edits,
+                        );
                     }
                 }
             }
@@ -11267,14 +11375,7 @@ impl Editor {
 
         self.transact(window, cx, |this, window, cx| {
             this.buffer.update(cx, |buffer, cx| {
-                let empty_str: Arc<str> = Arc::default();
-                buffer.edit(
-                    deletion_ranges
-                        .into_iter()
-                        .map(|range| (range, empty_str.clone())),
-                    None,
-                    cx,
-                );
+                buffer.edit(edits, None, cx);
             });
             let selections = this
                 .selections
@@ -26375,16 +26476,19 @@ fn ordered_list_marker(
     None
 }
 
+const ORDERED_LIST_BACKWARD_SCAN_LIMIT: u32 = 256;
+
 fn previous_ordered_list_number_at_indent(
     before_row: u32,
     indent_len: u32,
     snapshot: &MultiBufferSnapshot,
     language: &LanguageScope,
 ) -> u32 {
-    for row in (0..before_row).rev() {
+    let scan_limit = before_row.saturating_sub(ORDERED_LIST_BACKWARD_SCAN_LIMIT);
+    for row in (scan_limit..before_row).rev() {
         let row = MultiBufferRow(row);
         if snapshot.is_line_blank(row) {
-            return 0;
+            continue;
         }
 
         let row_indent_len = snapshot.indent_size_for_line(row).len;
@@ -26404,15 +26508,13 @@ fn previous_ordered_list_number_at_indent(
 }
 
 fn renumber_following_ordered_list_siblings_after_indent(
-    moved_start_row: u32,
+    mut next_number: u32,
     following_start_row: u32,
     indent_len: u32,
     snapshot: &MultiBufferSnapshot,
     language: &LanguageScope,
     edits: &mut Vec<(Range<Point>, String)>,
 ) {
-    let mut next_number =
-        previous_ordered_list_number_at_indent(moved_start_row, indent_len, snapshot, language) + 1;
     let max_row = snapshot.max_point().row;
 
     for row in following_start_row..=max_row {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31468,7 +31468,7 @@ async fn test_tab_ordered_list_single_line_renumbering(cx: &mut TestAppContext) 
     "};
     cx.assert_editor_state(expected.replace("$", " ").as_str());
 
-    // Case 4: Multi-row indent of 5/6 after an existing nested list also resets to 1/2.
+    // Case 4: Multi-row indent of 5/6 after an existing nested list continues from 3/4.
     cx.set_state(indoc! {"
         1. list
         2. list
@@ -31484,8 +31484,8 @@ async fn test_tab_ordered_list_single_line_renumbering(cx: &mut TestAppContext) 
         2. list
           1. list
           2. list
-          «1. list
-          2. listˇ»
+          «3. list
+          4. listˇ»
     "};
     cx.assert_editor_state(expected);
 
@@ -31502,8 +31502,8 @@ async fn test_tab_ordered_list_single_line_renumbering(cx: &mut TestAppContext) 
     let expected = indoc! {"
         1. top
           1. child
-          «1. moved a
-          2. moved bˇ»
+          «2. moved a
+          3. moved bˇ»
         2. trailing
     "};
     cx.assert_editor_state(expected);
@@ -31522,7 +31522,7 @@ async fn test_tab_ordered_list_single_line_renumbering(cx: &mut TestAppContext) 
     let expected = indoc! {"
         1. top
           intro
-        «    helper
+          «  helper
           1. moved a
           2. moved bˇ»
         2. trailing
@@ -31634,7 +31634,7 @@ async fn test_tab_list_outdent(cx: &mut TestAppContext) {
     cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
     let expected = indoc! {"
         1. parent
-        «2. child a
+        2. «child a
         3. child bˇ»
     "};
     cx.assert_editor_state(expected);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31507,6 +31507,137 @@ async fn test_tab_ordered_list_single_line_renumbering(cx: &mut TestAppContext) 
         2. trailing
     "};
     cx.assert_editor_state(expected);
+
+    // Case 6: Selection can start before the moved ordered rows; trailing sibling still renumbers.
+    cx.set_state(indoc! {"
+        1. top
+          intro
+        «  helper
+        2. moved a
+        3. moved bˇ»
+        4. trailing
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        1. top
+          intro
+        «    helper
+          1. moved a
+          2. moved bˇ»
+        2. trailing
+    "};
+    cx.assert_editor_state(expected);
+
+    // Case 7: Blank lines above the moved block do not reset trailing list continuation.
+    cx.set_state(indoc! {"
+        1. top
+
+        «2. moved a
+        3. moved bˇ»
+        4. trailing
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        1. top
+
+          «1. moved a
+          2. moved bˇ»
+        2. trailing
+    "};
+    cx.assert_editor_state(expected);
+}
+
+#[gpui::test]
+async fn test_tab_list_outdent(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    // Case 1: Outdenting a sub-item continues parent list numbering.
+    // The parent list has "1. parent", so the outdented item becomes "2.".
+    let initial = indoc! {"
+        1. parent
+          2. ˇchild
+    "};
+    cx.set_state(initial);
+    cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
+    let expected = indoc! {"
+        1. parent
+        2. ˇchild
+    "};
+    cx.assert_editor_state(expected);
+
+    // Case 2: Outdenting after two parent items picks up the next number in sequence.
+    let initial = indoc! {"
+        1. first
+        2. second
+          1. ˇchild
+    "};
+    cx.set_state(initial);
+    cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
+    let expected = indoc! {"
+        1. first
+        2. second
+        3. ˇchild
+    "};
+    cx.assert_editor_state(expected);
+
+    // Case 3: Outdenting when there is no preceding parent at the target indent
+    // starts at 1 (nothing to continue from).
+    let initial = indoc! {"
+          1. ˇorphan
+    "};
+    cx.set_state(initial);
+    cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
+    let expected = indoc! {"
+        1. ˇorphan
+    "};
+    cx.assert_editor_state(expected);
+
+    // Case 4: Outdenting an already top-level item with no indentation is a no-op
+    // (no indentation to remove, list number stays as-is).
+    cx.set_state(indoc! {"
+        3. ˇitem
+    "});
+    cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
+    cx.assert_editor_state(indoc! {"
+        3. ˇitem
+    "});
+
+    // Case 5: Outdenting an empty ordered list item now renumbers correctly
+    // (the marker continues the parent list even with no content after it).
+    let initial = indoc! {"
+        1. parent
+          3. ˇ
+    "};
+    cx.set_state(initial);
+    cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
+    let expected = indoc! {"
+        1. parent
+        2. ˇ
+    "};
+    cx.assert_editor_state(expected);
+
+    // Case 6: Outdenting multiple rows uses a shared running counter. The first row
+    // scans backward to find `1. parent`, so it becomes `2.` and each subsequent row
+    // increments from there.
+    let initial = indoc! {"
+        1. parent
+          «1. child a
+          2. child bˇ»
+    "};
+    cx.set_state(initial);
+    cx.update_editor(|e, window, cx| e.outdent(&Outdent, window, cx));
+    let expected = indoc! {"
+        1. parent
+        «2. child a
+        3. child bˇ»
+    "};
+    cx.assert_editor_state(expected);
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31422,6 +31422,94 @@ async fn test_tab_list_indent(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_tab_ordered_list_single_line_renumbering(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    // Case 1: Single-line indent resets ordered marker to 1 when there is content.
+    cx.set_state(indoc! {"
+        2. ˇsub item
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        $$1. ˇsub item
+    "};
+    cx.assert_editor_state(expected.replace("$", " ").as_str());
+
+    // Case 2: Single-line indent of an empty ordered item also resets to 1.
+    cx.set_state(indoc! {"
+        2. ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        $$1. ˇ
+    "};
+    cx.assert_editor_state(expected.replace("$", " ").as_str());
+
+    // Case 3: Multi-row indent renumbers sequentially starting at 1.
+    cx.set_state(indoc! {"
+        1. parent
+        «2. child a
+        3. child bˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        1. parent
+        $$«1. child a
+        $$2. child bˇ»
+    "};
+    cx.assert_editor_state(expected.replace("$", " ").as_str());
+
+    // Case 4: Multi-row indent of 5/6 after an existing nested list also resets to 1/2.
+    cx.set_state(indoc! {"
+        1. list
+        2. list
+          1. list
+          2. list
+        «5. list
+        6. listˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        1. list
+        2. list
+          1. list
+          2. list
+          «1. list
+          2. listˇ»
+    "};
+    cx.assert_editor_state(expected);
+
+    // Case 5: Following sibling at original indent is renumbered to close the gap.
+    cx.set_state(indoc! {"
+        1. top
+          1. child
+        «2. moved a
+        3. moved bˇ»
+        4. trailing
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        1. top
+          1. child
+          «1. moved a
+          2. moved bˇ»
+        2. trailing
+    "};
+    cx.assert_editor_state(expected);
+}
+
+#[gpui::test]
 async fn test_local_worktree_trust(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     cx.update(|cx| project::trusted_worktrees::init(HashMap::default(), cx));


### PR DESCRIPTION
Fixes #48244 

Fix ordered list renumbering on indent and outdent in Markdown

### Summary

When tabbing (indenting) or shift-tabbing (outdenting) ordered list items in a Markdown file, Zed previously left the list numbers unchanged — resulting in broken sequences like `1. item` → `  2. item` after indenting, or `  2. child` → `2. child` after outdenting (skipping the correct continuation number).

This PR fixes both indent and outdent to correctly renumber ordered list markers:

**Indent (`Tab`)**
- Single-line indent resets the marker to `1.` (start of a new nested list)
- Multi-row indent renumbers selected items sequentially starting from `1.`
- After indenting, trailing siblings at the original indent level are renumbered to close the gap

**Outdent (`Shift+Tab`)**
- Outdented items pick up the correct next number by scanning backward for the last item at the target indent level
- Multiple selected rows share a running counter, incrementing from where the parent list left off
- Trailing siblings at the deeper (original) indent are renumbered to fill the hole left behind
- Trailing siblings at the shallower (target) indent are renumbered to account for the newly inserted items

### Implementation

Added four new helper functions in `crates/editor/src/editor.rs`:
- `ordered_list_marker` — parses an ordered list marker at a given row/indent using the language's `ordered_list` config
- `ordered_list_indent_renumber` — thin wrapper used during indent to get `(start_col, end_col, new_text)` for a marker
- `previous_ordered_list_number_at_indent` — scans backward (up to 256 lines) to find the last list number at a given indent level
- `renumber_following_ordered_list_siblings_after_indent` — scans forward from a row, renumbering sibling items at the same indent level

The outdent path was also refactored from building a separate `deletion_ranges` vec to a unified `edits: Vec<(Range<Point>, String)>` so that marker-renumber edits can be emitted alongside the deletion edits in a single `buffer.edit()` call.

### Tests

Two new async tests added to `crates/editor/src/editor_tests.rs`:

**`test_tab_ordered_list_single_line_renumbering`** (7 cases)
- Single-line indent resets to `1.`
- Single-line indent of empty item resets to `1.`
- Multi-row indent renumbers `2., 3.` → `1., 2.`
- Multi-row indent after an existing nested list resets correctly
- Trailing sibling at original indent is renumbered to close the gap
- Selection starting before the moved ordered rows still renumbers trailing sibling
- Blank lines above the moved block don't reset trailing list continuation

**`test_tab_list_outdent`** (6 cases)
- Outdenting a sub-item continues parent list numbering
- Outdenting after two parent items picks up the next number in sequence
- Outdenting with no preceding parent at the target indent starts at `1.`
- Outdenting a top-level item with no indentation is a no-op
- Outdenting an empty ordered list item renumbers correctly
- Outdenting multiple rows uses a shared running counter

#### Release Notes:

- Fixed ordered list markers not being renumbered when indenting or outdenting list items in Markdown

#### Video

https://github.com/user-attachments/assets/eb64aa51-60aa-47a7-ae44-ac54f30429de
