### PR TITLE
Reload buffer from disk before ACP readTextFile returns

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2412,6 +2412,18 @@ impl AcpThread {
 
             let buffer = load.await?;
 
+            // If the buffer has no unsaved user edits, reload it from disk to
+            // ensure we return fresh content. This avoids returning stale data
+            // when an ACP agent modifies files via terminal before reading them
+            // back, as the file watcher may not have picked up the change yet.
+            let needs_reload = buffer.update(cx, |buffer, _| {
+                !buffer.has_unsaved_edits() && buffer.file().is_some()
+            });
+            if needs_reload {
+                let reload_rx = buffer.update(cx, |buffer, cx| buffer.reload(cx));
+                reload_rx.await.ok();
+            }
+
             let snapshot = if reuse_shared_snapshot {
                 this.read_with(cx, |this, _| {
                     this.shared_buffers.get(&buffer.clone()).cloned()


### PR DESCRIPTION
## Summary

- When an ACP agent modifies files via terminal/Bash and then reads them back, `readTextFile` returned stale content from Zed's in-memory buffer because the file watcher hadn't picked up the disk change yet
- Before returning buffer content for an ACP read, check if the buffer has no unsaved user edits and reload it from disk if so
- This ensures fresh content without overwriting any in-progress user work

## Test plan

- [ ] Verify manually: have an ACP agent run a Bash command that modifies a file, then immediately read it back — should return the new content
- [ ] Verify that buffers with unsaved user edits are NOT reloaded (user work preserved)
- [ ] Verify no performance regression from the reload on large files

Fixes #49162, #49000

Release Notes:

- Fixed ACP `readTextFile` returning stale buffer content after files are modified via terminal