### PR TITLE
languages: Fix semantic tokens for Go

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -5,7 +5,10 @@ use futures::StreamExt;
 use gpui::{App, AsyncApp, Task};
 use http_client::github::latest_github_release;
 pub use language::*;
-use language::{LanguageToolchainStore, LspAdapterDelegate, LspInstaller};
+use language::{
+    LanguageName, LanguageToolchainStore, LspAdapterDelegate, LspInstaller,
+    language_settings::language_settings,
+};
 use lsp::{LanguageServerBinary, LanguageServerName};
 
 use project::lsp_store::language_server_settings;
@@ -207,6 +210,12 @@ impl LspAdapter for GoLspAdapter {
         delegate: &Arc<dyn LspAdapterDelegate>,
         cx: &mut AsyncApp,
     ) -> Result<Option<serde_json::Value>> {
+        let semantic_tokens_enabled = cx.update(|cx| {
+            language_settings(Some(LanguageName::new("Go")), None, cx)
+                .semantic_tokens
+                .enabled()
+        });
+
         let mut default_config = json!({
             "usePlaceholders": false,
             "hints": {
@@ -217,7 +226,8 @@ impl LspAdapter for GoLspAdapter {
                 "functionTypeParameters": true,
                 "parameterNames": true,
                 "rangeVariableTypes": true
-            }
+            },
+            "semanticTokens": semantic_tokens_enabled
         });
 
         let project_initialization_options = cx.update(|cx| {


### PR DESCRIPTION
Closes #51620

gopls requires more specific initialization for semantic tokens that other language-servers for reasons that aren't entirely clear to me, it is however a small fix to make it work. still trying to track down other malfunctioning language servers in the semantic token realm, so if you have suggestions let me know.

original behavior (on nightly v0.229):
<img width="1784" height="1123" alt="nightly_behavior" src="https://github.com/user-attachments/assets/5d976b34-2720-425c-8617-800291862909" />

updated behavior:
<img width="1784" height="1124" alt="fix_applied" src="https://github.com/user-attachments/assets/17c528b9-fea8-4309-9306-44673afc9fc3" />

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- gopls: fixed semantic token support with gopls.
