### PR TITLE
Fix cascading window position

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -49,7 +49,8 @@ use crate::{
     PlatformKeyboardMapper, Point, Priority, PromptBuilder, PromptButton, PromptHandle,
     PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation, ScreenCaptureSource,
     SharedString, SubscriberSet, Subscription, SvgRenderer, Task, TextRenderingMode, TextSystem,
-    ThermalState, Window, WindowAppearance, WindowHandle, WindowId, WindowInvalidator,
+    ThermalState, Window, WindowAppearance, WindowBounds, WindowHandle, WindowId,
+    WindowInvalidator,
     colors::{Colors, GlobalColors},
     hash, init_app_menus,
 };
@@ -646,6 +647,8 @@ pub struct App {
     pub(crate) text_rendering_mode: Rc<Cell<TextRenderingMode>>,
 
     pub(crate) window_update_stack: Vec<WindowId>,
+    /// Last-known bounds for each window, used by `default_bounds` when the active window is on the update stack.
+    pub(crate) window_bounds_cache: FxHashMap<WindowId, WindowBounds>,
     pub(crate) mode: GpuiMode,
     flushing_effects: bool,
     pending_updates: usize,
@@ -702,6 +705,7 @@ impl App {
                 new_entity_observers: SubscriberSet::new(),
                 windows: SlotMap::with_key(),
                 window_update_stack: Vec::new(),
+                window_bounds_cache: FxHashMap::default(),
                 window_handles: FxHashMap::default(),
                 focus_handles: Arc::new(RwLock::new(SlotMap::with_key())),
                 keymap: Rc::new(RefCell::new(Keymap::default())),
@@ -1549,6 +1553,8 @@ impl App {
         self.update(|cx| {
             let mut window = cx.windows.get_mut(id)?.take()?;
 
+            cx.window_bounds_cache.insert(id, window.window_bounds());
+
             let root_view = window.root.clone().unwrap();
 
             cx.window_update_stack.push(window.handle.id);
@@ -1559,6 +1565,7 @@ impl App {
                 if window.removed {
                     cx.window_handles.remove(&id);
                     cx.windows.remove(id);
+                    cx.window_bounds_cache.remove(&id);
 
                     cx.window_closed_observers.clone().retain(&(), |callback| {
                         callback(cx);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1048,13 +1048,12 @@ pub(crate) struct ElementStateBox {
 }
 
 fn default_bounds(display_id: Option<DisplayId>, cx: &mut App) -> WindowBounds {
-    // TODO, BUG: if you open a window with the currently active window
-    // on the stack, this will erroneously fallback to `None`
-    //
-    // TODO these should be the initial window bounds not considering maximized/fullscreen
-    let active_window_bounds = cx
-        .active_window()
-        .and_then(|w| w.update(cx, |_, window, _| window.window_bounds()).ok());
+    let active_window_bounds = cx.active_window().and_then(|w| {
+        let id = w.id;
+        w.update(cx, |_, window, _| window.window_bounds())
+            .ok()
+            .or_else(|| cx.window_bounds_cache.get(&id).copied())
+    });
 
     const CASCADE_OFFSET: f32 = 25.0;
 
@@ -5690,5 +5689,63 @@ pub fn outline(
         border_widths: (1.).into(),
         border_color: border_color.into(),
         border_style,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        AppContext, Bounds, Context, Render, TestAppContext, Window, WindowBounds, WindowOptions,
+        point, px, size,
+    };
+
+    struct Empty;
+
+    impl Render for Empty {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl crate::IntoElement {
+            crate::div()
+        }
+    }
+
+    /// A new window opened from inside an existing window's update should cascade from the active window's position.
+    #[gpui::test]
+    fn test_new_window_cascades_from_active_window(cx: &mut TestAppContext) {
+        let window_a = cx
+            .update(|cx| {
+                cx.open_window(
+                    WindowOptions {
+                        window_bounds: Some(WindowBounds::Windowed(Bounds {
+                            origin: point(px(100.), px(100.)),
+                            size: size(px(800.), px(600.)),
+                        })),
+                        ..Default::default()
+                    },
+                    |_, cx| cx.new(|_| Empty),
+                )
+            })
+            .unwrap();
+
+        window_a
+            .update(cx, |_, window, _| window.activate_window())
+            .unwrap();
+
+        let window_b = window_a
+            .update(cx, |_, _window, cx| {
+                cx.open_window(
+                    WindowOptions::default(), // no bounds → triggers default_bounds()
+                    |_, cx| cx.new(|_| Empty),
+                )
+            })
+            .unwrap()
+            .unwrap();
+
+        let b_origin = window_b
+            .update(cx, |_, window, _| match window.window_bounds() {
+                WindowBounds::Windowed(b) => b.origin,
+                other => panic!("expected Windowed, got {:?}", other),
+            })
+            .unwrap();
+
+        assert_eq!(b_origin, point(px(125.), px(125.)));
     }
 }


### PR DESCRIPTION
## Context

Fixes default window cascading when a new window is opened while the active window is on the update stack. We cache the active window’s last-known bounds before entering updates and fall back to that cache when `active_window()` can’t be read. Adds a GPUI test to lock in the behavior.

## How to Review

- Focus on window bounds caching and cleanup in `crates/gpui/src/app.rs`
- Review `default_bounds` fallback logic in `crates/gpui/src/window.rs`
- Review the new test in `crates/gpui/src/window.rs`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed new window cascade positioning when opening from an active window update
