### PR TITLE
agent: Add ability to duplicate threads

### DIFF
--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -1,7 +1,8 @@
 use crate::{DbThread, DbThreadMetadata, ThreadsDatabase};
 use agent_client_protocol as acp;
 use anyhow::{Result, anyhow};
-use gpui::{App, Context, Entity, Global, Task, prelude::*};
+use chrono::Utc;
+use gpui::{App, Context, Entity, Global, SharedString, Task, prelude::*};
 use util::path_list::PathList;
 
 struct GlobalThreadStore(Entity<ThreadStore>);
@@ -62,6 +63,45 @@ impl ThreadStore {
             let database = database_future.await.map_err(|err| anyhow!(err))?;
             database.save_thread(id, thread, folder_paths).await?;
             this.update(cx, |this, cx| this.reload(cx))
+        })
+    }
+
+    pub fn duplicate_thread(
+        &mut self,
+        source_id: acp::SessionId,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<(acp::SessionId, SharedString)>> {
+        let folder_paths = self
+            .thread_from_session_id(&source_id)
+            .map(|meta| meta.folder_paths.clone())
+            .unwrap_or_default();
+
+        let database_future = ThreadsDatabase::connect(cx);
+
+        cx.spawn(async move |this, cx| {
+            let database = database_future.await.map_err(|err| anyhow!(err))?;
+
+            let mut thread = database
+                .load_thread(source_id)
+                .await?
+                .ok_or_else(|| anyhow!("Thread not found"))?;
+
+            let new_id = acp::SessionId::new(uuid::Uuid::new_v4().to_string());
+
+            thread.title = SharedString::from(format!("Copy of {}", thread.title));
+            thread.updated_at = Utc::now();
+            thread.draft_prompt = None;
+            thread.ui_scroll_position = None;
+
+            let title = thread.title.clone();
+
+            database
+                .save_thread(new_id.clone(), thread, folder_paths)
+                .await?;
+
+            this.update(cx, |this, cx| this.reload(cx))?;
+
+            Ok((new_id, title))
         })
     }
 

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -328,4 +328,83 @@ mod tests {
         assert_eq!(entries[0].id, first_id);
         assert_eq!(entries[1].id, second_id);
     }
+
+    #[gpui::test]
+    async fn test_duplicate_thread_creates_copy(cx: &mut TestAppContext) {
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        cx.run_until_parked();
+
+        let original_id = session_id("thread-a");
+        let original_thread = make_thread(
+            "My Thread",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
+
+        let save_task = thread_store.update(cx, |store, cx| {
+            store.save_thread(original_id.clone(), original_thread, PathList::default(), cx)
+        });
+        save_task.await.unwrap();
+        cx.run_until_parked();
+
+        let (new_id, new_title) = thread_store
+            .update(cx, |store, cx| {
+                store.duplicate_thread(original_id.clone(), cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        assert_ne!(new_id, original_id);
+        assert_eq!(new_title.as_ref(), "Copy of My Thread");
+
+        let entries: Vec<_> = thread_store.read_with(cx, |store, _cx| store.entries().collect());
+        assert_eq!(entries.len(), 2);
+        // The duplicate has a newer updated_at, so it should sort first.
+        assert_eq!(entries[0].id, new_id);
+        assert_eq!(entries[0].title.as_ref(), "Copy of My Thread");
+        assert_eq!(entries[1].id, original_id);
+        assert_eq!(entries[1].title.as_ref(), "My Thread");
+    }
+
+    #[gpui::test]
+    async fn test_duplicate_thread_preserves_original(cx: &mut TestAppContext) {
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        cx.run_until_parked();
+
+        let original_id = session_id("thread-a");
+        let original_time = Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
+        let original_thread = make_thread("Important Chat", original_time);
+
+        let save_task = thread_store.update(cx, |store, cx| {
+            store.save_thread(original_id.clone(), original_thread, PathList::default(), cx)
+        });
+        save_task.await.unwrap();
+        cx.run_until_parked();
+
+        let (new_id, _) = thread_store
+            .update(cx, |store, cx| {
+                store.duplicate_thread(original_id.clone(), cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // Load both threads from the database and verify the original is untouched.
+        let original_loaded = thread_store
+            .update(cx, |store, cx| store.load_thread(original_id.clone(), cx))
+            .await
+            .unwrap()
+            .expect("original thread should exist");
+        let duplicate_loaded = thread_store
+            .update(cx, |store, cx| store.load_thread(new_id, cx))
+            .await
+            .unwrap()
+            .expect("duplicate thread should exist");
+
+        assert_eq!(original_loaded.title.as_ref(), "Important Chat");
+        assert_eq!(original_loaded.updated_at, original_time);
+
+        assert_eq!(duplicate_loaded.title.as_ref(), "Copy of Important Chat");
+        assert!(duplicate_loaded.updated_at > original_time);
+    }
 }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -29,7 +29,7 @@ use zed_actions::agent::{
 use crate::ui::{AcpOnboardingModal, ClaudeCodeOnboardingModal, HoldForDefault};
 use crate::{
     AddContextServer, AgentDiffPane, ConversationView, CopyThreadToClipboard, CycleStartThreadIn,
-    Follow, InlineAssistant, LoadThreadFromClipboard, NewTextThread, NewThread,
+    DuplicateThread, Follow, InlineAssistant, LoadThreadFromClipboard, NewTextThread, NewThread,
     OpenActiveThreadAsMarkdown, OpenAgentDiff, OpenHistory, ResetTrialEndUpsell, ResetTrialUpsell,
     StartThreadIn, ToggleNavigationMenu, ToggleNewThreadMenu, ToggleOptionsMenu,
     agent_configuration::{AgentConfiguration, AssistantConfigurationEvent},
@@ -303,6 +303,13 @@ pub fn init(cx: &mut App) {
                         workspace.focus_panel::<AgentPanel>(window, cx);
                         panel.update(cx, |panel, cx| {
                             panel.load_thread_from_clipboard(window, cx);
+                        });
+                    }
+                })
+                .register_action(|workspace, _: &DuplicateThread, window, cx| {
+                    if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                        panel.update(cx, |panel, cx| {
+                            panel.duplicate_thread(window, cx);
                         });
                     }
                 })
@@ -1747,6 +1754,62 @@ impl AgentPanel {
                     .detach_and_log_err(cx);
             });
         }
+    }
+
+    fn duplicate_thread(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let ActiveView::AgentThread {
+            conversation_view, ..
+        } = &self.active_view
+        else {
+            Self::show_deferred_toast(&self.workspace, "No active thread to duplicate", cx);
+            return;
+        };
+
+        let session_id = conversation_view
+            .read(cx)
+            .active_thread()
+            .map(|view| view.read(cx).thread.read(cx).session_id().clone());
+
+        let Some(session_id) = session_id else {
+            Self::show_deferred_toast(&self.workspace, "No active thread to duplicate", cx);
+            return;
+        };
+
+        let thread_store = self.thread_store.clone();
+        let workspace = self.workspace.clone();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let (new_session_id, title) = thread_store
+                .update(&mut cx.clone(), |store, cx| {
+                    store.duplicate_thread(session_id, cx)
+                })
+                .await?;
+
+            this.update_in(cx, |this, window, cx| {
+                this.open_thread(new_session_id, None, Some(title), window, cx);
+            })?;
+
+            this.update_in(cx, |_, _window, cx| {
+                if let Some(workspace) = workspace.upgrade() {
+                    workspace.update(cx, |workspace, cx| {
+                        struct ThreadDuplicatedToast;
+                        workspace.show_toast(
+                            workspace::Toast::new(
+                                workspace::notifications::NotificationId::unique::<
+                                    ThreadDuplicatedToast,
+                                >(),
+                                "Thread duplicated",
+                            )
+                            .autohide(),
+                            cx,
+                        );
+                    });
+                }
+            })?;
+
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
     }
 
     fn copy_thread_to_clipboard(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -3430,6 +3493,7 @@ impl AgentPanel {
                                             );
                                         }
                                     })
+                                    .action("Duplicate Thread", Box::new(DuplicateThread))
                                     .separator();
                             }
                         }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -109,6 +109,8 @@ actions!(
         AddContextServer,
         /// Removes the currently selected thread.
         RemoveSelectedThread,
+        /// Duplicates the current thread, creating a copy with a new session ID.
+        DuplicateThread,
         /// Starts a chat conversation with follow-up enabled.
         ChatWithFollow,
         /// Cycles to the next inline assist suggestion.


### PR DESCRIPTION
## Context

Adds a "Duplicate Thread" option to the agent panel, allowing users to clone an existing conversation thread without losing the original.

This addresses a common workflow where users run long agent conversations, hit context window limits, and want to branch off from an earlier point — but currently doing so overwrites the old conversation. With this change, users can duplicate the thread, continue in the copy, and keep the original intact for reference.

See discussion: https://github.com/zed-industries/zed/discussions/47047

## Screenshot

<img width="242" height="335" alt="Screenshot 2026-03-19 at 09 11 41" src="https://github.com/user-attachments/assets/d970b6c4-0ba3-43c2-be1d-c23003d4e80f" />

## How to Review

Small PR (~115 lines of logic + tests), three files:

1. **`crates/agent_ui/src/agent_ui.rs`** — New `DuplicateThread` action definition (2 lines)
2. **`crates/agent/src/thread_store.rs`** — Core `duplicate_thread` method on `ThreadStore`:
   loads the thread from the DB, saves a copy with a new session ID, prefixed
   title, fresh timestamp, and cleared UI state. Two tests added here.
3. **`crates/agent_ui/src/agent_panel.rs`** — Wires it up: registers the action,
   adds a `duplicate_thread` handler that calls the store method then opens the
   copy, and adds a "Duplicate Thread" entry to the ⋯ panel menu under
   "Current Thread" (next to "Regenerate Thread Title").

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added "Duplicate Thread" option to the agent panel menu, allowing users to
  clone an existing conversation thread while preserving the original.
