### PR TITLE
Disable the `tilt` LSP by default for "Starlark" files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2168,7 +2168,7 @@
       },
     },
     "Starlark": {
-      "language_servers": ["starpls", "!buck2-lsp", "..."],
+      "language_servers": ["starpls", "!buck2-lsp", "!tilt", "..."],
     },
     "Svelte": {
       "language_servers": ["svelte-language-server", "..."],


### PR DESCRIPTION
This matches how the `buck2-lsp` works for that extension.

Fixes https://github.com/zaucy/zed-starlark/issues/18

Before you mark this PR as ready for review, make sure that you have:
- [ ] (n/a) Added a solid test coverage and/or screenshots from doing manual testing 
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
