### PR TITLE
Fix guided tour false positive in PR size check

### DIFF
--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -144,7 +144,11 @@ jobs:
 
               const alreadyCommented = comments.some(c => c.body.includes(MARKER));
               if (!alreadyCommented) {
-                const prBody = context.payload.pull_request.body || '';
+                // Strip HTML comments before checking — the PR template's
+                // placeholder text contains "guided tour" and "read in order"
+                // which causes false positives.
+                const prBody = (context.payload.pull_request.body || '')
+                  .replace(/<!--[\s\S]*?-->/g, '');
                 const guidedTourPresent = /how to review|guided tour|read.*in.*order/i.test(prBody);
 
                 let body = `${MARKER}\n`;


### PR DESCRIPTION
## Context

The size check workflow's guided tour detection matches text inside HTML comment placeholders in the PR template (e.g., `<!-- provide a guided tour — numbered list of files/commits to read in order -->`), producing false positives like the one on #51957.

Fix: strip `<!-- -->` comments from the PR body before running the regex.

## How to Review

- Single file: `.github/workflows/pr-size-check.yml`, lines 148-151
- The `.replace(/<!--[\s\S]*?-->/g, '')` runs in `actions/github-script` JS, not shell

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A