### PR TITLE
vim/helix: Use grapheme count on replace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10735,6 +10735,7 @@ dependencies = [
  "theme",
  "tracing",
  "tree-sitter",
+ "unicode-segmentation",
  "util",
  "zlog",
  "ztracing",

--- a/crates/multi_buffer/Cargo.toml
+++ b/crates/multi_buffer/Cargo.toml
@@ -45,6 +45,7 @@ tree-sitter.workspace = true
 ztracing.workspace = true
 tracing.workspace = true
 util.workspace = true
+unicode-segmentation.workspace = true
 
 [dev-dependencies]
 buffer_diff = { workspace = true, features = ["test-support"] }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -54,6 +54,7 @@ use text::{
     subscription::{Subscription, Topic},
 };
 use theme::SyntaxTheme;
+use unicode_segmentation::UnicodeSegmentation;
 use util::post_inc;
 use ztracing::instrument;
 
@@ -7251,6 +7252,16 @@ impl MultiBufferSnapshot {
             }
         }
         excerpt_edits
+    }
+
+    /// Returns the number of graphemes in `range`.
+    ///
+    /// This counts user-visible characters like `e\u{301}` as one.
+    pub fn grapheme_count_for_range(&self, range: &Range<MultiBufferOffset>) -> usize {
+        self.text_for_range(range.clone())
+            .collect::<String>()
+            .graphemes(true)
+            .count()
     }
 }
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -711,42 +711,34 @@ impl Vim {
                 let display_map = editor.display_snapshot(cx);
                 let selections = editor.selections.all_display(&display_map);
 
-                // Store selection info for positioning after edit
-                let selection_info: Vec<_> = selections
-                    .iter()
-                    .map(|selection| {
-                        let range = selection.range();
-                        let start_offset = range.start.to_offset(&display_map, Bias::Left);
-                        let end_offset = range.end.to_offset(&display_map, Bias::Left);
-                        let was_empty = range.is_empty();
-                        let was_reversed = selection.reversed;
-                        (
-                            display_map.buffer_snapshot().anchor_before(start_offset),
-                            end_offset - start_offset,
-                            was_empty,
-                            was_reversed,
-                        )
-                    })
-                    .collect();
-
                 let mut edits = Vec::new();
+                let mut selection_info = Vec::new();
                 for selection in &selections {
                     let mut range = selection.range();
+                    let was_empty = range.is_empty();
+                    let was_reversed = selection.reversed;
 
-                    // For empty selections, extend to replace one character
-                    if range.is_empty() {
+                    if was_empty {
                         range.end = movement::saturating_right(&display_map, range.start);
                     }
 
                     let byte_range = range.start.to_offset(&display_map, Bias::Left)
                         ..range.end.to_offset(&display_map, Bias::Left);
 
+                    let char_count = display_map
+                        .buffer_snapshot()
+                        .text_for_range(byte_range.clone())
+                        .map(|chunk| chunk.chars().count())
+                        .sum::<usize>();
+
+                    selection_info.push((
+                        display_map.buffer_snapshot().anchor_before(byte_range.start),
+                        char_count,
+                        was_empty,
+                        was_reversed,
+                    ));
+
                     if !byte_range.is_empty() {
-                        let char_count = display_map
-                            .buffer_snapshot()
-                            .text_for_range(byte_range.clone())
-                            .map(|chunk| chunk.chars().count())
-                            .sum::<usize>();
                         let replacement_text = text.repeat(char_count);
                         edits.push((byte_range, replacement_text));
                     }
@@ -758,14 +750,12 @@ impl Vim {
                 let snapshot = editor.buffer().read(cx).snapshot(cx);
                 let ranges: Vec<_> = selection_info
                     .into_iter()
-                    .map(|(start_anchor, original_len, was_empty, was_reversed)| {
+                    .map(|(start_anchor, char_count, was_empty, was_reversed)| {
                         let start_point = start_anchor.to_point(&snapshot);
                         if was_empty {
-                            // For cursor-only, collapse to start
                             start_point..start_point
                         } else {
-                            // For selections, span the replaced text
-                            let replacement_len = text.len() * original_len;
+                            let replacement_len = text.len() * char_count;
                             let end_offset = start_anchor.to_offset(&snapshot) + replacement_len;
                             let end_point = snapshot.offset_to_point(end_offset);
                             if was_reversed {
@@ -2379,5 +2369,16 @@ mod test {
             line twoˇ"},
             Mode::Insert,
         );
+    }
+
+    #[gpui::test]
+    async fn test_helix_replace_multibyte(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // "Hällö" is 5 chars but 7 bytes; replace should produce 5 '1's, not 7
+        cx.set_state("«Hällöˇ» Wörld", Mode::HelixNormal);
+        cx.simulate_keystrokes("r 1");
+        cx.assert_state("«11111ˇ» Wörld", Mode::HelixNormal);
     }
 }

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -742,7 +742,12 @@ impl Vim {
                         ..range.end.to_offset(&display_map, Bias::Left);
 
                     if !byte_range.is_empty() {
-                        let replacement_text = text.repeat(byte_range.end - byte_range.start);
+                        let char_count = display_map
+                            .buffer_snapshot()
+                            .text_for_range(byte_range.clone())
+                            .map(|chunk| chunk.chars().count())
+                            .sum::<usize>();
+                        let replacement_text = text.repeat(char_count);
                         edits.push((byte_range, replacement_text));
                     }
                 }

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -725,21 +725,14 @@ impl Vim {
                     let byte_range = range.start.to_offset(&display_map, Bias::Left)
                         ..range.end.to_offset(&display_map, Bias::Left);
 
-                    let char_count = display_map
-                        .buffer_snapshot()
-                        .text_for_range(byte_range.clone())
-                        .map(|chunk| chunk.chars().count())
-                        .sum::<usize>();
+                    let snapshot = display_map.buffer_snapshot();
+                    let grapheme_count = snapshot.grapheme_count_for_range(&byte_range);
+                    let anchor = snapshot.anchor_before(byte_range.start);
 
-                    selection_info.push((
-                        display_map.buffer_snapshot().anchor_before(byte_range.start),
-                        char_count,
-                        was_empty,
-                        was_reversed,
-                    ));
+                    selection_info.push((anchor, grapheme_count, was_empty, was_reversed));
 
                     if !byte_range.is_empty() {
-                        let replacement_text = text.repeat(char_count);
+                        let replacement_text = text.repeat(grapheme_count);
                         edits.push((byte_range, replacement_text));
                     }
                 }
@@ -750,12 +743,12 @@ impl Vim {
                 let snapshot = editor.buffer().read(cx).snapshot(cx);
                 let ranges: Vec<_> = selection_info
                     .into_iter()
-                    .map(|(start_anchor, char_count, was_empty, was_reversed)| {
+                    .map(|(start_anchor, grapheme_count, was_empty, was_reversed)| {
                         let start_point = start_anchor.to_point(&snapshot);
                         if was_empty {
                             start_point..start_point
                         } else {
-                            let replacement_len = text.len() * char_count;
+                            let replacement_len = text.len() * grapheme_count;
                             let end_offset = start_anchor.to_offset(&snapshot) + replacement_len;
                             let end_point = snapshot.offset_to_point(end_offset);
                             if was_reversed {
@@ -2372,13 +2365,20 @@ mod test {
     }
 
     #[gpui::test]
-    async fn test_helix_replace_multibyte(cx: &mut gpui::TestAppContext) {
+    async fn test_helix_replace_uses_graphemes(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
         cx.enable_helix();
 
-        // "Hällö" is 5 chars but 7 bytes; replace should produce 5 '1's, not 7
         cx.set_state("«Hällöˇ» Wörld", Mode::HelixNormal);
         cx.simulate_keystrokes("r 1");
         cx.assert_state("«11111ˇ» Wörld", Mode::HelixNormal);
+
+        cx.set_state("«e\u{301}ˇ»", Mode::HelixNormal);
+        cx.simulate_keystrokes("r 1");
+        cx.assert_state("«1ˇ»", Mode::HelixNormal);
+
+        cx.set_state("«🙂ˇ»", Mode::HelixNormal);
+        cx.simulate_keystrokes("r 1");
+        cx.assert_state("«1ˇ»", Mode::HelixNormal);
     }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -53,6 +53,7 @@ use std::{mem, ops::Range, sync::Arc};
 use surrounds::SurroundsType;
 use theme::ThemeSettings;
 use ui::{IntoElement, SharedString, px};
+use unicode_segmentation::UnicodeSegmentation;
 use vim_mode_setting::HelixModeSetting;
 use vim_mode_setting::VimModeSetting;
 use workspace::{self, Pane, Workspace};

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -53,7 +53,6 @@ use std::{mem, ops::Range, sync::Arc};
 use surrounds::SurroundsType;
 use theme::ThemeSettings;
 use ui::{IntoElement, SharedString, px};
-use unicode_segmentation::UnicodeSegmentation;
 use vim_mode_setting::HelixModeSetting;
 use vim_mode_setting::VimModeSetting;
 use workspace::{self, Pane, Workspace};

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -788,7 +788,12 @@ impl Vim {
                     {
                         let range = row_range.start.to_offset(&display_map, Bias::Right)
                             ..row_range.end.to_offset(&display_map, Bias::Right);
-                        let text = text.repeat(range.end - range.start);
+                        let char_count = display_map
+                            .buffer_snapshot()
+                            .text_for_range(range.clone())
+                            .map(|chunk| chunk.chars().count())
+                            .sum::<usize>();
+                        let text = text.repeat(char_count);
                         edits.push((range, text));
                     }
                 }
@@ -1984,5 +1989,15 @@ mod test {
         // The specific behavior of syntax sibling selection in vim mode
         // would depend on the key bindings configured, but the actions
         // are now available for use
+    }
+
+    #[gpui::test]
+    async fn test_visual_replace_multibyte(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        // "Hällö" is 5 chars but 7 bytes; replace should produce 5 '1's, not 7
+        cx.set_state("«Hällöˇ» Wörld", Mode::Visual);
+        cx.simulate_keystrokes("r 1");
+        cx.assert_state("ˇ11111 Wörld", Mode::Normal);
     }
 }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -788,12 +788,10 @@ impl Vim {
                     {
                         let range = row_range.start.to_offset(&display_map, Bias::Right)
                             ..row_range.end.to_offset(&display_map, Bias::Right);
-                        let char_count = display_map
+                        let grapheme_count = display_map
                             .buffer_snapshot()
-                            .text_for_range(range.clone())
-                            .map(|chunk| chunk.chars().count())
-                            .sum::<usize>();
-                        let text = text.repeat(char_count);
+                            .grapheme_count_for_range(&range);
+                        let text = text.repeat(grapheme_count);
                         edits.push((range, text));
                     }
                 }
@@ -1992,12 +1990,19 @@ mod test {
     }
 
     #[gpui::test]
-    async fn test_visual_replace_multibyte(cx: &mut gpui::TestAppContext) {
+    async fn test_visual_replace_uses_graphemes(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
 
-        // "Hällö" is 5 chars but 7 bytes; replace should produce 5 '1's, not 7
         cx.set_state("«Hällöˇ» Wörld", Mode::Visual);
         cx.simulate_keystrokes("r 1");
         cx.assert_state("ˇ11111 Wörld", Mode::Normal);
+
+        cx.set_state("«e\u{301}ˇ»", Mode::Visual);
+        cx.simulate_keystrokes("r 1");
+        cx.assert_state("ˇ1", Mode::Normal);
+
+        cx.set_state("«🙂ˇ»", Mode::Visual);
+        cx.simulate_keystrokes("r 1");
+        cx.assert_state("ˇ1", Mode::Normal);
     }
 }


### PR DESCRIPTION
Closes #51772 

Multibyte characters are not handled properly with vim/helix replace, they replace based on bytes, instead of characters, so you will end up with too many new characters.

Vim Behavior Before:

https://github.com/user-attachments/assets/55b22f43-e403-4d09-9dcf-53ce9395c2a4

Vim Behavior After:

https://github.com/user-attachments/assets/d08b3f18-23e6-4c59-b2b3-a938fe4a27eb

Helix Before:

https://github.com/user-attachments/assets/3d4d4227-d6d6-4309-9620-852d6778bd57

Helix After:

https://github.com/user-attachments/assets/47051062-75fb-496e-9063-8079eea2e6c1


I also added tests for the functionality.


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed vim/helix's replace action to take into consideration grapheme count
