### PR TITLE
Add cmd-shift-j and ctrl-shift-j keybindings to toggle terminal panel focus

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -638,6 +638,7 @@
       "ctrl-shift-b": "outline_panel::ToggleFocus",
       "ctrl-shift-g": "git_panel::ToggleFocus",
       "ctrl-shift-d": "debug_panel::ToggleFocus",
+      "ctrl-shift-j": "terminal_panel::ToggleFocus",
       "ctrl-?": "agent::ToggleFocus",
       "alt-save": "workspace::SaveAll",
       "ctrl-alt-s": "workspace::SaveAll",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -703,6 +703,7 @@
       "cmd-shift-b": "outline_panel::ToggleFocus",
       "ctrl-shift-g": "git_panel::ToggleFocus",
       "cmd-shift-d": "debug_panel::ToggleFocus",
+      "cmd-shift-j": "terminal_panel::ToggleFocus",
       "cmd-?": "agent::ToggleFocus",
       "cmd-alt-s": "workspace::SaveAll",
       "cmd-k n": "encoding_selector::Toggle",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -630,6 +630,7 @@
       "ctrl-shift-b": "outline_panel::ToggleFocus",
       "ctrl-shift-g": "git_panel::ToggleFocus",
       "ctrl-shift-d": "debug_panel::ToggleFocus",
+      "ctrl-shift-j": "terminal_panel::ToggleFocus",
       "ctrl-shift-/": "agent::ToggleFocus",
       "ctrl-k s": "workspace::SaveAll",
       "ctrl-k n": "encoding_selector::Toggle",


### PR DESCRIPTION
Closes #51668

This PR adds `cmd-shift-j` (macOS) and `ctrl-shift-j` (Linux/Windows) as default keybindings to toggle focus for the terminal panel. 

The rationale here is that if a user presses `cmd+shift+d` to open the debug mode in the lower pane (which is usually reserved for the terminal and typically opened with `cmd+j`), they are currently forced to use the mouse to switch back to the terminal panel. 

Alternatively, `cmd+j` could be programmed to automatically switch back to the terminal when the lower panel is already open to debug mode, which would have fixed the issue. However, adding `cmd-shift-j` is a more consistent addition, cleanly matching `cmd-shift-d` for the debugger.

Release Notes:

- Added `cmd-shift-j` / `ctrl-shift-j` keybindings to toggle terminal panel focus