### PR TITLE
gpui_linux: Set _NET_WM_NAME during X11 window creation

### DIFF
--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -533,12 +533,22 @@ impl X11WindowState {
                 && let Some(title) = titlebar.title
             {
                 check_reply(
-                    || "X11 ChangeProperty8 on window title failed.",
+                    || "X11 ChangeProperty8 on WM_NAME failed.",
                     xcb.change_property8(
                         xproto::PropMode::REPLACE,
                         x_window,
                         xproto::AtomEnum::WM_NAME,
                         xproto::AtomEnum::STRING,
+                        title.as_bytes(),
+                    ),
+                )?;
+                check_reply(
+                    || "X11 ChangeProperty8 on _NET_WM_NAME failed.",
+                    xcb.change_property8(
+                        xproto::PropMode::REPLACE,
+                        x_window,
+                        atoms._NET_WM_NAME,
+                        atoms.UTF8_STRING,
                         title.as_bytes(),
                     ),
                 )?;


### PR DESCRIPTION
#### Context

On X11, the Settings window title displayed as `"Zed â██ Settings"` instead of "Zed — Settings"`. The em-dash (U+2014) was garbled because the window creation path only set the legacy `WM_NAME` property (Latin-1 encoded), but never set `_NET_WM_NAME` (UTF-8). Modern taskbars prefer `_NET_WM_NAME`, so without it they fell back to `WM_NAME` and misinterpreted the UTF-8 bytes as Latin-1.

`set_title()` already sets both properties, which is why windows that update their title after creation (like the main workspace) were unaffected.

The fix adds `_NET_WM_NAME` during window creation, matching what `set_title()` already does.

#### Closes #51871

#### How to Review

Single change in `crates/gpui_linux/src/linux/x11/window.rs` focus on the new `_NET_WM_NAME` property being set alongside the existing `WM_NAME` in `X11Window::new`.

#### Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

#### Video

[Screencast from 2026-03-19 11-19-45.webm](https://github.com/user-attachments/assets/ff810e37-90ac-4ce2-a8f5-ad83e66aa3b8)


Release Notes:

- Fixed garbled characters in window titles on Linux X11 (e.g., Settings window)
