### PR TITLE
agent_servers: Launch ACP servers from the project root

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -164,6 +164,7 @@ pub async fn connect(
     agent_id: AgentId,
     display_name: SharedString,
     command: AgentServerCommand,
+    startup_cwd: Option<PathBuf>,
     default_mode: Option<acp::SessionModeId>,
     default_model: Option<acp::ModelId>,
     default_config_options: HashMap<String, String>,
@@ -173,6 +174,7 @@ pub async fn connect(
         agent_id,
         display_name,
         command.clone(),
+        startup_cwd,
         default_mode,
         default_model,
         default_config_options,
@@ -189,6 +191,7 @@ impl AcpConnection {
         agent_id: AgentId,
         display_name: SharedString,
         command: AgentServerCommand,
+        startup_cwd: Option<PathBuf>,
         default_mode: Option<acp::SessionModeId>,
         default_model: Option<acp::ModelId>,
         default_config_options: HashMap<String, String>,
@@ -198,17 +201,21 @@ impl AcpConnection {
         let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
         let mut child =
             builder.build_std_command(Some(command.path.display().to_string()), &command.args);
+        if let Some(startup_cwd) = startup_cwd.as_ref() {
+            child.current_dir(startup_cwd);
+        }
         child.envs(command.env.iter().flatten());
+        log::debug!(
+            "Spawning external agent server: {:?}, {:?}, cwd: {:?}",
+            command.path,
+            command.args,
+            startup_cwd
+        );
         let mut child = Child::spawn(child, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
 
         let stdout = child.stdout.take().context("Failed to take stdout")?;
         let stdin = child.stdin.take().context("Failed to take stdin")?;
         let stderr = child.stderr.take().context("Failed to take stderr")?;
-        log::debug!(
-            "Spawning external agent server: {:?}, {:?}",
-            command.path,
-            command.args
-        );
         log::trace!("Spawned (pid: {})", child.id());
 
         let sessions = Rc::new(RefCell::new(HashMap::default()));

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -15,23 +15,26 @@ use acp_thread::AgentConnection;
 use anyhow::Result;
 use gpui::{App, AppContext, Entity, Task};
 use settings::SettingsStore;
-use std::{any::Any, rc::Rc, sync::Arc};
+use std::{any::Any, path::PathBuf, rc::Rc, sync::Arc};
 
 pub use acp::AcpConnection;
 
 pub struct AgentServerDelegate {
     store: Entity<AgentServerStore>,
     new_version_available: Option<watch::Sender<Option<String>>>,
+    startup_cwd: Option<PathBuf>,
 }
 
 impl AgentServerDelegate {
     pub fn new(
         store: Entity<AgentServerStore>,
         new_version_tx: Option<watch::Sender<Option<String>>>,
+        startup_cwd: Option<PathBuf>,
     ) -> Self {
         Self {
             store,
             new_version_available: new_version_tx,
+            startup_cwd,
         }
     }
 }

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -351,6 +351,7 @@ impl AgentServer for CustomAgentServer {
             }
         }
         let store = delegate.store.downgrade();
+        let startup_cwd = delegate.startup_cwd.clone();
         cx.spawn(async move |cx| {
             if is_registry_agent && agent_id.as_ref() == GEMINI_ID {
                 if let Some(api_key) = cx.update(api_key_for_gemini_cli).await.ok() {
@@ -373,6 +374,7 @@ impl AgentServer for CustomAgentServer {
                 agent_id,
                 display_name,
                 command,
+                startup_cwd,
                 default_mode,
                 default_model,
                 default_config_options,

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -432,7 +432,7 @@ pub async fn new_test_thread(
     cx: &mut TestAppContext,
 ) -> Entity<AcpThread> {
     let store = project.read_with(cx, |project, _| project.agent_server_store().clone());
-    let delegate = AgentServerDelegate::new(store, None);
+    let delegate = AgentServerDelegate::new(store, None, None);
 
     let connection = cx.update(|cx| server.connect(delegate, cx)).await.unwrap();
 

--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -1,11 +1,11 @@
-use std::rc::Rc;
+use std::{path::PathBuf, rc::Rc};
 
 use acp_thread::{AgentConnection, LoadError};
 use agent_servers::{AgentServer, AgentServerDelegate};
 use anyhow::Result;
 use collections::HashMap;
 use futures::{FutureExt, future::Shared};
-use gpui::{AppContext, Context, Entity, EventEmitter, SharedString, Subscription, Task};
+use gpui::{App, AppContext, Context, Entity, EventEmitter, SharedString, Subscription, Task};
 use project::{AgentServerStore, AgentServersUpdated, Project};
 use watch::Receiver;
 
@@ -158,7 +158,11 @@ impl AgentConnectionStore {
         let (new_version_tx, new_version_rx) = watch::channel::<Option<String>>(None);
 
         let agent_server_store = self.project.read(cx).agent_server_store().clone();
-        let delegate = AgentServerDelegate::new(agent_server_store, Some(new_version_tx));
+        let delegate = AgentServerDelegate::new(
+            agent_server_store,
+            Some(new_version_tx),
+            self.startup_cwd(cx),
+        );
 
         let connect_task = server.connect(delegate, cx);
         let connect_task = cx.spawn(async move |_this, cx| match connect_task.await {
@@ -177,5 +181,53 @@ impl AgentConnectionStore {
             },
         });
         (new_version_rx, connect_task)
+    }
+
+    fn startup_cwd(&self, cx: &App) -> Option<PathBuf> {
+        let project = self.project.read(cx);
+        if !project.is_local() {
+            return None;
+        }
+
+        project
+            .active_project_directory(cx)
+            .map(|path| path.to_path_buf())
+            .or_else(|| {
+                project.visible_worktrees(cx).find_map(|worktree| {
+                    worktree.read(cx).root_dir().map(|path| path.to_path_buf())
+                })
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+    use project::{FakeFs, Project};
+    use std::path::Path;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme::init(theme::LoadThemes::JustBase, cx);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_startup_cwd_uses_visible_project_root(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", serde_json::json!({ "src": { "main.rs": "" } }))
+            .await;
+
+        let project = Project::test(fs, [Path::new("/project")], cx).await;
+        let store = cx.update(|cx| cx.new(|cx| AgentConnectionStore::new(project, cx)));
+
+        store.read_with(cx, |store, cx| {
+            assert_eq!(store.startup_cwd(cx), Some(PathBuf::from("/project")));
+        });
     }
 }

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -561,7 +561,7 @@ impl MentionSet {
             thread_store,
         ));
         let delegate =
-            AgentServerDelegate::new(project.read(cx).agent_server_store().clone(), None);
+            AgentServerDelegate::new(project.read(cx).agent_server_store().clone(), None, None);
         let connection = server.connect(delegate, cx);
         cx.spawn(async move |_, cx| {
             let agent = connection.await?;


### PR DESCRIPTION
Changes:
- derive a startup cwd for custom agent connections from the active local project root
- pass the startup cwd through AgentServerDelegate into ACP connection startup
- spawn ACP child processes with an explicit current_dir instead of inheriting Zed's process cwd
- keep mention-set and ACP e2e delegate call sites aligned with the new delegate shape
- add a focused test covering startup cwd selection for visible project roots

Why:
- custom ACP servers were inheriting Zed's long-lived process cwd, which breaks in sandbox environments that only bind the cwd of where the additional zed window is spawned into the sandbox

Validation:
- nix develop .#default --command cargo fmt --check --package agent_servers --package agent_ui
- nix develop .#default --command cargo test -p agent_ui test_startup_cwd_uses_visible_project_root --lib
- nix develop .#default --command cargo clippy -p agent_ui --lib --tests -- -D warnings
- nix develop .#default --command cargo clippy -p agent_servers --lib -- -D warnings


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed custom ACP agents sometimes inheriting the wrong working directory instead of the active project root.
