### PR TITLE
helix: Fix multiline selection w.r.t. multibyte characters

### DIFF
--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -2,10 +2,18 @@ use std::ops::Range;
 
 use editor::{DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot};
 use gpui::Context;
+use language::{self, PointUtf16};
+use multi_buffer;
 use text::Bias;
 use ui::Window;
 
 use crate::Vim;
+
+#[derive(Copy, Clone)]
+enum Direction {
+    Above,
+    Below,
+}
 
 impl Vim {
     /// Creates a duplicate of every selection below it in the first place that has both its start
@@ -16,14 +24,7 @@ impl Vim {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.duplicate_selections(
-            times,
-            window,
-            cx,
-            &|prev_point| *prev_point.row_mut() += 1,
-            &|prev_range, map| prev_range.end.row() >= map.max_point().row(),
-            false,
-        );
+        self.duplicate_selections(times, window, cx, Direction::Below);
     }
 
     /// Creates a duplicate of every selection above it in the first place that has both its start
@@ -34,14 +35,7 @@ impl Vim {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.duplicate_selections(
-            times,
-            window,
-            cx,
-            &|prev_point| *prev_point.row_mut() = prev_point.row().0.saturating_sub(1),
-            &|prev_range, _| prev_range.start.row() == DisplayPoint::zero().row(),
-            true,
-        );
+        self.duplicate_selections(times, window, cx, Direction::Above);
     }
 
     fn duplicate_selections(
@@ -49,9 +43,7 @@ impl Vim {
         times: Option<usize>,
         window: &mut Window,
         cx: &mut Context<Self>,
-        advance_search: &dyn Fn(&mut DisplayPoint),
-        end_search: &dyn Fn(&Range<DisplayPoint>, &DisplaySnapshot) -> bool,
-        above: bool,
+        direction: Direction,
     ) {
         let times = times.unwrap_or(1);
         self.update_editor(cx, |_, editor, cx| {
@@ -59,7 +51,7 @@ impl Vim {
             let map = editor.display_snapshot(cx);
             let mut original_selections = editor.selections.all_display(&map);
             // The order matters, because it is recorded when the selections are added.
-            if above {
+            if matches!(direction, Direction::Above) {
                 original_selections.reverse();
             }
 
@@ -68,12 +60,9 @@ impl Vim {
                 selections.push(display_point_range_to_offset_range(&origin, &map));
                 let mut last_origin = origin;
                 for _ in 1..=times {
-                    if let Some(duplicate) = find_next_valid_duplicate_space(
-                        last_origin.clone(),
-                        &map,
-                        &advance_search,
-                        &end_search,
-                    ) {
+                    if let Some(duplicate) =
+                        find_next_valid_duplicate_space(last_origin.clone(), &map, direction)
+                    {
                         selections.push(display_point_range_to_offset_range(&duplicate, &map));
                         last_origin = duplicate;
                     } else {
@@ -90,22 +79,65 @@ impl Vim {
 }
 
 fn find_next_valid_duplicate_space(
-    mut origin: Range<DisplayPoint>,
+    origin: Range<DisplayPoint>,
     map: &DisplaySnapshot,
-    advance_search: &impl Fn(&mut DisplayPoint),
-    end_search: &impl Fn(&Range<DisplayPoint>, &DisplaySnapshot) -> bool,
+    direction: Direction,
 ) -> Option<Range<DisplayPoint>> {
-    while !end_search(&origin, map) {
-        advance_search(&mut origin.start);
-        advance_search(&mut origin.end);
+    let buffer = map.buffer_snapshot();
+    let start_col_utf16 = buffer
+        .point_to_point_utf16(origin.start.to_point(map))
+        .column;
+    let end_col_utf16 = buffer.point_to_point_utf16(origin.end.to_point(map)).column;
 
-        if map.clip_point(origin.start, Bias::Left) == origin.start
-            && map.clip_point(origin.end, Bias::Right) == origin.end
+    let line_len_utf16 = |row: u32| {
+        let byte_len = buffer.line_len(multi_buffer::MultiBufferRow(row));
+        buffer
+            .point_to_point_utf16(language::Point::new(row, byte_len))
+            .column
+    };
+
+    let mut tracker = origin;
+    loop {
+        match direction {
+            Direction::Below => {
+                if tracker.end.row() >= map.max_point().row() {
+                    return None;
+                }
+                *tracker.start.row_mut() += 1;
+                *tracker.end.row_mut() += 1;
+            }
+            Direction::Above => {
+                if tracker.start.row() == DisplayPoint::zero().row() {
+                    return None;
+                }
+                *tracker.start.row_mut() = tracker.start.row().0.saturating_sub(1);
+                *tracker.end.row_mut() = tracker.end.row().0.saturating_sub(1);
+            }
+        }
+
+        let start_row = DisplayPoint::new(tracker.start.row(), 0).to_point(map).row;
+        let end_row = DisplayPoint::new(tracker.end.row(), 0).to_point(map).row;
+
+        if start_col_utf16 > line_len_utf16(start_row) || end_col_utf16 > line_len_utf16(end_row) {
+            continue;
+        }
+
+        let start_col = buffer
+            .point_utf16_to_point(PointUtf16::new(start_row, start_col_utf16))
+            .column;
+        let end_col = buffer
+            .point_utf16_to_point(PointUtf16::new(end_row, end_col_utf16))
+            .column;
+
+        let candidate_start = DisplayPoint::new(tracker.start.row(), start_col);
+        let candidate_end = DisplayPoint::new(tracker.end.row(), end_col);
+
+        if map.clip_point(candidate_start, Bias::Left) == candidate_start
+            && map.clip_point(candidate_end, Bias::Right) == candidate_end
         {
-            return Some(origin);
+            return Some(candidate_start..candidate_end);
         }
     }
-    None
 }
 
 fn display_point_range_to_offset_range(
@@ -228,6 +260,30 @@ mod tests {
             fox «jˇ»umps
             over« ˇ»the
             lazy« ˇ»dog."},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_selection_duplication_multibyte(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // Selection on a line with multibyte chars should duplicate to the
+        // same character column on the next line, not skip it.
+        cx.set_state(
+            indoc! {"
+            H«äˇ»llo
+            Hallo"},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+            H«äˇ»llo
+            H«aˇ»llo"},
             Mode::HelixNormal,
         );
     }

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -2,8 +2,8 @@ use std::ops::Range;
 
 use editor::{DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot};
 use gpui::Context;
-use language::{self, PointUtf16};
-use multi_buffer;
+use language::{Point, PointUtf16};
+use multi_buffer::MultiBufferRow;
 use text::Bias;
 use ui::Window;
 
@@ -90,33 +90,33 @@ fn find_next_valid_duplicate_space(
     let end_col_utf16 = buffer.point_to_point_utf16(origin.end.to_point(map)).column;
 
     let line_len_utf16 = |row: u32| {
-        let byte_len = buffer.line_len(multi_buffer::MultiBufferRow(row));
+        let byte_len = buffer.line_len(MultiBufferRow(row));
         buffer
-            .point_to_point_utf16(language::Point::new(row, byte_len))
+            .point_to_point_utf16(Point::new(row, byte_len))
             .column
     };
 
-    let mut tracker = origin;
+    let mut candidate = origin;
     loop {
         match direction {
             Direction::Below => {
-                if tracker.end.row() >= map.max_point().row() {
+                if candidate.end.row() >= map.max_point().row() {
                     return None;
                 }
-                *tracker.start.row_mut() += 1;
-                *tracker.end.row_mut() += 1;
+                *candidate.start.row_mut() += 1;
+                *candidate.end.row_mut() += 1;
             }
             Direction::Above => {
-                if tracker.start.row() == DisplayPoint::zero().row() {
+                if candidate.start.row() == DisplayPoint::zero().row() {
                     return None;
                 }
-                *tracker.start.row_mut() = tracker.start.row().0.saturating_sub(1);
-                *tracker.end.row_mut() = tracker.end.row().0.saturating_sub(1);
+                *candidate.start.row_mut() = candidate.start.row().0.saturating_sub(1);
+                *candidate.end.row_mut() = candidate.end.row().0.saturating_sub(1);
             }
         }
 
-        let start_row = DisplayPoint::new(tracker.start.row(), 0).to_point(map).row;
-        let end_row = DisplayPoint::new(tracker.end.row(), 0).to_point(map).row;
+        let start_row = DisplayPoint::new(candidate.start.row(), 0).to_point(map).row;
+        let end_row = DisplayPoint::new(candidate.end.row(), 0).to_point(map).row;
 
         if start_col_utf16 > line_len_utf16(start_row) || end_col_utf16 > line_len_utf16(end_row) {
             continue;
@@ -129,8 +129,8 @@ fn find_next_valid_duplicate_space(
             .point_utf16_to_point(PointUtf16::new(end_row, end_col_utf16))
             .column;
 
-        let candidate_start = DisplayPoint::new(tracker.start.row(), start_col);
-        let candidate_end = DisplayPoint::new(tracker.end.row(), end_col);
+        let candidate_start = DisplayPoint::new(candidate.start.row(), start_col);
+        let candidate_end = DisplayPoint::new(candidate.end.row(), end_col);
 
         if map.clip_point(candidate_start, Bias::Left) == candidate_start
             && map.clip_point(candidate_end, Bias::Right) == candidate_end
@@ -260,6 +260,32 @@ mod tests {
             fox «jˇ»umps
             over« ˇ»the
             lazy« ˇ»dog."},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_selection_duplication_multiline_multibyte(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // Multiline selection on rows with multibyte chars should preserve
+        // the visual column on both start and end rows.
+        cx.set_state(
+            indoc! {"
+            «Häˇ»llo
+            Hëllo
+            Hallo"},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+            «Häˇ»llo
+            «Hëˇ»llo
+            Hallo"},
             Mode::HelixNormal,
         );
     }


### PR DESCRIPTION
Closes #51783 

I made this separate from #51780 because despite fixing very similar issues, the parts of the code base they touch are totally unrelated and fixing it for the editor doesn't fix it for helix. that and the refactor to the helix duplicate code seemed excessive all included in one PR.

Behavior Before:

https://github.com/user-attachments/assets/fe747a5f-ab99-45d9-b1d1-52e1f95f1fa3

Behavior After:

https://github.com/user-attachments/assets/e223e281-6726-4e0c-a278-9d44ca93fc3c


I also added new tests that are passing and all the helix tests pass.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- helix: fixed duplicating cursor on lines with multibyte characters
