### PR TITLE
workspace: Fix pinned tabs count when restoring panes with failed items

### DIFF
--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -351,8 +351,17 @@ impl SerializedPane {
                 }
             })?;
         }
+
+        // `items` contains `None` for each item that failed to deserialize.
+        // Only `Some` entries are added to the pane above, so the pinned
+        // count must only count those — not the total serialized count.
+        let pinned_count = items
+            .iter()
+            .take(self.pinned_count)
+            .filter(|item| item.is_some())
+            .count();
         pane.update(cx, |pane, _| {
-            pane.set_pinned_count(self.pinned_count.min(items.len()));
+            pane.set_pinned_count(pinned_count);
         })?;
 
         anyhow::Ok(items)


### PR DESCRIPTION
When deserializing panes, some items may fail to load and become `None`. The pinned count should only include successfully loaded items, not the original count which may exceed the number of actual items. Also see https://github.com/zed-industries/zed/issues/33342#issuecomment-3003251907.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed pinned tabs count when restoring panes with failed items
