### PR TITLE
Fix file rename on FUSE-based filesystems

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -644,9 +644,12 @@ impl Fs for RealFs {
                             code == libc::ENOSYS
                                 || code == libc::ENOTSUP
                                 || code == libc::EOPNOTSUPP
+                                || code == libc::EINVAL
                         }) =>
                     {
                         // For case when filesystem or kernel does not support atomic no-overwrite rename.
+                        // EINVAL is returned by FUSE-based filesystems (e.g. NTFS via ntfs-3g)
+                        // that don't support RENAME_NOREPLACE.
                         true
                     }
                     Err(error) => return Err(error.into()),


### PR DESCRIPTION
Fixes #51778

#### Fix

- Add `EINVAL` to the list of error codes that trigger the metadata-based rename fallback in `crates/fs/src/fs.rs`
- FUSE filesystems (NTFS via ntfs-3g, exFAT, etc.) return `EINVAL` when `renameat2` is called with `RENAME_NOREPLACE`, since they don't support the flag.
- The existing fallback already handles `ENOSYS`, `ENOTSUP`, and `EOPNOTSUPP` for similar unsupported-operation cases.

#### Video

[Screencast from 2026-03-17 23-37-35.webm](https://github.com/user-attachments/assets/77e35d97-a87c-4acf-99b8-0e74df667275)

Release Notes:

- Fixed file and directory renaming failing in the project panel on FUSE-based filesystems (e.g. NTFS, exFAT drives on Linux).