### PR TITLE
editor: Fix panic in `refresh_inline_values` when spanning cross excerpts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23664,6 +23664,14 @@ impl Editor {
                         editor.buffer.read(cx).buffer(excerpt.buffer_id())
                     })?;
 
+                    if current_execution_position
+                        .text_anchor
+                        .buffer_id
+                        .is_some_and(|id| id != buffer.read(cx).remote_id())
+                    {
+                        return Some(Task::ready(Ok(Vec::new())));
+                    }
+
                     let range =
                         buffer.read(cx).anchor_before(0)..current_execution_position.text_anchor;
 


### PR DESCRIPTION


Fixes ZED-5VQ

Release Notes:

- N/A *or* Added/Fixed/Improved ...
