### PR TITLE
extension_ci: Use temporary fork for release action

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -230,7 +230,7 @@ jobs:
 
         echo "extension_id=${EXTENSION_ID}" >> "$GITHUB_OUTPUT"
     - name: extension_bump::release_action
-      uses: huacnlee/zed-extension-action@v2
+      uses: zed-extensions/update-action@543925fc45da8866b0d017218a656c8a3296ed3f
       with:
         extension-name: ${{ steps.get-extension-id.outputs.extension_id }}
         push-to: zed-industries/extensions

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -427,11 +427,15 @@ fn release_action(
     tag: JobOutput,
     generated_token: StepOutput,
 ) -> Step<Use> {
-    named::uses("huacnlee", "zed-extension-action", "v2")
-        .add_with(("extension-name", extension_id.to_string()))
-        .add_with(("push-to", "zed-industries/extensions"))
-        .add_with(("tag", tag.to_string()))
-        .add_env(("COMMITTER_TOKEN", generated_token.to_string()))
+    named::uses(
+        "zed-extensions",
+        "update-action",
+        "543925fc45da8866b0d017218a656c8a3296ed3f",
+    )
+    .add_with(("extension-name", extension_id.to_string()))
+    .add_with(("push-to", "zed-industries/extensions"))
+    .add_with(("tag", tag.to_string()))
+    .add_env(("COMMITTER_TOKEN", generated_token.to_string()))
 }
 
 fn extension_workflow_secrets() -> (WorkflowSecret, WorkflowSecret) {


### PR DESCRIPTION
Moving to the for here before the fix gets upstreamed. We might revisit this at a later point anyway.

Release Notes:

- N/A
