### PR TITLE
languages: Update J/TSX component highlighting to use semantic `tag.component` scope

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -328,26 +328,26 @@
 ; JSX elements
 (jsx_opening_element
   [
-    (identifier) @type
+    (identifier) @tag.component
     (member_expression
-      object: (identifier) @type
-      property: (property_identifier) @type)
+      object: (identifier) @tag.component
+      property: (property_identifier) @tag.component)
   ])
 
 (jsx_closing_element
   [
-    (identifier) @type
+    (identifier) @tag.component
     (member_expression
-      object: (identifier) @type
-      property: (property_identifier) @type)
+      object: (identifier) @tag.component
+      property: (property_identifier) @tag.component)
   ])
 
 (jsx_self_closing_element
   [
-    (identifier) @type
+    (identifier) @tag.component
     (member_expression
-      object: (identifier) @type
-      property: (property_identifier) @type)
+      object: (identifier) @tag.component
+      property: (property_identifier) @tag.component)
   ])
 
 (jsx_opening_element

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -389,26 +389,26 @@
 
 (jsx_opening_element
   [
-    (identifier) @type
+    (identifier) @tag.component
     (member_expression
-      object: (identifier) @type
-      property: (property_identifier) @type)
+      object: (identifier) @tag.component
+      property: (property_identifier) @tag.component)
   ])
 
 (jsx_closing_element
   [
-    (identifier) @type
+    (identifier) @tag.component
     (member_expression
-      object: (identifier) @type
-      property: (property_identifier) @type)
+      object: (identifier) @tag.component
+      property: (property_identifier) @tag.component)
   ])
 
 (jsx_self_closing_element
   [
-    (identifier) @type
+    (identifier) @tag.component
     (member_expression
-      object: (identifier) @type
-      property: (property_identifier) @type)
+      object: (identifier) @tag.component
+      property: (property_identifier) @tag.component)
   ])
 
 (jsx_opening_element


### PR DESCRIPTION
Changes JSX component identifiers from generic `@type` to the more specific `@tag.component` scope in both JavaScript and TypeScript syntax highlighting. This allows themes to style React/JSX components distinctly from regular types.

The only thing to be aware of is the **visual change for JSX/TSX users**: components that were previously teal (via `@type`) will now inherit whatever their theme's `tag` color is. For themes like Gruvbox, and One (perhaps other built-in themes too?) that define `tag` with a color, components will pick that up. For themes that leave `tag` unstyled (including the fallback theme), components will lose their teal color. That’s a deliberate trade-off with these changes, something I also mention in https://github.com/zed-industries/zed/issues/51478#issuecomment-4056409919.

Closes #51478.

| Before | After |
|--------|--------|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/df6d0aa5-f6c9-4da2-bc19-389d16a83f40" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/325969c3-b594-4532-9b65-5953686b7bdc" /> |

Ayu Light

| Before | After |
|--------|--------|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/4550f80c-9f6c-49be-b6fb-0e6917225c78" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/0e4155aa-ada4-4d83-ad75-dce54a3b33a3" /> | 

One Dark

| Before | After |
|--------|--------|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/f57e814a-6834-4963-beeb-fc7652072cae" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/a05aa4e8-da21-405d-8881-fc851574a283" /> | 

Gruvbox Light

| Before | After |
|--------|--------|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/c06557d0-ef82-4a53-94e7-72f4f0293342" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/77cdcf82-e152-4cf4-807e-0ada9053bbd1" /> | 

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Updated J/TSX component highlighting to use semantic `tag.component` scope
