### PR TITLE
settings_content: Fix hover descriptions for newtype wrapper settings

### DIFF
--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1187,15 +1187,15 @@ pub struct WhichKeySettingsContent {
     pub delay_ms: Option<u64>,
 }
 
+// An ExtendingVec in the settings can only accumulate new values.
+//
+// This is useful for things like private files where you only want
+// to allow new values to be added.
+//
+// Consider using a HashMap<String, bool> instead of this type
+// (like auto_install_extensions) so that user settings files can both add
+// and remove values from the set.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-/// An ExtendingVec in the settings can only accumulate new values.
-///
-/// This is useful for things like private files where you only want
-/// to allow new values to be added.
-///
-/// Consider using a HashMap<String, bool> instead of this type
-/// (like auto_install_extensions) so that user settings files can both add
-/// and remove values from the set.
 pub struct ExtendingVec<T>(pub Vec<T>);
 
 impl<T> Into<Vec<T>> for ExtendingVec<T> {
@@ -1215,10 +1215,10 @@ impl<T: Clone> merge_from::MergeFrom for ExtendingVec<T> {
     }
 }
 
-/// A SaturatingBool in the settings can only ever be set to true,
-/// later attempts to set it to false will be ignored.
-///
-/// Used by `disable_ai`.
+// A SaturatingBool in the settings can only ever be set to true,
+// later attempts to set it to false will be ignored.
+//
+// Used by `disable_ai`.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct SaturatingBool(pub bool);
 


### PR DESCRIPTION
Happened to notice it when debugging some stuff. I initially only caught `git_hosting_providers`, but AI found another instance.

| `disable_ai` | `git_hosting_providers` |
|--------|--------|
| <img width="596" height="125" alt="image" src="https://github.com/user-attachments/assets/1f829a9f-9e6e-45c0-8fb1-585d3bb3cfc3" /> | <img width="634" height="207" alt="image" src="https://github.com/user-attachments/assets/be2504f4-0b52-45a5-a859-b7609a366d0e" /> |

Release Notes:

- Fix hover descriptions for newtype wrapper settings
