### PR TITLE
Use `-e` instead of `-c` when getting environment from nushell

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -73,13 +73,27 @@ async fn capture_unix(
             command.arg("-l");
         }
     }
+
+    match shell_kind {
+        // Nushell does not allow non-interactive login shells.
+        // Instead of doing "-l -i -c '<command>'"
+        // use "-l -e '<command>; exit'" instead
+        ShellKind::Nushell => command.arg("-e"),
+        _ => command.args(["-i", "-c"]),
+    };
+
     // cd into the directory, triggering directory specific side-effects (asdf, direnv, etc)
     command_string.push_str(&format!("cd '{}';", directory.display()));
     if let Some(prefix) = shell_kind.command_prefix() {
         command_string.push(prefix);
     }
     command_string.push_str(&format!("{} --printenv {}", zed_path, redir));
-    command.args(["-i", "-c", &command_string]);
+
+    if let ShellKind::Nushell = shell_kind {
+        command_string.push_str("; exit");
+    }
+
+    command.arg(&command_string);
 
     super::set_pre_exec_to_start_new_session(&mut command);
 


### PR DESCRIPTION
Closes #38200

Applied [suggestion](https://github.com/zed-industries/zed/issues/38200#issuecomment-3354159899) from issue to use `-l -e` instead of `-l -i -c` when running on nushell because of how it treats `-l` as implying interactive session. Using `-e` also means that command needs to end with `exit` to terminate shell manually. With this changes everything now works fine in my testing.

Before, zed fails to load environment variables and there is error in logs:

<img width="367" height="92" alt="image" src="https://github.com/user-attachments/assets/9ef08d06-a509-4c96-85fe-8291bfc95b39" />

<img width="1711" height="115" alt="image" src="https://github.com/user-attachments/assets/fe3a6248-6f73-4773-a2c8-db55a95aaec1" />

With this patch everything works fine and all language servers and stuff loads fine:

<img width="565" height="73" alt="image" src="https://github.com/user-attachments/assets/7477913d-42f9-41b0-a7b6-92831f406be4" />

Tested on nixos unstable. Nushell version 0.110.0 and 0.111.0. Zed version 0.223.3+stable and compiled from main fail. Zed from this branch works.

Release Notes:

- Fixed loading environment variables when nushell is used as shell
