### PR TITLE
Improve guided tour detection to use structural check

### DIFF
--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -144,12 +144,14 @@ jobs:
 
               const alreadyCommented = comments.some(c => c.body.includes(MARKER));
               if (!alreadyCommented) {
-                // Strip HTML comments before checking — the PR template's
-                // placeholder text contains "guided tour" and "read in order"
-                // which causes false positives.
-                const prBody = (context.payload.pull_request.body || '')
-                  .replace(/<!--[\s\S]*?-->/g, '');
-                const guidedTourPresent = /how to review|guided tour|read.*in.*order/i.test(prBody);
+                // Check if the author wrote content in the "How to Review" section.
+                // Extract the section, strip HTML comment placeholders from the
+                // template, and check for any remaining non-whitespace content.
+                const rawBody = context.payload.pull_request.body || '';
+                const howToReview = rawBody.match(/## How to Review\s*\n([\s\S]*?)(?=\n## |$)/i);
+                const guidedTourPresent = howToReview
+                  ? howToReview[1].replace(/<!--[\s\S]*?-->/g, '').trim().length > 0
+                  : false;
 
                 let body = `${MARKER}\n`;
                 body += `### :straight_ruler: PR Size: **${totalChanges} lines changed** (${sizeLabel})\n\n`;
@@ -158,7 +160,7 @@ jobs:
                 body += `- Ensure the PR description includes a **guided tour** in the "How to Review" section so reviewers know where to start\n`;
 
                 if (guidedTourPresent) {
-                  body += `\n:white_check_mark: Guided tour detected — thank you!\n`;
+                  body += `\n:white_check_mark: "How to Review" section appears to include guidance — thank you!\n`;
                 }
 
                 await github.rest.issues.createComment({


### PR DESCRIPTION
## Context

Follow-up to #51964. The previous fix (stripping HTML comments) still had a false positive: the `## How to Review` heading itself matched the `how to review` alternative in the regex. Every PR using the template would trigger the "guided tour detected" message.

Replace the regex with structural detection: extract the "How to Review" section, strip template placeholders, and check if the author actually wrote content there. Also softens the confirmation message to "appears to include guidance."

## How to Review

- Single file: `.github/workflows/pr-size-check.yml`, lines 147-154
- The `rawBody.match(...)` extracts content between `## How to Review` and the next `##` heading
- Confirmed: PR #51957's body returns `false`, a PR with actual content returns `true`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A