### PR TITLE
extensions_ui: Remove upsell banners for Bash

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -232,7 +232,6 @@ enum Feature {
     ExtensionTailwind,
     ExtensionTy,
     Git,
-    LanguageBash,
     LanguageC,
     LanguageCpp,
     LanguageGo,
@@ -262,7 +261,6 @@ fn keywords_by_feature() -> &'static BTreeMap<Feature, Vec<&'static str>> {
             (Feature::ExtensionTailwind, vec!["tail", "tailwind"]),
             (Feature::ExtensionTy, vec!["ty"]),
             (Feature::Git, vec!["git"]),
-            (Feature::LanguageBash, vec!["sh", "bash"]),
             (Feature::LanguageC, vec!["c", "clang"]),
             (Feature::LanguageCpp, vec!["c++", "cpp", "clang"]),
             (Feature::LanguageGo, vec!["go", "golang"]),
@@ -1640,12 +1638,6 @@ impl ExtensionsPage {
                     "Zed comes with basic Git support—more features are coming in the future."
                         .into(),
                     "https://zed.dev/docs/git".into(),
-                    false,
-                    cx,
-                ),
-                Feature::LanguageBash => self.render_feature_upsell_banner(
-                    "Shell support is built-in to Zed!".into(),
-                    "https://zed.dev/docs/languages/bash".into(),
                     false,
                     cx,
                 ),


### PR DESCRIPTION
## Context

Closes #51917

Zed's built-in support only covers Tree-sitter highlighting for Bash, with no language server included. An extension is still required to get full language support, so we should not show banners to users who want to install an extension for it, because this is truly needed.

## How to Review

Removed the `LanguageBash` related code blocks in `crates/extensions_ui/src/extensions_ui.rs`.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A or Added/Fixed/Improved ...
