### PR TITLE
language_models: Apply JSON schema subset transform to xAI

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -641,11 +641,11 @@ impl LanguageModel for CloudLanguageModel {
     fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {
         match self.model.provider {
             cloud_llm_client::LanguageModelProvider::Anthropic
-            | cloud_llm_client::LanguageModelProvider::OpenAi
-            | cloud_llm_client::LanguageModelProvider::XAi => {
+            | cloud_llm_client::LanguageModelProvider::OpenAi => {
                 LanguageModelToolSchemaFormat::JsonSchema
             }
-            cloud_llm_client::LanguageModelProvider::Google => {
+            cloud_llm_client::LanguageModelProvider::Google
+            | cloud_llm_client::LanguageModelProvider::XAi => {
                 LanguageModelToolSchemaFormat::JsonSchemaSubset
             }
         }


### PR DESCRIPTION
The conversations on Grok 4 were failing right away on the first message in a conversation when using Zed provided model directly, but not the xAI API directly.

The reason we were seeing this is that when sending the JSON schemas for built-in tools to the cloud API, we didn't use the transform we use for xAI in a BYOK context. The xAI API doesn't support the full JSON schema spec, and specifically for the spawn_agent tool, we were generating a `oneOf` type for a field. Applying that transformation in the cloud case too fixes the issue.

Release Notes:

- Fixed broken (failing on first message) xAI models over the Zed provider on profiles using the spawn_agent tool, including the default Ask and Write profiles.
