### PR TITLE
acp: Add agent websites to the registry page

### DIFF
--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -479,6 +479,7 @@ mod tests {
                         description: SharedString::from(""),
                         version: SharedString::from("1.0.0"),
                         repository: None,
+                        website: None,
                         icon_path: None,
                     },
                     package: id,

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -404,16 +404,15 @@ impl AgentRegistryPage {
         });
 
         let website_button = agent.website().map(|website| {
-            let website_for_tooltip: SharedString = website.to_string().into();
-            let website_for_click = website.to_string();
-
+            let website = website.clone();
+            let website_for_click = website.clone();
             IconButton::new(
                 SharedString::from(format!("agent-website-{}", agent.id())),
                 IconName::Link,
             )
             .icon_size(IconSize::Small)
             .tooltip(move |_, cx| {
-                Tooltip::with_meta("Visit Agent Website", None, website_for_tooltip.clone(), cx)
+                Tooltip::with_meta("Visit Agent Website", None, website.clone(), cx)
             })
             .on_click(move |_, _, cx| {
                 cx.open_url(&website_for_click);

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -403,6 +403,23 @@ impl AgentRegistryPage {
             })
         });
 
+        let website_button = agent.website().map(|website| {
+            let website_for_tooltip: SharedString = website.to_string().into();
+            let website_for_click = website.to_string();
+
+            IconButton::new(
+                SharedString::from(format!("agent-website-{}", agent.id())),
+                IconName::Link,
+            )
+            .icon_size(IconSize::Small)
+            .tooltip(move |_, cx| {
+                Tooltip::with_meta("Visit Agent Website", None, website_for_tooltip.clone(), cx)
+            })
+            .on_click(move |_, _, cx| {
+                cx.open_url(&website_for_click);
+            })
+        });
+
         AgentRegistryCard::new()
             .child(
                 h_flex()
@@ -441,7 +458,8 @@ impl AgentRegistryPage {
                                     .color(Color::Muted)
                                     .truncate(),
                             )
-                            .when_some(repository_button, |this, button| this.child(button)),
+                            .when_some(repository_button, |this, button| this.child(button))
+                            .when_some(website_button, |this, button| this.child(button)),
                     ),
             )
     }

--- a/crates/project/src/agent_registry_store.rs
+++ b/crates/project/src/agent_registry_store.rs
@@ -23,6 +23,7 @@ pub struct RegistryAgentMetadata {
     pub description: SharedString,
     pub version: SharedString,
     pub repository: Option<SharedString>,
+    pub website: Option<SharedString>,
     pub icon_path: Option<SharedString>,
 }
 
@@ -73,6 +74,10 @@ impl RegistryAgent {
 
     pub fn repository(&self) -> Option<&SharedString> {
         self.metadata().repository.as_ref()
+    }
+
+    pub fn website(&self) -> Option<&SharedString> {
+        self.metadata().website.as_ref()
     }
 
     pub fn icon_path(&self) -> Option<&SharedString> {
@@ -369,6 +374,7 @@ async fn build_registry_agents(
             description: entry.description.into(),
             version: entry.version.into(),
             repository: entry.repository.map(Into::into),
+            website: entry.website.map(Into::into),
             icon_path,
         };
 
@@ -567,6 +573,8 @@ struct RegistryEntry {
     description: String,
     #[serde(default)]
     repository: Option<String>,
+    #[serde(default)]
+    website: Option<String>,
     #[serde(default)]
     icon: Option<String>,
     distribution: RegistryDistribution,


### PR DESCRIPTION
## Context

The registry now distinguishes between websites and repos, so we can show either or both if available.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
