### PR TITLE
worktree: Canonicalize path in Worktree::local to ensure it is absolute

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -378,6 +378,10 @@ impl Worktree {
         cx: &mut AsyncApp,
     ) -> Result<Entity<Self>> {
         let abs_path = path.into();
+        let abs_path: Arc<Path> = match fs.canonicalize(&abs_path).await {
+            Ok(canonical) => canonical.into(),
+            Err(_) => abs_path,
+        };
         let metadata = fs
             .metadata(&abs_path)
             .await


### PR DESCRIPTION
Closes #51769

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed a crash on Windows when trusting a worktree opened with a relative path
