### PR TITLE
Add text selection and copy support to Markdown Preview

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1338,6 +1338,7 @@
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
       "alt-down": "markdown::ScrollDownByItem",
+      "cmd-c": "markdown::CopyRichSelection",
     },
   },
   {

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -653,6 +653,8 @@ pub struct InteractiveText {
     text: StyledText,
     click_listener:
         Option<Box<dyn Fn(&[Range<usize>], InteractiveTextClickEvent, &mut Window, &mut App)>>,
+    mouse_down_listener: Option<Box<dyn Fn(usize, MouseDownEvent, &mut Window, &mut App)>>,
+    mouse_up_listener: Option<Box<dyn Fn(usize, MouseUpEvent, &mut Window, &mut App)>>,
     hover_listener: Option<Box<dyn Fn(Option<usize>, MouseMoveEvent, &mut Window, &mut App)>>,
     tooltip_builder: Option<Rc<dyn Fn(usize, &mut Window, &mut App) -> Option<AnyView>>>,
     tooltip_id: Option<TooltipId>,
@@ -680,6 +682,8 @@ impl InteractiveText {
             element_id: id.into(),
             text,
             click_listener: None,
+            mouse_down_listener: None,
+            mouse_up_listener: None,
             hover_listener: None,
             tooltip_builder: None,
             tooltip_id: None,
@@ -703,6 +707,26 @@ impl InteractiveText {
             }
         }));
         self.clickable_ranges = ranges;
+        self
+    }
+
+    /// on_mouse_down is called when the user presses the mouse over a character in the text,
+    /// passing the hovered character index.
+    pub fn on_mouse_down(
+        mut self,
+        listener: impl Fn(usize, MouseDownEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.mouse_down_listener = Some(Box::new(listener));
+        self
+    }
+
+    /// on_mouse_up is called when the user releases the mouse over a character in the text,
+    /// passing the hovered character index.
+    pub fn on_mouse_up(
+        mut self,
+        listener: impl Fn(usize, MouseUpEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.mouse_up_listener = Some(Box::new(listener));
         self
     }
 
@@ -848,6 +872,32 @@ impl Element for InteractiveText {
                             }
                         });
                     }
+                }
+
+                if let Some(mouse_down_listener) = self.mouse_down_listener.take() {
+                    let hitbox = hitbox.clone();
+                    let text_layout = text_layout.clone();
+                    window.on_mouse_event(move |event: &MouseDownEvent, phase, window, cx| {
+                        if phase == DispatchPhase::Bubble
+                            && hitbox.is_hovered(window)
+                            && let Ok(index) = text_layout.index_for_position(event.position)
+                        {
+                            mouse_down_listener(index, event.clone(), window, cx);
+                        }
+                    });
+                }
+
+                if let Some(mouse_up_listener) = self.mouse_up_listener.take() {
+                    let hitbox = hitbox.clone();
+                    let text_layout = text_layout.clone();
+                    window.on_mouse_event(move |event: &MouseUpEvent, phase, window, cx| {
+                        if phase == DispatchPhase::Bubble
+                            && hitbox.is_hovered(window)
+                            && let Ok(index) = text_layout.index_for_position(event.position)
+                        {
+                            mouse_up_listener(index, event.clone(), window, cx);
+                        }
+                    });
                 }
 
                 window.on_mouse_event({

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1623,6 +1623,39 @@ pub struct ClipboardItem {
     pub entries: Vec<ClipboardEntry>,
 }
 
+/// Rich text with multiple format support for clipboard operations
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RichText {
+    /// Plain text fallback (required)
+    pub plain_text: String,
+    /// HTML formatted content (optional)
+    pub html: Option<String>,
+    /// RTF formatted content (optional)
+    pub rtf: Option<String>,
+}
+
+impl RichText {
+    /// Create new rich text with plain content
+    pub fn new(plain_text: impl Into<String>) -> Self {
+        Self {
+            plain_text: plain_text.into(),
+            html: None,
+            rtf: None,
+        }
+    }
+
+    /// Add HTML format
+    pub fn with_html(mut self, html: impl Into<String>) -> Self {
+        self.html = Some(html.into());
+        self
+    }
+
+    /// Check if has any rich format
+    pub fn is_rich(&self) -> bool {
+        self.html.is_some() || self.rtf.is_some()
+    }
+}
+
 /// Either a ClipboardString or a ClipboardImage
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ClipboardEntry {
@@ -1632,6 +1665,8 @@ pub enum ClipboardEntry {
     Image(Image),
     /// A file entry
     ExternalPaths(crate::ExternalPaths),
+    /// Rich text with HTML/RTF support
+    RichText(RichText),
 }
 
 impl ClipboardItem {
@@ -1657,6 +1692,15 @@ impl ClipboardItem {
         Self {
             entries: vec![ClipboardEntry::String(
                 ClipboardString::new(text).with_json_metadata(metadata),
+            )],
+        }
+    }
+
+    /// Create a rich text clipboard item with HTML
+    pub fn new_rich_text(plain_text: impl Into<String>, html: impl Into<String>) -> Self {
+        Self {
+            entries: vec![ClipboardEntry::RichText(
+                RichText::new(plain_text).with_html(html),
             )],
         }
     }

--- a/crates/gpui_macos/src/pasteboard.rs
+++ b/crates/gpui_macos/src/pasteboard.rs
@@ -10,7 +10,7 @@ use objc::{msg_send, runtime::Object, sel, sel_impl};
 use strum::IntoEnumIterator as _;
 
 use crate::ns_string;
-use gpui::{ClipboardEntry, ClipboardItem, ClipboardString, Image, ImageFormat, hash};
+use gpui::{ClipboardEntry, ClipboardItem, ClipboardString, Image, ImageFormat, RichText, hash};
 
 pub struct Pasteboard {
     inner: id,
@@ -138,6 +138,9 @@ impl Pasteboard {
                     // Writing an empty list of entries just clears the clipboard.
                     self.inner.clearContents();
                 }
+                [ClipboardEntry::RichText(rich_text)] => {
+                    self.write_rich_text(rich_text);
+                }
                 [ClipboardEntry::String(string)] => {
                     self.write_plaintext(string);
                 }
@@ -204,6 +207,30 @@ impl Pasteboard {
                 );
                 self.inner
                     .setData_forType(metadata_bytes, self.metadata_type);
+            }
+        }
+    }
+
+    fn write_rich_text(&self, rich_text: &RichText) {
+        unsafe {
+            self.inner.clearContents();
+
+            let text_bytes = NSData::dataWithBytes_length_(
+                nil,
+                rich_text.plain_text.as_ptr() as *const c_void,
+                rich_text.plain_text.len() as u64,
+            );
+            self.inner
+                .setData_forType(text_bytes, NSPasteboardTypeString);
+
+            if let Some(html) = rich_text.html.as_ref() {
+                let html_type = ns_string("public.html");
+                let html_bytes = NSData::dataWithBytes_length_(
+                    nil,
+                    html.as_ptr() as *const c_void,
+                    html.len() as u64,
+                );
+                self.inner.setData_forType(html_bytes, html_type);
             }
         }
     }

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -6,6 +6,7 @@ mod markdown_minifier;
 pub mod markdown_parser;
 pub mod markdown_preview_view;
 pub mod markdown_renderer;
+pub mod markdown_to_html;
 
 pub use zed_actions::preview::markdown::{OpenPreview, OpenPreviewToTheSide};
 
@@ -27,7 +28,9 @@ actions!(
         /// Scrolls down by one markdown element in the markdown preview
         ScrollDownByItem,
         /// Opens a following markdown preview that syncs with the editor.
-        OpenFollowingPreview
+        OpenFollowingPreview,
+        /// Copy selection with rich HTML formatting.
+        CopyRichSelection
     ]
 );
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -6,11 +6,14 @@ use std::{ops::Range, path::PathBuf};
 use anyhow::Result;
 use editor::scroll::Autoscroll;
 use editor::{Editor, EditorEvent, MultiBufferOffset, SelectionEffects};
+use fs::normalize_path;
 use gpui::{
     App, ClickEvent, Context, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, IsZero, ListState, ParentElement, Render, RetainAllImageCache, Styled,
-    Subscription, Task, WeakEntity, Window, list,
+    IntoElement, IsZero, ListState, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    ParentElement, Render, RetainAllImageCache, Styled, Subscription, Task, WeakEntity, Window,
+    list,
 };
+use language::CharClassifier;
 use language::LanguageRegistry;
 use settings::Settings;
 use theme::ThemeSettings;
@@ -42,6 +45,8 @@ pub struct MarkdownPreviewView {
     mermaid_state: MermaidState,
     parsing_markdown_task: Option<Task<Result<()>>>,
     mode: MarkdownPreviewMode,
+    preview_text_index: Option<PreviewTextIndex>,
+    preview_selection: Option<PreviewSelection>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -55,6 +60,43 @@ pub enum MarkdownPreviewMode {
 struct EditorState {
     editor: Entity<Editor>,
     _subscription: Subscription,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PreviewTextIndex {
+    text: String,
+    block_ranges: Vec<Range<usize>>,
+    chunk_ranges: Vec<Range<usize>>,
+}
+
+#[derive(Clone, Debug)]
+struct PreviewSelection {
+    start: usize,
+    end: usize,
+    reversed: bool,
+    dragging: bool,
+    dragged: bool,
+    mode: PreviewSelectMode,
+}
+
+#[derive(Clone, Debug)]
+enum PreviewSelectMode {
+    Character,
+    Word(Range<usize>),
+    Chunk(Range<usize>),
+}
+
+impl Default for PreviewSelection {
+    fn default() -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            reversed: false,
+            dragging: false,
+            dragged: false,
+            mode: PreviewSelectMode::Character,
+        }
+    }
 }
 
 impl MarkdownPreviewView {
@@ -126,6 +168,26 @@ impl MarkdownPreviewView {
                 cx.notify();
             }
         });
+
+        workspace.register_action(move |workspace, _: &crate::CopyRichSelection, window, cx| {
+            if let Some(view) = workspace.active_item_as::<MarkdownPreviewView>(cx) {
+                view.update(cx, |this, cx| {
+                    this.copy_rich(window, cx);
+                });
+            }
+        });
+    }
+
+    fn copy_rich(&self, _window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(contents) = &self.contents
+            && let Some(selection) = self.current_selection_range()
+            && let Some(exported) = crate::markdown_to_html::export_selection(contents, selection)
+        {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_rich_text(
+                exported.plain_text,
+                exported.html,
+            ));
+        }
     }
 
     fn find_existing_independent_preview_item_idx(
@@ -219,6 +281,8 @@ impl MarkdownPreviewView {
                 parsing_markdown_task: None,
                 image_cache: RetainAllImageCache::new(cx),
                 mode,
+                preview_text_index: None,
+                preview_selection: None,
             };
 
             this.set_editor(active_editor, window, cx);
@@ -355,6 +419,8 @@ impl MarkdownPreviewView {
             view.update(cx, move |view, cx| {
                 view.mermaid_state.update(&contents, cx);
                 let markdown_blocks_count = contents.children.len();
+                view.preview_text_index = Some(PreviewTextIndex::from_markdown(&contents));
+                view.preview_selection = None;
                 view.contents = Some(contents);
                 let scroll_top = view.list_state.logical_scroll_top();
                 view.list_state.reset(markdown_blocks_count);
@@ -510,6 +576,292 @@ impl MarkdownPreviewView {
         }
         cx.notify();
     }
+
+    fn current_selection_range(&self) -> Option<Range<usize>> {
+        self.preview_selection.as_ref().and_then(|selection| {
+            (selection.end > selection.start).then_some(selection.start..selection.end)
+        })
+    }
+
+    fn should_follow_text_clicks(&self) -> bool {
+        self.preview_selection
+            .as_ref()
+            .is_none_or(|selection| !selection.dragged)
+    }
+
+    fn begin_text_selection(
+        &mut self,
+        index: usize,
+        chunk_range: Range<usize>,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.focus_handle(cx).focus(window, cx);
+
+        let mut selection = PreviewSelection {
+            start: index,
+            end: index,
+            reversed: false,
+            dragging: event.button == MouseButton::Left,
+            dragged: false,
+            mode: PreviewSelectMode::Character,
+        };
+
+        match event.click_count {
+            2 => {
+                if let Some(text_index) = &self.preview_text_index {
+                    let word = surrounding_word_range(&text_index.text, index);
+                    selection.start = word.start;
+                    selection.end = word.end;
+                    selection.mode = PreviewSelectMode::Word(word);
+                }
+            }
+            3.. => {
+                selection.start = chunk_range.start;
+                selection.end = chunk_range.end;
+                selection.mode = PreviewSelectMode::Chunk(chunk_range);
+            }
+            _ => {}
+        }
+
+        self.preview_selection = Some(selection);
+        cx.notify();
+    }
+
+    fn hover_text_selection(
+        &mut self,
+        index: Option<usize>,
+        _event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(index) = index else {
+            return;
+        };
+        let Some(selection) = self.preview_selection.as_mut() else {
+            return;
+        };
+        if !selection.dragging {
+            return;
+        }
+
+        let previous = selection.start..selection.end;
+        selection.dragged |= selection.start != index && selection.end != index;
+        selection.set_head(index, self.preview_text_index.as_ref());
+        if previous != (selection.start..selection.end) {
+            cx.notify();
+        }
+    }
+
+    fn finish_text_selection(
+        &mut self,
+        _event: &MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(selection) = self.preview_selection.as_mut()
+            && selection.dragging
+        {
+            selection.dragging = false;
+            cx.notify();
+        }
+    }
+}
+
+impl PreviewSelection {
+    fn tail(&self) -> usize {
+        if self.reversed { self.end } else { self.start }
+    }
+
+    fn set_head(&mut self, head: usize, index: Option<&PreviewTextIndex>) {
+        match &self.mode {
+            PreviewSelectMode::Character => {
+                if head < self.tail() {
+                    if !self.reversed {
+                        self.end = self.start;
+                        self.reversed = true;
+                    }
+                    self.start = head;
+                } else {
+                    if self.reversed {
+                        self.start = self.end;
+                        self.reversed = false;
+                    }
+                    self.end = head;
+                }
+            }
+            PreviewSelectMode::Word(original_range) => {
+                let Some(index) = index else {
+                    return;
+                };
+                let head_range = surrounding_word_range(&index.text, head);
+                if head < original_range.start {
+                    self.start = head_range.start;
+                    self.end = original_range.end;
+                    self.reversed = true;
+                } else if head >= original_range.end {
+                    self.start = original_range.start;
+                    self.end = head_range.end;
+                    self.reversed = false;
+                } else {
+                    self.start = original_range.start;
+                    self.end = original_range.end;
+                    self.reversed = false;
+                }
+            }
+            PreviewSelectMode::Chunk(original_range) => {
+                let Some(index) = index else {
+                    return;
+                };
+                let head_range = index.chunk_range_containing(head).unwrap_or(head..head);
+                if head < original_range.start {
+                    self.start = head_range.start;
+                    self.end = original_range.end;
+                    self.reversed = true;
+                } else if head >= original_range.end {
+                    self.start = original_range.start;
+                    self.end = head_range.end;
+                    self.reversed = false;
+                } else {
+                    self.start = original_range.start;
+                    self.end = original_range.end;
+                    self.reversed = false;
+                }
+            }
+        }
+    }
+}
+
+impl PreviewTextIndex {
+    fn from_markdown(markdown: &ParsedMarkdown) -> Self {
+        let mut this = Self::default();
+        let mut cursor = 0;
+
+        for block in &markdown.children {
+            let start = cursor;
+            collect_selectable_text(block, &mut cursor, &mut this.text, &mut this.chunk_ranges);
+            this.block_ranges.push(start..cursor);
+        }
+
+        this
+    }
+
+    fn chunk_range_containing(&self, index: usize) -> Option<Range<usize>> {
+        self.chunk_ranges
+            .iter()
+            .find(|range| {
+                range.contains(&index)
+                    || (index == range.end
+                        && self
+                            .chunk_ranges
+                            .last()
+                            .is_some_and(|last_range| last_range == *range))
+            })
+            .cloned()
+    }
+}
+
+fn collect_selectable_text(
+    block: &ParsedMarkdownElement,
+    cursor: &mut usize,
+    text: &mut String,
+    chunk_ranges: &mut Vec<Range<usize>>,
+) {
+    use crate::markdown_elements::{MarkdownParagraphChunk, ParsedMarkdownElement};
+
+    let mut push_chunk = |contents: &str| {
+        if contents.is_empty() {
+            return;
+        }
+        let range = *cursor..*cursor + contents.len();
+        *cursor = range.end;
+        text.push_str(contents);
+        chunk_ranges.push(range);
+    };
+
+    match block {
+        ParsedMarkdownElement::Paragraph(chunks) => {
+            for chunk in chunks {
+                if let MarkdownParagraphChunk::Text(parsed) = chunk {
+                    push_chunk(parsed.contents.as_ref());
+                }
+            }
+        }
+        ParsedMarkdownElement::Heading(heading) => {
+            for chunk in &heading.contents {
+                if let MarkdownParagraphChunk::Text(parsed) = chunk {
+                    push_chunk(parsed.contents.as_ref());
+                }
+            }
+        }
+        ParsedMarkdownElement::ListItem(item) => {
+            for block in &item.content {
+                collect_selectable_text(block, cursor, text, chunk_ranges);
+            }
+        }
+        ParsedMarkdownElement::Table(table) => {
+            if let Some(caption) = &table.caption {
+                for chunk in caption {
+                    if let MarkdownParagraphChunk::Text(parsed) = chunk {
+                        push_chunk(parsed.contents.as_ref());
+                    }
+                }
+            }
+            for row in table.header.iter().chain(table.body.iter()) {
+                for column in &row.columns {
+                    for chunk in &column.children {
+                        if let MarkdownParagraphChunk::Text(parsed) = chunk {
+                            push_chunk(parsed.contents.as_ref());
+                        }
+                    }
+                }
+            }
+        }
+        ParsedMarkdownElement::BlockQuote(block_quote) => {
+            for block in &block_quote.children {
+                collect_selectable_text(block, cursor, text, chunk_ranges);
+            }
+        }
+        ParsedMarkdownElement::CodeBlock(code_block) => push_chunk(code_block.contents.as_ref()),
+        ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => {}
+    }
+}
+
+fn surrounding_word_range(text: &str, index: usize) -> Range<usize> {
+    if text.is_empty() {
+        return 0..0;
+    }
+
+    let index = index.min(text.len().saturating_sub(1));
+    let classifier = CharClassifier::new(None);
+
+    let mut prev_chars = text[..index].chars().rev().peekable();
+    let mut next_chars = text[index..].chars().peekable();
+    let word_kind = std::cmp::max(
+        prev_chars.peek().map(|&ch| classifier.kind(ch)),
+        next_chars.peek().map(|&ch| classifier.kind(ch)),
+    );
+
+    let mut start = index;
+    for ch in prev_chars {
+        if Some(classifier.kind(ch)) == word_kind {
+            start -= ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    let mut end = index;
+    for ch in next_chars {
+        if Some(classifier.kind(ch)) == word_kind {
+            end += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    start..end
 }
 
 impl Focusable for MarkdownPreviewView {
@@ -561,6 +913,7 @@ impl Render for MarkdownPreviewView {
             .on_action(cx.listener(MarkdownPreviewView::scroll_down))
             .on_action(cx.listener(MarkdownPreviewView::scroll_up_by_item))
             .on_action(cx.listener(MarkdownPreviewView::scroll_down_by_item))
+            .capture_any_mouse_up(cx.listener(MarkdownPreviewView::finish_text_selection))
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()
@@ -575,11 +928,80 @@ impl Render for MarkdownPreviewView {
                                 return div().into_any();
                             };
 
+                            let weak_view = cx.weak_entity();
                             let mut render_cx = RenderContext::new(
                                 Some(this.workspace.clone()),
                                 &this.mermaid_state,
                                 window,
                                 cx,
+                            )
+                            .with_text_selection(
+                                this.current_selection_range(),
+                                this.preview_text_index
+                                    .as_ref()
+                                    .and_then(|index| index.block_ranges.get(ix))
+                                    .map(|range: &Range<usize>| range.start)
+                                    .unwrap_or_default(),
+                                {
+                                    let weak_view = weak_view.clone();
+                                    move |index, chunk_range: Range<usize>, event: &MouseDownEvent, window, cx| {
+                                        weak_view
+                                            .update(cx, |this, cx| {
+                                                this.begin_text_selection(index, chunk_range, event, window, cx);
+                                            })
+                                            .ok();
+                                    }
+                                },
+                                {
+                                    let weak_view = weak_view.clone();
+                                    move |index: Option<usize>, event: &MouseMoveEvent, window, cx| {
+                                        weak_view
+                                            .update(cx, |this, cx| {
+                                                this.hover_text_selection(index, event, window, cx);
+                                            })
+                                            .ok();
+                                    }
+                                },
+                                {
+                                    let weak_view = weak_view.clone();
+                                    move |_index, _chunk_range: Range<usize>, event: &MouseUpEvent, window, cx| {
+                                        weak_view
+                                            .update(cx, |this, cx| {
+                                                this.finish_text_selection(event, window, cx);
+                                            })
+                                            .ok();
+                                    }
+                                },
+                                move |link: &crate::markdown_elements::Link, window, cx| {
+                                    weak_view
+                                        .update(cx, |this, cx| {
+                                            if !this.should_follow_text_clicks() {
+                                                return;
+                                            }
+
+                                            match link {
+                                                crate::markdown_elements::Link::Web { url } => cx.open_url(url),
+                                                crate::markdown_elements::Link::Path { path, .. } => {
+                                                    if let Some(workspace) = this.workspace.upgrade() {
+                                                        _ = workspace.update(cx, |workspace, cx| {
+                                                            workspace
+                                                                .open_abs_path(
+                                                                    normalize_path(path.as_path()),
+                                                                    workspace::OpenOptions {
+                                                                        visible: Some(workspace::OpenVisible::None),
+                                                                        ..Default::default()
+                                                                    },
+                                                                    window,
+                                                                    cx,
+                                                                )
+                                                                .detach();
+                                                        });
+                                                    }
+                                                }
+                                            }
+                                        })
+                                        .ok();
+                                },
                             )
                             .with_checkbox_clicked_callback(cx.listener(
                                 move |this, e: &CheckboxClickedEvent, window, cx| {
@@ -624,6 +1046,7 @@ impl Render for MarkdownPreviewView {
                                 .on_click(cx.listener(
                                     move |this, event: &ClickEvent, window, cx| {
                                         if event.click_count() == 2
+                                            && this.current_selection_range().is_none()
                                             && let Some(source_range) = this
                                                 .contents
                                                 .as_ref()

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -824,7 +824,9 @@ fn collect_selectable_text(
             }
         }
         ParsedMarkdownElement::CodeBlock(code_block) => push_chunk(code_block.contents.as_ref()),
-        ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => {}
+        ParsedMarkdownElement::HorizontalRule(_)
+        | ParsedMarkdownElement::Image(_)
+        | ParsedMarkdownElement::MermaidDiagram(_) => {}
     }
 }
 

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -13,8 +13,9 @@ use fs::normalize_path;
 use gpui::{
     AbsoluteLength, Animation, AnimationExt, AnyElement, App, AppContext as _, Context, Div,
     Element, ElementId, Entity, HighlightStyle, Hsla, ImageSource, InteractiveText, IntoElement,
-    Keystroke, Modifiers, ParentElement, Render, RenderImage, Resource, SharedString, Styled,
-    StyledText, Task, TextStyle, WeakEntity, Window, div, img, pulsating_between, rems,
+    Keystroke, Modifiers, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Render,
+    RenderImage, Resource, SharedString, Styled, StyledText, Task, TextStyle, WeakEntity, Window,
+    div, img, pulsating_between, rems,
 };
 use settings::Settings;
 use std::{
@@ -43,6 +44,13 @@ impl CheckboxClickedEvent {
 }
 
 type CheckboxClickedCallback = Arc<Box<dyn Fn(&CheckboxClickedEvent, &mut Window, &mut App)>>;
+type TextMouseDownCallback =
+    Arc<Box<dyn Fn(usize, Range<usize>, &MouseDownEvent, &mut Window, &mut App)>>;
+type TextMouseHoverCallback =
+    Arc<Box<dyn Fn(Option<usize>, &MouseMoveEvent, &mut Window, &mut App)>>;
+type TextMouseUpCallback =
+    Arc<Box<dyn Fn(usize, Range<usize>, &MouseUpEvent, &mut Window, &mut App)>>;
+type LinkClickCallback = Arc<Box<dyn Fn(&Link, &mut Window, &mut App)>>;
 
 type MermaidDiagramCache = HashMap<ParsedMarkdownMermaidDiagramContents, CachedMermaidDiagram>;
 
@@ -189,6 +197,13 @@ pub struct RenderContext<'a> {
     syntax_theme: Arc<SyntaxTheme>,
     indent: usize,
     checkbox_clicked_callback: Option<CheckboxClickedCallback>,
+    text_mouse_down_callback: Option<TextMouseDownCallback>,
+    text_mouse_hover_callback: Option<TextMouseHoverCallback>,
+    text_mouse_up_callback: Option<TextMouseUpCallback>,
+    link_click_callback: Option<LinkClickCallback>,
+    selection_range: Option<Range<usize>>,
+    next_text_offset: usize,
+    selection_background_color: Hsla,
     is_last_child: bool,
     mermaid_state: &'a MermaidState,
 }
@@ -228,6 +243,13 @@ impl<'a> RenderContext<'a> {
             code_block_background_color: theme.colors().surface_background,
             code_span_background_color: theme.colors().editor_document_highlight_read_background,
             checkbox_clicked_callback: None,
+            text_mouse_down_callback: None,
+            text_mouse_hover_callback: None,
+            text_mouse_up_callback: None,
+            link_click_callback: None,
+            selection_range: None,
+            next_text_offset: 0,
+            selection_background_color: theme.colors().element_selection_background,
             is_last_child: false,
             mermaid_state,
         }
@@ -238,6 +260,24 @@ impl<'a> RenderContext<'a> {
         callback: impl Fn(&CheckboxClickedEvent, &mut Window, &mut App) + 'static,
     ) -> Self {
         self.checkbox_clicked_callback = Some(Arc::new(Box::new(callback)));
+        self
+    }
+
+    pub fn with_text_selection(
+        mut self,
+        selection_range: Option<Range<usize>>,
+        next_text_offset: usize,
+        on_mouse_down: impl Fn(usize, Range<usize>, &MouseDownEvent, &mut Window, &mut App) + 'static,
+        on_mouse_hover: impl Fn(Option<usize>, &MouseMoveEvent, &mut Window, &mut App) + 'static,
+        on_mouse_up: impl Fn(usize, Range<usize>, &MouseUpEvent, &mut Window, &mut App) + 'static,
+        on_link_click: impl Fn(&Link, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.selection_range = selection_range;
+        self.next_text_offset = next_text_offset;
+        self.text_mouse_down_callback = Some(Arc::new(Box::new(on_mouse_down)));
+        self.text_mouse_hover_callback = Some(Arc::new(Box::new(on_mouse_hover)));
+        self.text_mouse_up_callback = Some(Arc::new(Box::new(on_mouse_up)));
+        self.link_click_callback = Some(Arc::new(Box::new(on_link_click)));
         self
     }
 
@@ -255,6 +295,35 @@ impl<'a> RenderContext<'a> {
             .font_size
             .to_rems(self.window_rem_size)
             .mul(rems)
+    }
+
+    fn next_text_range(&mut self, len: usize) -> Range<usize> {
+        let range = self.next_text_offset..self.next_text_offset + len;
+        self.next_text_offset += len;
+        range
+    }
+
+    fn selection_highlights(
+        &self,
+        text_range: &Range<usize>,
+    ) -> Vec<(Range<usize>, HighlightStyle)> {
+        let Some(selection) = self.selection_range.as_ref() else {
+            return Vec::new();
+        };
+
+        let start = selection.start.max(text_range.start);
+        let end = selection.end.min(text_range.end);
+        if start >= end {
+            return Vec::new();
+        }
+
+        vec![(
+            (start - text_range.start)..(end - text_range.start),
+            HighlightStyle {
+                background_color: Some(self.selection_background_color),
+                ..Default::default()
+            },
+        )]
     }
 
     /// This ensures that children inside of block quotes
@@ -747,18 +816,59 @@ fn render_markdown_code_block(
     parsed: &ParsedMarkdownCodeBlock,
     cx: &mut RenderContext,
 ) -> AnyElement {
-    let body = if let Some(highlights) = parsed.highlights.as_ref() {
-        StyledText::new(parsed.contents.clone()).with_default_highlights(
-            &cx.buffer_text_style,
+    let text_range = cx.next_text_range(parsed.contents.len());
+    let selection_highlights = cx.selection_highlights(&text_range);
+    let syntax_highlights = parsed
+        .highlights
+        .as_ref()
+        .map(|highlights| {
             highlights.iter().filter_map(|(range, highlight_id)| {
                 highlight_id
                     .style(cx.syntax_theme.as_ref())
                     .map(|style| (range.clone(), style))
-            }),
-        )
-    } else {
-        StyledText::new(parsed.contents.clone())
-    };
+            })
+        })
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+
+    let body = InteractiveText::new(
+        cx.next_id(&parsed.source_range),
+        StyledText::new(parsed.contents.clone()).with_default_highlights(
+            &cx.buffer_text_style,
+            gpui::combine_highlights(syntax_highlights, selection_highlights),
+        ),
+    )
+    .when_some(cx.text_mouse_down_callback.clone(), |this, callback| {
+        let text_range = text_range.clone();
+        this.on_mouse_down(move |index, event, window, cx| {
+            callback(
+                text_range.start + index,
+                text_range.clone(),
+                &event,
+                window,
+                cx,
+            );
+        })
+    })
+    .when_some(cx.text_mouse_hover_callback.clone(), |this, callback| {
+        let start = text_range.start;
+        this.on_hover(move |index, event, window, cx| {
+            callback(index.map(|index| start + index), &event, window, cx);
+        })
+    })
+    .when_some(cx.text_mouse_up_callback.clone(), |this, callback| {
+        let text_range = text_range.clone();
+        this.on_mouse_up(move |index, event, window, cx| {
+            callback(
+                text_range.start + index,
+                text_range.clone(),
+                &event,
+                window,
+                cx,
+            );
+        })
+    });
 
     let copy_block_button = CopyButton::new("copy-codeblock", parsed.contents.clone())
         .tooltip_label("Copy Codeblock")
@@ -887,11 +997,15 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
     let code_span_bg_color = cx.code_span_background_color;
     let text_style = cx.text_style.clone();
     let link_color = cx.link_color;
+    let link_click_callback = cx.link_click_callback.clone();
 
     for parsed_region in parsed_new {
         match parsed_region {
             MarkdownParagraphChunk::Text(parsed) => {
+                let link_click_callback = link_click_callback.clone();
                 let element_id = cx.next_id(&parsed.source_range);
+                let text_range = cx.next_text_range(parsed.contents.len());
+                let selection_highlights = cx.selection_highlights(&text_range);
 
                 let highlights = gpui::combine_highlights(
                     parsed.highlights.iter().filter_map(|(range, highlight)| {
@@ -920,7 +1034,9 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                             None
                         }
                     }),
-                );
+                )
+                .collect::<Vec<_>>();
+                let highlights = gpui::combine_highlights(highlights, selection_highlights);
                 let mut links = Vec::new();
                 let mut link_ranges = Vec::new();
                 for (range, region) in parsed.regions.iter() {
@@ -937,6 +1053,36 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                             StyledText::new(parsed.contents.clone())
                                 .with_default_highlights(&text_style, highlights),
                         )
+                        .when_some(cx.text_mouse_down_callback.clone(), |this, callback| {
+                            let text_range = text_range.clone();
+                            this.on_mouse_down(move |index, event, window, cx| {
+                                callback(
+                                    text_range.start + index,
+                                    text_range.clone(),
+                                    &event,
+                                    window,
+                                    cx,
+                                );
+                            })
+                        })
+                        .when_some(cx.text_mouse_hover_callback.clone(), |this, callback| {
+                            let start = text_range.start;
+                            this.on_hover(move |index, event, window, cx| {
+                                callback(index.map(|index| start + index), &event, window, cx);
+                            })
+                        })
+                        .when_some(cx.text_mouse_up_callback.clone(), |this, callback| {
+                            let text_range = text_range.clone();
+                            this.on_mouse_up(move |index, event, window, cx| {
+                                callback(
+                                    text_range.start + index,
+                                    text_range.clone(),
+                                    &event,
+                                    window,
+                                    cx,
+                                );
+                            })
+                        })
                         .tooltip({
                             let links = links.clone();
                             let link_ranges = link_ranges.clone();
@@ -951,23 +1097,29 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                         })
                         .on_click(
                             link_ranges,
-                            move |clicked_range_ix, window, cx| match &links[clicked_range_ix] {
-                                Link::Web { url } => cx.open_url(url),
-                                Link::Path { path, .. } => {
-                                    if let Some(workspace) = &workspace {
-                                        _ = workspace.update(cx, |workspace, cx| {
-                                            workspace
-                                                .open_abs_path(
-                                                    normalize_path(path.clone().as_path()),
-                                                    OpenOptions {
-                                                        visible: Some(OpenVisible::None),
-                                                        ..Default::default()
-                                                    },
-                                                    window,
-                                                    cx,
-                                                )
-                                                .detach();
-                                        });
+                            move |clicked_range_ix, window, cx| {
+                                if let Some(callback) = &link_click_callback {
+                                    callback(&links[clicked_range_ix], window, cx);
+                                } else {
+                                    match &links[clicked_range_ix] {
+                                        Link::Web { url } => cx.open_url(url),
+                                        Link::Path { path, .. } => {
+                                            if let Some(workspace) = &workspace {
+                                                _ = workspace.update(cx, |workspace, cx| {
+                                                    workspace
+                                                        .open_abs_path(
+                                                            normalize_path(path.clone().as_path()),
+                                                            OpenOptions {
+                                                                visible: Some(OpenVisible::None),
+                                                                ..Default::default()
+                                                            },
+                                                            window,
+                                                            cx,
+                                                        )
+                                                        .detach();
+                                                });
+                                            }
+                                        }
                                     }
                                 }
                             },

--- a/crates/markdown_preview/src/markdown_to_html.rs
+++ b/crates/markdown_preview/src/markdown_to_html.rs
@@ -418,7 +418,9 @@ fn append_selectable_text(
             ParsedMarkdownElement::CodeBlock(code_block) => {
                 out.push_str(code_block.contents.as_ref())
             }
-            ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => {}
+            ParsedMarkdownElement::HorizontalRule(_)
+            | ParsedMarkdownElement::Image(_)
+            | ParsedMarkdownElement::MermaidDiagram(_) => {}
         }
     }
 }
@@ -476,7 +478,9 @@ fn selectable_block_len(block: &crate::markdown_elements::ParsedMarkdownElement)
             block_quote.children.iter().map(selectable_block_len).sum()
         }
         ParsedMarkdownElement::CodeBlock(code_block) => code_block.contents.len(),
-        ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => 0,
+        ParsedMarkdownElement::HorizontalRule(_)
+        | ParsedMarkdownElement::Image(_)
+        | ParsedMarkdownElement::MermaidDiagram(_) => 0,
     }
 }
 
@@ -605,7 +609,9 @@ fn export_block(
             html.push_str("</code></pre>");
             Some(BlockSelection { plain_text, html })
         }
-        ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => None,
+        ParsedMarkdownElement::HorizontalRule(_)
+        | ParsedMarkdownElement::Image(_)
+        | ParsedMarkdownElement::MermaidDiagram(_) => None,
     }
 }
 

--- a/crates/markdown_preview/src/markdown_to_html.rs
+++ b/crates/markdown_preview/src/markdown_to_html.rs
@@ -1,0 +1,1015 @@
+// /tmp/zed-workers/markdown_to_html.rs
+//
+// HTML generator for a parsed markdown document, intended for clipboard operations.
+//
+// Notes:
+// - This file is intentionally self-contained for easy vendoring.
+// - If your codebase already defines `ParsedMarkdown`, `Block`, `Inline`, etc.,
+//   delete the AST here and wire `MarkdownHtmlRenderer` to your existing types.
+#![allow(dead_code)]
+
+use std::fmt::Write;
+use std::ops::Range;
+
+/// A parsed markdown document.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ParsedMarkdown {
+    pub blocks: Vec<Block>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Block {
+    Paragraph(Vec<Inline>),
+    Heading {
+        level: u8,
+        content: Vec<Inline>,
+    },
+
+    /// A list is rendered as `<ol>` when ordered, otherwise `<ul>`.
+    List {
+        ordered: bool,
+        start: Option<u64>,
+        items: Vec<ListItem>,
+    },
+
+    CodeBlock {
+        language: Option<String>,
+        code: String,
+    },
+    BlockQuote(Vec<Block>),
+    Table {
+        header: Vec<Vec<Inline>>,
+        align: Vec<TableAlign>,
+        rows: Vec<Vec<Vec<Inline>>>,
+    },
+    Image {
+        alt: String,
+        url: String,
+        title: Option<String>,
+    },
+    HorizontalRule,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListItem {
+    /// `None` => normal bullet/ordered item. `Some(true/false)` => task item.
+    pub task: Option<bool>,
+    pub blocks: Vec<Block>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableAlign {
+    Default,
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Inline {
+    Text(String),
+    Code(String),
+    Emph(Vec<Inline>),
+    Strong(Vec<Inline>),
+    Link {
+        text: Vec<Inline>,
+        url: String,
+        title: Option<String>,
+    },
+    SoftBreak,
+    HardBreak,
+}
+
+pub struct MarkdownHtmlRenderer {
+    /// Wrap output in a `.markdown-body` container and include inline CSS.
+    pub include_css: bool,
+}
+
+impl Default for MarkdownHtmlRenderer {
+    fn default() -> Self {
+        Self { include_css: true }
+    }
+}
+
+impl MarkdownHtmlRenderer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Render a complete HTML document for clipboard consumption.
+    pub fn render(&self, doc: &ParsedMarkdown) -> String {
+        let mut out = String::new();
+
+        out.push_str("<!doctype html><html><head><meta charset=\"utf-8\">");
+        if self.include_css {
+            out.push_str("<style>");
+            out.push_str(GITHUBISH_CSS);
+            out.push_str("</style>");
+        }
+        out.push_str("</head><body>");
+        out.push_str("<article class=\"markdown-body\">");
+
+        for block in &doc.blocks {
+            self.render_block(&mut out, block);
+        }
+
+        out.push_str("</article></body></html>");
+        out
+    }
+
+    pub fn render_block(&self, out: &mut String, block: &Block) {
+        match block {
+            Block::Paragraph(inlines) => {
+                out.push_str("<p>");
+                self.render_inlines(out, inlines);
+                out.push_str("</p>");
+            }
+            Block::Heading { level, content } => {
+                let lvl = (*level).clamp(1, 6);
+                let _ = write!(out, "<h{lvl}>");
+                self.render_inlines(out, content);
+                let _ = write!(out, "</h{lvl}>");
+            }
+            Block::List {
+                ordered,
+                start,
+                items,
+            } => {
+                if *ordered {
+                    if let Some(s) = start {
+                        let _ = write!(out, "<ol start=\"{}\">", escape_attr(&s.to_string()));
+                    } else {
+                        out.push_str("<ol>");
+                    }
+                } else {
+                    out.push_str("<ul>");
+                }
+
+                for item in items {
+                    self.render_list_item(out, item);
+                }
+
+                if *ordered {
+                    out.push_str("</ol>");
+                } else {
+                    out.push_str("</ul>");
+                }
+            }
+            Block::CodeBlock { language, code } => {
+                out.push_str("<pre><code");
+                if let Some(lang) = language.as_ref().filter(|s| !s.trim().is_empty()) {
+                    let _ = write!(out, " class=\"language-{}\"", escape_attr(lang.trim()));
+                }
+                out.push_str(">");
+                out.push_str(&escape_html(code));
+                out.push_str("</code></pre>");
+            }
+            Block::BlockQuote(children) => {
+                out.push_str("<blockquote>");
+                for b in children {
+                    self.render_block(out, b);
+                }
+                out.push_str("</blockquote>");
+            }
+            Block::Table {
+                header,
+                align,
+                rows,
+            } => {
+                out.push_str("<table><thead><tr>");
+                for (i, cell) in header.iter().enumerate() {
+                    out.push_str("<th");
+                    if let Some(a) = align.get(i).copied() {
+                        if let Some(css) = table_align_css(a) {
+                            let _ = write!(out, " style=\"text-align:{}\"", css);
+                        }
+                    }
+                    out.push_str(">");
+                    self.render_inlines(out, cell);
+                    out.push_str("</th>");
+                }
+                out.push_str("</tr></thead><tbody>");
+
+                for row in rows {
+                    out.push_str("<tr>");
+                    for (i, cell) in row.iter().enumerate() {
+                        out.push_str("<td");
+                        if let Some(a) = align.get(i).copied() {
+                            if let Some(css) = table_align_css(a) {
+                                let _ = write!(out, " style=\"text-align:{}\"", css);
+                            }
+                        }
+                        out.push_str(">");
+                        self.render_inlines(out, cell);
+                        out.push_str("</td>");
+                    }
+                    out.push_str("</tr>");
+                }
+
+                out.push_str("</tbody></table>");
+            }
+            Block::Image { alt, url, title } => {
+                out.push_str("<p><img");
+                let _ = write!(out, " alt=\"{}\"", escape_attr(alt));
+                let _ = write!(out, " src=\"{}\"", escape_attr(url));
+                if let Some(t) = title.as_ref().filter(|s| !s.is_empty()) {
+                    let _ = write!(out, " title=\"{}\"", escape_attr(t));
+                }
+                out.push_str("></p>");
+            }
+            Block::HorizontalRule => out.push_str("<hr>"),
+        }
+    }
+
+    fn render_list_item(&self, out: &mut String, item: &ListItem) {
+        out.push_str("<li>");
+
+        if let Some(checked) = item.task {
+            // Matches GitHub’s task list markup well enough for clipboard use.
+            out.push_str("<input type=\"checkbox\" disabled");
+            if checked {
+                out.push_str(" checked");
+            }
+            out.push_str("> ");
+        }
+
+        // If the item is a single paragraph, keep it compact; otherwise render blocks.
+        match item.blocks.as_slice() {
+            [Block::Paragraph(inlines)] => self.render_inlines(out, inlines),
+            _ => {
+                for b in &item.blocks {
+                    self.render_block(out, b);
+                }
+            }
+        }
+
+        out.push_str("</li>");
+    }
+
+    fn render_inlines(&self, out: &mut String, inlines: &[Inline]) {
+        for inline in inlines {
+            match inline {
+                Inline::Text(s) => out.push_str(&escape_html(s)),
+                Inline::Code(s) => {
+                    out.push_str("<code>");
+                    out.push_str(&escape_html(s));
+                    out.push_str("</code>");
+                }
+                Inline::Emph(children) => {
+                    out.push_str("<em>");
+                    self.render_inlines(out, children);
+                    out.push_str("</em>");
+                }
+                Inline::Strong(children) => {
+                    out.push_str("<strong>");
+                    self.render_inlines(out, children);
+                    out.push_str("</strong>");
+                }
+                Inline::Link { text, url, title } => {
+                    out.push_str("<a");
+                    let _ = write!(out, " href=\"{}\"", escape_attr(url));
+                    if let Some(t) = title.as_ref().filter(|s| !s.is_empty()) {
+                        let _ = write!(out, " title=\"{}\"", escape_attr(t));
+                    }
+                    out.push_str(">");
+                    self.render_inlines(out, text);
+                    out.push_str("</a>");
+                }
+                Inline::SoftBreak => out.push('\n'),
+                Inline::HardBreak => out.push_str("<br>"),
+            }
+        }
+    }
+}
+
+fn table_align_css(a: TableAlign) -> Option<&'static str> {
+    match a {
+        TableAlign::Default => None,
+        TableAlign::Left => Some("left"),
+        TableAlign::Center => Some("center"),
+        TableAlign::Right => Some("right"),
+    }
+}
+
+pub fn escape_html(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+pub fn escape_attr(input: &str) -> String {
+    // Attribute escaping is identical for our use-case; kept separate for clarity.
+    escape_html(input)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectionExport {
+    pub plain_text: String,
+    pub html: String,
+}
+
+pub fn selectable_text_len(doc: &crate::markdown_elements::ParsedMarkdown) -> usize {
+    doc.children.iter().map(selectable_block_len).sum()
+}
+
+pub fn selectable_text(doc: &crate::markdown_elements::ParsedMarkdown) -> String {
+    let mut text = String::with_capacity(selectable_text_len(doc));
+    append_selectable_text(&doc.children, &mut text);
+    text
+}
+
+pub fn export_selection(
+    doc: &crate::markdown_elements::ParsedMarkdown,
+    selection: Range<usize>,
+) -> Option<SelectionExport> {
+    let selection = clamp_selection(selection, selectable_text_len(doc))?;
+    let mut exporter = SelectionExporter::new(selection);
+    let blocks = export_blocks(&doc.children, &mut exporter);
+    if blocks.plain_text.is_empty() || blocks.html.is_empty() {
+        return None;
+    }
+
+    Some(SelectionExport {
+        plain_text: blocks.plain_text,
+        html: wrap_html_document(&blocks.html),
+    })
+}
+
+fn clamp_selection(selection: Range<usize>, max_len: usize) -> Option<Range<usize>> {
+    let start = selection.start.min(max_len);
+    let end = selection.end.min(max_len);
+    (start < end).then_some(start..end)
+}
+
+fn wrap_html_document(body: &str) -> String {
+    let mut out = String::new();
+    out.push_str("<!doctype html><html><head><meta charset=\"utf-8\">");
+    out.push_str("<style>");
+    out.push_str(GITHUBISH_CSS);
+    out.push_str("</style>");
+    out.push_str("</head><body><article class=\"markdown-body\">");
+    out.push_str(body);
+    out.push_str("</article></body></html>");
+    out
+}
+
+fn append_selectable_text(
+    blocks: &[crate::markdown_elements::ParsedMarkdownElement],
+    out: &mut String,
+) {
+    use crate::markdown_elements::{MarkdownParagraphChunk, ParsedMarkdownElement};
+
+    for block in blocks {
+        match block {
+            ParsedMarkdownElement::Paragraph(chunks) => {
+                for chunk in chunks {
+                    if let MarkdownParagraphChunk::Text(text) = chunk {
+                        out.push_str(text.contents.as_ref());
+                    }
+                }
+            }
+            ParsedMarkdownElement::Heading(heading) => {
+                for chunk in &heading.contents {
+                    if let MarkdownParagraphChunk::Text(text) = chunk {
+                        out.push_str(text.contents.as_ref());
+                    }
+                }
+            }
+            ParsedMarkdownElement::ListItem(item) => append_selectable_text(&item.content, out),
+            ParsedMarkdownElement::Table(table) => {
+                if let Some(caption) = &table.caption {
+                    for chunk in caption {
+                        if let MarkdownParagraphChunk::Text(text) = chunk {
+                            out.push_str(text.contents.as_ref());
+                        }
+                    }
+                }
+                for row in &table.header {
+                    for column in &row.columns {
+                        for chunk in &column.children {
+                            if let MarkdownParagraphChunk::Text(text) = chunk {
+                                out.push_str(text.contents.as_ref());
+                            }
+                        }
+                    }
+                }
+                for row in &table.body {
+                    for column in &row.columns {
+                        for chunk in &column.children {
+                            if let MarkdownParagraphChunk::Text(text) = chunk {
+                                out.push_str(text.contents.as_ref());
+                            }
+                        }
+                    }
+                }
+            }
+            ParsedMarkdownElement::BlockQuote(block_quote) => {
+                append_selectable_text(&block_quote.children, out)
+            }
+            ParsedMarkdownElement::CodeBlock(code_block) => {
+                out.push_str(code_block.contents.as_ref())
+            }
+            ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => {}
+        }
+    }
+}
+
+fn selectable_block_len(block: &crate::markdown_elements::ParsedMarkdownElement) -> usize {
+    use crate::markdown_elements::{MarkdownParagraphChunk, ParsedMarkdownElement};
+
+    match block {
+        ParsedMarkdownElement::Paragraph(chunks) => chunks
+            .iter()
+            .map(|chunk| match chunk {
+                MarkdownParagraphChunk::Text(text) => text.contents.len(),
+                MarkdownParagraphChunk::Image(_) => 0,
+            })
+            .sum(),
+        ParsedMarkdownElement::Heading(heading) => heading
+            .contents
+            .iter()
+            .map(|chunk| match chunk {
+                MarkdownParagraphChunk::Text(text) => text.contents.len(),
+                MarkdownParagraphChunk::Image(_) => 0,
+            })
+            .sum(),
+        ParsedMarkdownElement::ListItem(item) => {
+            item.content.iter().map(selectable_block_len).sum()
+        }
+        ParsedMarkdownElement::Table(table) => {
+            let caption_len = table
+                .caption
+                .as_ref()
+                .map(|caption| {
+                    caption
+                        .iter()
+                        .map(|chunk| match chunk {
+                            MarkdownParagraphChunk::Text(text) => text.contents.len(),
+                            MarkdownParagraphChunk::Image(_) => 0,
+                        })
+                        .sum::<usize>()
+                })
+                .unwrap_or_default();
+            let rows_len = table
+                .header
+                .iter()
+                .chain(table.body.iter())
+                .flat_map(|row| row.columns.iter())
+                .flat_map(|column| column.children.iter())
+                .map(|chunk| match chunk {
+                    MarkdownParagraphChunk::Text(text) => text.contents.len(),
+                    MarkdownParagraphChunk::Image(_) => 0,
+                })
+                .sum::<usize>();
+            caption_len + rows_len
+        }
+        ParsedMarkdownElement::BlockQuote(block_quote) => {
+            block_quote.children.iter().map(selectable_block_len).sum()
+        }
+        ParsedMarkdownElement::CodeBlock(code_block) => code_block.contents.len(),
+        ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => 0,
+    }
+}
+
+#[derive(Debug, Default)]
+struct SelectionExporter {
+    selection: Range<usize>,
+    cursor: usize,
+}
+
+#[derive(Debug)]
+struct BlockSelection {
+    plain_text: String,
+    html: String,
+}
+
+impl SelectionExporter {
+    fn new(selection: Range<usize>) -> Self {
+        Self {
+            selection,
+            cursor: 0,
+        }
+    }
+
+    fn selected_range(&mut self, len: usize) -> Option<Range<usize>> {
+        let start = self.cursor;
+        let end = start + len;
+        if self.selection.end <= start || self.selection.start >= end {
+            self.cursor = end;
+            return None;
+        }
+
+        let overlap = self.selection.start.max(start)..self.selection.end.min(end);
+        self.cursor = end;
+        Some((overlap.start - start)..(overlap.end - start))
+    }
+}
+
+fn export_blocks(
+    blocks: &[crate::markdown_elements::ParsedMarkdownElement],
+    exporter: &mut SelectionExporter,
+) -> BlockSelection {
+    let mut plain_text = String::new();
+    let mut html = String::new();
+    let mut first = true;
+
+    for block in blocks {
+        let Some(selection) = export_block(block, exporter) else {
+            continue;
+        };
+
+        if !first {
+            plain_text.push('\n');
+        }
+        plain_text.push_str(&selection.plain_text);
+        html.push_str(&selection.html);
+        first = false;
+    }
+
+    BlockSelection { plain_text, html }
+}
+
+fn export_block(
+    block: &crate::markdown_elements::ParsedMarkdownElement,
+    exporter: &mut SelectionExporter,
+) -> Option<BlockSelection> {
+    use crate::markdown_elements::ParsedMarkdownElement;
+
+    match block {
+        ParsedMarkdownElement::Paragraph(chunks) => {
+            let inline = export_paragraph(chunks, exporter)?;
+            Some(BlockSelection {
+                plain_text: inline.plain_text,
+                html: format!("<p>{}</p>", inline.html),
+            })
+        }
+        ParsedMarkdownElement::Heading(heading) => {
+            let inline = export_paragraph(&heading.contents, exporter)?;
+            let level = match heading.level {
+                crate::markdown_elements::HeadingLevel::H1 => 1,
+                crate::markdown_elements::HeadingLevel::H2 => 2,
+                crate::markdown_elements::HeadingLevel::H3 => 3,
+                crate::markdown_elements::HeadingLevel::H4 => 4,
+                crate::markdown_elements::HeadingLevel::H5 => 5,
+                crate::markdown_elements::HeadingLevel::H6 => 6,
+            };
+            Some(BlockSelection {
+                plain_text: inline.plain_text,
+                html: format!("<h{level}>{}</h{level}>", inline.html),
+            })
+        }
+        ParsedMarkdownElement::ListItem(item) => {
+            let selection = export_blocks(&item.content, exporter);
+            if selection.html.is_empty() {
+                return None;
+            }
+            Some(BlockSelection {
+                plain_text: selection.plain_text,
+                html: format!("<li>{}</li>", selection.html),
+            })
+        }
+        ParsedMarkdownElement::Table(table) => export_table(table, exporter),
+        ParsedMarkdownElement::BlockQuote(block_quote) => {
+            let selection = export_blocks(&block_quote.children, exporter);
+            if selection.html.is_empty() {
+                return None;
+            }
+            Some(BlockSelection {
+                plain_text: selection.plain_text,
+                html: format!("<blockquote>{}</blockquote>", selection.html),
+            })
+        }
+        ParsedMarkdownElement::CodeBlock(code_block) => {
+            let selected = exporter.selected_range(code_block.contents.len())?;
+            let plain_text = code_block.contents[selected.clone()].to_string();
+            let mut html = String::new();
+            html.push_str("<pre><code");
+            if let Some(language) = code_block
+                .language
+                .as_ref()
+                .filter(|language| !language.is_empty())
+            {
+                let _ = write!(html, " class=\"language-{}\"", escape_attr(language));
+            }
+            html.push('>');
+            html.push_str(&escape_html(&plain_text));
+            html.push_str("</code></pre>");
+            Some(BlockSelection { plain_text, html })
+        }
+        ParsedMarkdownElement::HorizontalRule(_) | ParsedMarkdownElement::Image(_) => None,
+    }
+}
+
+fn export_table(
+    table: &crate::markdown_elements::ParsedMarkdownTable,
+    exporter: &mut SelectionExporter,
+) -> Option<BlockSelection> {
+    let caption = table
+        .caption
+        .as_ref()
+        .and_then(|caption| export_paragraph(caption, exporter));
+
+    let header_rows = table
+        .header
+        .iter()
+        .filter_map(|row| export_table_row(row, exporter))
+        .collect::<Vec<_>>();
+    let body_rows = table
+        .body
+        .iter()
+        .filter_map(|row| export_table_row(row, exporter))
+        .collect::<Vec<_>>();
+
+    if caption.is_none() && header_rows.is_empty() && body_rows.is_empty() {
+        return None;
+    }
+
+    let mut plain_parts = Vec::new();
+    let mut html = String::new();
+
+    if let Some(caption) = caption {
+        plain_parts.push(caption.plain_text);
+        html.push_str("<p>");
+        html.push_str(&caption.html);
+        html.push_str("</p>");
+    }
+
+    html.push_str("<table>");
+    if !header_rows.is_empty() {
+        html.push_str("<thead>");
+        for row in &header_rows {
+            plain_parts.push(row.plain_text.clone());
+            html.push_str(&row.html);
+        }
+        html.push_str("</thead>");
+    }
+    if !body_rows.is_empty() {
+        html.push_str("<tbody>");
+        for row in &body_rows {
+            plain_parts.push(row.plain_text.clone());
+            html.push_str(&row.html);
+        }
+        html.push_str("</tbody>");
+    }
+    html.push_str("</table>");
+
+    Some(BlockSelection {
+        plain_text: plain_parts.join("\n"),
+        html,
+    })
+}
+
+fn export_table_row(
+    row: &crate::markdown_elements::ParsedMarkdownTableRow,
+    exporter: &mut SelectionExporter,
+) -> Option<BlockSelection> {
+    let mut plain_cells = Vec::new();
+    let mut html = String::new();
+    let mut has_selected_cell = false;
+
+    html.push_str("<tr>");
+    for column in &row.columns {
+        let exported = export_paragraph(&column.children, exporter);
+        if exported.is_some() {
+            has_selected_cell = true;
+        }
+
+        let tag = if column.is_header { "th" } else { "td" };
+        html.push('<');
+        html.push_str(tag);
+        if let Some(alignment) = table_alignment_css(column.alignment) {
+            let _ = write!(html, " style=\"text-align:{}\"", alignment);
+        }
+        html.push('>');
+        if let Some(exported) = exported {
+            plain_cells.push(exported.plain_text);
+            html.push_str(&exported.html);
+        }
+        html.push_str("</");
+        html.push_str(tag);
+        html.push('>');
+    }
+    html.push_str("</tr>");
+
+    has_selected_cell.then_some(BlockSelection {
+        plain_text: plain_cells.join("\t"),
+        html,
+    })
+}
+
+fn export_paragraph(
+    chunks: &[crate::markdown_elements::MarkdownParagraphChunk],
+    exporter: &mut SelectionExporter,
+) -> Option<BlockSelection> {
+    use crate::markdown_elements::MarkdownParagraphChunk;
+
+    let mut plain_text = String::new();
+    let mut html = String::new();
+
+    for chunk in chunks {
+        match chunk {
+            MarkdownParagraphChunk::Text(text) => {
+                let Some(selected) = exporter.selected_range(text.contents.len()) else {
+                    continue;
+                };
+                plain_text.push_str(&text.contents[selected.clone()]);
+                html.push_str(&render_selected_text(text, selected));
+            }
+            MarkdownParagraphChunk::Image(_) => {}
+        }
+    }
+
+    (!plain_text.is_empty()).then_some(BlockSelection { plain_text, html })
+}
+
+fn render_selected_text(
+    text: &crate::markdown_elements::ParsedMarkdownText,
+    selection: Range<usize>,
+) -> String {
+    let mut boundaries = vec![selection.start, selection.end];
+
+    for (range, _) in &text.highlights {
+        if let Some(overlap) = intersect(&selection, range) {
+            boundaries.push(overlap.start);
+            boundaries.push(overlap.end);
+        }
+    }
+
+    for (range, _) in &text.regions {
+        if let Some(overlap) = intersect(&selection, range) {
+            boundaries.push(overlap.start);
+            boundaries.push(overlap.end);
+        }
+    }
+
+    boundaries.sort_unstable();
+    boundaries.dedup();
+
+    let mut html = String::new();
+    for window in boundaries.windows(2) {
+        let range = window[0]..window[1];
+        if range.is_empty() {
+            continue;
+        }
+
+        let style = segment_style(text, &range);
+        let mut segment = escape_html(&text.contents[range.clone()]);
+
+        if style.code {
+            segment = format!("<code>{}</code>", segment);
+        }
+        if style.strikethrough {
+            segment = format!("<del>{}</del>", segment);
+        }
+        if style.underline {
+            segment = format!("<ins>{}</ins>", segment);
+        }
+        if style.italic {
+            segment = format!("<em>{}</em>", segment);
+        }
+        if style.bold {
+            segment = format!("<strong>{}</strong>", segment);
+        }
+        if let Some(href) = style.link_href {
+            segment = format!("<a href=\"{}\">{}</a>", escape_attr(&href), segment);
+        }
+
+        html.push_str(&segment);
+    }
+
+    html
+}
+
+#[derive(Default)]
+struct SegmentStyle {
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    strikethrough: bool,
+    code: bool,
+    link_href: Option<String>,
+}
+
+fn segment_style(
+    text: &crate::markdown_elements::ParsedMarkdownText,
+    range: &Range<usize>,
+) -> SegmentStyle {
+    let mut style = SegmentStyle::default();
+
+    for (highlight_range, highlight) in &text.highlights {
+        if !highlight_range.contains(&range.start) {
+            continue;
+        }
+
+        match highlight {
+            crate::markdown_elements::MarkdownHighlight::Style(markdown_style) => {
+                style.bold |= markdown_style.weight != gpui::FontWeight::default();
+                style.italic |= markdown_style.italic || markdown_style.oblique;
+                style.underline |= markdown_style.underline;
+                style.strikethrough |= markdown_style.strikethrough;
+            }
+            crate::markdown_elements::MarkdownHighlight::Code(_) => {
+                style.code = true;
+            }
+        }
+    }
+
+    for (region_range, region) in &text.regions {
+        if !region_range.contains(&range.start) {
+            continue;
+        }
+
+        style.code |= region.code;
+        if style.link_href.is_none() {
+            style.link_href = region.link.as_ref().map(link_href);
+        }
+    }
+
+    style
+}
+
+fn link_href(link: &crate::markdown_elements::Link) -> String {
+    match link {
+        crate::markdown_elements::Link::Web { url } => url.clone(),
+        crate::markdown_elements::Link::Path { display_path, .. } => {
+            display_path.to_string_lossy().to_string()
+        }
+    }
+}
+
+fn intersect(left: &Range<usize>, right: &Range<usize>) -> Option<Range<usize>> {
+    let start = left.start.max(right.start);
+    let end = left.end.min(right.end);
+    (start < end).then_some(start..end)
+}
+
+fn table_alignment_css(
+    alignment: crate::markdown_elements::ParsedMarkdownTableAlignment,
+) -> Option<&'static str> {
+    match alignment {
+        crate::markdown_elements::ParsedMarkdownTableAlignment::None => None,
+        crate::markdown_elements::ParsedMarkdownTableAlignment::Left => Some("left"),
+        crate::markdown_elements::ParsedMarkdownTableAlignment::Center => Some("center"),
+        crate::markdown_elements::ParsedMarkdownTableAlignment::Right => Some("right"),
+    }
+}
+
+// Minimal GitHub-flavored markdown look, designed for paste targets.
+// Not a verbatim copy of GitHub’s stylesheet.
+const GITHUBISH_CSS: &str = r#"
+  :root {
+    --fg: #1f2328;
+    --muted: #59636e;
+    --border: #d0d7de;
+    --bg: #ffffff;
+    --code-bg: #f6f8fa;
+    --link: #0969da;
+  }
+  body { margin: 0; background: var(--bg); color: var(--fg); }
+  .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    padding: 16px;
+    word-wrap: break-word;
+  }
+  .markdown-body p { margin: 0 0 16px; }
+  .markdown-body h1, .markdown-body h2, .markdown-body h3,
+  .markdown-body h4, .markdown-body h5, .markdown-body h6 {
+    margin: 24px 0 16px;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+  .markdown-body h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid var(--border); }
+  .markdown-body h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid var(--border); }
+  .markdown-body h3 { font-size: 1.25em; }
+  .markdown-body h4 { font-size: 1em; }
+  .markdown-body h5 { font-size: 0.875em; }
+  .markdown-body h6 { font-size: 0.85em; color: var(--muted); }
+  .markdown-body a { color: var(--link); text-decoration: none; }
+  .markdown-body a:hover { text-decoration: underline; }
+  .markdown-body ul, .markdown-body ol { margin: 0 0 16px; padding-left: 2em; }
+  .markdown-body li { margin: 0.25em 0; }
+  .markdown-body code {
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.95em;
+    background: var(--code-bg);
+    padding: 0.15em 0.35em;
+    border-radius: 6px;
+  }
+  .markdown-body pre {
+    margin: 0 0 16px;
+    padding: 16px;
+    overflow: auto;
+    background: var(--code-bg);
+    border-radius: 6px;
+  }
+  .markdown-body pre code { background: transparent; padding: 0; }
+  .markdown-body blockquote {
+    margin: 0 0 16px;
+    padding: 0 1em;
+    color: var(--muted);
+    border-left: 0.25em solid var(--border);
+  }
+  .markdown-body hr {
+    height: 0.25em;
+    padding: 0;
+    margin: 24px 0;
+    background-color: var(--border);
+    border: 0;
+  }
+  .markdown-body table {
+    border-spacing: 0;
+    border-collapse: collapse;
+    margin: 0 0 16px;
+    width: 100%;
+  }
+  .markdown-body th, .markdown-body td {
+    border: 1px solid var(--border);
+    padding: 6px 13px;
+  }
+  .markdown-body th { font-weight: 600; background: #f6f8fa; }
+  .markdown-body img { max-width: 100%; }
+"#;
+
+// Conversion from markdown_elements types to markdown_to_html types
+impl From<&crate::markdown_elements::ParsedMarkdown> for ParsedMarkdown {
+    fn from(doc: &crate::markdown_elements::ParsedMarkdown) -> Self {
+        Self {
+            blocks: doc.children.iter().map(|child| child.into()).collect(),
+        }
+    }
+}
+
+impl From<&crate::markdown_elements::ParsedMarkdownElement> for Block {
+    fn from(elem: &crate::markdown_elements::ParsedMarkdownElement) -> Self {
+        use crate::markdown_elements::ParsedMarkdownElement;
+        match elem {
+            ParsedMarkdownElement::Paragraph(chunks) => {
+                let inlines: Vec<Inline> = chunks.iter().map(|c| c.into()).collect();
+                Block::Paragraph(inlines)
+            }
+            _ => Block::Paragraph(vec![]),
+        }
+    }
+}
+
+impl From<&crate::markdown_elements::MarkdownParagraphChunk> for Inline {
+    fn from(chunk: &crate::markdown_elements::MarkdownParagraphChunk) -> Self {
+        use crate::markdown_elements::MarkdownParagraphChunk;
+        match chunk {
+            MarkdownParagraphChunk::Text(text) => Inline::Text(text.contents.to_string()),
+            MarkdownParagraphChunk::Image(image) => {
+                let url = match &image.link {
+                    crate::markdown_elements::Link::Web { url } => url.clone(),
+                    crate::markdown_elements::Link::Path { display_path, .. } => {
+                        display_path.to_string_lossy().to_string()
+                    }
+                };
+                Inline::Text(format!("[Image: {}]", url))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::markdown_parser::parse_markdown;
+
+    async fn parse(input: &str) -> crate::markdown_elements::ParsedMarkdown {
+        parse_markdown(input, None, None).await
+    }
+
+    #[gpui::test]
+    async fn exports_partial_bold_selection_as_rich_html() {
+        let parsed = parse("Hello **world**").await;
+
+        let selection = export_selection(&parsed, 6..11).expect("selection export");
+
+        assert_eq!(selection.plain_text, "world");
+        assert!(selection.html.contains("<strong>world</strong>"));
+        assert!(!selection.html.contains("Hello "));
+    }
+
+    #[gpui::test]
+    async fn exports_selection_across_inline_styles() {
+        let parsed = parse("Hello **world** and `code`").await;
+
+        let selection = export_selection(&parsed, 6..20).expect("selection export");
+
+        assert_eq!(selection.plain_text, "world and code");
+        assert!(selection.html.contains("<strong>world</strong>"));
+        assert!(selection.html.contains("<code>code</code>"));
+        assert!(!selection.html.contains("Hello "));
+    }
+}


### PR DESCRIPTION
## Summary
- add text selection to Markdown Preview, including drag selection plus double-click word and triple-click chunk selection
- copy selected preview content as rendered text, and write rich HTML to the clipboard on macOS so paste behavior matches rendered preview output more closely
- preserve existing preview behavior such as editor sync, link activation semantics, and checkbox interactions

## Why
Markdown Preview currently cannot be selected or copied like a normal rendered document. This makes the preview much less useful than editors such as VS Code for workflows where users want to copy rendered content instead of markdown source.

## Test Plan
- ran `cargo fmt --all --check`
- ran `cargo test -p markdown_preview --features gpui/macos-blade`
- manually verified drag selection in Markdown Preview
- manually verified double-click word selection
- manually verified triple-click chunk selection
- manually verified copied text pastes as rendered text
- manually verified preview links still open when there is no selection drag
- manually verified dragging across linked text does not open the link
- manually verified editor-to-preview sync still works

Fixes #16727
