### PR TITLE
Add `xcodebuild -runFirstLaunch` fallback for Metal toolchain installation documentation

### DIFF
--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -118,7 +118,8 @@ xcrun: error: unable to find utility "metal", not a developer tool or in PATH
 
 Try `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
 
-If you're on macOS 26, try `xcodebuild -downloadComponent MetalToolchain`
+If you're on macOS 26, try `xcodebuild -downloadComponent MetalToolchain`.
+If that command fails, run `xcodebuild -runFirstLaunch` and try downloading the toolchain again.
 
 ### Cargo errors claiming that a dependency is using unstable features
 


### PR DESCRIPTION
When setting up on macOS 26, `xcodebuild -downloadComponent MetalToolchain` can fail if Xcode hasn't been initialized yet. Running `xcodebuild -runFirstLaunch` first resolves this.

Release Notes:

- N/A