### PR TITLE
vim: Add helix alias `reflow` for vim rewrap

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -3,7 +3,7 @@ use collections::{HashMap, HashSet};
 use command_palette_hooks::{CommandInterceptItem, CommandInterceptResult};
 use editor::{
     Bias, Editor, EditorSettings, SelectionEffects, ToPoint,
-    actions::{Rewrap, SortLinesCaseInsensitive, SortLinesCaseSensitive},
+    actions::{SortLinesCaseInsensitive, SortLinesCaseSensitive},
     display_map::ToDisplayPoint,
 };
 use futures::AsyncWriteExt as _;
@@ -47,6 +47,7 @@ use crate::{
         search::{FindCommand, ReplaceCommand, Replacement},
     },
     object::Object,
+    rewrap::Rewrap,
     state::{Mark, Mode},
     visual::VisualDeleteLine,
 };
@@ -3558,10 +3559,10 @@ mod test {
 
         cx.assert_state(
             indoc! {"
+                0123456789
+                0123456789
+                0123456789
                 ˇ0123456789
-                0123456789
-                0123456789
-                0123456789
             "},
             Mode::Normal,
         );

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -3537,4 +3537,33 @@ mod test {
             Mode::Normal,
         );
     }
+
+    #[gpui::test]
+    async fn test_reflow(cx: &mut TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.update_editor(|editor, _window, cx| {
+            editor.set_hard_wrap(Some(10), cx);
+        });
+
+        cx.set_state(
+            indoc! {"
+                ˇ0123456789 0123456789 0123456789 0123456789
+            "},
+            Mode::Normal,
+        );
+
+        cx.simulate_keystrokes(": reflow");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇ0123456789
+                0123456789
+                0123456789
+                0123456789
+            "},
+            Mode::Normal,
+        );
+    }
 }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1725,7 +1725,7 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         )
         .range(wrap_count),
         VimCommand::new(("j", "oin"), JoinLines).range(select_range),
-        VimCommand::new(("reflow", ""), Rewrap),
+        VimCommand::new(("reflow", ""), Rewrap).range(select_range),
         VimCommand::new(("fo", "ld"), editor::actions::FoldSelectedRanges).range(act_on_range),
         VimCommand::new(("foldo", "pen"), editor::actions::UnfoldLines)
             .bang(editor::actions::UnfoldRecursive)
@@ -3562,6 +3562,26 @@ mod test {
                 0123456789
                 0123456789
                 0123456789
+            "},
+            Mode::Normal,
+        );
+
+        cx.set_state(
+            indoc! {"
+                «0123456789 0123456789ˇ»
+                0123456789 0123456789
+            "},
+            Mode::VisualLine,
+        );
+
+        cx.simulate_keystrokes(": reflow");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇ0123456789
+                0123456789
+                0123456789 0123456789
             "},
             Mode::Normal,
         );

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -3,7 +3,7 @@ use collections::{HashMap, HashSet};
 use command_palette_hooks::{CommandInterceptItem, CommandInterceptResult};
 use editor::{
     Bias, Editor, EditorSettings, SelectionEffects, ToPoint,
-    actions::{SortLinesCaseInsensitive, SortLinesCaseSensitive},
+    actions::{Rewrap, SortLinesCaseInsensitive, SortLinesCaseSensitive},
     display_map::ToDisplayPoint,
 };
 use futures::AsyncWriteExt as _;
@@ -1725,6 +1725,7 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         )
         .range(wrap_count),
         VimCommand::new(("j", "oin"), JoinLines).range(select_range),
+        VimCommand::new(("reflow", ""), Rewrap),
         VimCommand::new(("fo", "ld"), editor::actions::FoldSelectedRanges).range(act_on_range),
         VimCommand::new(("foldo", "pen"), editor::actions::UnfoldLines)
             .bang(editor::actions::UnfoldRecursive)


### PR DESCRIPTION

<img width="994" height="248" alt="Screenshot 2026-03-17 at 2 34 13 PM" src="https://github.com/user-attachments/assets/46ed60f4-f9b0-4414-8c4f-286390efa431" />
<img width="854" height="257" alt="Screenshot 2026-03-17 at 2 34 32 PM" src="https://github.com/user-attachments/assets/4d765d1d-cbec-4034-b387-afaee4d0a069" />

Before you mark this PR as ready for review, make sure that you have:

- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Add support for helix's `:reflow` command 
