### PR TITLE
Fix the inability to click the highlight tree view

### DIFF
--- a/crates/language_tools/src/highlights_tree_view.rs
+++ b/crates/language_tools/src/highlights_tree_view.rs
@@ -209,20 +209,32 @@ impl HighlightsTreeView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(editor) = active_item
-            .filter(|item| item.item_id() != cx.entity_id())
-            .and_then(|item| item.downcast::<Editor>())
-        else {
-            self.clear(cx);
-            return;
+        let active_editor = match active_item {
+            Some(active_item) => {
+                if active_item.item_id() == cx.entity_id() {
+                    return;
+                } else {
+                    match active_item.downcast::<Editor>() {
+                        Some(active_editor) => active_editor,
+                        None => {
+                            self.clear(cx);
+                            return;
+                        }
+                    }
+                }
+            }
+            None => {
+                self.clear(cx);
+                return;
+            }
         };
 
         let is_different_editor = self
             .editor
             .as_ref()
-            .is_none_or(|state| state.editor != editor);
+            .is_none_or(|state| state.editor != active_editor);
         if is_different_editor {
-            self.set_editor(editor, window, cx);
+            self.set_editor(active_editor, window, cx);
         }
     }
 


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/14de9b93-d1d0-4ac8-b51d-a0fe80543ca0


After:

https://github.com/user-attachments/assets/ec27b342-5a3b-4f5d-b28a-0db4256518ef



Release Notes:

- Fixed highlight tree view usability
