### PR TITLE
git_ui: Add starts_open setting to git panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -922,6 +922,10 @@
     ///
     /// Default: false
     "tree_view": false,
+    // Whether the git panel should open on startup.
+    //
+    // Default: false
+    "starts_open": false,
     // Whether to show a badge on the git panel icon with the count of uncommitted changes.
     //
     // Default: false

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5824,6 +5824,10 @@ impl Panel for GitPanel {
         Box::new(ToggleFocus)
     }
 
+    fn starts_open(&self, _: &Window, cx: &App) -> bool {
+        GitPanelSettings::get_global(cx).starts_open
+    }
+
     fn activation_priority(&self) -> u32 {
         2
     }

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -29,6 +29,7 @@ pub struct GitPanelSettings {
     pub tree_view: bool,
     pub diff_stats: bool,
     pub show_count_badge: bool,
+    pub starts_open: bool,
 }
 
 impl ScrollbarVisibility for GitPanelSettings {
@@ -66,6 +67,7 @@ impl Settings for GitPanelSettings {
             tree_view: git_panel.tree_view.unwrap(),
             diff_stats: git_panel.diff_stats.unwrap(),
             show_count_badge: git_panel.show_count_badge.unwrap(),
+            starts_open: git_panel.starts_open.unwrap(),
         }
     }
 }

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -640,6 +640,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub show_count_badge: Option<bool>,
+
+    /// Whether the git panel should open on startup.
+    ///
+    /// Default: false
+    pub starts_open: Option<bool>,
 }
 
 #[derive(

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5097,7 +5097,8 @@ See the [debugger page](../debugger.md) for more information about debugging sup
     "collapse_untracked_diff": false,
     "scrollbar": {
       "show": null
-    }
+    },
+    "starts_open": false
   }
 }
 ```
@@ -5112,6 +5113,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `sort_by_path`: Whether to sort entries in the panel by path or by status (the default)
 - `collapse_untracked_diff`: Whether to collapse untracked files in the diff panel
 - `scrollbar`: When to show the scrollbar in the git panel
+- `starts_open`: Whether the git panel should open on startup
 
 ## Git Worktree Directory
 


### PR DESCRIPTION
Fixes #51542

Adds a `git_panel.starts_open` setting for parity with `project_panel`. When set to `true`, the git panel opens automatically in new workspaces that don't have saved panel state.

The default is `false`, matching current behavior (non-breaking).

### Usage

```json
{
  "git_panel": {
    "starts_open": true
  }
}
```

### Implementation

Follows the same pattern as `project_panel.starts_open`:

1. `GitPanelSettingsContent` - added `starts_open: Option<bool>` to the settings schema
2. `GitPanelSettings` - added `starts_open: bool` field
3. `GitPanel` Panel impl - overrides `starts_open()` to read from settings

Release Notes:

- Added `git_panel.starts_open` setting to control whether the git panel opens automatically in new workspaces (default: false)