### PR TITLE
markdown: Fix block quote continuation highlighting

### DIFF
--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -21,7 +21,10 @@
   (list_marker_parenthesis)
 ] @punctuation.list_marker.markup
 
-(block_quote_marker) @punctuation.markup
+[
+  (block_quote_marker)
+  (block_continuation)
+] @punctuation.markup
 
 (pipe_table_header
   "|" @punctuation.markup)


### PR DESCRIPTION
There is no highlight for block quotes continued on multiple lines

Currently, the ">" on lines 2 and 3 are not highlighted in the same way as line 1
<img width="291" height="73" alt="image" src="https://github.com/user-attachments/assets/7a2f2e25-6ee1-40a6-8833-f06ca7ee6ba9" />

After this PR,
<img width="249" height="75" alt="image" src="https://github.com/user-attachments/assets/34a2971f-8061-4d92-ac45-a8043d5d0566" />


for this input
```md
> abcd
>
> abcd
```

tree-sitter produces this 
```
(document [0, 0] - [3, 0]
  (section [0, 0] - [3, 0]
    (block_quote [0, 0] - [3, 0]
      (block_quote_marker [0, 0] - [0, 2])
      (paragraph [0, 2] - [1, 1]
        (inline [0, 2] - [0, 6])
        (block_continuation [1, 0] - [1, 1]))
      (block_continuation [2, 0] - [2, 2])
      (paragraph [2, 2] - [3, 0]
        (inline [2, 2] - [2, 6])))))
```

the screenshots in #43043 also show this issue

Release Notes:

- Fixed highlighting of block quotes continued over multiple lines in markdown files