### PR TITLE
editor: Fix indent-based folding breaking on multiline string literals

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2465,12 +2465,16 @@ impl std::ops::Deref for DisplaySnapshot {
     }
 }
 
-// Matches tree-sitter node kinds that represent multiline literals whose interior
-// indentation is content, not code structure. We match by substring because
-// grammars use varied names across languages (e.g. `string_literal`, `raw_string`,
-// `block_comment`, `heredoc_body`).
+// Matched by substring because tree-sitter grammars use varied node kind names
+// across languages (e.g. `string_literal`, `raw_string`, `block_comment`).
+// "heredoc" is separate because those nodes don't contain "string" or "comment"
+// in their names (e.g. `heredoc_body` in Bash, Ruby, Perl).
+const MULTILINE_LITERAL_NODE_PATTERNS: &[&str] = &["string", "comment", "heredoc"];
+
 fn is_multiline_literal_node(kind: &str) -> bool {
-    kind.contains("string") || kind.contains("comment") || kind.contains("heredoc")
+    MULTILINE_LITERAL_NODE_PATTERNS
+        .iter()
+        .any(|pattern| kind.contains(pattern))
 }
 
 /// A zero-indexed point in a text buffer consisting of a row and column adjusted for inserted blocks.

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2362,15 +2362,17 @@ impl DisplaySnapshot {
         }
     }
 
+    // Returns the end row of a multiline literal node containing `row`, so
+    // the indent-based fold scan can skip past content whose indentation is
+    // not structurally meaningful.
     fn multiline_literal_end_row(&self, row: u32) -> Option<u32> {
         let point = Point::new(row, 0);
         let (node, _) = self.buffer_snapshot().syntax_ancestor(point..point)?;
 
         let mut current = node;
         loop {
-            let kind = current.kind();
             if current.start_position().row != current.end_position().row
-                && (kind.contains("string") || kind.contains("comment") || kind.contains("heredoc"))
+                && is_multiline_literal_node(current.kind())
             {
                 return Some(current.end_position().row as u32);
             }
@@ -2461,6 +2463,14 @@ impl std::ops::Deref for DisplaySnapshot {
     fn deref(&self) -> &Self::Target {
         &self.block_snapshot
     }
+}
+
+// Matches tree-sitter node kinds that represent multiline literals whose interior
+// indentation is content, not code structure. We match by substring because
+// grammars use varied names across languages (e.g. `string_literal`, `raw_string`,
+// `block_comment`, `heredoc_body`).
+fn is_multiline_literal_node(kind: &str) -> bool {
+    kind.contains("string") || kind.contains("comment") || kind.contains("heredoc")
 }
 
 /// A zero-indexed point in a text buffer consisting of a row and column adjusted for inserted blocks.

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2315,12 +2315,14 @@ impl DisplaySnapshot {
             let max_point = self.buffer_snapshot().max_point();
             let mut end = None;
 
-            for row in (buffer_row.0 + 1)..=max_point.row {
+            let mut row = buffer_row.0 + 1;
+            while row <= max_point.row {
                 let line_indent = self.line_indent_for_buffer_row(MultiBufferRow(row));
                 if !line_indent.is_line_blank()
                     && line_indent.raw_len() <= start_line_indent.raw_len()
                 {
-                    if self.is_inside_multiline_literal(row) {
+                    if let Some(literal_end_row) = self.multiline_literal_end_row(row) {
+                        row = literal_end_row + 1;
                         continue;
                     }
                     let prev_row = row - 1;
@@ -2330,6 +2332,7 @@ impl DisplaySnapshot {
                     ));
                     break;
                 }
+                row += 1;
             }
 
             let mut row_before_line_breaks = end.unwrap_or(max_point);
@@ -2359,11 +2362,9 @@ impl DisplaySnapshot {
         }
     }
 
-    fn is_inside_multiline_literal(&self, row: u32) -> bool {
+    fn multiline_literal_end_row(&self, row: u32) -> Option<u32> {
         let point = Point::new(row, 0);
-        let Some((node, _)) = self.buffer_snapshot().syntax_ancestor(point..point) else {
-            return false;
-        };
+        let (node, _) = self.buffer_snapshot().syntax_ancestor(point..point)?;
 
         let mut current = node;
         loop {
@@ -2373,12 +2374,12 @@ impl DisplaySnapshot {
                     || kind.contains("comment")
                     || kind.contains("heredoc"))
             {
-                return true;
+                return Some(current.end_position().row as u32);
             }
             if let Some(parent) = current.parent() {
                 current = parent;
             } else {
-                return false;
+                return None;
             }
         }
     }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2320,6 +2320,9 @@ impl DisplaySnapshot {
                 if !line_indent.is_line_blank()
                     && line_indent.raw_len() <= start_line_indent.raw_len()
                 {
+                    if self.is_inside_multiline_literal(row) {
+                        continue;
+                    }
                     let prev_row = row - 1;
                     end = Some(Point::new(
                         prev_row,
@@ -2353,6 +2356,30 @@ impl DisplaySnapshot {
             })
         } else {
             None
+        }
+    }
+
+    fn is_inside_multiline_literal(&self, row: u32) -> bool {
+        let point = Point::new(row, 0);
+        let Some((node, _)) = self.buffer_snapshot().syntax_ancestor(point..point) else {
+            return false;
+        };
+
+        let mut current = node;
+        loop {
+            let kind = current.kind();
+            if current.start_position().row != current.end_position().row
+                && (kind.contains("string")
+                    || kind.contains("comment")
+                    || kind.contains("heredoc"))
+            {
+                return true;
+            }
+            if let Some(parent) = current.parent() {
+                current = parent;
+            } else {
+                return false;
+            }
         }
     }
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2370,9 +2370,7 @@ impl DisplaySnapshot {
         loop {
             let kind = current.kind();
             if current.start_position().row != current.end_position().row
-                && (kind.contains("string")
-                    || kind.contains("comment")
-                    || kind.contains("heredoc"))
+                && (kind.contains("string") || kind.contains("comment") || kind.contains("heredoc"))
             {
                 return Some(current.end_position().row as u32);
             }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1325,6 +1325,57 @@ fn test_fold_action_multiple_line_breaks(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_fold_with_multiline_string_containing_low_indentation(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let text = "
+        fn outer() {
+            fn inner() {
+                let text = r#\"
+        [
+          {
+            \"code\": \"custom\",
+            \"message\": \"error\"
+          }
+        ]
+        \"#;
+                println!(\"{}\", text);
+            }
+        }
+    "
+    .unindent();
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(&text, cx);
+        buffer.update(cx, |multi_buffer, cx| {
+            multi_buffer
+                .as_singleton()
+                .unwrap()
+                .update(cx, |buffer, cx| {
+                    buffer.set_language(Some(rust_lang()), cx);
+                });
+        });
+        build_editor(buffer, window, cx)
+    });
+
+    cx.executor().run_until_parked();
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.fold_at(MultiBufferRow(1), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                fn outer() {
+                    fn inner() {⋯
+                    }
+                }
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
 fn test_fold_at_level(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Closes #27839

Fix indent-based folding prematurely terminating when multiline string literals, comments kinds contain lines with lower indentation than surrounding code.

**Before Fix**
<img width="616" height="350" alt="스크린샷 2026-03-14 오전 1 17 49" src="https://github.com/user-attachments/assets/35c867fc-b78f-490d-b656-e3f59d570a8e" />


**After Fix**
<img width="655" height="549" alt="스크린샷 2026-03-13 오전 9 05 58" src="https://github.com/user-attachments/assets/4ed22df8-194e-479a-a379-a4e901be9132" />

<img width="655" height="549" alt="스크린샷 2026-03-13 오전 9 06 13" src="https://github.com/user-attachments/assets/b86e2ff0-7f6f-4a91-90e0-ee603dd7d81f" />

Before you mark this PR as ready for review, make sure that you have:
- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed indent-based code folding breaking when multiline strings or comments contain lines with less indentation than the surrounding code
