### PR TITLE
ci: Run clippy for Intel macOS target

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -263,6 +263,39 @@ jobs:
     - name: steps::show_sccache_stats
       run: sccache --show-stats || true
     timeout-minutes: 60
+  clippy_mac_x86_64:
+    needs:
+    - orchestrate
+    if: needs.orchestrate.outputs.run_tests == 'true'
+    runs-on: namespace-profile-mac-large
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        clean: false
+    - name: steps::setup_cargo_config
+      run: |
+        mkdir -p ./../.cargo
+        cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::cache_rust_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: rust
+        path: ~/.rustup
+    - name: rustup target add x86_64-apple-darwin
+      run: rustup target add x86_64-apple-darwin
+    - name: steps::setup_sccache
+      run: ./script/setup-sccache
+      env:
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        SCCACHE_BUCKET: sccache-zed
+    - name: steps::clippy
+      run: ./script/clippy --target x86_64-apple-darwin
+    - name: steps::show_sccache_stats
+      run: sccache --show-stats || true
+    timeout-minutes: 60
   run_tests_windows:
     needs:
     - orchestrate
@@ -731,6 +764,7 @@ jobs:
     - clippy_windows
     - clippy_linux
     - clippy_mac
+    - clippy_mac_x86_64
     - run_tests_windows
     - run_tests_linux
     - run_tests_mac
@@ -760,6 +794,7 @@ jobs:
         check_result "clippy_windows" "$RESULT_CLIPPY_WINDOWS"
         check_result "clippy_linux" "$RESULT_CLIPPY_LINUX"
         check_result "clippy_mac" "$RESULT_CLIPPY_MAC"
+        check_result "clippy_mac_x86_64" "$RESULT_CLIPPY_MAC_X86_64"
         check_result "run_tests_windows" "$RESULT_RUN_TESTS_WINDOWS"
         check_result "run_tests_linux" "$RESULT_RUN_TESTS_LINUX"
         check_result "run_tests_mac" "$RESULT_RUN_TESTS_MAC"
@@ -779,6 +814,7 @@ jobs:
         RESULT_CLIPPY_WINDOWS: ${{ needs.clippy_windows.result }}
         RESULT_CLIPPY_LINUX: ${{ needs.clippy_linux.result }}
         RESULT_CLIPPY_MAC: ${{ needs.clippy_mac.result }}
+        RESULT_CLIPPY_MAC_X86_64: ${{ needs.clippy_mac_x86_64.result }}
         RESULT_RUN_TESTS_WINDOWS: ${{ needs.run_tests_windows.result }}
         RESULT_RUN_TESTS_LINUX: ${{ needs.run_tests_linux.result }}
         RESULT_RUN_TESTS_MAC: ${{ needs.run_tests_mac.result }}

--- a/tooling/xtask/src/tasks/workflows/deploy_collab.rs
+++ b/tooling/xtask/src/tasks/workflows/deploy_collab.rs
@@ -33,7 +33,7 @@ fn style() -> NamedJob {
             .add_step(steps::cache_rust_dependencies_namespace())
             .map(steps::install_linux_dependencies)
             .add_step(steps::cargo_fmt())
-            .add_step(steps::clippy(Platform::Linux)),
+            .add_step(steps::clippy(Platform::Linux, None)),
     ))
 }
 

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -16,9 +16,9 @@ pub(crate) fn release() -> Workflow {
     let macos_tests = run_tests::run_platform_tests_no_filter(Platform::Mac);
     let linux_tests = run_tests::run_platform_tests_no_filter(Platform::Linux);
     let windows_tests = run_tests::run_platform_tests_no_filter(Platform::Windows);
-    let macos_clippy = run_tests::clippy(Platform::Mac);
-    let linux_clippy = run_tests::clippy(Platform::Linux);
-    let windows_clippy = run_tests::clippy(Platform::Windows);
+    let macos_clippy = run_tests::clippy(Platform::Mac, None);
+    let linux_clippy = run_tests::clippy(Platform::Linux, None);
+    let windows_clippy = run_tests::clippy(Platform::Windows, None);
     let check_scripts = run_tests::check_scripts();
 
     let create_draft_release = create_draft_release();

--- a/tooling/xtask/src/tasks/workflows/release_nightly.rs
+++ b/tooling/xtask/src/tasks/workflows/release_nightly.rs
@@ -18,7 +18,7 @@ pub fn release_nightly() -> Workflow {
     let style = check_style();
     // run only on windows as that's our fastest platform right now.
     let tests = run_platform_tests_no_filter(Platform::Windows);
-    let clippy_job = clippy(Platform::Windows);
+    let clippy_job = clippy(Platform::Windows, None);
     let nightly = Some(ReleaseChannel::Nightly);
 
     let bundle = ReleaseBundleJobs {

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -15,7 +15,7 @@ use crate::tasks::workflows::{
 };
 
 use super::{
-    runners::{self, Platform},
+    runners::{self, Arch, Platform},
     steps::{self, FluentBuilder, NamedJob, named, release_job},
 };
 
@@ -48,9 +48,10 @@ pub(crate) fn run_tests() -> Workflow {
     let mut jobs = vec![
         orchestrate,
         check_style(),
-        should_run_tests.guard(clippy(Platform::Windows)),
-        should_run_tests.guard(clippy(Platform::Linux)),
-        should_run_tests.guard(clippy(Platform::Mac)),
+        should_run_tests.guard(clippy(Platform::Windows, None)),
+        should_run_tests.guard(clippy(Platform::Linux, None)),
+        should_run_tests.guard(clippy(Platform::Mac, None)),
+        should_run_tests.guard(clippy(Platform::Mac, Some(Arch::X86_64))),
         should_run_tests.guard(run_platform_tests(Platform::Windows)),
         should_run_tests.guard(run_platform_tests(Platform::Linux)),
         should_run_tests.guard(run_platform_tests(Platform::Mac)),
@@ -489,7 +490,12 @@ fn check_workspace_binaries() -> NamedJob {
     ))
 }
 
-pub(crate) fn clippy(platform: Platform) -> NamedJob {
+pub(crate) fn clippy(platform: Platform, arch: Option<Arch>) -> NamedJob {
+    let target = arch.map(|arch| match (platform, arch) {
+        (Platform::Mac, Arch::X86_64) => "x86_64-apple-darwin",
+        (Platform::Mac, Arch::AARCH64) => "aarch64-apple-darwin",
+        _ => unimplemented!("cross-arch clippy not supported for {platform}/{arch}"),
+    });
     let runner = match platform {
         Platform::Windows => runners::WINDOWS_DEFAULT,
         Platform::Linux => runners::LINUX_DEFAULT,
@@ -507,16 +513,20 @@ pub(crate) fn clippy(platform: Platform) -> NamedJob {
             platform == Platform::Linux,
             steps::install_linux_dependencies,
         )
+        .when_some(target, |this, target| {
+            this.add_step(steps::install_rustup_target(target))
+        })
         .add_step(steps::setup_sccache(platform))
-        .add_step(steps::clippy(platform))
+        .add_step(steps::clippy(platform, target))
         .add_step(steps::show_sccache_stats(platform));
     if platform == Platform::Linux {
         job = use_clang(job);
     }
-    NamedJob {
-        name: format!("clippy_{platform}"),
-        job,
-    }
+    let name = match arch {
+        Some(arch) => format!("clippy_{platform}_{arch}"),
+        None => format!("clippy_{platform}"),
+    };
+    NamedJob { name, job }
 }
 
 pub(crate) fn run_platform_tests(platform: Platform) -> NamedJob {

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -211,11 +211,18 @@ pub fn clear_target_dir_if_large(platform: Platform) -> Step<Run> {
     }
 }
 
-pub fn clippy(platform: Platform) -> Step<Run> {
+pub fn clippy(platform: Platform, target: Option<&str>) -> Step<Run> {
     match platform {
         Platform::Windows => named::pwsh("./script/clippy.ps1"),
-        _ => named::bash("./script/clippy"),
+        _ => match target {
+            Some(target) => named::bash(format!("./script/clippy --target {target}")),
+            None => named::bash("./script/clippy"),
+        },
     }
+}
+
+pub fn install_rustup_target(target: &str) -> Step<Run> {
+    Step::new(format!("rustup target add {target}")).run(format!("rustup target add {target}"))
 }
 
 pub fn cache_rust_dependencies_namespace() -> Step<Use> {


### PR DESCRIPTION
## Context

We still build release bundles for `x84_64-apple-darwin`, but we don't check that this platform even compiles in CI. This recently led to a release_nightly failure: https://github.com/zed-industries/zed/actions/runs/23348649579. This PR adds a clippy job for that platform.

## How to Review

We generate the workflow yaml, so only the Rust code needs to be reviewed.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A