### PR TITLE
Add security scanning CI pipeline with cargo-audit and tools

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,14 +1,14 @@
 # Security scanning pipeline: SCA (dependency) + SAST (static analysis).
 #
 # Four concurrent jobs provide layered coverage:
-#   cargo-audit  — Rust-specific advisory database (RustSec)
+#   cargo-audit  — Rust-specific advisory database (RustSec) + cargo-deny license/advisory checks
 #   osv-scanner  — Broad SCA via Google's OSV database (Cargo, Docker, Python, Node)
 #   semgrep      — Fast, rules-based SAST (p/ci, p/rust, p/security-audit)
 #   codeql       — Deep semantic SAST (GitHub-native, Rust language support)
 #
 # Findings from OSV-Scanner, Semgrep, and CodeQL are uploaded as SARIF files
 # and appear in the repository's Security > Code scanning alerts UI.
-# cargo-audit results surface as CI annotations directly in pull requests.
+# cargo-audit and cargo-deny results surface as CI annotations directly in pull requests.
 
 name: Security Scanning
 on:
@@ -29,24 +29,32 @@ defaults:
     shell: bash -euo pipefail {0}
 
 jobs:
-  # ── SCA: Rust crate vulnerability audit (RustSec) ─────────────────────
-  # Uses the RustSec advisory database to flag known-vulnerable crate
-  # versions pinned in Cargo.lock. Results appear as PR annotations.
+  # ── SCA: Rust crate vulnerability audit (RustSec + cargo-deny) ────────
+  # cargo-audit checks Cargo.lock against the RustSec advisory database.
+  # cargo-deny provides additional advisory and license policy checks,
+  # configured to block on high-severity and above.
   cargo-audit:
     name: "SCA — cargo-audit"
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/v1.12.3/install-from-binstall-release.sh \
+            | bash
 
-      - name: Install cargo-audit
-        run: cargo binstall cargo-audit --no-confirm --locked
+      - name: Install cargo-audit and cargo-deny
+        run: cargo binstall cargo-audit cargo-deny --no-confirm --locked
 
       - name: Run cargo-audit
         run: cargo audit
+
+      - name: Run cargo-deny (advisories)
+        run: cargo deny check advisories
 
   # ── SCA: Broad dependency scanning (OSV) ──────────────────────────────
   # Google's OSV-Scanner checks Cargo.lock, Dockerfiles, pyproject.toml,
@@ -54,13 +62,14 @@ jobs:
   # SARIF report uploaded to GitHub Code Scanning.
   osv-scanner:
     name: "SCA — OSV-Scanner"
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Run OSV-Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+        uses: google/osv-scanner-action/osv-scanner-action@9a8bc41b9d6a0fcd5e2bed44b39aa7cca8ea44a3 # v2.3.3
         with:
           scan-args: |-
             --recursive
@@ -70,7 +79,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
         if: always()
         with:
           sarif_file: osv-results.sarif
@@ -82,13 +91,14 @@ jobs:
   # Produces a SARIF report uploaded to GitHub Code Scanning.
   semgrep:
     name: "SAST — Semgrep"
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Semgrep
-        run: python3 -m pip install semgrep
+        run: python3 -m pip install semgrep==1.155.0
 
       - name: Run Semgrep
         run: |
@@ -102,7 +112,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
         if: always()
         with:
           sarif_file: semgrep-results.sarif
@@ -114,18 +124,19 @@ jobs:
   # analysis) so no compilation is required.
   codeql:
     name: "SAST — CodeQL"
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
         with:
           category: codeql-rust

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,8 +9,9 @@
 # On scheduled runs and manual dispatches, findings from OSV-Scanner,
 # Semgrep, and CodeQL are uploaded as SARIF files and appear in the
 # repository's Security > Code scanning alerts UI.
-# On pull requests, scan results are uploaded to $GITHUB_OUTPUT for easy
-# reference, and SAST jobs fail on high or greater severity findings.
+# On pull requests, scan summaries appear in the job step summary and
+# counts are set as step outputs. SAST jobs fail on high or greater
+# severity findings.
 # cargo-audit and cargo-deny results surface as CI annotations directly in pull requests.
 
 name: Security Scanning
@@ -83,7 +84,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
+        uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         if: always() && github.event_name != 'pull_request'
         with:
           sarif_file: osv-results.sarif
@@ -94,13 +95,14 @@ jobs:
         id: osv-results
         run: |
           if [[ -f osv-results.sarif ]]; then
-            count=$(jq '[.runs[].results[]] | length' osv-results.sarif)
+            count=$(jq '[.runs[] | (.results // [])[]] | length' osv-results.sarif)
             echo "vulnerability_count=${count}" >> "$GITHUB_OUTPUT"
             {
-              echo "vulnerabilities<<EOF"
-              jq -r '.runs[].results[] | "- \(.ruleId): \(.message.text)"' osv-results.sarif
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+              echo "### OSV-Scanner Results"
+              echo "${count} vulnerability(ies) found"
+              echo ""
+              jq -r '[.runs[] | (.results // [])[]] | .[:20][] | "- \(.ruleId): \(.message.text)"' osv-results.sarif
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
           fi
@@ -131,7 +133,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
+        uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         if: always() && github.event_name != 'pull_request'
         with:
           sarif_file: semgrep-results.sarif
@@ -142,15 +144,16 @@ jobs:
         id: semgrep-results
         run: |
           if [[ -f semgrep-results.sarif ]]; then
-            count=$(jq '[.runs[].results[]] | length' semgrep-results.sarif)
+            count=$(jq '[.runs[] | (.results // [])[]] | length' semgrep-results.sarif)
             echo "finding_count=${count}" >> "$GITHUB_OUTPUT"
-            high_count=$(jq '[.runs[].results[] | select(.level == "error")] | length' semgrep-results.sarif)
+            high_count=$(jq '[.runs[] | (.results // [])[] | select(.level == "error")] | length' semgrep-results.sarif)
             echo "high_severity_count=${high_count}" >> "$GITHUB_OUTPUT"
             {
-              echo "findings<<EOF"
-              jq -r '.runs[].results[] | "- [\(.level)] \(.ruleId): \(.message.text)"' semgrep-results.sarif
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+              echo "### Semgrep Results"
+              echo "${count} finding(s), ${high_count} high/critical"
+              echo ""
+              jq -r '[.runs[] | (.results // [])[]] | .[:20][] | "- [\(.level)] \(.ruleId): \(.message.text)"' semgrep-results.sarif
+            } >> "$GITHUB_STEP_SUMMARY"
             if [[ "${high_count}" -gt 0 ]]; then
               echo "::error::Semgrep found ${high_count} high or critical severity finding(s)"
               exit 1
@@ -172,13 +175,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
+        uses: github/codeql-action/init@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
+        uses: github/codeql-action/analyze@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         with:
           category: codeql-rust
           output: codeql-results
@@ -190,15 +193,16 @@ jobs:
         run: |
           sarif_file=$(find codeql-results -name '*.sarif' -type f | head -1)
           if [[ -n "${sarif_file}" ]]; then
-            count=$(jq '[.runs[].results[]] | length' "${sarif_file}")
+            count=$(jq '[.runs[] | (.results // [])[]] | length' "${sarif_file}")
             echo "finding_count=${count}" >> "$GITHUB_OUTPUT"
-            high_count=$(jq '[.runs[].results[] | select(.level == "error")] | length' "${sarif_file}")
+            high_count=$(jq '[.runs[] | (.results // [])[] | select(.level == "error")] | length' "${sarif_file}")
             echo "high_severity_count=${high_count}" >> "$GITHUB_OUTPUT"
             {
-              echo "findings<<EOF"
-              jq -r '.runs[].results[] | "- [\(.level)] \(.ruleId): \(.message.text)"' "${sarif_file}"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+              echo "### CodeQL Results"
+              echo "${count} finding(s), ${high_count} high/critical"
+              echo ""
+              jq -r '[.runs[] | (.results // [])[]] | .[:20][] | "- [\(.level)] \(.ruleId): \(.message.text)"' "${sarif_file}"
+            } >> "$GITHUB_STEP_SUMMARY"
             if [[ "${high_count}" -gt 0 ]]; then
               echo "::error::CodeQL found ${high_count} high or critical severity finding(s)"
               exit 1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -91,7 +91,6 @@ jobs:
   # Produces a SARIF report uploaded to GitHub Code Scanning.
   semgrep:
     name: "SAST — Semgrep"
-    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -124,7 +123,6 @@ jobs:
   # analysis) so no compilation is required.
   codeql:
     name: "SAST — CodeQL"
-    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,14 +41,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Install cargo-binstall
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf \
-            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/v1.12.3/install-from-binstall-release.sh \
-            | bash
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
-      - name: Install cargo-audit and cargo-deny
-        run: cargo binstall cargo-audit cargo-deny --no-confirm --locked
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
 
       - name: Run cargo-audit
         run: cargo audit

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+      - name: Install cargo-binstall
+        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo binstall cargo-audit --no-confirm --locked
 
       - name: Run cargo-audit
         run: cargo audit

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,128 @@
+# Security scanning pipeline: SCA (dependency) + SAST (static analysis).
+#
+# Four concurrent jobs provide layered coverage:
+#   cargo-audit  — Rust-specific advisory database (RustSec)
+#   osv-scanner  — Broad SCA via Google's OSV database (Cargo, Docker, Python, Node)
+#   semgrep      — Fast, rules-based SAST (p/ci, p/rust, p/security-audit)
+#   codeql       — Deep semantic SAST (GitHub-native, Rust language support)
+#
+# Findings from OSV-Scanner, Semgrep, and CodeQL are uploaded as SARIF files
+# and appear in the repository's Security > Code scanning alerts UI.
+# cargo-audit results surface as CI annotations directly in pull requests.
+
+name: Security Scanning
+on:
+  pull_request:
+    branches:
+      - "**"
+  schedule:
+    # Weekly Monday 6:00 AM UTC — catches newly disclosed CVEs in existing code
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  security-events: write
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  # ── SCA: Rust crate vulnerability audit (RustSec) ─────────────────────
+  # Uses the RustSec advisory database to flag known-vulnerable crate
+  # versions pinned in Cargo.lock. Results appear as PR annotations.
+  cargo-audit:
+    name: "SCA — cargo-audit"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo-audit
+        run: cargo audit
+
+  # ── SCA: Broad dependency scanning (OSV) ──────────────────────────────
+  # Google's OSV-Scanner checks Cargo.lock, Dockerfiles, pyproject.toml,
+  # and package.json against the OSV vulnerability database. Produces a
+  # SARIF report uploaded to GitHub Code Scanning.
+  osv-scanner:
+    name: "SCA — OSV-Scanner"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+        with:
+          scan-args: |-
+            --recursive
+            --format=sarif
+            --output=osv-results.sarif
+            ./
+        continue-on-error: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: osv-results.sarif
+          category: osv-scanner
+
+  # ── SAST: Semgrep rules-based scanning ────────────────────────────────
+  # Runs the open-source Semgrep engine with curated rulesets targeting
+  # general CI issues, Rust-specific patterns, and security audit checks.
+  # Produces a SARIF report uploaded to GitHub Code Scanning.
+  semgrep:
+    name: "SAST — Semgrep"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Semgrep
+        run: python3 -m pip install semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/ci \
+            --config p/rust \
+            --config p/security-audit \
+            --sarif \
+            --output semgrep-results.sarif \
+            .
+        continue-on-error: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep-results.sarif
+          category: semgrep
+
+  # ── SAST: CodeQL deep semantic analysis ───────────────────────────────
+  # GitHub's native CodeQL engine performs deep data-flow and taint
+  # analysis on Rust source code. Uses build-mode: none (source-level
+  # analysis) so no compilation is required.
+  codeql:
+    name: "SAST — CodeQL"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: codeql-rust

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,8 +6,11 @@
 #   semgrep      — Fast, rules-based SAST (p/ci, p/rust, p/security-audit)
 #   codeql       — Deep semantic SAST (GitHub-native, Rust language support)
 #
-# Findings from OSV-Scanner, Semgrep, and CodeQL are uploaded as SARIF files
-# and appear in the repository's Security > Code scanning alerts UI.
+# On scheduled runs and manual dispatches, findings from OSV-Scanner,
+# Semgrep, and CodeQL are uploaded as SARIF files and appear in the
+# repository's Security > Code scanning alerts UI.
+# On pull requests, scan results are uploaded to $GITHUB_OUTPUT for easy
+# reference, and SAST jobs fail on high or greater severity findings.
 # cargo-audit and cargo-deny results surface as CI annotations directly in pull requests.
 
 name: Security Scanning
@@ -30,9 +33,9 @@ defaults:
 
 jobs:
   # ── SCA: Rust crate vulnerability audit (RustSec + cargo-deny) ────────
-  # cargo-audit checks Cargo.lock against the RustSec advisory database.
-  # cargo-deny provides additional advisory and license policy checks,
-  # configured to block on high-severity and above.
+  # cargo-audit checks Cargo.lock against the RustSec advisory database
+  # and will fail at any severity. cargo-deny provides additional
+  # advisory and license policy checks.
   cargo-audit:
     name: "SCA — cargo-audit"
     if: github.repository_owner == 'zed-industries'
@@ -81,10 +84,26 @@ jobs:
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner
+
+      - name: Output scan results
+        if: always() && github.event_name == 'pull_request'
+        id: osv-results
+        run: |
+          if [[ -f osv-results.sarif ]]; then
+            count=$(jq '[.runs[].results[]] | length' osv-results.sarif)
+            echo "vulnerability_count=${count}" >> "$GITHUB_OUTPUT"
+            {
+              echo "vulnerabilities<<EOF"
+              jq -r '.runs[].results[] | "- \(.ruleId): \(.message.text)"' osv-results.sarif
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
+          fi
 
   # ── SAST: Semgrep rules-based scanning ────────────────────────────────
   # Runs the open-source Semgrep engine with curated rulesets targeting
@@ -113,10 +132,33 @@ jobs:
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
+
+      - name: Output scan results
+        if: always() && github.event_name == 'pull_request'
+        id: semgrep-results
+        run: |
+          if [[ -f semgrep-results.sarif ]]; then
+            count=$(jq '[.runs[].results[]] | length' semgrep-results.sarif)
+            echo "finding_count=${count}" >> "$GITHUB_OUTPUT"
+            high_count=$(jq '[.runs[].results[] | select(.level == "error")] | length' semgrep-results.sarif)
+            echo "high_severity_count=${high_count}" >> "$GITHUB_OUTPUT"
+            {
+              echo "findings<<EOF"
+              jq -r '.runs[].results[] | "- [\(.level)] \(.ruleId): \(.message.text)"' semgrep-results.sarif
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            if [[ "${high_count}" -gt 0 ]]; then
+              echo "::error::Semgrep found ${high_count} high or critical severity finding(s)"
+              exit 1
+            fi
+          else
+            echo "finding_count=0" >> "$GITHUB_OUTPUT"
+            echo "high_severity_count=0" >> "$GITHUB_OUTPUT"
+          fi
 
   # ── SAST: CodeQL deep semantic analysis ───────────────────────────────
   # GitHub's native CodeQL engine performs deep data-flow and taint
@@ -139,3 +181,29 @@ jobs:
         uses: github/codeql-action/analyze@820e316d04456ee9c0aa26dfa4c22ad1ce68f8ee # v3
         with:
           category: codeql-rust
+          output: codeql-results
+          upload: ${{ github.event_name == 'pull_request' && 'never' || 'always' }}
+
+      - name: Output scan results
+        if: github.event_name == 'pull_request'
+        id: codeql-results
+        run: |
+          sarif_file=$(find codeql-results -name '*.sarif' -type f | head -1)
+          if [[ -n "${sarif_file}" ]]; then
+            count=$(jq '[.runs[].results[]] | length' "${sarif_file}")
+            echo "finding_count=${count}" >> "$GITHUB_OUTPUT"
+            high_count=$(jq '[.runs[].results[] | select(.level == "error")] | length' "${sarif_file}")
+            echo "high_severity_count=${high_count}" >> "$GITHUB_OUTPUT"
+            {
+              echo "findings<<EOF"
+              jq -r '.runs[].results[] | "- [\(.level)] \(.ruleId): \(.message.text)"' "${sarif_file}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            if [[ "${high_count}" -gt 0 ]]; then
+              echo "::error::CodeQL found ${high_count} high or critical severity finding(s)"
+              exit 1
+            fi
+          else
+            echo "finding_count=0" >> "$GITHUB_OUTPUT"
+            echo "high_severity_count=0" >> "$GITHUB_OUTPUT"
+          fi

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,22 @@
+# Semgrep ignore patterns — reduces noise from files that are not useful
+# for static analysis (build artifacts, vendored assets, lock files).
+
+# Build artifacts and dependencies
+target/
+**/target/
+node_modules/
+
+# Version control
+.git/
+
+# Lock files — scanned separately by SCA tools (cargo-audit, OSV-Scanner)
+Cargo.lock
+pnpm-lock.yaml
+
+# Binary / non-source assets
+assets/icons/
+assets/fonts/
+
+# Test fixtures that may contain intentional vulnerable patterns
+**/test_fixtures/
+**/fixtures/

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,7 @@
 yanked = "warn"
 
 [licenses]
-unlicensed = "allow"
+unlicensed = "warn"
 allow = [
     "MIT",
     "Apache-2.0",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+# cargo-deny configuration — used by the security scanning CI pipeline.
+# See https://embarkstudios.github.io/cargo-deny/
+
+# In cargo-deny 0.19+, all vulnerability advisories emit errors by default,
+# which is stricter than filtering for only high-severity advisories.
+# To downgrade specific advisories, add them to [advisories.ignore].
+
+[advisories]
+yanked = "warn"
+
+[licenses]
+unlicensed = "allow"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "BSL-1.0",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OpenSSL",
+]
+
+[bans]
+
+[sources]


### PR DESCRIPTION
This pull request introduces a comprehensive security scanning pipeline for the repository, adding configuration and workflow files to automate vulnerability and static analysis checks. The pipeline combines multiple tools for both dependency (SCA) and code (SAST) scanning, with results surfaced in GitHub's security UI and CI annotations. Supporting configuration files help reduce scan noise and enforce license/advisory policies.

Security scanning workflow:

* Added `.github/workflows/security-scan.yml` to run four concurrent jobs: Rust dependency audit (`cargo-audit` and `cargo-deny`), broad SCA (`osv-scanner`), rules-based SAST (`semgrep`), and deep semantic SAST (`codeql`). Results are uploaded as SARIF or CI annotations for visibility in GitHub's Security UI.

Configuration for scan tools:

* Added `deny.toml` to configure `cargo-deny` for dependency license/advisory checks, specifying allowed licenses and advisory handling.
* Added `.semgrepignore` to exclude build artifacts, lock files, binary assets, and test fixtures from Semgrep scans, reducing false positives and noise.