### PR TITLE
git_ui: Support snippet completions in commit message editor

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1010,6 +1010,26 @@
     },
   },
   {
+    "context": "CommitEditor > Editor && showing_completions",
+    "bindings": {
+      "enter": "editor::ConfirmCompletion",
+      "shift-enter": "editor::ConfirmCompletionReplace",
+      "tab": "editor::ComposeCompletion",
+    },
+  },
+  {
+    "context": "CommitEditor > Editor && in_snippet && has_next_tabstop && !showing_completions",
+    "bindings": {
+      "tab": "editor::NextSnippetTabstop",
+    },
+  },
+  {
+    "context": "CommitEditor > Editor && in_snippet && has_previous_tabstop && !showing_completions",
+    "bindings": {
+      "shift-tab": "editor::PreviousSnippetTabstop",
+    },
+  },
+  {
     "context": "DebugPanel",
     "bindings": {
       "ctrl-t": "debugger::ToggleThreadPicker",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1056,6 +1056,29 @@
     },
   },
   {
+    "context": "CommitEditor > Editor && showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "editor::ConfirmCompletion",
+      "shift-enter": "editor::ConfirmCompletionReplace",
+      "tab": "editor::ComposeCompletion",
+    },
+  },
+  {
+    "context": "CommitEditor > Editor && in_snippet && has_next_tabstop && !showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": "editor::NextSnippetTabstop",
+    },
+  },
+  {
+    "context": "CommitEditor > Editor && in_snippet && has_previous_tabstop && !showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "shift-tab": "editor::PreviousSnippetTabstop",
+    },
+  },
+  {
     "context": "GitPanel",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1013,6 +1013,29 @@
     },
   },
   {
+    "context": "CommitEditor > Editor && showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "editor::ConfirmCompletion",
+      "shift-enter": "editor::ConfirmCompletionReplace",
+      "tab": "editor::ComposeCompletion",
+    },
+  },
+  {
+    "context": "CommitEditor > Editor && in_snippet && has_next_tabstop && !showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": "editor::NextSnippetTabstop",
+    },
+  },
+  {
+    "context": "CommitEditor > Editor && in_snippet && has_previous_tabstop && !showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "shift-tab": "editor::PreviousSnippetTabstop",
+    },
+  },
+  {
     "context": "DebugPanel",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -682,11 +682,10 @@ pub(crate) fn commit_message_editor(
             max_lines: Some(max_lines),
         },
         buffer,
-        None,
+        Some(project),
         window,
         cx,
     );
-    commit_editor.set_collaboration_hub(Box::new(project));
     commit_editor.set_use_autoclose(false);
     commit_editor.set_show_gutter(false, cx);
     commit_editor.set_use_modal_editing(true);

--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -219,6 +219,8 @@ impl PickerDelegate for ScopeSelectorDelegate {
                         _ => Cow::Owned(language.await?.lsp_id()),
                     });
 
+                    fs::create_dir_all(snippets_dir())?;
+
                     workspace.update_in(cx, |workspace, window, cx| {
                         workspace
                             .with_local_workspace(window, cx, |workspace, window, cx| {


### PR DESCRIPTION
#### Fixes #50347

#### Summary:

- Pass project to Editor::new instead of None, enabling snippet completions in the git commit message editor
- Add fs::create_dir_all for the snippets directory to prevent errors when it doesn't exist yet
- Add keymap bindings for CommitEditor > Editor && showing_completions (after the base bindings, so they take precedence) to allow Enter/Tab to confirm/compose completions instead of inserting newlines or focusing the changes list
- Add keymap bindings for snippet tabstop navigation (Tab/Shift-Tab) in the commit editor

#### Tests :
- `cargo test -p git_ui`
- `cargo test -p editor test_snippet`
- `cargo test -p editor test_sort_snippet`
- `cargo test -p snippets_ui`
 -  all passed


#### Release Notes:
Fixed git commit snippets not showing completions in the commit message editor

####  Video :
[Screencast from 2026-03-19 00-42-30.webm](https://github.com/user-attachments/assets/2683a330-6969-4601-bcd3-d99ab607afbf)

