### PR TITLE
Add code region folding

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -614,6 +614,8 @@
     "breakpoints": true,
     // Whether to show fold buttons in the gutter.
     "folds": true,
+    // Whether to always show fold buttons for foldable rows in the gutter.
+    "always_show_fold_carets": false,
     // Minimum number of characters to reserve space for in the gutter.
     "min_line_number_digits": 4,
   },

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -139,6 +139,12 @@ pub enum FoldStatus {
     Foldable,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum CustomFoldMarker {
+    Start,
+    End,
+}
+
 /// Keys for tagging text highlights.
 ///
 /// Note the order is important as it determines the priority of the highlights, lower means higher priority
@@ -2269,6 +2275,68 @@ impl DisplaySnapshot {
             .unwrap_or(false)
     }
 
+    fn buffer_row_text(&self, buffer_row: MultiBufferRow) -> String {
+        let start = Point::new(buffer_row.0, 0);
+        let end = Point::new(buffer_row.0, self.buffer_snapshot().line_len(buffer_row));
+        self.buffer_snapshot().text_for_range(start..end).collect()
+    }
+
+    fn parse_custom_fold_marker(line: &str) -> Option<CustomFoldMarker> {
+        let trimmed = line.trim_start();
+        let rest = trimmed
+            .strip_prefix("//")
+            .or_else(|| trimmed.strip_prefix('#'))?
+            .trim_start();
+
+        let keyword = rest.split_whitespace().next().unwrap_or(rest);
+
+        match keyword {
+            "region" => Some(CustomFoldMarker::Start),
+            "endregion" => Some(CustomFoldMarker::End),
+            _ => None,
+        }
+    }
+
+    fn custom_fold_crease_for_buffer_row(&self, buffer_row: MultiBufferRow) -> Option<Crease<Point>> {
+        if self.is_line_folded(buffer_row) {
+            return None;
+        }
+
+        let marker = Self::parse_custom_fold_marker(&self.buffer_row_text(buffer_row))?;
+        if marker != CustomFoldMarker::Start {
+            return None;
+        }
+
+        let start = Point::new(buffer_row.0, self.buffer_snapshot().line_len(buffer_row));
+        let max_row = self.buffer_snapshot().max_row().0;
+        let mut depth = 1;
+
+        for row in buffer_row.0 + 1..=max_row {
+            match Self::parse_custom_fold_marker(&self.buffer_row_text(MultiBufferRow(row))) {
+                Some(CustomFoldMarker::Start) => depth += 1,
+                Some(CustomFoldMarker::End) => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let end = Point::new(row, self.buffer_snapshot().line_len(MultiBufferRow(row)));
+                        if end > start {
+                            return Some(Crease::Inline {
+                                range: start..end,
+                                placeholder: self.fold_placeholder.clone(),
+                                render_toggle: None,
+                                render_trailer: None,
+                                metadata: None,
+                            });
+                        }
+                        return None;
+                    }
+                }
+                None => {}
+            }
+        }
+
+        None
+    }
+
     #[instrument(skip_all)]
     pub fn crease_for_buffer_row(&self, buffer_row: MultiBufferRow) -> Option<Crease<Point>> {
         let start =
@@ -2307,6 +2375,8 @@ impl DisplaySnapshot {
                     render_toggle: render_toggle.clone(),
                 }),
             }
+        } else if let Some(crease) = self.custom_fold_crease_for_buffer_row(buffer_row) {
+            Some(crease)
         } else if !self.use_lsp_folding_ranges
             && self.starts_indent(MultiBufferRow(start.row))
             && !self.is_line_folded(MultiBufferRow(start.row))

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -27513,7 +27513,7 @@ impl EditorSnapshot {
 
         is_foldable |= self.crease_for_buffer_row(buffer_row).is_some();
 
-        if folded || (is_foldable && (row_contains_cursor || always_show_fold_carets)) {
+        if folded || (is_foldable && (row_contains_cursor || self.gutter_hovered || always_show_fold_carets)) {
             Some(
                 Disclosure::new(("gutter_crease", buffer_row.0), !folded)
                     .toggle_state(folded)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -27468,7 +27468,7 @@ impl EditorSnapshot {
     pub fn render_crease_toggle(
         &self,
         buffer_row: MultiBufferRow,
-        row_contains_cursor: bool,
+        _row_contains_cursor: bool,
         editor: Entity<Editor>,
         window: &mut Window,
         cx: &mut App,
@@ -27508,9 +27508,9 @@ impl EditorSnapshot {
             }
         }
 
-        is_foldable |= !self.use_lsp_folding_ranges && self.starts_indent(buffer_row);
+        is_foldable |= self.crease_for_buffer_row(buffer_row).is_some();
 
-        if folded || (is_foldable && (row_contains_cursor || self.gutter_hovered)) {
+        if folded || is_foldable {
             Some(
                 Disclosure::new(("gutter_crease", buffer_row.0), !folded)
                     .toggle_state(folded)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -27468,12 +27468,13 @@ impl EditorSnapshot {
     pub fn render_crease_toggle(
         &self,
         buffer_row: MultiBufferRow,
-        _row_contains_cursor: bool,
+        row_contains_cursor: bool,
         editor: Entity<Editor>,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
         let folded = self.is_line_folded(buffer_row);
+        let always_show_fold_carets = EditorSettings::get_global(cx).gutter.always_show_fold_carets;
         let mut is_foldable = false;
 
         if let Some(crease) = self
@@ -27483,7 +27484,9 @@ impl EditorSnapshot {
             is_foldable = true;
             match crease {
                 Crease::Inline { render_toggle, .. } | Crease::Block { render_toggle, .. } => {
-                    if let Some(render_toggle) = render_toggle {
+                    if let Some(render_toggle) = render_toggle
+                        && (folded || row_contains_cursor || always_show_fold_carets)
+                    {
                         let toggle_callback =
                             Arc::new(move |folded, window: &mut Window, cx: &mut App| {
                                 if folded {
@@ -27510,7 +27513,7 @@ impl EditorSnapshot {
 
         is_foldable |= self.crease_for_buffer_row(buffer_row).is_some();
 
-        if folded || is_foldable {
+        if folded || (is_foldable && (row_contains_cursor || always_show_fold_carets)) {
             Some(
                 Disclosure::new(("gutter_crease", buffer_row.0), !folded)
                     .toggle_state(folded)

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -130,6 +130,7 @@ pub struct Gutter {
     pub runnables: bool,
     pub breakpoints: bool,
     pub folds: bool,
+    pub always_show_fold_carets: bool,
 }
 
 /// Forcefully enable or disable the scrollbar for each axis
@@ -250,6 +251,7 @@ impl Settings for EditorSettings {
                 runnables: gutter.runnables.unwrap(),
                 breakpoints: gutter.breakpoints.unwrap(),
                 folds: gutter.folds.unwrap(),
+                always_show_fold_carets: gutter.always_show_fold_carets.unwrap(),
             },
             scroll_beyond_last_line: editor.scroll_beyond_last_line.unwrap(),
             vertical_scroll_margin: editor.vertical_scroll_margin.unwrap() as f64,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1150,6 +1150,93 @@ fn test_fold_action(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_fold_action_custom_region_markers_with_slash_comments(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(
+            &"
+                fn main() {
+                    // region setup
+                    let a = 1;
+                    let b = 2;
+                    // endregion setup
+                    println!(\"{a} {b}\");
+                }
+            "
+            .unindent(),
+            cx,
+        );
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.fold_at(MultiBufferRow(1), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                fn main() {
+                    // region setup⋯
+                    println!(\"{a} {b}\");
+                }
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
+fn test_fold_action_custom_region_markers_with_hash_comments_and_nesting(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(
+            &"
+                # region outer
+                echo one
+                # region inner
+                echo two
+                # endregion inner
+                echo three
+                # endregion outer
+                echo four
+            "
+            .unindent(),
+            cx,
+        );
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.fold_at(MultiBufferRow(2), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                # region outer
+                echo one
+                # region inner⋯
+                echo three
+                # endregion outer
+                echo four
+            "
+            .unindent(),
+        );
+
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                # region outer⋯
+                echo four
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
 fn test_fold_action_whitespace_sensitive_language(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
@@ -24019,6 +24106,31 @@ fn test_crease_insertion_and_rendering(cx: &mut TestAppContext) {
         .update(cx, |editor, window, cx| editor.snapshot(window, cx))
         .unwrap();
     assert!(!snapshot.is_line_folded(MultiBufferRow(1)));
+}
+
+#[gpui::test]
+fn test_custom_region_markers_render_gutter_toggle_without_hover(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(
+            "fn main() {\n    // region setup\n    let x = 1;\n    // endregion setup\n}\n",
+            cx,
+        );
+        build_editor(buffer, window, cx)
+    });
+
+    editor
+        .update(cx, |editor, window, cx| {
+            let snapshot = editor.snapshot(window, cx);
+            assert!(
+                snapshot
+                    .render_crease_toggle(MultiBufferRow(1), false, cx.entity(), window, cx)
+                    .is_some(),
+                "custom region markers should show a gutter fold toggle without hover"
+            );
+        })
+        .unwrap();
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24079,7 +24079,7 @@ fn test_crease_insertion_and_rendering(cx: &mut TestAppContext) {
             editor.insert_creases(Some(crease), cx);
             let snapshot = editor.snapshot(window, cx);
             let _div =
-                snapshot.render_crease_toggle(MultiBufferRow(1), false, cx.entity(), window, cx);
+                snapshot.render_crease_toggle(MultiBufferRow(1), true, cx.entity(), window, cx);
             snapshot
         })
         .unwrap();
@@ -24109,7 +24109,7 @@ fn test_crease_insertion_and_rendering(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-fn test_custom_region_markers_render_gutter_toggle_without_hover(cx: &mut TestAppContext) {
+fn test_custom_region_markers_hide_gutter_toggle_without_hover_by_default(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let editor = cx.add_window(|window, cx| {
@@ -24126,8 +24126,47 @@ fn test_custom_region_markers_render_gutter_toggle_without_hover(cx: &mut TestAp
             assert!(
                 snapshot
                     .render_crease_toggle(MultiBufferRow(1), false, cx.entity(), window, cx)
+                    .is_none(),
+                "custom region markers should not show a gutter fold toggle without hover by default"
+            );
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+fn test_custom_region_markers_render_gutter_toggle_without_hover_when_enabled(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|settings, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings
+                    .editor
+                    .gutter
+                    .get_or_insert_default()
+                    .always_show_fold_carets = Some(true);
+            });
+        });
+    });
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(
+            "fn main() {\n    // region setup\n    let x = 1;\n    // endregion setup\n}\n",
+            cx,
+        );
+        build_editor(buffer, window, cx)
+    });
+
+    editor
+        .update(cx, |editor, window, cx| {
+            let snapshot = editor.snapshot(window, cx);
+            assert!(
+                snapshot
+                    .render_crease_toggle(MultiBufferRow(1), false, cx.entity(), window, cx)
                     .is_some(),
-                "custom region markers should show a gutter fold toggle without hover"
+                "custom region markers should show a gutter fold toggle without hover when enabled"
             );
         })
         .unwrap();

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -331,6 +331,11 @@ impl VsCodeSettings {
                 "never" => Some(false),
                 _ => None,
             }),
+            always_show_fold_carets: self.read_enum("editor.showFoldingControls", |s| match s {
+                "always" => Some(true),
+                "mouseover" => Some(false),
+                _ => None,
+            }),
         })
     }
 

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -431,6 +431,10 @@ pub struct GutterContent {
     ///
     /// Default: true
     pub folds: Option<bool>,
+    /// Whether to always show fold buttons for foldable rows in the gutter.
+    ///
+    /// Default: false
+    pub always_show_fold_carets: Option<bool>,
 }
 
 /// How to render LSP `textDocument/documentColor` colors in the editor.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1812,7 +1812,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn gutter_section() -> [SettingsPageItem; 8] {
+    fn gutter_section() -> [SettingsPageItem; 9] {
         [
             SettingsPageItem::SectionHeader("Gutter"),
             SettingsPageItem::SettingItem(SettingItem {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1917,6 +1917,29 @@ fn editor_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Always Show Fold Carets",
+                description: "Always show fold carets for foldable rows in the gutter instead of only on active rows.",
+                field: Box::new(SettingField {
+                    json_path: Some("gutter.always_show_fold_carets"),
+                    pick: |settings_content| {
+                        settings_content
+                            .editor
+                            .gutter
+                            .as_ref()
+                            .and_then(|gutter| gutter.always_show_fold_carets.as_ref())
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .editor
+                            .gutter
+                            .get_or_insert_default()
+                            .always_show_fold_carets = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Min Line Number Digits",
                 description: "Minimum number of characters to reserve space for in the gutter.",
                 field: Box::new(SettingField {


### PR DESCRIPTION
Add region-based code folding marked with comments for better code organization. 
Regions use `// region [name]` / `// endregion` (and `#` variants) and integrate 
with the existing folding system for functions, classes, structs, etc.

Also adds a setting to always show fold carets in the gutter regardless of 
hover or selection state.

<details>
<summary>Code Regions</summary>
<img width="352" height="289" src="https://github.com/user-attachments/assets/069b7606-5f5a-4e32-abc3-8ff91119f74a" /> 
</details>

<details>
<summary>Always show fold carets setting</summary>
<img width="654" height="235" src="https://github.com/user-attachments/assets/b7dcb7d1-500a-4acd-a684-610ff339133e" />
</details>

<details>
<summary>Example with always show fold carets setting on</summary>
<img width="441" height="246" alt="Screenshot 2026-03-16 at 6 24 37 PM" src="https://github.com/user-attachments/assets/27dee9ad-9870-4d2b-b43f-f488e06612da" />
</details>

Release Notes:

- Added code region folding with `region` and `endregion` in comments.
  - supports `//` and `#` comments (eg. `// region`, `# region`)
- Added setting to always show folding carets in gutter regardless of selected lines or hover