### PR TITLE
gpui_macos: Fix cmd+backtick window cycling on Spanish keyboard layouts

### DIFF
--- a/crates/gpui_macos/src/gpui_macos.rs
+++ b/crates/gpui_macos/src/gpui_macos.rs
@@ -28,6 +28,7 @@ mod text_system;
 mod platform;
 mod window;
 mod window_appearance;
+mod window_cycle;
 
 use cocoa::{
     base::{id, nil},
@@ -46,6 +47,7 @@ pub(crate) use display_link::*;
 pub(crate) use keyboard::*;
 pub(crate) use platform::*;
 pub(crate) use window::*;
+pub(crate) use window_cycle::*;
 
 #[cfg(feature = "font-kit")]
 pub(crate) use text_system::*;

--- a/crates/gpui_macos/src/keyboard.rs
+++ b/crates/gpui_macos/src/keyboard.rs
@@ -1235,28 +1235,28 @@ fn get_key_equivalents(layout_id: &str) -> Option<HashMap<char, char>> {
             ('~', '>'),
         ],
         "com.apple.keylayout.Spanish-ISO" => &[
-            ('"', '¨'),
+            ('"', '^'),
             ('#', '·'),
             ('&', '/'),
+            ('\'', '`'),
             ('(', ')'),
             (')', '='),
             ('*', '('),
-            ('.', 'ç'),
-            ('/', '.'),
-            (':', 'º'),
-            (';', '´'),
-            ('<', '¿'),
-            ('>', 'Ç'),
+            ('/', '\''),
+            (':', '¿'),
+            (';', '¡'),
+            ('<', ';'),
+            ('=', '*'),
+            ('>', ':'),
             ('@', '"'),
             ('[', 'ñ'),
-            ('\'', '`'),
-            ('\\', '\''),
-            (']', ';'),
+            ('\\', 'ç'),
+            (']', '´'),
             ('^', '&'),
             ('`', '<'),
             ('{', 'Ñ'),
-            ('|', '"'),
-            ('}', '`'),
+            ('|', 'Ç'),
+            ('}', '¨'),
             ('~', '>'),
         ],
         "com.apple.keylayout.Swedish" => &[
@@ -1499,4 +1499,41 @@ fn get_key_equivalents(layout_id: &str) -> Option<HashMap<char, char>> {
     };
 
     Some(HashMap::from_iter(mappings.iter().cloned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::Modifiers;
+
+    use super::*;
+
+    #[test]
+    fn spanish_iso_maps_apostrophe_to_backtick() {
+        let mapper = MacKeyboardMapper::new("com.apple.keylayout.Spanish-ISO");
+        let mapped = mapper.map_key_equivalent(
+            Keystroke {
+                modifiers: Modifiers::none(),
+                key: "'".into(),
+                key_char: None,
+            },
+            true,
+        );
+
+        assert_eq!(mapped.inner().key, "`");
+    }
+
+    #[test]
+    fn spanish_iso_mapping_still_applies_with_command_pressed() {
+        let mapper = MacKeyboardMapper::new("com.apple.keylayout.Spanish-ISO");
+        let mapped = mapper.map_key_equivalent(
+            Keystroke {
+                modifiers: Modifiers::command(),
+                key: "'".into(),
+                key_char: None,
+            },
+            true,
+        );
+
+        assert_eq!(mapped.inner().key, "`");
+    }
 }

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -1,6 +1,6 @@
 use crate::{
     BoolExt, MacDispatcher, MacDisplay, MacKeyboardLayout, MacKeyboardMapper, MacWindow,
-    events::key_to_native, ns_string, pasteboard::Pasteboard, renderer,
+    MacWindowCycleShortcut, events::key_to_native, ns_string, pasteboard::Pasteboard, renderer,
     set_active_window_cursor_style,
 };
 use anyhow::{Context as _, anyhow};
@@ -184,6 +184,7 @@ pub(crate) struct MacPlatformState {
     keyboard_mapper: Rc<MacKeyboardMapper>,
     /// Mirrors `[NSCursor setHiddenUntilMouseMoves:]` state, which AppKit doesn't expose.
     cursor_visible: Arc<AtomicBool>,
+    window_cycle_shortcut: MacWindowCycleShortcut,
 }
 
 impl MacPlatform {
@@ -198,6 +199,11 @@ impl MacPlatform {
 
         let keyboard_layout = MacKeyboardLayout::new();
         let keyboard_mapper = Rc::new(MacKeyboardMapper::new(keyboard_layout.id()));
+        let window_cycle_shortcut = if headless {
+            MacWindowCycleShortcut::default()
+        } else {
+            MacWindowCycleShortcut::new()
+        };
 
         Self(Mutex::new(MacPlatformState {
             headless,
@@ -221,6 +227,7 @@ impl MacPlatform {
             menus: None,
             keyboard_mapper,
             cursor_visible: Arc::new(AtomicBool::new(true)),
+            window_cycle_shortcut,
         }))
     }
 
@@ -627,15 +634,23 @@ impl Platform for MacPlatform {
         handle: AnyWindowHandle,
         options: WindowParams,
     ) -> Result<Box<dyn PlatformWindow>> {
-        let (cursor_visible, foreground_executor, background_executor, renderer_context) = {
+        let (
+            cursor_visible,
+            foreground_executor,
+            background_executor,
+            renderer_context,
+            window_cycle_shortcut,
+        ) = {
             let guard = self.0.lock();
             (
                 guard.cursor_visible.clone(),
                 guard.foreground_executor.clone(),
                 guard.background_executor.clone(),
                 guard.renderer_context.clone(),
+                guard.window_cycle_shortcut.clone(),
             )
         };
+
 
         Ok(Box::new(MacWindow::open(
             handle,
@@ -644,6 +659,7 @@ impl Platform for MacPlatform {
             foreground_executor,
             background_executor,
             renderer_context,
+            window_cycle_shortcut,
         )))
     }
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1,8 +1,8 @@
 use crate::{
-    BoolExt, DisplayLink, MacDisplay, NSRange, NSStringExt, TISCopyCurrentKeyboardInputSource,
-    TISGetInputSourceProperty, events::platform_input_from_native,
-    kTISPropertyInputSourceIsASCIICapable, kTISPropertyInputSourceType, kTISTypeKeyboardInputMode,
-    ns_string, renderer,
+    BoolExt, DisplayLink, MacDisplay, MacWindowCycleShortcut, NSRange, NSStringExt,
+    TISCopyCurrentKeyboardInputSource, TISGetInputSourceProperty,
+    events::platform_input_from_native, kTISPropertyInputSourceIsASCIICapable,
+    kTISPropertyInputSourceType, kTISTypeKeyboardInputMode, ns_string, renderer,
 };
 #[cfg(any(test, feature = "test-support"))]
 use anyhow::Result;
@@ -493,6 +493,7 @@ struct MacWindowState {
     previous_modifiers_changed_event: Option<PlatformInput>,
     keystroke_for_do_command: Option<Keystroke>,
     do_command_handled: Option<bool>,
+    window_cycle_shortcut: MacWindowCycleShortcut,
     external_files_dragged: bool,
     // Whether the next left-mouse click is also the focusing click.
     first_mouse: bool,
@@ -680,6 +681,7 @@ impl MacWindow {
         foreground_executor: ForegroundExecutor,
         background_executor: BackgroundExecutor,
         renderer_context: renderer::Context,
+        window_cycle_shortcut: MacWindowCycleShortcut,
     ) -> Self {
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
@@ -823,6 +825,7 @@ impl MacWindow {
                 previous_modifiers_changed_event: None,
                 keystroke_for_do_command: None,
                 do_command_handled: None,
+                window_cycle_shortcut,
                 external_files_dragged: false,
                 first_mouse: false,
                 fullscreen_restore_bounds: Bounds::default(),
@@ -1957,6 +1960,13 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
     let Some(event) = event else {
         return NO;
     };
+
+    // AppKit reserves this shortcut for window cycling, and the active binding can change at runtime.
+    if matches!(&event, PlatformInput::KeyDown(_))
+        && lock.window_cycle_shortcut.matches(native_event)
+    {
+        return NO;
+    }
 
     let run_callback = |event: PlatformInput| -> BOOL {
         let mut callback = window_state.as_ref().lock().event_callback.take();

--- a/crates/gpui_macos/src/window_cycle.rs
+++ b/crates/gpui_macos/src/window_cycle.rs
@@ -1,0 +1,218 @@
+use cocoa::{
+    appkit::{NSEvent, NSEventModifierFlags},
+    base::id,
+    foundation::NSString,
+};
+use std::ffi::CStr;
+
+// Private CoreGraphicsServices ("SkyLight") API. Same calls WindowServer and
+// System Settings use to resolve the current value of a symbolic hotkey:
+// returns the user's plist override if present, otherwise the default baked
+// into SkyLight's hardcoded fallback table. Using it means we don't parse the
+// plist ourselves or hardcode any defaults.
+//
+// Each call costs ~10µs (Mach IPC to WindowServer). Even at unrealistic key
+// rates that's a fraction of a percent of one core, so we just call on every
+// matching attempt rather than maintaining a cached value + change watcher.
+#[link(name = "Carbon", kind = "framework")]
+unsafe extern "C" {
+    fn CGSGetSymbolicHotKeyValue(
+        hotkey: i32,
+        out_character: *mut u16,
+        out_key_code: *mut u16,
+        out_modifiers: *mut u32,
+    ) -> i32;
+    fn CGSIsSymbolicHotKeyEnabled(hotkey: i32) -> i32;
+}
+
+// "Move focus to next window". Stable Apple-internal identifier — see
+// kCGSMoveFocusToNextWindow / the "27" key in ~/Library/Preferences/
+// com.apple.symbolichotkeys.plist.
+const WINDOW_CYCLE_HOTKEY_ID: i32 = 27;
+
+const COMMAND_MODIFIER: u32 = 0x0010_0000;
+const SHIFT_MODIFIER: u32 = 0x0002_0000;
+const OPTION_MODIFIER: u32 = 0x0008_0000;
+const CONTROL_MODIFIER: u32 = 0x0004_0000;
+const FUNCTION_MODIFIER: u32 = 0x0080_0000;
+
+// Sentinel used by the CGS API (and the AppleSymbolicHotKeys plist) to mean
+// "no value" for a character or key code — matches kNoCharCode /
+// kHIKeyCodeNoKey in HIToolbox.
+const NO_VALUE: u16 = 0xFFFF;
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct MacWindowCycleShortcut;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct WindowCycleHotkey {
+    character: Option<u16>,
+    key_code: Option<u16>,
+    modifiers: u32,
+}
+
+impl MacWindowCycleShortcut {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    pub(crate) fn matches(&self, native_event: id) -> bool {
+        let Some(hotkey) = read_window_cycle_hotkey() else {
+            return false;
+        };
+
+        let key_code = unsafe { native_event.keyCode() as u16 };
+        let modifiers = unsafe { symbolic_hotkey_modifiers(native_event.modifierFlags()) };
+        let character = unsafe { first_character_ignoring_modifiers(native_event) };
+
+        hotkey.matches(character, key_code, modifiers)
+    }
+}
+
+impl WindowCycleHotkey {
+    // If the stored entry has a character (the typical SkyLight default and
+    // most locale overrides), match the produced character — that's what keeps
+    // cmd+backtick working across layouts even though the physical key moves.
+    // If the stored entry only has a key code (e.g. a plist entry whose
+    // character field is kNoCharCode/0xFFFF), match the physical key code.
+    // We never match both at once: doing so would over-claim shortcuts on
+    // layouts where the key code coincides with one we shouldn't reserve.
+    fn matches(self, character: Option<u16>, key_code: u16, modifiers: u32) -> bool {
+        if self.modifiers != modifiers {
+            return false;
+        }
+        match self.character {
+            Some(stored) => character == Some(stored),
+            None => self.key_code == Some(key_code),
+        }
+    }
+}
+
+fn read_window_cycle_hotkey() -> Option<WindowCycleHotkey> {
+    unsafe {
+        if CGSIsSymbolicHotKeyEnabled(WINDOW_CYCLE_HOTKEY_ID) == 0 {
+            return None;
+        }
+        let mut character: u16 = NO_VALUE;
+        let mut key_code: u16 = NO_VALUE;
+        let mut modifiers: u32 = 0;
+        let status = CGSGetSymbolicHotKeyValue(
+            WINDOW_CYCLE_HOTKEY_ID,
+            &mut character,
+            &mut key_code,
+            &mut modifiers,
+        );
+        if status != 0 {
+            return None;
+        }
+        Some(WindowCycleHotkey {
+            character: (character != NO_VALUE).then_some(character),
+            key_code: (key_code != NO_VALUE).then_some(key_code),
+            modifiers,
+        })
+    }
+}
+
+unsafe fn first_character_ignoring_modifiers(native_event: id) -> Option<u16> {
+    unsafe {
+        let characters: id = native_event.charactersIgnoringModifiers();
+        if characters.is_null() {
+            return None;
+        }
+        let utf8 = characters.UTF8String();
+        if utf8.is_null() {
+            return None;
+        }
+        let bytes = CStr::from_ptr(utf8).to_bytes();
+        std::str::from_utf8(bytes)
+            .ok()
+            .and_then(|s| s.chars().next())
+            .map(|ch| ch as u32)
+            .and_then(|ch| u16::try_from(ch).ok())
+    }
+}
+
+fn symbolic_hotkey_modifiers(modifier_flags: NSEventModifierFlags) -> u32 {
+    let mut modifiers = 0;
+
+    if modifier_flags.contains(NSEventModifierFlags::NSCommandKeyMask) {
+        modifiers |= COMMAND_MODIFIER;
+    }
+    if modifier_flags.contains(NSEventModifierFlags::NSShiftKeyMask) {
+        modifiers |= SHIFT_MODIFIER;
+    }
+    if modifier_flags.contains(NSEventModifierFlags::NSAlternateKeyMask) {
+        modifiers |= OPTION_MODIFIER;
+    }
+    if modifier_flags.contains(NSEventModifierFlags::NSControlKeyMask) {
+        modifiers |= CONTROL_MODIFIER;
+    }
+    if modifier_flags.contains(NSEventModifierFlags::NSFunctionKeyMask) {
+        modifiers |= FUNCTION_MODIFIER;
+    }
+
+    modifiers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_by_character_when_entry_has_one() {
+        let hotkey = WindowCycleHotkey {
+            character: Some(0x60),
+            key_code: Some(50),
+            modifiers: COMMAND_MODIFIER,
+        };
+        assert!(hotkey.matches(Some(0x60), 10, COMMAND_MODIFIER));
+        assert!(!hotkey.matches(Some(0xBA), 50, COMMAND_MODIFIER));
+        assert!(!hotkey.matches(None, 50, COMMAND_MODIFIER));
+    }
+
+    #[test]
+    fn matches_by_key_code_when_entry_has_no_character() {
+        let hotkey = WindowCycleHotkey {
+            character: None,
+            key_code: Some(10),
+            modifiers: COMMAND_MODIFIER,
+        };
+        assert!(hotkey.matches(None, 10, COMMAND_MODIFIER));
+        assert!(hotkey.matches(Some(0x60), 10, COMMAND_MODIFIER));
+        assert!(!hotkey.matches(Some(0x60), 50, COMMAND_MODIFIER));
+    }
+
+    #[test]
+    fn rejects_mismatched_modifiers() {
+        let hotkey = WindowCycleHotkey {
+            character: Some(0x60),
+            key_code: Some(50),
+            modifiers: COMMAND_MODIFIER,
+        };
+        assert!(!hotkey.matches(Some(0x60), 50, COMMAND_MODIFIER | SHIFT_MODIFIER));
+    }
+
+    #[test]
+    fn reads_current_window_cycle_from_macos() {
+        // Integration check: the CGS API returns some shortcut on every
+        // macOS install (either the plist override or the SkyLight default).
+        // We don't assert on the exact value because it's layout/user-specific.
+        let hotkey = read_window_cycle_hotkey();
+        assert!(hotkey.is_some());
+        assert_eq!(
+            hotkey.unwrap().modifiers & COMMAND_MODIFIER,
+            COMMAND_MODIFIER
+        );
+    }
+
+    #[test]
+    fn normalizes_native_modifier_flags() {
+        let modifiers = symbolic_hotkey_modifiers(
+            NSEventModifierFlags::NSCommandKeyMask
+                | NSEventModifierFlags::NSShiftKeyMask
+                | NSEventModifierFlags::NSAlphaShiftKeyMask,
+        );
+
+        assert_eq!(modifiers, COMMAND_MODIFIER | SHIFT_MODIFIER);
+    }
+}


### PR DESCRIPTION
Follows up on #51394.

## Problem

On Spanish keyboard layouts, cmd+backtick does not cycle windows because Zed's key_equivalents system remaps `cmd-'` (ToggleSelectedDiffHunks) onto the backtick key, consuming the event before macOS can handle window cycling.

## How key_equivalents remapping works

Zed replicates macOS's menu shortcut localization: when a US-defined shortcut like `cmd-'` can't be typed on another layout, macOS relocates it to a reachable key. These relocations form chains that terminate at layout-specific characters (like ñ, ¡, ç, ...) that have no US shortcut to displace.

On Spanish-ISO, the chain containing backtick is:

```
" -> ^ -> & -> / -> ' -> ` -> < -> ; -> ¡ (open exclamation)
```

The `' -> backtick` entry causes `cmd-'` (ToggleSelectedDiffHunks) to listen on the backtick key, shadowing macOS window cycling:

https://github.com/zed-industries/zed/blob/66d7452b78494699909e876d505222497e288a0e/crates/gpui_macos/src/keyboard.rs#L1225

## Fix

Bypass backtick in the chain by connecting its predecessor directly to its successor:

```
Before: ... -> ' -> ` -> < -> ; -> ¡
After:  ... -> ' -> < -> ; -> ¡       (backtick removed from chain)
```

This frees the backtick key for macOS window cycling.

The side effect is that ToggleSelectedDiffHunks moves from backtick to `<`.

This PR also removes a bogus `} -> backtick` entry in Spanish-ISO that looked like a transcription error from #20995. The original [keyboard-inspector](https://github.com/ConradIrwin/keyboard-inspector) data reported "not found" for `}`, which was incorrectly converted to a backtick mapping. Nothing maps TO `}` in the table, so removing it has no chain side effects.

## Scope

This PR only targets the two Spanish layouts (Spanish and Spanish-ISO). The same backtick collision affects other layouts via different US keys (`"`, `=`, `\`), but those are left for follow-up since they require testing with those physical keyboards.

| US key | Zed binding                              | Layouts affected (count) |
|--------|------------------------------------------|--------------------------|
| '      | cmd-' editor::ToggleSelectedDiffHunks    | Spanish, Spanish-ISO (2) |
| "      | cmd-" editor::ExpandAllDiffHunks         | German, Austrian, Brazilian, Portuguese, Swiss... (8) |
| =      | cmd-= zed::IncreaseBufferFontSize        | Danish, Finnish, Norwegian, Swedish... (13) |
| \      | cmd-\ pane::SplitRight                   | French, Belgian, ABC-AZERTY (4) |


Release Notes:

- Fixed cmd+backtick window cycling not working on Spanish keyboard layouts.