### PR TITLE
Allow users to persistently disable language servers via UI

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -797,6 +797,8 @@ actions!(
         SortLinesCaseSensitive,
         /// Stops the language server for the current file.
         StopLanguageServer,
+        /// Disables the language server for the current file permanently (persists to settings).
+        DisableLanguageServer,
         /// Switches between source and header files.
         SwitchSourceHeader,
         /// Inserts a tab character or indents.

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -20,7 +20,7 @@ use project::{
     LspStore, LspStoreEvent, Worktree, lsp_store::log_store::GlobalLogStore,
     project_settings::ProjectSettings,
 };
-use settings::{Settings as _, SettingsStore};
+use settings::{Settings as _, SettingsStore, update_settings_file};
 use ui::{
     ContextMenu, ContextMenuEntry, Indicator, PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*,
 };
@@ -537,6 +537,46 @@ impl LanguageServerState {
                                             .detach_and_log_err(cx);
                                     })
                                     .ok();
+                            });
+
+                            let lsp_store_for_disable = lsp_store.clone();
+                            let server_selector_for_disable = server_selector.clone();
+                            let server_name_for_disable = submenu_server_name.clone();
+                            let workspace_for_disable = workspace.clone();
+                            submenu = submenu.entry("Disable Server", None, move |_window, cx| {
+                                lsp_store_for_disable
+                                    .update(cx, |lsp_store, cx| {
+                                        lsp_store.suppress_language_server(
+                                            server_name_for_disable.clone(),
+                                        );
+                                        lsp_store
+                                            .stop_language_servers_for_buffers(
+                                                Vec::new(),
+                                                HashSet::from_iter([
+                                                    server_selector_for_disable.clone()
+                                                ]),
+                                                cx,
+                                            )
+                                            .detach_and_log_err(cx);
+                                    })
+                                    .ok();
+
+                                if let Some(workspace) = workspace_for_disable.upgrade() {
+                                    let fs = workspace.read(cx).project().read(cx).fs().clone();
+                                    let server_name = server_name_for_disable.0.to_string();
+                                    update_settings_file(fs, cx, move |content, _| {
+                                        let disabled_entry = format!("!{server_name}");
+                                        let defaults = &mut content.project.all_languages.defaults;
+                                        let servers = defaults
+                                            .language_servers
+                                            .get_or_insert_with(|| vec!["...".to_string()]);
+                                        if let Some(pos) = servers.iter().position(|s| *s == server_name) {
+                                            servers[pos] = disabled_entry;
+                                        } else if !servers.iter().any(|s| *s == disabled_entry) {
+                                            servers.push(disabled_entry);
+                                        }
+                                    });
+                                }
                             });
                         }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -329,6 +329,7 @@ pub struct LocalLspStore {
         HashMap<Option<SharedString>, HashMap<PathBuf, Option<SharedString>>>,
     >,
     restricted_worktrees_tasks: HashMap<WorktreeId, (Subscription, watch::Receiver<bool>)>,
+    suppressed_servers: HashSet<LanguageServerName>,
 
     buffers_to_refresh_hash_set: HashSet<BufferId>,
     buffers_to_refresh_queue: VecDeque<BufferId>,
@@ -4226,6 +4227,7 @@ impl LspStore {
                 buffer_pull_diagnostics_result_ids: HashMap::default(),
                 workspace_pull_diagnostics_result_ids: HashMap::default(),
                 restricted_worktrees_tasks: HashMap::default(),
+                suppressed_servers: HashSet::default(),
                 watched_manifest_filenames: ManifestProvidersStore::global(cx)
                     .manifest_file_names(),
             }),
@@ -5212,6 +5214,11 @@ impl LspStore {
                         )
                         .collect::<Vec<_>>();
                     for node in nodes {
+                        if let Some(name) = node.name() {
+                            if local.suppressed_servers.contains(&name) {
+                                continue;
+                            }
+                        }
                         let server_id = node.server_id_or_init(|disposition| {
                             let path = &disposition.path;
                             let uri = Uri::from_file_path(worktree.read(cx).absolutize(&path.path));
@@ -10872,8 +10879,29 @@ impl LspStore {
     }
 
     pub fn restart_all_language_servers(&mut self, cx: &mut Context<Self>) {
+        if let Some(local) = self.as_local_mut() {
+            local.suppressed_servers.clear();
+        }
         let buffers = self.buffer_store.read(cx).buffers().collect();
         self.restart_language_servers_for_buffers(buffers, HashSet::default(), cx);
+    }
+
+    pub fn suppress_language_server(&mut self, server_name: LanguageServerName) {
+        if let Some(local) = self.as_local_mut() {
+            local.suppressed_servers.insert(server_name);
+        }
+    }
+
+    pub fn unsuppress_language_server(&mut self, server_name: &LanguageServerName) {
+        if let Some(local) = self.as_local_mut() {
+            local.suppressed_servers.remove(server_name);
+        }
+    }
+
+    pub fn is_server_suppressed(&self, server_name: &LanguageServerName) -> bool {
+        self.as_local()
+            .map(|local| local.suppressed_servers.contains(server_name))
+            .unwrap_or(false)
     }
 
     pub fn restart_language_servers_for_buffers(
@@ -10913,6 +10941,13 @@ impl LspStore {
             });
             cx.background_spawn(request).detach_and_log_err(cx);
         } else {
+            if let Some(local) = self.as_local_mut() {
+                for selector in &only_restart_servers {
+                    if let LanguageServerSelector::Name(name) = selector {
+                        local.suppressed_servers.remove(name);
+                    }
+                }
+            }
             let stop_task = if only_restart_servers.is_empty() {
                 self.stop_local_language_servers_for_buffers(&buffers, HashSet::default(), cx)
             } else {


### PR DESCRIPTION
Adds a **"Disable Server"** option to the LSP status menu that persistently disables a language server by writing `!server-name` to `settings.json`, leveraging the existing convention.

**What it does:**
- Suppresses the server immediately in the current session (prevents auto-restart on file open)
- Persists `!server-name` to settings so it stays disabled across restarts
- If the bare name already exists in settings, replaces it with the `!`-prefixed version (avoids duplicates)

**Files changed:**
- [lsp_store.rs](cci:7://file:///home/pankaj/turbine/zed-guild/zed/crates/project/src/lsp_store.rs:0:0-0:0) — session-level suppression via `suppressed_servers` set
- [lsp_button.rs](cci:7://file:///home/pankaj/turbine/zed-guild/zed/crates/language_tools/src/lsp_button.rs:0:0-0:0) — "Disable Server" menu entry with settings persistence
- [actions.rs](cci:7://file:///home/pankaj/turbine/zed-guild/zed/crates/editor/src/actions.rs:0:0-0:0) — `DisableLanguageServer` action definition

- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

<img width="704" height="245" alt="Screenshot from 2026-03-14 06-02-44" src="https://github.com/user-attachments/assets/e9949c27-5c18-4555-90c8-5ed7680baa9b" />


Release Notes:

- Added a "Disable Server" option to the language server status menu to persistently prevent servers from starting.
