### PR TITLE
vim: Fix crash when navigating search matches in Helix select mode at end of file

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -876,12 +876,12 @@ impl Vim {
             self.update_editor(cx, |_vim, editor, cx| {
                 let snapshot = editor.snapshot(window, cx);
                 editor.change_selections(SelectionEffects::default(), window, cx, |s| {
-                    s.select_anchor_ranges(
-                        prior_selections
-                            .iter()
-                            .cloned()
-                            .chain(s.all_anchors(&snapshot).iter().map(|s| s.range())),
-                    );
+                    let current = s.all_anchors(&snapshot);
+                    let all_ranges = prior_selections
+                        .iter()
+                        .cloned()
+                        .chain(current.iter().map(|s| s.range()));
+                    s.select_ranges(all_ranges);
                 })
             });
         }


### PR DESCRIPTION
#### Fixes #51573

Fixes a panic in Helix mode when pressing n to select the next search match while in select mode (v) after the last match is reached and search wraps to the beginning of the file.

#### Root Cause :
`do_helix_select` combines prior selections with the new match via select_anchor_ranges, which internally resolves all anchors using a forward-only rope cursor (resolve_selections_wrapping_blocks → resolve_selections_point → summaries_for_anchors). This resolution flat-maps all selections into [start₁, end₁, start₂, end₂, ...] and traverses them sequentially with a rope cursor that can only move forward.

When search wraps around, prior selections (end of file) are chained before the new match (start of file), producing out-of-order anchors that violate the cursor's forward-only invariant:

cannot summarize backward from 38 to 10
Sorting the ranges by start anchor alone was also insufficient - overlapping selections still produce out-of-order interleaved anchors in the flat-mapped sequence.


#### Fix :
Replaced `select_anchor_ranges` with `select_ranges`, which resolves each anchor to an offset independently (via Anchor::to_offset) and delegates to `select()` - which sorts by offset and merges overlaps internally. This makes it correct API for combining selections from independent sources that may be unordered or overlapping. Both code paths ultimately store Selection<Anchor> - `select_ranges` simply skips the ordered-anchor resolution step that was causing the crash.

```
// Before: requires anchors in monotonic order, panics on wrap-around
s.select_anchor_ranges(
    prior_selections.iter().cloned()
        .chain(s.all_anchors(&snapshot).iter().map(|s| s.range())),
);
```

```
/ After: resolves each anchor independently, sorts/merges internally
let current = s.all_anchors(&snapshot);
let all_ranges = prior_selections.iter().cloned()
    .chain(current.iter().map(|s| s.range()));
s.select_ranges(all_ranges);
```

### Tests : 

-  cargo test -p vim test_helix_select_next_match
-  cargo test -p vim test_helix_select_mode 
-  cargo test -p vim test_search 
-  cargo test -p vim test_v_search 

--- all passed.

 
#### Release Notes :
Fixed a crash in Helix mode when pressing n to select the next search match after reaching the end of the file.

#### Video :
[Screencast from 2026-03-15 15-21-11.webm](https://github.com/user-attachments/assets/daf4e437-67d3-44e2-87eb-be8e08cb573d)
