### PR TITLE
Fix multi-character bracket auto-close in language injection contexts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4591,48 +4591,96 @@ impl Editor {
             }
             all_selections_read_only = false;
 
-            if let Some(scope) = snapshot.language_scope_at(selection.head()) {
+            {
+                let all_scopes = snapshot.language_scopes_at(selection.head());
+                // Use the deepest scope for autoclose-before checks
+                let scope = snapshot.language_scope_at(selection.head());
+
                 // Determine if the inserted text matches the opening or closing
                 // bracket of any of this language's bracket pairs.
+                // We collect pairs from ALL scopes and prefer the longest match.
                 let mut bracket_pair = None;
                 let mut is_bracket_pair_start = false;
                 let mut is_bracket_pair_end = false;
                 if !text.is_empty() {
+                    // First, find the best match from the deepest scope only.
+                    let mut deepest_start_match: Option<BracketPair> = None;
+                    let mut deepest_start_len: usize = 0;
                     let mut bracket_pair_matching_end = None;
                     // `text` can be empty when a user is using IME (e.g. Chinese Wubi Simplified)
                     //  and they are removing the character that triggered IME popup.
-                    for (pair, enabled) in scope.brackets() {
-                        if !pair.close && !pair.surround {
-                            continue;
-                        }
+                    if let Some(deepest_scope) = all_scopes.first() {
+                        for (pair, enabled) in deepest_scope.brackets() {
+                            if !pair.close && !pair.surround {
+                                continue;
+                            }
 
-                        if enabled && pair.start.ends_with(text.as_ref()) {
-                            let prefix_len = pair.start.len() - text.len();
-                            let preceding_text_matches_prefix = prefix_len == 0
-                                || (selection.start.column >= (prefix_len as u32)
-                                    && snapshot.contains_str_at(
-                                        Point::new(
-                                            selection.start.row,
-                                            selection.start.column - (prefix_len as u32),
-                                        ),
-                                        &pair.start[..prefix_len],
-                                    ));
-                            if preceding_text_matches_prefix {
-                                bracket_pair = Some(pair.clone());
-                                is_bracket_pair_start = true;
-                                break;
+                            if enabled && pair.start.ends_with(text.as_ref()) {
+                                let prefix_len = pair.start.len() - text.len();
+                                let preceding_text_matches_prefix = prefix_len == 0
+                                    || (selection.start.column >= (prefix_len as u32)
+                                        && snapshot.contains_str_at(
+                                            Point::new(
+                                                selection.start.row,
+                                                selection.start.column - (prefix_len as u32),
+                                            ),
+                                            &pair.start[..prefix_len],
+                                        ));
+                                if preceding_text_matches_prefix
+                                    && pair.start.len() > deepest_start_len
+                                {
+                                    deepest_start_len = pair.start.len();
+                                    deepest_start_match = Some(pair.clone());
+                                }
+                            }
+                            if pair.end.as_str() == text.as_ref()
+                                && bracket_pair_matching_end.is_none()
+                            {
+                                bracket_pair_matching_end = Some(pair.clone());
                             }
                         }
-                        if pair.end.as_str() == text.as_ref() && bracket_pair_matching_end.is_none()
-                        {
-                            // take first bracket pair matching end, but don't break in case a later bracket
-                            // pair matches start
-                            bracket_pair_matching_end = Some(pair.clone());
+                    }
+
+                    // Only check outer scopes for LONGER matches if the deepest
+                    // scope had a match. This prevents outer scope brackets from
+                    // leaking into injected languages that intentionally omit them
+                    // (e.g., HTML's `<`/`>` should not auto-close inside JavaScript).
+                    let mut best_start_match = deepest_start_match.clone();
+                    let mut best_start_len = deepest_start_len;
+                    if deepest_start_len > 0 {
+                        for current_scope in all_scopes.iter().skip(1) {
+                            for (pair, enabled) in current_scope.brackets() {
+                                if !pair.close && !pair.surround {
+                                    continue;
+                                }
+                                if enabled
+                                    && pair.start.ends_with(text.as_ref())
+                                    && pair.start.len() > best_start_len
+                                {
+                                    let prefix_len = pair.start.len() - text.len();
+                                    let preceding_text_matches_prefix = prefix_len == 0
+                                        || (selection.start.column >= (prefix_len as u32)
+                                            && snapshot.contains_str_at(
+                                                Point::new(
+                                                    selection.start.row,
+                                                    selection.start.column
+                                                        - (prefix_len as u32),
+                                                ),
+                                                &pair.start[..prefix_len],
+                                            ));
+                                    if preceding_text_matches_prefix {
+                                        best_start_len = pair.start.len();
+                                        best_start_match = Some(pair.clone());
+                                    }
+                                }
+                            }
                         }
                     }
-                    if let Some(end) = bracket_pair_matching_end
-                        && bracket_pair.is_none()
-                    {
+
+                    if let Some(start) = best_start_match {
+                        bracket_pair = Some(start);
+                        is_bracket_pair_start = true;
+                    } else if let Some(end) = bracket_pair_matching_end {
                         bracket_pair = Some(end);
                         is_bracket_pair_end = true;
                     }
@@ -4648,10 +4696,12 @@ impl Editor {
                             // If the inserted text is a suffix of an opening bracket and the
                             // selection is preceded by the rest of the opening bracket, then
                             // insert the closing bracket.
-                            let following_text_allows_autoclose = snapshot
-                                .chars_at(selection.start)
-                                .next()
-                                .is_none_or(|c| scope.should_autoclose_before(c));
+                            let following_text_allows_autoclose = scope.as_ref().is_none_or(|s| {
+                                snapshot
+                                    .chars_at(selection.start)
+                                    .next()
+                                    .is_none_or(|c| s.should_autoclose_before(c))
+                            });
 
                             let preceding_text_allows_autoclose = selection.start.column == 0
                                 || snapshot
@@ -4732,8 +4782,31 @@ impl Editor {
                                     selection.id,
                                     bracket_pair.clone(),
                                 ));
+                                // When a multi-character bracket supersedes a previous
+                                // single-character auto-close, extend the edit range to
+                                // replace the stale auto-closed character.
+                                let edit_end = if bracket_pair.start.len() > 1 {
+                                    if let Some(region) = autoclose_region {
+                                        let region_end_point =
+                                            region.range.end.to_point(&snapshot);
+                                        if selection.end.row == region_end_point.row
+                                            && selection.end.column
+                                                == region_end_point.column
+                                                    - region.pair.end.len() as u32
+                                        {
+                                            // Extend past the stale auto-closed bracket
+                                            region_end_point
+                                        } else {
+                                            selection.end
+                                        }
+                                    } else {
+                                        selection.end
+                                    }
+                                } else {
+                                    selection.end
+                                };
                                 edits.push((
-                                    selection.range(),
+                                    selection.start..edit_end,
                                     format!("{}{}", text, bracket_pair.end).into(),
                                 ));
                                 bracket_inserted = true;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3958,6 +3958,74 @@ impl BufferSnapshot {
         })
     }
 
+    /// Returns all [`LanguageScope`]s at the given location, from deepest to shallowest.
+    /// This is useful for collecting bracket pairs from all injection layers.
+    pub fn language_scopes_at<D: ToOffset>(&self, position: D) -> Vec<LanguageScope> {
+        let offset = position.to_offset(self);
+        let text: &TextBufferSnapshot = self;
+
+        let mut scopes_with_depth: Vec<(LanguageScope, usize, usize)> = Vec::new();
+
+        for layer in self
+            .syntax
+            .layers_for_range(offset..offset, &self.text, false)
+        {
+            if let Some(ranges) = layer.included_sub_ranges
+                && !offset_in_sub_ranges(ranges, offset, text)
+            {
+                continue;
+            }
+
+            let mut cursor = layer.node().walk();
+
+            let mut range = None;
+            loop {
+                let child_range = cursor.node().byte_range();
+                if !child_range.contains(&offset) {
+                    break;
+                }
+
+                range = Some(child_range);
+                if cursor.goto_first_child_for_byte(offset).is_none() {
+                    break;
+                }
+            }
+
+            if let Some(range) = range {
+                scopes_with_depth.push((
+                    LanguageScope {
+                        language: layer.language.clone(),
+                        override_id: layer.override_id(offset, &self.text),
+                    },
+                    layer.depth,
+                    range.len(),
+                ));
+            }
+        }
+
+        // Sort by depth descending (deepest first), then by range length ascending (smallest first)
+        scopes_with_depth.sort_by(|a, b| {
+            b.1.cmp(&a.1).then_with(|| a.2.cmp(&b.2))
+        });
+
+        let mut scopes: Vec<LanguageScope> = scopes_with_depth
+            .into_iter()
+            .map(|(scope, _, _)| scope)
+            .collect();
+
+        // If no layers matched, fall back to the base language
+        if scopes.is_empty() {
+            if let Some(language) = self.language.clone() {
+                scopes.push(LanguageScope {
+                    language,
+                    override_id: None,
+                });
+            }
+        }
+
+        scopes
+    }
+
     /// Returns a tuple of the range and character kind of the word
     /// surrounding the given position.
     pub fn surrounding_word<T: ToOffset>(

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6743,6 +6743,12 @@ impl MultiBufferSnapshot {
             .and_then(|(buffer, offset)| buffer.language_scope_at(offset))
     }
 
+    pub fn language_scopes_at<T: ToOffset>(&self, point: T) -> Vec<LanguageScope> {
+        self.point_to_buffer_offset(point)
+            .map(|(buffer, offset)| buffer.language_scopes_at(offset))
+            .unwrap_or_default()
+    }
+
     pub fn char_classifier_at<T: ToOffset>(&self, point: T) -> CharClassifier {
         self.point_to_buffer_offset(point)
             .map(|(buffer, offset)| buffer.char_classifier_at(offset))


### PR DESCRIPTION
## Summary

- Fixes multi-character bracket pairs (e.g., `{{`/`}}`, `{%`/`%}`) not auto-closing in files with language injections
- Currently, only the deepest (injected) language's brackets are checked. For example, in Liquid files where `template_content` is injected as HTML, typing `{` triggers HTML's `{`/`}` pair, and the subsequent `{` or `%` never forms the intended `{{`/`}}` or `{%`/`%}` pair
- This affects any language that uses multi-character brackets and has injected content (Liquid, potentially Handlebars, Jinja, etc.)

### Changes

1. **`crates/language/src/buffer.rs`**: Added `language_scopes_at()` method that returns all language scopes at a position (deepest first), complementing the existing `language_scope_at()` which returns only the deepest
2. **`crates/multi_buffer/src/multi_buffer.rs`**: Added delegation for the new method
3. **`crates/editor/src/editor.rs`**: Modified bracket matching in `handle_input()` to:
   - Collect bracket pairs from all scopes at the cursor position
   - Prefer longer bracket pairs from outer scopes over shorter ones from the deepest scope (so Liquid's `{{` wins over HTML's `{`)
   - Only check outer scopes when the deepest scope already has a match, preventing bracket leaking (HTML's `<`/`>` won't auto-close inside `<script>` JavaScript)
   - Replace stale auto-closed brackets when a multi-character pair supersedes a previous single-character auto-close

## Test plan

- [x] All 28 existing `autoclose` tests pass
- [x] All 18 existing `bracket` tests pass  
- [x] `test_autoclose_with_embedded_language` specifically validates that injected language bracket scoping still works correctly (HTML `<`/`>` does not leak into JavaScript)
- [ ] Manual testing with Liquid files: `{{`, `{%`, `{{-`, `{%-` should auto-close correctly inside `template_content` (HTML injection zones)

### Repro steps (before fix)
1. Open a `.liquid` file with a Zed extension that injects HTML into `template_content`
2. Type `{{` — get `{{}` instead of `{{ | }}`
3. Type `{%` — get `{%}` instead of `{% | %}`

### Expected (after fix)
1. `{{` → `{{|}}` (cursor between)
2. `{%` → `{%|%}` (cursor between)

## Release Notes

- Fixed multi-character bracket pairs (e.g., `{{`/`}}`) not auto-closing correctly in files with language injections, such as Liquid templates with HTML injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)