### PR TITLE
extension_ci: Switch back to upstream action

### DIFF
--- a/.github/workflows/extension_auto_bump.yml
+++ b/.github/workflows/extension_auto_bump.yml
@@ -7,6 +7,8 @@ on:
     - main
     paths:
     - extensions/**
+    - '!extensions/slash-commands-example/**'
+    - '!extensions/test-extension/**'
     - '!extensions/workflows/**'
     - '!extensions/*.md'
 jobs:

--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -231,7 +231,7 @@ jobs:
         echo "extension_id=${EXTENSION_ID}" >> "$GITHUB_OUTPUT"
     - id: extension-update
       name: extension_bump::release_action
-      uses: zed-extensions/update-action@72da482880c2f32ec8aa6e0a0427ab92d52ae32d
+      uses: huacnlee/zed-extension-action@82920ff0876879f65ffbcfa3403589114a8919c6
       with:
         extension-name: ${{ steps.get-extension-id.outputs.extension_id }}
         push-to: zed-industries/extensions
@@ -269,12 +269,22 @@ jobs:
               return;
           }
 
+          // Assign staff member responsible for the bump
+          const pullNumber = parseInt(prNumber);
+
+          await github.rest.issues.addAssignees({
+              owner: 'zed-industries',
+              repo: 'extensions',
+              issue_number: pullNumber,
+              assignees: [author]
+          });
+          console.log(`Assigned ${author} to PR #${prNumber} in zed-industries/extensions`);
 
           // Get the GraphQL node ID
           const { data: pr } = await github.rest.pulls.get({
               owner: 'zed-industries',
               repo: 'extensions',
-              pull_number: parseInt(prNumber)
+              pull_number: pullNumber
           });
 
           await github.graphql(`

--- a/tooling/xtask/src/tasks/workflows/extension_auto_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_auto_bump.rs
@@ -25,6 +25,8 @@ pub(crate) fn extension_auto_bump() -> Workflow {
                 Push::default()
                     .add_branch("main")
                     .add_path("extensions/**")
+                    .add_path("!extensions/slash-commands-example/**")
+                    .add_path("!extensions/test-extension/**")
                     .add_path("!extensions/workflows/**")
                     .add_path("!extensions/*.md"),
             ),

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -433,9 +433,9 @@ fn release_action(
     generated_token: &StepOutput,
 ) -> (Step<Use>, StepOutput) {
     let step = named::uses(
-        "zed-extensions",
-        "update-action",
-        "72da482880c2f32ec8aa6e0a0427ab92d52ae32d",
+        "huacnlee",
+        "zed-extension-action",
+        "82920ff0876879f65ffbcfa3403589114a8919c6",
     )
     .id("extension-update")
     .add_with(("extension-name", extension_id.to_string()))
@@ -483,12 +483,22 @@ fn enable_automerge_if_staff(
                     return;
                 }
 
+                // Assign staff member responsible for the bump
+                const pullNumber = parseInt(prNumber);
+
+                await github.rest.issues.addAssignees({
+                    owner: 'zed-industries',
+                    repo: 'extensions',
+                    issue_number: pullNumber,
+                    assignees: [author]
+                });
+                console.log(`Assigned ${author} to PR #${prNumber} in zed-industries/extensions`);
 
                 // Get the GraphQL node ID
                 const { data: pr } = await github.rest.pulls.get({
                     owner: 'zed-industries',
                     repo: 'extensions',
-                    pull_number: parseInt(prNumber)
+                    pull_number: pullNumber
                 });
 
                 await github.graphql(`


### PR DESCRIPTION
This switches the action back to the upstream one where the changes were merged (thanks @\huacnlee for the quick action)

Aside from that, it does some minor fixes: It adds the bumper as an assignee on the extensions PR and also ensures we do not try to bump here in the repo for the test extensions.

Release Notes:

- N/A