### PR TITLE
gpui: Treat typographic apostrophes as word characters for line wrapping

### DIFF
--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -242,7 +242,7 @@ impl LineWrapper {
         // Some other known special characters that should be treated as word characters,
         // e.g. `a-b`, `var_name`, `I'm`/`won’t`, '@mention`, `#hashtag`, `100%`, `3.1415`,
         // `2^3`, `a~b`, `a=1`, `Self::new`, etc.
-        matches!(c, '-' | '_' | '.' | '\'' | '\u{2018}' | '\u{2019}' | '$' | '%' | '@' | '#' | '^' | '~' | ',' | '=' | ':') ||
+        matches!(c, '-' | '_' | '.' | '\'' | '’' | '‘' | '$' | '%' | '@' | '#' | '^' | '~' | ',' | '=' | ':') ||
         // `⋯` character is special used in Zed, to keep this at the end of the line.
         matches!(c, '⋯')
     }
@@ -838,8 +838,8 @@ mod tests {
         assert_word("a=1");
         assert_word("Self::is_word_char");
         assert_word("more⋯");
-        assert_word("won\u{2019}t"); // won’t
-        assert_word("\u{2018}twas"); // ‘twas
+        assert_word("won’t");
+        assert_word("‘twas");
 
         // Space
         assert_not_word("foo bar");

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -240,9 +240,9 @@ impl LineWrapper {
         matches!(c, '\u{0980}'..='\u{09FF}') ||
 
         // Some other known special characters that should be treated as word characters,
-        // e.g. `a-b`, `var_name`, `I'm`, '@mention`, `#hashtag`, `100%`, `3.1415`,
+        // e.g. `a-b`, `var_name`, `I'm`/`won’t`, '@mention`, `#hashtag`, `100%`, `3.1415`,
         // `2^3`, `a~b`, `a=1`, `Self::new`, etc.
-        matches!(c, '-' | '_' | '.' | '\'' | '$' | '%' | '@' | '#' | '^' | '~' | ',' | '=' | ':') ||
+        matches!(c, '-' | '_' | '.' | '\'' | '\u{2018}' | '\u{2019}' | '$' | '%' | '@' | '#' | '^' | '~' | ',' | '=' | ':') ||
         // `⋯` character is special used in Zed, to keep this at the end of the line.
         matches!(c, '⋯')
     }
@@ -838,6 +838,8 @@ mod tests {
         assert_word("a=1");
         assert_word("Self::is_word_char");
         assert_word("more⋯");
+        assert_word("won\u{2019}t"); // won’t
+        assert_word("\u{2018}twas"); // ‘twas
 
         // Space
         assert_not_word("foo bar");


### PR DESCRIPTION
The line wrapper's `is_word_char` function included the ASCII apostrophe (U+0027) but not the typographic right single quotation mark `'` (U+2019) or left single quotation mark `'` (U+2018). When Markdown rendering produces curly quotes, words like `won't` were being split at the apostrophe during line wrapping, producing `won` at the end of one line and `'t` at the start of the next.

This adds both typographic quote characters to `is_word_char` so they are treated the same as the ASCII apostrophe.

Release Notes:

- Fixed line wrapping splitting words at typographic apostrophes (e.g. "won't" breaking as "won" / "'t").