### PR TITLE
which-key: Removed some keys from the filter list that were wrongly filtered

### DIFF
--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -61,12 +61,8 @@ pub fn init(cx: &mut App) {
 pub static FILTERED_KEYSTROKES: LazyLock<Vec<Vec<Keystroke>>> = LazyLock::new(|| {
     [
         // Modifiers on normal vim commands
-        "g h",
         "g j",
         "g k",
-        "g l",
-        "g $",
-        "g ^",
         // Duplicate keys with "ctrl" held, e.g. "ctrl-w ctrl-a" is duplicate of "ctrl-w a"
         "ctrl-w ctrl-a",
         "ctrl-w ctrl-c",


### PR DESCRIPTION
Closes #49845

Follow up on #50992

Really simple, just removing some vim commands from the filter list that are useful enough to justify not being filtered out.

tested to make sure the changes work:
<img width="944" height="1123" alt="Screenshot 2026-03-13 at 11 23 52 PM" src="https://github.com/user-attachments/assets/23b2db73-d0e7-413b-aef7-efe62e84b542" />

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- which-key: fixed filter list for some vim commands
