### PR TITLE
Implement persistent identifiers for terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,6 +4712,7 @@ dependencies = [
  "sysinfo 0.37.2",
  "task",
  "tasks_ui",
+ "terminal",
  "terminal_view",
  "text",
  "theme",
@@ -17325,6 +17326,7 @@ dependencies = [
  "serde",
  "settings",
  "smol",
+ "sqlez",
  "sysinfo 0.37.2",
  "task",
  "theme",
@@ -17333,6 +17335,7 @@ dependencies = [
  "urlencoding",
  "util",
  "util_macros",
+ "uuid",
  "windows 0.61.3",
 ]
 
@@ -17377,6 +17380,7 @@ dependencies = [
  "theme",
  "ui",
  "util",
+ "uuid",
  "workspace",
  "zed_actions",
 ]

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2,6 +2,7 @@ mod connection;
 mod diff;
 mod mention;
 mod terminal;
+use ::terminal::TerminalIdentity;
 use action_log::{ActionLog, ActionLogTelemetry};
 use agent_client_protocol::{self as acp};
 use anyhow::{Context as _, Result, anyhow};
@@ -2618,6 +2619,7 @@ impl AcpThread {
                                 env,
                                 ..Default::default()
                             },
+                            TerminalIdentity::Anonymous,
                             cx,
                         )
                     })
@@ -2871,6 +2873,7 @@ mod tests {
         sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst},
         time::Duration,
     };
+    use terminal::TerminalIdentity;
     use util::path;
 
     fn init_test(cx: &mut TestAppContext) {
@@ -3077,6 +3080,7 @@ mod tests {
                     cx,
                     vec![],
                     PathStyle::local(),
+                    TerminalIdentity::Anonymous,
                 )
             })
             .await

--- a/crates/acp_thread/src/terminal.rs
+++ b/crates/acp_thread/src/terminal.rs
@@ -15,6 +15,7 @@ use std::{
     time::Instant,
 };
 use task::Shell;
+use terminal::TerminalIdentity;
 use util::get_default_system_shell_preferring_bash;
 
 pub struct Terminal {
@@ -248,6 +249,7 @@ pub async fn create_terminal_entity(
                     env,
                     ..Default::default()
                 },
+                TerminalIdentity::Anonymous,
                 cx,
             )
         })

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -64,6 +64,7 @@ settings.workspace = true
 sysinfo.workspace = true
 task.workspace = true
 tasks_ui.workspace = true
+terminal.workspace = true
 terminal_view.workspace = true
 text.workspace = true
 theme.workspace = true

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -50,6 +50,7 @@ use task::{
     BuildTaskDefinition, DebugScenario, SharedTaskContext, Shell, ShellBuilder, SpawnInTerminal,
     TaskContext, ZedDebugConfig, substitute_variables_in_str,
 };
+use terminal::TerminalIdentity;
 use terminal_view::TerminalView;
 use ui::{
     FluentBuilder, IntoElement, Render, StatefulInteractiveElement, Tab, Tooltip, VisibleOnHover,
@@ -1149,6 +1150,7 @@ impl RunningState {
                     .update(cx, |project, cx| {
                         project.create_terminal_task(
                             task_with_shell.clone(),
+                            TerminalIdentity::Anonymous,
                             cx,
                         )
                     }).await?;
@@ -1318,8 +1320,9 @@ impl RunningState {
         let workspace = self.workspace.clone();
         let weak_project = project.downgrade();
 
-        let terminal_task =
-            project.update(cx, |project, cx| project.create_terminal_task(kind, cx));
+        let terminal_task = project.update(cx, |project, cx| {
+            project.create_terminal_task(kind, TerminalIdentity::Anonymous, cx)
+        });
         let terminal_task = cx.spawn_in(window, async move |_, cx| {
             let terminal = terminal_task.await?;
 

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use task::{Shell, ShellBuilder, ShellKind, SpawnInTerminal};
 use terminal::{
-    TaskState, TaskStatus, Terminal, TerminalBuilder, insert_zed_terminal_env,
+    TaskState, TaskStatus, Terminal, TerminalBuilder, TerminalIdentity, insert_zed_terminal_env,
     terminal_settings::TerminalSettings,
 };
 use util::{command::new_std_command, get_default_system_shell, maybe, rel_path::RelPath};
@@ -61,6 +61,7 @@ impl Project {
     pub fn create_terminal_task(
         &mut self,
         spawn_task: SpawnInTerminal,
+        identity: TerminalIdentity,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
         let is_via_remote = self.remote_client.is_some();
@@ -132,6 +133,7 @@ impl Project {
         cx.spawn(async move |project, cx| {
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
+            identity.add_into_env(&mut env);
 
             let activation_script = maybe!(async {
                 for toolchain in toolchains {
@@ -256,6 +258,7 @@ impl Project {
                         cx,
                         activation_script,
                         path_style,
+                        identity,
                     ))
                 })??
                 .await?;
@@ -288,9 +291,10 @@ impl Project {
     pub fn create_terminal_shell(
         &mut self,
         cwd: Option<PathBuf>,
+        identity: TerminalIdentity,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
-        self.create_terminal_shell_internal(cwd, false, cx)
+        self.create_terminal_shell_internal(cwd, identity, false, cx)
     }
 
     /// Creates a local terminal even if the project is remote.
@@ -298,6 +302,7 @@ impl Project {
     /// In local projects: opens in the project directory (same as regular terminals).
     pub fn create_local_terminal(
         &mut self,
+        identity: TerminalIdentity,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
         let working_directory = if self.remote_client.is_some() {
@@ -307,7 +312,7 @@ impl Project {
             // Local project: use project directory like normal terminals
             self.active_project_directory(cx).map(|p| p.to_path_buf())
         };
-        self.create_terminal_shell_internal(working_directory, true, cx)
+        self.create_terminal_shell_internal(working_directory, identity, true, cx)
     }
 
     /// Internal method for creating terminal shells.
@@ -316,6 +321,7 @@ impl Project {
     fn create_terminal_shell_internal(
         &mut self,
         cwd: Option<PathBuf>,
+        identity: TerminalIdentity,
         force_local: bool,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
@@ -375,6 +381,7 @@ impl Project {
             let shell_kind = ShellKind::new(&shell, path_style.is_windows());
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
+            identity.add_into_env(&mut env);
 
             let activation_script = maybe!(async {
                 for toolchain in toolchains {
@@ -421,6 +428,7 @@ impl Project {
                         cx,
                         activation_script,
                         path_style,
+                        identity,
                     ))
                 })??
                 .await?;
@@ -459,7 +467,7 @@ impl Project {
         // We cannot clone the task's terminal, as it will effectively re-spawn the task, which might not be desirable.
         // For now, create a new shell instead.
         if terminal.read(cx).task().is_some() {
-            return self.create_terminal_shell(cwd, cx);
+            return self.create_terminal_shell(cwd, TerminalIdentity::persistable(), cx);
         }
         let local_path = if self.is_via_remote_server() {
             None
@@ -470,6 +478,7 @@ impl Project {
         let builder = terminal.read(cx).clone_builder(cx, local_path);
         cx.spawn(async |project, cx| {
             let terminal = builder.await?;
+
             project.update(cx, |project, cx| {
                 let terminal_handle = cx.new(|cx| terminal.subscribe(cx));
 

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -33,6 +33,7 @@ release_channel.workspace = true
 schemars.workspace = true
 serde.workspace = true
 settings.workspace = true
+sqlez.workspace = true
 sysinfo.workspace = true
 smol.workspace = true
 task.workspace = true
@@ -41,6 +42,7 @@ thiserror.workspace = true
 url.workspace = true
 util.workspace = true
 urlencoding.workspace = true
+uuid.workspace = true
 parking_lot.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -66,13 +66,14 @@ use std::{
 };
 use thiserror::Error;
 
+use crate::mappings::{colors::to_alac_rgb, keys::to_esc_str};
 use gpui::{
     App, AppContext as _, BackgroundExecutor, Bounds, ClipboardItem, Context, EventEmitter, Hsla,
     Keystroke, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point,
     Rgba, ScrollWheelEvent, Size, Task, TouchPhase, Window, actions, black, px,
 };
-
-use crate::mappings::{colors::to_alac_rgb, keys::to_esc_str};
+use sqlez::bindable::Bind;
+use sqlez::statement::Statement;
 
 actions!(
     terminal,
@@ -417,6 +418,7 @@ impl TerminalBuilder {
             path_style,
             #[cfg(any(test, feature = "test-support"))]
             input_log: Vec::new(),
+            identity: TerminalIdentity::Anonymous,
         };
 
         Ok(TerminalBuilder {
@@ -441,6 +443,7 @@ impl TerminalBuilder {
         cx: &App,
         activation_script: Vec<String>,
         path_style: PathStyle,
+        identity: TerminalIdentity,
     ) -> Task<Result<TerminalBuilder>> {
         let version = release_channel::AppVersion::global(cx);
         let background_executor = cx.background_executor().clone();
@@ -650,6 +653,7 @@ impl TerminalBuilder {
                 path_style,
                 #[cfg(any(test, feature = "test-support"))]
                 input_log: Vec::new(),
+                identity,
             };
 
             if !activation_script.is_empty() && no_task {
@@ -842,6 +846,46 @@ enum TerminalType {
     DisplayOnly,
 }
 
+#[derive(Clone)]
+pub enum TerminalIdentity {
+    Anonymous,
+    Persisted(uuid::Uuid),
+}
+
+impl TerminalIdentity {
+    pub fn persistable() -> Self {
+        Self::Persisted(uuid::Uuid::new_v4())
+    }
+
+    pub fn add_into_env(&self, env: &mut HashMap<String, String>) {
+        match self {
+            TerminalIdentity::Anonymous => {}
+            TerminalIdentity::Persisted(id) => {
+                let key = "ZED_PERSISTENCE_ID".to_string();
+                env.insert(key, format!("{}", id.as_hyphenated()));
+            }
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        match self {
+            TerminalIdentity::Anonymous => String::new(),
+            TerminalIdentity::Persisted(id) => format!("{}", id.as_hyphenated()),
+        }
+    }
+}
+
+impl Bind for TerminalIdentity {
+    fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
+        match self {
+            TerminalIdentity::Anonymous => None::<Option<String>>.bind(statement, start_index),
+            TerminalIdentity::Persisted(id) => {
+                format!("{}", id.as_hyphenated()).bind(statement, start_index)
+            }
+        }
+    }
+}
+
 pub struct Terminal {
     terminal_type: TerminalType,
     completion_tx: Option<Sender<Option<ExitStatus>>>,
@@ -876,6 +920,8 @@ pub struct Terminal {
     path_style: PathStyle,
     #[cfg(any(test, feature = "test-support"))]
     input_log: Vec<Vec<u8>>,
+    /// Marker to identify terminals across sessions
+    identity: TerminalIdentity,
 }
 
 struct CopyTemplate {
@@ -2294,11 +2340,18 @@ impl Terminal {
 
     pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Task<Result<TerminalBuilder>> {
         let working_directory = self.working_directory().or_else(|| cwd);
+        let mut env = self.template.env.clone();
+        let identity = match &self.identity {
+            TerminalIdentity::Anonymous => self.identity.clone(),
+            TerminalIdentity::Persisted(_) => TerminalIdentity::persistable(),
+        };
+        identity.add_into_env(&mut env);
+
         TerminalBuilder::new(
             working_directory,
             None,
             self.template.shell.clone(),
-            self.template.env.clone(),
+            env,
             self.template.cursor_shape,
             self.template.alternate_scroll,
             self.template.max_scroll_history_lines,
@@ -2310,7 +2363,12 @@ impl Terminal {
             cx,
             self.activation_script.clone(),
             self.path_style,
+            identity,
         )
+    }
+
+    pub fn identity(&self) -> &TerminalIdentity {
+        &self.identity
     }
 }
 
@@ -2597,6 +2655,7 @@ mod tests {
                     cx,
                     vec![],
                     PathStyle::local(),
+                    TerminalIdentity::Anonymous,
                 )
             })
             .await
@@ -2819,6 +2878,7 @@ mod tests {
                     cx,
                     Vec::new(),
                     PathStyle::local(),
+                    TerminalIdentity::Anonymous,
                 )
             })
             .await
@@ -3307,6 +3367,7 @@ mod tests {
                         cx,
                         vec![],
                         PathStyle::local(),
+                        TerminalIdentity::Anonymous,
                     )
                 })
                 .await

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -44,6 +44,7 @@ terminal.workspace = true
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
+uuid.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -14,6 +14,7 @@ use db::{
     sqlez::{domain::Domain, statement::Statement, thread_safe_connection::ThreadSafeConnection},
     sqlez_macros::sql,
 };
+use terminal::TerminalIdentity;
 use workspace::{
     ItemHandle, ItemId, Member, Pane, PaneAxis, PaneGroup, SerializableItem as _, Workspace,
     WorkspaceDb, WorkspaceId,
@@ -253,7 +254,8 @@ async fn deserialize_pane_group(
                             .flatten();
                         let terminal = project
                             .update(cx, |project, cx| {
-                                project.create_terminal_shell(working_directory, cx)
+                                let identity = TerminalIdentity::Anonymous;
+                                project.create_terminal_shell(working_directory, identity, cx)
                             })
                             .await
                             .log_err();
@@ -422,6 +424,9 @@ impl Domain for TerminalDb {
         sql! (
             ALTER TABLE terminals ADD COLUMN custom_title TEXT;
         ),
+        sql! (
+            ALTER TABLE terminals ADD COLUMN identity TEXT;
+        ),
     ];
 }
 
@@ -511,6 +516,33 @@ impl TerminalDb {
             SELECT custom_title
             FROM terminals
             WHERE item_id = ? AND workspace_id = ?
+        }
+    }
+
+    query! {
+        fn query_identity(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<String>> {
+            SELECT identity FROM terminals WHERE item_id = ? AND workspace_id = ?
+        }
+    }
+
+    pub fn get_identity(
+        &self,
+        item_id: ItemId,
+        workspace_id: WorkspaceId,
+    ) -> Result<TerminalIdentity> {
+        let identity = self.query_identity(item_id, workspace_id)?;
+        match identity {
+            None => Ok(TerminalIdentity::persistable()),
+            Some(id) => Ok(TerminalIdentity::Persisted(uuid::Uuid::try_parse(&id)?)),
+        }
+    }
+
+    query! {
+        pub async fn save_identity(item_id: ItemId, workspace_id: WorkspaceId, identity: TerminalIdentity) -> Result<()> {
+            INSERT INTO terminals (item_id, workspace_id, identity)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT (workspace_id, item_id)
+            DO UPDATE SET identity = excluded.identity;
         }
     }
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -38,6 +38,7 @@ use workspace::{
 };
 
 use anyhow::{Result, anyhow};
+use terminal::TerminalIdentity;
 use zed_actions::assistant::InlineAssist;
 
 const TERMINAL_PANEL_KEY: &str = "TerminalPanel";
@@ -491,7 +492,11 @@ impl TerminalPanel {
                         cx,
                         working_directory,
                     ),
-                    None => project.create_terminal_shell(working_directory, cx),
+                    None => project.create_terminal_shell(
+                        working_directory,
+                        TerminalIdentity::Anonymous,
+                        cx,
+                    ),
                 })
                 .await
                 .log_err()?;
@@ -533,11 +538,17 @@ impl TerminalPanel {
         terminal_panel
             .update(cx, |panel, cx| {
                 if action.local {
-                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                    panel.add_local_terminal_shell(
+                        RevealStrategy::Always,
+                        TerminalIdentity::persistable(),
+                        window,
+                        cx,
+                    )
                 } else {
                     panel.add_terminal_shell(
                         Some(action.working_directory.clone()),
                         RevealStrategy::Always,
+                        TerminalIdentity::persistable(),
                         window,
                         cx,
                     )
@@ -641,7 +652,11 @@ impl TerminalPanel {
                 .workspace
                 .update(cx, |workspace, cx| {
                     Self::add_center_terminal(workspace, window, cx, |project, cx| {
-                        project.create_terminal_task(spawn_task, cx)
+                        project.create_terminal_task(
+                            spawn_task,
+                            TerminalIdentity::persistable(),
+                            cx,
+                        )
                     })
                 })
                 .unwrap_or_else(|e| Task::ready(Err(e))),
@@ -663,11 +678,17 @@ impl TerminalPanel {
         terminal_panel
             .update(cx, |this, cx| {
                 if action.local {
-                    this.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                    this.add_local_terminal_shell(
+                        RevealStrategy::Always,
+                        TerminalIdentity::persistable(),
+                        window,
+                        cx,
+                    )
                 } else {
                     this.add_terminal_shell(
                         default_working_directory(workspace, cx),
                         RevealStrategy::Always,
+                        TerminalIdentity::persistable(),
                         window,
                         cx,
                     )
@@ -785,7 +806,9 @@ impl TerminalPanel {
             })?;
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone())?;
             let terminal = project
-                .update(cx, |project, cx| project.create_terminal_task(task, cx))
+                .update(cx, |project, cx| {
+                    project.create_terminal_task(task, TerminalIdentity::Anonymous, cx)
+                })
                 .await?;
             let result = workspace.update_in(cx, |workspace, window, cx| {
                 let terminal_view = Box::new(cx.new(|cx| {
@@ -829,19 +852,21 @@ impl TerminalPanel {
         &mut self,
         cwd: Option<PathBuf>,
         reveal_strategy: RevealStrategy,
+        identity: TerminalIdentity,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
-        self.add_terminal_shell_internal(false, cwd, reveal_strategy, window, cx)
+        self.add_terminal_shell_internal(false, cwd, reveal_strategy, identity, window, cx)
     }
 
     fn add_local_terminal_shell(
         &mut self,
         reveal_strategy: RevealStrategy,
+        identity: TerminalIdentity,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
-        self.add_terminal_shell_internal(true, None, reveal_strategy, window, cx)
+        self.add_terminal_shell_internal(true, None, reveal_strategy, identity, window, cx)
     }
 
     fn add_terminal_shell_internal(
@@ -849,6 +874,7 @@ impl TerminalPanel {
         force_local: bool,
         cwd: Option<PathBuf>,
         reveal_strategy: RevealStrategy,
+        identity: TerminalIdentity,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
@@ -865,11 +891,15 @@ impl TerminalPanel {
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone())?;
             let terminal = if force_local {
                 project
-                    .update(cx, |project, cx| project.create_local_terminal(cx))
+                    .update(cx, |project, cx| {
+                        project.create_local_terminal(identity, cx)
+                    })
                     .await
             } else {
                 project
-                    .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                    .update(cx, |project, cx| {
+                        project.create_terminal_shell(cwd, identity, cx)
+                    })
                     .await
             };
 
@@ -991,7 +1021,7 @@ impl TerminalPanel {
             })??;
             let new_terminal = project
                 .update(cx, |project, cx| {
-                    project.create_terminal_task(spawn_task, cx)
+                    project.create_terminal_task(spawn_task, TerminalIdentity::Anonymous, cx)
                 })
                 .await?;
             terminal_to_replace.update_in(cx, |terminal_to_replace, window, cx| {
@@ -1600,8 +1630,14 @@ impl Panel for TerminalPanel {
                 return;
             };
 
-            this.add_terminal_shell(kind, RevealStrategy::Always, window, cx)
-                .detach_and_log_err(cx)
+            this.add_terminal_shell(
+                kind,
+                RevealStrategy::Always,
+                TerminalIdentity::persistable(),
+                window,
+                cx,
+            )
+            .detach_and_log_err(cx)
         })
     }
 
@@ -1761,7 +1797,13 @@ mod tests {
             let task = window_handle
                 .update(cx, |_, window, cx| {
                     terminal_panel.update(cx, |panel, cx| {
-                        panel.add_terminal_shell(None, RevealStrategy::Always, window, cx)
+                        panel.add_terminal_shell(
+                            None,
+                            RevealStrategy::Always,
+                            TerminalIdentity::Anonymous,
+                            window,
+                            cx,
+                        )
                     })
                 })
                 .unwrap();
@@ -1844,7 +1886,13 @@ mod tests {
         window_handle
             .update(cx, |_, window, cx| {
                 terminal_panel.update(cx, |terminal_panel, cx| {
-                    terminal_panel.add_terminal_shell(None, RevealStrategy::Always, window, cx)
+                    terminal_panel.add_terminal_shell(
+                        None,
+                        RevealStrategy::Always,
+                        TerminalIdentity::Anonymous,
+                        window,
+                        cx,
+                    )
                 })
             })
             .unwrap()
@@ -1888,7 +1936,12 @@ mod tests {
         let result = window_handle
             .update(cx, |_, window, cx| {
                 terminal_panel.update(cx, |terminal_panel, cx| {
-                    terminal_panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                    terminal_panel.add_local_terminal_shell(
+                        RevealStrategy::Always,
+                        TerminalIdentity::Anonymous,
+                        window,
+                        cx,
+                    )
                 })
             })
             .unwrap()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -33,7 +33,7 @@ use task::TaskId;
 use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Paste, ScrollLineDown, ScrollLineUp,
     ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop, ShowCharacterPalette, TaskState,
-    TaskStatus, Terminal, TerminalBounds, ToggleViMode,
+    TaskStatus, Terminal, TerminalBounds, TerminalIdentity, ToggleViMode,
     alacritty_terminal::{
         index::Point as AlacPoint,
         term::{TermMode, point_to_viewport, search::RegexSearch},
@@ -212,11 +212,12 @@ impl TerminalView {
     ) {
         let local = action.local;
         let working_directory = default_working_directory(workspace, cx);
+        let identity = TerminalIdentity::persistable();
         TerminalPanel::add_center_terminal(workspace, window, cx, move |project, cx| {
             if local {
-                project.create_local_terminal(cx)
+                project.create_local_terminal(identity, cx)
             } else {
-                project.create_terminal_shell(working_directory, cx)
+                project.create_terminal_shell(working_directory, identity, cx)
             }
         })
         .detach_and_log_err(cx);
@@ -1703,6 +1704,7 @@ impl SerializableItem for TerminalView {
         _window: &mut Window,
         cx: &mut App,
     ) -> Task<anyhow::Result<()>> {
+        log::info!("scheduling delete terminal db with alive items: {alive_items:?}");
         delete_unloaded_items(alive_items, workspace_id, "terminals", &TERMINAL_DB, cx)
     }
 
@@ -1726,6 +1728,7 @@ impl SerializableItem for TerminalView {
         let workspace_id = self.workspace_id?;
         let cwd = terminal.working_directory();
         let custom_title = self.custom_title.clone();
+        let identity = terminal.identity().clone();
         self.needs_serialize = false;
 
         Some(cx.background_spawn(async move {
@@ -1736,6 +1739,9 @@ impl SerializableItem for TerminalView {
             }
             TERMINAL_DB
                 .save_custom_title(item_id, workspace_id, custom_title)
+                .await?;
+            TERMINAL_DB
+                .save_identity(item_id, workspace_id, identity)
                 .await?;
             Ok(())
         }))
@@ -1754,7 +1760,7 @@ impl SerializableItem for TerminalView {
         cx: &mut App,
     ) -> Task<anyhow::Result<Entity<Self>>> {
         window.spawn(cx, async move |cx| {
-            let (cwd, custom_title) = cx
+            let (cwd, custom_title, identity) = cx
                 .update(|_window, cx| {
                     let from_db = TERMINAL_DB
                         .get_working_directory(item_id, workspace_id)
@@ -1775,13 +1781,19 @@ impl SerializableItem for TerminalView {
                         .log_err()
                         .flatten()
                         .filter(|title| !title.trim().is_empty());
-                    (cwd, custom_title)
+                    let identity = TERMINAL_DB
+                        .get_identity(item_id, workspace_id)
+                        .log_err()
+                        .unwrap_or_else(TerminalIdentity::persistable);
+                    (cwd, custom_title, identity)
                 })
                 .ok()
-                .unwrap_or((None, None));
+                .unwrap_or_else(|| (None, None, TerminalIdentity::persistable()));
 
             let terminal = project
-                .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                .update(cx, |project, cx| {
+                    project.create_terminal_shell(cwd, identity, cx)
+                })
                 .await?;
             cx.update(|window, cx| {
                 cx.new(|cx| {
@@ -2492,7 +2504,9 @@ mod tests {
         let (project, workspace) = init_test(cx).await;
 
         let terminal = project
-            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .update(cx, |project, cx| {
+                project.create_terminal_shell(None, TerminalIdentity::Anonymous, cx)
+            })
             .await
             .unwrap();
 
@@ -2522,7 +2536,9 @@ mod tests {
         let (project, workspace) = init_test(cx).await;
 
         let terminal = project
-            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .update(cx, |project, cx| {
+                project.create_terminal_shell(None, TerminalIdentity::Anonymous, cx)
+            })
             .await
             .unwrap();
 
@@ -2553,7 +2569,9 @@ mod tests {
         let (project, workspace) = init_test(cx).await;
 
         let terminal = project
-            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .update(cx, |project, cx| {
+                project.create_terminal_shell(None, TerminalIdentity::Anonymous, cx)
+            })
             .await
             .unwrap();
 
@@ -2590,7 +2608,9 @@ mod tests {
         let (project, workspace) = init_test(cx).await;
 
         let terminal = project
-            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .update(cx, |project, cx| {
+                project.create_terminal_shell(None, TerminalIdentity::Anonymous, cx)
+            })
             .await
             .unwrap();
 
@@ -2622,7 +2642,9 @@ mod tests {
         let (project, workspace) = init_test(cx).await;
 
         let terminal = project
-            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .update(cx, |project, cx| {
+                project.create_terminal_shell(None, TerminalIdentity::Anonymous, cx)
+            })
             .await
             .unwrap();
 
@@ -2662,7 +2684,9 @@ mod tests {
         let (project, workspace) = init_test(cx).await;
 
         let terminal = project
-            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .update(cx, |project, cx| {
+                project.create_terminal_shell(None, TerminalIdentity::Anonymous, cx)
+            })
             .await
             .unwrap();
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2377,6 +2377,7 @@ pub fn delete_unloaded_items(
         let query = format!(
             "DELETE FROM {table} WHERE workspace_id = ? AND item_id NOT IN ({placeholders})"
         );
+        log::info!("delete_unloaded_items from {table}");
 
         db.write(move |conn| {
             let mut statement = Statement::prepare(conn, query)?;


### PR DESCRIPTION
Hi! I am looking for high level design feedback before I clean this up and add tests.

This change implements prerequisites for #20589. I am assuming the following design goals -

- Users would want to use terminals created inside zed workspace from outside zed
- Users bring their own terminal persistence environment like tmux, screen, zmx
- Users customize their bashrc to read the environment and find the current zed-assigned terminal id

To satisfy both constraints, an environment variable `ZED_PERSISTENCE_ID` [^0] is added to newly created terminal environment. This variable is set for user created center / terminal pane terminals. This is not set for tasks, agent commands and other one-off terminal instances.

This terminal id is persisted as a new column in `terminals` db and restored on workspace load.

Example:

<img width="1397" height="967" alt="image" src="https://github.com/user-attachments/assets/71d2eb61-00eb-4147-9cf8-a86e8a0bde9e" />

Designs considered but discarded:

- Exposing entity id / item id as environment variable: Not stable ids on restarting zed
- Using a custom pool of short names/numbers: Harder to persist in db compared to uuid

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

[^0]: Temporary name, open to suggestions