### PR TITLE
gpui: Prevent vertical scrolling when horizontal scrolling is dominant on trackpad

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1151,6 +1151,10 @@ impl Element for List {
                 accumulated_scroll_delta = accumulated_scroll_delta.coalesce(event.delta);
                 let mut pixel_delta = accumulated_scroll_delta.pixel_delta(px(20.));
                 if pixel_delta.x.abs() > pixel_delta.y.abs() {
+                     accumulated_scroll_delta = match accumulated_scroll_delta {
+                         ScrollDelta::Pixels(p) => ScrollDelta::Pixels(point(p.x, px(0.))),
+                         ScrollDelta::Lines(p) => ScrollDelta::Lines(point(p.x, 0.)),
+                     };
                     pixel_delta.y = px(0.);
                 }
                 list_state.0.borrow_mut().scroll(

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1149,7 +1149,10 @@ impl Element for List {
         window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
             if phase == DispatchPhase::Bubble && hitbox_id.should_handle_scroll(window) {
                 accumulated_scroll_delta = accumulated_scroll_delta.coalesce(event.delta);
-                let pixel_delta = accumulated_scroll_delta.pixel_delta(px(20.));
+                let mut pixel_delta = accumulated_scroll_delta.pixel_delta(px(20.));
+                if pixel_delta.x.abs() > pixel_delta.y.abs() {
+                    pixel_delta.y = px(0.);
+                }
                 list_state.0.borrow_mut().scroll(
                     &scroll_top,
                     height,


### PR DESCRIPTION
Closes #40623
This is prevents vertical scrolling when horizontal scrolling is dominant on trackpad in agent panel.

Before: 

https://github.com/user-attachments/assets/d9e9fad9-51e9-482e-a1d8-f166e2143efe

After: 

https://github.com/user-attachments/assets/4ff09069-cda7-47af-acd2-b567276c46cf

How vscode handles it:

https://github.com/user-attachments/assets/11cc9d64-bef3-425e-9e79-462f25a91771

If u compare all three, you will notice even vscode has this issue, this PR reduces this issue to a decent extent, as I keep getting aggressive with scrolling we can see that in the end (in the second video) u can notice some vertical scrolling but I don't think we need to handle such cases but we need to change the current behaviour as it makes code very hard to read.


Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:
Prevents vertical scroll on horizontal scrolling.
- N/A *or* Added/Fixed/Improved ...
