### PR TITLE
Normalize newlines in titles and summaries

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -799,6 +799,7 @@ impl ActiveView {
                                 return;
                             }
                             let new_summary = editor.read(cx).text(cx);
+                            let new_summary = new_summary.replace('\n', " ").replace('\r', " ");
 
                             text_thread_editor.update(cx, |text_thread_editor, cx| {
                                 text_thread_editor

--- a/crates/agent_ui/src/connection_view/thread_view.rs
+++ b/crates/agent_ui/src/connection_view/thread_view.rs
@@ -1435,6 +1435,7 @@ impl ThreadView {
                 }
 
                 let new_title = title_editor.read(cx).text(cx);
+                let new_title = new_title.replace('\n', " ").replace('\r', " ");
                 thread.update(cx, |thread, cx| {
                     thread
                         .set_title(new_title.into(), cx)

--- a/crates/agent_ui/src/text_thread_history.rs
+++ b/crates/agent_ui/src/text_thread_history.rs
@@ -17,11 +17,11 @@ use ui::{
 
 const DEFAULT_TITLE: &SharedString = &SharedString::new_static("New Thread");
 
-fn thread_title(entry: &SavedTextThreadMetadata) -> &SharedString {
+fn thread_title(entry: &SavedTextThreadMetadata) -> SharedString {
     if entry.title.is_empty() {
-        DEFAULT_TITLE
+        DEFAULT_TITLE.clone()
     } else {
-        &entry.title
+        entry.title.replace('\n', " ").replace('\r', " ").into()
     }
 }
 
@@ -200,7 +200,7 @@ impl TextThreadHistory {
                 let mut candidates = Vec::with_capacity(entries.len());
 
                 for (idx, entry) in entries.iter().enumerate() {
-                    candidates.push(StringMatchCandidate::new(idx, thread_title(entry)));
+                    candidates.push(StringMatchCandidate::new(idx, &thread_title(entry)));
                 }
 
                 const MAX_MATCHES: usize = 100;
@@ -416,7 +416,7 @@ impl TextThreadHistory {
             EntryTimeFormat::TimeOnly => format.format_timestamp(timestamp, self.local_timezone),
         };
 
-        let title = thread_title(entry).clone();
+        let title = thread_title(entry);
         let full_date =
             EntryTimeFormat::DateAndTime.format_timestamp(timestamp, self.local_timezone);
 

--- a/crates/agent_ui/src/thread_history_view.rs
+++ b/crates/agent_ui/src/thread_history_view.rs
@@ -18,12 +18,13 @@ use ui::{
 
 const DEFAULT_TITLE: &SharedString = &SharedString::new_static("New Thread");
 
-pub(crate) fn thread_title(entry: &AgentSessionInfo) -> &SharedString {
+pub(crate) fn thread_title(entry: &AgentSessionInfo) -> SharedString {
     entry
         .title
-        .as_ref()
+        .as_deref()
         .filter(|title| !title.is_empty())
-        .unwrap_or(DEFAULT_TITLE)
+        .map(|title| title.replace('\n', " ").replace('\r', " ").into())
+        .unwrap_or_else(|| DEFAULT_TITLE.clone())
 }
 
 pub struct ThreadHistoryView {
@@ -203,7 +204,7 @@ impl ThreadHistoryView {
                 let mut candidates = Vec::with_capacity(entries.len());
 
                 for (idx, entry) in entries.iter().enumerate() {
-                    candidates.push(StringMatchCandidate::new(idx, thread_title(entry)));
+                    candidates.push(StringMatchCandidate::new(idx, &thread_title(entry)));
                 }
 
                 const MAX_MATCHES: usize = 100;
@@ -429,7 +430,7 @@ impl ThreadHistoryView {
             (_, None) => "—".to_string(),
         };
 
-        let title = thread_title(entry).clone();
+        let title = thread_title(entry);
         let full_date = entry_time
             .map(|time| {
                 EntryTimeFormat::DateAndTime.format_timestamp(time.timestamp(), self.local_timezone)
@@ -678,7 +679,7 @@ impl HistoryEntryElement {
 impl RenderOnce for HistoryEntryElement {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let id = ElementId::Name(self.entry.session_id.0.clone().into());
-        let title = thread_title(&self.entry).clone();
+        let title = thread_title(&self.entry);
         let formatted_time = self
             .entry
             .updated_at


### PR DESCRIPTION
- Normalize newline and carriage return chars in user text for thread titles and summaries by replacing with spaces
- Change title helpers to return owned SharedString and adjust call sites to avoid extra clones

Closes #51148


<img width="736" height="141" alt="image" src="https://github.com/user-attachments/assets/ef7e7294-a79d-4458-bac8-68758620fa0b" />
