### PR TITLE
Clamp mapped buffer range to excerpt end

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -7838,13 +7838,13 @@ impl<'a> MultiBufferExcerpt<'a> {
         let start = self.diff_transforms.start().output_dimension.0 + overshoot;
 
         let end = if buffer_range.start < buffer_range.end {
-            let overshoot = buffer_range.end - self.buffer_offset;
+            let clamped_end = buffer_range.end.min(self.excerpt.buffer_end_offset());
+            let overshoot = clamped_end - self.buffer_offset;
             let excerpt_offset = self.excerpt_offset + overshoot;
             let excerpt_seek_dim = excerpt_offset;
             self.diff_transforms
                 .seek_forward(&excerpt_seek_dim, Bias::Right);
             let overshoot = excerpt_offset - self.diff_transforms.start().excerpt_dimension;
-            // todo(lw): Clamp end to the excerpt boundaries
             self.diff_transforms.start().output_dimension.0 + overshoot
         } else {
             start

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -508,6 +508,33 @@ async fn test_diff_hunks_in_range(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_map_range_from_buffer_clamps_to_excerpt_end(cx: &mut App) {
+    let buffer = cx.new(|cx| Buffer::local("abcdef", cx));
+    let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));
+
+    multibuffer.update(cx, |multibuffer, cx| {
+        multibuffer.set_excerpt_ranges_for_path(
+            PathKey::sorted(0),
+            buffer.clone(),
+            &buffer.read(cx).snapshot(),
+            vec![ExcerptRange::new(Point::new(0, 1)..Point::new(0, 4))],
+            cx,
+        );
+    });
+
+    let snapshot = multibuffer.read(cx).snapshot(cx);
+    let mut excerpt = snapshot
+        .excerpt_containing(MultiBufferOffset(0)..MultiBufferOffset(1))
+        .expect("missing excerpt");
+    let buffer_range = excerpt.buffer_range();
+    let expected_end = excerpt.start_offset() + (buffer_range.end - buffer_range.start);
+    let mapped = excerpt.map_range_from_buffer(buffer_range.start..(buffer_range.end + 2));
+
+    assert_eq!(mapped.start, excerpt.start_offset());
+    assert_eq!(mapped.end, expected_end);
+}
+
+#[gpui::test]
 async fn test_diff_hunks_in_range_query_starting_at_added_row(cx: &mut TestAppContext) {
     let base_text = "one\ntwo\nthree\n";
     let text = "one\nTWO\nthree\n";


### PR DESCRIPTION
## Context

Clamp `map_range_from_buffer` end offsets to excerpt boundaries to prevent ranges from mapping outside the excerpt. Added a test to cover the partial-overlap case.

## How to Review

Focus on the end clamping logic in `crates/multi_buffer/src/multi_buffer.rs` and the new test in `crates/multi_buffer/src/multi_buffer_tests.rs`.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed clamping of mapped buffer ranges to excerpt boundaries
