### PR TITLE
gpui_macos: Fix x86_64 build error in Submenu

### DIFF
--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -414,7 +414,7 @@ impl MacPlatform {
                         submenu.addItem_(Self::create_menu_item(item, delegate, actions, keymap));
                     }
                     item.setSubmenu_(submenu);
-                    item.setEnabled_(!disabled);
+                    item.setEnabled_(if *disabled { NO } else { YES });
                     item.setTitle_(ns_string(name));
                     item
                 }


### PR DESCRIPTION
Missed in #52028.

Release Notes:

- N/A
