### PR TITLE
languages: Exclude angle brackets from rainbow bracket colorization for TSX

### DIFF
--- a/crates/languages/src/tsx/brackets.scm
+++ b/crates/languages/src/tsx/brackets.scm
@@ -7,14 +7,17 @@
 ("{" @open
   "}" @close)
 
-("<" @open
+(("<" @open
   ">" @close)
+  (#set! rainbow.exclude))
 
-("<" @open
+(("<" @open
   "/>" @close)
+  (#set! rainbow.exclude))
 
-("</" @open
+(("</" @open
   ">" @close)
+  (#set! rainbow.exclude))
 
 (("\"" @open
   "\"" @close)


### PR DESCRIPTION
## Summary

Angle brackets in TSX (`<`, `>`, `/>`, `</`) are always paired with JSX tag syntax — they don't indicate bracket nesting depth — so rainbow colorization adds noise without useful information.

This mirrors #46808, which applied the same fix to the HTML extension.

## Changes

- Added `(#set! rainbow.exclude)` to all three angle bracket patterns in `crates/languages/src/tsx/brackets.scm`

## Before / After

Before: angle brackets in JSX tags receive rainbow colors alongside `{}`, `()`, `[]`, making every tag visually noisy.

After: only `{}`, `()`, and `[]` receive rainbow colors — angle brackets are excluded, matching the HTML extension behavior.

> Screenshots: I don't have a built copy of Zed handy to attach — happy to add one if a maintainer needs it before merging.

Release Notes:

- Removed rainbow bracket colorization for angled brackets within TSX.