### PR TITLE
Fix not being able to open the log file

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -278,12 +278,13 @@ fn main() {
 
     if stdout_is_a_pty() {
         zlog::init_output_stdout();
-    } else {
-        let result = zlog::init_output_file(paths::log_file(), Some(paths::old_log_file()));
-        if let Err(err) = result {
-            eprintln!("Could not open log file: {}... Defaulting to stdout", err);
+    }
+    let result = zlog::init_output_file(paths::log_file(), Some(paths::old_log_file()));
+    if let Err(err) = result {
+        eprintln!("Could not open log file: {}... Defaulting to stdout", err);
+        if !stdout_is_a_pty() {
             zlog::init_output_stdout();
-        };
+        }
     }
     ztracing::init();
 


### PR DESCRIPTION
Closes #51351

When Zed is launched from a terminal (e.g. `cargo run`), `stdout_is_a_pty()` returns `true` and only the stdout log sink was initialized — the file at `~/.local/share/zed/logs/Zed.log` was never created. Running **zed: open log** then failed with "No such file or directory".

The stdout and file sinks in `zlog` are independent. This change always initializes the file sink; the stdout sink is also enabled when running in a pty, so developer log output in the terminal is preserved.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Manual test video below :

[Screencast from 2026-03-13 01-45-24.webm](https://github.com/user-attachments/assets/aba7ca87-d66b-423e-81e1-bbeff308a94d)


Release Notes:

- Fixed "zed: open log" when Zed is launched from a terminal  (e.g. `cargo run`),

