### PR TITLE
Revert "project: Support resolving paths with worktree names prefixed"

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1890,69 +1890,6 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_hover_filenames_with_worktree_prefix(cx: &mut gpui::TestAppContext) {
-        init_test(cx, |_| {});
-        let mut cx = EditorLspTestContext::new_rust(
-            lsp::ServerCapabilities {
-                ..Default::default()
-            },
-            cx,
-        )
-        .await;
-
-        let fs = cx.update_workspace(|workspace, _, cx| workspace.project().read(cx).fs().clone());
-        fs.as_fake()
-            .insert_file(
-                path!("/root/dir/file2.rs"),
-                "This is file2.rs".as_bytes().to_vec(),
-            )
-            .await;
-
-        #[cfg(not(target_os = "windows"))]
-        cx.set_state(indoc! {"
-            Go to root/dir/file2.rs if you want.ˇ
-        "});
-        #[cfg(target_os = "windows")]
-        cx.set_state(indoc! {"
-            Go to root/dir/file2.rs if you want.ˇ
-        "});
-
-        let screen_coord = cx.pixel_position(indoc! {"
-            Go to root/diˇr/file2.rs if you want.
-        "});
-
-        cx.simulate_mouse_move(screen_coord, None, Modifiers::secondary_key());
-        cx.assert_editor_text_highlights(
-            HighlightKey::HoveredLinkState,
-            indoc! {"
-            Go to «root/dir/file2.rsˇ» if you want.
-        "},
-        );
-
-        cx.simulate_click(screen_coord, Modifiers::secondary_key());
-
-        cx.update_workspace(|workspace, _, cx| assert_eq!(workspace.items(cx).count(), 2));
-        cx.update_workspace(|workspace, _, cx| {
-            let active_editor = workspace.active_item_as::<Editor>(cx).unwrap();
-
-            let buffer = active_editor
-                .read(cx)
-                .buffer()
-                .read(cx)
-                .as_singleton()
-                .unwrap();
-
-            let file = buffer.read(cx).file().unwrap();
-            let file_path = file.as_local().unwrap().abs_path(cx);
-
-            assert_eq!(
-                file_path,
-                std::path::PathBuf::from(path!("/root/dir/file2.rs"))
-            );
-        });
-    }
-
-    #[gpui::test]
     async fn test_hover_directories(cx: &mut gpui::TestAppContext) {
         init_test(cx, |_| {});
         let mut cx = EditorLspTestContext::new_rust(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4590,53 +4590,30 @@ impl Project {
         let worktrees_with_ids: Vec<_> = self
             .worktrees(cx)
             .map(|worktree| {
-                let read = worktree.read(cx);
-                let id = read.id();
-                (
-                    worktree,
-                    id,
-                    read.is_visible().then(|| read.root_name_arc()),
-                )
+                let id = worktree.read(cx).id();
+                (worktree, id)
             })
             .collect();
 
         cx.spawn(async move |_, cx| {
             if let Some(buffer_worktree_id) = buffer_worktree_id
-                && let Some((worktree, _, root_name)) = worktrees_with_ids
+                && let Some((worktree, _)) = worktrees_with_ids
                     .iter()
-                    .find(|(_, id, _)| *id == buffer_worktree_id)
+                    .find(|(_, id)| *id == buffer_worktree_id)
             {
                 for candidate in candidates.iter() {
                     if let Some(path) = Self::resolve_path_in_worktree(worktree, candidate, cx) {
                         return Some(path);
                     }
-                    if let Some(root_name) = root_name {
-                        if let Ok(candidate) = candidate.strip_prefix(root_name) {
-                            if let Some(path) =
-                                Self::resolve_path_in_worktree(worktree, candidate, cx)
-                            {
-                                return Some(path);
-                            }
-                        }
-                    }
                 }
             }
-            for (worktree, id, root_name) in worktrees_with_ids {
+            for (worktree, id) in worktrees_with_ids {
                 if Some(id) == buffer_worktree_id {
                     continue;
                 }
                 for candidate in candidates.iter() {
                     if let Some(path) = Self::resolve_path_in_worktree(&worktree, candidate, cx) {
                         return Some(path);
-                    }
-                    if let Some(root_name) = &root_name {
-                        if let Ok(candidate) = candidate.strip_prefix(root_name) {
-                            if let Some(path) =
-                                Self::resolve_path_in_worktree(&worktree, candidate, cx)
-                            {
-                                return Some(path);
-                            }
-                        }
                     }
                 }
             }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2466,10 +2466,6 @@ impl Snapshot {
         &self.root_name
     }
 
-    pub fn root_name_arc(&self) -> Arc<RelPath> {
-        self.root_name.clone()
-    }
-
     pub fn root_name_str(&self) -> &str {
         self.root_name.as_unix_str()
     }


### PR DESCRIPTION
Reverts zed-industries/zed#50692

The test here doesn't pass, unsure how this managed to even get merged