### PR TITLE
Trigger buffer refresh when buffer is updated externally in remote session

### DIFF
--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -464,12 +464,13 @@ impl LocalBufferStore {
         cx: &mut Context<BufferStore>,
     ) {
         let snapshot = worktree_handle.read(cx).snapshot();
-        for (path, entry_id, _) in changes {
+        for (path, entry_id, path_change) in changes {
             Self::local_worktree_entry_changed(
                 this,
                 *entry_id,
                 path,
                 worktree_handle,
+                *path_change,
                 &snapshot,
                 cx,
             );
@@ -481,6 +482,7 @@ impl LocalBufferStore {
         entry_id: ProjectEntryId,
         path: &Arc<RelPath>,
         worktree: &Entity<worktree::Worktree>,
+        path_change: PathChange,
         snapshot: &worktree::Snapshot,
         cx: &mut Context<BufferStore>,
     ) -> Option<()> {
@@ -550,7 +552,12 @@ impl LocalBufferStore {
                 }
             };
 
-            if new_file == *old_file {
+            let force_reload_needed_for_updated_path = matches!(
+                path_change,
+                PathChange::Updated | PathChange::AddedOrUpdated
+            ) && new_file == *old_file;
+
+            if !force_reload_needed_for_updated_path && new_file == *old_file {
                 return None;
             }
 
@@ -594,7 +601,15 @@ impl LocalBufferStore {
                     .ok();
             }
 
+            let new_file_disk_state = new_file.disk_state;
             buffer.file_updated(Arc::new(new_file), cx);
+            if force_reload_needed_for_updated_path
+                && !buffer.is_dirty()
+                && matches!(new_file_disk_state, DiskState::Present { .. })
+            {
+                cx.emit(BufferEvent::ReloadNeeded);
+                cx.notify();
+            }
             Some(events)
         })?;
 

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1145,6 +1145,14 @@ impl BufferStore {
         cx: &mut Context<Self>,
     ) {
         match event {
+            BufferEvent::ReloadNeeded => {
+                if let Some((downstream_client, _)) = self.downstream_client.as_ref()
+                    && !downstream_client.is_via_collab()
+                {
+                    self.reload_buffers([buffer.clone()].into_iter().collect(), true, cx)
+                        .detach_and_log_err(cx);
+                }
+            }
             BufferEvent::FileHandleChanged => {
                 self.buffer_changed_file(buffer, cx);
             }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -5848,6 +5848,116 @@ async fn test_dirty_buffer_reloads_after_undo(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_clean_buffer_reloads_on_unchanged_metadata(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "file.txt": "content_a",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/file.txt"), cx))
+        .await
+        .unwrap();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "content_a");
+        assert!(!buffer.is_dirty());
+    });
+
+    // Freeze mtime so the next write produces the same file metadata.
+    let metadata = fs
+        .metadata(path!("/dir/file.txt").as_ref())
+        .await
+        .unwrap()
+        .unwrap();
+    fs.set_next_mtime(metadata.mtime.timestamp_for_user());
+
+    // External tool writes new content with the same byte length.
+    // atomic_write changes the inode (so the worktree detects the entry
+    // changed and emits PathChange::Updated), but because we froze mtime
+    // and the size is identical, the File comparison yields equal — exactly
+    // the scenario that occurs on filesystems with coarse mtime granularity.
+    fs.atomic_write(
+        PathBuf::from(path!("/dir/file.txt")),
+        "content_b".to_string(),
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(
+            buffer.text(),
+            "content_b",
+            "clean buffer should reload even when file metadata is unchanged"
+        );
+        assert!(!buffer.is_dirty());
+    });
+}
+
+#[gpui::test]
+async fn test_dirty_buffer_skips_reload_on_unchanged_metadata(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "file.txt": "content_a",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/file.txt"), cx))
+        .await
+        .unwrap();
+
+    // User makes an edit, making the buffer dirty.
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "user: ")], None, cx);
+    });
+
+    buffer.read_with(cx, |buffer, _| {
+        assert!(buffer.is_dirty());
+        assert_eq!(buffer.text(), "user: content_a");
+    });
+
+    // Freeze mtime and write externally with same byte length.
+    let metadata = fs
+        .metadata(path!("/dir/file.txt").as_ref())
+        .await
+        .unwrap()
+        .unwrap();
+    fs.set_next_mtime(metadata.mtime.timestamp_for_user());
+
+    fs.atomic_write(
+        PathBuf::from(path!("/dir/file.txt")),
+        "content_b".to_string(),
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(
+            buffer.text(),
+            "user: content_a",
+            "dirty buffer should not reload when file metadata is unchanged"
+        );
+        assert!(buffer.is_dirty());
+    });
+}
+
+#[gpui::test]
 async fn test_buffer_file_changes_on_disk(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -367,17 +367,26 @@ impl HeadlessProject {
         event: &BufferEvent,
         cx: &mut Context<Self>,
     ) {
-        if let BufferEvent::Operation {
-            operation,
-            is_local: true,
-        } = event
-        {
-            cx.background_spawn(self.session.request(proto::UpdateBuffer {
-                project_id: REMOTE_SERVER_PROJECT_ID,
-                buffer_id: buffer.read(cx).remote_id().to_proto(),
-                operations: vec![serialize_operation(operation)],
-            }))
-            .detach()
+        match event {
+            BufferEvent::ReloadNeeded => {
+                self.buffer_store
+                    .update(cx, |buffer_store, cx| {
+                        buffer_store.reload_buffers([buffer.clone()].into_iter().collect(), true, cx)
+                    })
+                    .detach_and_log_err(cx);
+            }
+            BufferEvent::Operation {
+                operation,
+                is_local: true,
+            } => {
+                cx.background_spawn(self.session.request(proto::UpdateBuffer {
+                    project_id: REMOTE_SERVER_PROJECT_ID,
+                    buffer_id: buffer.read(cx).remote_id().to_proto(),
+                    operations: vec![serialize_operation(operation)],
+                }))
+                .detach()
+            }
+            _ => {}
         }
     }
 

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -368,13 +368,6 @@ impl HeadlessProject {
         cx: &mut Context<Self>,
     ) {
         match event {
-            BufferEvent::ReloadNeeded => {
-                self.buffer_store
-                    .update(cx, |buffer_store, cx| {
-                        buffer_store.reload_buffers([buffer.clone()].into_iter().collect(), true, cx)
-                    })
-                    .detach_and_log_err(cx);
-            }
             BufferEvent::Operation {
                 operation,
                 is_local: true,


### PR DESCRIPTION
## Context

  When editing a project over SSH remote sessions, external tools (such as
  terminal-based AI agents) can modify files on the remote server. The file
  watcher detects the change and reports a `PathChange::Updated` event, but
  because filesystem timestamp granularity can be coarse (e.g. 1-second on
  ext4), the new file metadata (mtime, size) often matches the old metadata.
  The existing code short-circuits with an early return when `new_file == old_file`,
  so the buffer never reloads and the editor shows stale content until the user
  manually closes and reopens the file or reloads the window.

  ## Solution

  Thread the `PathChange` into `local_worktree_entry_changed` so it can detect
  when the watcher reports `Updated`/`AddedOrUpdated` even though metadata looks
  unchanged. In that case, force-emit `BufferEvent::ReloadNeeded` (an existing
  event variant) to trigger an async buffer reload, but only when:

  - The buffer is not dirty (never overwrite unsaved user edits)
  - The file is present on disk (not deleted)

  Handle this event in `BufferStore::on_buffer_event` for non-collab downstream
  clients (i.e. SSH remote server connections). The existing handler in
  `Project::on_buffer_event` already covers the local project case.

  ## How to Review

  1. Start in `local_worktree_entry_changed` in `buffer_store.rs` — the
     `force_reload_needed_for_updated_path` flag and its two use sites are the
     core change.
  2. Then look at the `ReloadNeeded` arm in `BufferStore::on_buffer_event` — it
     mirrors the existing pattern in `Project::on_buffer_event` (project.rs:3648).
  3. The `headless_project.rs` change is a cosmetic `if let` → `match` refactor
     with no behavioral change.
  4. Verify there is no double-reload path (there isn't — see analysis above).

  ## Self-Review Checklist

  - [x] I've reviewed my own diff for quality, security, and reliability
  - [ ] Unsafe blocks (if any) have justifying comments
  - [ ] The content is consistent with the UI/UX checklist
  - [ ] Tests cover the new/changed behavior
  - [x] Performance impact has been considered and is acceptable

  Release Notes:

  - Fixed remote SSH buffers not refreshing when files are modified externally by terminal tools or AI agents