### PR TITLE
agent_ui: Add archive view to the sidebar

### DIFF
--- a/assets/icons/archive.svg
+++ b/assets/icons/archive.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.4 2.60001H2.6C2.26863 2.60001 2 2.86864 2 3.20001V5.00001C2 5.33138 2.26863 5.60001 2.6 5.60001H13.4C13.7314 5.60001 14 5.33138 14 5.00001V3.20001C14 2.86864 13.7314 2.60001 13.4 2.60001Z" stroke="#C6CAD0" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.2 5.60004V12.2C3.2 12.5183 3.32643 12.8235 3.55147 13.0486C3.77651 13.2736 4.08174 13.4 4.4 13.4H11.6C11.9183 13.4 12.2235 13.2736 12.4485 13.0486C12.6736 12.8235 12.8 12.5183 12.8 12.2V5.60004" stroke="#C6CAD0" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.8 8H9.2" stroke="#C6CAD0" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1232,12 +1232,6 @@ impl AgentPanel {
 
         cx.defer_in(window, move |this, window, cx| {
             this.sidebar = find_or_create_sidebar_for_window(window, cx);
-            if let Some(sidebar) = &this.sidebar {
-                let history = this.acp_history.clone();
-                sidebar.update(cx, |sidebar, cx| {
-                    sidebar.set_history(history, cx);
-                });
-            }
             cx.notify();
         });
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1244,6 +1244,12 @@ impl AgentPanel {
 
         cx.defer_in(window, move |this, window, cx| {
             this.sidebar = find_or_create_sidebar_for_window(window, cx);
+            if let Some(sidebar) = &this.sidebar {
+                let history = this.acp_history.clone();
+                sidebar.update(cx, |sidebar, cx| {
+                    sidebar.set_history(history, cx);
+                });
+            }
             cx.notify();
         });
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -34,6 +34,7 @@ mod text_thread_editor;
 mod text_thread_history;
 mod thread_history;
 mod thread_history_view;
+mod threads_archive_view;
 mod ui;
 
 use std::rc::Rc;

--- a/crates/agent_ui/src/sidebar.rs
+++ b/crates/agent_ui/src/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::threads_archive_view::{ThreadsArchiveView, ThreadsArchiveViewEvent};
 use crate::{AgentPanel, AgentPanelEvent, NewThread};
-use acp_thread::{ThreadStatus};
+use acp_thread::ThreadStatus;
 use action_log::DiffStats;
 use agent::ThreadStore;
 use agent_client_protocol as acp;

--- a/crates/agent_ui/src/sidebar.rs
+++ b/crates/agent_ui/src/sidebar.rs
@@ -1,11 +1,11 @@
-use crate::thread_history::ThreadHistory;
+use crate::threads_archive_view::{ThreadsArchiveView, ThreadsArchiveViewEvent};
 use crate::{AgentPanel, AgentPanelEvent, NewThread};
 use acp_thread::{AgentSessionInfo, ThreadStatus};
 use action_log::DiffStats;
 use agent::ThreadStore;
 use agent_client_protocol as acp;
 use agent_settings::AgentSettings;
-use chrono::{Datelike as _, Local, NaiveDate, TimeDelta, Utc};
+use chrono::Utc;
 use db::kvp::KEY_VALUE_STORE;
 use editor::Editor;
 use feature_flags::{AgentV2FeatureFlag, FeatureFlagViewExt as _};
@@ -51,54 +51,6 @@ enum SidebarView {
     #[default]
     ThreadList,
     Archive,
-}
-
-#[derive(Clone)]
-enum ArchiveListItem {
-    BucketSeparator(TimeBucket),
-    Entry {
-        session: AgentSessionInfo,
-        highlight_positions: Vec<usize>,
-    },
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TimeBucket {
-    Today,
-    Yesterday,
-    ThisWeek,
-    PastWeek,
-    Older,
-}
-
-impl TimeBucket {
-    fn from_dates(reference: NaiveDate, date: NaiveDate) -> Self {
-        if date == reference {
-            return TimeBucket::Today;
-        }
-        if date == reference - TimeDelta::days(1) {
-            return TimeBucket::Yesterday;
-        }
-        let week = date.iso_week();
-        if reference.iso_week() == week {
-            return TimeBucket::ThisWeek;
-        }
-        let last_week = (reference - TimeDelta::days(7)).iso_week();
-        if week == last_week {
-            return TimeBucket::PastWeek;
-        }
-        TimeBucket::Older
-    }
-
-    fn label(&self) -> &'static str {
-        match self {
-            TimeBucket::Today => "Today",
-            TimeBucket::Yesterday => "Yesterday",
-            TimeBucket::ThisWeek => "This Week",
-            TimeBucket::PastWeek => "Past Week",
-            TimeBucket::Older => "Older",
-        }
-    }
 }
 
 fn read_sidebar_open_state(multi_workspace_id: u64) -> bool {
@@ -268,12 +220,8 @@ pub struct Sidebar {
     collapsed_groups: HashSet<PathList>,
     expanded_groups: HashMap<PathList, usize>,
     view: SidebarView,
-    history: Option<Entity<ThreadHistory>>,
-    archive_list_state: ListState,
-    archive_items: Vec<ArchiveListItem>,
-    archive_selection: Option<usize>,
-    archive_filter_editor: Entity<Editor>,
-    _history_subscription: Option<gpui::Subscription>,
+    archive_view: Option<Entity<ThreadsArchiveView>>,
+    _subscriptions: Vec<gpui::Subscription>,
 }
 
 impl Sidebar {
@@ -291,19 +239,6 @@ impl Sidebar {
             editor.set_placeholder_text("Search…", window, cx);
             editor
         });
-
-        let archive_filter_editor = cx.new(|cx| {
-            let mut editor = Editor::single_line(window, cx);
-            editor.set_placeholder_text("Search threads archive…", window, cx);
-            editor
-        });
-
-        cx.subscribe(&archive_filter_editor, |this: &mut Self, _, event, cx| {
-            if let editor::EditorEvent::BufferEdited = event {
-                this.update_archive_items(cx);
-            }
-        })
-        .detach();
 
         cx.subscribe_in(
             &multi_workspace,
@@ -387,12 +322,8 @@ impl Sidebar {
             collapsed_groups: HashSet::new(),
             expanded_groups: HashMap::new(),
             view: SidebarView::default(),
-            history: None,
-            archive_list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
-            archive_items: Vec::new(),
-            archive_selection: None,
-            archive_filter_editor,
-            _history_subscription: None,
+            archive_view: None,
+            _subscriptions: Vec::new(),
         }
     }
 
@@ -1409,16 +1340,6 @@ impl Sidebar {
         self.filter_editor.clone()
     }
 
-    fn render_archive_filter_input(&self) -> impl IntoElement {
-        self.archive_filter_editor.clone()
-    }
-
-    fn reset_archive_filter_editor_text(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.archive_filter_editor.update(cx, |editor, cx| {
-            editor.set_text("", window, cx);
-        });
-    }
-
     fn render_view_more(
         &self,
         ix: usize,
@@ -1572,138 +1493,10 @@ impl Sidebar {
                     .icon_color(Color::Muted)
                     .icon_size(IconSize::Small)
                     .icon_position(IconPosition::Start)
-                    .on_click(cx.listener(|this, _, _window, cx| {
-                        this.show_archive(cx);
-                    })),
-            )
-    }
-
-    fn render_archive_header(
-        &self,
-        docked_right: bool,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let has_query = !self.archive_filter_editor.read(cx).text(cx).is_empty();
-
-        h_flex()
-            .h(Tab::container_height(cx))
-            .px_1()
-            .gap_1p5()
-            .border_b_1()
-            .border_color(cx.theme().colors().border)
-            .child(
-                IconButton::new("back", IconName::ArrowLeft)
-                    .icon_size(IconSize::Small)
-                    .tooltip(Tooltip::text("Back to Sidebar"))
                     .on_click(cx.listener(|this, _, window, cx| {
-                        this.show_thread_list(window, cx);
+                        this.show_archive(window, cx);
                     })),
             )
-            .child(self.render_archive_filter_input())
-            .when(has_query, |this| {
-                this.when(!docked_right, |this| this.pr_1p5()).child(
-                    IconButton::new("clear_archive_filter", IconName::Close)
-                        .shape(IconButtonShape::Square)
-                        .tooltip(Tooltip::text("Clear Search"))
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            this.reset_archive_filter_editor_text(window, cx);
-                            this.update_archive_items(cx);
-                        })),
-                )
-            })
-    }
-
-    fn render_archive_list_entry(
-        &mut self,
-        ix: usize,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let Some(item) = self.archive_items.get(ix) else {
-            return div().into_any_element();
-        };
-
-        match item {
-            ArchiveListItem::BucketSeparator(bucket) => div()
-                .w_full()
-                .px_2()
-                .pt_3()
-                .pb_1()
-                .child(
-                    Label::new(bucket.label())
-                        .size(LabelSize::Small)
-                        .color(Color::Muted),
-                )
-                .into_any_element(),
-            ArchiveListItem::Entry {
-                session,
-                highlight_positions,
-            } => {
-                let is_selected = self.archive_selection == Some(ix);
-                let title: SharedString =
-                    session.title.clone().unwrap_or_else(|| "Untitled".into());
-                let session_info = session.clone();
-                let highlight_positions = highlight_positions.clone();
-
-                let timestamp = session.created_at.or(session.updated_at).map(|entry_time| {
-                    let now = Utc::now();
-                    let duration = now.signed_duration_since(entry_time);
-
-                    let minutes = duration.num_minutes();
-                    let hours = duration.num_hours();
-                    let days = duration.num_days();
-                    let weeks = days / 7;
-                    let months = days / 30;
-
-                    if minutes < 60 {
-                        format!("{}m", minutes.max(1))
-                    } else if hours < 24 {
-                        format!("{}h", hours)
-                    } else if weeks < 4 {
-                        format!("{}w", weeks.max(1))
-                    } else {
-                        format!("{}mo", months.max(1))
-                    }
-                });
-
-                let id = SharedString::from(format!("archive-entry-{}", ix));
-
-                let title_label = if highlight_positions.is_empty() {
-                    Label::new(title)
-                        .size(LabelSize::Small)
-                        .truncate()
-                        .into_any_element()
-                } else {
-                    HighlightedLabel::new(title, highlight_positions)
-                        .size(LabelSize::Small)
-                        .truncate()
-                        .into_any_element()
-                };
-
-                ListItem::new(id)
-                    .toggle_state(is_selected)
-                    .child(
-                        h_flex()
-                            .min_w_0()
-                            .w_full()
-                            .py_1()
-                            .px_0p5()
-                            .gap_1()
-                            .justify_between()
-                            .child(title_label)
-                            .when_some(timestamp, |this, ts| {
-                                this.child(
-                                    Label::new(ts).size(LabelSize::Small).color(Color::Muted),
-                                )
-                            }),
-                    )
-                    .on_click(cx.listener(move |this, _, window, cx| {
-                        this.archive_selection = None;
-                        this.open_archive_thread(session_info.clone(), window, cx);
-                    }))
-                    .into_any_element()
-            }
-        }
     }
 
     fn open_archive_thread(
@@ -1776,84 +1569,46 @@ impl Sidebar {
         self.is_open
     }
 
-    pub fn set_history(&mut self, history: Entity<ThreadHistory>, cx: &mut Context<Self>) {
-        self._history_subscription = Some(cx.observe(&history, |this, _, cx| {
-            if this.view == SidebarView::Archive {
-                this.update_archive_items(cx);
-            }
-        }));
-        self.history = Some(history);
-    }
+    fn show_archive(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(active_workspace) = self.multi_workspace.upgrade().and_then(|w| {
+            w.read(cx)
+                .workspaces()
+                .get(w.read(cx).active_workspace_index())
+                .cloned()
+        }) else {
+            return;
+        };
+        let Some(agent_panel) = active_workspace.read(cx).panel::<AgentPanel>(cx) else {
+            return;
+        };
 
-    fn show_archive(&mut self, cx: &mut Context<Self>) {
+        let agent_connection_store = agent_panel.read(cx).connection_store().clone();
+
+        let archive_view = cx.new(|cx| ThreadsArchiveView::new(agent_connection_store, window, cx));
+        let subscription = cx.subscribe_in(
+            &archive_view,
+            window,
+            |this, _, event: &ThreadsArchiveViewEvent, window, cx| match event {
+                ThreadsArchiveViewEvent::Close => {
+                    this.show_thread_list(window, cx);
+                }
+                ThreadsArchiveViewEvent::OpenThread(session_info) => {
+                    this.open_archive_thread(session_info.clone(), window, cx);
+                }
+            },
+        );
+
+        self._subscriptions.push(subscription);
+        self.archive_view = Some(archive_view);
         self.view = SidebarView::Archive;
-        self.archive_selection = None;
-
-        if let Some(history) = &self.history {
-            history.update(cx, |history, cx| {
-                history.refresh_full_history(cx);
-            });
-        }
-
-        self.update_archive_items(cx);
         cx.notify();
     }
 
     fn show_thread_list(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.view = SidebarView::ThreadList;
-        self.reset_archive_filter_editor_text(window, cx);
+        self.archive_view = None;
+        self._subscriptions.clear();
         window.focus(&self.focus_handle, cx);
-        cx.notify();
-    }
-
-    fn update_archive_items(&mut self, cx: &mut Context<Self>) {
-        let Some(history) = &self.history else {
-            return;
-        };
-
-        let sessions = history.read(cx).sessions().to_vec();
-        let query = self.archive_filter_editor.read(cx).text(cx).to_lowercase();
-        let today = Local::now().naive_local().date();
-
-        let mut items = Vec::with_capacity(sessions.len() + 5);
-        let mut current_bucket: Option<TimeBucket> = None;
-
-        for session in sessions {
-            let highlight_positions = if !query.is_empty() {
-                let title = session.title.as_ref().map(|t| t.as_ref()).unwrap_or("");
-                match fuzzy_match_positions(&query, title) {
-                    Some(positions) => positions,
-                    None => continue,
-                }
-            } else {
-                Vec::new()
-            };
-
-            let entry_bucket = session
-                .updated_at
-                .map(|timestamp| {
-                    let entry_date = timestamp.with_timezone(&Local).naive_local().date();
-                    TimeBucket::from_dates(today, entry_date)
-                })
-                .unwrap_or(TimeBucket::Older);
-
-            if Some(entry_bucket) != current_bucket {
-                current_bucket = Some(entry_bucket);
-                items.push(ArchiveListItem::BucketSeparator(entry_bucket));
-            }
-
-            items.push(ArchiveListItem::Entry {
-                session,
-                highlight_positions,
-            });
-        }
-
-        self.archive_items = items;
-        self.archive_list_state = ListState::new(
-            self.archive_items.len(),
-            gpui::ListAlignment::Top,
-            px(1000.),
-        );
         cx.notify();
     }
 
@@ -1965,47 +1720,11 @@ impl Render for Sidebar {
                     )
                     .child(self.render_thread_list_footer(cx)),
                 SidebarView::Archive => {
-                    let has_session_list = self
-                        .history
-                        .as_ref()
-                        .map(|h| h.read(cx).has_session_list())
-                        .unwrap_or(false);
-                    let is_empty = self.archive_items.is_empty();
-                    let has_query = !self.archive_filter_editor.read(cx).text(cx).is_empty();
-
-                    let empty_state_container = |label: SharedString| {
-                        v_flex()
-                            .flex_1()
-                            .justify_center()
-                            .items_center()
-                            .child(Label::new(label).size(LabelSize::Small).color(Color::Muted))
-                    };
-
-                    this.child(self.render_archive_header(docked_right, cx))
-                        .child(if !has_session_list {
-                            empty_state_container("Start a thread to see your archive.".into())
-                                .into_any_element()
-                        } else if is_empty && has_query {
-                            empty_state_container("No threads match your search.".into())
-                                .into_any_element()
-                        } else if is_empty {
-                            empty_state_container("No archived threads yet.".into())
-                                .into_any_element()
-                        } else {
-                            v_flex()
-                                .flex_1()
-                                .overflow_hidden()
-                                .child(
-                                    list(
-                                        self.archive_list_state.clone(),
-                                        cx.processor(Self::render_archive_list_entry),
-                                    )
-                                    .flex_1()
-                                    .size_full(),
-                                )
-                                .vertical_scrollbar_for(&self.archive_list_state, window, cx)
-                                .into_any_element()
-                        })
+                    if let Some(archive_view) = &self.archive_view {
+                        this.child(archive_view.clone())
+                    } else {
+                        this
+                    }
                 }
             })
     }

--- a/crates/agent_ui/src/sidebar.rs
+++ b/crates/agent_ui/src/sidebar.rs
@@ -1578,13 +1578,31 @@ impl Sidebar {
         }) else {
             return;
         };
+
         let Some(agent_panel) = active_workspace.read(cx).panel::<AgentPanel>(cx) else {
             return;
         };
 
+        let thread_store = agent_panel.read(cx).thread_store().clone();
+        let fs = active_workspace.read(cx).project().read(cx).fs().clone();
         let agent_connection_store = agent_panel.read(cx).connection_store().clone();
+        let agent_server_store = active_workspace
+            .read(cx)
+            .project()
+            .read(cx)
+            .agent_server_store()
+            .clone();
 
-        let archive_view = cx.new(|cx| ThreadsArchiveView::new(agent_connection_store, window, cx));
+        let archive_view = cx.new(|cx| {
+            ThreadsArchiveView::new(
+                agent_connection_store,
+                agent_server_store,
+                thread_store,
+                fs,
+                window,
+                cx,
+            )
+        });
         let subscription = cx.subscribe_in(
             &archive_view,
             window,

--- a/crates/agent_ui/src/sidebar.rs
+++ b/crates/agent_ui/src/sidebar.rs
@@ -1,24 +1,24 @@
+use crate::thread_history::ThreadHistory;
 use crate::{AgentPanel, AgentPanelEvent, NewThread};
-use acp_thread::ThreadStatus;
+use acp_thread::{AgentSessionInfo, ThreadStatus};
 use action_log::DiffStats;
 use agent::ThreadStore;
 use agent_client_protocol as acp;
 use agent_settings::AgentSettings;
-use chrono::Utc;
+use chrono::{Datelike as _, Local, NaiveDate, TimeDelta, Utc};
 use db::kvp::KEY_VALUE_STORE;
-use editor::{Editor, EditorElement, EditorStyle};
+use editor::Editor;
 use feature_flags::{AgentV2FeatureFlag, FeatureFlagViewExt as _};
 use gpui::{
-    Action as _, AnyElement, App, Context, Entity, FocusHandle, Focusable, FontStyle, ListState,
-    Pixels, Render, SharedString, TextStyle, WeakEntity, Window, actions, list, prelude::*, px,
-    relative, rems,
+    Action as _, AnyElement, App, Context, Entity, FocusHandle, Focusable, ListState, Pixels,
+    Render, SharedString, WeakEntity, Window, actions, list, prelude::*, px,
 };
 use menu::{Cancel, Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use project::Event as ProjectEvent;
 use settings::Settings;
 use std::collections::{HashMap, HashSet};
 use std::mem;
-use theme::{ActiveTheme, ThemeSettings};
+use theme::ActiveTheme;
 use ui::{
     AgentThreadStatus, ButtonStyle, HighlightedLabel, IconButtonShape, ListItem, Tab, ThreadItem,
     Tooltip, WithScrollbar, prelude::*,
@@ -45,6 +45,61 @@ const MIN_WIDTH: Pixels = px(200.0);
 const MAX_WIDTH: Pixels = px(800.0);
 const DEFAULT_THREADS_SHOWN: usize = 5;
 const SIDEBAR_STATE_KEY: &str = "sidebar_state";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum SidebarView {
+    #[default]
+    ThreadList,
+    Archive,
+}
+
+#[derive(Clone)]
+enum ArchiveListItem {
+    BucketSeparator(TimeBucket),
+    Entry {
+        session: AgentSessionInfo,
+        highlight_positions: Vec<usize>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TimeBucket {
+    Today,
+    Yesterday,
+    ThisWeek,
+    PastWeek,
+    Older,
+}
+
+impl TimeBucket {
+    fn from_dates(reference: NaiveDate, date: NaiveDate) -> Self {
+        if date == reference {
+            return TimeBucket::Today;
+        }
+        if date == reference - TimeDelta::days(1) {
+            return TimeBucket::Yesterday;
+        }
+        let week = date.iso_week();
+        if reference.iso_week() == week {
+            return TimeBucket::ThisWeek;
+        }
+        let last_week = (reference - TimeDelta::days(7)).iso_week();
+        if week == last_week {
+            return TimeBucket::PastWeek;
+        }
+        TimeBucket::Older
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            TimeBucket::Today => "Today",
+            TimeBucket::Yesterday => "Yesterday",
+            TimeBucket::ThisWeek => "This Week",
+            TimeBucket::PastWeek => "Past Week",
+            TimeBucket::Older => "Older",
+        }
+    }
+}
 
 fn read_sidebar_open_state(multi_workspace_id: u64) -> bool {
     KEY_VALUE_STORE
@@ -211,6 +266,13 @@ pub struct Sidebar {
     active_entry_index: Option<usize>,
     collapsed_groups: HashSet<PathList>,
     expanded_groups: HashMap<PathList, usize>,
+    view: SidebarView,
+    history: Option<Entity<ThreadHistory>>,
+    archive_list_state: ListState,
+    archive_items: Vec<ArchiveListItem>,
+    archive_selection: Option<usize>,
+    archive_filter_editor: Entity<Editor>,
+    _history_subscription: Option<gpui::Subscription>,
 }
 
 impl Sidebar {
@@ -228,6 +290,19 @@ impl Sidebar {
             editor.set_placeholder_text("Search…", window, cx);
             editor
         });
+
+        let archive_filter_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Search threads archive…", window, cx);
+            editor
+        });
+
+        cx.subscribe(&archive_filter_editor, |this: &mut Self, _, event, cx| {
+            if let editor::EditorEvent::BufferEdited = event {
+                this.update_archive_items(cx);
+            }
+        })
+        .detach();
 
         cx.subscribe_in(
             &multi_workspace,
@@ -310,6 +385,13 @@ impl Sidebar {
             active_entry_index: None,
             collapsed_groups: HashSet::new(),
             expanded_groups: HashMap::new(),
+            view: SidebarView::default(),
+            history: None,
+            archive_list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
+            archive_items: Vec::new(),
+            archive_selection: None,
+            archive_filter_editor,
+            _history_subscription: None,
         }
     }
 
@@ -1230,28 +1312,18 @@ impl Sidebar {
             .into_any_element()
     }
 
-    fn render_filter_input(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let settings = ThemeSettings::get_global(cx);
-        let text_style = TextStyle {
-            color: cx.theme().colors().text,
-            font_family: settings.ui_font.family.clone(),
-            font_features: settings.ui_font.features.clone(),
-            font_fallbacks: settings.ui_font.fallbacks.clone(),
-            font_size: rems(0.875).into(),
-            font_weight: settings.ui_font.weight,
-            font_style: FontStyle::Normal,
-            line_height: relative(1.3),
-            ..Default::default()
-        };
+    fn render_filter_input(&self) -> impl IntoElement {
+        self.filter_editor.clone()
+    }
 
-        EditorElement::new(
-            &self.filter_editor,
-            EditorStyle {
-                local_player: cx.theme().players().local(),
-                text: text_style,
-                ..Default::default()
-            },
-        )
+    fn render_archive_filter_input(&self) -> impl IntoElement {
+        self.archive_filter_editor.clone()
+    }
+
+    fn reset_archive_filter_editor_text(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.archive_filter_editor.update(cx, |editor, cx| {
+            editor.set_text("", window, cx);
+        });
     }
 
     fn render_view_more(
@@ -1358,6 +1430,219 @@ impl Sidebar {
             .into_any_element()
     }
 
+    fn render_thread_list_header(
+        &self,
+        docked_right: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let has_query = self.has_filter_query(cx);
+
+        h_flex()
+            .h(Tab::container_height(cx))
+            .flex_none()
+            .gap_1p5()
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .when(!docked_right, |this| {
+                this.child(self.render_sidebar_toggle_button(false, cx))
+            })
+            .child(self.render_filter_input())
+            .when(has_query, |this| {
+                this.when(!docked_right, |this| this.pr_1p5()).child(
+                    IconButton::new("clear_filter", IconName::Close)
+                        .shape(IconButtonShape::Square)
+                        .tooltip(Tooltip::text("Clear Search"))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.reset_filter_editor_text(window, cx);
+                            this.update_entries(cx);
+                        })),
+                )
+            })
+            .when(docked_right, |this| {
+                this.pl_2()
+                    .pr_0p5()
+                    .child(self.render_sidebar_toggle_button(true, cx))
+            })
+    }
+
+    fn render_thread_list_footer(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        h_flex()
+            .p_1p5()
+            .border_t_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                Button::new("view-archive", "Archive")
+                    .full_width()
+                    .label_size(LabelSize::Small)
+                    .style(ButtonStyle::Outlined)
+                    .icon(IconName::Archive)
+                    .icon_color(Color::Muted)
+                    .icon_size(IconSize::Small)
+                    .icon_position(IconPosition::Start)
+                    .on_click(cx.listener(|this, _, _window, cx| {
+                        this.show_archive(cx);
+                    })),
+            )
+    }
+
+    fn render_archive_header(
+        &self,
+        docked_right: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let has_query = !self.archive_filter_editor.read(cx).text(cx).is_empty();
+
+        h_flex()
+            .h(Tab::container_height(cx))
+            .px_1()
+            .gap_1p5()
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                IconButton::new("back", IconName::ArrowLeft)
+                    .icon_size(IconSize::Small)
+                    .tooltip(Tooltip::text("Back to Sidebar"))
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.show_thread_list(window, cx);
+                    })),
+            )
+            .child(self.render_archive_filter_input())
+            .when(has_query, |this| {
+                this.when(!docked_right, |this| this.pr_1p5()).child(
+                    IconButton::new("clear_archive_filter", IconName::Close)
+                        .shape(IconButtonShape::Square)
+                        .tooltip(Tooltip::text("Clear Search"))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.reset_archive_filter_editor_text(window, cx);
+                            this.update_archive_items(cx);
+                        })),
+                )
+            })
+    }
+
+    fn render_archive_list_entry(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let Some(item) = self.archive_items.get(ix) else {
+            return div().into_any_element();
+        };
+
+        match item {
+            ArchiveListItem::BucketSeparator(bucket) => div()
+                .w_full()
+                .px_2()
+                .pt_3()
+                .pb_1()
+                .child(
+                    Label::new(bucket.label())
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .into_any_element(),
+            ArchiveListItem::Entry {
+                session,
+                highlight_positions,
+            } => {
+                let is_selected = self.archive_selection == Some(ix);
+                let title: SharedString =
+                    session.title.clone().unwrap_or_else(|| "Untitled".into());
+                let session_info = session.clone();
+                let highlight_positions = highlight_positions.clone();
+
+                let timestamp = session.created_at.or(session.updated_at).map(|entry_time| {
+                    let now = Utc::now();
+                    let duration = now.signed_duration_since(entry_time);
+
+                    let minutes = duration.num_minutes();
+                    let hours = duration.num_hours();
+                    let days = duration.num_days();
+                    let weeks = days / 7;
+                    let months = days / 30;
+
+                    if minutes < 60 {
+                        format!("{}m", minutes.max(1))
+                    } else if hours < 24 {
+                        format!("{}h", hours)
+                    } else if weeks < 4 {
+                        format!("{}w", weeks.max(1))
+                    } else {
+                        format!("{}mo", months.max(1))
+                    }
+                });
+
+                let id = SharedString::from(format!("archive-entry-{}", ix));
+
+                let title_label = if highlight_positions.is_empty() {
+                    Label::new(title)
+                        .size(LabelSize::Small)
+                        .truncate()
+                        .into_any_element()
+                } else {
+                    HighlightedLabel::new(title, highlight_positions)
+                        .size(LabelSize::Small)
+                        .truncate()
+                        .into_any_element()
+                };
+
+                ListItem::new(id)
+                    .toggle_state(is_selected)
+                    .child(
+                        h_flex()
+                            .min_w_0()
+                            .w_full()
+                            .py_1()
+                            .px_0p5()
+                            .gap_1()
+                            .justify_between()
+                            .child(title_label)
+                            .when_some(timestamp, |this, ts| {
+                                this.child(
+                                    Label::new(ts).size(LabelSize::Small).color(Color::Muted),
+                                )
+                            }),
+                    )
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.archive_selection = None;
+                        this.open_archive_thread(session_info.clone(), window, cx);
+                    }))
+                    .into_any_element()
+            }
+        }
+    }
+
+    fn open_archive_thread(
+        &mut self,
+        session_info: AgentSessionInfo,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
+            return;
+        };
+        let workspace = multi_workspace.read(cx).workspace().clone();
+
+        workspace.update(cx, |workspace, cx| {
+            workspace.open_panel::<AgentPanel>(window, cx);
+        });
+
+        if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
+            agent_panel.update(cx, |panel, cx| {
+                panel.load_agent_thread(
+                    session_info.session_id,
+                    session_info.cwd,
+                    session_info.title,
+                    window,
+                    cx,
+                );
+            });
+        }
+
+        self.show_thread_list(window, cx);
+    }
+
     fn render_sidebar_toggle_button(
         &self,
         docked_right: bool,
@@ -1396,6 +1681,87 @@ impl Sidebar {
 impl Sidebar {
     pub fn is_open(&self) -> bool {
         self.is_open
+    }
+
+    pub fn set_history(&mut self, history: Entity<ThreadHistory>, cx: &mut Context<Self>) {
+        self._history_subscription = Some(cx.observe(&history, |this, _, cx| {
+            if this.view == SidebarView::Archive {
+                this.update_archive_items(cx);
+            }
+        }));
+        self.history = Some(history);
+    }
+
+    fn show_archive(&mut self, cx: &mut Context<Self>) {
+        self.view = SidebarView::Archive;
+        self.archive_selection = None;
+
+        if let Some(history) = &self.history {
+            history.update(cx, |history, cx| {
+                history.refresh_full_history(cx);
+            });
+        }
+
+        self.update_archive_items(cx);
+        cx.notify();
+    }
+
+    fn show_thread_list(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.view = SidebarView::ThreadList;
+        self.reset_archive_filter_editor_text(window, cx);
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    fn update_archive_items(&mut self, cx: &mut Context<Self>) {
+        let Some(history) = &self.history else {
+            return;
+        };
+
+        let sessions = history.read(cx).sessions().to_vec();
+        let query = self.archive_filter_editor.read(cx).text(cx).to_lowercase();
+        let today = Local::now().naive_local().date();
+
+        let mut items = Vec::with_capacity(sessions.len() + 5);
+        let mut current_bucket: Option<TimeBucket> = None;
+
+        for session in sessions {
+            let highlight_positions = if !query.is_empty() {
+                let title = session.title.as_ref().map(|t| t.as_ref()).unwrap_or("");
+                match fuzzy_match_positions(&query, title) {
+                    Some(positions) => positions,
+                    None => continue,
+                }
+            } else {
+                Vec::new()
+            };
+
+            let entry_bucket = session
+                .updated_at
+                .map(|timestamp| {
+                    let entry_date = timestamp.with_timezone(&Local).naive_local().date();
+                    TimeBucket::from_dates(today, entry_date)
+                })
+                .unwrap_or(TimeBucket::Older);
+
+            if Some(entry_bucket) != current_bucket {
+                current_bucket = Some(entry_bucket);
+                items.push(ArchiveListItem::BucketSeparator(entry_bucket));
+            }
+
+            items.push(ArchiveListItem::Entry {
+                session,
+                highlight_positions,
+            });
+        }
+
+        self.archive_items = items;
+        self.archive_list_state = ListState::new(
+            self.archive_items.len(),
+            gpui::ListAlignment::Top,
+            px(1000.),
+        );
+        cx.notify();
     }
 
     pub fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
@@ -1465,7 +1831,7 @@ impl Focusable for Sidebar {
 impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let ui_font = theme::setup_ui_font(window, cx);
-        let has_query = self.has_filter_query(cx);
+        let docked_right = AgentSettings::get_global(cx).dock == settings::DockPosition::Right;
 
         v_flex()
             .id("workspace-sidebar")
@@ -1484,51 +1850,68 @@ impl Render for Sidebar {
             .font(ui_font)
             .size_full()
             .bg(cx.theme().colors().surface_background)
-            .child({
-                let docked_right =
-                    AgentSettings::get_global(cx).dock == settings::DockPosition::Right;
-
-                h_flex()
-                    .h(Tab::container_height(cx))
-                    .flex_none()
-                    .gap_1p5()
-                    .border_b_1()
-                    .border_color(cx.theme().colors().border)
-                    .when(!docked_right, |this| {
-                        this.child(self.render_sidebar_toggle_button(false, cx))
-                    })
-                    .child(self.render_filter_input(cx))
-                    .when(has_query, |this| {
-                        this.when(!docked_right, |this| this.pr_1p5()).child(
-                            IconButton::new("clear_filter", IconName::Close)
-                                .shape(IconButtonShape::Square)
-                                .tooltip(Tooltip::text("Clear Search"))
-                                .on_click(cx.listener(|this, _, window, cx| {
-                                    this.reset_filter_editor_text(window, cx);
-                                    this.update_entries(cx);
-                                })),
-                        )
-                    })
-                    .when(docked_right, |this| {
-                        this.pl_2()
-                            .pr_0p5()
-                            .child(self.render_sidebar_toggle_button(true, cx))
-                    })
-            })
-            .child(
-                v_flex()
-                    .flex_1()
-                    .overflow_hidden()
+            .map(|this| match self.view {
+                SidebarView::ThreadList => this
+                    .child(self.render_thread_list_header(docked_right, cx))
                     .child(
-                        list(
-                            self.list_state.clone(),
-                            cx.processor(Self::render_list_entry),
-                        )
-                        .flex_1()
-                        .size_full(),
+                        v_flex()
+                            .flex_1()
+                            .overflow_hidden()
+                            .child(
+                                list(
+                                    self.list_state.clone(),
+                                    cx.processor(Self::render_list_entry),
+                                )
+                                .flex_1()
+                                .size_full(),
+                            )
+                            .vertical_scrollbar_for(&self.list_state, window, cx),
                     )
-                    .vertical_scrollbar_for(&self.list_state, window, cx),
-            )
+                    .child(self.render_thread_list_footer(cx)),
+                SidebarView::Archive => {
+                    let has_session_list = self
+                        .history
+                        .as_ref()
+                        .map(|h| h.read(cx).has_session_list())
+                        .unwrap_or(false);
+                    let is_empty = self.archive_items.is_empty();
+                    let has_query = !self.archive_filter_editor.read(cx).text(cx).is_empty();
+
+                    let empty_state_container = |label: SharedString| {
+                        v_flex()
+                            .flex_1()
+                            .justify_center()
+                            .items_center()
+                            .child(Label::new(label).size(LabelSize::Small).color(Color::Muted))
+                    };
+
+                    this.child(self.render_archive_header(docked_right, cx))
+                        .child(if !has_session_list {
+                            empty_state_container("Start a thread to see your archive.".into())
+                                .into_any_element()
+                        } else if is_empty && has_query {
+                            empty_state_container("No threads match your search.".into())
+                                .into_any_element()
+                        } else if is_empty {
+                            empty_state_container("No archived threads yet.".into())
+                                .into_any_element()
+                        } else {
+                            v_flex()
+                                .flex_1()
+                                .overflow_hidden()
+                                .child(
+                                    list(
+                                        self.archive_list_state.clone(),
+                                        cx.processor(Self::render_archive_list_entry),
+                                    )
+                                    .flex_1()
+                                    .size_full(),
+                                )
+                                .vertical_scrollbar_for(&self.archive_list_state, window, cx)
+                                .into_any_element()
+                        })
+                }
+            })
     }
 }
 

--- a/crates/agent_ui/src/sidebar.rs
+++ b/crates/agent_ui/src/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::threads_archive_view::{ThreadsArchiveView, ThreadsArchiveViewEvent};
 use crate::{AgentPanel, AgentPanelEvent, NewThread};
-use acp_thread::{AgentSessionInfo, ThreadStatus};
+use acp_thread::{ThreadStatus};
 use action_log::DiffStats;
 use agent::ThreadStore;
 use agent_client_protocol as acp;
@@ -1491,42 +1491,12 @@ impl Sidebar {
                     .style(ButtonStyle::Outlined)
                     .icon(IconName::Archive)
                     .icon_color(Color::Muted)
-                    .icon_size(IconSize::Small)
+                    .icon_size(IconSize::XSmall)
                     .icon_position(IconPosition::Start)
                     .on_click(cx.listener(|this, _, window, cx| {
                         this.show_archive(window, cx);
                     })),
             )
-    }
-
-    fn open_archive_thread(
-        &mut self,
-        session_info: AgentSessionInfo,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
-            return;
-        };
-        let workspace = multi_workspace.read(cx).workspace().clone();
-
-        workspace.update(cx, |workspace, cx| {
-            workspace.open_panel::<AgentPanel>(window, cx);
-        });
-
-        if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
-            agent_panel.update(cx, |panel, cx| {
-                panel.load_agent_thread(
-                    session_info.session_id,
-                    session_info.cwd,
-                    session_info.title,
-                    window,
-                    cx,
-                );
-            });
-        }
-
-        self.show_thread_list(window, cx);
     }
 
     fn render_sidebar_toggle_button(
@@ -1610,8 +1580,8 @@ impl Sidebar {
                 ThreadsArchiveViewEvent::Close => {
                     this.show_thread_list(window, cx);
                 }
-                ThreadsArchiveViewEvent::OpenThread(session_info) => {
-                    this.open_archive_thread(session_info.clone(), window, cx);
+                ThreadsArchiveViewEvent::OpenThread(_session_info) => {
+                    //TODO: Actually open thread once we support it
                 }
             },
         );

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -404,6 +404,7 @@ impl ThreadsArchiveView {
 
                 ListItem::new(id)
                     .toggle_state(is_selected)
+                    .disabled(true)
                     .child(
                         h_flex()
                             .min_w_0()
@@ -531,7 +532,7 @@ impl ThreadsArchiveView {
                                 entry = entry.icon(IconName::ZedAgent);
                             }
 
-                            entry = entry.disabled(true).icon_color(Color::Muted).handler({
+                            entry = entry.icon_color(Color::Muted).handler({
                                 let this = this.clone();
                                 let agent = Agent::Custom {
                                     name: item.id.0.clone(),

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1,15 +1,25 @@
+use std::sync::Arc;
+
 use crate::{Agent, agent_connection_store::AgentConnectionStore, thread_history::ThreadHistory};
 use acp_thread::AgentSessionInfo;
-use agent_settings::AgentSettings;
+use agent::ThreadStore;
 use chrono::{Datelike as _, Local, NaiveDate, TimeDelta, Utc};
 use editor::Editor;
+use fs::Fs;
 use gpui::{
     AnyElement, App, Context, Entity, EventEmitter, FocusHandle, Focusable, ListState, Render,
-    SharedString, Window, list, prelude::*, px,
+    SharedString, Subscription, Task, Window, list, prelude::*, px,
 };
-use settings::Settings;
+use itertools::Itertools as _;
+use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
+use project::{AgentServerStore, ExternalAgentServerName};
 use theme::ActiveTheme;
-use ui::{HighlightedLabel, ListItem, Tab, Tooltip, WithScrollbar, prelude::*};
+use ui::{
+    ButtonLike, ContextMenu, ContextMenuEntry, HighlightedLabel, ListItem, PopoverMenu,
+    PopoverMenuHandle, Tab, TintColor, Tooltip, WithScrollbar, prelude::*,
+};
+use util::ResultExt as _;
+use zed_actions::editor::{MoveDown, MoveUp};
 
 #[derive(Clone)]
 enum ArchiveListItem {
@@ -86,6 +96,11 @@ impl EventEmitter<ThreadsArchiveViewEvent> for ThreadsArchiveView {}
 
 pub struct ThreadsArchiveView {
     agent_connection_store: Entity<AgentConnectionStore>,
+    agent_server_store: Entity<AgentServerStore>,
+    thread_store: Entity<ThreadStore>,
+    fs: Arc<dyn Fs>,
+    history: Option<Entity<ThreadHistory>>,
+    _history_subscription: Subscription,
     selected_agent: Agent,
     focus_handle: FocusHandle,
     list_state: ListState,
@@ -93,11 +108,16 @@ pub struct ThreadsArchiveView {
     selection: Option<usize>,
     filter_editor: Entity<Editor>,
     _subscriptions: Vec<gpui::Subscription>,
+    selected_agent_menu: PopoverMenuHandle<ContextMenu>,
+    _refresh_history_task: Task<()>,
 }
 
 impl ThreadsArchiveView {
     pub fn new(
         agent_connection_store: Entity<AgentConnectionStore>,
+        agent_server_store: Entity<AgentServerStore>,
+        thread_store: Entity<ThreadStore>,
+        fs: Arc<dyn Fs>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -105,7 +125,7 @@ impl ThreadsArchiveView {
 
         let filter_editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
-            editor.set_placeholder_text("Search threads archive…", window, cx);
+            editor.set_placeholder_text("Search archive…", window, cx);
             editor
         });
 
@@ -116,16 +136,13 @@ impl ThreadsArchiveView {
                 }
             });
 
-        // let history_subscription = cx.observe(&history, |this, _, cx| {
-        //     this.update_items(cx);
-        // });
-
-        // history.update(cx, |history, cx| {
-        //     history.refresh_full_history(cx);
-        // });
-
         let mut this = Self {
             agent_connection_store,
+            agent_server_store,
+            thread_store,
+            fs,
+            history: None,
+            _history_subscription: Subscription::new(|| {}),
             selected_agent: Agent::NativeAgent,
             focus_handle,
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
@@ -133,24 +150,50 @@ impl ThreadsArchiveView {
             selection: None,
             filter_editor,
             _subscriptions: vec![filter_editor_subscription],
+            selected_agent_menu: PopoverMenuHandle::default(),
+            _refresh_history_task: Task::ready(()),
         };
-        this.update_items(cx);
+        this.set_selected_agent(Agent::NativeAgent, cx);
         this
     }
 
-    fn history(&self, cx: &mut Context<Self>) -> Entity<ThreadHistory> {
-        self.agent_connection_store
-            .read(cx)
-            .entry(&self.selected_agent)
-            .unwrap()
-            .read(cx)
-            .history()
-            .unwrap()
-            .clone()
+    fn set_selected_agent(&mut self, agent: Agent, cx: &mut Context<Self>) {
+        self.selected_agent = agent.clone();
+
+        let server = agent.server(self.fs.clone(), self.thread_store.clone());
+        let connection = self
+            .agent_connection_store
+            .update(cx, |store, cx| store.request_connection(agent, server, cx));
+
+        let task = connection.read(cx).wait_for_connection();
+        self._refresh_history_task = cx.spawn(async move |this, cx| {
+            if let Some(state) = task.await.log_err() {
+                this.update(cx, |this, cx| this.set_history(state.history, cx))
+                    .ok();
+            }
+        });
+
+        cx.notify();
+    }
+
+    fn set_history(&mut self, history: Entity<ThreadHistory>, cx: &mut Context<Self>) {
+        self._history_subscription = cx.observe(&history, |this, _, cx| {
+            this.update_items(cx);
+        });
+        history.update(cx, |history, cx| {
+            history.refresh_full_history(cx);
+        });
+        self.history = Some(history);
+        self.update_items(cx);
+        cx.notify();
     }
 
     fn update_items(&mut self, cx: &mut Context<Self>) {
-        let sessions = self.history(cx).read(cx).sessions().to_vec();
+        let Some(history) = self.history.as_ref() else {
+            return;
+        };
+
+        let sessions = history.read(cx).sessions().to_vec();
         let query = self.filter_editor.read(cx).text(cx).to_lowercase();
         let today = Local::now().naive_local().date();
 
@@ -187,8 +230,8 @@ impl ThreadsArchiveView {
             });
         }
 
+        self.list_state.reset(items.len());
         self.items = items;
-        self.list_state = ListState::new(self.items.len(), gpui::ListAlignment::Top, px(1000.));
         cx.notify();
     }
 
@@ -214,35 +257,82 @@ impl ThreadsArchiveView {
         cx.emit(ThreadsArchiveViewEvent::OpenThread(session_info));
     }
 
-    fn render_header(&self, docked_right: bool, cx: &mut Context<Self>) -> impl IntoElement {
-        let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
+    fn is_selectable_item(&self, ix: usize) -> bool {
+        matches!(self.items.get(ix), Some(ArchiveListItem::Entry { .. }))
+    }
 
-        h_flex()
-            .h(Tab::container_height(cx))
-            .px_1()
-            .gap_1p5()
-            .border_b_1()
-            .border_color(cx.theme().colors().border)
-            .child(
-                IconButton::new("back", IconName::ArrowLeft)
-                    .icon_size(IconSize::Small)
-                    .tooltip(Tooltip::text("Back to Sidebar"))
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.go_back(window, cx);
-                    })),
-            )
-            .child(self.filter_editor.clone())
-            .when(has_query, |this| {
-                this.when(!docked_right, |this| this.pr_1p5()).child(
-                    IconButton::new("clear_archive_filter", IconName::Close)
-                        .icon_size(IconSize::Small)
-                        .tooltip(Tooltip::text("Clear Search"))
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            this.reset_filter_editor_text(window, cx);
-                            this.update_items(cx);
-                        })),
-                )
-            })
+    fn find_next_selectable(&self, start: usize) -> Option<usize> {
+        (start..self.items.len()).find(|&i| self.is_selectable_item(i))
+    }
+
+    fn find_previous_selectable(&self, start: usize) -> Option<usize> {
+        (0..=start).rev().find(|&i| self.is_selectable_item(i))
+    }
+
+    fn editor_move_down(&mut self, _: &MoveDown, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_next(&SelectNext, window, cx);
+    }
+
+    fn editor_move_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_previous(&SelectPrevious, window, cx);
+    }
+
+    fn select_next(&mut self, _: &SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+        let next = match self.selection {
+            Some(ix) => self.find_next_selectable(ix + 1),
+            None => self.find_next_selectable(0),
+        };
+        if let Some(next) = next {
+            self.selection = Some(next);
+            self.list_state.scroll_to_reveal_item(next);
+            cx.notify();
+        }
+    }
+
+    fn select_previous(
+        &mut self,
+        _: &SelectPrevious,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let prev = match self.selection {
+            Some(ix) if ix > 0 => self.find_previous_selectable(ix - 1),
+            None => {
+                let last = self.items.len().saturating_sub(1);
+                self.find_previous_selectable(last)
+            }
+            _ => return,
+        };
+        if let Some(prev) = prev {
+            self.selection = Some(prev);
+            self.list_state.scroll_to_reveal_item(prev);
+            cx.notify();
+        }
+    }
+
+    fn select_first(&mut self, _: &SelectFirst, _window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(first) = self.find_next_selectable(0) {
+            self.selection = Some(first);
+            self.list_state.scroll_to_reveal_item(first);
+            cx.notify();
+        }
+    }
+
+    fn select_last(&mut self, _: &SelectLast, _window: &mut Window, cx: &mut Context<Self>) {
+        let last = self.items.len().saturating_sub(1);
+        if let Some(last) = self.find_previous_selectable(last) {
+            self.selection = Some(last);
+            self.list_state.scroll_to_reveal_item(last);
+            cx.notify();
+        }
+    }
+
+    fn confirm(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(ix) = self.selection else { return };
+        let Some(ArchiveListItem::Entry { session, .. }) = self.items.get(ix) else {
+            return;
+        };
+        self.open_thread(session.clone(), window, cx);
     }
 
     fn render_list_entry(
@@ -319,7 +409,8 @@ impl ThreadsArchiveView {
                             .min_w_0()
                             .w_full()
                             .py_1()
-                            .px_0p5()
+                            .pl_0p5()
+                            .pr_1p5()
                             .gap_1()
                             .justify_between()
                             .child(title_label)
@@ -336,6 +427,175 @@ impl ThreadsArchiveView {
             }
         }
     }
+
+    fn render_agent_picker(&self, cx: &mut Context<Self>) -> PopoverMenu<ContextMenu> {
+        let agent_server_store = self.agent_server_store.clone();
+
+        let (chevron_icon, icon_color) = if self.selected_agent_menu.is_deployed() {
+            (IconName::ChevronUp, Color::Accent)
+        } else {
+            (IconName::ChevronDown, Color::Muted)
+        };
+
+        let selected_agent_icon = if let Agent::Custom { name } = &self.selected_agent {
+            let store = agent_server_store.read(cx);
+            let icon = store.agent_icon(&ExternalAgentServerName(name.clone()));
+
+            if let Some(icon) = icon {
+                Icon::from_external_svg(icon)
+            } else {
+                Icon::new(IconName::Sparkle)
+            }
+            .color(Color::Muted)
+            .size(IconSize::Small)
+        } else {
+            Icon::new(IconName::ZedAgent)
+                .color(Color::Muted)
+                .size(IconSize::Small)
+        };
+
+        let this = cx.weak_entity();
+
+        PopoverMenu::new("agent_history_menu")
+            .trigger(
+                ButtonLike::new("selected_agent")
+                    .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                    .child(
+                        h_flex().gap_1().child(selected_agent_icon).child(
+                            Icon::new(chevron_icon)
+                                .color(icon_color)
+                                .size(IconSize::XSmall),
+                        ),
+                    ),
+            )
+            .menu(move |window, cx| {
+                Some(ContextMenu::build(window, cx, |menu, _window, cx| {
+                    menu.item(
+                        ContextMenuEntry::new("Zed Agent")
+                            .icon(IconName::ZedAgent)
+                            .icon_color(Color::Muted)
+                            .handler({
+                                let this = this.clone();
+                                move |_, cx| {
+                                    this.update(cx, |this, cx| {
+                                        this.set_selected_agent(Agent::NativeAgent, cx)
+                                    })
+                                    .ok();
+                                }
+                            }),
+                    )
+                    .separator()
+                    .map(|mut menu| {
+                        let agent_server_store = agent_server_store.read(cx);
+                        let registry_store = project::AgentRegistryStore::try_global(cx);
+                        let registry_store_ref = registry_store.as_ref().map(|s| s.read(cx));
+
+                        struct AgentMenuItem {
+                            id: ExternalAgentServerName,
+                            display_name: SharedString,
+                        }
+
+                        let agent_items = agent_server_store
+                            .external_agents()
+                            .map(|name| {
+                                let display_name = agent_server_store
+                                    .agent_display_name(name)
+                                    .or_else(|| {
+                                        registry_store_ref
+                                            .as_ref()
+                                            .and_then(|store| store.agent(name.0.as_ref()))
+                                            .map(|a| a.name().clone())
+                                    })
+                                    .unwrap_or_else(|| name.0.clone());
+                                AgentMenuItem {
+                                    id: name.clone(),
+                                    display_name,
+                                }
+                            })
+                            .sorted_unstable_by_key(|e| e.display_name.to_lowercase())
+                            .collect::<Vec<_>>();
+
+                        for item in &agent_items {
+                            let mut entry = ContextMenuEntry::new(item.display_name.clone());
+
+                            let icon_path = agent_server_store.agent_icon(&item.id).or_else(|| {
+                                registry_store_ref
+                                    .as_ref()
+                                    .and_then(|store| store.agent(item.id.0.as_str()))
+                                    .and_then(|a| a.icon_path().cloned())
+                            });
+
+                            if let Some(icon_path) = icon_path {
+                                entry = entry.custom_icon_svg(icon_path);
+                            } else {
+                                entry = entry.icon(IconName::ZedAgent);
+                            }
+
+                            entry = entry.icon_color(Color::Muted).handler({
+                                let this = this.clone();
+                                let agent = Agent::Custom {
+                                    name: item.id.0.clone(),
+                                };
+                                move |_, cx| {
+                                    this.update(cx, |this, cx| {
+                                        this.set_selected_agent(agent.clone(), cx)
+                                    })
+                                    .ok();
+                                }
+                            });
+
+                            menu = menu.item(entry);
+                        }
+                        menu
+                    })
+                }))
+            })
+            .with_handle(self.selected_agent_menu.clone())
+            .anchor(gpui::Corner::TopRight)
+            .offset(gpui::Point {
+                x: px(1.0),
+                y: px(1.0),
+            })
+    }
+
+    fn render_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
+
+        h_flex()
+            .h(Tab::container_height(cx))
+            .px_1()
+            .gap_1p5()
+            .justify_between()
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                h_flex()
+                    .flex_1()
+                    .w_full()
+                    .gap_1p5()
+                    .child(
+                        IconButton::new("back", IconName::ArrowLeft)
+                            .icon_size(IconSize::Small)
+                            .tooltip(Tooltip::text("Back to Sidebar"))
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.go_back(window, cx);
+                            })),
+                    )
+                    .child(self.filter_editor.clone())
+                    .when(has_query, |this| {
+                        this.border_r_1().child(
+                            IconButton::new("clear_archive_filter", IconName::Close)
+                                .icon_size(IconSize::Small)
+                                .tooltip(Tooltip::text("Clear Search"))
+                                .on_click(cx.listener(|this, _, window, cx| {
+                                    this.reset_filter_editor_text(window, cx);
+                                    this.update_items(cx);
+                                })),
+                        )
+                    }),
+            )
+            .child(self.render_agent_picker(cx))
+    }
 }
 
 impl Focusable for ThreadsArchiveView {
@@ -346,9 +606,6 @@ impl Focusable for ThreadsArchiveView {
 
 impl Render for ThreadsArchiveView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let docked_right = AgentSettings::get_global(cx).dock == settings::DockPosition::Right;
-
-        let has_session_list = self.history(cx).read(cx).has_session_list();
         let is_empty = self.items.is_empty();
         let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
 
@@ -363,13 +620,17 @@ impl Render for ThreadsArchiveView {
         v_flex()
             .key_context("ThreadsArchiveView")
             .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::select_next))
+            .on_action(cx.listener(Self::select_previous))
+            .on_action(cx.listener(Self::editor_move_down))
+            .on_action(cx.listener(Self::editor_move_up))
+            .on_action(cx.listener(Self::select_first))
+            .on_action(cx.listener(Self::select_last))
+            .on_action(cx.listener(Self::confirm))
             .size_full()
             .bg(cx.theme().colors().surface_background)
-            .child(self.render_header(docked_right, cx))
-            .child(if !has_session_list {
-                empty_state_container("Start a thread to see your archive.".into())
-                    .into_any_element()
-            } else if is_empty && has_query {
+            .child(self.render_header(cx))
+            .child(if has_query {
                 empty_state_container("No threads match your search.".into()).into_any_element()
             } else if is_empty {
                 empty_state_container("No archived threads yet.".into()).into_any_element()

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -411,7 +411,7 @@ impl ThreadsArchiveView {
                             .py_1()
                             .pl_0p5()
                             .pr_1p5()
-                            .gap_1()
+                            .gap_2()
                             .justify_between()
                             .child(title_label)
                             .when_some(timestamp, |this, ts| {
@@ -531,7 +531,7 @@ impl ThreadsArchiveView {
                                 entry = entry.icon(IconName::ZedAgent);
                             }
 
-                            entry = entry.icon_color(Color::Muted).handler({
+                            entry = entry.disabled(true).icon_color(Color::Muted).handler({
                                 let this = this.clone();
                                 let agent = Agent::Custom {
                                     name: item.id.0.clone(),

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -630,7 +630,7 @@ impl Render for ThreadsArchiveView {
             .size_full()
             .bg(cx.theme().colors().surface_background)
             .child(self.render_header(cx))
-            .child(if has_query {
+            .child(if is_empty && has_query {
                 empty_state_container("No threads match your search.".into()).into_any_element()
             } else if is_empty {
                 empty_state_container("No archived threads yet.".into()).into_any_element()

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1,0 +1,392 @@
+use crate::{Agent, agent_connection_store::AgentConnectionStore, thread_history::ThreadHistory};
+use acp_thread::AgentSessionInfo;
+use agent_settings::AgentSettings;
+use chrono::{Datelike as _, Local, NaiveDate, TimeDelta, Utc};
+use editor::Editor;
+use gpui::{
+    AnyElement, App, Context, Entity, EventEmitter, FocusHandle, Focusable, ListState, Render,
+    SharedString, Window, list, prelude::*, px,
+};
+use settings::Settings;
+use theme::ActiveTheme;
+use ui::{HighlightedLabel, ListItem, Tab, Tooltip, WithScrollbar, prelude::*};
+
+#[derive(Clone)]
+enum ArchiveListItem {
+    BucketSeparator(TimeBucket),
+    Entry {
+        session: AgentSessionInfo,
+        highlight_positions: Vec<usize>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TimeBucket {
+    Today,
+    Yesterday,
+    ThisWeek,
+    PastWeek,
+    Older,
+}
+
+impl TimeBucket {
+    fn from_dates(reference: NaiveDate, date: NaiveDate) -> Self {
+        if date == reference {
+            return TimeBucket::Today;
+        }
+        if date == reference - TimeDelta::days(1) {
+            return TimeBucket::Yesterday;
+        }
+        let week = date.iso_week();
+        if reference.iso_week() == week {
+            return TimeBucket::ThisWeek;
+        }
+        let last_week = (reference - TimeDelta::days(7)).iso_week();
+        if week == last_week {
+            return TimeBucket::PastWeek;
+        }
+        TimeBucket::Older
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            TimeBucket::Today => "Today",
+            TimeBucket::Yesterday => "Yesterday",
+            TimeBucket::ThisWeek => "This Week",
+            TimeBucket::PastWeek => "Past Week",
+            TimeBucket::Older => "Older",
+        }
+    }
+}
+
+fn fuzzy_match_positions(query: &str, text: &str) -> Option<Vec<usize>> {
+    let query = query.to_lowercase();
+    let text_lower = text.to_lowercase();
+    let mut positions = Vec::new();
+    let mut query_chars = query.chars().peekable();
+    for (i, c) in text_lower.chars().enumerate() {
+        if query_chars.peek() == Some(&c) {
+            positions.push(i);
+            query_chars.next();
+        }
+    }
+    if query_chars.peek().is_none() {
+        Some(positions)
+    } else {
+        None
+    }
+}
+
+pub enum ThreadsArchiveViewEvent {
+    Close,
+    OpenThread(AgentSessionInfo),
+}
+
+impl EventEmitter<ThreadsArchiveViewEvent> for ThreadsArchiveView {}
+
+pub struct ThreadsArchiveView {
+    agent_connection_store: Entity<AgentConnectionStore>,
+    selected_agent: Agent,
+    focus_handle: FocusHandle,
+    list_state: ListState,
+    items: Vec<ArchiveListItem>,
+    selection: Option<usize>,
+    filter_editor: Entity<Editor>,
+    _subscriptions: Vec<gpui::Subscription>,
+}
+
+impl ThreadsArchiveView {
+    pub fn new(
+        agent_connection_store: Entity<AgentConnectionStore>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let focus_handle = cx.focus_handle();
+
+        let filter_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Search threads archive…", window, cx);
+            editor
+        });
+
+        let filter_editor_subscription =
+            cx.subscribe(&filter_editor, |this: &mut Self, _, event, cx| {
+                if let editor::EditorEvent::BufferEdited = event {
+                    this.update_items(cx);
+                }
+            });
+
+        // let history_subscription = cx.observe(&history, |this, _, cx| {
+        //     this.update_items(cx);
+        // });
+
+        // history.update(cx, |history, cx| {
+        //     history.refresh_full_history(cx);
+        // });
+
+        let mut this = Self {
+            agent_connection_store,
+            selected_agent: Agent::NativeAgent,
+            focus_handle,
+            list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
+            items: Vec::new(),
+            selection: None,
+            filter_editor,
+            _subscriptions: vec![filter_editor_subscription],
+        };
+        this.update_items(cx);
+        this
+    }
+
+    fn history(&self, cx: &mut Context<Self>) -> Entity<ThreadHistory> {
+        self.agent_connection_store
+            .read(cx)
+            .entry(&self.selected_agent)
+            .unwrap()
+            .read(cx)
+            .history()
+            .unwrap()
+            .clone()
+    }
+
+    fn update_items(&mut self, cx: &mut Context<Self>) {
+        let sessions = self.history(cx).read(cx).sessions().to_vec();
+        let query = self.filter_editor.read(cx).text(cx).to_lowercase();
+        let today = Local::now().naive_local().date();
+
+        let mut items = Vec::with_capacity(sessions.len() + 5);
+        let mut current_bucket: Option<TimeBucket> = None;
+
+        for session in sessions {
+            let highlight_positions = if !query.is_empty() {
+                let title = session.title.as_ref().map(|t| t.as_ref()).unwrap_or("");
+                match fuzzy_match_positions(&query, title) {
+                    Some(positions) => positions,
+                    None => continue,
+                }
+            } else {
+                Vec::new()
+            };
+
+            let entry_bucket = session
+                .updated_at
+                .map(|timestamp| {
+                    let entry_date = timestamp.with_timezone(&Local).naive_local().date();
+                    TimeBucket::from_dates(today, entry_date)
+                })
+                .unwrap_or(TimeBucket::Older);
+
+            if Some(entry_bucket) != current_bucket {
+                current_bucket = Some(entry_bucket);
+                items.push(ArchiveListItem::BucketSeparator(entry_bucket));
+            }
+
+            items.push(ArchiveListItem::Entry {
+                session,
+                highlight_positions,
+            });
+        }
+
+        self.items = items;
+        self.list_state = ListState::new(self.items.len(), gpui::ListAlignment::Top, px(1000.));
+        cx.notify();
+    }
+
+    fn reset_filter_editor_text(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.filter_editor.update(cx, |editor, cx| {
+            editor.set_text("", window, cx);
+        });
+    }
+
+    fn go_back(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.reset_filter_editor_text(window, cx);
+        cx.emit(ThreadsArchiveViewEvent::Close);
+    }
+
+    fn open_thread(
+        &mut self,
+        session_info: AgentSessionInfo,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.selection = None;
+        self.reset_filter_editor_text(window, cx);
+        cx.emit(ThreadsArchiveViewEvent::OpenThread(session_info));
+    }
+
+    fn render_header(&self, docked_right: bool, cx: &mut Context<Self>) -> impl IntoElement {
+        let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
+
+        h_flex()
+            .h(Tab::container_height(cx))
+            .px_1()
+            .gap_1p5()
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                IconButton::new("back", IconName::ArrowLeft)
+                    .icon_size(IconSize::Small)
+                    .tooltip(Tooltip::text("Back to Sidebar"))
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.go_back(window, cx);
+                    })),
+            )
+            .child(self.filter_editor.clone())
+            .when(has_query, |this| {
+                this.when(!docked_right, |this| this.pr_1p5()).child(
+                    IconButton::new("clear_archive_filter", IconName::Close)
+                        .icon_size(IconSize::Small)
+                        .tooltip(Tooltip::text("Clear Search"))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.reset_filter_editor_text(window, cx);
+                            this.update_items(cx);
+                        })),
+                )
+            })
+    }
+
+    fn render_list_entry(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let Some(item) = self.items.get(ix) else {
+            return div().into_any_element();
+        };
+
+        match item {
+            ArchiveListItem::BucketSeparator(bucket) => div()
+                .w_full()
+                .px_2()
+                .pt_3()
+                .pb_1()
+                .child(
+                    Label::new(bucket.label())
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .into_any_element(),
+            ArchiveListItem::Entry {
+                session,
+                highlight_positions,
+            } => {
+                let is_selected = self.selection == Some(ix);
+                let title: SharedString =
+                    session.title.clone().unwrap_or_else(|| "Untitled".into());
+                let session_info = session.clone();
+                let highlight_positions = highlight_positions.clone();
+
+                let timestamp = session.created_at.or(session.updated_at).map(|entry_time| {
+                    let now = Utc::now();
+                    let duration = now.signed_duration_since(entry_time);
+
+                    let minutes = duration.num_minutes();
+                    let hours = duration.num_hours();
+                    let days = duration.num_days();
+                    let weeks = days / 7;
+                    let months = days / 30;
+
+                    if minutes < 60 {
+                        format!("{}m", minutes.max(1))
+                    } else if hours < 24 {
+                        format!("{}h", hours)
+                    } else if weeks < 4 {
+                        format!("{}w", weeks.max(1))
+                    } else {
+                        format!("{}mo", months.max(1))
+                    }
+                });
+
+                let id = SharedString::from(format!("archive-entry-{}", ix));
+
+                let title_label = if highlight_positions.is_empty() {
+                    Label::new(title)
+                        .size(LabelSize::Small)
+                        .truncate()
+                        .into_any_element()
+                } else {
+                    HighlightedLabel::new(title, highlight_positions)
+                        .size(LabelSize::Small)
+                        .truncate()
+                        .into_any_element()
+                };
+
+                ListItem::new(id)
+                    .toggle_state(is_selected)
+                    .child(
+                        h_flex()
+                            .min_w_0()
+                            .w_full()
+                            .py_1()
+                            .px_0p5()
+                            .gap_1()
+                            .justify_between()
+                            .child(title_label)
+                            .when_some(timestamp, |this, ts| {
+                                this.child(
+                                    Label::new(ts).size(LabelSize::Small).color(Color::Muted),
+                                )
+                            }),
+                    )
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.open_thread(session_info.clone(), window, cx);
+                    }))
+                    .into_any_element()
+            }
+        }
+    }
+}
+
+impl Focusable for ThreadsArchiveView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for ThreadsArchiveView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let docked_right = AgentSettings::get_global(cx).dock == settings::DockPosition::Right;
+
+        let has_session_list = self.history(cx).read(cx).has_session_list();
+        let is_empty = self.items.is_empty();
+        let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
+
+        let empty_state_container = |label: SharedString| {
+            v_flex()
+                .flex_1()
+                .justify_center()
+                .items_center()
+                .child(Label::new(label).size(LabelSize::Small).color(Color::Muted))
+        };
+
+        v_flex()
+            .key_context("ThreadsArchiveView")
+            .track_focus(&self.focus_handle)
+            .size_full()
+            .bg(cx.theme().colors().surface_background)
+            .child(self.render_header(docked_right, cx))
+            .child(if !has_session_list {
+                empty_state_container("Start a thread to see your archive.".into())
+                    .into_any_element()
+            } else if is_empty && has_query {
+                empty_state_container("No threads match your search.".into()).into_any_element()
+            } else if is_empty {
+                empty_state_container("No archived threads yet.".into()).into_any_element()
+            } else {
+                v_flex()
+                    .flex_1()
+                    .overflow_hidden()
+                    .child(
+                        list(
+                            self.list_state.clone(),
+                            cx.processor(Self::render_list_entry),
+                        )
+                        .flex_1()
+                        .size_full(),
+                    )
+                    .vertical_scrollbar_for(&self.list_state, window, cx)
+                    .into_any_element()
+            })
+    }
+}

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -27,6 +27,7 @@ pub enum IconName {
     AiVZero,
     AiXAi,
     AiZed,
+    Archive,
     ArrowCircle,
     ArrowDown,
     ArrowDown10,


### PR DESCRIPTION
This PR adds a button to the bottom of the sidebar that opens the archive view, which at the moment, only shows the same, uncategorized thread list available in the regular agent panel's history view.

Release Notes:

- N/A
