### PR TITLE
git_ui: Hide status icon when status_style is set to label_color

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5157,7 +5157,9 @@ impl GitPanel {
                         }),
                 )
             })
-            .child(git_status_icon(status))
+            .when(status_style != StatusStyle::LabelColor, |el| {
+                el.child(git_status_icon(status))
+            })
             .map(|this| {
                 if tree_view {
                     this.pl(px(depth as f32 * TREE_INDENT)).child(


### PR DESCRIPTION
## Context

When `git_panel.status_style` is set to `label_color`, the git panel 
should indicate file status through text color only, without showing 
status icons. However, the icons were still being rendered regardless 
of this setting.

The root cause: `git_status_icon(status)` was called unconditionally 
in `render_status_entry`, with no check against the current 
`status_style` value.

Closes #51714

## How to Review

Single change in `crates/git_ui/src/git_panel.rs` — 
`render_status_entry` function. The icon render call is now wrapped 
in `.when(status_style != StatusStyle::LabelColor, ...)`.

Release Notes:

- Fixed git panel status icons still showing when `git_panel.status_style` 
  is set to `label_color`

Bug:
<img width="2559" height="1357" alt="image" src="https://github.com/user-attachments/assets/3cad9f96-8b5c-4554-8b9f-f931026bdfe1" />

Fix:
<img width="1512" height="801" alt="image" src="https://github.com/user-attachments/assets/99f36d11-a8b2-412a-ab73-18200f6594d2" />
