### PR TITLE
ui: Hide zero values in diff stat display

### DIFF
--- a/crates/ui/src/components/diff_stat.rs
+++ b/crates/ui/src/components/diff_stat.rs
@@ -38,16 +38,20 @@ impl RenderOnce for DiffStat {
         h_flex()
             .id(self.id)
             .gap_1()
-            .child(
-                Label::new(format!("+\u{2009}{}", self.added))
-                    .color(Color::Success)
-                    .size(self.label_size),
-            )
-            .child(
-                Label::new(format!("\u{2012}\u{2009}{}", self.removed))
-                    .color(Color::Error)
-                    .size(self.label_size),
-            )
+            .when(self.added > 0, |this| {
+                this.child(
+                    Label::new(format!("+\u{2009}{}", self.added))
+                        .color(Color::Success)
+                        .size(self.label_size),
+                )
+            })
+            .when(self.removed > 0, |this| {
+                this.child(
+                    Label::new(format!("\u{2012}\u{2009}{}", self.removed))
+                        .color(Color::Error)
+                        .size(self.label_size),
+                )
+            })
             .when_some(tooltip, |this, tooltip| {
                 this.tooltip(Tooltip::text(tooltip))
             })


### PR DESCRIPTION
## Context

The diff stat always showed both additions and removals, even when one was zero. I think hiding zeros improves readability. 
<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

### Before/After
<img width="358" height="482" alt="image" src="https://github.com/user-attachments/assets/606eceb9-6efb-4bb4-8bab-25979513daae" />

<img width="358" height="482" alt="image" src="https://github.com/user-attachments/assets/051a1960-55bd-4afa-9008-873b27a32168" />


## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Improved diff stats to only show non-zero additions and removals.
