### PR TITLE
languages: Highlight `await` as `keyword.control` in JS/TS/TSX files

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -247,7 +247,6 @@
   "abstract"
   "as"
   "async"
-  "await"
   "debugger"
   "declare"
   "default"
@@ -309,6 +308,7 @@
   "try"
   "while"
   "yield"
+  "await"
 ] @keyword.control
 
 (switch_default

--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -293,6 +293,7 @@
 ] @keyword.import
 
 [
+  "await"
   "break"
   "case"
   "catch"
@@ -308,7 +309,6 @@
   "try"
   "while"
   "yield"
-  "await"
 ] @keyword.control
 
 (switch_default

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -268,7 +268,6 @@
   "abstract"
   "as"
   "async"
-  "await"
   "debugger"
   "declare"
   "default"
@@ -333,6 +332,7 @@
   "try"
   "while"
   "yield"
+  "await"
 ] @keyword.control
 
 (switch_default

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -317,6 +317,7 @@
 ] @keyword.import
 
 [
+  "await"
   "break"
   "case"
   "catch"
@@ -332,7 +333,6 @@
   "try"
   "while"
   "yield"
-  "await"
 ] @keyword.control
 
 (switch_default

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -436,6 +436,7 @@
 ] @keyword.import
 
 [
+  "await"
   "break"
   "case"
   "catch"
@@ -451,7 +452,6 @@
   "try"
   "while"
   "yield"
-  "await"
 ] @keyword.control
 
 (switch_default

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -387,7 +387,6 @@
   "abstract"
   "as"
   "async"
-  "await"
   "debugger"
   "declare"
   "default"
@@ -452,6 +451,7 @@
   "try"
   "while"
   "yield"
+  "await"
 ] @keyword.control
 
 (switch_default


### PR DESCRIPTION
## Context

Fixes https://github.com/zed-industries/zed/issues/51921

`await` was grouped under the generic `@keyword` capture in the tree-sitter highlights queries for JavaScript, TypeScript, and TSX. It should be `@keyword.control`, since it's a control flow keyword — same as `return`, `yield`, `throw`, `break`, etc., which were already correctly classified.

This aligns Zed's highlighting with VSCode's behavior, where `await` is tokenized as `keyword.control`.

## How to Review

Three single-line moves across highlights files — `await` removed from the `@keyword` list, added to the `@keyword.control` list:
1. `crates/languages/src/javascript/highlights.scm`
2. `crates/languages/src/typescript/highlights.scm`
3. `crates/languages/src/tsx/highlights.scm`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Image :
<img width="3072" height="1728" alt="Screenshot from 2026-03-20 22-15-40" src="https://github.com/user-attachments/assets/9e849d4d-dad4-4fa0-b3b8-8e633f96c585" />

Release Notes:

- Fixed `await` keyword not being highlighted as `keyword.control` in JavaScript, TypeScript, and TSX files
