### PR TITLE
debugger: Show hover values for stopped sessions

### DIFF
--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -21,6 +21,8 @@ mod dap_logger;
 #[cfg(test)]
 mod debugger_panel;
 #[cfg(test)]
+mod hover_values;
+#[cfg(test)]
 mod inline_values;
 #[cfg(test)]
 mod module_list;

--- a/crates/debugger_ui/src/tests/hover_values.rs
+++ b/crates/debugger_ui/src/tests/hover_values.rs
@@ -1,0 +1,167 @@
+use dap::{
+    StackFrame,
+    requests::{Evaluate, Scopes, StackTrace, Threads},
+};
+use editor::{
+    Editor, EditorMode, MultiBuffer, MultiBufferOffset, SelectionEffects,
+    actions::Hover as HoverAction,
+};
+use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
+use language::rust_lang;
+use project::{FakeFs, Project};
+use serde_json::json;
+use util::path;
+
+use crate::{
+    debugger_panel::DebugPanel,
+    tests::{init_test, init_test_workspace, start_debug_session},
+};
+
+const SOURCE: &str =
+    "fn main() {\n    let value = 42;\n    let x = value + 1;\n    println!(\"{}\", x);\n}\n";
+
+fn hover_source<C: gpui::AppContext>(editor: &gpui::Entity<Editor>, cx: &C) -> Option<String> {
+    editor.read_with(cx, |editor, cx| {
+        editor
+            .hover_state
+            .info_popovers
+            .first()
+            .and_then(|popover| {
+                popover.parsed_content.as_ref().map(|markdown| {
+                    markdown.read_with(cx, |markdown, _| markdown.source().to_string())
+                })
+            })
+    })
+}
+
+fn trigger_hover(editor: &gpui::Entity<Editor>, cx: &mut VisualTestContext, offset: usize) {
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selection| {
+            selection.select_ranges([MultiBufferOffset(offset)..MultiBufferOffset(offset)])
+        });
+        editor::hover_popover::hover(editor, &HoverAction, window, cx);
+    });
+}
+
+#[gpui::test]
+async fn test_hover_values_after_debugger_stop_when_hover_is_retriggered(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(path!("/project"), json!({ "main.rs": SOURCE }))
+        .await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    workspace
+        .update(cx, |workspace, window, cx| {
+            workspace.focus_panel::<DebugPanel>(window, cx)
+        })
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+    client.on_request::<StackTrace, _>(move |_, _| {
+        Ok(dap::StackTraceResponse {
+            stack_frames: vec![StackFrame {
+                id: 1,
+                name: "Stack Frame 1".into(),
+                source: Some(dap::Source {
+                    name: Some("main.rs".into()),
+                    path: Some(path!("/project/main.rs").into()),
+                    source_reference: None,
+                    presentation_hint: None,
+                    origin: None,
+                    sources: None,
+                    adapter_data: None,
+                    checksums: None,
+                }),
+                line: 3,
+                column: 1,
+                end_line: None,
+                end_column: None,
+                can_restart: None,
+                instruction_pointer_reference: None,
+                module_id: None,
+                presentation_hint: None,
+            }],
+            total_frames: None,
+        })
+    });
+    client.on_request::<Scopes, _>(move |_, _| Ok(dap::ScopesResponse { scopes: vec![] }));
+    client.on_request::<Evaluate, _>(move |_, args| {
+        assert_eq!(args.expression, "value");
+        assert_eq!(args.context, Some(dap::EvaluateArgumentsContext::Hover));
+        Ok(dap::EvaluateResponse {
+            result: "42".into(),
+            type_: Some("i32".into()),
+            presentation_hint: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+            value_location_reference: None,
+        })
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/project/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+    cx.run_until_parked();
+
+    let (editor, editor_cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer.clone(), cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    editor_cx.run_until_parked();
+
+    let hover_offset = SOURCE.find("value + 1").unwrap();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+    assert!(hover_source(&editor, editor_cx).is_none());
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    editor_cx.run_until_parked();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+
+    let hover = hover_source(&editor, editor_cx).expect("expected visible hover after stop");
+    assert!(
+        hover.contains("42"),
+        "expected debugger value, got: {hover:?}"
+    );
+    assert!(
+        hover.contains("type: i32"),
+        "expected debugger type, got: {hover:?}"
+    );
+}

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2617,6 +2617,45 @@ impl Session {
         })
     }
 
+    pub fn evaluate_hover_expression(
+        &self,
+        stack_frame_id: StackFrameId,
+        expression: String,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<dap::EvaluateResponse>> {
+        let session = cx.entity();
+        cx.spawn(async move |_, cx| {
+            let hover_eval_task = session.read_with(cx, |session, _| {
+                session.state.request_dap(EvaluateCommand {
+                    expression: expression.clone(),
+                    frame_id: Some(stack_frame_id),
+                    source: None,
+                    context: Some(EvaluateArgumentsContext::Hover),
+                })
+            });
+
+            match hover_eval_task.await {
+                Ok(response) => Some(response),
+                Err(error) => {
+                    log::debug!(
+                        "Falling back to EvaluateArgumentsContext::Variables after hover evaluation failed: {error:#}"
+                    );
+
+                    let variables_eval_task = session.read_with(cx, |session, _| {
+                        session.state.request_dap(EvaluateCommand {
+                            expression,
+                            frame_id: Some(stack_frame_id),
+                            source: None,
+                            context: Some(EvaluateArgumentsContext::Variables),
+                        })
+                    });
+
+                    variables_eval_task.await.log_err()
+                }
+            }
+        })
+    }
+
     pub fn refresh_watchers(&mut self, frame_id: u64, cx: &mut Context<Self>) {
         let watches = self.watchers.clone();
         for (_, watch) in watches.into_iter() {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4168,8 +4168,62 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Option<Vec<Hover>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.lsp_store
-            .update(cx, |lsp_store, cx| lsp_store.hover(buffer, position, cx))
+        let lsp_hover = self
+            .lsp_store
+            .update(cx, |lsp_store, cx| lsp_store.hover(buffer, position, cx));
+
+        let debug_hover =
+            self.active_debug_session(cx)
+                .and_then(|(session, active_stack_frame)| {
+                    let buffer_path = BreakpointStore::abs_path_from_buffer(buffer, cx)?;
+                    if buffer_path.as_ref() != active_stack_frame.path.as_ref() {
+                        return None;
+                    }
+
+                    let snapshot = buffer.read(cx).snapshot();
+                    let (expression, range) = hovered_debug_expression(&snapshot, position)?;
+                    let stack_frame_id = active_stack_frame.stack_frame_id;
+                    let evaluate = session.update(cx, |session, cx| {
+                        session.evaluate_hover_expression(stack_frame_id, expression, cx)
+                    });
+
+                    Some((evaluate, range))
+                });
+
+        match debug_hover {
+            Some((evaluate, range)) => cx.background_spawn(async move {
+                let mut hovers = lsp_hover.await.unwrap_or_default();
+                if let Some(response) = evaluate.await {
+                    let mut debug_contents = vec![HoverBlock {
+                        text: response.result,
+                        kind: HoverBlockKind::PlainText,
+                    }];
+
+                    if let Some(type_) = response.type_.filter(|type_| !type_.is_empty()) {
+                        debug_contents.push(HoverBlock {
+                            text: format!("type: {type_}"),
+                            kind: HoverBlockKind::PlainText,
+                        });
+                    }
+
+                    if let Some(existing_hover) = hovers.first_mut() {
+                        let mut merged_contents = debug_contents;
+                        merged_contents.append(&mut existing_hover.contents);
+                        existing_hover.contents = merged_contents;
+                        existing_hover.range.get_or_insert(range);
+                    } else {
+                        hovers.push(Hover {
+                            contents: debug_contents,
+                            range: Some(range),
+                            language: None,
+                        });
+                    }
+                }
+
+                Some(hovers)
+            }),
+            None => lsp_hover,
+        }
     }
 
     pub fn linked_edits(
@@ -6196,6 +6250,84 @@ fn proto_to_prompt(level: proto::language_server_prompt_request::Level) -> gpui:
         proto::language_server_prompt_request::Level::Warning(_) => gpui::PromptLevel::Warning,
         proto::language_server_prompt_request::Level::Critical(_) => gpui::PromptLevel::Critical,
     }
+}
+
+fn hovered_debug_expression(
+    snapshot: &language::BufferSnapshot,
+    position: PointUtf16,
+) -> Option<(String, Range<Anchor>)> {
+    hovered_debug_variable_expression(snapshot, position)
+        .or_else(|| hovered_debug_member_expression(snapshot, position))
+}
+
+fn hovered_debug_variable_expression(
+    snapshot: &language::BufferSnapshot,
+    position: PointUtf16,
+) -> Option<(String, Range<Anchor>)> {
+    let offset = snapshot.point_utf16_to_offset(position);
+
+    snapshot
+        .debug_variables_query(offset..offset)
+        .filter_map(|(range, capture_kind)| {
+            (capture_kind == language::DebuggerTextObject::Variable
+                && range.start <= offset
+                && offset <= range.end)
+                .then(|| {
+                    let expression = snapshot.text_for_range(range.clone()).collect::<String>();
+                    let anchor_range =
+                        snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end);
+                    (expression, anchor_range, range.end - range.start)
+                })
+        })
+        .min_by_key(|(_, _, len)| *len)
+        .map(|(expression, range, _)| (expression, range))
+}
+
+fn hovered_debug_member_expression(
+    snapshot: &language::BufferSnapshot,
+    position: PointUtf16,
+) -> Option<(String, Range<Anchor>)> {
+    let offset = snapshot.point_utf16_to_offset(position);
+    let mut node = snapshot.syntax_ancestor(offset..offset)?;
+    let mut best_match = None;
+
+    loop {
+        let byte_range = node.byte_range();
+        if byte_range.start > offset || offset > byte_range.end {
+            break;
+        }
+
+        let expression = snapshot
+            .text_for_range(byte_range.clone())
+            .collect::<String>();
+        if looks_like_debug_hover_member_expression(&expression) {
+            best_match = Some((
+                expression,
+                snapshot.anchor_before(byte_range.start)..snapshot.anchor_after(byte_range.end),
+            ));
+        }
+
+        let Some(parent) = node.parent() else {
+            break;
+        };
+        node = parent;
+    }
+
+    best_match
+}
+
+fn looks_like_debug_hover_member_expression(expression: &str) -> bool {
+    !expression.is_empty()
+        && expression.len() <= 128
+        && !expression.contains(char::is_whitespace)
+        && (expression.contains('.') || expression.contains('[') || expression.contains("->"))
+        && expression.chars().all(|char| {
+            char.is_alphanumeric()
+                || matches!(
+                    char,
+                    '_' | '.' | '[' | ']' | '(' | ')' | '"' | '\'' | '-' | '>'
+                )
+        })
 }
 
 fn provide_inline_values(

--- a/crates/project/tests/integration/debugger.rs
+++ b/crates/project/tests/integration/debugger.rs
@@ -247,6 +247,238 @@ mod python_locator {
     }
 }
 
+mod hover {
+    use std::{path::Path, sync::Arc};
+
+    use dap::{
+        DapRegistry, EvaluateArgumentsContext,
+        adapters::{DebugAdapterName, DebugTaskDefinition},
+        client::DebugAdapterClient,
+        requests::Evaluate,
+    };
+    use fs::FakeFs;
+    use futures::StreamExt as _;
+    use gpui::{BackgroundExecutor, Entity, TestAppContext};
+    use language::{Buffer, FakeLspAdapter, ToPointUtf16, rust_lang};
+    use parking_lot::Mutex;
+    use project::{
+        Project,
+        debugger::{
+            breakpoint_store::ActiveStackFrame,
+            session::{Session, SessionQuirks, ThreadId},
+        },
+    };
+    use serde_json::json;
+    use task::SharedTaskContext;
+    use util::path;
+
+    use crate::init_test;
+
+    const SOURCE: &str = "fn main() {
+    let value = 42;
+    let x = value + 1;
+    println!(\"{}\", x);
+}
+";
+
+    async fn init_project(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) -> Entity<Project> {
+        init_test(cx);
+        cx.executor().allow_parking();
+        cx.update(|cx| DapRegistry::global(cx).add_adapter(Arc::new(dap::FakeAdapter::new())));
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(path!("/project"), json!({ "main.rs": SOURCE }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        project
+            .read_with(cx, |project, _| project.languages().clone())
+            .add(rust_lang());
+        project
+    }
+
+    async fn boot_session<T: Fn(&Arc<DebugAdapterClient>) + 'static>(
+        project: &Entity<Project>,
+        configure: T,
+        cx: &mut TestAppContext,
+    ) -> Entity<Session> {
+        let worktree = project.update(cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .next()
+                .expect("test project should have one worktree")
+        });
+        let _subscription = project::debugger::test::intercept_debug_sessions(cx, configure);
+        let dap_store = project.read_with(cx, |project, _| project.dap_store());
+        let (session, boot_task) = dap_store.update(cx, |dap_store, cx| {
+            let session = dap_store.new_session(
+                None,
+                DebugAdapterName(dap::FakeAdapter::ADAPTER_NAME.into()),
+                SharedTaskContext::default(),
+                None,
+                SessionQuirks::default(),
+                cx,
+            );
+            let boot_task = dap_store.boot_session(
+                session.clone(),
+                DebugTaskDefinition {
+                    adapter: dap::FakeAdapter::ADAPTER_NAME.into(),
+                    label: "test".into(),
+                    config: json!({ "request": "launch" }),
+                    tcp_connection: None,
+                },
+                worktree,
+                cx,
+            );
+            (session, boot_task)
+        });
+        boot_task.await.expect("session should boot");
+        cx.run_until_parked();
+        session
+    }
+
+    fn set_active_stack_frame(
+        project: &Entity<Project>,
+        session: &Entity<Session>,
+        buffer: &Entity<Buffer>,
+        cx: &mut TestAppContext,
+    ) {
+        let session_id = session.read_with(cx, |session, _| session.session_id());
+        let position = buffer.read_with(cx, |buffer, _| buffer.snapshot().anchor_before(0));
+        project.update(cx, |project, cx| {
+            project.breakpoint_store().update(cx, |store, cx| {
+                store.set_active_position(
+                    ActiveStackFrame {
+                        session_id,
+                        thread_id: ThreadId(1),
+                        stack_frame_id: 1,
+                        path: Arc::<Path>::from(Path::new(path!("/project/main.rs"))),
+                        position,
+                    },
+                    cx,
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    async fn test_hover_merges_debug_content_before_lsp_hover(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let project = init_project(executor, cx).await;
+        let evaluation_contexts = Arc::new(Mutex::new(Vec::new()));
+        let languages = project.read_with(cx, |project, _| project.languages().clone());
+        let mut fake_servers = languages.register_fake_lsp(
+            "Rust",
+            FakeLspAdapter {
+                capabilities: lsp::ServerCapabilities {
+                    hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                    ..lsp::ServerCapabilities::default()
+                },
+                ..FakeLspAdapter::default()
+            },
+        );
+        let session = boot_session(
+            &project,
+            {
+                let evaluation_contexts = evaluation_contexts.clone();
+                move |client| {
+                    let evaluation_contexts = evaluation_contexts.clone();
+                    client.on_request::<Evaluate, _>(move |_, args| {
+                        let context = args.context.clone();
+                        evaluation_contexts
+                            .lock()
+                            .push((args.expression.clone(), context.clone()));
+
+                        match context {
+                            Some(EvaluateArgumentsContext::Hover) => Err(dap::ErrorResponse {
+                                error: Some(dap::Message {
+                                    id: 1,
+                                    format: "hover unsupported".into(),
+                                    variables: None,
+                                    send_telemetry: None,
+                                    show_user: None,
+                                    url: None,
+                                    url_label: None,
+                                }),
+                            }),
+                            Some(EvaluateArgumentsContext::Variables) => {
+                                Ok(dap::EvaluateResponse {
+                                    result: "42".into(),
+                                    type_: Some("i32".into()),
+                                    presentation_hint: None,
+                                    variables_reference: 0,
+                                    named_variables: None,
+                                    indexed_variables: None,
+                                    memory_reference: None,
+                                    value_location_reference: None,
+                                })
+                            }
+                            other => panic!("unexpected evaluate context: {other:?}"),
+                        }
+                    });
+                }
+            },
+            cx,
+        )
+        .await;
+
+        let (buffer, _handle) = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer_with_lsp(path!("/project/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+        fake_servers
+            .next()
+            .await
+            .expect("failed to get language server")
+            .set_request_handler::<lsp::request::HoverRequest, _, _>(move |_, _| async move {
+                Ok(Some(lsp::Hover {
+                    contents: lsp::HoverContents::Scalar(lsp::MarkedString::String(
+                        "lsp hover".to_string(),
+                    )),
+                    range: None,
+                }))
+            });
+
+        set_active_stack_frame(&project, &session, &buffer, cx);
+        let hover_offset = SOURCE.find("value + 1").unwrap();
+        let hover_position = buffer.read_with(cx, |buffer, _| hover_offset.to_point_utf16(buffer));
+        let hover = project
+            .update(cx, |project, cx| project.hover(&buffer, hover_position, cx))
+            .await
+            .and_then(|mut hovers| hovers.pop())
+            .expect("expected merged hover");
+
+        assert_eq!(
+            hover
+                .contents
+                .into_iter()
+                .map(|block| block.text)
+                .collect::<Vec<_>>(),
+            vec![
+                "42".to_string(),
+                "type: i32".to_string(),
+                "lsp hover".to_string()
+            ]
+        );
+        assert_eq!(
+            *evaluation_contexts.lock(),
+            vec![
+                ("value".to_string(), Some(EvaluateArgumentsContext::Hover),),
+                (
+                    "value".to_string(),
+                    Some(EvaluateArgumentsContext::Variables),
+                ),
+            ]
+        );
+    }
+}
+
 mod memory {
     use project::debugger::{
         MemoryCell,


### PR DESCRIPTION
This implements debugger hover values for stopped debug sessions.

Current expression support:
- local identifiers, e.g. `value`
- member expressions, e.g. `obj.field` and `a.b.c`
- index expressions, e.g. `values[1]`

When a debug session is stopped on the same source file, hovering one of these expressions now evaluates it in the active stack frame and shows the runtime value before the LSP hover content.

> This PR is finished with codex;

## Release Notes:

- Improved debugger hovers to show runtime values for stopped sessions, including identifiers, member expressions, and index expressions.

## Screenshots

> Build under Macos26.1

<img width="882" height="472" alt="Snipaste_2026-03-18_22-38-49" src="https://github.com/user-attachments/assets/405b38b8-906a-4ac4-9636-f66717d6f7ea" />
<img width="852" height="475" alt="Snipaste_2026-03-18_22-39-22" src="https://github.com/user-attachments/assets/eda055e5-f2b0-479a-b483-180ace76b7cb" />

## TODO

- [ ] ~~debug the failure with codelldb c++ scenario; Removed for next PR~~

