### PR TITLE
git_ui: Don't display the merge conflict notification if an agent is running

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -507,6 +507,14 @@ pub fn init(cx: &mut App) {
         },
     )
     .detach();
+
+    cx.set_global(workspace::AgentActivityCallbacks {
+        is_generating_in_workspace: |workspace, cx| {
+            workspace
+                .panel::<AgentPanel>(cx)
+                .is_some_and(|panel| panel.read(cx).is_any_thread_generating(cx))
+        },
+    });
 }
 
 fn conflict_resource_block(conflict: &ConflictContent) -> acp::ContentBlock {
@@ -2094,6 +2102,25 @@ impl AgentPanel {
                 .map(|r| r.read(cx).thread.clone()),
             _ => None,
         }
+    }
+
+    /// Returns true if any thread (active or background) is currently generating.
+    pub fn is_any_thread_generating(&self, cx: &App) -> bool {
+        if let Some(thread) = self.active_agent_thread(cx) {
+            if thread.read(cx).status() == ThreadStatus::Generating {
+                return true;
+            }
+        }
+
+        for server_view in self.background_threads.values() {
+            if let Some(thread_view) = server_view.read(cx).parent_thread(cx) {
+                if thread_view.read(cx).thread.read(cx).status() == ThreadStatus::Generating {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     /// Returns the primary thread views for all retained connections: the

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -507,14 +507,6 @@ pub fn init(cx: &mut App) {
         },
     )
     .detach();
-
-    cx.set_global(workspace::AgentActivityCallbacks {
-        is_generating_in_workspace: |workspace, cx| {
-            workspace
-                .panel::<AgentPanel>(cx)
-                .is_some_and(|panel| panel.read(cx).is_any_thread_generating(cx))
-        },
-    });
 }
 
 fn conflict_resource_block(conflict: &ConflictContent) -> acp::ContentBlock {
@@ -2102,25 +2094,6 @@ impl AgentPanel {
                 .map(|r| r.read(cx).thread.clone()),
             _ => None,
         }
-    }
-
-    /// Returns true if any thread (active or background) is currently generating.
-    pub fn is_any_thread_generating(&self, cx: &App) -> bool {
-        if let Some(thread) = self.active_agent_thread(cx) {
-            if thread.read(cx).status() == ThreadStatus::Generating {
-                return true;
-            }
-        }
-
-        for server_view in self.background_threads.values() {
-            if let Some(thread_view) = server_view.read(cx).parent_thread(cx) {
-                if thread_view.read(cx).thread.read(cx).status() == ThreadStatus::Generating {
-                    return true;
-                }
-            }
-        }
-
-        false
     }
 
     /// Returns the primary thread views for all retained connections: the

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -733,10 +733,13 @@ impl ThreadView {
                 }
             }
         }));
+        if self.parent_id.is_none() {
+            self.suppress_merge_conflict_notification(cx);
+        }
         generation
     }
 
-    pub fn stop_turn(&mut self, generation: usize) {
+    pub fn stop_turn(&mut self, generation: usize, cx: &mut Context<Self>) {
         if self.turn_fields.turn_generation != generation {
             return;
         }
@@ -747,6 +750,25 @@ impl ThreadView {
             .map(|started| started.elapsed());
         self.turn_fields.last_turn_tokens = self.turn_fields.turn_tokens.take();
         self.turn_fields._turn_timer_task = None;
+        if self.parent_id.is_none() {
+            self.unsuppress_merge_conflict_notification(cx);
+        }
+    }
+
+    fn suppress_merge_conflict_notification(&self, cx: &mut Context<Self>) {
+        self.workspace
+            .update(cx, |workspace, cx| {
+                workspace.suppress_notification(&workspace::merge_conflict_notification_id(), cx);
+            })
+            .ok();
+    }
+
+    fn unsuppress_merge_conflict_notification(&self, cx: &mut Context<Self>) {
+        self.workspace
+            .update(cx, |workspace, _cx| {
+                workspace.unsuppress(workspace::merge_conflict_notification_id());
+            })
+            .ok();
     }
 
     pub fn update_turn_tokens(&mut self, cx: &App) {
@@ -956,7 +978,7 @@ impl ThreadView {
                 let mut cx = cx.clone();
                 move || {
                     this.update(&mut cx, |this, cx| {
-                        this.stop_turn(generation);
+                        this.stop_turn(generation, cx);
                         cx.notify();
                     })
                     .ok();

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -19,7 +19,7 @@ use std::{cell::RefCell, ops::Range, rc::Rc, sync::Arc};
 use ui::{ActiveTheme, Divider, Element as _, Styled, Window, prelude::*};
 use util::{ResultExt as _, debug_panic, maybe};
 use workspace::{
-    Workspace,
+    AgentActivityCallbacks, Workspace,
     notifications::{NotificationId, simple_message_notification::MessageNotification},
 };
 use zed_actions::agent::{
@@ -543,6 +543,10 @@ pub(crate) fn register_conflict_notification(
                 | GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::StatusesChanged, _)
         );
         if !AgentSettings::get_global(cx).enabled || !conflicts_changed {
+            return;
+        }
+
+        if AgentActivityCallbacks::is_generating(workspace, cx) {
             return;
         }
 

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -18,10 +18,7 @@ use settings::Settings;
 use std::{cell::RefCell, ops::Range, rc::Rc, sync::Arc};
 use ui::{ActiveTheme, Divider, Element as _, Styled, Window, prelude::*};
 use util::{ResultExt as _, debug_panic, maybe};
-use workspace::{
-    AgentActivityCallbacks, Workspace,
-    notifications::{NotificationId, simple_message_notification::MessageNotification},
-};
+use workspace::{Workspace, notifications::simple_message_notification::MessageNotification};
 use zed_actions::agent::{
     ConflictContent, ResolveConflictedFilesWithAgent, ResolveConflictsWithAgent,
 };
@@ -499,12 +496,6 @@ fn render_conflict_buttons(
         .into_any()
 }
 
-struct MergeConflictNotification;
-
-fn merge_conflict_notification_id() -> NotificationId {
-    NotificationId::unique::<MergeConflictNotification>()
-}
-
 fn collect_conflicted_file_paths(workspace: &Workspace, cx: &App) -> Vec<String> {
     let project = workspace.project().read(cx);
     let git_store = project.git_store().read(cx);
@@ -546,12 +537,12 @@ pub(crate) fn register_conflict_notification(
             return;
         }
 
-        if AgentActivityCallbacks::is_generating(workspace, cx) {
+        if workspace.is_notification_suppressed(workspace::merge_conflict_notification_id()) {
             return;
         }
 
         let paths = collect_conflicted_file_paths(workspace, cx);
-        let notification_id = merge_conflict_notification_id();
+        let notification_id = workspace::merge_conflict_notification_id();
         let current_paths_set: HashSet<String> = paths.iter().cloned().collect();
 
         if paths.is_empty() {

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -234,6 +234,14 @@ impl Workspace {
         self.suppressed_notifications.insert(id.clone());
     }
 
+    pub fn is_notification_suppressed(&self, notification_id: NotificationId) -> bool {
+        self.suppressed_notifications.contains(&notification_id)
+    }
+
+    pub fn unsuppress(&mut self, notification_id: NotificationId) {
+        self.suppressed_notifications.remove(&notification_id);
+    }
+
     pub fn show_initial_notifications(&mut self, cx: &mut Context<Self>) {
         // Allow absence of the global so that tests don't need to initialize it.
         let app_notifications = GLOBAL_APP_NOTIFICATIONS

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7268,6 +7268,21 @@ impl GlobalAnyActiveCall {
         cx.global()
     }
 }
+
+/// Callbacks for checking agent activity state.
+pub struct AgentActivityCallbacks {
+    pub is_generating_in_workspace: fn(workspace: &Workspace, cx: &App) -> bool,
+}
+
+impl Global for AgentActivityCallbacks {}
+
+impl AgentActivityCallbacks {
+    pub fn is_generating(workspace: &Workspace, cx: &App) -> bool {
+        cx.try_global::<Self>()
+            .is_some_and(|callbacks| (callbacks.is_generating_in_workspace)(workspace, cx))
+    }
+}
+
 /// Workspace-local view of a remote participant's location.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ParticipantLocation {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7269,18 +7269,9 @@ impl GlobalAnyActiveCall {
     }
 }
 
-/// Callbacks for checking agent activity state.
-pub struct AgentActivityCallbacks {
-    pub is_generating_in_workspace: fn(workspace: &Workspace, cx: &App) -> bool,
-}
-
-impl Global for AgentActivityCallbacks {}
-
-impl AgentActivityCallbacks {
-    pub fn is_generating(workspace: &Workspace, cx: &App) -> bool {
-        cx.try_global::<Self>()
-            .is_some_and(|callbacks| (callbacks.is_generating_in_workspace)(workspace, cx))
-    }
+pub fn merge_conflict_notification_id() -> NotificationId {
+    struct MergeConflictNotification;
+    NotificationId::unique::<MergeConflictNotification>()
 }
 
 /// Workspace-local view of a remote participant's location.


### PR DESCRIPTION
This PR is motivated by internal feedback in which the notification that we show inviting to resolve merging conflicts with an agent also pops up if the agent itself ran `git merge`. In this case, the notification is unnecessary noise. So, what I'm doing here is simply _not_ showing it if there's a running agent.

I want to note that this change is accepting a trade-off here, in which there could be cases that even if an agent is running, the notification can still be useful. There could be other ways to identify whether the agent is running `git merge`, but they all felt a bit too complex for the moment. And given this is reasonably an edge case, I'm favoring a simple approach for now.

Release Notes:

- N/A
