### PR TITLE
editor: Add diagnostics to the minimap

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -593,6 +593,19 @@
     "current_line_highlight": null,
     // Maximum number of columns to display in the minimap.
     "max_width_columns": 80,
+    // Which diagnostic levels to show as markers in the minimap.
+    // This setting can take five values:
+    // 1. Show all diagnostics (hint, information, warning, error):
+    //    "all" (default)
+    // 2. Show information, warning, and error diagnostics:
+    //    "information"
+    // 3. Show warning and error diagnostics:
+    //    "warning"
+    // 4. Show only error diagnostics:
+    //    "error"
+    // 5. Do not show any diagnostics:
+    //    "none"
+    "diagnostics": "all",
   },
   // Enable middle-click paste on Linux.
   "middle_click_paste": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1170,6 +1170,7 @@ pub struct Editor {
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
     gutter_highlights: HashMap<TypeId, GutterHighlight>,
     scrollbar_marker_state: ScrollbarMarkerState,
+    minimap_marker_state: ScrollbarMarkerState,
     active_indent_guides_state: ActiveIndentGuidesState,
     nav_history: Option<ItemNavHistory>,
     context_menu: RefCell<Option<CodeContextMenu>>,
@@ -2402,6 +2403,7 @@ impl Editor {
             background_highlights: HashMap::default(),
             gutter_highlights: HashMap::default(),
             scrollbar_marker_state: ScrollbarMarkerState::default(),
+            minimap_marker_state: ScrollbarMarkerState::default(),
             active_indent_guides_state: ActiveIndentGuidesState::default(),
             nav_history: None,
             context_menu: RefCell::new(None),
@@ -20078,6 +20080,7 @@ impl Editor {
         cx.notify();
 
         self.scrollbar_marker_state.dirty = true;
+        self.minimap_marker_state.dirty = true;
         self.update_data_on_scroll(window, cx);
         self.folds_did_change(cx);
     }
@@ -20220,6 +20223,7 @@ impl Editor {
 
         cx.notify();
         self.scrollbar_marker_state.dirty = true;
+        self.minimap_marker_state.dirty = true;
         self.active_indent_guides_state.dirty = true;
     }
 
@@ -23222,6 +23226,7 @@ impl Editor {
         self.background_highlights
             .insert(key, (Arc::new(color_fetcher), Arc::from(ranges)));
         self.scrollbar_marker_state.dirty = true;
+        self.minimap_marker_state.dirty = true;
         cx.notify();
     }
 
@@ -23233,6 +23238,7 @@ impl Editor {
         let text_highlights = self.background_highlights.remove(&key)?;
         if !text_highlights.1.is_empty() {
             self.scrollbar_marker_state.dirty = true;
+            self.minimap_marker_state.dirty = true;
             cx.notify();
         }
         Some(text_highlights)
@@ -23724,6 +23730,7 @@ impl Editor {
                 is_local,
             } => {
                 self.scrollbar_marker_state.dirty = true;
+                self.minimap_marker_state.dirty = true;
                 self.active_indent_guides_state.dirty = true;
                 self.refresh_active_diagnostics(cx);
                 self.refresh_code_actions(window, cx);
@@ -23892,6 +23899,7 @@ impl Editor {
         self.refresh_active_diagnostics(cx);
         self.refresh_inline_diagnostics(true, window, cx);
         self.scrollbar_marker_state.dirty = true;
+        self.minimap_marker_state.dirty = true;
         cx.notify();
     }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -103,6 +103,7 @@ pub struct Minimap {
     pub thumb_border: MinimapThumbBorder,
     pub current_line_highlight: Option<CurrentLineHighlight>,
     pub max_width_columns: num::NonZeroU32,
+    pub diagnostics: ScrollbarDiagnostics,
 }
 
 impl Minimap {
@@ -243,6 +244,7 @@ impl Settings for EditorSettings {
                 thumb_border: minimap.thumb_border.unwrap(),
                 current_line_highlight: minimap.current_line_highlight,
                 max_width_columns: minimap.max_width_columns.unwrap(),
+                diagnostics: minimap.diagnostics.unwrap(),
             },
             gutter: Gutter {
                 min_line_number_digits: gutter.min_line_number_digits.unwrap(),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7257,6 +7257,112 @@ impl EditorElement {
         });
     }
 
+    fn refresh_slow_minimap_markers(
+        &self,
+        layout: &EditorLayout,
+        minimap_layout: &ScrollbarLayout,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        self.editor.update(cx, |editor, cx| {
+            if editor.buffer_kind(cx) != ItemBufferKind::Singleton
+                || !editor
+                    .minimap_marker_state
+                    .should_refresh(minimap_layout.hitbox.size)
+            {
+                return;
+            }
+
+            let minimap_layout = minimap_layout.clone();
+            let snapshot = layout.position_map.snapshot.clone();
+            let theme = cx.theme().clone();
+            let minimap_settings = EditorSettings::get_global(cx).minimap;
+
+            editor.minimap_marker_state.dirty = false;
+            editor.minimap_marker_state.pending_refresh =
+                Some(cx.spawn_in(window, async move |editor, cx| {
+                    let minimap_size = minimap_layout.hitbox.size;
+                    let minimap_markers = cx
+                        .background_spawn(async move {
+                            let mut marker_quads = Vec::new();
+
+                            if minimap_settings.diagnostics != ScrollbarDiagnostics::None {
+                                let max_point =
+                                    snapshot.display_snapshot.buffer_snapshot().max_point();
+                                let diagnostics = snapshot
+                                    .buffer_snapshot()
+                                    .diagnostics_in_range::<Point>(Point::zero()..max_point)
+                                    .filter(|diagnostic| {
+                                        match (
+                                            minimap_settings.diagnostics,
+                                            diagnostic.diagnostic.severity,
+                                        ) {
+                                            (ScrollbarDiagnostics::All, _) => true,
+                                            (
+                                                ScrollbarDiagnostics::Error,
+                                                lsp::DiagnosticSeverity::ERROR,
+                                            ) => true,
+                                            (
+                                                ScrollbarDiagnostics::Warning,
+                                                lsp::DiagnosticSeverity::ERROR
+                                                | lsp::DiagnosticSeverity::WARNING,
+                                            ) => true,
+                                            (
+                                                ScrollbarDiagnostics::Information,
+                                                lsp::DiagnosticSeverity::ERROR
+                                                | lsp::DiagnosticSeverity::WARNING
+                                                | lsp::DiagnosticSeverity::INFORMATION,
+                                            ) => true,
+                                            (_, _) => false,
+                                        }
+                                    })
+                                    .sorted_by_key(|diagnostic| {
+                                        std::cmp::Reverse(diagnostic.diagnostic.severity)
+                                    });
+
+                                let marker_row_ranges = diagnostics.map(|diagnostic| {
+                                    let start_display = diagnostic
+                                        .range
+                                        .start
+                                        .to_display_point(&snapshot.display_snapshot);
+                                    let end_display = diagnostic
+                                        .range
+                                        .end
+                                        .to_display_point(&snapshot.display_snapshot);
+                                    let mut color = match diagnostic.diagnostic.severity {
+                                        lsp::DiagnosticSeverity::ERROR => theme.status().error,
+                                        lsp::DiagnosticSeverity::WARNING => theme.status().warning,
+                                        lsp::DiagnosticSeverity::INFORMATION => theme.status().info,
+                                        _ => theme.status().hint,
+                                    };
+                                    color.fade_out(0.5);
+                                    ColoredRange {
+                                        start: start_display.row(),
+                                        end: end_display.row(),
+                                        color,
+                                    }
+                                });
+                                marker_quads.extend(
+                                    minimap_layout.marker_quads_for_ranges(marker_row_ranges, None),
+                                );
+                            }
+
+                            Arc::from(marker_quads)
+                        })
+                        .await;
+
+                    editor.update(cx, |editor, cx| {
+                        editor.minimap_marker_state.markers = minimap_markers;
+                        editor.minimap_marker_state.scrollbar_size = minimap_size;
+                        editor.minimap_marker_state.pending_refresh = None;
+                        cx.notify();
+                    })?;
+
+                    Ok(())
+                }));
+        });
+    }
+
     fn paint_highlighted_range(
         &self,
         range: Range<DisplayPoint>,
@@ -7377,15 +7483,29 @@ impl EditorElement {
     }
 
     fn paint_minimap(&self, layout: &mut EditorLayout, window: &mut Window, cx: &mut App) {
-        if let Some(mut layout) = layout.minimap.take() {
-            let minimap_hitbox = layout.thumb_layout.hitbox.clone();
+        if let Some(mut minimap_layout) = layout.minimap.take() {
+            let minimap_hitbox = minimap_layout.thumb_layout.hitbox.clone();
             let dragging_minimap = self.editor.read(cx).scroll_manager.is_dragging_minimap();
 
-            window.paint_layer(layout.thumb_layout.hitbox.bounds, |window| {
+            window.paint_layer(minimap_layout.thumb_layout.hitbox.bounds, |window| {
                 window.with_element_namespace("minimap", |window| {
-                    layout.minimap.paint(window, cx);
-                    if let Some(thumb_bounds) = layout.thumb_layout.thumb_bounds {
-                        let minimap_thumb_color = match layout.thumb_layout.thumb_state {
+                    minimap_layout.minimap.paint(window, cx);
+
+                    self.refresh_slow_minimap_markers(
+                        layout,
+                        &minimap_layout.thumb_layout,
+                        window,
+                        cx,
+                    );
+                    let minimap_markers = self.editor.read(cx).minimap_marker_state.markers.clone();
+                    for marker in minimap_markers.iter() {
+                        let mut marker = marker.clone();
+                        marker.bounds.origin += minimap_hitbox.origin;
+                        window.paint_quad(marker);
+                    }
+
+                    if let Some(thumb_bounds) = minimap_layout.thumb_layout.thumb_bounds {
+                        let minimap_thumb_color = match minimap_layout.thumb_layout.thumb_state {
                             ScrollbarThumbState::Idle => {
                                 cx.theme().colors().minimap_thumb_background
                             }
@@ -7396,7 +7516,7 @@ impl EditorElement {
                                 cx.theme().colors().minimap_thumb_active_background
                             }
                         };
-                        let minimap_thumb_border = match layout.thumb_border_style {
+                        let minimap_thumb_border = match minimap_layout.thumb_border_style {
                             MinimapThumbBorder::Full => Edges::all(ScrollbarLayout::BORDER_WIDTH),
                             MinimapThumbBorder::LeftOnly => Edges {
                                 left: ScrollbarLayout::BORDER_WIDTH,
@@ -7439,9 +7559,9 @@ impl EditorElement {
 
             let minimap_axis = ScrollbarAxis::Vertical;
             let pixels_per_line = Pixels::from(
-                ScrollPixelOffset::from(minimap_hitbox.size.height) / layout.max_scroll_top,
+                ScrollPixelOffset::from(minimap_hitbox.size.height) / minimap_layout.max_scroll_top,
             )
-            .min(layout.minimap_line_height);
+            .min(minimap_layout.minimap_line_height);
 
             let mut mouse_position = window.mouse_position();
 
@@ -7479,7 +7599,7 @@ impl EditorElement {
                         } else if minimap_hitbox.is_hovered(window) {
                             editor.scroll_manager.set_is_hovering_minimap_thumb(
                                 !event.dragging()
-                                    && layout
+                                    && minimap_layout
                                         .thumb_layout
                                         .thumb_bounds
                                         .is_some_and(|bounds| bounds.contains(&event.position)),
@@ -7510,7 +7630,7 @@ impl EditorElement {
                         editor.update(cx, |editor, cx| {
                             if minimap_hitbox.is_hovered(window) {
                                 editor.scroll_manager.set_is_hovering_minimap_thumb(
-                                    layout
+                                    minimap_layout
                                         .thumb_layout
                                         .thumb_bounds
                                         .is_some_and(|bounds| bounds.contains(&event.position)),
@@ -7534,7 +7654,7 @@ impl EditorElement {
 
                         let event_position = event.position;
 
-                        let Some(thumb_bounds) = layout.thumb_layout.thumb_bounds else {
+                        let Some(thumb_bounds) = minimap_layout.thumb_layout.thumb_bounds else {
                             return;
                         };
 
@@ -7547,11 +7667,11 @@ impl EditorElement {
                                     - thumb_bounds.size.along(minimap_axis) / 2.0)
                                     .max(Pixels::ZERO);
 
-                                let scroll_offset = (layout.minimap_scroll_top
+                                let scroll_offset = (minimap_layout.minimap_scroll_top
                                     + ScrollPixelOffset::from(
-                                        top_position / layout.minimap_line_height,
+                                        top_position / minimap_layout.minimap_line_height,
                                     ))
-                                .min(layout.max_scroll_top);
+                                .min(minimap_layout.max_scroll_top);
 
                                 let scroll_position = editor
                                     .scroll_position(cx)

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -390,6 +390,11 @@ pub struct MinimapContent {
     ///
     /// Default: 80
     pub max_width_columns: Option<num::NonZeroU32>,
+
+    /// Which diagnostic levels to show as markers in the minimap.
+    ///
+    /// Default: all
+    pub diagnostics: Option<ScrollbarDiagnostics>,
 }
 
 /// Forcefully enable or disable the scrollbar for each axis

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2174,7 +2174,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn minimap_section() -> [SettingsPageItem; 7] {
+    fn minimap_section() -> [SettingsPageItem; 8] {
         [
             SettingsPageItem::SectionHeader("Minimap"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -2302,6 +2302,30 @@ fn editor_page() -> SettingsPage {
                             .minimap
                             .get_or_insert_default()
                             .max_width_columns = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Diagnostics",
+                description: "Which diagnostic indicators to show in the minimap.",
+                field: Box::new(SettingField {
+                    json_path: Some("minimap.diagnostics"),
+                    pick: |settings_content| {
+                        settings_content
+                            .editor
+                            .minimap
+                            .as_ref()?
+                            .diagnostics
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .editor
+                            .minimap
+                            .get_or_insert_default()
+                            .diagnostics = value;
                     },
                 }),
                 metadata: None,

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -285,6 +285,7 @@ TBD: Centered layout related settings
     "thumb": "always",              // When to show thumb (always, hover)
     "thumb_border": "left_open",    // Thumb border (left_open, right_open, full, none)
     "max_width_columns": 80,        // Maximum width of minimap
+    "diagnostics": "all",           // Show diagnostics (none, error, warning, information, all)
     "current_line_highlight": null  // Highlight current line (null, line, gutter)
   },
 


### PR DESCRIPTION
Closes #31269

This PR adds diagnostic highlighting in the minimap.
As I'm not very proficient with rust I used claude to generate the logic.

This feature was only tested on Linux, as I don't own a mac and don't have a windows installation ready.
During testing I couldn't make out any performance degradation.

| Settings                  | Minimap UI                      |
|------|------|
|<img  height="450" alt="image" src="https://github.com/user-attachments/assets/b933aab8-93a9-4463-9520-626e28cd6b86" />|<img  height="300" alt="image" src="https://github.com/user-attachments/assets/a0b08b58-c9fd-4691-b239-e44ac79d51cb" />|



Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added diagnostic highlighting in the minimap
