### PR TITLE
languages: Fix incorrect `zsh` syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9625,6 +9625,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
+ "tree-sitter-zsh",
  "unindent",
  "url",
  "util",
@@ -18490,6 +18491,16 @@ dependencies = [
 name = "tree-sitter-yaml"
 version = "0.6.1"
 source = "git+https://github.com/zed-industries/tree-sitter-yaml?rev=baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a#baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zsh"
+version = "0.63.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0d613c4b13d1aaddbec78b4f0fae3de98bc82462b9153d8793a25d7387d4e6"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -732,6 +732,7 @@ toml_edit = { version = "0.22", default-features = false, features = [
 tower-http = "0.4.4"
 tree-sitter = { version = "0.26", features = ["wasm"] }
 tree-sitter-bash = "0.25.1"
+tree-sitter-zsh = "0.63.1"
 tree-sitter-c = "0.24.1"
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "5cb9b693cfd7bfacab1d9ff4acac1a4150700609" }
 tree-sitter-css = "0.23"

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -103,6 +103,7 @@ pretty_assertions.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 tree-sitter-bash.workspace = true
 tree-sitter-zsh.workspace = true
+tree-sitter-rust.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true
 tree-sitter-css.workspace = true

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -31,6 +31,7 @@ load-grammars = [
     "tree-sitter-rust",
     "tree-sitter-typescript",
     "tree-sitter-yaml",
+    "tree-sitter-zsh"
 ]
 
 [dependencies]
@@ -93,6 +94,7 @@ tree-sitter-regex = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-yaml = { workspace = true, optional = true }
+tree-sitter-zsh = { workspace = true, optional = true }
 url.workspace = true
 util.workspace = true
 
@@ -100,6 +102,7 @@ util.workspace = true
 pretty_assertions.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 tree-sitter-bash.workspace = true
+tree-sitter-zsh.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true
 tree-sitter-css.workspace = true

--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -1,9 +1,9 @@
 name = "Shell Script"
 code_fence_block_name = "bash"
 grammar = "bash"
-path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "bats", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD", "APKBUILD"]
+path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "bats", "profile", ".env", "PKGBUILD", "APKBUILD"]
 line_comments = ["# "]
-first_line_pattern = '^#!.*\b(?:ash|bash|bats|dash|sh|zsh)\b'
+first_line_pattern = '^#!.*\b(?:ash|bash|bats|dash|sh)\b'
 autoclose_before = "}])"
 brackets = [
     { start = "[", end = "]", close = true, newline = false },

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -32,6 +32,7 @@ mod tailwindcss;
 mod typescript;
 mod vtsls;
 mod yaml;
+mod zsh;
 
 pub(crate) use package_json::{PackageJson, PackageJsonData};
 
@@ -63,6 +64,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
     #[cfg(feature = "load-grammars")]
     languages.register_native_grammars([
         ("bash", tree_sitter_bash::LANGUAGE),
+        ("zsh", tree_sitter_zsh::LANGUAGE),
         ("c", tree_sitter_c::LANGUAGE),
         ("cpp", tree_sitter_cpp::LANGUAGE),
         ("css", tree_sitter_css::LANGUAGE),
@@ -115,6 +117,11 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         LanguageInfo {
             name: "bash",
             context: Some(Arc::new(bash::bash_task_context())),
+            ..Default::default()
+        },
+        LanguageInfo {
+            name: "zsh",
+            context: Some(Arc::new(zsh::zsh_task_context())),
             ..Default::default()
         },
         LanguageInfo {

--- a/crates/languages/src/zsh.rs
+++ b/crates/languages/src/zsh.rs
@@ -1,0 +1,156 @@
+use project::ContextProviderWithTasks;
+use task::{TaskTemplate, TaskTemplates, VariableName};
+
+pub(super) fn zsh_task_context() -> ContextProviderWithTasks {
+    ContextProviderWithTasks::new(TaskTemplates(vec![
+        TaskTemplate {
+            label: "execute selection".to_owned(),
+            command: VariableName::SelectedText.template_value(),
+            ..TaskTemplate::default()
+        },
+        TaskTemplate {
+            label: format!("run '{}'", VariableName::File.template_value()),
+            command: VariableName::File.template_value(),
+            tags: vec!["zsh-script".to_owned()],
+            ..TaskTemplate::default()
+        },
+    ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::{AppContext as _, BorrowAppContext, Context, TestAppContext};
+    use language::{AutoindentMode, Buffer};
+    use settings::SettingsStore;
+    use std::num::NonZeroU32;
+    use unindent::Unindent;
+    use util::test::marked_text_offsets;
+
+    #[gpui::test]
+    async fn test_zsh_autoindent(cx: &mut TestAppContext) {
+        cx.executor().set_block_on_ticks(usize::MAX..=usize::MAX);
+        let language = crate::language("zsh", tree_sitter_zsh::LANGUAGE.into());
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2)
+                });
+            });
+        });
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            let expect_indents_to =
+                |buffer: &mut Buffer, cx: &mut Context<Buffer>, input: &str, expected: &str| {
+                    buffer.edit(
+                        [(0..buffer.len(), input)],
+                        Some(AutoindentMode::EachLine),
+                        cx,
+                    );
+                    assert_eq!(buffer.text(), expected);
+                };
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "#!/usr/bin/env zsh\n#",
+                "#!/usr/bin/env zsh\n#",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "function name() {\necho \"Hello, World!\"\n}",
+                "function name() {\n  echo \"Hello, World!\"\n}",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "if true;then\nfoo\nelse\nbar\nfi",
+                "if true;then\n  foo\nelse\n  bar\nfi",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "if true;then\nfoo\nelif true;then\nbar\nelse\nbar\nfi",
+                "if true;then\n  foo\nelif true;then\n  bar\nelse\n  bar\nfi",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "case $1 in\nfoo) echo \"Hello, World!\";;\n*) echo \"Unknown argument\";;\nesac",
+                "case $1 in\n  foo) echo \"Hello, World!\";;\n  *) echo \"Unknown argument\";;\nesac",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "for i in {1..10};do\nfoo\ndone",
+                "for i in {1..10};do\n  foo\ndone",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "while true; do\nfoo\ndone",
+                "while true; do\n  foo\ndone",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "array=(\n1\n2\n3\n)",
+                "array=(\n  1\n  2\n  3\n)",
+            );
+
+            expect_indents_to(
+                &mut buffer,
+                cx,
+                "foo() {\necho \"Hello, World!\"\n}",
+                "foo() {\n  echo \"Hello, World!\"\n}",
+            );
+
+            let (input, offsets) = marked_text_offsets(
+                &r#"
+                if foo; then
+                  1ˇ
+                else
+                  3
+                fi
+                "#
+                .unindent(),
+            );
+
+            buffer.edit([(0..buffer.len(), input)], None, cx);
+            buffer.edit(
+                [(offsets[0]..offsets[0], "\n")],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            buffer.edit(
+                [(offsets[0] + 3..offsets[0] + 3, "elif")],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            let expected = r#"
+                if foo; then
+                  1
+                elif
+                else
+                  3
+                fi
+                "#
+            .unindent();
+
+            pretty_assertions::assert_eq!(buffer.text(), expected);
+
+            buffer
+        });
+    }
+}

--- a/crates/languages/src/zsh/brackets.scm
+++ b/crates/languages/src/zsh/brackets.scm
@@ -1,0 +1,62 @@
+("(" @open
+  ")" @close)
+
+("[" @open
+  "]" @close)
+
+("{" @open
+  "}" @close)
+
+(("\"" @open
+  "\"")
+  (#set! rainbow.exclude))
+
+(("`" @open
+  "`" @close)
+  (#set! rainbow.exclude))
+
+(("do" @open
+  "done" @close)
+  (#set! newline.only)
+  (#set! rainbow.exclude))
+
+((case_statement
+  ("in" @open
+    "esac" @close))
+  (#set! newline.only)
+  (#set! rainbow.exclude))
+
+((if_statement
+  (elif_clause
+    "then" @open)
+  (else_clause
+    "else" @close))
+  (#set! newline.only)
+  (#set! rainbow.exclude))
+
+((if_statement
+  (else_clause
+    "else" @open)
+  "fi" @close)
+  (#set! newline.only)
+  (#set! rainbow.exclude))
+
+((if_statement
+  "then" @open
+  (elif_clause
+    "elif" @close))
+  (#set! newline.only)
+  (#set! rainbow.exclude))
+
+((if_statement
+  "then" @open
+  (else_clause
+    "else" @close))
+  (#set! newline.only)
+  (#set! rainbow.exclude))
+
+((if_statement
+  ("then" @open
+    "fi" @close))
+  (#set! newline.only)
+  (#set! rainbow.exclude))

--- a/crates/languages/src/zsh/config.toml
+++ b/crates/languages/src/zsh/config.toml
@@ -1,0 +1,32 @@
+name = "Zsh"
+code_fence_block_name = "zsh"
+grammar = "zsh"
+path_suffixes = ["zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".zsh"]
+line_comments = ["# "]
+first_line_pattern = '^#!.*\bzsh\b'
+autoclose_before = "}])"
+brackets = [
+    { start = "[", end = "]", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "do", end = "done", close = false, newline = true, not_in = ["comment", "string"] },
+    { start = "then", end = "fi", close = false, newline = true, not_in = ["comment", "string"] },
+    { start = "then", end = "else", close = false, newline = true, not_in = ["comment", "string"] },
+    { start = "then", end = "elif", close = false, newline = true, not_in = ["comment", "string"] },
+    { start = "in", end = "esac", close = false, newline = true, not_in = ["comment", "string"] },
+]
+
+auto_indent_using_last_non_empty_line = false
+increase_indent_pattern = "^\\s*(\\b(else|elif)\\b|([^#]+\\b(do|then|in)\\b)|([\\w\\*]+\\)))\\s*$"
+decrease_indent_patterns = [
+  { pattern = "^\\s*elif\\b.*",    valid_after = ["if", "elif"] },
+  { pattern = "^\\s*else\\b.*",    valid_after = ["if", "elif", "for", "while"] },
+  { pattern = "^\\s*fi\\b.*",      valid_after = ["if", "elif", "else"] },
+  { pattern = "^\\s*done\\b.*",    valid_after = ["for", "while"] },
+  { pattern = "^\\s*esac\\b.*",    valid_after = ["case"] },
+  { pattern = "^\\s*[\\w\\*]+\\)\\s*$", valid_after = ["case_item"] },
+]
+
+decrease_indent_pattern = "(^|\\s+|;)(elif)\\b.*$"

--- a/crates/languages/src/zsh/highlights.scm
+++ b/crates/languages/src/zsh/highlights.scm
@@ -1,0 +1,35 @@
+; Comments
+(comment) @comment
+
+; Strings
+(string) @string
+
+; Keywords
+[
+  "if"
+  "then"
+  "else"
+  "elif"
+  "fi"
+  "for"
+  "while"
+  "do"
+  "done"
+  "case"
+  "esac"
+  "in"
+  "function"
+  "local"
+  "export"
+  "unset"
+] @keyword.control
+
+; Numbers
+(number) @number
+
+; Variables
+(variable_name) @variable
+(special_variable_name) @variable.special
+
+; Function names
+(word) @function

--- a/crates/languages/src/zsh/highlights.scm
+++ b/crates/languages/src/zsh/highlights.scm
@@ -1,35 +1,59 @@
-; Comments
-(comment) @comment
-
-; Strings
-(string) @string
-
-; Keywords
 [
-  "if"
-  "then"
-  "else"
-  "elif"
-  "fi"
-  "for"
-  "while"
+  (string)
+  (raw_string)
+  (heredoc_body)
+  (heredoc_start)
+] @string
+
+[
+    (command_name) 
+    (declaration_command) 
+] @function
+
+
+(variable_name) @property
+
+[
+  "case"
   "do"
   "done"
-  "case"
+  "elif"
+  "else"
   "esac"
-  "in"
-  "function"
-  "local"
   "export"
+  "fi"
+  "for"
+  "function"
+  "if"
+  "in"
+  "select"
+  "then"
   "unset"
-] @keyword.control
+  "until"
+  "while"
+] @keyword
 
-; Numbers
-(number) @number
+(comment) @comment
 
-; Variables
-(variable_name) @variable
-(special_variable_name) @variable.special
+(function_definition name: (word) @function)
 
-; Function names
-(word) @function
+(file_descriptor) @number
+
+[
+  (command_substitution)
+  (process_substitution)
+  (expansion)
+] @embedded
+
+[
+  "&&"
+  ">"
+  ">>"
+  "<"
+  "|"
+] @operator
+
+(
+  (command (_) @constant)
+  (#match? @constant "^-")
+)

--- a/crates/languages/src/zsh/indents.scm
+++ b/crates/languages/src/zsh/indents.scm
@@ -1,0 +1,27 @@
+(_
+  "["
+  "]" @end) @indent
+
+(_
+  "{"
+  "}" @end) @indent
+
+(_
+  "("
+  ")" @end) @indent
+
+(function_definition) @start.function
+
+(if_statement) @start.if
+
+(elif_clause) @start.elif
+
+(else_clause) @start.else
+
+(for_statement) @start.for
+
+(while_statement) @start.while
+
+(case_statement) @start.case
+
+(case_item) @start.case_item

--- a/crates/languages/src/zsh/injections.scm
+++ b/crates/languages/src/zsh/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/crates/languages/src/zsh/overrides.scm
+++ b/crates/languages/src/zsh/overrides.scm
@@ -1,0 +1,3 @@
+(comment) @comment.inclusive
+
+(string) @string

--- a/crates/languages/src/zsh/redactions.scm
+++ b/crates/languages/src/zsh/redactions.scm
@@ -1,0 +1,2 @@
+(variable_assignment
+  value: (_) @redact)

--- a/crates/languages/src/zsh/runnables.scm
+++ b/crates/languages/src/zsh/runnables.scm
@@ -1,0 +1,5 @@
+; Run zsh scripts
+((program
+  .
+  (_) @run) @_zsh-script
+  (#set! tag zsh-script))

--- a/crates/languages/src/zsh/textobjects.scm
+++ b/crates/languages/src/zsh/textobjects.scm
@@ -1,0 +1,7 @@
+(function_definition
+  body: (_
+    "{"
+    (_)* @function.inside
+    "}")) @function.around
+
+(comment) @comment.around


### PR DESCRIPTION
Closes #51555 


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] NO UI CHANGES


Release Notes:

- Fixed incorrect `zsh` syntax highlighting particularly noticed with strings.


#### Notes
- This also fixes the languages crates test not running due to missing `tree-sitter-rust.workspace = true` in `Cargo.toml` 

p.s. not sure if this was addressed in other commits. 