### PR TITLE
keymap: update default keybinding for "format document & format selection" to align with vscode and zed-windows

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -117,7 +117,7 @@
       "ctrl-shift-end": "editor::SelectToEnd",
       "ctrl-a": "editor::SelectAll",
       "ctrl-l": "editor::SelectLine",
-      "ctrl-shift-i": "editor::Format",
+      "alt-shift-f": "editor::Format",
       "alt-shift-o": "editor::OrganizeImports",
       "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
       "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
@@ -507,6 +507,7 @@
       "ctrl-k ctrl-shift-d": ["editor::SelectPrevious", { "replace_newest": true }], // editor.action.moveSelectionToPreviousFindMatch
       "ctrl-k ctrl-i": "editor::Hover",
       "ctrl-k ctrl-b": "editor::BlameHover",
+      "ctrl-k ctrl-f": "editor::FormatSelections",
       "ctrl-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "ctrl-k ctrl-c": ["editor::ToggleComments", { "advance_downwards": false }],
       "f8": ["editor::GoToDiagnostic", { "severity": { "min": "hint", "max": "error" } }],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -135,7 +135,7 @@
       "cmd-shift-down": "editor::SelectToEnd",
       "cmd-a": "editor::SelectAll",
       "cmd-l": "editor::SelectLine",
-      "cmd-shift-i": "editor::Format",
+      "alt-shift-f": "editor::Format",
       "alt-shift-o": "editor::OrganizeImports",
       "cmd-shift-left": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
       "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
@@ -563,6 +563,7 @@
       "cmd-k ctrl-cmd-d": ["editor::SelectPrevious", { "replace_newest": true }], // editor.action.moveSelectionToPreviousFindMatch
       "cmd-k cmd-i": "editor::Hover",
       "cmd-k cmd-b": "editor::BlameHover",
+      "cmd-k cmd-f": "editor::FormatSelections",
       "cmd-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "f8": ["editor::GoToDiagnostic", { "severity": { "min": "hint", "max": "error" } }],
       "shift-f8": ["editor::GoToPreviousDiagnostic", { "severity": { "min": "hint", "max": "error" } }],


### PR DESCRIPTION
- Close https://github.com/zed-industries/zed/issues/36010
- and https://github.com/zed-industries/zed/issues/7151#issuecomment-1923824499

<img width="2080" height="488" alt="image" src="https://github.com/user-attachments/assets/776114bd-4114-48ab-bcab-ce78d88b33e0" />

The fix only applies to macos & linux. As for windows, keybindings are already correct.

https://github.com/zed-industries/zed/blob/b0fd10134f27690d449fad18323f6da299b3db31/assets/keymaps/default-windows.json#L115

https://github.com/zed-industries/zed/blob/b0fd10134f27690d449fad18323f6da299b3db31/assets/keymaps/default-windows.json#L513

Reference: [VSCode default keyboard shortcuts](https://code.visualstudio.com/docs/reference/default-keybindings#_rich-languages-editing)

Release Notes:

- Update default keybinding for "editor: format" to `shift+alt+f` on mac/linux (align with vscode)
- Add default keybinding for "editor: format selection" to `cmd+k cmd+f` on mac/linux (align with vscode)