### PR TITLE
Fix .git/info/exclude patterns matching against wrong root

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3233,12 +3233,20 @@ async fn is_git_dir(path: &Path, fs: &dyn Fs) -> bool {
 }
 
 async fn build_gitignore(abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
+    let root = abs_path.parent().unwrap_or_else(|| Path::new("/"));
+    build_gitignore_from_root(root, abs_path, fs).await
+}
+
+// Like `build_gitignore`, but allows specifying the root directory against
+// which patterns are matched. This is needed for `info/exclude`, whose
+// patterns are relative to the working-tree root rather than to the
+// `.git/info/` directory that contains the file.
+async fn build_gitignore_from_root(root: &Path, abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
     let contents = fs
         .load(abs_path)
         .await
         .with_context(|| format!("failed to load gitignore file at {}", abs_path.display()))?;
-    let parent = abs_path.parent().unwrap_or_else(|| Path::new("/"));
-    let mut builder = GitignoreBuilder::new(parent);
+    let mut builder = GitignoreBuilder::new(root);
     for line in contents.lines() {
         builder.add_line(Some(abs_path.into()), line)?;
     }
@@ -5074,7 +5082,9 @@ impl BackgroundScanner {
         // Load gitignores asynchronously (outside the lock)
         let mut loaded_excludes: Vec<(Arc<Path>, Arc<Gitignore>)> = Vec::new();
         for (work_dir_abs_path, exclude_abs_path) in excludes_to_load {
-            if let Ok(current_exclude) = build_gitignore(&exclude_abs_path, self.fs.as_ref()).await
+            if let Ok(current_exclude) =
+                build_gitignore_from_root(&work_dir_abs_path, &exclude_abs_path, self.fs.as_ref())
+                    .await
             {
                 loaded_excludes.push((work_dir_abs_path, Arc::new(current_exclude)));
             }
@@ -5395,7 +5405,9 @@ async fn discover_ancestor_git_repo(
             }
 
             let repo_exclude_abs_path = ancestor_dot_git.join(REPO_EXCLUDE);
-            if let Ok(repo_exclude) = build_gitignore(&repo_exclude_abs_path, fs.as_ref()).await {
+            if let Ok(repo_exclude) =
+                build_gitignore_from_root(ancestor, &repo_exclude_abs_path, fs.as_ref()).await
+            {
                 exclude = Some(Arc::new(repo_exclude));
             }
 

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -2692,6 +2692,66 @@ async fn test_repo_exclude(executor: BackgroundExecutor, cx: &mut TestAppContext
     });
 }
 
+#[gpui::test]
+async fn test_repo_exclude_anchored_pattern(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    let project_dir = Path::new(path!("/project"));
+    fs.insert_tree(
+        project_dir,
+        json!({
+            ".git": {
+                "info": {
+                    // Anchored pattern: must match at repo root, not relative to .git/info/
+                    "exclude": "/build\n"
+                }
+            },
+            "build": {
+                "output.o": ""
+            },
+            "src": {
+                "main.rs": "",
+                "build": {
+                    "helper.rs": ""
+                }
+            },
+        }),
+    )
+    .await;
+
+    let worktree = Worktree::local(
+        project_dir,
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    // The anchored pattern "/build" should ignore the top-level "build" directory
+    // but not "src/build". With the wrong root (.git/info/), the pattern would
+    // look for .git/info/build and neither directory would be ignored.
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            &[],
+            &["build"],
+            &["src/main.rs", "src/build/helper.rs"],
+            &[],
+        );
+    });
+}
+
 #[track_caller]
 fn check_worktree_entries(
     tree: &Worktree,


### PR DESCRIPTION
Entries in `.git/info/exclude` were not being properly shown as ignored files in the project panel. This was due to the fact that `build_gitignore` was matching against the wrong root when loading entries from `.git/info/exclude`: it was using `.git/info` as the root, but the patterns in that file are relative to the repository root. Entries in `.git/info/exclude` will now be relative to the repository root, and those entries will be shown as ignored in the project panel.

Before you mark this PR as ready for review, make sure that you have:
- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects
- [X] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed a bug in which entries in `.git/info/exclude` where not properly marked as ignored in the project panel.
