### PR TITLE
settings: Fix incorrect worktree root for symlinked settings.json on Windows

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9093,6 +9093,9 @@ pub fn create_and_open_local_file(
                         .read_with(cx, |project, cx| project.try_windows_path_to_wsl(path, cx));
                     cx.spawn_in(window, async move |workspace, cx| {
                         let path = path.await?;
+
+                        let path = fs.canonicalize(&path).await.unwrap_or(path);
+
                         let mut items = workspace
                             .update_in(cx, |workspace, window, cx| {
                                 workspace.open_paths(


### PR DESCRIPTION
Closes #47007 

After #50974, symlinked `settings.json` can be opened and saved, but the worktree ends up rooted at the file itself rather than its parent directory, which causes this error to be logged when changing settings via the settings GUI:

```
2026-03-18T22:24:05+01:00 ERROR [worktree] ignoring event
"C:\\Users\\Bryan\\dev\\bryanpth\\dotfiles\\config\\zed\\settings.json~RF1ab7ae0.TMP" outside of root path
"C:\\Users\\Bryan\\dev\\bryanpth\\dotfiles\\config\\zed\\settings.json"
```

Fixed by canonicalizing the symlink path before passing to `open_paths`.
Tested with a symlinked settings.json, both directly and through WSL.

Release Notes:
- Fixed incorrect worktree root when settings.json is a symlink on Windows
