### PR TITLE
editor: Fix gutter hitbox hover check

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1243,7 +1243,7 @@ impl EditorElement {
         let gutter_hitbox = &position_map.gutter_hitbox;
         let modifiers = event.modifiers;
         let text_hovered = text_hitbox.is_hovered(window);
-        let gutter_hovered = gutter_hitbox.bounds.contains(&event.position);
+        let gutter_hovered = gutter_hitbox.is_hovered(window);
         editor.set_gutter_hovered(gutter_hovered, cx);
         editor.show_mouse_cursor(cx);
 


### PR DESCRIPTION
The gutter hitbox would previously check the hover using the position, ignoring any occluding hitboxes rendered above it.

This would then trigger the crease toggles to show which should not happen in that case, since the gutter was not really hovered.

Release Notes:

- Fixed an issue where the crease toggles in the gutter would sometimes show when interacting with a popover present over the editor gutter.
