### PR TITLE
docs: Update the docs regarding semantic tokens to provide some warning

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1136,6 +1136,7 @@
   // - "combined": Use LSP semantic tokens together with tree-sitter highlighting as base.
   // - "full": Use LSP semantic tokens exclusively to highlight the text, tree-sitter syntax highlighting is off.
   //
+  // "full" may result in reduced/zero syntax highlighting if your LSP doesn't fully support the feature
   // May require language server restart to properly apply.
   "semantic_tokens": "off",
 

--- a/docs/src/semantic-tokens.md
+++ b/docs/src/semantic-tokens.md
@@ -41,6 +41,8 @@ You can configure this globally or per-language:
 }
 ```
 
+> **Warning:** `"full"` mode relies entirely on semantic tokens from your language server. Many LSPs provide only a limited subset of token types—or none at all—so `"full"` may result in little or no syntax highlighting. We recommend `"combined"` for most users.
+
 > **Note:** Changing the `semantic_tokens` mode may require a language server restart to take effect. Use the `lsp: restart language servers` command from the command palette if highlighting doesn't update immediately.
 
 ## Customizing Token Colors


### PR DESCRIPTION
Closes #51430

All the details in that issue, just update the docs to give a better warning about `"semantic_tokens: "full"`

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- docs: improved info regarding different modes of semantic tokens
