### PR TITLE
markdown_preview: Prevent stackoverflows in markdown parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10247,6 +10247,7 @@ dependencies = [
  "pretty_assertions",
  "pulldown-cmark 0.13.0",
  "settings",
+ "stacksafe",
  "theme",
  "ui",
  "urlencoding",

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -30,6 +30,7 @@ markup5ever_rcdom.workspace = true
 pretty_assertions.workspace = true
 pulldown-cmark.workspace = true
 settings.workspace = true
+stacksafe.workspace = true
 theme.workspace = true
 ui.workspace = true
 urlencoding.workspace = true

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -10,6 +10,7 @@ use language::LanguageRegistry;
 use markdown::parser::PARSE_OPTIONS;
 use markup5ever_rcdom::RcDom;
 use pulldown_cmark::{Alignment, Event, Parser, Tag, TagEnd};
+use stacksafe::stacksafe;
 use std::{
     cell::RefCell, collections::HashMap, mem, ops::Range, path::PathBuf, rc::Rc, sync::Arc, vec,
 };
@@ -907,6 +908,7 @@ impl<'a> MarkdownParser<'a> {
         elements
     }
 
+    #[stacksafe]
     fn parse_html_node(
         &self,
         source_range: Range<usize>,
@@ -1013,6 +1015,7 @@ impl<'a> MarkdownParser<'a> {
         }
     }
 
+    #[stacksafe]
     fn parse_paragraph(
         &self,
         source_range: Range<usize>,


### PR DESCRIPTION
Fixes ZED-5TR

Release Notes:

- Fixed a stack overflow when parsing deeply nested html in markdown files
