### PR TITLE
git_ui: Fix diff clipboard adding newline when buffer has no trailing newline

### DIFF
--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -88,7 +88,12 @@ impl TextDiffView {
         let source_buffer_snapshot = source_buffer.read(cx).snapshot();
         let mut clipboard_text = diff_data.clipboard_text.clone();
 
-        if !clipboard_text.ends_with("\n") {
+        // Only append a newline to the clipboard text if the expanded selection
+        // ends at a line boundary (column 0). When the selection includes the
+        // last line of a file without a trailing newline, the selection can't be
+        // extended to the next line, so we shouldn't add a newline to the
+        // clipboard content either — otherwise the diff will never be clean.
+        if expanded_selection_range.end.column == 0 && !clipboard_text.ends_with("\n") {
             clipboard_text.push_str("\n");
         }
 
@@ -617,6 +622,24 @@ mod tests {
             ),
             "Clipboard ↔ text.txt @ L1:1-7",
             &format!("Clipboard ↔ {} @ L1:1-7", path!("test/text.txt")),
+            cx,
+        )
+        .await;
+    }
+
+    #[gpui::test]
+    async fn test_diffing_clipboard_no_trailing_newline_full_buffer(cx: &mut TestAppContext) {
+        base_test(
+            path!("/test"),
+            path!("/test/text.txt"),
+            "hello world",
+            "hello worldˇ",
+            &unindent(
+                "
+                  ˇhello world",
+            ),
+            "Clipboard ↔ text.txt @ L1:1-12",
+            &format!("Clipboard ↔ {} @ L1:1-12", path!("test/text.txt")),
             cx,
         )
         .await;


### PR DESCRIPTION
## Summary

The "diff clipboard with selection" command always appends a `\n` to the clipboard content to match the line-extended selection. But when the selection includes the last line of a file that has no trailing newline, the selection can't actually be extended further. The `\n` still gets added to the clipboard though, so the diff can never be clean.

This fixes it by only appending the newline when the selection was actually extended to a line boundary.

Also adds a test for this case.

Closes #49204

## Test plan

1. Open a buffer with no trailing newline (e.g. just `hello world`)
2. Copy the buffer contents
3. Run "editor: diff clipboard with selection"
4. Verify the diff shows no differences
5. Repeat with a buffer that has a trailing newline and verify it still works as before