### PR TITLE
agent_ui: Rename `ExternalAgent` to `Agent`

### DIFF
--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -9,7 +9,7 @@ use gpui::{AppContext, Context, Entity, EventEmitter, SharedString, Subscription
 use project::{AgentServerStore, AgentServersUpdated, Project};
 use watch::Receiver;
 
-use crate::{ExternalAgent, ThreadHistory};
+use crate::{Agent, ThreadHistory};
 use project::ExternalAgentServerName;
 
 pub enum AgentConnectionEntry {
@@ -53,7 +53,7 @@ impl EventEmitter<AgentConnectionEntryEvent> for AgentConnectionEntry {}
 
 pub struct AgentConnectionStore {
     project: Entity<Project>,
-    entries: HashMap<ExternalAgent, Entity<AgentConnectionEntry>>,
+    entries: HashMap<Agent, Entity<AgentConnectionEntry>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -68,13 +68,13 @@ impl AgentConnectionStore {
         }
     }
 
-    pub fn entry(&self, key: &ExternalAgent) -> Option<&Entity<AgentConnectionEntry>> {
+    pub fn entry(&self, key: &Agent) -> Option<&Entity<AgentConnectionEntry>> {
         self.entries.get(key)
     }
 
     pub fn request_connection(
         &mut self,
-        key: ExternalAgent,
+        key: Agent,
         server: Rc<dyn AgentServer>,
         cx: &mut Context<Self>,
     ) -> Entity<AgentConnectionEntry> {
@@ -142,8 +142,8 @@ impl AgentConnectionStore {
     ) {
         let store = store.read(cx);
         self.entries.retain(|key, _| match key {
-            ExternalAgent::NativeAgent => true,
-            ExternalAgent::Custom { name } => store
+            Agent::NativeAgent => true,
+            Agent::Custom { name } => store
                 .external_agents
                 .contains_key(&ExternalAgentServerName(name.clone())),
         });

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -42,7 +42,7 @@ use crate::{
     ui::EndTrialUpsell,
 };
 use crate::{
-    AgentInitialContent, ExternalAgent, ExternalSourcePrompt, NewExternalAgentThread,
+    Agent, AgentInitialContent, ExternalSourcePrompt, NewExternalAgentThread,
     NewNativeAgentThreadFromSummary,
 };
 use crate::{
@@ -738,11 +738,11 @@ impl AgentType {
     }
 }
 
-impl From<ExternalAgent> for AgentType {
-    fn from(value: ExternalAgent) -> Self {
+impl From<Agent> for AgentType {
+    fn from(value: Agent) -> Self {
         match value {
-            ExternalAgent::Custom { name } => Self::Custom { name },
-            ExternalAgent::NativeAgent => Self::NativeAgent,
+            Agent::Custom { name } => Self::Custom { name },
+            Agent::NativeAgent => Self::NativeAgent,
         }
     }
 }
@@ -1283,7 +1283,7 @@ impl AgentPanel {
         cx: &mut Context<Self>,
     ) {
         self.external_thread(
-            Some(crate::ExternalAgent::NativeAgent),
+            Some(crate::Agent::NativeAgent),
             Some(session_id),
             cwd,
             title,
@@ -1335,7 +1335,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let agent = ExternalAgent::NativeAgent;
+        let agent = Agent::NativeAgent;
 
         let server = agent.server(self.fs.clone(), self.thread_store.clone());
         let session_id = action.from_session_id.clone();
@@ -1417,7 +1417,7 @@ impl AgentPanel {
 
     fn external_thread(
         &mut self,
-        agent_choice: Option<crate::ExternalAgent>,
+        agent_choice: Option<crate::Agent>,
         resume_session_id: Option<acp::SessionId>,
         cwd: Option<PathBuf>,
         title: Option<SharedString>,
@@ -1435,7 +1435,7 @@ impl AgentPanel {
 
         #[derive(Serialize, Deserialize)]
         struct LastUsedExternalAgent {
-            agent: crate::ExternalAgent,
+            agent: crate::Agent,
         }
 
         let thread_store = self.thread_store.clone();
@@ -1473,7 +1473,7 @@ impl AgentPanel {
         } else {
             cx.spawn_in(window, async move |this, cx| {
                 let ext_agent = if is_via_collab {
-                    ExternalAgent::NativeAgent
+                    Agent::NativeAgent
                 } else {
                     cx.background_spawn(async move {
                         KEY_VALUE_STORE.read_kvp(LAST_USED_EXTERNAL_AGENT_KEY)
@@ -1485,7 +1485,7 @@ impl AgentPanel {
                         serde_json::from_str::<LastUsedExternalAgent>(&value).log_err()
                     })
                     .map(|agent| agent.agent)
-                    .unwrap_or(ExternalAgent::NativeAgent)
+                    .unwrap_or(Agent::NativeAgent)
                 };
 
                 let server = ext_agent.server(fs, thread_store);
@@ -1554,7 +1554,7 @@ impl AgentPanel {
         match &self.selected_agent {
             AgentType::TextThread | AgentType::NativeAgent => true,
             AgentType::Custom { name } => {
-                let agent = ExternalAgent::Custom { name: name.clone() };
+                let agent = Agent::Custom { name: name.clone() };
                 self.connection_store
                     .read(cx)
                     .entry(&agent)
@@ -1574,7 +1574,7 @@ impl AgentPanel {
                 let history = self
                     .connection_store
                     .read(cx)
-                    .entry(&ExternalAgent::NativeAgent)?
+                    .entry(&Agent::NativeAgent)?
                     .read(cx)
                     .history()?
                     .clone();
@@ -1584,7 +1584,7 @@ impl AgentPanel {
                 })
             }
             AgentType::Custom { name } => {
-                let agent = ExternalAgent::Custom { name: name.clone() };
+                let agent = Agent::Custom { name: name.clone() };
                 let history = self
                     .connection_store
                     .read(cx)
@@ -2376,10 +2376,10 @@ impl AgentPanel {
         cx.notify();
     }
 
-    fn selected_external_agent(&self) -> Option<ExternalAgent> {
+    fn selected_external_agent(&self) -> Option<Agent> {
         match &self.selected_agent {
-            AgentType::NativeAgent => Some(ExternalAgent::NativeAgent),
-            AgentType::Custom { name } => Some(ExternalAgent::Custom { name: name.clone() }),
+            AgentType::NativeAgent => Some(Agent::NativeAgent),
+            AgentType::Custom { name } => Some(Agent::Custom { name: name.clone() }),
             AgentType::TextThread => None,
         }
     }
@@ -2448,7 +2448,7 @@ impl AgentPanel {
                 window.dispatch_action(NewTextThread.boxed_clone(), cx);
             }
             AgentType::NativeAgent => self.external_thread(
-                Some(crate::ExternalAgent::NativeAgent),
+                Some(crate::Agent::NativeAgent),
                 None,
                 None,
                 None,
@@ -2458,7 +2458,7 @@ impl AgentPanel {
                 cx,
             ),
             AgentType::Custom { name } => self.external_thread(
-                Some(crate::ExternalAgent::Custom { name }),
+                Some(crate::Agent::Custom { name }),
                 None,
                 None,
                 None,
@@ -2544,7 +2544,7 @@ impl AgentPanel {
         initial_content: Option<AgentInitialContent>,
         workspace: WeakEntity<Workspace>,
         project: Entity<Project>,
-        ext_agent: ExternalAgent,
+        ext_agent: Agent,
         focus: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -4976,7 +4976,7 @@ impl rules_library::InlineAssistDelegate for PromptLibraryInlineAssist {
                 .read(cx)
                 .connection_store()
                 .read(cx)
-                .entry(&crate::ExternalAgent::NativeAgent)
+                .entry(&crate::Agent::NativeAgent)
                 .and_then(|s| s.read(cx).history())
             else {
                 log::error!("No connection entry found for native agent");
@@ -5158,7 +5158,7 @@ impl AgentPanel {
         let workspace = self.workspace.clone();
         let project = self.project.clone();
 
-        let ext_agent = ExternalAgent::Custom {
+        let ext_agent = Agent::Custom {
             name: server.name(),
         };
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -205,7 +205,7 @@ pub struct NewThread;
 #[serde(deny_unknown_fields)]
 pub struct NewExternalAgentThread {
     /// Which agent to use for the conversation.
-    agent: Option<ExternalAgent>,
+    agent: Option<Agent>,
 }
 
 #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
@@ -218,7 +218,7 @@ pub struct NewNativeAgentThreadFromSummary {
 // TODO unify this with AgentType
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ExternalAgent {
+pub enum Agent {
     NativeAgent,
     Custom { name: SharedString },
 }
@@ -227,7 +227,7 @@ pub enum ExternalAgent {
 // the registry: "claude_code" -> Custom { name: "claude-acp" }, "codex" -> Custom { name:
 // "codex-acp" }, "gemini" -> Custom { name: "gemini" }.
 // Can be removed at some point in the future and go back to #[derive(Deserialize)].
-impl<'de> serde::Deserialize<'de> for ExternalAgent {
+impl<'de> serde::Deserialize<'de> for Agent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -280,7 +280,7 @@ impl<'de> serde::Deserialize<'de> for ExternalAgent {
     }
 }
 
-impl ExternalAgent {
+impl Agent {
     pub fn server(
         &self,
         fs: Arc<dyn fs::Fs>,
@@ -752,20 +752,20 @@ mod tests {
         use project::agent_server_store::{CLAUDE_AGENT_NAME, CODEX_NAME, GEMINI_NAME};
 
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""claude_code""#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#""claude_code""#).unwrap(),
+            Agent::Custom {
                 name: CLAUDE_AGENT_NAME.into(),
             },
         );
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""codex""#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#""codex""#).unwrap(),
+            Agent::Custom {
                 name: CODEX_NAME.into(),
             },
         );
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""gemini""#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#""gemini""#).unwrap(),
+            Agent::Custom {
                 name: GEMINI_NAME.into(),
             },
         );
@@ -774,12 +774,12 @@ mod tests {
     #[test]
     fn test_deserialize_current_external_agent_variants() {
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#""native_agent""#).unwrap(),
-            ExternalAgent::NativeAgent,
+            serde_json::from_str::<Agent>(r#""native_agent""#).unwrap(),
+            Agent::NativeAgent,
         );
         assert_eq!(
-            serde_json::from_str::<ExternalAgent>(r#"{"custom":{"name":"my-agent"}}"#).unwrap(),
-            ExternalAgent::Custom {
+            serde_json::from_str::<Agent>(r#"{"custom":{"name":"my-agent"}}"#).unwrap(),
+            Agent::Custom {
                 name: "my-agent".into(),
             },
         );

--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -76,9 +76,9 @@ use crate::message_editor::{MessageEditor, MessageEditorEvent};
 use crate::profile_selector::{ProfileProvider, ProfileSelector};
 use crate::ui::{AgentNotification, AgentNotificationEvent};
 use crate::{
-    AgentDiffPane, AgentInitialContent, AgentPanel, AllowAlways, AllowOnce, AuthorizeToolCall,
-    ClearMessageQueue, CycleFavoriteModels, CycleModeSelector, CycleThinkingEffort,
-    EditFirstQueuedMessage, ExpandMessageEditor, ExternalAgent, Follow, KeepAll, NewThread,
+    Agent, AgentDiffPane, AgentInitialContent, AgentPanel, AllowAlways, AllowOnce,
+    AuthorizeToolCall, ClearMessageQueue, CycleFavoriteModels, CycleModeSelector,
+    CycleThinkingEffort, EditFirstQueuedMessage, ExpandMessageEditor, Follow, KeepAll, NewThread,
     OpenAddContextMenu, OpenAgentDiff, OpenHistory, RejectAll, RejectOnce,
     RemoveFirstQueuedMessage, SendImmediately, SendNextQueuedMessage, ToggleFastMode,
     ToggleProfileSelector, ToggleThinkingEffortMenu, ToggleThinkingMode, UndoLastReject,
@@ -309,7 +309,7 @@ impl EventEmitter<AcpServerViewEvent> for ConnectionView {}
 pub struct ConnectionView {
     agent: Rc<dyn AgentServer>,
     connection_store: Entity<AgentConnectionStore>,
-    connection_key: ExternalAgent,
+    connection_key: Agent,
     agent_server_store: Entity<AgentServerStore>,
     workspace: WeakEntity<Workspace>,
     project: Entity<Project>,
@@ -477,7 +477,7 @@ impl ConnectionView {
     pub fn new(
         agent: Rc<dyn AgentServer>,
         connection_store: Entity<AgentConnectionStore>,
-        connection_key: ExternalAgent,
+        connection_key: Agent,
         resume_session_id: Option<acp::SessionId>,
         cwd: Option<PathBuf>,
         title: Option<SharedString>,
@@ -597,7 +597,7 @@ impl ConnectionView {
     fn initial_state(
         agent: Rc<dyn AgentServer>,
         connection_store: Entity<AgentConnectionStore>,
-        connection_key: ExternalAgent,
+        connection_key: Agent,
         resume_session_id: Option<acp::SessionId>,
         cwd: Option<PathBuf>,
         title: Option<SharedString>,
@@ -2918,7 +2918,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::default_response()),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     None,
@@ -3030,7 +3030,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(ResumeOnlyAgentConnection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("resume-session")),
@@ -3087,7 +3087,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("session-1")),
@@ -3142,7 +3142,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("session-1")),
@@ -3197,7 +3197,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection)),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     Some(SessionId::new("session-1")),
@@ -3514,7 +3514,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(agent),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     None,
@@ -3729,7 +3729,7 @@ pub(crate) mod tests {
         let connection_store =
             cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
 
-        let agent_key = ExternalAgent::Custom {
+        let agent_key = Agent::Custom {
             name: "Test".into(),
         };
 
@@ -4479,7 +4479,7 @@ pub(crate) mod tests {
                 ConnectionView::new(
                     Rc::new(StubAgentServer::new(connection.as_ref().clone())),
                     connection_store,
-                    ExternalAgent::Custom {
+                    Agent::Custom {
                         name: "Test".into(),
                     },
                     None,

--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -281,7 +281,7 @@ impl InlineAssistant {
         let Some(history) = agent_panel
             .connection_store()
             .read(cx)
-            .entry(&crate::ExternalAgent::NativeAgent)
+            .entry(&crate::Agent::NativeAgent)
             .and_then(|s| s.read(cx).history().cloned())
         else {
             log::error!("No connection entry found for native agent");
@@ -1981,7 +1981,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
                 let history = panel
                     .connection_store()
                     .read(cx)
-                    .entry(&crate::ExternalAgent::NativeAgent)
+                    .entry(&crate::Agent::NativeAgent)
                     .and_then(|e| e.read(cx).history())
                     .context("no history found for native agent")?
                     .downgrade();


### PR DESCRIPTION
Name is confusing, since the `NativeAgent` variant is not an external agent

Release Notes:

- N/A 