### PR TITLE
Reload remote buffers on external file changes with unchanged metadata

### DIFF
--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -464,12 +464,13 @@ impl LocalBufferStore {
         cx: &mut Context<BufferStore>,
     ) {
         let snapshot = worktree_handle.read(cx).snapshot();
-        for (path, entry_id, _) in changes {
+        for (path, entry_id, path_change) in changes {
             Self::local_worktree_entry_changed(
                 this,
                 *entry_id,
                 path,
                 worktree_handle,
+                *path_change,
                 &snapshot,
                 cx,
             );
@@ -481,6 +482,7 @@ impl LocalBufferStore {
         entry_id: ProjectEntryId,
         path: &Arc<RelPath>,
         worktree: &Entity<worktree::Worktree>,
+        path_change: PathChange,
         snapshot: &worktree::Snapshot,
         cx: &mut Context<BufferStore>,
     ) -> Option<()> {
@@ -550,7 +552,12 @@ impl LocalBufferStore {
                 }
             };
 
-            if new_file == *old_file {
+            let force_reload_needed_for_updated_path = matches!(
+                path_change,
+                PathChange::Updated | PathChange::AddedOrUpdated
+            ) && new_file == *old_file;
+
+            if !force_reload_needed_for_updated_path && new_file == *old_file {
                 return None;
             }
 
@@ -594,7 +601,15 @@ impl LocalBufferStore {
                     .ok();
             }
 
+            let new_file_disk_state = new_file.disk_state;
             buffer.file_updated(Arc::new(new_file), cx);
+            if force_reload_needed_for_updated_path
+                && !buffer.is_dirty()
+                && matches!(new_file_disk_state, DiskState::Present { .. })
+            {
+                cx.emit(BufferEvent::ReloadNeeded);
+                cx.notify();
+            }
             Some(events)
         })?;
 
@@ -1145,6 +1160,14 @@ impl BufferStore {
         cx: &mut Context<Self>,
     ) {
         match event {
+            BufferEvent::ReloadNeeded => {
+                if let Some((downstream_client, _)) = self.downstream_client.as_ref()
+                    && !downstream_client.is_via_collab()
+                {
+                    self.reload_buffers([buffer.clone()].into_iter().collect(), true, cx)
+                        .detach_and_log_err(cx);
+                }
+            }
             BufferEvent::FileHandleChanged => {
                 self.buffer_changed_file(buffer, cx);
             }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -5848,6 +5848,116 @@ async fn test_dirty_buffer_reloads_after_undo(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_clean_buffer_reloads_on_unchanged_metadata(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "file.txt": "content_a",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/file.txt"), cx))
+        .await
+        .unwrap();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "content_a");
+        assert!(!buffer.is_dirty());
+    });
+
+    // Freeze mtime so the next write produces the same file metadata.
+    let metadata = fs
+        .metadata(path!("/dir/file.txt").as_ref())
+        .await
+        .unwrap()
+        .unwrap();
+    fs.set_next_mtime(metadata.mtime.timestamp_for_user());
+
+    // External tool writes new content with the same byte length.
+    // atomic_write changes the inode (so the worktree detects the entry
+    // changed and emits PathChange::Updated), but because we froze mtime
+    // and the size is identical, the File comparison yields equal — exactly
+    // the scenario that occurs on filesystems with coarse mtime granularity.
+    fs.atomic_write(
+        PathBuf::from(path!("/dir/file.txt")),
+        "content_b".to_string(),
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(
+            buffer.text(),
+            "content_b",
+            "clean buffer should reload even when file metadata is unchanged"
+        );
+        assert!(!buffer.is_dirty());
+    });
+}
+
+#[gpui::test]
+async fn test_dirty_buffer_skips_reload_on_unchanged_metadata(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "file.txt": "content_a",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/file.txt"), cx))
+        .await
+        .unwrap();
+
+    // User makes an edit, making the buffer dirty.
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "user: ")], None, cx);
+    });
+
+    buffer.read_with(cx, |buffer, _| {
+        assert!(buffer.is_dirty());
+        assert_eq!(buffer.text(), "user: content_a");
+    });
+
+    // Freeze mtime and write externally with same byte length.
+    let metadata = fs
+        .metadata(path!("/dir/file.txt").as_ref())
+        .await
+        .unwrap()
+        .unwrap();
+    fs.set_next_mtime(metadata.mtime.timestamp_for_user());
+
+    fs.atomic_write(
+        PathBuf::from(path!("/dir/file.txt")),
+        "content_b".to_string(),
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(
+            buffer.text(),
+            "user: content_a",
+            "dirty buffer should not reload when file metadata is unchanged"
+        );
+        assert!(buffer.is_dirty());
+    });
+}
+
+#[gpui::test]
 async fn test_buffer_file_changes_on_disk(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
When an external tool modifies a file over SSH, the file watcher reports PathChange::Updated but filesystem timestamp granularity can cause the file metadata (mtime, size) to appear unchanged. Previously, the buffer store would short-circuit and never reload the buffer.

Emit BufferEvent::ReloadNeeded when the watcher reports an update for a clean buffer whose metadata is unchanged. Handle this event in BufferStore::on_buffer_event for non-collab downstream clients to trigger an async reload from disk.

## Context

On SSH/NFS filesystems with coarse mtime granularity (often 1-second resolution), an external tool like a formatter or code generator can write new content where the mtime lands in the same tick and the byte length doesn't change. The file watcher still picks up the inode change and reports `PathChange::Updated`, but `local_worktree_entry_changed` compares the old and new `File` structs, finds them equal, and bails out without reloading. The buffer just shows stale content.

This PR threads `PathChange` into `local_worktree_entry_changed` so it can tell the difference between a real watcher update and a no-op. When the path change is `Updated` or `AddedOrUpdated`, the metadata matches, and the buffer is clean, it emits `BufferEvent::ReloadNeeded`. The handler in `BufferStore::on_buffer_event` picks this up for non-collab downstream clients and triggers an async reload from disk. Dirty buffers are left alone so we don't blow away user edits.

## How to Review

Two files:

1. **`crates/project/src/buffer_store.rs`** - The core change. The `force_reload_needed_for_updated_path` flag in `local_worktree_entry_changed` (lines 555-561) and the `ReloadNeeded` emission (lines 606-612) are the interesting parts. Also check the new `BufferEvent::ReloadNeeded` arm in `on_buffer_event` (lines 1163-1169), specifically the `!downstream_client.is_via_collab()` guard.
2. **`crates/project/tests/integration/project_tests.rs`** - Two new tests. `test_clean_buffer_reloads_on_unchanged_metadata` covers the happy path (clean buffer reloads), `test_dirty_buffer_skips_reload_on_unchanged_metadata` checks that dirty buffers are left alone. Both freeze the mtime with `set_next_mtime` and use `atomic_write` to simulate an external tool.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed remote buffers not refreshing when an external tool modifies a file over SSH and the filesystem metadata (mtime, size) appears unchanged.