### PR TITLE
client: Respect the default organization ID from the server

### DIFF
--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -269,6 +269,7 @@ pub fn make_get_authenticated_user_response(
         },
         feature_flags: vec![],
         organizations: vec![],
+        default_organization_id: None,
         plans_by_organization: BTreeMap::new(),
         plan: PlanInfo {
             plan: KnownOrUnknown::Known(Plan::ZedPro),

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -818,10 +818,10 @@ impl UserStore {
         self.organizations = response.organizations.into_iter().map(Arc::new).collect();
         self.current_organization = response
             .default_organization_id
-            .and_then(|default| {
+            .and_then(|default_organization_id| {
                 self.organizations
                     .iter()
-                    .find(|organization| organization.id == default)
+                    .find(|organization| organization.id == default_organization_id)
                     .cloned()
             })
             .or_else(|| self.organizations.first().cloned());

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -816,7 +816,15 @@ impl UserStore {
         }
 
         self.organizations = response.organizations.into_iter().map(Arc::new).collect();
-        self.current_organization = self.organizations.first().cloned();
+        self.current_organization = response
+            .default_organization_id
+            .and_then(|default| {
+                self.organizations
+                    .iter()
+                    .find(|organization| organization.id == default)
+                    .cloned()
+            })
+            .or_else(|| self.organizations.first().cloned());
         self.plans_by_organization = response
             .plans_by_organization
             .into_iter()

--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -23,6 +23,8 @@ pub struct GetAuthenticatedUserResponse {
     #[serde(default)]
     pub organizations: Vec<Organization>,
     #[serde(default)]
+    pub default_organization_id: Option<OrganizationId>,
+    #[serde(default)]
     pub plans_by_organization: BTreeMap<OrganizationId, KnownOrUnknown<Plan, String>>,
     pub plan: PlanInfo,
 }


### PR DESCRIPTION
This PR updates the `UserStore` to use the `default_organization_id` returned from the server to set the default organization rather than always picking the first one.

Closes CLO-530.

Release Notes:

- N/A
