### PR TITLE
git_ui: Fix new staged files staying untracked

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -284,8 +284,8 @@ impl GitHeaderEntry {
             Section::Conflict => {
                 repo.had_conflict_on_last_merge_head_change(&status_entry.repo_path)
             }
-            Section::Tracked => !status.is_created(),
-            Section::New => status.is_created(),
+            Section::Tracked => !status.is_untracked(),
+            Section::New => status.is_untracked(),
         }
     }
     pub fn title(&self) -> &'static str {
@@ -1663,7 +1663,7 @@ impl GitPanel {
             .entries
             .iter()
             .filter_map(|entry| entry.status_entry())
-            .filter(|status_entry| status_entry.status.is_created())
+            .filter(|status_entry| status_entry.status.is_untracked())
             .cloned()
             .collect::<Vec<_>>();
 
@@ -3526,7 +3526,7 @@ impl GitPanel {
         for entry in repo.cached_status() {
             self.changes_count += 1;
             let is_conflict = repo.had_conflict_on_last_merge_head_change(&entry.repo_path);
-            let is_new = entry.status.is_created();
+            let is_new = entry.status.is_untracked();
             let staging = entry.status.staging();
 
             if let Some(pending) = repo.pending_ops_for_path(&entry.repo_path)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6783,6 +6783,83 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_staged_added_file_in_tracked_section(cx: &mut TestAppContext) {
+        use GitListEntry::*;
+
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}"
+                    },
+                    "new_staged.txt": "staged content",
+                    "new_untracked.txt": "untracked content"
+                }
+            }),
+        )
+        .await;
+
+        fs.set_status_for_repo(
+            Path::new(path!("/root/project/.git")),
+            &[
+                ("src/main.rs", StatusCode::Modified.worktree()),
+                ("new_staged.txt", StatusCode::Added.index()),
+                ("new_untracked.txt", FileStatus::Untracked),
+            ],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        let entries = panel.read_with(cx, |panel, _| panel.entries.clone());
+        #[rustfmt::skip]
+        pretty_assertions::assert_matches!(
+            entries.as_slice(),
+            &[
+                // Staged-added file should be in Tracked, not New
+                Header(GitHeaderEntry { header: Section::Tracked }),
+                Status(GitStatusEntry { staging: StageStatus::Staged, .. }),
+                Status(GitStatusEntry { staging: StageStatus::Unstaged, .. }),
+                // Only truly untracked files in New
+                Header(GitHeaderEntry { header: Section::New }),
+                Status(GitStatusEntry { staging: StageStatus::Unstaged, .. }),
+            ],
+        );
+    }
+
+    #[gpui::test]
     async fn test_bulk_staging_with_sort_by_paths(cx: &mut TestAppContext) {
         use GitListEntry::*;
 


### PR DESCRIPTION
#### Fixes #51711

When a new file was staged with `git add`, it remained in the"Untracked" section of the git panel instead of moving to "Tracked".

#### Fix :

- The grouping logic used `is_created()` to determine section membership, which returns true for both truly untracked files (`??`) and staged-added files (`A `). Replaced with `is_untracked()` which only matches `FileStatus::Untracked`.

- Also fixed `TrashUntrackedFiles` to not include staged-added files. 

#### Test :

- added `test_staged_added_file_in_tracked_section` test - passed.

#### Release Notes :
- Fixed staged new files incorrectly showing in the "Untracked" section of the git panel.


#### Video :
[Screencast from 2026-03-17 09-54-46.webm](https://github.com/user-attachments/assets/ee1e5001-e559-455c-8206-13c238243a5a)