### PR TITLE
project: Fix didSave not sent for servers using TextDocumentSyncKind

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -14350,8 +14350,16 @@ fn include_text(server: &lsp::LanguageServer) -> Option<bool> {
                 Some(save_options.include_text.unwrap_or(false))
             }
         },
-        // We do not have any save info. Kind affects didChange only.
-        lsp::TextDocumentSyncCapability::Kind(_) => None,
+        // Kind only specifies how didChange is synced, but for backwards compatibility
+        // with servers that don't declare explicit save options, send didSave without text
+        // for any non-None sync kind.
+        lsp::TextDocumentSyncCapability::Kind(kind) => {
+            if *kind != lsp::TextDocumentSyncKind::NONE {
+                Some(false)
+            } else {
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #51722

PR #36441 changed `include_text` to return `None` for the `TextDocumentSyncCapability::Kind` arm, reasoning that `Kind` only affects `didChange`. However, servers using this legacy form (like the Elle LSP) never declared explicit `SaveOptions` and relied on receiving `textDocument/didSave`. This restores that behavior by sending `didSave` without text for any non-`NONE` sync kind.

Release Notes:

- Fixed `textDocument/didSave` not being sent to language servers that declare `TextDocumentSyncKind` without explicit save options.