### PR TITLE
Preserve ACP config options when starting thread in new worktree

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2888,6 +2888,8 @@ impl AgentPanel {
             .window_handle()
             .downcast::<workspace::MultiWorkspace>();
 
+        let selected_agent = self.selected_agent();
+
         let task = cx.spawn_in(window, async move |this, cx| {
             // Await the branch listings we kicked off earlier.
             let mut existing_branches = Vec::new();
@@ -2987,6 +2989,7 @@ impl AgentPanel {
                 non_git_paths,
                 has_non_git,
                 content,
+                selected_agent,
                 cx,
             )
             .await
@@ -3020,6 +3023,7 @@ impl AgentPanel {
         non_git_paths: Vec<PathBuf>,
         has_non_git: bool,
         content: Vec<acp::ContentBlock>,
+        selected_agent: Option<Agent>,
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
         let init: Option<
@@ -3105,7 +3109,7 @@ impl AgentPanel {
                 if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
                     panel.update(cx, |panel, cx| {
                         panel.external_thread(
-                            None,
+                            selected_agent,
                             None,
                             None,
                             None,
@@ -6267,6 +6271,160 @@ mod tests {
             AgentType::Custom {
                 name: "my-agent".into(),
             },
+        );
+    }
+
+    #[gpui::test]
+    async fn test_worktree_creation_preserves_selected_agent(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let app_state = cx.update(|cx| {
+            cx.update_flags(true, vec!["agent-v2".to_string()]);
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+
+            let app_state = workspace::AppState::test(cx);
+            workspace::init(app_state.clone(), cx);
+            app_state
+        });
+
+        let fs = app_state.fs.as_fake();
+        fs.insert_tree(
+            "/project",
+            json!({
+                ".git": {},
+                "src": {
+                    "main.rs": "fn main() {}"
+                }
+            }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/project/.git"), Some("main"));
+
+        let project = Project::test(app_state.fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+
+        // Register a callback so new workspaces also get an AgentPanel.
+        cx.update(|cx| {
+            cx.observe_new(
+                |workspace: &mut Workspace,
+                 window: Option<&mut Window>,
+                 cx: &mut Context<Workspace>| {
+                    if let Some(window) = window {
+                        let project = workspace.project().clone();
+                        let text_thread_store =
+                            cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
+                        let panel = cx.new(|cx| {
+                            AgentPanel::new(workspace, text_thread_store, None, window, cx)
+                        });
+                        workspace.add_panel(panel, window, cx);
+                    }
+                },
+            )
+            .detach();
+        });
+
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        // Wait for the project to discover the git repository.
+        cx.run_until_parked();
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
+            let panel =
+                cx.new(|cx| AgentPanel::new(workspace, text_thread_store, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        cx.run_until_parked();
+
+        // Open a thread (needed so there's an active thread view).
+        panel.update_in(cx, |panel, window, cx| {
+            panel.open_external_thread_with_server(
+                Rc::new(StubAgentServer::default_response()),
+                window,
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        // Set the selected agent to Codex (a custom agent) and start_thread_in
+        // to NewWorktree. We do this AFTER opening the thread because
+        // open_external_thread_with_server overrides selected_agent_type.
+        panel.update(cx, |panel, cx| {
+            panel.selected_agent_type = AgentType::Custom {
+                name: CODEX_NAME.into(),
+            };
+            panel.set_start_thread_in(&StartThreadIn::NewWorktree, cx);
+        });
+
+        // Verify the panel has the Codex agent selected.
+        panel.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent_type,
+                AgentType::Custom {
+                    name: CODEX_NAME.into()
+                },
+            );
+        });
+
+        // Directly call handle_worktree_creation_requested, which is what
+        // handle_first_send_requested does when start_thread_in == NewWorktree.
+        let content = vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "Hello from test",
+        ))];
+        panel.update_in(cx, |panel, window, cx| {
+            panel.handle_worktree_creation_requested(content, window, cx);
+        });
+
+        // Let the async worktree creation + workspace setup complete.
+        cx.run_until_parked();
+
+        // Find the new workspace's AgentPanel and verify it used the Codex agent.
+        let found_codex = multi_workspace
+            .read_with(cx, |multi_workspace, cx| {
+                // There should be more than one workspace now (the original + the new worktree).
+                assert!(
+                    multi_workspace.workspaces().len() > 1,
+                    "expected a new workspace to have been created, found {}",
+                    multi_workspace.workspaces().len(),
+                );
+
+                // Check the newest workspace's panel for the correct agent.
+                let new_workspace = multi_workspace
+                    .workspaces()
+                    .iter()
+                    .find(|ws| ws.entity_id() != workspace.entity_id())
+                    .expect("should find the new workspace");
+                let new_panel = new_workspace
+                    .read(cx)
+                    .panel::<AgentPanel>(cx)
+                    .expect("new workspace should have an AgentPanel");
+
+                new_panel.read(cx).selected_agent_type.clone()
+            })
+            .unwrap();
+
+        assert_eq!(
+            found_codex,
+            AgentType::Custom {
+                name: CODEX_NAME.into()
+            },
+            "the new worktree workspace should use the same agent (Codex) that was selected in the original panel",
         );
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -890,6 +890,7 @@ pub struct AgentPanel {
     selected_agent_type: AgentType,
     start_thread_in: StartThreadIn,
     worktree_creation_status: Option<WorktreeCreationStatus>,
+    pending_config_overrides: Vec<(acp::SessionConfigId, acp::SessionConfigValueId)>,
     _thread_view_subscription: Option<Subscription>,
     _active_thread_focus_subscription: Option<Subscription>,
     _worktree_creation_task: Option<Task<()>>,
@@ -1226,6 +1227,7 @@ impl AgentPanel {
             selected_agent_type: AgentType::default(),
             start_thread_in: StartThreadIn::default(),
             worktree_creation_status: None,
+            pending_config_overrides: Vec::new(),
             _thread_view_subscription: None,
             _active_thread_focus_subscription: None,
             _worktree_creation_task: None,
@@ -2215,6 +2217,7 @@ impl AgentPanel {
                     cx.observe_in(server_view, window, |this, server_view, window, cx| {
                         this._thread_view_subscription =
                             Self::subscribe_to_active_thread_view(&server_view, window, cx);
+                        this.apply_pending_config_overrides(cx);
                         cx.emit(AgentPanelEvent::ActiveViewChanged);
                         this.serialize(cx);
                         cx.notify();
@@ -2417,6 +2420,58 @@ impl AgentPanel {
             AgentType::NativeAgent => Some(Agent::NativeAgent),
             AgentType::Custom { name } => Some(Agent::Custom { name: name.clone() }),
             AgentType::TextThread => None,
+        }
+    }
+
+    /// Captures the currently selected config option values (e.g., model,
+    /// permissions mode) from the active thread's ACP session.
+    fn capture_config_overrides(
+        &self,
+        cx: &App,
+    ) -> Vec<(acp::SessionConfigId, acp::SessionConfigValueId)> {
+        let Some(thread_view) = self.as_active_thread_view(cx) else {
+            return Vec::new();
+        };
+        let thread = thread_view.read(cx).thread.read(cx);
+        let connection = thread.connection();
+        let session_id = thread.session_id();
+        let Some(config_provider) = connection.session_config_options(session_id, cx) else {
+            return Vec::new();
+        };
+        config_provider
+            .config_options()
+            .into_iter()
+            .filter_map(|opt| match &opt.kind {
+                acp::SessionConfigKind::Select(select) => {
+                    Some((opt.id.clone(), select.current_value.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Applies any pending config option overrides to the active thread's ACP
+    /// session.  Called once after a new worktree workspace's thread becomes
+    /// ready, then the pending overrides are drained so they are applied only
+    /// once.
+    fn apply_pending_config_overrides(&mut self, cx: &mut Context<Self>) {
+        if self.pending_config_overrides.is_empty() {
+            return;
+        }
+        let Some(thread_view) = self.as_active_thread_view(cx) else {
+            return;
+        };
+        let thread = thread_view.read(cx).thread.read(cx);
+        let connection = thread.connection();
+        let session_id = thread.session_id();
+        let Some(config_provider) = connection.session_config_options(session_id, cx) else {
+            return;
+        };
+        let overrides = std::mem::take(&mut self.pending_config_overrides);
+        for (config_id, value) in overrides {
+            config_provider
+                .set_config_option(config_id, value, cx)
+                .detach();
         }
     }
 
@@ -2889,6 +2944,7 @@ impl AgentPanel {
             .downcast::<workspace::MultiWorkspace>();
 
         let selected_agent = self.selected_agent();
+        let config_overrides = self.capture_config_overrides(cx);
 
         let task = cx.spawn_in(window, async move |this, cx| {
             // Await the branch listings we kicked off earlier.
@@ -2990,6 +3046,7 @@ impl AgentPanel {
                 has_non_git,
                 content,
                 selected_agent,
+                config_overrides,
                 cx,
             )
             .await
@@ -3024,6 +3081,7 @@ impl AgentPanel {
         has_non_git: bool,
         content: Vec<acp::ContentBlock>,
         selected_agent: Option<Agent>,
+        config_overrides: Vec<(acp::SessionConfigId, acp::SessionConfigValueId)>,
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
         let init: Option<
@@ -3108,6 +3166,7 @@ impl AgentPanel {
                 workspace.focus_panel::<AgentPanel>(window, cx);
                 if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
                     panel.update(cx, |panel, cx| {
+                        panel.pending_config_overrides = config_overrides;
                         panel.external_thread(
                             selected_agent,
                             None,


### PR DESCRIPTION
Follow-up to #51628. When starting a thread in a new worktree, the ACP-specific settings (e.g. "Bypass Permissions" mode, model selection like "Opus") were reset to their defaults in the new workspace, even though the agent dropdown was now preserved.

The fix captures the current session config option selections before worktree creation, stores them as `pending_config_overrides` on the new workspace's AgentPanel, and applies them via `set_config_option` once the new thread's ACP session is established.

Release Notes:

- Fixed "Start Thread in New Worktree" resetting ACP agent settings (e.g. model and permissions mode) to defaults.