### PR TITLE
Ensure that sidebar toggle button works, regardless of focus

### DIFF
--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -1,6 +1,6 @@
-use crate::{ItemHandle, Pane, ToggleWorkspaceSidebar};
+use crate::{ItemHandle, MultiWorkspace, Pane, ToggleWorkspaceSidebar};
 use gpui::{
-    Action, AnyView, App, Context, Decorations, Entity, IntoElement, ParentElement, Render, Styled,
+    AnyView, App, Context, Decorations, Entity, IntoElement, ParentElement, Render, Styled,
     Subscription, Window,
 };
 use std::any::TypeId;
@@ -104,8 +104,12 @@ impl StatusBar {
                 .tooltip(move |_, cx| {
                     Tooltip::for_action("Open Threads Sidebar", &ToggleWorkspaceSidebar, cx)
                 })
-                .on_click(|_, window, cx| {
-                    window.dispatch_action(ToggleWorkspaceSidebar.boxed_clone(), cx);
+                .on_click(move |_, window, cx| {
+                    if let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() {
+                        multi_workspace.update(cx, |multi_workspace, cx| {
+                            multi_workspace.toggle_sidebar(window, cx);
+                        });
+                    }
                 }),
             )
             .child(Divider::vertical().color(ui::DividerColor::Border))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3695,6 +3695,8 @@ impl Workspace {
                         focus_center = true;
                     }
                 } else {
+                    let focus_handle = &active_panel.panel_focus_handle(cx);
+                    window.focus(focus_handle, cx);
                     reveal_dock = true;
                 }
             }
@@ -11094,8 +11096,7 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(!panel.is_zoomed(window, cx));
-            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
-            assert!(pane.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
         // Focus and zoom panel
@@ -11153,8 +11154,7 @@ mod tests {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(panel.is_zoomed(window, cx));
             assert!(workspace.zoomed.is_some());
-            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
-            assert!(pane.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
         // Unzoom and close the panel, zoom the active pane.

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3695,8 +3695,6 @@ impl Workspace {
                         focus_center = true;
                     }
                 } else {
-                    let focus_handle = &active_panel.panel_focus_handle(cx);
-                    window.focus(focus_handle, cx);
                     reveal_dock = true;
                 }
             }
@@ -11073,6 +11071,7 @@ mod tests {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(!panel.is_zoomed(window, cx));
             assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(pane.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
         // Close the dock
@@ -11084,6 +11083,7 @@ mod tests {
             assert!(!workspace.right_dock().read(cx).is_open());
             assert!(!panel.is_zoomed(window, cx));
             assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(pane.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
         // Open the dock
@@ -11094,7 +11094,8 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(!panel.is_zoomed(window, cx));
-            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(pane.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
         // Focus and zoom panel
@@ -11152,7 +11153,8 @@ mod tests {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(panel.is_zoomed(window, cx));
             assert!(workspace.zoomed.is_some());
-            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(pane.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
         // Unzoom and close the panel, zoom the active pane.


### PR DESCRIPTION
Previously, the sidebar toggle worked via an action, which is dependent on what is focused. I changed it to directly call a method.

Release Notes:

- N/A
