### PR TITLE
agent_servers: Don't wrap ACP commands with terminal shell

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -12,8 +12,6 @@ use futures::io::BufReader;
 use project::agent_server_store::AgentServerCommand;
 use project::{AgentId, Project};
 use serde::Deserialize;
-use settings::Settings as _;
-use task::ShellBuilder;
 use util::ResultExt as _;
 use util::path_list::PathList;
 use util::process::Child;
@@ -29,7 +27,7 @@ use gpui::{App, AppContext as _, AsyncApp, Entity, SharedString, Task, WeakEntit
 
 use acp_thread::{AcpThread, AuthRequired, LoadError, TerminalProviderEvent};
 use terminal::TerminalBuilder;
-use terminal::terminal_settings::{AlternateScroll, CursorShape, TerminalSettings};
+use terminal::terminal_settings::{AlternateScroll, CursorShape};
 
 use crate::GEMINI_ID;
 
@@ -194,12 +192,10 @@ impl AcpConnection {
         default_config_options: HashMap<String, String>,
         cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
-        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
-        let mut child =
-            builder.build_std_command(Some(command.path.display().to_string()), &command.args);
-        child.envs(command.env.iter().flatten());
-        let mut child = Child::spawn(child, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
+        let mut std_command = util::command::new_std_command(&command.path);
+        std_command.args(&command.args);
+        std_command.envs(command.env.iter().flatten());
+        let mut child = Child::spawn(std_command, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
 
         let stdout = child.stdout.take().context("Failed to take stdout")?;
         let stdin = child.stdin.take().context("Failed to take stdin")?;


### PR DESCRIPTION
## Summary

`AcpConnection::stdio()` wraps agent server commands (like GitHub Copilot ACP) with the user's terminal shell via `ShellBuilder`. This causes spawn failures when the terminal shell is `wsl.exe` — common on Windows+WSL setups.

### What breaks

**Local project (no remote):**
```
failed to spawn command "wsl.exe -d ubuntu" "-C" "&'C:\Program Files\nodejs\npm.cmd' exec ... @github/copilot@1.0.10 -- --acp"
```

**Remote WSL project:**
```
failed to spawn command "wsl.exe -d ubuntu" "-C" "wsl.exe --distribution Ubuntu --cd ... -- /usr/bin/zsh -i -c 'exec env ... npm exec ...'"
```

### Root cause

1. `ShellKind::new("wsl.exe", true)` falls through to `PowerShell` (the Windows fallback for unknown programs), adding a `-C` flag that `wsl.exe` does not understand
2. `Shell::Program("wsl.exe -d ubuntu")` becomes the program name with embedded spaces — not a valid executable path
3. For remote WSL projects, the command is already transport-wrapped by `WslRemoteConnection::build_command()`, so the shell wrapper produces a broken double-wrapped command

### Fix

Remove the `ShellBuilder` wrapping entirely and execute the command directly — matching how LSP servers already work (`lsp.rs:421-429`). `AgentServerCommand` provides the fully-resolved binary path, args, and environment, so shell wrapping is unnecessary.

Related to #48172

Release Notes:

- Fixed ACP agent servers (e.g. GitHub Copilot) failing to spawn on Windows when the terminal shell is set to `wsl.exe`