### PR TITLE
Fix PR size check failing on fork PRs

### DIFF
--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -11,7 +11,7 @@
 name: PR Size Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
Follow-up https://github.com/zed-industries/zed/pull/51876

Use `pull_request_target` for PR size check so the workflow has write permissions to manage labels on fork PRs. Safe since we don't execute any PR code here.

Failing example: https://github.com/zed-industries/zed/actions/runs/23282504031/job/67698793729?pr=48845

Release Notes:

- N/A
