### PR TITLE
TabSwitcher delayed autosave

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -56,7 +56,11 @@ pub struct TabSwitcher {
     init_modifiers: Option<Modifiers>,
 }
 
-impl ModalView for TabSwitcher {}
+impl ModalView for TabSwitcher {
+    fn blocks_focus_change_autosave(&self) -> bool {
+        false
+    }
+}
 
 pub fn init(cx: &mut App) {
     cx.observe_new(TabSwitcher::register).detach();

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -23,7 +23,7 @@ use ui::{
 };
 use util::ResultExt;
 use workspace::{
-    Event as WorkspaceEvent, ModalView, Pane, SaveIntent, Workspace,
+    AutosaveSetting, Event as WorkspaceEvent, ModalView, Pane, SaveIntent, Workspace,
     item::{ItemHandle, ItemSettings, ShowDiagnostics, TabContentParams},
     pane::{render_item_indicator, tab_details},
 };
@@ -58,7 +58,7 @@ pub struct TabSwitcher {
 
 impl ModalView for TabSwitcher {
     fn blocks_focus_change_autosave(&self) -> bool {
-        false
+        true
     }
 }
 
@@ -140,6 +140,7 @@ impl TabSwitcher {
         let weak_workspace = workspace.weak_handle();
 
         let project = workspace.project().clone();
+        let initially_focused_item = workspace.active_item(cx);
         let original_items: Vec<_> = workspace
             .panes()
             .iter()
@@ -154,6 +155,7 @@ impl TabSwitcher {
                 weak_workspace,
                 is_global,
                 open_in_active_pane,
+                initially_focused_item,
                 window,
                 cx,
                 original_items,
@@ -258,6 +260,7 @@ pub struct TabSwitcherDelegate {
     is_all_panes: bool,
     open_in_active_pane: bool,
     restored_items: bool,
+    initially_focused_item: Option<Box<dyn ItemHandle>>,
 }
 
 impl TabMatch {
@@ -341,6 +344,7 @@ impl TabSwitcherDelegate {
         workspace: WeakEntity<Workspace>,
         is_all_panes: bool,
         open_in_active_pane: bool,
+        initially_focused_item: Option<Box<dyn ItemHandle>>,
         window: &mut Window,
         cx: &mut Context<TabSwitcher>,
         original_items: Vec<(Entity<Pane>, usize)>,
@@ -358,7 +362,27 @@ impl TabSwitcherDelegate {
             open_in_active_pane,
             original_items,
             restored_items: false,
+            initially_focused_item,
         }
+    }
+
+    fn initially_focused_item_to_autosave(
+        &self,
+        selected_item_id: EntityId,
+        cx: &App,
+    ) -> Option<Box<dyn ItemHandle>> {
+        let item = self
+            .initially_focused_item
+            .as_ref()
+            .filter(|item| item.item_id() != selected_item_id)
+            .filter(|item| item.workspace_settings(cx).autosave == AutosaveSetting::OnFocusChange)?
+            .boxed_clone();
+
+        Some(item)
+    }
+
+    fn autosave_item(&self, item: &dyn ItemHandle, window: &mut Window, cx: &mut App) {
+        Pane::autosave_item(item, self.project.clone(), window, cx).detach_and_log_err(cx);
     }
 
     fn subscribe_to_updates(
@@ -646,6 +670,7 @@ impl TabSwitcherDelegate {
     fn confirm_open_in_active_pane(
         &mut self,
         selected_match: TabMatch,
+        autosave_item: Option<Box<dyn ItemHandle>>,
         window: &mut Window,
         cx: &mut Context<Picker<TabSwitcherDelegate>>,
     ) {
@@ -676,6 +701,9 @@ impl TabSwitcherDelegate {
             current_pane.update(cx, |pane, cx| {
                 pane.activate_item(index, true, true, window, cx);
             });
+            if let Some(item) = autosave_item.as_ref() {
+                self.autosave_item(item.as_ref(), window, cx);
+            }
         } else if selected_match.item.project_path(cx).is_some()
             && selected_match.item.can_split(cx)
         {
@@ -685,11 +713,16 @@ impl TabSwitcherDelegate {
             let database_id = workspace.read(cx).database_id();
             let task = selected_match.item.clone_on_split(database_id, window, cx);
             let current_pane = current_pane.downgrade();
+            let project = self.project.clone();
             cx.spawn_in(window, async move |_, cx| {
                 if let Some(clone) = task.await {
                     current_pane
                         .update_in(cx, |pane, window, cx| {
                             pane.add_item(clone, true, true, None, window, cx);
+                            if let Some(item) = autosave_item.as_ref() {
+                                Pane::autosave_item(item.as_ref(), project.clone(), window, cx)
+                                    .detach_and_log_err(cx);
+                            }
                         })
                         .log_err();
                 }
@@ -708,6 +741,9 @@ impl TabSwitcherDelegate {
                 window,
                 cx,
             );
+            if let Some(item) = autosave_item.as_ref() {
+                self.autosave_item(item.as_ref(), window, cx);
+            }
         }
     }
 }
@@ -778,6 +814,8 @@ impl PickerDelegate for TabSwitcherDelegate {
         let Some(selected_match) = self.matches.get(self.selected_index()).cloned() else {
             return;
         };
+        let selected_item_id = selected_match.item.item_id();
+        let autosave_item = self.initially_focused_item_to_autosave(selected_item_id, cx);
 
         self.restored_items = true;
         for (pane, index) in self.original_items.iter() {
@@ -787,7 +825,7 @@ impl PickerDelegate for TabSwitcherDelegate {
         }
 
         if self.open_in_active_pane {
-            self.confirm_open_in_active_pane(selected_match, window, cx);
+            self.confirm_open_in_active_pane(selected_match, autosave_item, window, cx);
         } else {
             selected_match
                 .pane
@@ -797,6 +835,9 @@ impl PickerDelegate for TabSwitcherDelegate {
                     }
                 })
                 .ok();
+            if let Some(item) = autosave_item.as_ref() {
+                self.autosave_item(item.as_ref(), window, cx);
+            }
         }
     }
 

--- a/crates/tab_switcher/src/tab_switcher_tests.rs
+++ b/crates/tab_switcher/src/tab_switcher_tests.rs
@@ -1,11 +1,15 @@
 use super::*;
 use editor::Editor;
-use gpui::{TestAppContext, VisualTestContext};
+use gpui::{TestAppContext, UpdateGlobal, VisualTestContext};
 use menu::SelectPrevious;
 use project::{Project, ProjectPath};
 use serde_json::json;
+use settings::SettingsStore;
 use util::{path, rel_path::rel_path};
-use workspace::{ActivatePreviousItem, AppState, MultiWorkspace, Workspace, item::test::TestItem};
+use workspace::{
+    ActivatePreviousItem, AppState, AutosaveSetting, MultiWorkspace, Workspace,
+    item::test::{TestItem, TestProjectItem},
+};
 
 #[ctor::ctor]
 fn init_logger() {
@@ -188,6 +192,65 @@ async fn test_open_with_single_item(cx: &mut gpui::TestAppContext) {
     tab_switcher.update(cx, |tab_switcher, _| {
         assert_eq!(tab_switcher.delegate.matches.len(), 1);
         assert_match_selection(tab_switcher, 0, tab);
+    });
+}
+
+#[gpui::test]
+async fn test_confirm_switch_autosaves_initial_item_after_switch(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    let project = Project::test(app_state.fs.clone(), [], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let first_item = cx.new(|cx| {
+        TestItem::new(cx)
+            .with_label("first")
+            .with_dirty(true)
+            .with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+    });
+    let second_item = cx.new(|cx| {
+        TestItem::new(cx)
+            .with_label("second")
+            .with_project_items(&[TestProjectItem::new(2, "2.txt", cx)])
+    });
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.workspace.autosave = Some(AutosaveSetting::OnFocusChange);
+            })
+        });
+
+        workspace.add_item_to_active_pane(Box::new(first_item.clone()), None, true, window, cx);
+        workspace.add_item_to_active_pane(Box::new(second_item.clone()), None, true, window, cx);
+        workspace.active_pane().update(cx, |pane, cx| {
+            pane.activate_item(0, true, true, window, cx);
+        });
+    });
+    cx.run_until_parked();
+
+    open_tab_switcher(false, &workspace, cx);
+    cx.run_until_parked();
+
+    first_item.read_with(cx, |item, _| {
+        assert_eq!(
+            item.save_count, 0,
+            "opening TabSwitcher should not autosave"
+        );
+    });
+
+    cx.dispatch_action(menu::Confirm);
+    cx.run_until_parked();
+
+    first_item.read_with(cx, |item, _| {
+        assert_eq!(
+            item.save_count, 1,
+            "confirming the switch should autosave the old tab"
+        );
+    });
+    second_item.read_with(cx, |item, _| {
+        assert_eq!(item.save_count, 0);
     });
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -950,7 +950,7 @@ impl<T: Item> ItemHandle for Entity<T> {
                         // since the user is still interacting with the workspace.
                         let focus_handle = item.item_focus_handle(cx);
                         if !focus_handle.contains_focused(window, cx)
-                            && !workspace.has_active_modal(window, cx)
+                            && !workspace.active_modal_blocks_focus_change_autosave(cx)
                         {
                             Pane::autosave_item(&item, workspace.project.clone(), window, cx)
                                 .detach_and_log_err(cx);

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -26,6 +26,10 @@ pub trait ModalView: ManagedView {
     fn render_bare(&self) -> bool {
         false
     }
+
+    fn blocks_focus_change_autosave(&self) -> bool {
+        true
+    }
 }
 
 trait ModalViewHandle {
@@ -33,6 +37,7 @@ trait ModalViewHandle {
     fn view(&self) -> AnyView;
     fn fade_out_background(&self, cx: &mut App) -> bool;
     fn render_bare(&self, cx: &mut App) -> bool;
+    fn blocks_focus_change_autosave(&self, cx: &App) -> bool;
 }
 
 impl<V: ModalView> ModalViewHandle for Entity<V> {
@@ -50,6 +55,10 @@ impl<V: ModalView> ModalViewHandle for Entity<V> {
 
     fn render_bare(&self, cx: &mut App) -> bool {
         self.read(cx).render_bare()
+    }
+
+    fn blocks_focus_change_autosave(&self, cx: &App) -> bool {
+        self.read(cx).blocks_focus_change_autosave()
     }
 }
 
@@ -188,6 +197,12 @@ impl ModalLayer {
 
     pub fn has_active_modal(&self) -> bool {
         self.active_modal.is_some()
+    }
+
+    pub fn active_modal_blocks_focus_change_autosave(&self, cx: &App) -> bool {
+        self.active_modal
+            .as_ref()
+            .is_some_and(|modal| modal.modal.blocks_focus_change_autosave(cx))
     }
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6929,6 +6929,12 @@ impl Workspace {
         self.modal_layer.read(cx).has_active_modal()
     }
 
+    pub fn active_modal_blocks_focus_change_autosave(&self, cx: &App) -> bool {
+        self.modal_layer
+            .read(cx)
+            .active_modal_blocks_focus_change_autosave(cx)
+    }
+
     pub fn active_modal<V: ManagedView + 'static>(&self, cx: &App) -> Option<Entity<V>> {
         self.modal_layer.read(cx).active_modal()
     }


### PR DESCRIPTION
In #51801 the tab losing focus to the TabSwitcher triggers autosave immediately. This PR used Codex to see if the Zed team preferred autosaving to remain blocked until the TabSwitcher gives focus to a new tab. If this is the preferred approach, I will make any adjustments needed to ensure it meets the quality expectations Zed has.

Closes #47968

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- N/A Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

<details><summary>Recording of fix</summary><video src="https://github.com/user-attachments/assets/17a818c2-12a0-463b-ab4f-8b15bca6388f">Unable to load video</video></details>

Release Notes:

- Fixed tab switcher not triggering autosave
