### PR TITLE
languages: Prevent `bsn` macro from injecting rust layer

### DIFF
--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -10,7 +10,7 @@
     (scoped_identifier
       (identifier) @_macro_name .)
   ]
-  (#not-any-of? @_macro_name "view" "html")
+  (#not-any-of? @_macro_name "view" "html" "bsn")
   (token_tree) @injection.content
   (#set! injection.language "rust"))
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/51240

We don’t parse bsn as embedded Rust anymore. We expect bsn to get its own Tree-sitter implementation in the future, which should improve this. This fixes broken syntax highlighting for string literals. See line 66 in the comparison below.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/230ae057-f315-4290-8f51-bcd21e6557d7" />

Release Notes:

- N/A
