### PR TITLE
markdown_preview: Add preview font size multiplier

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -74,6 +74,10 @@
   "agent_ui_font_size": null,
   // The default font size for user messages in the agent panel.
   "agent_buffer_font_size": 12,
+  // Scales markdown preview typography relative to the buffer font size.
+  // 1.0 uses the buffer font size unchanged, 1.2 makes it 20% larger,
+  // and 0.8 makes it 20% smaller.
+  "markdown_preview_font_size_multiplier": 1.0,
   // How much to fade out unused code.
   "unnecessary_code_fade": 0.3,
   // Active pane styling settings.

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -547,7 +547,8 @@ impl Item for MarkdownPreviewView {
 
 impl Render for MarkdownPreviewView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let buffer_size = ThemeSettings::get_global(cx).buffer_font_size(cx);
+        let markdown_preview_font_size =
+            ThemeSettings::get_global(cx).markdown_preview_font_size(cx);
         let buffer_line_height = ThemeSettings::get_global(cx).buffer_line_height;
 
         v_flex()
@@ -564,10 +565,10 @@ impl Render for MarkdownPreviewView {
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()
-            .text_size(buffer_size)
+            .text_size(markdown_preview_font_size)
             .line_height(relative(buffer_line_height.value()))
-            .child(div().flex_grow().map(|this| {
-                this.child(
+            .child(
+                div().flex_grow().child(
                     list(
                         self.list_state.clone(),
                         cx.processor(|this, ix, window, cx| {
@@ -668,8 +669,8 @@ impl Render for MarkdownPreviewView {
                         }),
                     )
                     .size_full(),
-                )
-            }))
+                ),
+            )
             .vertical_scrollbar_for(&self.list_state, window, cx)
     }
 }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -208,7 +208,7 @@ impl<'a> RenderContext<'a> {
         let mut buffer_text_style = window.text_style();
         buffer_text_style.font_family = buffer_font_family.clone();
         buffer_text_style.font_features = buffer_font_features;
-        buffer_text_style.font_size = AbsoluteLength::from(settings.buffer_font_size(cx));
+        buffer_text_style.font_size = AbsoluteLength::from(settings.markdown_preview_font_size(cx));
 
         RenderContext {
             workspace,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -929,6 +929,7 @@ impl VsCodeSettings {
             buffer_font_features: None,
             agent_ui_font_size: None,
             agent_buffer_font_size: None,
+            markdown_preview_font_size_multiplier: None,
             theme: None,
             icon_theme: None,
             ui_density: None,

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -149,6 +149,11 @@ pub struct ThemeSettingsContent {
     pub agent_ui_font_size: Option<FontSize>,
     /// The font size for user messages in the agent panel.
     pub agent_buffer_font_size: Option<FontSize>,
+    /// Scales markdown preview typography relative to the buffer font size.
+    ///
+    /// `1.0` uses the buffer font size unchanged, `1.2` makes the preview 20% larger,
+    /// and `0.8` makes it 20% smaller.
+    pub markdown_preview_font_size_multiplier: Option<f32>,
     /// The name of the Zed theme to use.
     pub theme: Option<ThemeSelection>,
     /// The name of the icon theme to use.

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 const MIN_FONT_SIZE: Pixels = px(6.0);
 const MAX_FONT_SIZE: Pixels = px(100.0);
 const MIN_LINE_HEIGHT: f32 = 1.0;
+const DEFAULT_MARKDOWN_PREVIEW_FONT_SIZE_MULTIPLIER: f32 = 1.0;
 
 #[derive(
     Debug,
@@ -114,6 +115,8 @@ pub struct ThemeSettings {
     agent_ui_font_size: Option<Pixels>,
     /// The agent buffer font size. Determines the size of user messages in the agent panel.
     agent_buffer_font_size: Option<Pixels>,
+    /// Scales markdown preview typography relative to the buffer font size.
+    markdown_preview_font_size_multiplier: f32,
     /// The line height for buffers, and the terminal.
     ///
     /// Changing this may affect the spacing of some UI elements.
@@ -498,6 +501,11 @@ impl ThemeSettings {
             .unwrap_or_else(|| self.buffer_font_size(cx))
     }
 
+    /// Returns the markdown preview font size.
+    pub fn markdown_preview_font_size(&self, cx: &App) -> Pixels {
+        self.buffer_font_size(cx) * self.markdown_preview_font_size_multiplier
+    }
+
     /// Returns the buffer font size, read from the settings.
     ///
     /// The real buffer font size is stored in-memory, to support temporary font size changes.
@@ -730,6 +738,9 @@ impl settings::Settings for ThemeSettings {
             buffer_line_height: content.buffer_line_height.unwrap().into(),
             agent_ui_font_size: content.agent_ui_font_size.map(|s| s.into_gpui()),
             agent_buffer_font_size: content.agent_buffer_font_size.map(|s| s.into_gpui()),
+            markdown_preview_font_size_multiplier: content
+                .markdown_preview_font_size_multiplier
+                .unwrap_or(DEFAULT_MARKDOWN_PREVIEW_FONT_SIZE_MULTIPLIER),
             theme: theme_selection,
             experimental_theme_overrides: content.experimental_theme_overrides.clone(),
             theme_overrides: content.theme_overrides.clone(),


### PR DESCRIPTION
Markdown preview currently always follows `buffer_font_size`, which makes it hard to make preview content more readable without also changing editor text size.

This adds a dedicated `markdown_preview_font_size_multiplier` setting so users can increase or decrease markdown preview text size independently while keeping the existing preview rendering behaviour unchanged.

> [!NOTE]
> Why not `markdown_preview_font_size`? I thought that a multiplier is better because markdown preview should stay relative to `buffer_font_size`, not become a separate typography system.
>
> - stays in sync when users change editor font size
> - expresses the real intent: "make preview a bit bigger/smaller than editor text"
> - avoids another absolute font-size setting to manage
>
> But, perhaps, I am wrong with my assumptions.

**What changed:**

- added `markdown_preview_font_size_multiplier` to theme settings
- documented the setting in default settings
- applied the multiplier to markdown preview font sizing
- kept the implementation minimal & avoided changing the preview rendering model

Release Notes:

- Improved markdown preview font size customisation via `markdown_preview_font_size_multiplier` setting