### PR TITLE
Fix pip hash verification in assign-reviewers workflow

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -75,9 +75,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pyyaml==6.0.3 \
-            --require-hashes --no-deps -q --only-binary ':all:' \
-            -c /dev/stdin <<< "pyyaml==6.0.3 --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"
+          pip install --no-deps -q --only-binary ':all:' \
+            -r /dev/stdin <<< "pyyaml==6.0.3 --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"
 
       - name: Assign reviewers
         env:


### PR DESCRIPTION
## Summary

Fix failing `assign-reviewers` workflow — pip's `--hash` syntax only works in requirements files (`-r`), not constraint files (`-c`). The `-c /dev/stdin` approach caused: `hashes are missing from some requirements`.

Failing run: https://github.com/zed-industries/zed/actions/runs/23272148116/job/67667106308

Coordinator PR: https://github.com/zed-industries/codeowner-coordinator/pull/84

## Test plan

- [x] Verified locally: good hash installs cleanly, bad hash rejected
- [ ] After merge: verify assign-reviewers workflow passes on next PR

Release Notes:

- N/A