### PR TITLE
Forward CSS language server formatting settings

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13637,6 +13637,85 @@ async fn setup_range_format_test(
     (project, editor, cx, fake_server)
 }
 
+async fn setup_css_format_test(
+    capabilities: lsp::ServerCapabilities,
+    cx: &mut TestAppContext,
+) -> (
+    Entity<Project>,
+    Entity<Editor>,
+    &mut gpui::VisualTestContext,
+    lsp::FakeLanguageServer,
+) {
+    init_test(cx, |settings| {
+        settings.defaults.formatter = Some(FormatterList::Single(Formatter::LanguageServer(
+            settings::LanguageServerFormatterSpecifier::Current,
+        )))
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.css"), Default::default()).await;
+
+    let project = Project::test(fs, [path!("/").as_ref()], cx).await;
+
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(Arc::new(Language::new(
+        LanguageConfig {
+            name: "CSS".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["css".to_string()],
+                ..Default::default()
+            },
+            ..LanguageConfig::default()
+        },
+        None,
+    )));
+
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "CSS",
+        FakeLspAdapter {
+            name: "vscode-css-language-server",
+            capabilities,
+            ..Default::default()
+        },
+    );
+
+    update_test_project_settings(cx, &|project_settings| {
+        project_settings.lsp.0.insert(
+            "vscode-css-language-server".into(),
+            LspSettings {
+                binary: None,
+                initialization_options: None,
+                settings: Some(json!({
+                    "css": {
+                        "format": {
+                            "spaceAroundSelectorSeparator": true,
+                            "newlineBetweenSelectors": false,
+                        }
+                    }
+                })),
+                enable_lsp_tasks: true,
+                fetch: None,
+            },
+        );
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.css"), cx)
+        })
+        .await
+        .unwrap();
+
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), buffer, window, cx)
+    });
+
+    let fake_server = fake_servers.next().await.unwrap();
+
+    (project, editor, cx, fake_server)
+}
+
 #[gpui::test]
 async fn test_range_format_on_save_success(cx: &mut TestAppContext) {
     let (project, editor, cx, fake_server) = setup_range_format_test(cx).await;
@@ -13916,6 +13995,104 @@ async fn test_document_format_manual_trigger(cx: &mut TestAppContext) {
         editor.update(cx, |editor, cx| editor.text(cx)),
         "one\ntwo\nthree\n"
     );
+}
+
+#[gpui::test]
+async fn test_css_document_formatting_forwards_server_format_settings(cx: &mut TestAppContext) {
+    let (project, editor, cx, fake_server) = setup_css_format_test(
+        lsp::ServerCapabilities {
+            document_formatting_provider: Some(lsp::OneOf::Left(true)),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("body>main {}\n", window, cx)
+    });
+
+    let format = editor
+        .update_in(cx, |editor, window, cx| {
+            editor.perform_format(
+                project,
+                FormatTrigger::Manual,
+                FormatTarget::Buffers(editor.buffer().read(cx).all_buffers()),
+                window,
+                cx,
+            )
+        })
+        .unwrap();
+
+    fake_server
+        .set_request_handler::<lsp::request::Formatting, _, _>(move |params, _| async move {
+            assert_eq!(params.options.tab_size, 4);
+            assert_eq!(
+                params
+                    .options
+                    .properties
+                    .get("spaceAroundSelectorSeparator"),
+                Some(&lsp::FormattingProperty::Bool(true))
+            );
+            assert_eq!(
+                params.options.properties.get("newlineBetweenSelectors"),
+                Some(&lsp::FormattingProperty::Bool(false))
+            );
+            Ok(Some(Vec::new()))
+        })
+        .next()
+        .await;
+
+    format.await;
+}
+
+#[gpui::test]
+async fn test_css_range_formatting_forwards_server_format_settings(cx: &mut TestAppContext) {
+    let (project, editor, cx, fake_server) = setup_css_format_test(
+        lsp::ServerCapabilities {
+            document_range_formatting_provider: Some(lsp::OneOf::Left(true)),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("body>main {}\n", window, cx)
+    });
+
+    let format = editor
+        .update_in(cx, |editor, window, cx| {
+            editor.perform_format(
+                project,
+                FormatTrigger::Manual,
+                FormatTarget::Buffers(editor.buffer().read(cx).all_buffers()),
+                window,
+                cx,
+            )
+        })
+        .unwrap();
+
+    fake_server
+        .set_request_handler::<lsp::request::RangeFormatting, _, _>(move |params, _| async move {
+            assert_eq!(params.options.tab_size, 4);
+            assert_eq!(
+                params
+                    .options
+                    .properties
+                    .get("spaceAroundSelectorSeparator"),
+                Some(&lsp::FormattingProperty::Bool(true))
+            );
+            assert_eq!(
+                params.options.properties.get("newlineBetweenSelectors"),
+                Some(&lsp::FormattingProperty::Bool(false))
+            );
+            Ok(Some(Vec::new()))
+        })
+        .next()
+        .await;
+
+    format.await;
 }
 
 #[gpui::test]

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -6,7 +6,7 @@ use crate::{
     InlayHintLabel, InlayHintLabelPart, InlayHintLabelPartTooltip, InlayHintTooltip, Location,
     LocationLink, LspAction, LspPullDiagnostics, MarkupContent, PrepareRenameResponse,
     ProjectTransaction, PulledDiagnostics, ResolveState,
-    lsp_store::{LocalLspStore, LspFoldingRange, LspStore},
+    lsp_store::{LocalLspStore, LspFoldingRange, LspStore, language_server_settings_for},
 };
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
@@ -33,6 +33,7 @@ use lsp::{
     OneOf, RenameOptions, ServerCapabilities,
 };
 use serde_json::Value;
+use settings::SettingsLocation;
 use signature_help::{lsp_to_proto_signature, proto_to_lsp_signature};
 use std::{
     cmp::Reverse, collections::hash_map, mem, ops::Range, path::Path, str::FromStr, sync::Arc,
@@ -62,6 +63,55 @@ pub fn lsp_formatting_options(settings: &LanguageSettings) -> lsp::FormattingOpt
         insert_final_newline: Some(settings.ensure_final_newline_on_save),
         ..lsp::FormattingOptions::default()
     }
+}
+
+pub fn lsp_formatting_options_for_server(
+    settings: &LanguageSettings,
+    buffer: &Buffer,
+    language_server_name: &language::LanguageServerName,
+    cx: &App,
+) -> lsp::FormattingOptions {
+    let mut options = lsp_formatting_options(settings);
+
+    if language_server_name.as_ref() as &str != "vscode-css-language-server" {
+        return options;
+    }
+
+    let Some(file) = buffer.file() else {
+        return options;
+    };
+
+    let Some(language) = buffer.language() else {
+        return options;
+    };
+
+    let language_id = language.lsp_id();
+    if !matches!(language_id.as_str(), "css" | "scss" | "less") {
+        return options;
+    }
+
+    let settings_location = SettingsLocation {
+        worktree_id: file.worktree_id(cx),
+        path: file.path().as_ref(),
+    };
+
+    let Some(format_settings) =
+        language_server_settings_for(settings_location, language_server_name, cx)
+            .and_then(|settings| settings.settings.as_ref())
+            .and_then(|settings| settings.get(language_id.as_str()))
+            .and_then(|settings| settings.get("format"))
+            .and_then(Value::as_object)
+    else {
+        return options;
+    };
+
+    for (key, value) in format_settings {
+        if let Ok(property) = serde_json::from_value::<lsp::FormattingProperty>(value.clone()) {
+            options.properties.insert(key.clone(), property);
+        }
+    }
+
+    options
 }
 
 pub fn file_path_to_lsp_url(path: &Path) -> Result<lsp::Uri> {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2233,6 +2233,14 @@ impl LocalLspStore {
                 .global_lsp_settings
                 .get_request_timeout()
         });
+        let formatting_options = buffer_handle.read_with(cx, |buffer, cx| {
+            lsp_command::lsp_formatting_options_for_server(
+                settings,
+                buffer,
+                &language_server.name(),
+                cx,
+            )
+        });
         let lsp_edits = {
             let mut lsp_ranges = Vec::new();
             this.update(cx, |_this, cx| {
@@ -2256,7 +2264,7 @@ impl LocalLspStore {
                         lsp::DocumentRangeFormattingParams {
                             text_document: text_document.clone(),
                             range,
-                            options: lsp_command::lsp_formatting_options(settings),
+                            options: formatting_options.clone(),
                             work_done_progress_params: Default::default(),
                         },
                         request_timeout,
@@ -2317,6 +2325,14 @@ impl LocalLspStore {
                 .global_lsp_settings
                 .get_request_timeout()
         });
+        let formatting_options = buffer.read_with(cx, |buffer, cx| {
+            lsp_command::lsp_formatting_options_for_server(
+                settings,
+                buffer,
+                &language_server.name(),
+                cx,
+            )
+        });
 
         let lsp_edits = if matches!(formatting_provider, Some(p) if *p != OneOf::Left(false)) {
             let _timer = zlog::time!(logger => "format-full");
@@ -2324,7 +2340,7 @@ impl LocalLspStore {
                 .request::<lsp::request::Formatting>(
                     lsp::DocumentFormattingParams {
                         text_document,
-                        options: lsp_command::lsp_formatting_options(settings),
+                        options: formatting_options.clone(),
                         work_done_progress_params: Default::default(),
                     },
                     request_timeout,
@@ -2340,7 +2356,7 @@ impl LocalLspStore {
                     lsp::DocumentRangeFormattingParams {
                         text_document: text_document.clone(),
                         range: lsp::Range::new(buffer_start, buffer_end),
-                        options: lsp_command::lsp_formatting_options(settings),
+                        options: formatting_options,
                         work_done_progress_params: Default::default(),
                     },
                     request_timeout,


### PR DESCRIPTION
## Summary

Fixes #51378 by forwarding CSS language server formatting settings (e.g., `spaceAroundSelectorSeparator`, `newlineBetweenSelectors`) into formatting requests. This allows users to configure CSS formatting behavior through LSP settings.

## Changes

- Add `lsp_formatting_options_for_server()` function to extract and apply language server-specific format settings for CSS
- Update document formatting and range formatting calls to use the new function instead of generic options
- Add regression tests for CSS document and range formatting with server settings

## Validation

All tests pass:
- `cargo test -p editor test_css_document_formatting_forwards_server_format_settings` ✓
- `cargo test -p editor test_css_range_formatting_forwards_server_format_settings` ✓
- `cargo test -p editor test_document_format_manual_trigger` ✓
- `cargo check -p project -p editor --tests` ✓
- `./script/clippy -p project -p editor --tests` ✓

## Release Notes

- Fixed CSS formatting not respecting language server configuration settings (e.g., `css.format.spaceAroundSelectorSeparator`, `css.format.newlineBetweenSelectors`)