### PR TITLE
agent_ui: Show estimated cost per agent thread

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -959,6 +959,8 @@ pub struct TokenUsage {
     pub used_tokens: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    pub cache_creation_input_tokens: u64,
     pub max_output_tokens: Option<u64>,
 }
 

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -2920,6 +2920,8 @@ async fn test_truncate_first_message(cx: &mut TestAppContext) {
                 max_output_tokens: None,
                 input_tokens: 32_000,
                 output_tokens: 16_000,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             })
         );
     });
@@ -2982,6 +2984,8 @@ async fn test_truncate_first_message(cx: &mut TestAppContext) {
                 max_output_tokens: None,
                 input_tokens: 40_000,
                 output_tokens: 20_000,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             })
         );
     });
@@ -3090,6 +3094,8 @@ async fn test_truncate_second_message(cx: &mut TestAppContext) {
                 max_output_tokens: None,
                 input_tokens: 40_000,
                 output_tokens: 20_000,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             })
         );
     });

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1668,6 +1668,8 @@ impl Thread {
             used_tokens: usage.total_tokens(),
             input_tokens: usage.input_tokens,
             output_tokens: usage.output_tokens,
+            cache_read_input_tokens: usage.cache_read_input_tokens,
+            cache_creation_input_tokens: usage.cache_creation_input_tokens,
         })
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -8,7 +8,7 @@ use editor::actions::OpenExcerpts;
 use crate::StartThreadIn;
 use crate::message_editor::SharedSessionCapabilities;
 use gpui::{Corner, List};
-use language_model::{LanguageModelCostInfo, LanguageModelEffortLevel, Speed};
+use language_model::{LanguageModelCostInfo, LanguageModelEffortLevel, Speed, TokenUsage};
 use settings::update_settings_file;
 use ui::{ButtonLike, SplitButton, SplitButtonStyle, Tab};
 use workspace::SERIALIZATION_THROTTLE_TIME;
@@ -3249,13 +3249,18 @@ impl ThreadView {
             let output = crate::text_thread_editor::humanize_token_count(usage.output_tokens);
             let output_max = crate::text_thread_editor::humanize_token_count(max_output_tokens);
 
+            let model_token_usage = TokenUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_read_input_tokens: usage.cache_read_input_tokens,
+                cache_creation_input_tokens: usage.cache_creation_input_tokens,
+            };
+
             let estimated_cost = self
                 .as_native_thread(cx)
                 .and_then(|thread| thread.read(cx).model().cloned())
                 .and_then(|model| model.model_cost_info())
-                .and_then(|cost_info| {
-                    cost_info.estimate_cost(usage.input_tokens, usage.output_tokens)
-                })
+                .and_then(|cost_info| cost_info.estimate_cost(&model_token_usage))
                 .map(LanguageModelCostInfo::format_cost);
 
             Some(
@@ -3326,13 +3331,18 @@ impl ThreadView {
 
             let percentage = format!("{}%", (progress_ratio * 100.0).round() as u32);
 
+            let model_token_usage = TokenUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_read_input_tokens: usage.cache_read_input_tokens,
+                cache_creation_input_tokens: usage.cache_creation_input_tokens,
+            };
+
             let estimated_cost = self
                 .as_native_thread(cx)
                 .and_then(|thread| thread.read(cx).model().cloned())
                 .and_then(|model| model.model_cost_info())
-                .and_then(|cost_info| {
-                    cost_info.estimate_cost(usage.input_tokens, usage.output_tokens)
-                })
+                .and_then(|cost_info| cost_info.estimate_cost(&model_token_usage))
                 .map(LanguageModelCostInfo::format_cost);
 
             let (user_rules_count, project_rules_count) = self

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -8,7 +8,7 @@ use editor::actions::OpenExcerpts;
 use crate::StartThreadIn;
 use crate::message_editor::SharedSessionCapabilities;
 use gpui::{Corner, List};
-use language_model::{LanguageModelEffortLevel, Speed};
+use language_model::{LanguageModelCostInfo, LanguageModelEffortLevel, Speed};
 use settings::update_settings_file;
 use ui::{ButtonLike, SplitButton, SplitButtonStyle, Tab};
 use workspace::SERIALIZATION_THROTTLE_TIME;
@@ -3249,6 +3249,15 @@ impl ThreadView {
             let output = crate::text_thread_editor::humanize_token_count(usage.output_tokens);
             let output_max = crate::text_thread_editor::humanize_token_count(max_output_tokens);
 
+            let estimated_cost = self
+                .as_native_thread(cx)
+                .and_then(|thread| thread.read(cx).model().cloned())
+                .and_then(|model| model.model_cost_info())
+                .and_then(|cost_info| {
+                    cost_info.estimate_cost(usage.input_tokens, usage.output_tokens)
+                })
+                .map(LanguageModelCostInfo::format_cost);
+
             Some(
                 h_flex()
                     .flex_shrink_0()
@@ -3294,6 +3303,9 @@ impl ThreadView {
                                     .color(Color::Muted),
                             ),
                     )
+                    .when_some(estimated_cost, |this, cost| {
+                        this.child(Label::new(cost).size(LabelSize::Small).color(Color::Muted))
+                    })
                     .into_any_element(),
             )
         } else {
@@ -3313,6 +3325,15 @@ impl ThreadView {
             let separator_color = Color::Custom(cx.theme().colors().text_disabled.opacity(0.6));
 
             let percentage = format!("{}%", (progress_ratio * 100.0).round() as u32);
+
+            let estimated_cost = self
+                .as_native_thread(cx)
+                .and_then(|thread| thread.read(cx).model().cloned())
+                .and_then(|model| model.model_cost_info())
+                .and_then(|cost_info| {
+                    cost_info.estimate_cost(usage.input_tokens, usage.output_tokens)
+                })
+                .map(LanguageModelCostInfo::format_cost);
 
             let (user_rules_count, project_rules_count) = self
                 .as_native_thread(cx)
@@ -3361,6 +3382,21 @@ impl ThreadView {
                                         .child(Label::new("/").color(separator_color))
                                         .child(Label::new(max.clone()).color(Color::Muted)),
                                 )
+                                .when_some(estimated_cost.clone(), |this, cost| {
+                                    this.child(
+                                        v_flex()
+                                            .mt_1p5()
+                                            .pt_1p5()
+                                            .border_t_1()
+                                            .border_color(cx.theme().colors().border_variant)
+                                            .child(
+                                                Label::new("Estimated cost")
+                                                    .color(Color::Muted)
+                                                    .size(LabelSize::Small),
+                                            )
+                                            .child(Label::new(cost)),
+                                    )
+                                })
                                 .when(user_rules_count > 0 || project_rules_count > 0, |this| {
                                     this.child(
                                         v_flex()

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -932,6 +932,30 @@ impl LanguageModelCostInfo {
             SharedString::from(format!("{:.2}", cost))
         }
     }
+
+    pub fn estimate_cost(&self, input_tokens: u64, output_tokens: u64) -> Option<f64> {
+        match self {
+            LanguageModelCostInfo::TokenCost {
+                input_token_cost_per_1m,
+                output_token_cost_per_1m,
+            } => {
+                let cost = (input_tokens as f64 * input_token_cost_per_1m / 1_000_000.0)
+                    + (output_tokens as f64 * output_token_cost_per_1m / 1_000_000.0);
+                Some(cost)
+            }
+            LanguageModelCostInfo::RequestCost { .. } => None,
+        }
+    }
+
+    pub fn format_cost(cost: f64) -> SharedString {
+        if cost < 0.005 {
+            SharedString::from("< $0.01")
+        } else if cost < 10.0 {
+            SharedString::from(format!("${:.2}", cost))
+        } else {
+            SharedString::from(format!("${:.0}", cost))
+        }
+    }
 }
 
 impl LanguageModelProviderId {
@@ -1173,5 +1197,46 @@ mod tests {
         assert_eq!(deserialized.id, original.id);
         assert_eq!(deserialized.name, original.name);
         assert_eq!(deserialized.thought_signature, None);
+    }
+
+    #[test]
+    fn test_estimate_cost_with_token_pricing() {
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 3.0,
+            output_token_cost_per_1m: 15.0,
+        };
+
+        let cost = cost_info.estimate_cost(100_000, 20_000);
+        assert_eq!(cost, Some(0.6));
+    }
+
+    #[test]
+    fn test_estimate_cost_returns_none_for_request_cost() {
+        let cost_info = LanguageModelCostInfo::RequestCost {
+            cost_per_request: 1.0,
+        };
+
+        assert_eq!(cost_info.estimate_cost(100_000, 20_000), None);
+    }
+
+    #[test]
+    fn test_estimate_cost_with_zero_tokens() {
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 3.0,
+            output_token_cost_per_1m: 15.0,
+        };
+
+        assert_eq!(cost_info.estimate_cost(0, 0), Some(0.0));
+    }
+
+    #[test]
+    fn test_format_cost() {
+        assert_eq!(
+            LanguageModelCostInfo::format_cost(0.001).as_ref(),
+            "< $0.01"
+        );
+        assert_eq!(LanguageModelCostInfo::format_cost(0.47).as_ref(), "$0.47");
+        assert_eq!(LanguageModelCostInfo::format_cost(1.23).as_ref(), "$1.23");
+        assert_eq!(LanguageModelCostInfo::format_cost(15.5).as_ref(), "$16");
     }
 }

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -898,10 +898,12 @@ pub struct LanguageModelProviderName(pub SharedString);
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LanguageModelCostInfo {
-    /// Cost per 1,000 input and output tokens
+    /// Cost per 1,000,000 input and output tokens
     TokenCost {
         input_token_cost_per_1m: f64,
         output_token_cost_per_1m: f64,
+        cache_read_input_token_cost_per_1m: Option<f64>,
+        cache_creation_input_token_cost_per_1m: Option<f64>,
     },
     /// Cost per request
     RequestCost { cost_per_request: f64 },
@@ -917,6 +919,7 @@ impl LanguageModelCostInfo {
             LanguageModelCostInfo::TokenCost {
                 input_token_cost_per_1m,
                 output_token_cost_per_1m,
+                ..
             } => {
                 let input_cost = Self::cost_value_to_string(input_token_cost_per_1m);
                 let output_cost = Self::cost_value_to_string(output_token_cost_per_1m);
@@ -933,14 +936,25 @@ impl LanguageModelCostInfo {
         }
     }
 
-    pub fn estimate_cost(&self, input_tokens: u64, output_tokens: u64) -> Option<f64> {
+    pub fn estimate_cost(&self, usage: &TokenUsage) -> Option<f64> {
         match self {
             LanguageModelCostInfo::TokenCost {
                 input_token_cost_per_1m,
                 output_token_cost_per_1m,
+                cache_read_input_token_cost_per_1m,
+                cache_creation_input_token_cost_per_1m,
             } => {
-                let cost = (input_tokens as f64 * input_token_cost_per_1m / 1_000_000.0)
-                    + (output_tokens as f64 * output_token_cost_per_1m / 1_000_000.0);
+                let mut cost = (usage.input_tokens as f64 * input_token_cost_per_1m / 1_000_000.0)
+                    + (usage.output_tokens as f64 * output_token_cost_per_1m / 1_000_000.0);
+
+                if let Some(cache_read_rate) = cache_read_input_token_cost_per_1m {
+                    cost += usage.cache_read_input_tokens as f64 * cache_read_rate / 1_000_000.0;
+                }
+                if let Some(cache_creation_rate) = cache_creation_input_token_cost_per_1m {
+                    cost += usage.cache_creation_input_tokens as f64 * cache_creation_rate
+                        / 1_000_000.0;
+                }
+
                 Some(cost)
             }
             LanguageModelCostInfo::RequestCost { .. } => None,
@@ -1204,9 +1218,16 @@ mod tests {
         let cost_info = LanguageModelCostInfo::TokenCost {
             input_token_cost_per_1m: 3.0,
             output_token_cost_per_1m: 15.0,
+            cache_read_input_token_cost_per_1m: None,
+            cache_creation_input_token_cost_per_1m: None,
         };
 
-        let cost = cost_info.estimate_cost(100_000, 20_000);
+        let usage = TokenUsage {
+            input_tokens: 100_000,
+            output_tokens: 20_000,
+            ..Default::default()
+        };
+        let cost = cost_info.estimate_cost(&usage);
         assert_eq!(cost, Some(0.6));
     }
 
@@ -1216,7 +1237,12 @@ mod tests {
             cost_per_request: 1.0,
         };
 
-        assert_eq!(cost_info.estimate_cost(100_000, 20_000), None);
+        let usage = TokenUsage {
+            input_tokens: 100_000,
+            output_tokens: 20_000,
+            ..Default::default()
+        };
+        assert_eq!(cost_info.estimate_cost(&usage), None);
     }
 
     #[test]
@@ -1224,9 +1250,59 @@ mod tests {
         let cost_info = LanguageModelCostInfo::TokenCost {
             input_token_cost_per_1m: 3.0,
             output_token_cost_per_1m: 15.0,
+            cache_read_input_token_cost_per_1m: None,
+            cache_creation_input_token_cost_per_1m: None,
         };
 
-        assert_eq!(cost_info.estimate_cost(0, 0), Some(0.0));
+        assert_eq!(cost_info.estimate_cost(&TokenUsage::default()), Some(0.0));
+    }
+
+    #[test]
+    fn test_estimate_cost_with_cache_tokens() {
+        // Anthropic Claude Sonnet 4 pricing (example):
+        // input: $3/1M, output: $15/1M, cache_read: $0.30/1M, cache_write: $3.75/1M
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 3.0,
+            output_token_cost_per_1m: 15.0,
+            cache_read_input_token_cost_per_1m: Some(0.30),
+            cache_creation_input_token_cost_per_1m: Some(3.75),
+        };
+
+        let usage = TokenUsage {
+            input_tokens: 10_000,
+            output_tokens: 5_000,
+            cache_read_input_tokens: 200_000,
+            cache_creation_input_tokens: 50_000,
+        };
+        let cost = cost_info.estimate_cost(&usage);
+        // input: 10k * 3.0 / 1M = 0.03
+        // output: 5k * 15.0 / 1M = 0.075
+        // cache_read: 200k * 0.30 / 1M = 0.06
+        // cache_write: 50k * 3.75 / 1M = 0.1875
+        // total = 0.3525
+        assert_eq!(cost, Some(0.3525));
+    }
+
+    #[test]
+    fn test_estimate_cost_cache_tokens_without_cache_pricing() {
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 3.0,
+            output_token_cost_per_1m: 15.0,
+            cache_read_input_token_cost_per_1m: None,
+            cache_creation_input_token_cost_per_1m: None,
+        };
+
+        let usage = TokenUsage {
+            input_tokens: 10_000,
+            output_tokens: 5_000,
+            cache_read_input_tokens: 200_000,
+            cache_creation_input_tokens: 50_000,
+        };
+        let cost = cost_info.estimate_cost(&usage);
+        // Only input + output counted when no cache pricing set
+        // input: 10k * 3.0 / 1M = 0.03
+        // output: 5k * 15.0 / 1M = 0.075
+        assert_eq!(cost, Some(0.105));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Zed tracks token usage per agent thread and knows model pricing, but these two pieces of data are never combined. Users see "45.2k / 1M" tokens and have no way to know what that cost in dollars without checking their provider dashboard.

This adds estimated cost to the token usage display in agent threads. When a model provides pricing data (`LanguageModelCostInfo::TokenCost`), the cost is calculated from cumulative input/output token counts and displayed alongside the existing token information.

**In the circular progress tooltip** (non-split display): cost appears as a new "Estimated cost" section below the context percentage.

**In the split token display**: cost appears as an inline label after the output token count.

Models without pricing data (local models, credit-based Zed-hosted models using `RequestCost`) gracefully omit the cost label.

## Why this matters

Users choosing between models for a task (Opus vs Haiku, GPT-4o vs GPT-4o-mini) currently can't see real-time cost. The subagent model discussion ([#52042](https://github.com/zed-industries/zed/issues/52042)) exists specifically because cost is opaque. Users reporting unexpected token consumption in [#50254](https://github.com/zed-industries/zed/issues/50254) and [#51646](https://github.com/zed-industries/zed/issues/51646) would benefit from seeing cost accumulate in real-time.

## Changes

- `crates/language_model/src/language_model.rs`: Added `estimate_cost()` and `format_cost()` to `LanguageModelCostInfo`. Cost is calculated as `(input_tokens * input_rate / 1M) + (output_tokens * output_rate / 1M)`. Formatting handles sub-cent amounts ("< $0.01"), normal range ("$0.47"), and large amounts ("$16").
- `crates/agent_ui/src/conversation_view/thread_view.rs`: Added cost display to both the split token display (inline label) and circular progress tooltip (new section) in `render_token_usage()`.
- 4 unit tests for cost calculation and formatting.

## Testing

- `cargo test -p language_model -- test_estimate_cost test_format_cost` - all 4 tests pass
- `cargo check -p agent_ui` - compiles cleanly
- `cargo clippy -p language_model -p agent_ui` - no warnings
- `cargo fmt -- --check` - clean

This contribution was developed with AI assistance (Claude Code).

Release Notes:

- Added estimated cost display in agent thread token usage tooltip