### PR TITLE
editor: Re-serialize on file handle change to fix stale path after rename

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24283,9 +24283,13 @@ impl Editor {
             }
             multi_buffer::Event::DirtyChanged => cx.emit(EditorEvent::DirtyChanged),
             multi_buffer::Event::Saved => cx.emit(EditorEvent::Saved),
-            multi_buffer::Event::FileHandleChanged
-            | multi_buffer::Event::Reloaded
-            | multi_buffer::Event::BufferDiffChanged => cx.emit(EditorEvent::TitleChanged),
+            multi_buffer::Event::FileHandleChanged => {
+                cx.emit(EditorEvent::TitleChanged);
+                cx.emit(EditorEvent::FileHandleChanged);
+            }
+            multi_buffer::Event::Reloaded | multi_buffer::Event::BufferDiffChanged => {
+                cx.emit(EditorEvent::TitleChanged)
+            }
             multi_buffer::Event::DiagnosticsUpdated => {
                 self.update_diagnostics_state(window, cx);
             }
@@ -28102,6 +28106,7 @@ pub enum EditorEvent {
     DirtyChanged,
     Saved,
     TitleChanged,
+    FileHandleChanged,
     SelectionsChanged {
         local: bool,
     },

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1404,7 +1404,10 @@ impl SerializableItem for Editor {
         self.should_serialize_buffer()
             && matches!(
                 event,
-                EditorEvent::Saved | EditorEvent::DirtyChanged | EditorEvent::BufferEdited
+                EditorEvent::Saved
+                    | EditorEvent::DirtyChanged
+                    | EditorEvent::BufferEdited
+                    | EditorEvent::FileHandleChanged
             )
     }
 }


### PR DESCRIPTION
Closes #51629

When a file is renamed via the project panel while open in an editor, Zed would restore the old (no longer existing) path on reload .

On rename, `language::Buffer` emits `BufferEvent::FileHandleChanged`, which propagates to `multi_buffer::Event::FileHandleChanged` → `EditorEvent::TitleChanged`. However, `should_serialize()` only matched `Saved | DirtyChanged | BufferEdited`, so no re-serialization was triggered and the `editors` DB table retained the stale `abs_path`.

The fix adds a dedicated `EditorEvent::FileHandleChanged` variant, emits it alongside `TitleChanged` when the buffer's file handle changes, and adds it to `should_serialize()`. Since `Editor::serialize()` already reads the current path from the buffer at call time, this naturally writes the new path to the DB.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed renamed files being restored with their old name after reload

Manual test video below :

[Screencast from 2026-03-16 23-28-46.webm](https://github.com/user-attachments/assets/76a9af97-a9e8-49a3-9712-60e4efcb4753)

