### PR TITLE
gpui_linux: Set _NET_WM_NAME on X11 window creation to support UTF-8 titles

### DIFF
--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -542,6 +542,16 @@ impl X11WindowState {
                         title.as_bytes(),
                     ),
                 )?;
+                check_reply(
+                    || "X11 ChangeProperty8 on _NET_WM_NAME failed.",
+                    xcb.change_property8(
+                        xproto::PropMode::REPLACE,
+                        x_window,
+                        atoms._NET_WM_NAME,
+                        atoms.UTF8_STRING,
+                        title.as_bytes(),
+                    ),
+                )?;
             }
 
             if params.kind == WindowKind::PopUp {


### PR DESCRIPTION
## Context

On Linux X11, the Settings window title was displayed as garbled text
("Zed â██ Settings") in taskbars and window previews due to incorrect
character encoding.

**Root cause:** During X11 window creation, only `WM_NAME` was set with
type `STRING` (Latin-1). The em-dash character (U+2014) in "Zed — Settings"
is a multi-byte UTF-8 sequence (`0xE2 0x80 0x94`), which Latin-1 cannot
represent correctly.

**Fix:** Also set `_NET_WM_NAME` with type `UTF8_STRING` during window
creation, consistent with how `set_title()` already handles subsequent
title updates.

Fixes #51871

<img width="688" height="599" alt="image" src="https://github.com/user-attachments/assets/e5b35b02-aebb-4d6b-bef3-ac83dda4095a" />

<img width="767" height="593" alt="image" src="https://github.com/user-attachments/assets/47d02a86-77de-461f-a70f-b83e58aca8ac" />

Release Notes:

- Fixed window title displaying garbled characters (e.g. "Zed â██ Settings") on Linux X11 due to missing UTF-8 encoding for the `_NET_WM_NAME` property.
