### PR TITLE
Allow modals to opt out of blocking autosave

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -56,7 +56,11 @@ pub struct TabSwitcher {
     init_modifiers: Option<Modifiers>,
 }
 
-impl ModalView for TabSwitcher {}
+impl ModalView for TabSwitcher {
+    fn blocks_focus_change_autosave(&self) -> bool {
+        false
+    }
+}
 
 pub fn init(cx: &mut App) {
     cx.observe_new(TabSwitcher::register).detach();

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -950,7 +950,7 @@ impl<T: Item> ItemHandle for Entity<T> {
                         // since the user is still interacting with the workspace.
                         let focus_handle = item.item_focus_handle(cx);
                         if !focus_handle.contains_focused(window, cx)
-                            && !workspace.has_active_modal(window, cx)
+                            && !workspace.active_modal_blocks_focus_change_autosave(cx)
                         {
                             Pane::autosave_item(&item, workspace.project.clone(), window, cx)
                                 .detach_and_log_err(cx);

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -26,6 +26,10 @@ pub trait ModalView: ManagedView {
     fn render_bare(&self) -> bool {
         false
     }
+
+    fn blocks_focus_change_autosave(&self) -> bool {
+        true
+    }
 }
 
 trait ModalViewHandle {
@@ -33,6 +37,7 @@ trait ModalViewHandle {
     fn view(&self) -> AnyView;
     fn fade_out_background(&self, cx: &mut App) -> bool;
     fn render_bare(&self, cx: &mut App) -> bool;
+    fn blocks_focus_change_autosave(&self, cx: &App) -> bool;
 }
 
 impl<V: ModalView> ModalViewHandle for Entity<V> {
@@ -50,6 +55,10 @@ impl<V: ModalView> ModalViewHandle for Entity<V> {
 
     fn render_bare(&self, cx: &mut App) -> bool {
         self.read(cx).render_bare()
+    }
+
+    fn blocks_focus_change_autosave(&self, cx: &App) -> bool {
+        self.read(cx).blocks_focus_change_autosave()
     }
 }
 
@@ -188,6 +197,12 @@ impl ModalLayer {
 
     pub fn has_active_modal(&self) -> bool {
         self.active_modal.is_some()
+    }
+
+    pub fn active_modal_blocks_focus_change_autosave(&self, cx: &App) -> bool {
+        self.active_modal
+            .as_ref()
+            .is_some_and(|modal| modal.modal.blocks_focus_change_autosave(cx))
     }
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6929,6 +6929,12 @@ impl Workspace {
         self.modal_layer.read(cx).has_active_modal()
     }
 
+    pub fn active_modal_blocks_focus_change_autosave(&self, cx: &App) -> bool {
+        self.modal_layer
+            .read(cx)
+            .active_modal_blocks_focus_change_autosave(cx)
+    }
+
     pub fn active_modal<V: ManagedView + 'static>(&self, cx: &App) -> Option<Entity<V>> {
         self.modal_layer.read(cx).active_modal()
     }


### PR DESCRIPTION
Currently, autosave behavior is guarded by 

1. if the item has lost focus and 
2. an unconditional check if a modal is active. 

This allows the TabSwitcher to block autosave when it gains focus, preventing autosave from ever triggering for the file which lost focus. 

This PR allows modals to opt out of blocking autosave, however, I am concerned having autosave trigger immediately on TabSwitcher getting focus may cause the `unwanted formatting and cursor jumps` mentioned in the comment above the `item.rs` change. I have a PR built on this one which only triggers autosave when the TabSwitcher focuses the *new* tab (#51802)

- Add ModalView::blocks_focus_change_autosave with a default of true so existing modals continue to block autosave.
- Thread the check through ModalViewHandle, ModalLayer, and Workspace and use it when deciding whether to autosave items on focus change.
- Implement TabSwitcher to return false.

Closes #47968

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- N/A Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

<details><summary>Recording of fix</summary><video src="https://github.com/user-attachments/assets/3902c8bc-d050-4116-a731-c9af748aeb15">Unable to load video</video></details>

Release Notes:

- Fixed tab switcher not triggering autosave
