### PR TITLE
pdf_viewer: Add lightweight PDF viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "color"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6191,6 +6200,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fast_image_resize"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc7fe45cf92b43817ff62a3723e862b85bd1d06288f63007f7645d1d2f7a060"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "num-traits",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6243,6 +6264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -6365,6 +6395,7 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -6437,6 +6468,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "font-types"
@@ -8070,6 +8110,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "hayro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec16ea18d2ab01c94ab300f9415f8900cd056085c6926f70a7c3e7391192769"
+dependencies = [
+ "bytemuck",
+ "fast_image_resize",
+ "hayro-interpret",
+ "image",
+ "kurbo 0.12.0",
+ "vello_cpu",
+]
+
+[[package]]
+name = "hayro-ccitt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2db6494c3070f0e3cd9de52ee1a562ba3b2f832cd17b5537180c28294ca088eb"
+
+[[package]]
+name = "hayro-font"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d688da07ebfa1f0508697bdcc739a80a840706e2cfba39360820003a9bc49ed2"
+dependencies = [
+ "log",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298f36b94e75fa4055b4a71db9c641085d6197b214a4e13f3c4aedebb5cea234"
+dependencies = [
+ "bitflags 2.10.0",
+ "hayro-font",
+ "hayro-syntax",
+ "kurbo 0.12.0",
+ "log",
+ "moxcms 0.7.11",
+ "phf 0.13.1",
+ "rustc-hash 2.1.1",
+ "siphasher 1.0.1",
+ "skrifa 0.40.0",
+ "smallvec",
+ "yoke 0.8.0",
+]
+
+[[package]]
+name = "hayro-jbig2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7d4358462d3e5aeeb4dcfdea5467821d6551f6cb4607cc037ac99131bc1e32"
+dependencies = [
+ "hayro-ccitt",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3935d37666b8312aa40c4b2cbd1639d3c6fdc92f86ee52d6b93222e7192df077"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d8a5e080cc7429956acf933caf1ef8d4880ae70cbb26eeaec3ae228c7c5f61"
+dependencies = [
+ "fearless_simd",
+ "log",
+]
+
+[[package]]
+name = "hayro-syntax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08efad1aa85ea1e19ae3bb46832779222c32887fae7b30d53a07b1d1c0ba553"
+dependencies = [
+ "flate2",
+ "hayro-ccitt",
+ "hayro-jbig2",
+ "hayro-jpeg2000 0.2.0",
+ "log",
+ "rustc-hash 2.1.1",
+ "smallvec",
+ "zune-jpeg 0.5.13",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8656,7 +8790,7 @@ dependencies = [
  "exr",
  "gif",
  "image-webp",
- "moxcms",
+ "moxcms 0.7.11",
  "num-traits",
  "png 0.18.0",
  "qoi",
@@ -8664,8 +8798,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core",
- "zune-jpeg",
+ "zune-core 0.4.12",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -9302,6 +9436,17 @@ name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -10693,9 +10838,19 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c588e11a3082784af229e23e8e4ecf5bcc6fbe4f69101e0421ce8d79da7f0b40"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -12016,6 +12171,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0008e816fcdaf229cdd540e9b6ca2dc4a10d65c31624abb546c6420a02846e61"
 
 [[package]]
+name = "pdf_viewer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "db",
+ "editor",
+ "file_icons",
+ "gpui",
+ "hayro",
+ "hayro-interpret",
+ "hayro-syntax",
+ "image",
+ "language",
+ "log",
+ "project",
+ "rpdfium",
+ "serde",
+ "settings",
+ "smallvec",
+ "theme",
+ "ui",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "peg"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12059,6 +12240,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
+]
+
+[[package]]
+name = "peniko"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo 0.12.0",
+ "linebender_resource_handle",
+ "smallvec",
 ]
 
 [[package]]
@@ -12569,6 +12763,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12599,6 +12804,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand 2.3.0",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12625,6 +12840,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12638,6 +12866,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -13995,6 +14232,16 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8941f8e9d5f8ad3aebea330d01ac68c0167600eb31a86ecd86e97be4d13b51f5"
+dependencies = [
+ "bytemuck",
+ "font-types 0.9.0",
+]
+
+[[package]]
+name = "read-fonts"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
@@ -14680,6 +14927,161 @@ dependencies = [
  "util",
  "zlog",
  "zstd",
+]
+
+[[package]]
+name = "rpdfium"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4404300ec35ff5576e4db287b1681cdbf781d339c02a53ad209f4a0984fe89"
+dependencies = [
+ "rayon",
+ "rpdfium-codec",
+ "rpdfium-core",
+ "rpdfium-doc",
+ "rpdfium-font",
+ "rpdfium-graphics",
+ "rpdfium-page",
+ "rpdfium-parser",
+ "rpdfium-render",
+ "rpdfium-text",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rpdfium-codec"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46e8da4827ae6e472bf26bafda77373c0fe04b9d5b9e1b708c134e96377b013"
+dependencies = [
+ "flate2",
+ "hayro-jbig2",
+ "hayro-jpeg2000 0.1.1",
+ "rpdfium-core",
+ "thiserror 2.0.17",
+ "tracing",
+ "zune-jpeg 0.5.13",
+]
+
+[[package]]
+name = "rpdfium-core"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda73ef96f202bf02ac850d4aacc9f4ec3e472762617ac54412d950c23adce1d"
+dependencies = [
+ "getrandom 0.3.4",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+ "unicode-bidi",
+]
+
+[[package]]
+name = "rpdfium-doc"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b318431af868aa5454c628e22b45fee3185e36537b0213e059dfaf93c1f8fbf"
+dependencies = [
+ "rpdfium-core",
+ "rpdfium-page",
+ "rpdfium-parser",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rpdfium-font"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a268b9fda50e8333f512eb6a640e18fd893fa51edd79d27f635371aab82f82"
+dependencies = [
+ "dashmap",
+ "read-fonts 0.34.0",
+ "rpdfium-core",
+ "rpdfium-graphics",
+ "rpdfium-parser",
+ "skrifa 0.36.0",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "rpdfium-graphics"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e05540e0aadb9030a7f71ce226b99663c9ae756dcf863c0fa33bfc748aea147"
+dependencies = [
+ "rpdfium-core",
+]
+
+[[package]]
+name = "rpdfium-page"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1ec68c5fbfe3d03894831a8a9fcae9fdeababc2872447d355a078e6f0d02ff"
+dependencies = [
+ "rpdfium-codec",
+ "rpdfium-core",
+ "rpdfium-font",
+ "rpdfium-graphics",
+ "rpdfium-parser",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "rpdfium-parser"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f95a1634fc99a4fa28635c5b56d2f38361e30e9443f8ebf4262bfa6c4092b7"
+dependencies = [
+ "aes",
+ "cbc",
+ "dashmap",
+ "getrandom 0.3.4",
+ "md-5",
+ "rpdfium-codec",
+ "rpdfium-core",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "rpdfium-render"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ca9d4ef2098d93df23e3870d70263d054e43f9b6ae88a13e1b2ef8850ee883"
+dependencies = [
+ "dashmap",
+ "moxcms 0.8.1",
+ "rpdfium-codec",
+ "rpdfium-core",
+ "rpdfium-doc",
+ "rpdfium-font",
+ "rpdfium-graphics",
+ "rpdfium-page",
+ "rpdfium-parser",
+ "thiserror 2.0.17",
+ "tiny-skia",
+ "tracing",
+]
+
+[[package]]
+name = "rpdfium-text"
+version = "7676.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9ed74064f92380c508ce8323d4fc81c958042f96db2ee2d42d399eaccb5c87"
+dependencies = [
+ "rpdfium-core",
+ "rpdfium-font",
+ "rpdfium-graphics",
+ "rpdfium-page",
+ "rpdfium-parser",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -16017,6 +16419,16 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37004372610e83ee2a4c69c7d896b41f33da6a3dc1a4fe07dd9b2629a549b1dc"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.34.0",
+]
+
+[[package]]
+name = "skrifa"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
@@ -16802,7 +17214,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
  "siphasher 1.0.1",
 ]
 
@@ -17596,7 +18008,7 @@ dependencies = [
  "half",
  "quick-error 2.0.1",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -18868,7 +19280,7 @@ dependencies = [
  "flate2",
  "fontdb 0.23.0",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -19043,6 +19455,33 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vello_common"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc01cc9e1e2511e5e77024e8d4c2287b9272cafc05ba669ed1056579219dd73"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.15.5",
+ "log",
+ "peniko",
+ "png 0.17.16",
+ "skrifa 0.37.0",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9228d8ed0f1f030de9a09b66b4750012194c0f171030ec74214ba1ca3b9eed23"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.15.5",
+ "vello_common",
+]
 
 [[package]]
 name = "vercel"
@@ -21956,6 +22395,7 @@ dependencies = [
  "outline_panel",
  "parking_lot",
  "paths",
+ "pdf_viewer",
  "picker",
  "pkg-config",
  "pretty_assertions",
@@ -22380,6 +22820,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
 name = "zlog"
 version = "0.1.0"
 dependencies = [
@@ -22452,6 +22898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22466,7 +22918,16 @@ version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+dependencies = [
+ "zune-core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ members = [
     "crates/http_client_tls",
     "crates/icons",
     "crates/image_viewer",
+    "crates/pdf_viewer",
     "crates/inspector_ui",
     "crates/install_cli",
     "crates/journal",
@@ -344,6 +345,8 @@ http_client = { path = "crates/http_client" }
 http_client_tls = { path = "crates/http_client_tls" }
 icons = { path = "crates/icons" }
 image_viewer = { path = "crates/image_viewer" }
+pdf_viewer = { path = "crates/pdf_viewer" }
+rpdfium = "7676.6.4"
 edit_prediction_types = { path = "crates/edit_prediction_types" }
 edit_prediction_ui = { path = "crates/edit_prediction_ui" }
 edit_prediction_context = { path = "crates/edit_prediction_context" }

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1432,6 +1432,18 @@
     },
   },
   {
+    "context": "PdfViewer",
+    "bindings": {
+      "ctrl-=": "pdf_viewer::ZoomIn",
+      "ctrl-+": "pdf_viewer::ZoomIn",
+      "ctrl--": "pdf_viewer::ZoomOut",
+      "ctrl-0": "pdf_viewer::ResetZoom",
+      "ctrl-shift-0": "pdf_viewer::FitToView",
+      "ctrl-shift-c": "pdf_viewer::CopyPageText",
+      "ctrl-shift-m": "pdf_viewer::ToggleViewMode"
+    }
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "alt-1": "new_process_modal::ActivateTaskTab",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1510,6 +1510,19 @@
     },
   },
   {
+    "context": "PdfViewer",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-=": "pdf_viewer::ZoomIn",
+      "cmd-+": "pdf_viewer::ZoomIn",
+      "cmd--": "pdf_viewer::ZoomOut",
+      "cmd-0": "pdf_viewer::ResetZoom",
+      "cmd-shift-0": "pdf_viewer::FitToView",
+      "cmd-shift-c": "pdf_viewer::CopyPageText",
+      "cmd-shift-m": "pdf_viewer::ToggleViewMode"
+    }
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "cmd-1": "new_process_modal::ActivateTaskTab",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1425,6 +1425,18 @@
     },
   },
   {
+    "context": "PdfViewer",
+    "bindings": {
+      "ctrl-=": "pdf_viewer::ZoomIn",
+      "ctrl-+": "pdf_viewer::ZoomIn",
+      "ctrl--": "pdf_viewer::ZoomOut",
+      "ctrl-0": "pdf_viewer::ResetZoom",
+      "ctrl-shift-0": "pdf_viewer::FitToView",
+      "ctrl-shift-c": "pdf_viewer::CopyPageText",
+      "ctrl-shift-m": "pdf_viewer::ToggleViewMode"
+    }
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "alt-1": "new_process_modal::ActivateTaskTab",

--- a/crates/pdf_viewer/Cargo.toml
+++ b/crates/pdf_viewer/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "pdf_viewer"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/pdf_viewer.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+db.workspace = true
+editor.workspace = true
+file_icons.workspace = true
+gpui.workspace = true
+hayro = "0.5"
+hayro-interpret = "0.5"
+hayro-syntax = "0.5"
+image.workspace = true
+language.workspace = true
+log.workspace = true
+project.workspace = true
+rpdfium.workspace = true
+serde.workspace = true
+settings.workspace = true
+smallvec.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true

--- a/crates/pdf_viewer/src/pdf_renderer.rs
+++ b/crates/pdf_viewer/src/pdf_renderer.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use gpui::RenderImage;
+use image::Frame;
+use smallvec::SmallVec;
+
+/// Holds a parsed PDF document using hayro (rendering) and rpdfium (text extraction).
+pub struct PdfDocument {
+    hayro_pdf: hayro_syntax::Pdf,
+    #[allow(dead_code)]
+    rpdfium_library: rpdfium::ArcLibrary,
+    rpdfium_document: Option<rpdfium::ArcDocument>,
+}
+
+// hayro_syntax::Pdf is not Send by default, but we need it for background rendering.
+// SAFETY: We only access the Pdf from one thread at a time (render tasks are sequential per page).
+unsafe impl Send for PdfDocument {}
+unsafe impl Sync for PdfDocument {}
+
+#[derive(Debug)]
+pub enum PdfLoadError {
+    ParseError(String),
+    PasswordProtected,
+}
+
+impl std::fmt::Display for PdfLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PdfLoadError::ParseError(message) => write!(f, "Failed to parse PDF: {message}"),
+            PdfLoadError::PasswordProtected => write!(f, "This PDF is password-protected"),
+        }
+    }
+}
+
+impl std::error::Error for PdfLoadError {}
+
+impl PdfDocument {
+    pub fn open(data: Vec<u8>) -> std::result::Result<Self, PdfLoadError> {
+        // Parse with hayro for rendering
+        let hayro_pdf = hayro_syntax::Pdf::new(Arc::new(data.clone()))
+            .map_err(|error| PdfLoadError::ParseError(format!("{error:?}")))?;
+
+        // Parse with rpdfium for text extraction (best-effort)
+        let rpdfium_library = rpdfium::ArcLibrary::new();
+        let rpdfium_document =
+            rpdfium::ArcDocument::open(&rpdfium_library, data, &rpdfium::OpenOptions::default())
+                .ok();
+
+        Ok(Self {
+            hayro_pdf,
+            rpdfium_library,
+            rpdfium_document,
+        })
+    }
+
+    pub fn page_count(&self) -> u32 {
+        self.hayro_pdf.pages().len() as u32
+    }
+
+    /// Page dimensions in points (72 points = 1 inch).
+    pub fn page_dimensions(&self, page_index: u32) -> Result<(f64, f64)> {
+        let pages = self.hayro_pdf.pages();
+        let page = pages
+            .get(page_index as usize)
+            .ok_or_else(|| anyhow::anyhow!("page {page_index} out of range"))?;
+        let (width, height) = page.render_dimensions();
+        Ok((width as f64, height as f64))
+    }
+
+    /// Render a single page to RGBA pixels via hayro. CPU-intensive — call from background thread.
+    pub fn render_page(&self, page_index: u32, dpi: f32) -> Result<RenderedPage> {
+        let pages = self.hayro_pdf.pages();
+        let page = pages
+            .get(page_index as usize)
+            .ok_or_else(|| anyhow::anyhow!("page {page_index} out of range"))?;
+
+        let scale = dpi / 72.0;
+        let render_settings = hayro::RenderSettings {
+            x_scale: scale,
+            y_scale: scale,
+            ..hayro::RenderSettings::default()
+        };
+        let interp_settings = hayro_interpret::InterpreterSettings::default();
+
+        let pixmap = hayro::render(page, &interp_settings, &render_settings);
+
+        let width = pixmap.width() as u32;
+        let height = pixmap.height() as u32;
+
+        // Convert PremulRgba8 pixels to flat RGBA bytes
+        let pixel_data = pixmap.data();
+        let mut rgba_bytes: Vec<u8> = Vec::with_capacity(pixel_data.len() * 4);
+        for pixel in pixel_data {
+            rgba_bytes.push(pixel.r);
+            rgba_bytes.push(pixel.g);
+            rgba_bytes.push(pixel.b);
+            rgba_bytes.push(pixel.a);
+        }
+
+        Ok(RenderedPage {
+            width,
+            height,
+            data: rgba_bytes,
+        })
+    }
+
+    /// Extract all text from a page via rpdfium.
+    pub fn extract_page_text(&self, page_index: u32) -> Result<String> {
+        let document = self
+            .rpdfium_document
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("rpdfium document not available for text extraction"))?;
+        let page = document.page(page_index)?;
+        let text_page = page.text()?;
+        Ok(text_page.all_page_text().to_string())
+    }
+}
+
+/// A rendered page as raw RGBA pixels.
+pub struct RenderedPage {
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<u8>,
+}
+
+impl RenderedPage {
+    pub fn into_render_image(self) -> Arc<RenderImage> {
+        // Convert RGBA to BGRA (RenderImage expects BGRA format)
+        let mut bgra_data = self.data;
+        for pixel in bgra_data.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+        }
+
+        let buffer = image::ImageBuffer::from_raw(self.width, self.height, bgra_data)
+            .expect("pixel buffer dimensions should match");
+
+        let frame = Frame::new(buffer);
+        Arc::new(RenderImage::new(SmallVec::from_const([frame])))
+    }
+}

--- a/crates/pdf_viewer/src/pdf_viewer.rs
+++ b/crates/pdf_viewer/src/pdf_viewer.rs
@@ -229,23 +229,22 @@ impl PdfView {
         total
     }
 
-    fn render_visible_pages(&mut self, cx: &mut Context<Self>) {
+    fn render_all_pages(&mut self, cx: &mut Context<Self>) {
         let Some(document) = self.document.clone() else {
             return;
         };
 
-        let visible_range = self.visible_page_range();
+        let page_count = document.page_count();
         let dpi = self.effective_dpi();
         let generation = self.cache_generation;
 
-        for page_index in visible_range.clone() {
+        for page_index in 0..page_count {
             if self.page_cache.contains_key(&page_index) {
                 continue;
             }
 
             let document = document.clone();
             cx.spawn({
-                let page_index = page_index;
                 async move |this, cx| {
                     let rendered = cx
                         .background_executor()
@@ -265,16 +264,6 @@ impl PdfView {
                 }
             })
             .detach();
-        }
-
-        let pages_to_evict: Vec<u32> = self
-            .page_cache
-            .keys()
-            .copied()
-            .filter(|page_index| !visible_range.contains(page_index))
-            .collect();
-        for page_index in pages_to_evict {
-            self.page_cache.remove(&page_index);
         }
     }
 
@@ -478,7 +467,7 @@ impl PdfView {
                 .into_any_element();
         }
 
-        self.render_visible_pages(cx);
+        self.render_all_pages(cx);
 
         match self.view_mode {
             ViewMode::ContinuousScroll => self.render_continuous_scroll(cx),

--- a/crates/pdf_viewer/src/pdf_viewer.rs
+++ b/crates/pdf_viewer/src/pdf_viewer.rs
@@ -1,0 +1,940 @@
+mod pdf_renderer;
+pub use pdf_renderer::{PdfDocument, PdfLoadError, RenderedPage};
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use editor::{EditorSettings, items::entry_git_aware_label_color};
+use file_icons::FileIcons;
+use gpui::*;
+use language::File as _;
+use project::pdf_store::PdfItemEvent;
+use project::{PdfItem, Project, ProjectPath};
+use settings::Settings;
+use theme::ThemeSettings;
+use ui::prelude::*;
+use util::ResultExt;
+use util::paths::PathExt;
+use workspace::{
+    ItemId, ItemSettings, Pane, ToolbarItemLocation, Workspace, WorkspaceId,
+    invalid_item_view::InvalidItemView,
+    item::{HighlightedText, Item, ProjectItem, SerializableItem, TabContentParams},
+};
+
+actions!(
+    pdf_viewer,
+    [
+        /// Zoom in the PDF view.
+        ZoomIn,
+        /// Zoom out the PDF view.
+        ZoomOut,
+        /// Reset zoom to 100%.
+        ResetZoom,
+        /// Fit the PDF page to the view.
+        FitToView,
+        /// Copy the text content of the current page.
+        CopyPageText,
+        /// Toggle between continuous scroll and single page mode.
+        ToggleViewMode,
+    ]
+);
+
+const MIN_ZOOM: f32 = 0.1;
+const MAX_ZOOM: f32 = 10.0;
+const ZOOM_STEP: f32 = 1.1;
+const SCROLL_LINE_MULTIPLIER: f32 = 40.0;
+const DEFAULT_DPI: f32 = 144.0;
+const PAGE_GAP: f32 = 12.0;
+const PAGE_SHADOW_SIZE: f32 = 2.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ViewMode {
+    ContinuousScroll,
+    SinglePage,
+}
+
+impl Default for ViewMode {
+    fn default() -> Self {
+        ViewMode::ContinuousScroll
+    }
+}
+
+pub enum PdfViewEvent {
+    TitleChanged,
+}
+
+impl EventEmitter<PdfViewEvent> for PdfView {}
+impl EventEmitter<()> for PdfView {}
+
+pub struct PdfView {
+    pdf_item: Entity<PdfItem>,
+    project: Entity<Project>,
+    focus_handle: FocusHandle,
+    document: Option<Arc<PdfDocument>>,
+    load_error: Option<String>,
+    zoom_level: f32,
+    scroll_offset: f32,
+    current_page: u32,
+    view_mode: ViewMode,
+    page_cache: HashMap<u32, Arc<RenderImage>>,
+    cache_generation: u64,
+    container_size: Option<Size<Pixels>>,
+    _subscription: gpui::Subscription,
+}
+
+impl PdfView {
+    pub fn new(
+        pdf_item: Entity<PdfItem>,
+        project: Entity<Project>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let subscription = cx.subscribe(&pdf_item, Self::on_pdf_event);
+
+        let mut this = Self {
+            pdf_item,
+            project,
+            focus_handle: cx.focus_handle(),
+            document: None,
+            load_error: None,
+            zoom_level: 1.0,
+            scroll_offset: 0.0,
+            current_page: 0,
+            view_mode: ViewMode::default(),
+            page_cache: HashMap::new(),
+            cache_generation: 0,
+            container_size: None,
+            _subscription: subscription,
+        };
+        this.parse_document(cx);
+        this
+    }
+
+    fn parse_document(&mut self, cx: &mut Context<Self>) {
+        let data = self.pdf_item.read(cx).data.clone();
+
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { PdfDocument::open(data) })
+                .await;
+
+            this.update(cx, |this, cx| match result {
+                Ok(document) => {
+                    this.document = Some(Arc::new(document));
+                    this.load_error = None;
+                    this.page_cache.clear();
+                    this.cache_generation += 1;
+                    cx.notify();
+                }
+                Err(error) => {
+                    this.load_error = Some(error.to_string());
+                    this.document = None;
+                    cx.notify();
+                }
+            })
+            .log_err();
+        })
+        .detach();
+    }
+
+    fn on_pdf_event(&mut self, _: Entity<PdfItem>, event: &PdfItemEvent, cx: &mut Context<Self>) {
+        match event {
+            PdfItemEvent::Reloaded => {
+                self.page_cache.clear();
+                self.cache_generation += 1;
+                self.parse_document(cx);
+            }
+            PdfItemEvent::FileHandleChanged => {
+                cx.emit(PdfViewEvent::TitleChanged);
+                cx.notify();
+            }
+        }
+    }
+
+    fn page_count(&self) -> u32 {
+        self.document
+            .as_ref()
+            .map(|document| document.page_count())
+            .unwrap_or(0)
+    }
+
+    fn effective_dpi(&self) -> f32 {
+        DEFAULT_DPI * self.zoom_level
+    }
+
+    fn page_pixel_size(&self, page_index: u32) -> Option<(f32, f32)> {
+        let document = self.document.as_ref()?;
+        let (width_points, height_points) = document.page_dimensions(page_index).ok()?;
+        let scale = self.zoom_level * DEFAULT_DPI / 72.0;
+        Some((width_points as f32 * scale, height_points as f32 * scale))
+    }
+
+    fn visible_page_range(&self) -> std::ops::Range<u32> {
+        let page_count = self.page_count();
+        if page_count == 0 {
+            return 0..0;
+        }
+
+        if self.view_mode == ViewMode::SinglePage {
+            let page = self.current_page.min(page_count.saturating_sub(1));
+            return page..page + 1;
+        }
+
+        let container_height = self
+            .container_size
+            .map(|size| f32::from(size.height))
+            .unwrap_or(800.0);
+
+        let scroll = self.scroll_offset;
+        let mut accumulated_height: f32 = 0.0;
+        let mut first_visible = None;
+        let mut last_visible = 0u32;
+
+        for page_index in 0..page_count {
+            let (_, page_height) = self.page_pixel_size(page_index).unwrap_or((600.0, 800.0));
+            let page_top = accumulated_height;
+            let page_bottom = accumulated_height + page_height;
+            accumulated_height = page_bottom + PAGE_GAP;
+
+            if page_bottom > scroll && page_top < scroll + container_height {
+                if first_visible.is_none() {
+                    first_visible = Some(page_index);
+                }
+                last_visible = page_index;
+            }
+        }
+
+        let first = first_visible.unwrap_or(0);
+        let buffer_start = first.saturating_sub(1);
+        let buffer_end = (last_visible + 2).min(page_count);
+
+        buffer_start..buffer_end
+    }
+
+    fn total_content_height(&self) -> f32 {
+        let page_count = self.page_count();
+        if page_count == 0 {
+            return 0.0;
+        }
+
+        let mut total: f32 = 0.0;
+        for page_index in 0..page_count {
+            let (_, page_height) = self.page_pixel_size(page_index).unwrap_or((600.0, 800.0));
+            total += page_height;
+        }
+        total += PAGE_GAP * (page_count.saturating_sub(1)) as f32;
+        total
+    }
+
+    fn render_visible_pages(&mut self, cx: &mut Context<Self>) {
+        let Some(document) = self.document.clone() else {
+            return;
+        };
+
+        let visible_range = self.visible_page_range();
+        let dpi = self.effective_dpi();
+        let generation = self.cache_generation;
+
+        for page_index in visible_range.clone() {
+            if self.page_cache.contains_key(&page_index) {
+                continue;
+            }
+
+            let document = document.clone();
+            cx.spawn({
+                let page_index = page_index;
+                async move |this, cx| {
+                    let rendered = cx
+                        .background_executor()
+                        .spawn(async move { document.render_page(page_index, dpi) })
+                        .await;
+
+                    if let Ok(rendered_page) = rendered {
+                        let image = rendered_page.into_render_image();
+                        this.update(cx, |this, cx| {
+                            if this.cache_generation == generation {
+                                this.page_cache.insert(page_index, image);
+                                cx.notify();
+                            }
+                        })
+                        .log_err();
+                    }
+                }
+            })
+            .detach();
+        }
+
+        let pages_to_evict: Vec<u32> = self
+            .page_cache
+            .keys()
+            .copied()
+            .filter(|page_index| !visible_range.contains(page_index))
+            .collect();
+        for page_index in pages_to_evict {
+            self.page_cache.remove(&page_index);
+        }
+    }
+
+    fn set_zoom(&mut self, new_zoom: f32, cx: &mut Context<Self>) {
+        let old_zoom = self.zoom_level;
+        self.zoom_level = new_zoom.clamp(MIN_ZOOM, MAX_ZOOM);
+        if (self.zoom_level - old_zoom).abs() > f32::EPSILON {
+            self.page_cache.clear();
+            self.cache_generation += 1;
+            let ratio = self.zoom_level / old_zoom;
+            self.scroll_offset *= ratio;
+            cx.notify();
+        }
+    }
+
+    fn zoom_in(&mut self, _: &ZoomIn, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(self.zoom_level * ZOOM_STEP, cx);
+    }
+
+    fn zoom_out(&mut self, _: &ZoomOut, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(self.zoom_level / ZOOM_STEP, cx);
+    }
+
+    fn reset_zoom(&mut self, _: &ResetZoom, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(1.0, cx);
+    }
+
+    fn fit_to_view(&mut self, _: &FitToView, _window: &mut Window, cx: &mut Context<Self>) {
+        let Some(container_size) = self.container_size else {
+            return;
+        };
+        let page_index = self.current_page.min(self.page_count().saturating_sub(1));
+        let Some((page_width_points, _)) = self
+            .document
+            .as_ref()
+            .and_then(|document| document.page_dimensions(page_index).ok())
+        else {
+            return;
+        };
+
+        let container_width: f32 = container_size.width.into();
+        let page_width_at_zoom_1 = page_width_points as f32 * DEFAULT_DPI / 72.0;
+        if page_width_at_zoom_1 > 0.0 {
+            let fit_zoom = (container_width - PAGE_SHADOW_SIZE * 2.0 - 20.0) / page_width_at_zoom_1;
+            self.set_zoom(fit_zoom.min(MAX_ZOOM), cx);
+        }
+    }
+
+    fn toggle_view_mode(
+        &mut self,
+        _: &ToggleViewMode,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.view_mode = match self.view_mode {
+            ViewMode::ContinuousScroll => ViewMode::SinglePage,
+            ViewMode::SinglePage => ViewMode::ContinuousScroll,
+        };
+        cx.notify();
+    }
+
+    fn copy_page_text(&mut self, _: &CopyPageText, _window: &mut Window, cx: &mut Context<Self>) {
+        self.copy_all_text(cx);
+    }
+
+    fn copy_all_text(&mut self, cx: &mut Context<Self>) {
+        let Some(document) = self.document.as_ref() else {
+            return;
+        };
+        let mut all_text = String::new();
+        for page_index in 0..document.page_count() {
+            if let Ok(text) = document.extract_page_text(page_index) {
+                if !text.is_empty() {
+                    if !all_text.is_empty() {
+                        all_text.push('\n');
+                    }
+                    all_text.push_str(&text);
+                }
+            }
+        }
+        if !all_text.is_empty() {
+            cx.write_to_clipboard(ClipboardItem::new_string(all_text));
+        }
+    }
+
+    fn handle_scroll_wheel(
+        &mut self,
+        event: &ScrollWheelEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Ctrl+scroll or Cmd+scroll = zoom (like typical PDF viewers)
+        if event.modifiers.control || event.modifiers.platform {
+            let delta: f32 = match event.delta {
+                ScrollDelta::Pixels(pixels) => pixels.y.into(),
+                ScrollDelta::Lines(lines) => lines.y * SCROLL_LINE_MULTIPLIER,
+            };
+            let zoom_factor = if delta > 0.0 {
+                ZOOM_STEP
+            } else {
+                1.0 / ZOOM_STEP
+            };
+            self.set_zoom(self.zoom_level * zoom_factor, cx);
+        }
+        // Plain scroll is handled natively by GPUI's overflow_y_scroll
+    }
+
+    fn update_current_page_from_scroll(&mut self) {
+        let page_count = self.page_count();
+        if page_count == 0 {
+            return;
+        }
+
+        let viewport_center = self.scroll_offset
+            + self
+                .container_size
+                .map(|size| f32::from(size.height) / 2.0)
+                .unwrap_or(400.0);
+
+        let mut accumulated_height: f32 = 0.0;
+        for page_index in 0..page_count {
+            let (_, page_height) = self.page_pixel_size(page_index).unwrap_or((600.0, 800.0));
+            let page_center = accumulated_height + page_height / 2.0;
+            accumulated_height += page_height + PAGE_GAP;
+
+            if page_center >= viewport_center {
+                self.current_page = page_index;
+                return;
+            }
+        }
+        self.current_page = page_count.saturating_sub(1);
+    }
+
+    fn render_toolbar(&self, cx: &Context<Self>) -> AnyElement {
+        let page_count = self.page_count();
+        let current_display = if page_count > 0 {
+            format!("Page {} / {}", self.current_page + 1, page_count)
+        } else {
+            "Loading...".to_string()
+        };
+
+        let zoom_percentage = format!("{}%", (self.zoom_level * 100.0).round() as i32);
+
+        let mode_label = match self.view_mode {
+            ViewMode::ContinuousScroll => "Scroll",
+            ViewMode::SinglePage => "Single",
+        };
+
+        let colors = cx.theme().colors();
+
+        h_flex()
+            .w_full()
+            .justify_between()
+            .px_2()
+            .py_1()
+            .bg(colors.title_bar_background)
+            .border_b_1()
+            .border_color(colors.border)
+            .child(
+                h_flex()
+                    .gap_2()
+                    .child(
+                        Label::new(current_display)
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child(
+                        Label::new(mode_label)
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                    ),
+            )
+            .child(
+                h_flex().gap_1().child(
+                    Label::new(zoom_percentage)
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                ),
+            )
+            .into_any_element()
+    }
+
+    fn render_pages(&mut self, cx: &mut Context<Self>) -> AnyElement {
+        let page_count = self.page_count();
+        if page_count == 0 {
+            if let Some(error) = &self.load_error {
+                return div()
+                    .size_full()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(Label::new(error.clone()).color(Color::Error))
+                    .into_any_element();
+            }
+            return div()
+                .size_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(Label::new("Loading PDF...").color(Color::Muted))
+                .into_any_element();
+        }
+
+        self.render_visible_pages(cx);
+
+        match self.view_mode {
+            ViewMode::ContinuousScroll => self.render_continuous_scroll(cx),
+            ViewMode::SinglePage => self.render_single_page(cx),
+        }
+    }
+
+    fn render_continuous_scroll(&self, _cx: &mut Context<Self>) -> AnyElement {
+        let page_count = self.page_count();
+        let mut pages_container = v_flex().w_full().items_center().p_2();
+
+        for page_index in 0..page_count {
+            let (page_width, page_height) =
+                self.page_pixel_size(page_index).unwrap_or((600.0, 800.0));
+
+            let page_element = self.render_page_element(page_index, page_width, page_height);
+            pages_container = pages_container
+                .child(page_element)
+                .child(div().h(px(PAGE_GAP)));
+        }
+
+        div()
+            .id("pdf-scroll-container")
+            .size_full()
+            .overflow_y_scroll()
+            .child(pages_container)
+            .into_any_element()
+    }
+
+    fn render_single_page(&self, _cx: &mut Context<Self>) -> AnyElement {
+        let page_index = self.current_page.min(self.page_count().saturating_sub(1));
+        let (page_width, page_height) = self.page_pixel_size(page_index).unwrap_or((600.0, 800.0));
+
+        div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(self.render_page_element(page_index, page_width, page_height))
+            .into_any_element()
+    }
+
+    fn render_page_element(
+        &self,
+        page_index: u32,
+        page_width: f32,
+        page_height: f32,
+    ) -> AnyElement {
+        let page_content = if let Some(cached_image) = self.page_cache.get(&page_index) {
+            div()
+                .w(px(page_width))
+                .h(px(page_height))
+                .child(
+                    img(ImageSource::Render(cached_image.clone()))
+                        .w(px(page_width))
+                        .h(px(page_height)),
+                )
+                .into_any_element()
+        } else {
+            div()
+                .w(px(page_width))
+                .h(px(page_height))
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(Label::new("Rendering...").color(Color::Muted))
+                .into_any_element()
+        };
+
+        div()
+            .bg(gpui::white())
+            .shadow_md()
+            .rounded(px(PAGE_SHADOW_SIZE))
+            .child(page_content)
+            .into_any_element()
+    }
+}
+
+impl Focusable for PdfView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for PdfView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.container_size = None;
+
+        let toolbar = self.render_toolbar(cx);
+        let pages = self.render_pages(cx);
+
+        div()
+            .id("pdf-viewer")
+            .track_focus(&self.focus_handle(cx))
+            .key_context("PdfViewer")
+            .on_action(cx.listener(Self::zoom_in))
+            .on_action(cx.listener(Self::zoom_out))
+            .on_action(cx.listener(Self::reset_zoom))
+            .on_action(cx.listener(Self::fit_to_view))
+            .on_action(cx.listener(Self::copy_page_text))
+            .on_action(cx.listener(Self::toggle_view_mode))
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .child(
+                v_flex().size_full().child(toolbar).child(
+                    div()
+                        .id("pdf-pages-container")
+                        .flex_1()
+                        .overflow_hidden()
+                        .relative()
+                        .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel))
+                        .child(pages)
+                        .child(
+                            // Floating copy button in top-right corner
+                            div()
+                                .absolute()
+                                .top_2()
+                                .right_2()
+                                .child(
+                                    div()
+                                        .id("pdf-copy-button")
+                                        .rounded_md()
+                                        .px_3()
+                                        .py_1()
+                                        .bg(cx.theme().colors().element_background)
+                                        .border_1()
+                                        .border_color(cx.theme().colors().border)
+                                        .hover(|style| style.bg(cx.theme().colors().element_hover))
+                                        .cursor_pointer()
+                                        .on_click(cx.listener(|this, _, _window, cx| {
+                                            this.copy_all_text(cx);
+                                        }))
+                                        .child(
+                                            Label::new("Copy All Text")
+                                                .size(LabelSize::Small)
+                                        )
+                                ),
+                        ),
+                ),
+            )
+    }
+}
+
+impl Item for PdfView {
+    type Event = PdfViewEvent;
+
+    fn to_item_events(event: &Self::Event, f: &mut dyn FnMut(workspace::item::ItemEvent)) {
+        match event {
+            PdfViewEvent::TitleChanged => {
+                f(workspace::item::ItemEvent::UpdateTab);
+                f(workspace::item::ItemEvent::UpdateBreadcrumbs);
+            }
+        }
+    }
+
+    fn for_each_project_item(
+        &self,
+        cx: &App,
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
+    ) {
+        f(self.pdf_item.entity_id(), self.pdf_item.read(cx))
+    }
+
+    fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
+        let abs_path = self.pdf_item.read(cx).abs_path(cx)?;
+        let file_path = abs_path.compact().to_string_lossy().into_owned();
+        Some(file_path.into())
+    }
+
+    fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
+        let project_path = self.pdf_item.read(cx).project_path(cx);
+
+        let label_color = if ItemSettings::get_global(cx).git_status {
+            let git_status = self
+                .project
+                .read(cx)
+                .project_path_git_status(&project_path, cx)
+                .map(|status| status.summary())
+                .unwrap_or_default();
+
+            self.project
+                .read(cx)
+                .entry_for_path(&project_path, cx)
+                .map(|entry| {
+                    entry_git_aware_label_color(git_status, entry.is_ignored, params.selected)
+                })
+                .unwrap_or_else(|| params.text_color())
+        } else {
+            params.text_color()
+        };
+
+        Label::new(self.tab_content_text(params.detail.unwrap_or_default(), cx))
+            .single_line()
+            .color(label_color)
+            .when(params.preview, |this| this.italic())
+            .into_any_element()
+    }
+
+    fn tab_content_text(&self, _: usize, cx: &App) -> SharedString {
+        self.pdf_item
+            .read(cx)
+            .file_name(cx)
+            .to_string()
+            .into()
+    }
+
+    fn tab_icon(&self, _: &Window, cx: &App) -> Option<Icon> {
+        let path = self.pdf_item.read(cx).abs_path(cx)?;
+        ItemSettings::get_global(cx)
+            .file_icons
+            .then(|| FileIcons::get_icon(&path, cx))
+            .flatten()
+            .map(Icon::from_path)
+    }
+
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
+        let show_breadcrumb = EditorSettings::get_global(cx).toolbar.breadcrumbs;
+        if show_breadcrumb {
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<(Vec<HighlightedText>, Option<Font>)> {
+        let text = breadcrumbs_text_for_pdf(self.project.read(cx), self.pdf_item.read(cx), cx);
+        let font = ThemeSettings::get_global(cx).buffer_font.clone();
+
+        Some((
+            vec![HighlightedText {
+                text: text.into(),
+                highlights: vec![],
+            }],
+            Some(font),
+        ))
+    }
+
+    fn can_split(&self) -> bool {
+        true
+    }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: Option<WorkspaceId>,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<Entity<Self>>>
+    where
+        Self: Sized,
+    {
+        let pdf_item = self.pdf_item.clone();
+        let project = self.project.clone();
+        let document = self.document.clone();
+        let zoom_level = self.zoom_level;
+        let current_page = self.current_page;
+        let view_mode = self.view_mode;
+
+        Task::ready(Some(cx.new(|cx| {
+            let subscription = cx.subscribe(&pdf_item, Self::on_pdf_event);
+            Self {
+                pdf_item,
+                project,
+                focus_handle: cx.focus_handle(),
+                document,
+                load_error: None,
+                zoom_level,
+                scroll_offset: 0.0,
+                current_page,
+                view_mode,
+                page_cache: HashMap::new(),
+                cache_generation: 0,
+                container_size: None,
+                _subscription: subscription,
+            }
+        })))
+    }
+
+    fn has_deleted_file(&self, cx: &App) -> bool {
+        self.pdf_item.read(cx).file.disk_state().is_deleted()
+    }
+
+    fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {
+        workspace::item::ItemBufferKind::Singleton
+    }
+}
+
+fn breadcrumbs_text_for_pdf(project: &Project, pdf: &PdfItem, cx: &App) -> String {
+    let mut path = pdf.file.path().clone();
+    if project.visible_worktrees(cx).count() > 1
+        && let Some(worktree) = project.worktree_for_id(pdf.project_path(cx).worktree_id, cx)
+    {
+        path = worktree.read(cx).root_name().join(&path);
+    }
+
+    path.display(project.path_style(cx)).to_string()
+}
+
+impl ProjectItem for PdfView {
+    type Item = PdfItem;
+
+    fn for_project_item(
+        project: Entity<Project>,
+        _: Option<&Pane>,
+        item: Entity<Self::Item>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        Self::new(item, project, window, cx)
+    }
+
+    fn for_broken_project_item(
+        abs_path: &Path,
+        is_local: bool,
+        error: &anyhow::Error,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<InvalidItemView>
+    where
+        Self: Sized,
+    {
+        Some(InvalidItemView::new(abs_path, is_local, error, window, cx))
+    }
+}
+
+impl SerializableItem for PdfView {
+    fn serialized_item_kind() -> &'static str {
+        "PdfView"
+    }
+
+    fn deserialize(
+        project: Entity<Project>,
+        _workspace: WeakEntity<Workspace>,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<Entity<Self>>> {
+        window.spawn(cx, async move |cx| {
+            let pdf_path = persistence::PDF_VIEWER
+                .get_pdf_path(item_id, workspace_id)?
+                .context("No PDF path found")?;
+
+            let (worktree, relative_path) = project
+                .update(cx, |project, cx| {
+                    project.find_or_create_worktree(pdf_path.clone(), false, cx)
+                })
+                .await
+                .context("Path not found")?;
+            let worktree_id = worktree.update(cx, |worktree, _cx| worktree.id());
+
+            let project_path = ProjectPath {
+                worktree_id,
+                path: relative_path,
+            };
+
+            let pdf_item = project
+                .update(cx, |project, cx| project.open_pdf(project_path, cx))
+                .await?;
+
+            cx.update(
+                |window, cx| Ok(cx.new(|cx| PdfView::new(pdf_item, project, window, cx))),
+            )?
+        })
+    }
+
+    fn cleanup(
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<()>> {
+        workspace::delete_unloaded_items(
+            alive_items,
+            workspace_id,
+            "pdf_viewers",
+            &persistence::PDF_VIEWER,
+            cx,
+        )
+    }
+
+    fn serialize(
+        &mut self,
+        workspace: &mut Workspace,
+        item_id: ItemId,
+        _closing: bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<anyhow::Result<()>>> {
+        let workspace_id = workspace.database_id()?;
+        let pdf_path = self.pdf_item.read(cx).abs_path(cx)?;
+
+        Some(cx.background_spawn(async move {
+            persistence::PDF_VIEWER
+                .save_pdf_path(item_id, workspace_id, pdf_path)
+                .await
+        }))
+    }
+
+    fn should_serialize(&self, _event: &Self::Event) -> bool {
+        false
+    }
+}
+
+pub fn init(cx: &mut App) {
+    workspace::register_project_item::<PdfView>(cx);
+    workspace::register_serializable_item::<PdfView>(cx);
+}
+
+mod persistence {
+    use std::path::PathBuf;
+    use db::{
+        query,
+        sqlez::{domain::Domain, thread_safe_connection::ThreadSafeConnection},
+        sqlez_macros::sql,
+    };
+    use workspace::{ItemId, WorkspaceDb, WorkspaceId};
+
+    pub struct PdfViewerDb(ThreadSafeConnection);
+
+    impl Domain for PdfViewerDb {
+        const NAME: &str = stringify!(PdfViewerDb);
+        const MIGRATIONS: &[&str] = &[sql!(
+            CREATE TABLE pdf_viewers (
+                workspace_id INTEGER,
+                item_id INTEGER UNIQUE,
+                pdf_path BLOB,
+                PRIMARY KEY(workspace_id, item_id),
+                FOREIGN KEY(workspace_id) REFERENCES workspaces(workspace_id)
+                ON DELETE CASCADE
+            ) STRICT;
+        )];
+    }
+
+    db::static_connection!(PDF_VIEWER, PdfViewerDb, [WorkspaceDb]);
+
+    impl PdfViewerDb {
+        query! {
+            pub async fn save_pdf_path(
+                item_id: ItemId,
+                workspace_id: WorkspaceId,
+                pdf_path: PathBuf
+            ) -> Result<()> {
+                INSERT OR REPLACE INTO pdf_viewers(item_id, workspace_id, pdf_path)
+                VALUES (?, ?, ?)
+            }
+        }
+
+        query! {
+            pub fn get_pdf_path(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<PathBuf>> {
+                SELECT pdf_path
+                FROM pdf_viewers
+                WHERE item_id = ? AND workspace_id = ?
+            }
+        }
+    }
+}

--- a/crates/project/src/pdf_store.rs
+++ b/crates/project/src/pdf_store.rs
@@ -1,0 +1,519 @@
+use crate::{
+    Project, ProjectEntryId, ProjectItem, ProjectPath,
+    worktree_store::{WorktreeStore, WorktreeStoreEvent},
+};
+use anyhow::{Context as _, Result};
+use collections::{HashMap, hash_map};
+use futures::StreamExt;
+use gpui::{App, Context, Entity, EventEmitter, Subscription, Task, WeakEntity, prelude::*};
+use language::{DiskState, File};
+use std::num::NonZeroU64;
+use std::path::PathBuf;
+use std::sync::Arc;
+use util::ResultExt;
+use worktree::{LoadedBinaryFile, PathChange, Worktree};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
+pub struct PdfId(NonZeroU64);
+
+impl std::fmt::Display for PdfId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<NonZeroU64> for PdfId {
+    fn from(id: NonZeroU64) -> Self {
+        PdfId(id)
+    }
+}
+
+#[derive(Debug)]
+pub enum PdfItemEvent {
+    Reloaded,
+    FileHandleChanged,
+}
+
+impl EventEmitter<PdfItemEvent> for PdfItem {}
+
+pub enum PdfStoreEvent {
+    PdfAdded(Entity<PdfItem>),
+}
+
+impl EventEmitter<PdfStoreEvent> for PdfStore {}
+
+pub struct PdfItem {
+    pub id: PdfId,
+    pub file: Arc<worktree::File>,
+    pub data: Vec<u8>,
+}
+
+impl PdfItem {
+    pub fn project_path(&self, cx: &App) -> ProjectPath {
+        ProjectPath {
+            worktree_id: self.file.worktree_id(cx),
+            path: self.file.path().clone(),
+        }
+    }
+
+    pub fn abs_path(&self, cx: &App) -> Option<PathBuf> {
+        Some(self.file.as_local()?.abs_path(cx))
+    }
+
+    pub fn file_name<'a>(&'a self, cx: &'a App) -> &'a str {
+        self.file.file_name(cx)
+    }
+
+    fn file_updated(&mut self, new_file: Arc<worktree::File>, cx: &mut Context<Self>) {
+        let mut file_changed = false;
+
+        let old_file = &self.file;
+        if new_file.path() != old_file.path() {
+            file_changed = true;
+        }
+
+        let old_state = old_file.disk_state();
+        let new_state = new_file.disk_state();
+        if old_state != new_state {
+            file_changed = true;
+        }
+
+        self.file = new_file;
+        if file_changed {
+            cx.emit(PdfItemEvent::FileHandleChanged);
+            cx.notify();
+        }
+    }
+
+    pub fn reload(&mut self, cx: &mut Context<Self>) {
+        let Some(local_file) = self.file.as_local() else {
+            return;
+        };
+
+        let content = local_file.load_bytes(cx);
+        cx.spawn(async move |this, cx| {
+            if let Some(data) = content
+                .await
+                .context("Failed to load PDF content")
+                .log_err()
+            {
+                this.update(cx, |this, cx| {
+                    this.data = data;
+                    cx.emit(PdfItemEvent::Reloaded);
+                })
+                .log_err();
+            }
+        })
+        .detach();
+    }
+}
+
+pub fn is_pdf_file(project: &Entity<Project>, path: &ProjectPath, cx: &App) -> bool {
+    // First check the relative path's extension
+    if let Some(ext) = path.path.extension() {
+        return ext.eq_ignore_ascii_case("pdf");
+    }
+
+    // When opening a single file, Zed treats the file as the worktree root,
+    // so the relative path is empty. Check the worktree's abs path instead.
+    if let Some(abs_path) = project.read(cx).absolute_path(path, cx) {
+        if let Some(ext) = abs_path.extension() {
+            return ext.to_str().is_some_and(|e| e.eq_ignore_ascii_case("pdf"));
+        }
+    }
+
+    false
+}
+
+impl ProjectItem for PdfItem {
+    fn try_open(
+        project: &Entity<Project>,
+        path: &ProjectPath,
+        cx: &mut App,
+    ) -> Option<Task<Result<Entity<Self>>>> {
+        log::info!("PdfItem::try_open called for path: {:?}, extension: {:?}, is_pdf: {}", path.path, path.path.extension(), is_pdf_file(project, path, cx));
+        if is_pdf_file(project, path, cx) {
+            Some(cx.spawn({
+                let path = path.clone();
+                let project = project.clone();
+                async move |cx| {
+                    project
+                        .update(cx, |project, cx| project.open_pdf(path, cx))
+                        .await
+                }
+            }))
+        } else {
+            None
+        }
+    }
+
+    fn entry_id(&self, _: &App) -> Option<ProjectEntryId> {
+        self.file.entry_id
+    }
+
+    fn project_path(&self, cx: &App) -> Option<ProjectPath> {
+        Some(PdfItem::project_path(self, cx))
+    }
+
+    fn is_dirty(&self) -> bool {
+        false
+    }
+}
+
+struct LocalPdfStore {
+    local_pdf_ids_by_path: HashMap<ProjectPath, PdfId>,
+    local_pdf_ids_by_entry_id: HashMap<ProjectEntryId, PdfId>,
+    pdf_store: WeakEntity<PdfStore>,
+    _subscription: Subscription,
+}
+
+pub struct PdfStore {
+    opened_pdfs: HashMap<PdfId, WeakEntity<PdfItem>>,
+    worktree_store: Entity<WorktreeStore>,
+    local_store: Entity<LocalPdfStore>,
+    #[allow(clippy::type_complexity)]
+    loading_pdfs_by_path: HashMap<
+        ProjectPath,
+        postage::watch::Receiver<Option<Result<Entity<PdfItem>, Arc<anyhow::Error>>>>,
+    >,
+}
+
+impl PdfStore {
+    pub fn local(worktree_store: Entity<WorktreeStore>, cx: &mut Context<Self>) -> Self {
+        let this = cx.weak_entity();
+        let local_store = cx.new(|cx| {
+            let subscription = cx.subscribe(
+                &worktree_store,
+                |this: &mut LocalPdfStore, _, event, cx| {
+                    if let WorktreeStoreEvent::WorktreeAdded(worktree) = event {
+                        this.subscribe_to_worktree(worktree, cx);
+                    }
+                },
+            );
+
+            LocalPdfStore {
+                local_pdf_ids_by_path: Default::default(),
+                local_pdf_ids_by_entry_id: Default::default(),
+                pdf_store: this,
+                _subscription: subscription,
+            }
+        });
+
+        Self {
+            opened_pdfs: Default::default(),
+            loading_pdfs_by_path: Default::default(),
+            worktree_store,
+            local_store,
+        }
+    }
+
+    pub fn pdfs(&self) -> impl '_ + Iterator<Item = Entity<PdfItem>> {
+        self.opened_pdfs
+            .values()
+            .filter_map(|pdf| pdf.upgrade())
+    }
+
+    pub fn get(&self, pdf_id: PdfId) -> Option<Entity<PdfItem>> {
+        self.opened_pdfs
+            .get(&pdf_id)
+            .and_then(|pdf| pdf.upgrade())
+    }
+
+    pub fn get_by_path(&self, path: &ProjectPath, cx: &App) -> Option<Entity<PdfItem>> {
+        self.pdfs()
+            .find(|pdf| &pdf.read(cx).project_path(cx) == path)
+    }
+
+    pub fn open_pdf(
+        &mut self,
+        project_path: ProjectPath,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<PdfItem>>> {
+        let existing_pdf = self.get_by_path(&project_path, cx);
+        if let Some(existing_pdf) = existing_pdf {
+            return Task::ready(Ok(existing_pdf));
+        }
+
+        let Some(worktree) = self
+            .worktree_store
+            .read(cx)
+            .worktree_for_id(project_path.worktree_id, cx)
+        else {
+            return Task::ready(Err(anyhow::anyhow!("no such worktree")));
+        };
+
+        let loading_watch = match self.loading_pdfs_by_path.entry(project_path.clone()) {
+            hash_map::Entry::Occupied(entry) => entry.get().clone(),
+
+            hash_map::Entry::Vacant(entry) => {
+                let (mut tx, rx) = postage::watch::channel();
+                entry.insert(rx.clone());
+
+                let load_pdf = self.open_pdf_in_worktree(project_path.path.clone(), worktree, cx);
+
+                cx.spawn({
+                    let project_path = project_path.clone();
+                    async move |this, cx| {
+                        let load_result = load_pdf.await;
+                        *tx.borrow_mut() = Some(this.update(cx, |this, _cx| {
+                            this.loading_pdfs_by_path.remove(&project_path);
+                            let pdf = load_result.map_err(Arc::new)?;
+                            Ok(pdf)
+                        })?);
+                        anyhow::Ok(())
+                    }
+                })
+                .detach();
+                rx
+            }
+        };
+
+        cx.background_spawn(async move {
+            Self::wait_for_loading_pdf(loading_watch)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))
+        })
+    }
+
+    fn open_pdf_in_worktree(
+        &self,
+        path: Arc<util::rel_path::RelPath>,
+        worktree: Entity<Worktree>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<PdfItem>>> {
+        let local_store = self.local_store.clone();
+
+        let load_file = worktree.update(cx, |worktree, cx| {
+            worktree.load_binary_file(path.as_ref(), cx)
+        });
+
+        cx.spawn(async move |pdf_store, cx| {
+            let LoadedBinaryFile { file, content } = load_file.await?;
+
+            let entity = cx.new(|cx| PdfItem {
+                id: cx.entity_id().as_non_zero_u64().into(),
+                file: file.clone(),
+                data: content,
+            });
+
+            let pdf_id = cx.read_entity(&entity, |model, _| model.id);
+
+            local_store.update(cx, |local_store, cx| {
+                pdf_store.update(cx, |pdf_store, cx| {
+                    pdf_store.add_pdf(entity.clone(), cx)
+                })??;
+                local_store.local_pdf_ids_by_path.insert(
+                    ProjectPath {
+                        worktree_id: file.worktree_id(cx),
+                        path: file.path.clone(),
+                    },
+                    pdf_id,
+                );
+
+                if let Some(entry_id) = file.entry_id {
+                    local_store
+                        .local_pdf_ids_by_entry_id
+                        .insert(entry_id, pdf_id);
+                }
+
+                anyhow::Ok(())
+            })?;
+
+            Ok(entity)
+        })
+    }
+
+    async fn wait_for_loading_pdf(
+        mut receiver: postage::watch::Receiver<
+            Option<Result<Entity<PdfItem>, Arc<anyhow::Error>>>,
+        >,
+    ) -> Result<Entity<PdfItem>, Arc<anyhow::Error>> {
+        loop {
+            if let Some(result) = receiver.borrow().as_ref() {
+                match result {
+                    Ok(pdf) => return Ok(pdf.to_owned()),
+                    Err(e) => return Err(e.to_owned()),
+                }
+            }
+            receiver.next().await;
+        }
+    }
+
+    fn add_pdf(&mut self, pdf: Entity<PdfItem>, cx: &mut Context<PdfStore>) -> Result<()> {
+        let pdf_id = pdf.read(cx).id;
+        self.opened_pdfs.insert(pdf_id, pdf.downgrade());
+        cx.subscribe(&pdf, Self::on_pdf_event).detach();
+        cx.emit(PdfStoreEvent::PdfAdded(pdf));
+        Ok(())
+    }
+
+    fn on_pdf_event(
+        &mut self,
+        pdf: Entity<PdfItem>,
+        event: &PdfItemEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let PdfItemEvent::FileHandleChanged = event {
+            self.local_store.update(cx, |local_store, cx| {
+                local_store.pdf_changed_file(pdf, cx);
+            });
+        }
+    }
+}
+
+impl LocalPdfStore {
+    fn subscribe_to_worktree(&mut self, worktree: &Entity<Worktree>, cx: &mut Context<Self>) {
+        cx.subscribe(worktree, |this, worktree, event, cx| {
+            if worktree.read(cx).is_local()
+                && let worktree::Event::UpdatedEntries(changes) = event
+            {
+                this.local_worktree_entries_changed(&worktree, changes, cx);
+            }
+        })
+        .detach();
+    }
+
+    fn local_worktree_entries_changed(
+        &mut self,
+        worktree_handle: &Entity<Worktree>,
+        changes: &[(Arc<util::rel_path::RelPath>, ProjectEntryId, PathChange)],
+        cx: &mut Context<Self>,
+    ) {
+        let snapshot = worktree_handle.read(cx).snapshot();
+        for (path, entry_id, _) in changes {
+            self.local_worktree_entry_changed(*entry_id, path, worktree_handle, &snapshot, cx);
+        }
+    }
+
+    fn local_worktree_entry_changed(
+        &mut self,
+        entry_id: ProjectEntryId,
+        path: &Arc<util::rel_path::RelPath>,
+        worktree: &Entity<worktree::Worktree>,
+        snapshot: &worktree::Snapshot,
+        cx: &mut Context<Self>,
+    ) -> Option<()> {
+        let project_path = ProjectPath {
+            worktree_id: snapshot.id(),
+            path: path.clone(),
+        };
+        let pdf_id = match self.local_pdf_ids_by_entry_id.get(&entry_id) {
+            Some(&pdf_id) => pdf_id,
+            None => self.local_pdf_ids_by_path.get(&project_path).copied()?,
+        };
+
+        let pdf = self
+            .pdf_store
+            .update(cx, |pdf_store, _| {
+                if let Some(pdf) = pdf_store.get(pdf_id) {
+                    Some(pdf)
+                } else {
+                    pdf_store.opened_pdfs.remove(&pdf_id);
+                    None
+                }
+            })
+            .ok()
+            .flatten();
+        let pdf = if let Some(pdf) = pdf {
+            pdf
+        } else {
+            self.local_pdf_ids_by_path.remove(&project_path);
+            self.local_pdf_ids_by_entry_id.remove(&entry_id);
+            return None;
+        };
+
+        pdf.update(cx, |pdf, cx| {
+            let old_file = &pdf.file;
+            if old_file.worktree != *worktree {
+                return;
+            }
+
+            let snapshot_entry = old_file
+                .entry_id
+                .and_then(|entry_id| snapshot.entry_for_id(entry_id))
+                .or_else(|| snapshot.entry_for_path(old_file.path.as_ref()));
+
+            let new_file = if let Some(entry) = snapshot_entry {
+                worktree::File {
+                    disk_state: match entry.mtime {
+                        Some(mtime) => DiskState::Present {
+                            mtime,
+                            size: entry.size,
+                        },
+                        None => old_file.disk_state,
+                    },
+                    is_local: true,
+                    entry_id: Some(entry.id),
+                    path: entry.path.clone(),
+                    worktree: worktree.clone(),
+                    is_private: entry.is_private,
+                }
+            } else {
+                worktree::File {
+                    disk_state: DiskState::Deleted,
+                    is_local: true,
+                    entry_id: old_file.entry_id,
+                    path: old_file.path.clone(),
+                    worktree: worktree.clone(),
+                    is_private: old_file.is_private,
+                }
+            };
+
+            if new_file == **old_file {
+                return;
+            }
+
+            if new_file.path != old_file.path {
+                self.local_pdf_ids_by_path.remove(&ProjectPath {
+                    path: old_file.path.clone(),
+                    worktree_id: old_file.worktree_id(cx),
+                });
+                self.local_pdf_ids_by_path.insert(
+                    ProjectPath {
+                        worktree_id: new_file.worktree_id(cx),
+                        path: new_file.path.clone(),
+                    },
+                    pdf_id,
+                );
+            }
+
+            if new_file.entry_id != old_file.entry_id {
+                if let Some(entry_id) = old_file.entry_id {
+                    self.local_pdf_ids_by_entry_id.remove(&entry_id);
+                }
+                if let Some(entry_id) = new_file.entry_id {
+                    self.local_pdf_ids_by_entry_id.insert(entry_id, pdf_id);
+                }
+            }
+
+            pdf.file_updated(Arc::new(new_file), cx);
+        });
+        None
+    }
+
+    fn pdf_changed_file(&mut self, pdf: Entity<PdfItem>, cx: &mut App) -> Option<()> {
+        let pdf = pdf.read(cx);
+        let file = &pdf.file;
+
+        let pdf_id = pdf.id;
+        if let Some(entry_id) = file.entry_id {
+            match self.local_pdf_ids_by_entry_id.get(&entry_id) {
+                Some(_) => {
+                    return None;
+                }
+                None => {
+                    self.local_pdf_ids_by_entry_id.insert(entry_id, pdf_id);
+                }
+            }
+        };
+        self.local_pdf_ids_by_path.insert(
+            ProjectPath {
+                worktree_id: file.worktree_id(cx),
+                path: file.path.clone(),
+            },
+            pdf_id,
+        );
+
+        Some(())
+    }
+}

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -8,6 +8,7 @@ pub mod debounced_delay;
 pub mod debugger;
 pub mod git_store;
 pub mod image_store;
+pub mod pdf_store;
 pub mod lsp_command;
 pub mod lsp_store;
 pub mod manifest_tree;
@@ -78,6 +79,8 @@ use futures::{
 };
 pub use image_store::{ImageItem, ImageStore};
 use image_store::{ImageItemEvent, ImageStoreEvent};
+pub use pdf_store::{PdfItem, PdfStore};
+use pdf_store::{PdfItemEvent, PdfStoreEvent};
 
 use ::git::{blame::Blame, status::FileStatus};
 use gpui::{
@@ -224,6 +227,7 @@ pub struct Project {
     buffer_store: Entity<BufferStore>,
     context_server_store: Entity<ContextServerStore>,
     image_store: Entity<ImageStore>,
+    pdf_store: Entity<PdfStore>,
     lsp_store: Entity<LspStore>,
     _subscriptions: Vec<gpui::Subscription>,
     buffers_needing_diff: HashSet<WeakEntity<Buffer>>,
@@ -1214,6 +1218,10 @@ impl Project {
             cx.subscribe(&image_store, Self::on_image_store_event)
                 .detach();
 
+            let pdf_store = cx.new(|cx| PdfStore::local(worktree_store.clone(), cx));
+            cx.subscribe(&pdf_store, Self::on_pdf_store_event)
+                .detach();
+
             let prettier_store = cx.new(|cx| {
                 PrettierStore::new(
                     node.clone(),
@@ -1293,6 +1301,7 @@ impl Project {
                 worktree_store,
                 buffer_store,
                 image_store,
+                pdf_store,
                 lsp_store,
                 context_server_store,
                 join_project_response_message_id: 0,
@@ -1398,6 +1407,9 @@ impl Project {
                     cx,
                 )
             });
+            let pdf_store = cx.new(|cx| PdfStore::local(worktree_store.clone(), cx));
+            cx.subscribe(&pdf_store, Self::on_pdf_store_event)
+                .detach();
             cx.subscribe(&buffer_store, Self::on_buffer_store_event)
                 .detach();
             let toolchain_store = cx.new(|cx| {
@@ -1508,6 +1520,7 @@ impl Project {
                 worktree_store,
                 buffer_store,
                 image_store,
+                pdf_store,
                 lsp_store,
                 context_server_store,
                 breakpoint_store,
@@ -1684,6 +1697,7 @@ impl Project {
         let image_store = cx.new(|cx| {
             ImageStore::remote(worktree_store.clone(), client.clone().into(), remote_id, cx)
         });
+        let pdf_store = cx.new(|cx| PdfStore::local(worktree_store.clone(), cx));
 
         let environment =
             cx.new(|cx| ProjectEnvironment::new(None, worktree_store.downgrade(), None, true, cx));
@@ -1793,10 +1807,14 @@ impl Project {
 
             cx.subscribe(&dap_store, Self::on_dap_store_event).detach();
 
+            cx.subscribe(&pdf_store, Self::on_pdf_store_event)
+                .detach();
+
             let mut project = Self {
                 buffer_ordered_messages_tx: tx,
                 buffer_store: buffer_store.clone(),
                 image_store,
+                pdf_store,
                 worktree_store: worktree_store.clone(),
                 lsp_store: lsp_store.clone(),
                 context_server_store,
@@ -3179,6 +3197,16 @@ impl Project {
         })
     }
 
+    pub fn open_pdf(
+        &mut self,
+        path: impl Into<ProjectPath>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<PdfItem>>> {
+        self.pdf_store.update(cx, |pdf_store, cx| {
+            pdf_store.open_pdf(path.into(), cx)
+        })
+    }
+
     async fn send_buffer_ordered_messages(
         project: WeakEntity<Self>,
         rx: UnboundedReceiver<BufferOrderedMessage>,
@@ -3327,6 +3355,22 @@ impl Project {
             ImageStoreEvent::ImageAdded(image) => {
                 cx.subscribe(image, |this, image, event, cx| {
                     this.on_image_event(image, event, cx);
+                })
+                .detach();
+            }
+        }
+    }
+
+    fn on_pdf_store_event(
+        &mut self,
+        _: Entity<PdfStore>,
+        event: &PdfStoreEvent,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            PdfStoreEvent::PdfAdded(pdf) => {
+                cx.subscribe(pdf, |this, pdf, event, cx| {
+                    this.on_pdf_event(pdf, event, cx);
                 })
                 .detach();
             }
@@ -3696,6 +3740,19 @@ impl Project {
         }
 
         None
+    }
+
+    fn on_pdf_event(
+        &mut self,
+        pdf: Entity<PdfItem>,
+        event: &PdfItemEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let PdfItemEvent::FileHandleChanged = event {
+            pdf.update(cx, |pdf, cx| {
+                pdf.reload(cx);
+            });
+        }
     }
 
     fn request_buffer_diff_recalculation(

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -131,6 +131,7 @@ edit_prediction.workspace = true
 edit_prediction_ui.workspace = true
 http_client.workspace = true
 image_viewer.workspace = true
+pdf_viewer.workspace = true
 inspector_ui.workspace = true
 install_cli.workspace = true
 journal.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -690,6 +690,7 @@ fn main() {
 
         editor::init(cx);
         image_viewer::init(cx);
+        pdf_viewer::init(cx);
         repl::notebook::init(cx);
         diagnostics::init(cx);
 


### PR DESCRIPTION
## Summary

- Add a pure-Rust PDF viewer that renders PDF files directly inside Zed editor tabs
- Follow the existing image viewer pattern for minimal footprint
- Use hayro for rendering (vello_cpu backend) and rpdfium for text extraction
- All dependencies are pure Rust — no native C library bundling required

## Features

- Visual PDF page rendering with continuous scroll
- Ctrl+scroll zoom, keyboard shortcuts (Ctrl+=/-/0)
- Floating "Copy All Text" button for text extraction
- Toggle between continuous scroll and single page mode
- Toolbar with page indicator, view mode, and zoom percentage
- Session persistence (reopens PDFs on Zed restart)
- Encrypted PDF detection

## Architecture

| Component | File | Purpose |
|-----------|------|---------|
| PdfItem/PdfStore | `crates/project/src/pdf_store.rs` | File handling (no PDF deps in project crate) |
| PdfRenderer | `crates/pdf_viewer/src/pdf_renderer.rs` | hayro rendering + rpdfium text extraction |
| PdfView | `crates/pdf_viewer/src/pdf_viewer.rs` | GPUI view with full workspace integration |

Designed for eventual conversion to an extension when the extension API supports custom views.

## Test plan

- [x] Open a single-page PDF — renders correctly
- [x] Open a multi-page PDF — scroll through pages
- [x] Ctrl+scroll to zoom in/out
- [x] Ctrl+=, Ctrl+-, Ctrl+0 keyboard shortcuts
- [x] Click "Copy All Text" button — text copied to clipboard
- [x] Ctrl+Shift+M toggles between scroll and single page mode
- [ ] Reopen Zed — PDF tab restored via session persistence
- [ ] Open an encrypted PDF — shows password-protected message
- [ ] Open a non-PDF file — opens in text editor, not PDF viewer

## Release Notes

- Added lightweight PDF viewer for rendering PDF files in editor tabs