### PR TITLE
editor: Preserve initiating selection in select all matches

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16088,10 +16088,13 @@ impl Editor {
 
         let mut new_selections = Vec::new();
 
-        let reversed = self
-            .selections
-            .oldest::<MultiBufferOffset>(&display_map)
-            .reversed;
+        let initial_selection = self.selections.oldest::<MultiBufferOffset>(&display_map);
+        let initial_range = if initial_selection.reversed {
+            initial_selection.end..initial_selection.start
+        } else {
+            initial_selection.start..initial_selection.end
+        };
+        let reversed = initial_selection.reversed;
         let buffer = display_map.buffer_snapshot();
         let query_matches = select_next_state
             .query
@@ -16105,13 +16108,19 @@ impl Editor {
                 MultiBufferOffset(query_match.start())..MultiBufferOffset(query_match.end())
             };
 
-            if !select_next_state.wordwise
-                || (!buffer.is_inside_word(offset_range.start, None)
-                    && !buffer.is_inside_word(offset_range.end, None))
+            if select_next_state.wordwise
+                && (buffer.is_inside_word(offset_range.start, None)
+                    || buffer.is_inside_word(offset_range.end, None))
             {
-                new_selections.push(offset_range.start..offset_range.end);
+                continue;
+            }
+
+            if offset_range != initial_range {
+                new_selections.push(offset_range);
             }
         }
+
+        new_selections.push(initial_range);
 
         select_next_state.done = true;
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9850,6 +9850,116 @@ async fn test_select_all_matches_does_not_scroll(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_select_all_matches_edit_keeps_scroll_on_initiating_selection(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let large_body_1 = "\nd".repeat(200);
+    let large_body_2 = "\ne".repeat(200);
+
+    cx.set_state(&format!(
+        "abc\nabc{large_body_1} «ˇa»bc{large_body_2}\nefabc\nabc"
+    ));
+    let initial_scroll_position = cx.update_editor(|editor, _, cx| {
+        let scroll_position = editor.scroll_position(cx);
+        assert!(
+            scroll_position.y > 0.0,
+            "Initial selection should start in the middle of the document"
+        );
+        scroll_position
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor
+            .select_all_matches(&SelectAllMatches, window, cx)
+            .unwrap();
+    });
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("x", window, cx);
+    });
+
+    let scroll_position_after_edit = cx.update_editor(|editor, _, cx| editor.scroll_position(cx));
+    assert_eq!(
+        initial_scroll_position, scroll_position_after_edit,
+        "Editing after select all matches should keep the initiating selection as the autoscroll target"
+    );
+}
+
+#[gpui::test]
+async fn test_select_all_matches_edit_keeps_scroll_on_reversed_initiating_selection(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let large_body_1 = "\nd".repeat(200);
+    let large_body_2 = "\ne".repeat(200);
+
+    cx.update_editor(|editor, window, cx| {
+        editor.set_text(
+            format!("abc\nabc{large_body_1} abc{large_body_2}\nefabc\nabc"),
+            window,
+            cx,
+        );
+    });
+    let target_point = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.display_snapshot(cx);
+        let target_offset = editor
+            .buffer()
+            .read(cx)
+            .read(cx)
+            .text_for_range(MultiBufferOffset(0)..snapshot.buffer_snapshot().len())
+            .collect::<String>()
+            .match_indices("abc")
+            .nth(2)
+            .map(|(offset, _)| MultiBufferOffset(offset))
+            .expect("third abc match should exist");
+        target_offset.to_point(snapshot.buffer_snapshot())
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.change_selections(
+            SelectionEffects::scroll(Autoscroll::fit()),
+            window,
+            cx,
+            |selections| {
+                selections.select_ranges([
+                    Point::new(target_point.row, target_point.column + 1)..target_point
+                ]);
+            },
+        );
+    });
+
+    let initial_scroll_position = cx.update_editor(|editor, _, cx| {
+        let scroll_position = editor.scroll_position(cx);
+        assert!(
+            scroll_position.y > 0.0,
+            "Reversed initiating selection should still start in the middle of the document"
+        );
+        scroll_position
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor
+            .select_all_matches(&SelectAllMatches, window, cx)
+            .unwrap();
+    });
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("x", window, cx);
+    });
+
+    let scroll_position_after_edit = cx.update_editor(|editor, _, cx| editor.scroll_position(cx));
+    assert_eq!(
+        initial_scroll_position, scroll_position_after_edit,
+        "Editing after select all matches should preserve a reversed initiating selection as newest"
+    );
+}
+
+#[gpui::test]
 async fn test_undo_format_scrolls_to_last_edit_pos(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Closes #32894

## Summary
 • preserve the initiating selection as the newest selection in `select_all_matches`
 • keep `Autoscroll::fit()` semantics unchanged and fix the bug at the selection ordering source instead
 • avoid unnecessary API expansion, editor state, or broader autoscroll changes
 • add regression coverage for both forward and reversed initiating selections when editing after `Select All Matches`

## Verification
 • `cargo fmt --all -- --check`
 • `./script/clippy -p editor`
 • `cargo test -p editor select_all_matches_does_not_scroll`
 • `cargo test -p editor select_all_matches_edit_keeps_scroll_on_initiating_selection`
 • `cargo test -p editor select_all_matches_edit_keeps_scroll_on_reversed_initiating_selection`

## Manual
 • Repro'd the issue with the caret on the middle match, ran `Select All Matches`, typed, and confirmed the viewport stayed anchored to the initiating match instead of jumping to the last occurrence.
 • Repeated with a reversed selection over the initiating match and confirmed the same behavior.
 • Confirmed the existing caret only `wordwise = true` behavior is unchanged: substring matches like `efabc` are excluded unless `abc` is explicitly selected first.

Release Notes:
 • Fixed `Select All Matches` so editing stays anchored to the initiating match instead of scrolling to the last occurrence.