### PR TITLE
glsl: Highlight null as builtin constant

### DIFF
--- a/extensions/glsl/languages/glsl/highlights.scm
+++ b/extensions/glsl/languages/glsl/highlights.scm
@@ -57,7 +57,7 @@
   (system_lib_string)
 ] @string
 
-(null) @constant
+(null) @constant.builtin
 
 [
   (number_literal)


### PR DESCRIPTION
Mostly just a test to check whether everything works properly now.

Release Notes:

- N/A
