### PR TITLE
editor: Accumulate consecutive KillRingCut line kills

### DIFF
--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -354,6 +354,22 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+        let selection_count = self.selections.count();
+        let first_selection = self.selections.first_anchor();
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let first_selection_is_empty = first_selection.start == first_selection.end;
+        let selection_start_point = first_selection.start.to_point(&snapshot);
+        let selection_start_row = selection_start_point.row;
+        let selection_start_column = selection_start_point.column;
+        let Some((_, text_anchor)) = self
+            .buffer
+            .read(cx)
+            .text_anchor_for_position(first_selection.start, cx)
+        else {
+            return;
+        };
+        let buffer_id = text_anchor.buffer_id;
+
         self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
             s.move_with(&mut |snapshot, sel| {
                 if sel.is_empty() {
@@ -365,7 +381,76 @@ impl Editor {
             });
         });
         let item = self.cut_common(false, window, cx);
-        cx.set_global(KillRing(item))
+
+        let Some(item_text) = item.text() else {
+            return;
+        };
+
+        let entry_metadata = item.entries().first().and_then(|entry| match entry {
+            ClipboardEntry::String(entry) => entry.metadata_json::<Vec<ClipboardSelection>>(),
+            _ => None,
+        });
+
+        let can_append = selection_count == 1 && first_selection_is_empty;
+        let item = if can_append {
+            if let Some(previous_ring) = cx.try_global::<KillRing>() {
+                if previous_ring.can_append
+                    && previous_ring.buffer_id == buffer_id
+                    && previous_ring.row == selection_start_row
+                    && previous_ring.column == selection_start_column
+                {
+                    let mut entries = previous_ring
+                        .metadata
+                        .as_ref()
+                        .map_or_else(Vec::new, Clone::clone);
+                    if let Some(metadata) = entry_metadata.as_ref() {
+                        entries.extend_from_slice(metadata);
+                    }
+
+                    let mut text = previous_ring.text.clone();
+                    text.push_str(&item_text);
+                    let text_len = text.len();
+
+                    KillRing {
+                        text,
+                        metadata: kill_ring_metadata_for_text(entries, text_len),
+                        row: previous_ring.row,
+                        column: previous_ring.column,
+                        buffer_id: previous_ring.buffer_id,
+                        can_append,
+                    }
+                } else {
+                    KillRing {
+                        text: item_text,
+                        metadata: entry_metadata,
+                        row: selection_start_row,
+                        column: selection_start_column,
+                        buffer_id,
+                        can_append,
+                    }
+                }
+            } else {
+                KillRing {
+                    text: item_text,
+                    metadata: entry_metadata,
+                    row: selection_start_row,
+                    column: selection_start_column,
+                    buffer_id,
+                    can_append,
+                }
+            }
+        } else {
+            KillRing {
+                text: item_text,
+                metadata: entry_metadata,
+                row: selection_start_row,
+                column: selection_start_column,
+                buffer_id,
+                can_append,
+            }
+        };
+
+        cx.set_global(item)
     }
 
     pub(super) fn kill_ring_yank(
@@ -374,15 +459,15 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let (text, metadata) = if let Some(KillRing(item)) = cx.try_global() {
-            if let Some(ClipboardEntry::String(kill_ring)) = item.entries().first() {
-                (kill_ring.text().to_string(), kill_ring.metadata_json())
-            } else {
-                return;
-            }
-        } else {
+        if !cx.has_global::<KillRing>() {
             return;
-        };
+        }
+
+        let (text, metadata) = cx.update_global::<KillRing, _>(|kill_ring, _| {
+            kill_ring.can_append = false;
+            (kill_ring.text.clone(), kill_ring.metadata.clone())
+        });
+
         self.do_paste(&text, metadata, false, window, cx);
     }
 
@@ -536,8 +621,35 @@ impl Editor {
     }
 }
 
-struct KillRing(ClipboardItem);
+struct KillRing {
+    text: String,
+    metadata: Option<Vec<ClipboardSelection>>,
+    row: u32,
+    column: u32,
+    buffer_id: BufferId,
+    can_append: bool,
+}
 impl Global for KillRing {}
+
+fn kill_ring_metadata_for_text(
+    mut metadata: Vec<ClipboardSelection>,
+    text_len: usize,
+) -> Option<Vec<ClipboardSelection>> {
+    match metadata.len() {
+        0 => None,
+        1 => Some(metadata),
+        _ => {
+            let first_selection = metadata.remove(0);
+            Some(vec![ClipboardSelection {
+                len: text_len,
+                is_entire_line: false,
+                first_line_indent: first_selection.first_line_indent,
+                file_path: None,
+                line_range: None,
+            }])
+        }
+    }
+}
 
 fn edit_for_markdown_paste<'a>(
     buffer: &MultiBufferSnapshot,

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -392,52 +392,32 @@ impl Editor {
         });
 
         let can_append = selection_count == 1 && first_selection_is_empty;
-        let item = if can_append {
-            if let Some(previous_ring) = cx.try_global::<KillRing>() {
-                if previous_ring.can_append
-                    && previous_ring.buffer_id == buffer_id
-                    && previous_ring.row == selection_start_row
-                    && previous_ring.column == selection_start_column
-                {
-                    let mut entries = previous_ring
-                        .metadata
-                        .as_ref()
-                        .map_or_else(Vec::new, Clone::clone);
-                    if let Some(metadata) = entry_metadata.as_ref() {
-                        entries.extend_from_slice(metadata);
-                    }
+        let item = if can_append
+            && let Some(previous_ring) = cx.try_global::<KillRing>()
+            && previous_ring.can_append
+            && previous_ring.buffer_id == buffer_id
+            && previous_ring.row == selection_start_row
+            && previous_ring.column == selection_start_column
+        {
+            let mut entries = previous_ring
+                .metadata
+                .as_ref()
+                .map_or_else(Vec::new, Clone::clone);
+            if let Some(metadata) = entry_metadata.as_ref() {
+                entries.extend_from_slice(metadata);
+            }
 
-                    let mut text = previous_ring.text.clone();
-                    text.push_str(&item_text);
-                    let text_len = text.len();
+            let mut text = previous_ring.text.clone();
+            text.push_str(&item_text);
+            let text_len = text.len();
 
-                    KillRing {
-                        text,
-                        metadata: kill_ring_metadata_for_text(entries, text_len),
-                        row: previous_ring.row,
-                        column: previous_ring.column,
-                        buffer_id: previous_ring.buffer_id,
-                        can_append,
-                    }
-                } else {
-                    KillRing {
-                        text: item_text,
-                        metadata: entry_metadata,
-                        row: selection_start_row,
-                        column: selection_start_column,
-                        buffer_id,
-                        can_append,
-                    }
-                }
-            } else {
-                KillRing {
-                    text: item_text,
-                    metadata: entry_metadata,
-                    row: selection_start_row,
-                    column: selection_start_column,
-                    buffer_id,
-                    can_append,
-                }
+            KillRing {
+                text,
+                metadata: kill_ring_metadata_for_text(entries, text_len),
+                row: previous_ring.row,
+                column: previous_ring.column,
+                buffer_id: previous_ring.buffer_id,
+                can_append,
             }
         } else {
             KillRing {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8993,6 +8993,110 @@ async fn test_cut_line_ends(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_kill_ring_cut_accumulates_multi_line_kills(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇone\ntwo");
+
+    cx.update_editor(|e, window, cx| {
+        e.kill_ring_cut(&KillRingCut, window, cx);
+        e.kill_ring_cut(&KillRingCut, window, cx);
+    });
+
+    cx.update_editor(|e, window, cx| e.kill_ring_yank(&KillRingYank, window, cx));
+    cx.assert_editor_state("one\nˇtwo");
+}
+
+#[gpui::test]
+async fn test_kill_ring_cut_matches_emacs_kill_line_sequence_at_end_of_buffer(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇa\nb\nc");
+
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+
+    cx.update_editor(|editor, _, cx| {
+        assert_eq!(editor.text(cx), "\nc");
+    });
+
+    cx.update_editor(|editor, window, cx| editor.kill_ring_yank(&KillRingYank, window, cx));
+    cx.update_editor(|editor, _, cx| {
+        assert_eq!(editor.text(cx), "a\nb\nc");
+    });
+}
+
+#[gpui::test]
+async fn test_kill_ring_cut_accumulates_final_line_without_trailing_newline(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇa\nb\nc");
+
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+
+    cx.update_editor(|editor, _, cx| {
+        assert_eq!(editor.text(cx), "");
+    });
+
+    cx.update_editor(|editor, window, cx| editor.kill_ring_yank(&KillRingYank, window, cx));
+    cx.update_editor(|editor, _, cx| {
+        assert_eq!(editor.text(cx), "a\nb\nc");
+    });
+}
+
+#[gpui::test]
+async fn test_kill_ring_yank_breaks_kill_ring_cut_accumulation(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇa\nb\nc");
+
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_yank(&KillRingYank, window, cx));
+    cx.update_editor(|editor, window, cx| editor.move_to_beginning(&MoveToBeginning, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_yank(&KillRingYank, window, cx));
+
+    cx.update_editor(|editor, _, cx| {
+        assert_eq!(editor.text(cx), "a\nb\nc");
+    });
+}
+
+#[gpui::test]
+async fn test_kill_ring_yank_pastes_accumulated_kill_at_each_cursor(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇone\ntwo");
+
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+    cx.update_editor(|editor, window, cx| editor.kill_ring_cut(&KillRingCut, window, cx));
+
+    cx.set_state("aˇ bˇ");
+    cx.update_editor(|editor, window, cx| editor.kill_ring_yank(&KillRingYank, window, cx));
+    cx.assert_editor_state("aone\nˇ bone\nˇ");
+}
+
+#[gpui::test]
 async fn test_clipboard(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Closes #22490

## Summary
 • Keep kill-ring state as a dedicated global structure (`text`, `metadata`, `row`, `column`, `buffer_id`) instead of a raw clipboard wrapper.
 • Update `editor::KillRingCut` to append consecutive empty-line kills only when all are true:
   - one selection only
   - previous selection was empty
   - same row/column
   - same buffer

 • Preserve existing behavior for non-empty and multi-selection cuts by replacing the ring payload instead of appending.
 • Preserve yank metadata behavior through the existing clipboard selection metadata path.
 • Add regression coverage in `editor_tests::test_kill_ring_cut_accumulates_multi_line_kills`.

## Verification
 • `cargo fmt --all -- --check`
 • `./script/check-keymaps`
 • `./script/clippy -p editor`
 • `cargo test -p editor -- --nocapture`
 • `cargo test -p editor editor_tests::test_kill_ring_cut_accumulates_multi_line_kills -- --exact`
 • `cargo test -p editor test_cut_line_ends -- --exact`

## Manual
 • `Ctrl+K`, `Ctrl+K`, `Ctrl+Y` with repeated line-end kills at same caret location pastes concatenated text.
 • Non-empty selection cut and multi-selection still replace as before (no unintended append).
 • Cut in one buffer then cut in another does not cross-append.
 • Moving caret between kills does not append.
 • Undo/redo around cut+yank path works cleanly.

Release Notes:

- Fixed Emacs-style kill-ring behavior so successive `KillRingCut` operations at the same caret context are accumulated and pasted together via one `KillRingYank`, while preserving existing non-empty selection and multi-selection semantics.