### PR TITLE
docs: Add callouts about student plan for usage and spend limits

### DIFF
--- a/docs/src/ai/plans-and-usage.md
+++ b/docs/src/ai/plans-and-usage.md
@@ -7,15 +7,17 @@ description: Understand Zed's AI plans, token-based usage metering, spend limits
 
 ## Available Plans {#plans}
 
-For costs and more information on pricing, visit [Zed’s pricing page](https://zed.dev/pricing).
+For costs and more information on pricing, visit [Zed's pricing page](https://zed.dev/pricing).
 
-Zed works without AI features or a subscription. No [authentication](../authentication.md) required for the editor itself.
+Zed works without AI features or a subscription. No [authentication](../authentication.md) is required for the editor itself.
 
 ## Usage {#usage}
 
 Usage of Zed's hosted models is measured on a token basis, converted to dollars at the rates lists on [the Models page](./models.md) (list price from the provider, +10%).
 
 Zed Pro comes with $5 of monthly dollar credit. A trial of Zed Pro includes $20 of credit, usable for 14 days. Monthly included credit resets on your monthly billing date.
+
+The [Zed Student plan](https://zed.dev/education) includes $10/month in token credits. The Student plan is available free for one year to verified university students.
 
 To view your current usage, you can visit your account at [dashboard.zed.dev/account](https://dashboard.zed.dev/account). Information from our metering and billing provider, Orb, is embedded on that page.
 
@@ -25,7 +27,9 @@ At the top of [the Account page](https://dashboard.zed.dev/account), you'll find
 
 The default value for all Pro users is $10, for a total monthly spend with Zed of $20 ($10 for your Pro subscription, $10 in incremental token spend). This can be set to $0 to limit your spend with Zed to exactly $10/month. If you adjust this limit _higher_ than $10 and consume more than $10 of incremental token spend, you'll be billed via [threshold billing](./billing.md#threshold-billing).
 
-Once the spend limit is hit, we’ll stop any further usage until your token spend limit resets.
+Once the spend limit is hit, we'll stop any further usage until your token spend limit resets.
+
+> **Note:** Spend limits are a Zed Pro feature. Student plan users do not currently have the ability to configure spend limits; usage is capped at the $10/month included credit.
 
 ## Business Usage {#business-usage}
 


### PR DESCRIPTION
Add details about how student plan differs in token usage and spend limits

Release Notes:

- N/A *or* Added/Fixed/Improved ...
