### PR TITLE
Give remote terminal sessions persistent IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13129,6 +13129,7 @@ dependencies = [
  "unindent",
  "url",
  "util",
+ "uuid",
  "watch",
  "wax",
  "which 6.0.3",
@@ -17294,6 +17295,7 @@ dependencies = [
  "urlencoding",
  "util",
  "util_macros",
+ "uuid",
  "windows 0.61.3",
 ]
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2901,6 +2901,7 @@ mod tests {
                     cx,
                     vec![],
                     PathStyle::local(),
+                    None,
                 )
             })
             .await

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -92,6 +92,7 @@ text.workspace = true
 toml.workspace = true
 url.workspace = true
 util.workspace = true
+uuid.workspace = true
 watch.workspace = true
 wax.workspace = true
 which.workspace = true

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -192,6 +192,7 @@ impl Project {
                                         env,
                                         path,
                                         remote_client,
+                                        "",
                                         cx,
                                     )?
                                 }
@@ -203,6 +204,7 @@ impl Project {
                                     env,
                                     path,
                                     remote_client,
+                                    "",
                                     cx,
                                 )?,
                             },
@@ -256,6 +258,7 @@ impl Project {
                         cx,
                         activation_script,
                         path_style,
+                        None,
                     ))
                 })??
                 .await?;
@@ -290,7 +293,7 @@ impl Project {
         cwd: Option<PathBuf>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
-        self.create_terminal_shell_internal(cwd, false, cx)
+        self.create_terminal_shell_internal(cwd, false, None, cx)
     }
 
     /// Creates a local terminal even if the project is remote.
@@ -307,7 +310,16 @@ impl Project {
             // Local project: use project directory like normal terminals
             self.active_project_directory(cx).map(|p| p.to_path_buf())
         };
-        self.create_terminal_shell_internal(working_directory, true, cx)
+        self.create_terminal_shell_internal(working_directory, true, None, cx)
+    }
+
+    pub fn create_terminal_shell_with_id(
+        &mut self,
+        cwd: Option<PathBuf>,
+        terminal_id: String,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Terminal>>> {
+        self.create_terminal_shell_internal(cwd, false, Some(terminal_id), cx)
     }
 
     /// Internal method for creating terminal shells.
@@ -317,6 +329,7 @@ impl Project {
         &mut self,
         cwd: Option<PathBuf>,
         force_local: bool,
+        terminal_id: Option<String>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
         let path = cwd.map(|p| Arc::from(&*p));
@@ -372,6 +385,8 @@ impl Project {
 
         let lang_registry = self.languages.clone();
         cx.spawn(async move |project, cx| {
+            let terminal_id =
+                terminal_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
             let shell_kind = ShellKind::new(&shell, path_style.is_windows());
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
@@ -400,7 +415,7 @@ impl Project {
                     let (shell, env) = {
                         match remote_client {
                             Some(remote_client) => {
-                                create_remote_shell(None, env, path, remote_client, cx)?
+                                create_remote_shell(None, env, path, remote_client, &terminal_id, cx)?
                             }
                             None => (settings.shell, env),
                         }
@@ -421,6 +436,7 @@ impl Project {
                         cx,
                         activation_script,
                         path_style,
+                        Some(terminal_id),
                     ))
                 })??
                 .await?;
@@ -609,9 +625,10 @@ fn create_remote_shell(
     mut env: HashMap<String, String>,
     working_directory: Option<Arc<Path>>,
     remote_client: Entity<RemoteClient>,
+    terminal_id: &str,
     cx: &mut App,
 ) -> Result<(Shell, HashMap<String, String>)> {
-    insert_zed_terminal_env(&mut env, &release_channel::AppVersion::global(cx));
+    insert_zed_terminal_env(&mut env, &release_channel::AppVersion::global(cx), terminal_id);
 
     let (program, args) = match spawn_command {
         Some((program, args)) => (Some(program.clone()), args),

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -40,6 +40,7 @@ theme.workspace = true
 thiserror.workspace = true
 url.workspace = true
 util.workspace = true
+uuid.workspace = true
 urlencoding.workspace = true
 parking_lot.workspace = true
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -140,6 +140,7 @@ pub enum Event {
     Wakeup,
     BlinkChanged(bool),
     SelectionsChanged,
+    SshDisconnect,
     NewNavigationTarget(Option<MaybeNavigationTarget>),
     Open(MaybeNavigationTarget),
 }
@@ -2252,7 +2253,11 @@ impl Terminal {
         let task = match &mut self.task {
             Some(task) => task,
             None => {
-                if self.child_exited.is_none_or(|e| e.code() == Some(0)) {
+                if self.is_remote_terminal
+                    && self.child_exited.is_some_and(|e| e.code() == Some(255))
+                {
+                    cx.emit(Event::SshDisconnect);
+                } else if self.child_exited.is_none_or(|e| e.code() == Some(0)) {
                     cx.emit(Event::CloseTerminal);
                 }
                 return;

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -120,12 +120,14 @@ const DEBUG_LINE_HEIGHT: Pixels = px(5.);
 pub fn insert_zed_terminal_env(
     env: &mut HashMap<String, String>,
     version: &impl std::fmt::Display,
+    terminal_id: &str,
 ) {
     env.insert("ZED_TERM".to_string(), "true".to_string());
     env.insert("TERM_PROGRAM".to_string(), "zed".to_string());
     env.insert("TERM".to_string(), "xterm-256color".to_string());
     env.insert("COLORTERM".to_string(), "truecolor".to_string());
     env.insert("TERM_PROGRAM_VERSION".to_string(), version.to_string());
+    env.insert("ZED_TAB_ID".to_string(), terminal_id.to_string());
 }
 
 ///Upward flowing events, for changing the title and such
@@ -395,6 +397,7 @@ impl TerminalBuilder {
             hyperlink_regex_searches: RegexSearches::default(),
             vi_mode_enabled: false,
             is_remote_terminal: false,
+            terminal_id: uuid::Uuid::new_v4().to_string(),
             last_mouse_move_time: Instant::now(),
             last_hyperlink_search_position: None,
             mouse_down_hyperlink: None,
@@ -410,6 +413,7 @@ impl TerminalBuilder {
                 path_hyperlink_regexes: Vec::default(),
                 path_hyperlink_timeout_ms: 0,
                 window_id,
+                terminal_id: uuid::Uuid::new_v4().to_string(),
             },
             child_exited: None,
             event_loop_task: Task::ready(Ok(())),
@@ -441,10 +445,14 @@ impl TerminalBuilder {
         cx: &App,
         activation_script: Vec<String>,
         path_style: PathStyle,
+        terminal_id: Option<String>,
     ) -> Task<Result<TerminalBuilder>> {
         let version = release_channel::AppVersion::global(cx);
         let background_executor = cx.background_executor().clone();
         let fut = async move {
+            let terminal_id =
+                terminal_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
             // Remove SHLVL so the spawned shell initializes it to 1, matching
             // the behavior of standalone terminal emulators like iTerm2/Kitty/Alacritty.
             env.remove("SHLVL");
@@ -458,7 +466,7 @@ impl TerminalBuilder {
                     .or_insert_with(|| "en_US.UTF-8".to_string());
             }
 
-            insert_zed_terminal_env(&mut env, &version);
+            insert_zed_terminal_env(&mut env, &version, &terminal_id);
 
             #[derive(Default)]
             struct ShellParams {
@@ -628,6 +636,7 @@ impl TerminalBuilder {
                 ),
                 vi_mode_enabled: false,
                 is_remote_terminal,
+                terminal_id: terminal_id.clone(),
                 last_mouse_move_time: Instant::now(),
                 last_hyperlink_search_position: None,
                 mouse_down_hyperlink: None,
@@ -643,6 +652,7 @@ impl TerminalBuilder {
                     path_hyperlink_regexes,
                     path_hyperlink_timeout_ms,
                     window_id,
+                    terminal_id,
                 },
                 child_exited: None,
                 event_loop_task: Task::ready(Ok(())),
@@ -863,6 +873,7 @@ pub struct Terminal {
     task: Option<TaskState>,
     vi_mode_enabled: bool,
     is_remote_terminal: bool,
+    terminal_id: String,
     last_mouse_move_time: Instant,
     last_hyperlink_search_position: Option<Point<Pixels>>,
     mouse_down_hyperlink: Option<(String, bool, Match)>,
@@ -887,6 +898,7 @@ struct CopyTemplate {
     path_hyperlink_regexes: Vec<String>,
     path_hyperlink_timeout_ms: u64,
     window_id: u64,
+    terminal_id: String,
 }
 
 #[derive(Debug)]
@@ -2292,6 +2304,10 @@ impl Terminal {
         self.vi_mode_enabled
     }
 
+    pub fn terminal_id(&self) -> &str {
+        &self.terminal_id
+    }
+
     pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Task<Result<TerminalBuilder>> {
         let working_directory = self.working_directory().or_else(|| cwd);
         TerminalBuilder::new(
@@ -2310,6 +2326,7 @@ impl Terminal {
             cx,
             self.activation_script.clone(),
             self.path_style,
+            Some(self.template.terminal_id.clone()),
         )
     }
 }
@@ -2597,6 +2614,7 @@ mod tests {
                     cx,
                     vec![],
                     PathStyle::local(),
+                    None,
                 )
             })
             .await
@@ -2743,6 +2761,7 @@ mod tests {
                     cx,
                     Vec::new(),
                     PathStyle::local(),
+                    None,
                 )
             })
             .await
@@ -2819,6 +2838,7 @@ mod tests {
                     cx,
                     Vec::new(),
                     PathStyle::local(),
+                    None,
                 )
             })
             .await
@@ -3307,6 +3327,7 @@ mod tests {
                         cx,
                         vec![],
                         PathStyle::local(),
+                        None,
                     )
                 })
                 .await

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -422,6 +422,9 @@ impl Domain for TerminalDb {
         sql! (
             ALTER TABLE terminals ADD COLUMN custom_title TEXT;
         ),
+        sql! (
+            ALTER TABLE terminals ADD COLUMN terminal_uuid TEXT;
+        ),
     ];
 }
 
@@ -509,6 +512,34 @@ impl TerminalDb {
     query! {
         pub fn get_custom_title(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<String>> {
             SELECT custom_title
+            FROM terminals
+            WHERE item_id = ? AND workspace_id = ?
+        }
+    }
+
+    pub async fn save_terminal_uuid(
+        &self,
+        item_id: ItemId,
+        workspace_id: WorkspaceId,
+        terminal_uuid: String,
+    ) -> Result<()> {
+        self.write(move |conn| {
+            let query = "INSERT INTO terminals (item_id, workspace_id, terminal_uuid)
+                VALUES (?1, ?2, ?3)
+                ON CONFLICT (workspace_id, item_id) DO UPDATE SET
+                    terminal_uuid = excluded.terminal_uuid";
+            let mut statement = Statement::prepare(conn, query)?;
+            let mut next_index = statement.bind(&item_id, 1)?;
+            next_index = statement.bind(&workspace_id, next_index)?;
+            statement.bind(&terminal_uuid, next_index)?;
+            statement.exec()
+        })
+        .await
+    }
+
+    query! {
+        pub fn get_terminal_uuid(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<String>> {
+            SELECT terminal_uuid
             FROM terminals
             WHERE item_id = ? AND workspace_id = ?
         }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -287,7 +287,7 @@ impl TerminalView {
             block_below_cursor: None,
             scroll_top: Pixels::ZERO,
             scroll_handle,
-            needs_serialize: false,
+            needs_serialize: true,
             custom_title: None,
             ime_state: None,
             self_handle: cx.entity().downgrade(),
@@ -1724,6 +1724,7 @@ impl SerializableItem for TerminalView {
         let workspace_id = self.workspace_id?;
         let cwd = terminal.working_directory();
         let custom_title = self.custom_title.clone();
+        let terminal_uuid = terminal.terminal_id().to_string();
         self.needs_serialize = false;
 
         Some(cx.background_spawn(async move {
@@ -1734,6 +1735,9 @@ impl SerializableItem for TerminalView {
             }
             TERMINAL_DB
                 .save_custom_title(item_id, workspace_id, custom_title)
+                .await?;
+            TERMINAL_DB
+                .save_terminal_uuid(item_id, workspace_id, terminal_uuid)
                 .await?;
             Ok(())
         }))
@@ -1752,7 +1756,7 @@ impl SerializableItem for TerminalView {
         cx: &mut App,
     ) -> Task<anyhow::Result<Entity<Self>>> {
         window.spawn(cx, async move |cx| {
-            let (cwd, custom_title) = cx
+            let (cwd, custom_title, terminal_uuid) = cx
                 .update(|_window, cx| {
                     let from_db = TERMINAL_DB
                         .get_working_directory(item_id, workspace_id)
@@ -1773,13 +1777,24 @@ impl SerializableItem for TerminalView {
                         .log_err()
                         .flatten()
                         .filter(|title| !title.trim().is_empty());
-                    (cwd, custom_title)
+                    let terminal_uuid = TERMINAL_DB
+                        .get_terminal_uuid(item_id, workspace_id)
+                        .log_err()
+                        .flatten()
+                        .filter(|uuid| !uuid.trim().is_empty());
+                    (cwd, custom_title, terminal_uuid)
                 })
                 .ok()
-                .unwrap_or((None, None));
+                .unwrap_or((None, None, None));
 
             let terminal = project
-                .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                .update(cx, |project, cx| {
+                    if let Some(terminal_uuid) = terminal_uuid {
+                        project.create_terminal_shell_with_id(cwd, terminal_uuid, cx)
+                    } else {
+                        project.create_terminal_shell(cwd, cx)
+                    }
+                })
                 .await?;
             cx.update(|window, cx| {
                 cx.new(|cx| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -145,6 +145,8 @@ pub struct TerminalView {
     scroll_handle: TerminalScrollHandle,
     ime_state: Option<ImeState>,
     self_handle: WeakEntity<Self>,
+    reconnect_task: Option<Task<()>>,
+    is_ssh_disconnected: bool,
     rename_editor: Option<Entity<Editor>>,
     rename_editor_subscription: Option<Subscription>,
     _subscriptions: Vec<Subscription>,
@@ -289,6 +291,8 @@ impl TerminalView {
             scroll_handle,
             needs_serialize: true,
             custom_title: None,
+            reconnect_task: None,
+            is_ssh_disconnected: false,
             ime_state: None,
             self_handle: cx.entity().downgrade(),
             rename_editor: None,
@@ -953,6 +957,46 @@ impl TerminalView {
         self.terminal = terminal;
     }
 
+    fn attempt_ssh_reconnect(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let terminal_id = self.terminal.read(cx).terminal_id().to_string();
+        let project = self.project.clone();
+
+        self.reconnect_task = Some(cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_secs(2))
+                .await;
+
+            let task = project.update(cx, |project, cx| {
+                project.create_terminal_shell_with_id(None, terminal_id, cx)
+            });
+
+            let result = match task {
+                Ok(task) => task.await,
+                Err(error) => Err(error),
+            };
+
+            match result {
+                Ok(new_terminal) => {
+                    this.update_in(cx, |this, window, cx| {
+                        this.set_terminal(new_terminal, window, cx);
+                        this.is_ssh_disconnected = false;
+                        this.reconnect_task = None;
+                        cx.emit(ItemEvent::UpdateTab);
+                        cx.notify();
+                    })
+                    .ok();
+                }
+                Err(error) => {
+                    log::error!("SSH reconnect failed: {error:?}");
+                    this.update(cx, |this, _cx| {
+                        this.reconnect_task = None;
+                    })
+                    .ok();
+                }
+            }
+        }));
+    }
+
     fn rerun_button(task: &TaskState) -> Option<IconButton> {
         if !task.spawned_task.show_rerun {
             return None;
@@ -1093,6 +1137,12 @@ fn subscribe_for_terminal_events(
                 },
                 Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
                 Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
+                Event::SshDisconnect => {
+                    terminal_view.is_ssh_disconnected = true;
+                    cx.emit(ItemEvent::UpdateTab);
+                    cx.notify();
+                    terminal_view.attempt_ssh_reconnect(window, cx);
+                }
                 Event::SelectionsChanged => {
                     window.invalidate_character_coordinates();
                     cx.emit(SearchEvent::ActiveMatchChanged)
@@ -1348,7 +1398,13 @@ impl Item for TerminalView {
                     }
                 }
             },
-            None => (IconName::Terminal, Color::Muted, None),
+            None => {
+                if self.is_ssh_disconnected {
+                    (IconName::Disconnected, Color::Warning, None)
+                } else {
+                    (IconName::Terminal, Color::Muted, None)
+                }
+            }
         };
 
         h_flex()

--- a/docs/src/terminal/session-persistence.md
+++ b/docs/src/terminal/session-persistence.md
@@ -1,0 +1,76 @@
+# Terminal Session Persistence with ZED_TAB_ID
+
+Zed injects a `ZED_TAB_ID` environment variable into every terminal session — a stable UUID that persists across workspace restores and SSH reconnects. You can use it to automatically attach to a named tmux or zellij session, so closing and reopening Zed (or reconnecting after an SSH drop) resumes exactly where you left off.
+
+## tmux
+
+### bash / zsh
+
+Add to `~/.bashrc` or `~/.zshrc`:
+
+```sh
+if [ -n "$ZED_TAB_ID" ]; then
+  if [ -z "$TMUX" ]; then
+    exec tmux new-session -A -s "$ZED_TAB_ID"
+  fi
+fi
+```
+
+### fish
+
+Add to `~/.config/fish/config.fish`:
+
+```fish
+if set -q ZED_TAB_ID; and not set -q TMUX
+    exec tmux new-session -A -s "$ZED_TAB_ID"
+end
+```
+
+## zellij
+
+Zellij works best inside Zed with a minimal config that starts your shell directly, locks the UI (so keybindings don't conflict with Zed), and hides the default bars.
+
+Create `~/.config/zellij/config.kdl` (or add to your existing config):
+
+```kdl
+// Start in locked mode so zellij keybindings don't conflict with Zed
+default_mode "locked"
+
+// Use fish (or your preferred shell)
+default_shell "fish"
+
+// Minimal UI — Zed already provides tabs, scrollback, etc.
+default_layout "compact"
+pane_frames false
+simplified_ui true
+```
+
+### bash / zsh
+
+Add to `~/.bashrc` or `~/.zshrc`:
+
+```sh
+if [ -n "$ZED_TAB_ID" ]; then
+  if [ -z "$ZELLIJ" ]; then
+    exec zellij attach --create "$ZED_TAB_ID"
+  fi
+fi
+```
+
+### fish
+
+Add to `~/.config/fish/config.fish`:
+
+```fish
+if set -q ZED_TAB_ID; and not set -q ZELLIJ
+    exec zellij attach --create "$ZED_TAB_ID"
+end
+```
+
+## How it works
+
+- `ZED_TAB_ID` is set to a UUID like `a1b2c3d4-e5f6-...` before the shell starts.
+- `tmux new-session -A -s` / `zellij attach --create` attaches to an existing session with that name, or creates one if it doesn't exist.
+- The `exec` replaces the shell process so that exiting tmux/zellij closes the terminal tab cleanly.
+- The `TMUX` / `ZELLIJ` guard prevents nesting when you're already inside a session.
+- The UUID is persisted to Zed's database, so reopening the workspace reuses the same ID and reattaches to the same session.


### PR DESCRIPTION
Solves https://github.com/zed-industries/zed/issues/20589 although in a hacky way.

Every tab gets assigned a random UUID on creation. This `ZED_TAB_ID` value persists across restarts and reconnects.

Then user can set their `.bashrc` / `.zshrc` / `config.fish` to automatically reattach to tmux or zellij session with that ID.

Works great, but this PR is 100% vibe coded, I have no intention of continuing working on it. I'm opening a PR just for archival purposes (so I can delete my fork). If anyone wants to pick it up and make something merge-able, that'd be awesome.

The only downside is that you lose native scrollback, and have to rely on tmux's or zellij's.

There are 2 obvious better solutions:
1. Keep terminal state in zed-server, like VSCode does. Serialize it on zed-server updates and restarts. That's a big change though.
2. Stay with this approach, but use `tmux -CC` instead of regular tmux, and interpret it client-side. This way we could have native scrollback back. However, it may be difficult to implement with Alacritty. Recently WezTerm and Ghostty started implementing native tmux CC support, if you are open to changing the terminal lib.

## Demo:

```
cargo build
./target/debug/zed
<projects: open remote>
echo Hello from previous session!
<workspace: reload>
```

Zed restarts and reconnects to same session:

<img width="1990" height="986" alt="image" src="https://github.com/user-attachments/assets/e421698e-0800-46f5-bbe9-2a39942b3629" />

```
$ env $ZED_TAB_ID
00e035cf-c527-40c5-9757-d148b0b9062e
```