### PR TITLE
python: Upgrade `pet` to improve toolchain discovery in WSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "pet"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "clap",
  "env_logger 0.10.2",
@@ -12151,14 +12151,18 @@ dependencies = [
  "pet-virtualenvwrapper",
  "pet-windows-registry",
  "pet-windows-store",
+ "pet-winpython",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
+ "winresource",
 ]
 
 [[package]]
 name = "pet-conda"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
@@ -12168,6 +12172,7 @@ dependencies = [
  "pet-fs",
  "pet-python-utils",
  "pet-reporter",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -12177,7 +12182,7 @@ dependencies = [
 [[package]]
 name = "pet-core"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "clap",
  "lazy_static",
@@ -12192,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "pet-env-var-path"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "lazy_static",
  "log",
@@ -12208,8 +12213,9 @@ dependencies = [
 [[package]]
 name = "pet-fs"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
+ "glob",
  "log",
  "msvc_spectre_libs",
  "windows-sys 0.59.0",
@@ -12218,7 +12224,7 @@ dependencies = [
 [[package]]
 name = "pet-global-virtualenvs"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12231,7 +12237,7 @@ dependencies = [
 [[package]]
 name = "pet-homebrew"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "lazy_static",
  "log",
@@ -12241,6 +12247,7 @@ dependencies = [
  "pet-fs",
  "pet-python-utils",
  "pet-virtualenv",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -12249,7 +12256,7 @@ dependencies = [
 [[package]]
 name = "pet-jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "env_logger 0.10.2",
  "log",
@@ -12262,7 +12269,7 @@ dependencies = [
 [[package]]
 name = "pet-linux-global-python"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12275,7 +12282,7 @@ dependencies = [
 [[package]]
 name = "pet-mac-commandlinetools"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12288,7 +12295,7 @@ dependencies = [
 [[package]]
 name = "pet-mac-python-org"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12301,7 +12308,7 @@ dependencies = [
 [[package]]
 name = "pet-mac-xcode"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12314,20 +12321,22 @@ dependencies = [
 [[package]]
 name = "pet-pipenv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
+ "lazy_static",
  "log",
  "msvc_spectre_libs",
  "pet-core",
  "pet-fs",
  "pet-python-utils",
  "pet-virtualenv",
+ "regex",
 ]
 
 [[package]]
 name = "pet-pixi"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12339,7 +12348,7 @@ dependencies = [
 [[package]]
 name = "pet-poetry"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "base64 0.22.1",
  "lazy_static",
@@ -12360,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "pet-pyenv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "lazy_static",
  "log",
@@ -12378,7 +12387,7 @@ dependencies = [
 [[package]]
 name = "pet-python-utils"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
@@ -12395,7 +12404,7 @@ dependencies = [
 [[package]]
 name = "pet-reporter"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "env_logger 0.10.2",
  "log",
@@ -12409,7 +12418,7 @@ dependencies = [
 [[package]]
 name = "pet-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
@@ -12424,7 +12433,7 @@ dependencies = [
 [[package]]
 name = "pet-uv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "pet-core",
@@ -12436,7 +12445,7 @@ dependencies = [
 [[package]]
 name = "pet-venv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12448,7 +12457,7 @@ dependencies = [
 [[package]]
 name = "pet-virtualenv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12460,7 +12469,7 @@ dependencies = [
 [[package]]
 name = "pet-virtualenvwrapper"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12473,7 +12482,7 @@ dependencies = [
 [[package]]
 name = "pet-windows-registry"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "lazy_static",
  "log",
@@ -12491,7 +12500,7 @@ dependencies = [
 [[package]]
 name = "pet-windows-store"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=d5b5bb0c4558a51d8cc76b514bc870fd1c042f16#d5b5bb0c4558a51d8cc76b514bc870fd1c042f16"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
 dependencies = [
  "lazy_static",
  "log",
@@ -12502,6 +12511,20 @@ dependencies = [
  "pet-virtualenv",
  "regex",
  "winreg 0.55.0",
+]
+
+[[package]]
+name = "pet-winpython"
+version = "0.1.0"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+dependencies = [
+ "lazy_static",
+ "log",
+ "pet-core",
+ "pet-fs",
+ "pet-python-utils",
+ "pet-virtualenv",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "pet"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "clap",
  "env_logger 0.10.2",
@@ -12162,7 +12162,7 @@ dependencies = [
 [[package]]
 name = "pet-conda"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
@@ -12182,7 +12182,7 @@ dependencies = [
 [[package]]
 name = "pet-core"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "clap",
  "lazy_static",
@@ -12197,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "pet-env-var-path"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",
@@ -12213,7 +12213,7 @@ dependencies = [
 [[package]]
 name = "pet-fs"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "glob",
  "log",
@@ -12224,7 +12224,7 @@ dependencies = [
 [[package]]
 name = "pet-global-virtualenvs"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12237,7 +12237,7 @@ dependencies = [
 [[package]]
 name = "pet-homebrew"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",
@@ -12256,7 +12256,7 @@ dependencies = [
 [[package]]
 name = "pet-jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "env_logger 0.10.2",
  "log",
@@ -12269,7 +12269,7 @@ dependencies = [
 [[package]]
 name = "pet-linux-global-python"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12282,7 +12282,7 @@ dependencies = [
 [[package]]
 name = "pet-mac-commandlinetools"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12295,7 +12295,7 @@ dependencies = [
 [[package]]
 name = "pet-mac-python-org"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12308,7 +12308,7 @@ dependencies = [
 [[package]]
 name = "pet-mac-xcode"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12321,7 +12321,7 @@ dependencies = [
 [[package]]
 name = "pet-pipenv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",
@@ -12336,7 +12336,7 @@ dependencies = [
 [[package]]
 name = "pet-pixi"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12348,7 +12348,7 @@ dependencies = [
 [[package]]
 name = "pet-poetry"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "base64 0.22.1",
  "lazy_static",
@@ -12369,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "pet-pyenv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",
@@ -12387,7 +12387,7 @@ dependencies = [
 [[package]]
 name = "pet-python-utils"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
@@ -12404,7 +12404,7 @@ dependencies = [
 [[package]]
 name = "pet-reporter"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "env_logger 0.10.2",
  "log",
@@ -12418,7 +12418,7 @@ dependencies = [
 [[package]]
 name = "pet-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
@@ -12433,7 +12433,7 @@ dependencies = [
 [[package]]
 name = "pet-uv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "pet-core",
@@ -12445,7 +12445,7 @@ dependencies = [
 [[package]]
 name = "pet-venv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12457,7 +12457,7 @@ dependencies = [
 [[package]]
 name = "pet-virtualenv"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12469,7 +12469,7 @@ dependencies = [
 [[package]]
 name = "pet-virtualenvwrapper"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "log",
  "msvc_spectre_libs",
@@ -12482,7 +12482,7 @@ dependencies = [
 [[package]]
 name = "pet-windows-registry"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",
@@ -12500,7 +12500,7 @@ dependencies = [
 [[package]]
 name = "pet-windows-store"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "pet-winpython"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/python-environment-tools.git?rev=72123ab4e91c799fb577283437c62b4dfe0e9d56#72123ab4e91c799fb577283437c62b4dfe0e9d56"
+source = "git+https://github.com/microsoft/python-environment-tools.git?rev=9e61a22af989fe54937bf07c9f9cff1bc53d9056#9e61a22af989fe54937bf07c9f9cff1bc53d9056"
 dependencies = [
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -636,13 +636,13 @@ parse_int = "0.9"
 pciid-parser = "0.8.0"
 pathdiff = "0.2"
 percent-encoding = "2.3.2"
-pet = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
-pet-conda = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
-pet-core = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
-pet-fs = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
-pet-poetry = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
-pet-reporter = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
-pet-virtualenv = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
+pet-conda = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
+pet-core = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
+pet-fs = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
+pet-poetry = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
+pet-reporter = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
+pet-virtualenv = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "9e61a22af989fe54937bf07c9f9cff1bc53d9056" }
 portable-pty = "0.9.0"
 postage = { version = "0.5", features = ["futures-traits"] }
 pretty_assertions = { version = "1.3.0", features = ["unstable"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -636,13 +636,13 @@ parse_int = "0.9"
 pciid-parser = "0.8.0"
 pathdiff = "0.2"
 percent-encoding = "2.3.2"
-pet = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
-pet-conda = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
-pet-core = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
-pet-fs = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
-pet-poetry = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
-pet-reporter = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
-pet-virtualenv = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "d5b5bb0c4558a51d8cc76b514bc870fd1c042f16" }
+pet = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet-conda = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet-core = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet-fs = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet-poetry = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet-reporter = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
+pet-virtualenv = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "72123ab4e91c799fb577283437c62b4dfe0e9d56" }
 portable-pty = "0.9.0"
 postage = { version = "0.5", features = ["futures-traits"] }
 pretty_assertions = { version = "1.3.0", features = ["unstable"] }

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1101,7 +1101,7 @@ fn python_env_kind_display(k: &PythonEnvironmentKind) -> &'static str {
         PythonEnvironmentKind::Venv => "venv",
         PythonEnvironmentKind::VirtualEnv => "virtualenv",
         PythonEnvironmentKind::VirtualEnvWrapper => "virtualenvwrapper",
-        PythonEnvironmentKind::WinPython => "Windows Python",
+        PythonEnvironmentKind::WinPython => "WinPython",
         PythonEnvironmentKind::WindowsStore => "global (Windows Store)",
         PythonEnvironmentKind::WindowsRegistry => "global (Windows Registry)",
         PythonEnvironmentKind::Uv => "uv",

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1101,6 +1101,7 @@ fn python_env_kind_display(k: &PythonEnvironmentKind) -> &'static str {
         PythonEnvironmentKind::Venv => "venv",
         PythonEnvironmentKind::VirtualEnv => "virtualenv",
         PythonEnvironmentKind::VirtualEnvWrapper => "virtualenvwrapper",
+        PythonEnvironmentKind::WinPython => "Windows Python",
         PythonEnvironmentKind::WindowsStore => "global (Windows Store)",
         PythonEnvironmentKind::WindowsRegistry => "global (Windows Registry)",
         PythonEnvironmentKind::Uv => "uv",


### PR DESCRIPTION
This PR updates the pet dependency to incorporate performance improvements from upstream.

Related Upstream Changes:
- Issue: microsoft/python-environment-tools#369
- PR: microsoft/python-environment-tools#370

Updating pet reduces toolchain discovery time in WSL environments, specifically when Conda is installed on the host Windows system. In my testing, the time from clicking the toolchain button to the list appearing was reduced by approximately 2 seconds.

While this is a notable improvement, discovery in WSL remains slightly slower than in native development or remote Linux environments, where toolchains are typically loaded near-instantaneously.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing (no need)
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Improved python toolchain discovery under WSL environment
