### PR TITLE
Add remote hostname to title bar project picker tooltip

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1113,12 +1113,21 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let (_, location, paths, _) = self.workspaces.get(hit.candidate_id)?;
                 let is_local = matches!(location, SerializedWorkspaceLocation::Local);
                 let paths_to_add = paths.paths().to_vec();
-                let tooltip_path: SharedString = paths
+                let ordered_paths: Vec<_> = paths
                     .ordered_paths()
                     .map(|p| p.compact().to_string_lossy().to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n")
-                    .into();
+                    .collect();
+                let tooltip_path: SharedString = match &location {
+                    SerializedWorkspaceLocation::Remote(options) => {
+                        let host = options.display_name();
+                        if ordered_paths.len() == 1 {
+                            format!("{} ({})", ordered_paths[0], host).into()
+                        } else {
+                            format!("{}\n({})", ordered_paths.join("\n"), host).into()
+                        }
+                    }
+                    _ => ordered_paths.join("\n").into(),
+                };
 
                 let mut path_start_offset = 0;
                 let (match_labels, paths): (Vec<_>, Vec<_>) = paths


### PR DESCRIPTION
Having multiple remote hosts with long project names makes the project picker tricky to use.

Added the remote hostname to the tooltip to avoid guessing.

**truncated project + hostname (no change)**
<img width="426" height="368" alt="Screenshot 2026-03-15 at 12 16 29 PM" src="https://github.com/user-attachments/assets/7b6b732e-cf3c-42c7-9912-1a69ee58b60e" />


**hostname in tooltip (multiline)**
<img width="495" height="366" alt="Screenshot 2026-03-15 at 12 16 56 PM" src="https://github.com/user-attachments/assets/77b60b3a-b8c0-4088-b3c2-3c105a097720" />

**hostname in tooltip (single line)**
<img width="426" height="366" alt="Screenshot 2026-03-15 at 12 17 15 PM" src="https://github.com/user-attachments/assets/baf4d4bd-2724-4a3e-ab29-39ff714fec0e" />


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Add remote hostname to title bar project picker tooltip.
