### PR TITLE
Fix agent panel thread titles breaking layout with newlines

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2256,7 +2256,13 @@ impl AgentPanel {
                         .title
                         .as_ref()
                         .filter(|title| !title.is_empty())
-                        .cloned()
+                        .map(|t| {
+                            if t.contains('\n') || t.contains('\r') {
+                                SharedString::from(t.replace(['\n', '\r'], " "))
+                            } else {
+                                t.clone()
+                            }
+                        })
                         .unwrap_or_else(|| SharedString::new_static(DEFAULT_THREAD_TITLE));
 
                     menu = menu.entry(title, None, {
@@ -2298,6 +2304,8 @@ impl AgentPanel {
                 for entry in entries {
                     let title = if entry.title.is_empty() {
                         SharedString::new_static(DEFAULT_THREAD_TITLE)
+                    } else if entry.title.contains('\n') || entry.title.contains('\r') {
+                        SharedString::from(entry.title.replace(['\n', '\r'], " "))
                     } else {
                         entry.title.clone()
                     };

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -1435,9 +1435,26 @@ impl ThreadView {
                 }
 
                 let new_title = title_editor.read(cx).text(cx);
+
+                // Strip newlines that may have been pasted into the title,
+                // as multi-line titles break the layout in history lists and menus.
+                let sanitized_title: String = new_title
+                    .chars()
+                    .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+                    .collect();
+
+                // If the title was changed by sanitization, update the editor
+                // to reflect the cleaned title.
+                if sanitized_title != new_title {
+                    title_editor.update(cx, |editor, cx| {
+                        editor.set_text(&sanitized_title, window, cx);
+                    });
+                    return;
+                }
+
                 thread.update(cx, |thread, cx| {
                     thread
-                        .set_title(new_title.into(), cx)
+                        .set_title(sanitized_title.into(), cx)
                         .detach_and_log_err(cx);
                 })
             }

--- a/crates/agent_ui/src/text_thread_history.rs
+++ b/crates/agent_ui/src/text_thread_history.rs
@@ -17,11 +17,13 @@ use ui::{
 
 const DEFAULT_TITLE: &SharedString = &SharedString::new_static("New Thread");
 
-fn thread_title(entry: &SavedTextThreadMetadata) -> &SharedString {
+fn thread_title(entry: &SavedTextThreadMetadata) -> SharedString {
     if entry.title.is_empty() {
-        DEFAULT_TITLE
+        DEFAULT_TITLE.clone()
+    } else if entry.title.contains('\n') || entry.title.contains('\r') {
+        SharedString::from(entry.title.replace(['\n', '\r'], " "))
     } else {
-        &entry.title
+        entry.title.clone()
     }
 }
 

--- a/crates/agent_ui/src/thread_history_view.rs
+++ b/crates/agent_ui/src/thread_history_view.rs
@@ -18,12 +18,19 @@ use ui::{
 
 const DEFAULT_TITLE: &SharedString = &SharedString::new_static("New Thread");
 
-pub(crate) fn thread_title(entry: &AgentSessionInfo) -> &SharedString {
-    entry
+pub(crate) fn thread_title(entry: &AgentSessionInfo) -> SharedString {
+    let title = entry
         .title
         .as_ref()
-        .filter(|title| !title.is_empty())
-        .unwrap_or(DEFAULT_TITLE)
+        .filter(|title| !title.is_empty());
+
+    match title {
+        Some(t) if t.contains('\n') || t.contains('\r') => {
+            SharedString::from(t.replace(['\n', '\r'], " "))
+        }
+        Some(t) => t.clone(),
+        None => DEFAULT_TITLE.clone(),
+    }
 }
 
 pub struct ThreadHistoryView {

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -362,8 +362,17 @@ impl ThreadsArchiveView {
                 highlight_positions,
             } => {
                 let is_selected = self.selection == Some(ix);
-                let title: SharedString =
-                    session.title.clone().unwrap_or_else(|| "Untitled".into());
+                let title: SharedString = session
+                    .title
+                    .clone()
+                    .map(|t| {
+                        if t.contains('\n') || t.contains('\r') {
+                            SharedString::from(t.replace(['\n', '\r'], " "))
+                        } else {
+                            t
+                        }
+                    })
+                    .unwrap_or_else(|| "Untitled".into());
                 let session_info = session.clone();
                 let highlight_positions = highlight_positions.clone();
 


### PR DESCRIPTION
## Summary

Closes #51148

Thread titles containing newline characters (`\n`, `\r`) break the layout in the agent panel's recent threads menu, history list, and archive view. Titles render across multiple lines where single-line display is expected.

This fix sanitizes titles in two places:

- **At input time**: when users paste multi-line text into the title editor, newlines are replaced with spaces before saving to prevent corrupted titles from being stored
- **At display time**: `thread_title()` helpers and menu entry construction strip newlines from titles, handling any existing data that already contains newlines

### Files changed
| File | Change |
|------|--------|
| `agent_panel.rs` | Sanitize titles in recent agent + text thread menus |
| `thread_view.rs` | Sanitize pasted text in title editor on `BufferEdited` |
| `thread_history_view.rs` | Sanitize in `thread_title()` helper |
| `text_thread_history.rs` | Sanitize in `thread_title()` helper |
| `threads_archive_view.rs` | Sanitize in archive list entry rendering |

## Test plan

- [ ] Open agent panel, create a thread with a multi-line title (paste text containing newlines)
- [ ] Verify the title editor collapses newlines to spaces
- [ ] Verify recent threads dropdown renders titles on a single line
- [ ] Click "View All" and verify history list renders titles on a single line
- [ ] Verify archive view renders titles on a single line