### PR TITLE
agent_ui: Add branch diff menu item to context menu

### DIFF
--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -3557,6 +3557,7 @@ impl ThreadView {
         let message_editor = self.message_editor.clone();
         let workspace = self.workspace.clone();
         let supports_images = self.prompt_capabilities.borrow().image;
+        let supports_embedded_context = self.prompt_capabilities.borrow().embedded_context;
 
         let has_editor_selection = workspace
             .upgrade()
@@ -3669,6 +3670,22 @@ impl ThreadView {
                                     zed_actions::agent::AddSelectionToThread.boxed_clone(),
                                     cx,
                                 );
+                            }
+                        }),
+                )
+                .item(
+                    ContextMenuEntry::new("Branch Diff")
+                        .icon(IconName::GitBranch)
+                        .icon_color(Color::Muted)
+                        .icon_size(IconSize::XSmall)
+                        .disabled(!supports_embedded_context)
+                        .handler({
+                            let message_editor = message_editor.clone();
+                            move |window, cx| {
+                                message_editor.focus_handle(cx).focus(window, cx);
+                                message_editor.update(cx, |editor, cx| {
+                                    editor.insert_context_type("diff", window, cx);
+                                });
                             }
                         }),
                 )

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -3680,7 +3680,6 @@ impl ThreadView {
                         .icon_size(IconSize::XSmall)
                         .disabled(!supports_embedded_context)
                         .handler({
-                            let message_editor = message_editor.clone();
                             move |window, cx| {
                                 message_editor.focus_handle(cx).focus(window, cx);
                                 message_editor.update(cx, |editor, cx| {


### PR DESCRIPTION
This PR adds the recently introduced "branch diff" mention option to the "Add Context" menu in the message editor:

<img width="450" height="582" alt="Screenshot 2026-03-13 at 9  58@2x" src="https://github.com/user-attachments/assets/1f5102e7-9018-4a5b-992d-43befa55dcbe" />

Release Notes:

- N/A
