### PR TITLE
search: Fix project search tooltip keybinding hint disappearing

### DIFF
--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -1,15 +1,20 @@
 use editor::EditorSettings;
+use gpui::FocusHandle;
 use settings::Settings as _;
 use ui::{ButtonCommon, Clickable, Context, Render, Tooltip, Window, prelude::*};
 use workspace::{ItemHandle, StatusItemView};
 
 pub const SEARCH_ICON: IconName = IconName::MagnifyingGlass;
 
-pub struct SearchButton;
+pub struct SearchButton {
+    pane_item_focus_handle: Option<FocusHandle>,
+}
 
 impl SearchButton {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            pane_item_focus_handle: None,
+        }
     }
 }
 
@@ -21,11 +26,25 @@ impl Render for SearchButton {
             return button.hidden();
         }
 
+        let focus_handle = self.pane_item_focus_handle.clone();
         button.child(
             IconButton::new("project-search-indicator", SEARCH_ICON)
                 .icon_size(IconSize::Small)
-                .tooltip(|_window, cx| {
-                    Tooltip::for_action("Project Search", &workspace::DeploySearch::default(), cx)
+                .tooltip(move |_window, cx| {
+                    if let Some(focus_handle) = &focus_handle {
+                        Tooltip::for_action_in(
+                            "Project Search",
+                            &workspace::DeploySearch::default(),
+                            focus_handle,
+                            cx,
+                        )
+                    } else {
+                        Tooltip::for_action(
+                            "Project Search",
+                            &workspace::DeploySearch::default(),
+                            cx,
+                        )
+                    }
                 })
                 .on_click(cx.listener(|_this, _, window, cx| {
                     window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);
@@ -37,9 +56,10 @@ impl Render for SearchButton {
 impl StatusItemView for SearchButton {
     fn set_active_pane_item(
         &mut self,
-        _active_pane_item: Option<&dyn ItemHandle>,
+        active_pane_item: Option<&dyn ItemHandle>,
         _window: &mut Window,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
+        self.pane_item_focus_handle = active_pane_item.map(|item| item.item_focus_handle(cx));
     }
 }


### PR DESCRIPTION
What
---
The keybinding hint in the Project Search status bar button tooltip disappears shortly after the tooltip appears, while the label "Project Search" remains. This is most reproducible with no file open.

Why
---
`SearchButton` used `Tooltip::for_action` with no stored focus handle, so `KeyBinding::render` called `window.focused(cx)` at render time to resolve the `pane::DeploySearch` binding. When the `Tooltip` entity re-rendered (it subscribes to theme settings changes) and the focused element was no longer in a `Pane` key context, the keybinding lookup failed silently and the shortcut hint vanished.

Fix
---
Store the active pane item's `FocusHandle` in `SearchButton` via `set_active_pane_item` and use `Tooltip::for_action_in` so the keybinding is always resolved against a stable `Pane` context. Falls back to `Tooltip::for_action` when no pane item is active.

Closes #51562

Test Plan
---

- [x] `cargo fmt --check`
- [ ] `cargo test --workspace`
   - currently blocked by an unrelated compile error test 
   - tests::test_terminal_kill_allows_wait_for_exit_to_complete ... FAILED
- [x] Manual verification of:
   -  Try to reproduce the issue and the keyboard shortcut visible for as long as the cursor is hovering over the button.
   
Release Notes
- Fixed Project Search status bar button tooltip keybinding hint disappearing while hovering

Screenshots
---
Current:
<img width="835" height="496" alt="image" src="https://github.com/user-attachments/assets/cb1ffdf2-7733-47f6-9030-041459c2734c" />

Expected:
<img width="835" height="496" alt="image" src="https://github.com/user-attachments/assets/84cb54b9-290c-4210-b86b-7ae9f8bf9ac0" />

Release Notes:

- N/A