### PR TITLE
Use the most recent serial of kinds KeyPress or MousePress when copying

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -867,14 +867,9 @@ impl LinuxClient for WaylandClient {
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             state.clipboard.set_primary(item);
-            let serial = {
-                let serial = state.serial_tracker.get(SerialKind::KeyPress);
-                if serial == 0 {
-                    state.serial_tracker.get(SerialKind::MousePress)
-                } else {
-                    serial
-                }
-            };
+            let serial = state
+                .serial_tracker
+                .latest_of(&[SerialKind::KeyPress, SerialKind::MousePress]);
             let data_source = primary_selection_manager.create_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());
@@ -894,14 +889,9 @@ impl LinuxClient for WaylandClient {
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             state.clipboard.set(item);
-            let serial = {
-                let serial = state.serial_tracker.get(SerialKind::KeyPress);
-                if serial == 0 {
-                    state.serial_tracker.get(SerialKind::MousePress)
-                } else {
-                    serial
-                }
-            };
+            let serial = state
+                .serial_tracker
+                .latest_of(&[SerialKind::KeyPress, SerialKind::MousePress]);
             let data_source = data_device_manager.create_data_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -867,7 +867,14 @@ impl LinuxClient for WaylandClient {
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             state.clipboard.set_primary(item);
-            let serial = state.serial_tracker.get(SerialKind::KeyPress);
+            let serial = {
+                let serial = state.serial_tracker.get(SerialKind::KeyPress);
+                if serial == 0 {
+                    state.serial_tracker.get(SerialKind::MousePress)
+                } else {
+                    serial
+                }
+            };
             let data_source = primary_selection_manager.create_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());
@@ -887,7 +894,14 @@ impl LinuxClient for WaylandClient {
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             state.clipboard.set(item);
-            let serial = state.serial_tracker.get(SerialKind::KeyPress);
+            let serial = {
+                let serial = state.serial_tracker.get(SerialKind::KeyPress);
+                if serial == 0 {
+                    state.serial_tracker.get(SerialKind::MousePress)
+                } else {
+                    serial
+                }
+            };
             let data_source = data_device_manager.create_data_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());

--- a/crates/gpui_linux/src/linux/wayland/serial.rs
+++ b/crates/gpui_linux/src/linux/wayland/serial.rs
@@ -46,4 +46,16 @@ impl SerialTracker {
             .map(|serial_data| serial_data.serial)
             .unwrap_or(0)
     }
+
+    /// Returns the latest tracked serial of the provided [`SerialKind`]s
+    ///
+    /// Will return 0 if not tracked.
+    pub fn latest_of(&self, kinds: &[SerialKind]) -> u32 {
+        kinds
+            .iter()
+            .filter_map(|kind| self.serials.get(kind))
+            .max_by_key(|serial_data| serial_data.serial)
+            .map(|serial_data| serial_data.serial)
+            .unwrap_or(0)
+    }
 }


### PR DESCRIPTION
## Context

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

Wayland's `write_to_clipboard` and `write_to_primary` exclusively use `SerialKind::KeyPress` as the `serial`. When Wayland users try to copy using the mouse without having pressed a key on the keyboard, `state.serial_tracker.get(SerialKind::KeyPress)` could return `0`, causing users to experience failed writes to the clipboard or primary with no visibility of what failed or why.

I have added a `latest_of(...)` helper in `crates/gpui_linux/src/linux/wayland/serial.rs` which returns the most recent tracked serial of the `SerialKind`s provided. In `crates/gpui_linux/src/linux/wayland/client.rs`, I call this new helper so `serial` is assigned the latest tracked serial of kind `KeyPress` or `MousePress`.

I, personally, only reproduced the bug on KDE Plasma (Wayland). All the reports with confirmed desktop environments have been KDE Plasma, though it may also affect other desktop environments. I have tested this fix  on KDE Plasma and Niri.

<details><summary>Old context for reference</summary>
WIP This change fixed mouse copying on KDE Plasma but broke it on others. I will review the new logs I gathered with actual values for `serial` using `SerialKind::KeyPress` and `SerialKind::MousePress`. Once I have, I will update the approach.

### Original Context
~~Wayland's `write_to_clipboard` and `write_to_primary` use `SerialKind::KeyPress`, exclusively. When Wayland users tried to copy using the mouse without having pressed a key on the keyboard, `state.serial_tracker.get(SerialKind::KeyPress)` could return `0`, causing users to experience failed writes to the clipboard or primary with no visibility of what failed or why.~~

~~This PR adds a fallback to `SerialKind::MousePress` when `state.serial_tracker.get(SerialKind::KeyPress)` returns `0` for both `write_to_clipboard` and `write_to_primary`. In my testing on KDE Plasma, this fixes the bug when users copy with the mouse from the context menu and when users use the middle mouse click for primary copy/pasting. I, personally, only reproduced the bug on KDE Plasma (Wayland). All the reports with confirmed desktop environments have been KDE Plasma, though it may also affect other desktop environments.~~
</details>
Closes #51636, #45482, and #44695 

### What I have manually tested
- [x] Copy with mouse, paste with mouse (no prior KeyPress)
- [x] Copy  with mouse, paste with keyboard (no prior KeyPress)
- [x] Select with mouse, paste with middle mouse button (no prior KeyPress)
- [x] Copy with keyboard, paste with keyboard
- [ ] Copy with keyboard, paste with mouse

### Still need help
- Is this the preferred approach?
- The first time I tested, the 3rd or 4th paste with the mouse pasted a stale clipboard entry (top two lines of buffer in video), but I have been unable to reproduce it.

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->
May need to be on KDE Plasma (see note in context section)
- `cargo run`
- Double click to select text (must select using the mouse)
- Middle mouse click to paste primary using `write_to_primary` and observe content is pasted correctly
- Click and drag to select different text
- Right click on text
- Select "copy" (must use mouse since keyboard keypresses sometimes avoided the bug)
- Right click and select "paste"
- Observe pasted content is correct

<details><summary>Recording of fix on KDE Plasma</summary>
https://github.com/user-attachments/assets/479a7167-d19d-4d4e-a53a-b67c29d49b9f
</details>

<details><summary>Recording of fix on Niri</summary>
https://github.com/user-attachments/assets/dbb2e2ea-d886-4ea2-955b-13b0e797974b
</details>

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Fix copy for some Wayland users
