### PR TITLE
rules_library: Register ActionSequence handler

### DIFF
--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -15,7 +15,7 @@ use picker::{Picker, PickerDelegate};
 use platform_title_bar::PlatformTitleBar;
 use release_channel::ReleaseChannel;
 use rope::Rope;
-use settings::Settings;
+use settings::{ActionSequence, Settings};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -1399,6 +1399,13 @@ impl Render for RulesLibrary {
             v_flex()
                 .id("rules-library")
                 .key_context("RulesLibrary")
+                .on_action(
+                    |action_sequence: &ActionSequence, window: &mut Window, cx: &mut App| {
+                        for action in &action_sequence.0 {
+                            window.dispatch_action(action.boxed_clone(), cx);
+                        }
+                    },
+                )
                 .on_action(cx.listener(|this, &NewRule, window, cx| this.new_rule(window, cx)))
                 .on_action(
                     cx.listener(|this, &DeleteRule, window, cx| {


### PR DESCRIPTION
## Context

User keybindings using `action::Sequence` (e.g., mapping Escape in insert mode
to a sequence of `vim::NormalBefore` + another action) don't work in the
RulesLibrary window. The `ActionSequence` handler is only registered on the
`Workspace` view, but the RulesLibrary opens as a separate window without a
Workspace in its element tree, so the action has no handler and fails to
dispatch.

This adds the `ActionSequence` handler to the RulesLibrary root element,
matching the same pattern used in Workspace.

Closes #51721

## How to Review

Small PR — single file change in `crates/rules_library/src/rules_library.rs`.
Focus on the new `.on_action()` for `ActionSequence` in the `Render` impl.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed `action::Sequence` keybindings not working in the Rules Library window



## Video:


https://github.com/user-attachments/assets/c6189a77-cdec-461a-8dc5-be066f14b385

