### PR TITLE
project: Fix error indicator not updating on language server stop

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -10783,6 +10783,7 @@ impl LspStore {
             }
         });
 
+        let mut updated_diagnostics_paths = HashMap::default();
         for (worktree_id, summaries) in self.diagnostic_summaries.iter_mut() {
             summaries.retain(|path, summaries_by_server_id| {
                 if summaries_by_server_id.remove(&server_id).is_some() {
@@ -10800,12 +10801,25 @@ impl LspStore {
                                 more_summaries: Vec::new(),
                             })
                             .log_err();
+                    } else {
+                        let project_path = ProjectPath {
+                            worktree_id: *worktree_id,
+                            path: path.clone(),
+                        };
+                        updated_diagnostics_paths
+                            .entry(server_id)
+                            .or_insert_with(Vec::new)
+                            .push(project_path);
                     }
                     !summaries_by_server_id.is_empty()
                 } else {
                     true
                 }
             });
+        }
+
+        for (server_id, paths) in updated_diagnostics_paths {
+            cx.emit(LspStoreEvent::DiagnosticsUpdated { server_id, paths });
         }
 
         let local = self.as_local_mut().unwrap();


### PR DESCRIPTION
## Context

Fixes #52021 

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

I notice that the LSP store function `stop_local_language_server` only emitted a `LspStoreEvent::DiagnosticsUpdated` when the LSP was running on a remote server:

https://github.com/zed-industries/zed/blob/b5c9a3623995d30465373dc082f6c0bb0549b2c2/crates/project/src/lsp_store.rs#L10790-L10804 

So I added the missing logic to send the event when running locally (see diff for details). 

This PR uses a similar strategy to the `handle_update_diagnostic_summary` function triggered by `stop_local_language_server` when using zed on a remote server:

https://github.com/zed-industries/zed/blob/b5c9a3623995d30465373dc082f6c0bb0549b2c2/crates/project/src/lsp_store.rs#L9368-L9370

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fix error indicators not disappearing when stopping a language server on local development
