### PR TITLE
agent_ui: Cleanup `AgentConnectionStore`

### DIFF
--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -10,7 +10,7 @@ use gpui::{AppContext, Context, Entity, EventEmitter, SharedString, Subscription
 use project::{AgentServerStore, AgentServersUpdated, Project};
 use watch::Receiver;
 
-use crate::{ExternalAgent, ThreadHistory};
+use crate::{Agent, ThreadHistory};
 use project::ExternalAgentServerName;
 
 pub enum AgentConnectionEntry {
@@ -55,7 +55,7 @@ impl EventEmitter<AgentConnectionEntryEvent> for AgentConnectionEntry {}
 pub struct AgentConnectionStore {
     project: Entity<Project>,
     thread_store: Entity<ThreadStore>,
-    entries: HashMap<ExternalAgent, Entity<AgentConnectionEntry>>,
+    entries: HashMap<Agent, Entity<AgentConnectionEntry>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -75,13 +75,13 @@ impl AgentConnectionStore {
         }
     }
 
-    pub fn entry(&self, key: &ExternalAgent) -> Option<&Entity<AgentConnectionEntry>> {
+    pub fn entry(&self, key: &Agent) -> Option<&Entity<AgentConnectionEntry>> {
         self.entries.get(key)
     }
 
     pub fn request_connection(
         &mut self,
-        agent: ExternalAgent,
+        agent: Agent,
         cx: &mut Context<Self>,
     ) -> Entity<AgentConnectionEntry> {
         self.entries.get(&agent).cloned().unwrap_or_else(|| {
@@ -154,8 +154,8 @@ impl AgentConnectionStore {
     ) {
         let store = store.read(cx);
         self.entries.retain(|key, _| match key {
-            ExternalAgent::NativeAgent => true,
-            ExternalAgent::Custom { name } => store
+            Agent::NativeAgent => true,
+            Agent::Custom { name } => store
                 .external_agents
                 .contains_key(&ExternalAgentServerName(name.clone())),
         });

--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use acp_thread::{AgentConnection, LoadError};
+use agent::ThreadStore;
 use agent_servers::{AgentServer, AgentServerDelegate};
 use anyhow::Result;
 use collections::HashMap;
@@ -53,16 +54,22 @@ impl EventEmitter<AgentConnectionEntryEvent> for AgentConnectionEntry {}
 
 pub struct AgentConnectionStore {
     project: Entity<Project>,
+    thread_store: Entity<ThreadStore>,
     entries: HashMap<ExternalAgent, Entity<AgentConnectionEntry>>,
     _subscriptions: Vec<Subscription>,
 }
 
 impl AgentConnectionStore {
-    pub fn new(project: Entity<Project>, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        project: Entity<Project>,
+        thread_store: Entity<ThreadStore>,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let agent_server_store = project.read(cx).agent_server_store().clone();
         let subscription = cx.subscribe(&agent_server_store, Self::handle_agent_servers_updated);
         Self {
             project,
+            thread_store,
             entries: HashMap::default(),
             _subscriptions: vec![subscription],
         }
@@ -74,11 +81,15 @@ impl AgentConnectionStore {
 
     pub fn request_connection(
         &mut self,
-        key: ExternalAgent,
-        server: Rc<dyn AgentServer>,
+        agent: ExternalAgent,
         cx: &mut Context<Self>,
     ) -> Entity<AgentConnectionEntry> {
-        self.entries.get(&key).cloned().unwrap_or_else(|| {
+        self.entries.get(&agent).cloned().unwrap_or_else(|| {
+            let server = agent.server(
+                self.project.read(cx).fs().clone(),
+                self.thread_store.clone(),
+            );
+
             let (mut new_version_rx, connect_task) = self.start_connection(server.clone(), cx);
             let connect_task = connect_task.shared();
 
@@ -86,10 +97,10 @@ impl AgentConnectionStore {
                 connect_task: connect_task.clone(),
             });
 
-            self.entries.insert(key.clone(), entry.clone());
+            self.entries.insert(agent.clone(), entry.clone());
 
             cx.spawn({
-                let key = key.clone();
+                let key = agent.clone();
                 let entry = entry.clone();
                 async move |this, cx| match connect_task.await {
                     Ok(connected_state) => {
@@ -123,7 +134,8 @@ impl AgentConnectionStore {
                                     version.clone().into(),
                                 ));
                             });
-                            this.update(cx, |this, _cx| this.entries.remove(&key)).ok();
+                            this.update(cx, |this, _cx| this.entries.remove(&agent))
+                                .ok();
                         }
                     }
                 }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1188,7 +1188,8 @@ impl AgentPanel {
             language_registry,
             text_thread_store,
             prompt_store,
-            connection_store: cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)),
+            connection_store: cx
+                .new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx)),
             configuration: None,
             configuration_subscription: None,
             focus_handle: cx.focus_handle(),
@@ -1337,12 +1338,11 @@ impl AgentPanel {
     ) {
         let agent = ExternalAgent::NativeAgent;
 
-        let server = agent.server(self.fs.clone(), self.thread_store.clone());
         let session_id = action.from_session_id.clone();
 
-        let entry = self.connection_store.update(cx, |store, cx| {
-            store.request_connection(agent.clone(), server, cx)
-        });
+        let entry = self
+            .connection_store
+            .update(cx, |store, cx| store.request_connection(agent.clone(), cx));
         let connect_task = entry.read(cx).wait_for_connection();
 
         cx.spawn_in(window, async move |this, cx| {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -42,7 +42,7 @@ use crate::{
     ui::EndTrialUpsell,
 };
 use crate::{
-    AgentInitialContent, ExternalAgent, ExternalSourcePrompt, NewExternalAgentThread,
+    Agent, AgentInitialContent, ExternalSourcePrompt, NewExternalAgentThread,
     NewNativeAgentThreadFromSummary,
 };
 use crate::{
@@ -738,11 +738,11 @@ impl AgentType {
     }
 }
 
-impl From<ExternalAgent> for AgentType {
-    fn from(value: ExternalAgent) -> Self {
+impl From<Agent> for AgentType {
+    fn from(value: Agent) -> Self {
         match value {
-            ExternalAgent::Custom { name } => Self::Custom { name },
-            ExternalAgent::NativeAgent => Self::NativeAgent,
+            Agent::Custom { name } => Self::Custom { name },
+            Agent::NativeAgent => Self::NativeAgent,
         }
     }
 }
@@ -1284,7 +1284,7 @@ impl AgentPanel {
         cx: &mut Context<Self>,
     ) {
         self.external_thread(
-            Some(crate::ExternalAgent::NativeAgent),
+            Some(crate::Agent::NativeAgent),
             Some(session_id),
             cwd,
             title,
@@ -1336,7 +1336,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let agent = ExternalAgent::NativeAgent;
+        let agent = Agent::NativeAgent;
 
         let session_id = action.from_session_id.clone();
 
@@ -1417,7 +1417,7 @@ impl AgentPanel {
 
     fn external_thread(
         &mut self,
-        agent_choice: Option<crate::ExternalAgent>,
+        agent_choice: Option<crate::Agent>,
         resume_session_id: Option<acp::SessionId>,
         cwd: Option<PathBuf>,
         title: Option<SharedString>,
@@ -1435,7 +1435,7 @@ impl AgentPanel {
 
         #[derive(Serialize, Deserialize)]
         struct LastUsedExternalAgent {
-            agent: crate::ExternalAgent,
+            agent: crate::Agent,
         }
 
         let thread_store = self.thread_store.clone();
@@ -1473,7 +1473,7 @@ impl AgentPanel {
         } else {
             cx.spawn_in(window, async move |this, cx| {
                 let ext_agent = if is_via_collab {
-                    ExternalAgent::NativeAgent
+                    Agent::NativeAgent
                 } else {
                     cx.background_spawn(async move {
                         KEY_VALUE_STORE.read_kvp(LAST_USED_EXTERNAL_AGENT_KEY)
@@ -1485,7 +1485,7 @@ impl AgentPanel {
                         serde_json::from_str::<LastUsedExternalAgent>(&value).log_err()
                     })
                     .map(|agent| agent.agent)
-                    .unwrap_or(ExternalAgent::NativeAgent)
+                    .unwrap_or(Agent::NativeAgent)
                 };
 
                 let server = ext_agent.server(fs, thread_store);
@@ -1554,7 +1554,7 @@ impl AgentPanel {
         match &self.selected_agent {
             AgentType::TextThread | AgentType::NativeAgent => true,
             AgentType::Custom { name } => {
-                let agent = ExternalAgent::Custom { name: name.clone() };
+                let agent = Agent::Custom { name: name.clone() };
                 self.connection_store
                     .read(cx)
                     .entry(&agent)
@@ -1574,7 +1574,7 @@ impl AgentPanel {
                 let history = self
                     .connection_store
                     .read(cx)
-                    .entry(&ExternalAgent::NativeAgent)?
+                    .entry(&Agent::NativeAgent)?
                     .read(cx)
                     .history()?
                     .clone();
@@ -1584,7 +1584,7 @@ impl AgentPanel {
                 })
             }
             AgentType::Custom { name } => {
-                let agent = ExternalAgent::Custom { name: name.clone() };
+                let agent = Agent::Custom { name: name.clone() };
                 let history = self
                     .connection_store
                     .read(cx)
@@ -2376,10 +2376,10 @@ impl AgentPanel {
         cx.notify();
     }
 
-    fn selected_external_agent(&self) -> Option<ExternalAgent> {
+    fn selected_external_agent(&self) -> Option<Agent> {
         match &self.selected_agent {
-            AgentType::NativeAgent => Some(ExternalAgent::NativeAgent),
-            AgentType::Custom { name } => Some(ExternalAgent::Custom { name: name.clone() }),
+            AgentType::NativeAgent => Some(Agent::NativeAgent),
+            AgentType::Custom { name } => Some(Agent::Custom { name: name.clone() }),
             AgentType::TextThread => None,
         }
     }
@@ -2448,7 +2448,7 @@ impl AgentPanel {
                 window.dispatch_action(NewTextThread.boxed_clone(), cx);
             }
             AgentType::NativeAgent => self.external_thread(
-                Some(crate::ExternalAgent::NativeAgent),
+                Some(crate::Agent::NativeAgent),
                 None,
                 None,
                 None,
@@ -2458,7 +2458,7 @@ impl AgentPanel {
                 cx,
             ),
             AgentType::Custom { name } => self.external_thread(
-                Some(crate::ExternalAgent::Custom { name }),
+                Some(crate::Agent::Custom { name }),
                 None,
                 None,
                 None,
@@ -2544,7 +2544,7 @@ impl AgentPanel {
         initial_content: Option<AgentInitialContent>,
         workspace: WeakEntity<Workspace>,
         project: Entity<Project>,
-        ext_agent: ExternalAgent,
+        ext_agent: Agent,
         focus: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -4976,7 +4976,7 @@ impl rules_library::InlineAssistDelegate for PromptLibraryInlineAssist {
                 .read(cx)
                 .connection_store()
                 .read(cx)
-                .entry(&crate::ExternalAgent::NativeAgent)
+                .entry(&crate::Agent::NativeAgent)
                 .and_then(|s| s.read(cx).history())
             else {
                 log::error!("No connection entry found for native agent");
@@ -5158,7 +5158,7 @@ impl AgentPanel {
         let workspace = self.workspace.clone();
         let project = self.project.clone();
 
-        let ext_agent = ExternalAgent::Custom {
+        let ext_agent = Agent::Custom {
             name: server.name(),
         };
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -205,7 +205,7 @@ pub struct NewThread;
 #[serde(deny_unknown_fields)]
 pub struct NewExternalAgentThread {
     /// Which agent to use for the conversation.
-    agent: Option<ExternalAgent>,
+    agent: Option<Agent>,
 }
 
 #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
@@ -218,7 +218,7 @@ pub struct NewNativeAgentThreadFromSummary {
 // TODO unify this with AgentType
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ExternalAgent {
+pub enum Agent {
     NativeAgent,
     Custom { name: SharedString },
 }
@@ -227,7 +227,7 @@ pub enum ExternalAgent {
 // the registry: "claude_code" -> Custom { name: "claude-acp" }, "codex" -> Custom { name:
 // "codex-acp" }, "gemini" -> Custom { name: "gemini" }.
 // Can be removed at some point in the future and go back to #[derive(Deserialize)].
-impl<'de> serde::Deserialize<'de> for ExternalAgent {
+impl<'de> serde::Deserialize<'de> for Agent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -280,7 +280,7 @@ impl<'de> serde::Deserialize<'de> for ExternalAgent {
     }
 }
 
-impl ExternalAgent {
+impl Agent {
     pub fn server(
         &self,
         fs: Arc<dyn fs::Fs>,
@@ -752,20 +752,20 @@ mod tests {
         use project::agent_server_store::{CLAUDE_AGENT_NAME, CODEX_NAME, GEMINI_NAME};
 
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""claude_code""#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#""claude_code""#).unwrap(),
+            Agent::Custom {
                 name: CLAUDE_AGENT_NAME.into(),
             },
         );
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""codex""#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#""codex""#).unwrap(),
+            Agent::Custom {
                 name: CODEX_NAME.into(),
             },
         );
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""gemini""#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#""gemini""#).unwrap(),
+            Agent::Custom {
                 name: GEMINI_NAME.into(),
             },
         );
@@ -774,12 +774,12 @@ mod tests {
     #[test]
     fn test_deserialize_current_external_agent_variants() {
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""native_agent""#).unwrap(),
-            ExternalAgent::NativeAgent,
+            serde_json::from_str::<Agent>(r#""native_agent""#).unwrap(),
+            Agent::NativeAgent,
         );
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#"{"custom":{"name":"my-agent"}}"#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#"{"custom":{"name":"my-agent"}}"#).unwrap(),
+            Agent::Custom {
                 name: "my-agent".into(),
             },
         );

--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -76,9 +76,9 @@ use crate::message_editor::{MessageEditor, MessageEditorEvent};
 use crate::profile_selector::{ProfileProvider, ProfileSelector};
 use crate::ui::{AgentNotification, AgentNotificationEvent};
 use crate::{
-    AgentDiffPane, AgentInitialContent, AgentPanel, AllowAlways, AllowOnce, AuthorizeToolCall,
-    ClearMessageQueue, CycleFavoriteModels, CycleModeSelector, CycleThinkingEffort,
-    EditFirstQueuedMessage, ExpandMessageEditor, ExternalAgent, Follow, KeepAll, NewThread,
+    Agent, AgentDiffPane, AgentInitialContent, AgentPanel, AllowAlways, AllowOnce,
+    AuthorizeToolCall, ClearMessageQueue, CycleFavoriteModels, CycleModeSelector,
+    CycleThinkingEffort, EditFirstQueuedMessage, ExpandMessageEditor, Follow, KeepAll, NewThread,
     OpenAddContextMenu, OpenAgentDiff, OpenHistory, RejectAll, RejectOnce,
     RemoveFirstQueuedMessage, SendImmediately, SendNextQueuedMessage, ToggleFastMode,
     ToggleProfileSelector, ToggleThinkingEffortMenu, ToggleThinkingMode, UndoLastReject,
@@ -307,9 +307,9 @@ pub enum AcpServerViewEvent {
 impl EventEmitter<AcpServerViewEvent> for ConnectionView {}
 
 pub struct ConnectionView {
-    agent: Rc<dyn AgentServer>,
+    agent_server: Rc<dyn AgentServer>,
     connection_store: Entity<AgentConnectionStore>,
-    connection_key: ExternalAgent,
+    agent: Agent,
     agent_server_store: Entity<AgentServerStore>,
     workspace: WeakEntity<Workspace>,
     project: Entity<Project>,
@@ -475,9 +475,9 @@ impl ConnectedServerState {
 
 impl ConnectionView {
     pub fn new(
-        agent: Rc<dyn AgentServer>,
+        agent_server: Rc<dyn AgentServer>,
         connection_store: Entity<AgentConnectionStore>,
-        connection_key: ExternalAgent,
+        agent: Agent,
         resume_session_id: Option<acp::SessionId>,
         cwd: Option<PathBuf>,
         title: Option<SharedString>,
@@ -515,18 +515,18 @@ impl ConnectionView {
         .detach();
 
         Self {
-            agent: agent.clone(),
+            agent_server: agent_server.clone(),
             connection_store: connection_store.clone(),
-            connection_key: connection_key.clone(),
+            agent: agent.clone(),
             agent_server_store,
             workspace,
             project: project.clone(),
             thread_store,
             prompt_store,
             server_state: Self::initial_state(
-                agent.clone(),
+                agent_server.clone(),
                 connection_store,
-                connection_key,
+                agent,
                 resume_session_id,
                 cwd,
                 title,
@@ -567,9 +567,9 @@ impl ConnectionView {
             .unwrap_or((None, None, None));
 
         let state = Self::initial_state(
-            self.agent.clone(),
+            self.agent_server.clone(),
             self.connection_store.clone(),
-            self.connection_key.clone(),
+            self.agent.clone(),
             resume_session_id,
             cwd,
             title,
@@ -595,9 +595,9 @@ impl ConnectionView {
     }
 
     fn initial_state(
-        agent: Rc<dyn AgentServer>,
+        agent_server: Rc<dyn AgentServer>,
         connection_store: Entity<AgentConnectionStore>,
-        connection_key: ExternalAgent,
+        agent: Agent,
         resume_session_id: Option<acp::SessionId>,
         cwd: Option<PathBuf>,
         title: Option<SharedString>,
@@ -607,7 +607,10 @@ impl ConnectionView {
         cx: &mut Context<Self>,
     ) -> ServerState {
         if project.read(cx).is_via_collab()
-            && agent.clone().downcast::<NativeAgentServer>().is_none()
+            && agent_server
+                .clone()
+                .downcast::<NativeAgentServer>()
+                .is_none()
         {
             return ServerState::LoadError {
                 error: LoadError::Other(
@@ -655,7 +658,7 @@ impl ConnectionView {
             .unwrap_or_else(|| paths::home_dir().as_path().into());
 
         let connection_entry =
-            connection_store.update(cx, |store, cx| store.request_connection(connection_key, cx));
+            connection_store.update(cx, |store, cx| store.request_connection(agent, cx));
 
         let connection_entry_subscription =
             cx.subscribe(&connection_entry, |this, _entry, event, cx| match event {
@@ -737,7 +740,7 @@ impl ConnectionView {
                             Self::handle_auth_required(
                                 this,
                                 err,
-                                agent.name(),
+                                agent_server.name(),
                                 connection,
                                 window,
                                 cx,
@@ -825,7 +828,7 @@ impl ConnectionView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<ThreadView> {
-        let agent_name = self.agent.name();
+        let agent_name = self.agent_server.name();
         let prompt_capabilities = Rc::new(RefCell::new(acp::PromptCapabilities::default()));
         let available_commands = Rc::new(RefCell::new(vec![]));
 
@@ -842,7 +845,7 @@ impl ConnectionView {
                 self.prompt_store.clone(),
                 prompt_capabilities.clone(),
                 available_commands.clone(),
-                self.agent.name(),
+                self.agent_server.name(),
             )
         });
 
@@ -877,7 +880,7 @@ impl ConnectionView {
         let model_selector;
         if let Some(config_options) = config_options_provider {
             // Use config options - don't create mode_selector or model_selector
-            let agent_server = self.agent.clone();
+            let agent_server = self.agent_server.clone();
             let fs = self.project.read(cx).fs().clone();
             config_options_view =
                 Some(cx.new(|cx| {
@@ -889,7 +892,7 @@ impl ConnectionView {
             // Fall back to legacy mode/model selectors
             config_options_view = None;
             model_selector = connection.model_selector(&session_id).map(|selector| {
-                let agent_server = self.agent.clone();
+                let agent_server = self.agent_server.clone();
                 let fs = self.project.read(cx).fs().clone();
                 cx.new(|cx| {
                     ModelSelectorPopover::new(
@@ -908,7 +911,7 @@ impl ConnectionView {
                 .session_modes(&session_id, cx)
                 .map(|session_modes| {
                     let fs = self.project.read(cx).fs().clone();
-                    cx.new(|_cx| ModeSelector::new(session_modes, self.agent.clone(), fs))
+                    cx.new(|_cx| ModeSelector::new(session_modes, self.agent_server.clone(), fs))
                 });
         }
 
@@ -968,16 +971,16 @@ impl ConnectionView {
             .agent_display_name(&ExternalAgentServerName(agent_name.clone()))
             .unwrap_or_else(|| agent_name.clone());
 
-        let agent_icon = self.agent.logo();
+        let agent_icon = self.agent_server.logo();
         let agent_icon_from_external_svg = self
             .agent_server_store
             .read(cx)
-            .agent_icon(&ExternalAgentServerName(self.agent.name()))
+            .agent_icon(&ExternalAgentServerName(self.agent_server.name()))
             .or_else(|| {
                 project::AgentRegistryStore::try_global(cx).and_then(|store| {
                     store
                         .read(cx)
-                        .agent(self.agent.name().as_ref())
+                        .agent(self.agent_server.name().as_ref())
                         .and_then(|a| a.icon_path().cloned())
                 })
             });
@@ -1162,12 +1165,14 @@ impl ConnectionView {
             ServerState::Connected(_) => "New Thread".into(),
             ServerState::Loading(_) => "Loading…".into(),
             ServerState::LoadError { error, .. } => match error {
-                LoadError::Unsupported { .. } => format!("Upgrade {}", self.agent.name()).into(),
-                LoadError::FailedToInstall(_) => {
-                    format!("Failed to Install {}", self.agent.name()).into()
+                LoadError::Unsupported { .. } => {
+                    format!("Upgrade {}", self.agent_server.name()).into()
                 }
-                LoadError::Exited { .. } => format!("{} Exited", self.agent.name()).into(),
-                LoadError::Other(_) => format!("Error Loading {}", self.agent.name()).into(),
+                LoadError::FailedToInstall(_) => {
+                    format!("Failed to Install {}", self.agent_server.name()).into()
+                }
+                LoadError::Exited { .. } => format!("{} Exited", self.agent_server.name()).into(),
+                LoadError::Other(_) => format!("Error Loading {}", self.agent_server.name()).into(),
             },
         }
     }
@@ -1445,8 +1450,8 @@ impl ConnectionView {
                 let agent_display_name = self
                     .agent_server_store
                     .read(cx)
-                    .agent_display_name(&ExternalAgentServerName(self.agent.name()))
-                    .unwrap_or_else(|| self.agent.name());
+                    .agent_display_name(&ExternalAgentServerName(self.agent_server.name()))
+                    .unwrap_or_else(|| self.agent_server.name());
 
                 if let Some(active) = self.active_thread() {
                     let new_placeholder =
@@ -1870,8 +1875,8 @@ impl ConnectionView {
         let agent_display_name = self
             .agent_server_store
             .read(cx)
-            .agent_display_name(&ExternalAgentServerName(self.agent.name()))
-            .unwrap_or_else(|| self.agent.name());
+            .agent_display_name(&ExternalAgentServerName(self.agent_server.name()))
+            .unwrap_or_else(|| self.agent_server.name());
 
         let show_fallback_description = auth_methods.len() > 1
             && configuration_view.is_none()
@@ -2032,7 +2037,7 @@ impl ConnectionView {
             LoadError::Other(_) => "other",
         };
 
-        let agent_name = self.agent.name();
+        let agent_name = self.agent_server.name();
 
         telemetry::event!(
             "Agent Panel Error Shown",
@@ -2091,7 +2096,7 @@ impl ConnectionView {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let (heading_label, description_label) = (
-            format!("Upgrade {} to work with Zed", self.agent.name()),
+            format!("Upgrade {} to work with Zed", self.agent_server.name()),
             if version.is_empty() {
                 format!(
                     "Currently using {}, which does not report a valid --version",
@@ -2211,7 +2216,7 @@ impl ConnectionView {
         let needed_count = self.queued_messages_len(cx);
         let queued_messages = self.queued_message_contents(cx);
 
-        let agent_name = self.agent.name();
+        let agent_name = self.agent_server.name();
         let workspace = self.workspace.clone();
         let project = self.project.downgrade();
         let Some(connected) = self.as_connected() else {
@@ -2390,7 +2395,7 @@ impl ConnectionView {
         }
 
         // TODO: Change this once we have title summarization for external agents.
-        let title = self.agent.name();
+        let title = self.agent_server.name();
 
         match settings.notify_when_agent_waiting {
             NotifyWhenAgentWaiting::PrimaryScreen => {
@@ -2579,7 +2584,7 @@ impl ConnectionView {
                 .unwrap_or_else(|| SharedString::from("The model"))
         } else {
             // ACP agent - use the agent name (e.g., "Claude Agent", "Gemini CLI")
-            self.agent.name()
+            self.agent_server.name()
         }
     }
 
@@ -2590,7 +2595,7 @@ impl ConnectionView {
     }
 
     pub(crate) fn reauthenticate(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let agent_name = self.agent.name();
+        let agent_name = self.agent_server.name();
         if let Some(active) = self.active_thread() {
             active.update(cx, |active, cx| active.clear_thread_error(cx));
         }
@@ -2918,7 +2923,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::default_response()),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     None,
@@ -3031,7 +3036,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(ResumeOnlyAgentConnection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("resume-session")),
@@ -3089,7 +3094,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("session-1")),
@@ -3145,7 +3150,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("session-1")),
@@ -3201,7 +3206,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("session-1")),
@@ -3519,7 +3524,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(agent),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     None,
@@ -3735,7 +3740,7 @@ pub(crate) mod tests {
             cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
         });
 
-        let agent_key = ExternalAgent::Custom {
+        let agent_key = Agent::Custom {
             name: "Test".into(),
         };
 
@@ -4486,7 +4491,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection.as_ref().clone())),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     None,

--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -654,9 +654,8 @@ impl ConnectionView {
             .or_else(|| worktree_roots.first().cloned())
             .unwrap_or_else(|| paths::home_dir().as_path().into());
 
-        let connection_entry = connection_store.update(cx, |store, cx| {
-            store.request_connection(connection_key, agent.clone(), cx)
-        });
+        let connection_entry =
+            connection_store.update(cx, |store, cx| store.request_connection(connection_key, cx));
 
         let connection_entry_subscription =
             cx.subscribe(&connection_entry, |this, _entry, event, cx| match event {
@@ -2910,8 +2909,9 @@ pub(crate) mod tests {
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let thread_view = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -3022,8 +3022,9 @@ pub(crate) mod tests {
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let thread_view = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -3079,8 +3080,9 @@ pub(crate) mod tests {
         let captured_cwd = connection.captured_cwd.clone();
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let _thread_view = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -3134,8 +3136,9 @@ pub(crate) mod tests {
         let captured_cwd = connection.captured_cwd.clone();
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let _thread_view = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -3189,8 +3192,9 @@ pub(crate) mod tests {
         let captured_cwd = connection.captured_cwd.clone();
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let _thread_view = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -3505,8 +3509,9 @@ pub(crate) mod tests {
 
         // Set up thread view in workspace 1
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project1.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project1.clone(), thread_store.clone(), cx))
+        });
 
         let agent = StubAgentServer::default_response();
         let thread_view = cx.update(|window, cx| {
@@ -3726,8 +3731,9 @@ pub(crate) mod tests {
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let agent_key = ExternalAgent::Custom {
             name: "Test".into(),
@@ -4470,8 +4476,9 @@ pub(crate) mod tests {
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
 
         let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
-        let connection_store =
-            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+        let connection_store = cx.update(|_window, cx| {
+            cx.new(|cx| AgentConnectionStore::new(project.clone(), thread_store.clone(), cx))
+        });
 
         let connection = Rc::new(StubAgentConnection::new());
         let thread_view = cx.update(|window, cx| {

--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -281,7 +281,7 @@ impl InlineAssistant {
         let Some(history) = agent_panel
             .connection_store()
             .read(cx)
-            .entry(&crate::ExternalAgent::NativeAgent)
+            .entry(&crate::Agent::NativeAgent)
             .and_then(|s| s.read(cx).history().cloned())
         else {
             log::error!("No connection entry found for native agent");
@@ -1981,7 +1981,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
                 let history = panel
                     .connection_store()
                     .read(cx)
-                    .entry(&crate::ExternalAgent::NativeAgent)
+                    .entry(&crate::Agent::NativeAgent)
                     .and_then(|e| e.read(cx).history())
                     .context("no history found for native agent")?
                     .downgrade();


### PR DESCRIPTION
Also rename ExternalAgent to Agent, since the variant `NativeAgent` is not external.

Release Notes:

- N/A