### PR TITLE
ai_onboarding: Add student plan examples to component preview

### DIFF
--- a/crates/ai_onboarding/src/ai_onboarding.rs
+++ b/crates/ai_onboarding/src/ai_onboarding.rs
@@ -372,6 +372,10 @@ impl Component for ZedAiOnboarding {
                         "Business Plan",
                         onboarding(SignInStatus::SignedIn, Some(Plan::ZedBusiness), false),
                     ),
+                    single_example(
+                        "Student Plan",
+                        onboarding(SignInStatus::SignedIn, Some(Plan::ZedStudent), false),
+                    ),
                 ])
                 .into_any_element(),
         )

--- a/crates/ai_onboarding/src/ai_upsell_card.rs
+++ b/crates/ai_onboarding/src/ai_upsell_card.rs
@@ -388,6 +388,17 @@ impl Component for AiUpsellCard {
                             }
                             .into_any_element(),
                         ),
+                        single_example(
+                            "Student Plan",
+                            AiUpsellCard {
+                                sign_in_status: SignInStatus::SignedIn,
+                                sign_in: Arc::new(|_, _| {}),
+                                account_too_young: false,
+                                user_plan: Some(Plan::ZedStudent),
+                                tab_index: Some(1),
+                            }
+                            .into_any_element(),
+                        ),
                     ],
                 ))
                 .into_any_element(),


### PR DESCRIPTION
This PR adds examples for the student plan to the component preview.

Release Notes:

- N/A
