### PR TITLE
client: Upgrade tiny_http (0.8.2 -> 0.12.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17715,15 +17715,14 @@ dependencies = [
 
 [[package]]
 name = "tiny_http"
-version = "0.8.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce51b50006056f590c9b7c3808c3bd70f0d1101666629713866c227d6e58d39"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
 dependencies = [
  "ascii",
- "chrono",
  "chunked_transfer",
+ "httpdate",
  "log",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -717,7 +717,7 @@ time = { version = "0.3", features = [
     "formatting",
     "local-offset",
 ] }
-tiny_http = "0.8"
+tiny_http = "0.12"
 tokio = { version = "1" }
 tokio-socks = { version = "0.5.2", default-features = false, features = [
     "futures-io",

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1388,7 +1388,11 @@ impl Client {
                     // Start an HTTP server to receive the redirect from Zed's sign-in page.
                     let server = tiny_http::Server::http("127.0.0.1:0")
                         .map_err(|e| anyhow!(e).context("failed to bind callback port"))?;
-                    let port = server.server_addr().port();
+                    let port = server
+                        .server_addr()
+                        .to_ip()
+                        .context("server not bound to a TCP address")?
+                        .port();
 
                     // Open the Zed sign-in page in the user's browser, with query parameters that indicate
                     // that the user is signing in from a Zed app running on the same device.


### PR DESCRIPTION
Used only for the sign in callback. I've made sure it still works as expected with a local build.

Release Notes:

- N/A
