### PR TITLE
gpui_wgpu: Release surface resources during destroy

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1609,7 +1609,9 @@ impl WgpuRenderer {
     }
 
     pub fn destroy(&mut self) {
-        // wgpu resources are automatically cleaned up when dropped
+        // Release surface-bound GPU resources eagerly so the underlying native
+        // window can be destroyed before the renderer itself is dropped.
+        self.resources.take();
     }
 
     /// Returns true if the GPU device was lost and recovery is needed.


### PR DESCRIPTION
## Summary

Implements the fix proposed by @israelrios in https://github.com/zed-industries/zed/issues/50269#issuecomment-4049006746.

The issue comment narrowed the hang down to X11 window teardown:

- when the Settings window is closed on X11, the UI thread can stall while `WgpuRenderer` is dropped during final `X11WindowState` teardown
- at that point, the X11 window has already been destroyed
- the proposed fix is to make `WgpuRenderer::destroy()` release surface-bound GPU resources eagerly so the native window is destroyed only after the `wgpu::Surface` and related resources are gone

This PR applies that change in `crates/gpui_wgpu/src/wgpu_renderer.rs` by calling `self.resources.take()` inside `destroy()`.

## Validation

I confirmed this fix locally on Linux Mint 21.3 Cinnamon by applying it to the `v0.227.1` build:

- opening and closing Settings no longer causes the main window to hang

## References

- Refs #50269
- Original analysis and fix proposal by @israelrios: https://github.com/zed-industries/zed/issues/50269#issuecomment-4049006746

Release Notes:

- Fixed a Linux/X11 issue where closing the Settings window could cause Zed to hang.
