### PR TITLE
Add deleted color to project panel

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1864,6 +1864,8 @@ pub fn entry_git_aware_label_color(git_status: GitSummary, ignored: bool, select
         Color::Ignored
     } else if git_status.conflict > 0 {
         Color::Conflict
+    } else if tracked.deleted > 0 {
+        Color::Deleted
     } else if tracked.modified > 0 {
         Color::Modified
     } else if tracked.added > 0 || git_status.untracked > 0 {


### PR DESCRIPTION
When a file is deleted, the parent folder isn't colored which makes it hard to know unless we look at the Git Panel.

This PR adds `Color::Deleted` to fix that.

<img width="366" height="428" alt="Screenshot 2026-03-14 at 7 56 04 PM" src="https://github.com/user-attachments/assets/6ed3a3c7-e7e7-4b48-b89c-705a7c1ff634" />

Release Notes:

- Improved project panel to color folder with deleted file
