### PR TITLE
acp_thread: Fix ACP permission prompt attachment

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1037,6 +1037,7 @@ pub struct AcpThread {
     title: SharedString,
     provisional_title: Option<SharedString>,
     entries: Vec<AgentThreadEntry>,
+    tool_call_aliases: HashMap<acp::ToolCallId, acp::ToolCallId>,
     plan: Plan,
     project: Entity<Project>,
     action_log: Entity<ActionLog>,
@@ -1223,6 +1224,7 @@ impl AcpThread {
             action_log,
             shared_buffers: Default::default(),
             entries: Default::default(),
+            tool_call_aliases: Default::default(),
             plan: Default::default(),
             title: title.into(),
             provisional_title: None,
@@ -1894,7 +1896,38 @@ impl AcpThread {
         Ok(())
     }
 
+    fn placeholder_tool_call_ix(&self, title: &str, cx: &App) -> Option<usize> {
+        self.entries
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(ix, entry)| {
+                let AgentThreadEntry::ToolCall(call) = entry else {
+                    return None;
+                };
+
+                let is_placeholder = call.content.is_empty()
+                    && call.raw_output.is_none()
+                    && matches!(
+                        call.status,
+                        ToolCallStatus::Pending | ToolCallStatus::InProgress
+                    )
+                    && call.label.read(cx).source() == title;
+
+                is_placeholder.then_some(ix)
+            })
+    }
+
+    fn resolve_tool_call_id<'a>(&'a self, id: &'a acp::ToolCallId) -> &'a acp::ToolCallId {
+        let mut resolved = id;
+        while let Some(next) = self.tool_call_aliases.get(resolved) {
+            resolved = next;
+        }
+        resolved
+    }
+
     fn index_for_tool_call(&self, id: &acp::ToolCallId) -> Option<usize> {
+        let id = self.resolve_tool_call_id(id);
         self.entries
             .iter()
             .enumerate()
@@ -1911,6 +1944,7 @@ impl AcpThread {
     }
 
     fn tool_call_mut(&mut self, id: &acp::ToolCallId) -> Option<(usize, &mut ToolCall)> {
+        let id = self.resolve_tool_call_id(id).clone();
         // The tool call we are looking for is typically the last one, or very close to the end.
         // At the moment, it doesn't seem like a hashmap would be a good fit for this use case.
         self.entries
@@ -1919,7 +1953,7 @@ impl AcpThread {
             .rev()
             .find_map(|(index, tool_call)| {
                 if let AgentThreadEntry::ToolCall(tool_call) = tool_call
-                    && &tool_call.id == id
+                    && tool_call.id == id
                 {
                     Some((index, tool_call))
                 } else {
@@ -1929,6 +1963,7 @@ impl AcpThread {
     }
 
     pub fn tool_call(&self, id: &acp::ToolCallId) -> Option<(usize, &ToolCall)> {
+        let id = self.resolve_tool_call_id(id);
         self.entries
             .iter()
             .enumerate()
@@ -2031,16 +2066,29 @@ impl AcpThread {
         };
 
         let tool_call_id = tool_call.tool_call_id.clone();
-        let should_insert_fresh_entry = self
-            .index_for_tool_call(&tool_call_id)
-            .is_some_and(|ix| ix + 1 < self.entries.len());
-
-        if should_insert_fresh_entry {
-            if let Some(ix) = self.index_for_tool_call(&tool_call_id) {
-                self.entries.remove(ix);
-                cx.emit(AcpThreadEvent::EntriesRemoved(ix..ix + 1));
-            }
-            self.insert_tool_call_entry(tool_call, status, cx)?;
+        if self.index_for_tool_call(&tool_call_id).is_none()
+            && let Some(title) = tool_call.fields.title.as_deref()
+            && let Some(ix) = self.placeholder_tool_call_ix(title, cx)
+        {
+            let AgentThreadEntry::ToolCall(call) = &mut self.entries[ix] else {
+                unreachable!()
+            };
+            let previous_id = call.id.clone();
+            call.id = tool_call_id.clone();
+            self.tool_call_aliases
+                .insert(previous_id, tool_call_id.clone());
+            let language_registry = self.project.read(cx).languages().clone();
+            let path_style = self.project.read(cx).path_style(cx);
+            call.update_fields(
+                tool_call.fields,
+                tool_call.meta,
+                language_registry,
+                path_style,
+                &self.terminals,
+                cx,
+            )?;
+            call.status = status;
+            cx.emit(AcpThreadEvent::EntryUpdated(ix));
         } else {
             self.upsert_tool_call_inner(tool_call, status, cx)?;
         }

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -598,6 +598,27 @@ impl Display for ToolCallStatus {
     }
 }
 
+impl ToolCallStatus {
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            ToolCallStatus::Completed
+                | ToolCallStatus::Failed
+                | ToolCallStatus::Rejected
+                | ToolCallStatus::Canceled
+        )
+    }
+
+    fn starts_new_tool_call(&self) -> bool {
+        matches!(
+            self,
+            ToolCallStatus::Pending
+                | ToolCallStatus::WaitingForConfirmation { .. }
+                | ToolCallStatus::InProgress
+        )
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum ContentBlock {
     Empty,
@@ -1821,7 +1842,13 @@ impl AcpThread {
             );
         }
 
-        if let Some(ix) = self.index_for_tool_call(&id) {
+        if let Some(ix) = self.index_for_tool_call(&id)
+            && !matches!(
+                &self.entries[ix],
+                AgentThreadEntry::ToolCall(call)
+                    if call.status.is_terminal() && status.starts_new_tool_call()
+            )
+        {
             let AgentThreadEntry::ToolCall(call) = &mut self.entries[ix] else {
                 unreachable!()
             };
@@ -1838,18 +1865,28 @@ impl AcpThread {
 
             cx.emit(AcpThreadEvent::EntryUpdated(ix));
         } else {
-            let call = ToolCall::from_acp(
-                update.try_into()?,
-                status,
-                language_registry,
-                self.project.read(cx).path_style(cx),
-                &self.terminals,
-                cx,
-            )?;
-            self.push_entry(AgentThreadEntry::ToolCall(call), cx);
+            self.insert_tool_call_entry(update, status, cx)?;
         };
 
         self.resolve_locations(id, cx);
+        Ok(())
+    }
+
+    fn insert_tool_call_entry(
+        &mut self,
+        update: acp::ToolCallUpdate,
+        status: ToolCallStatus,
+        cx: &mut Context<Self>,
+    ) -> Result<(), acp::Error> {
+        let call = ToolCall::from_acp(
+            update.try_into()?,
+            status,
+            self.project.read(cx).languages().clone(),
+            self.project.read(cx).path_style(cx),
+            &self.terminals,
+            cx,
+        )?;
+        self.push_entry(AgentThreadEntry::ToolCall(call), cx);
         Ok(())
     }
 
@@ -1990,7 +2027,15 @@ impl AcpThread {
         };
 
         let tool_call_id = tool_call.tool_call_id.clone();
-        self.upsert_tool_call_inner(tool_call, status, cx)?;
+        let should_insert_fresh_entry = self
+            .index_for_tool_call(&tool_call_id)
+            .is_some_and(|ix| ix + 1 < self.entries.len());
+
+        if should_insert_fresh_entry {
+            self.insert_tool_call_entry(tool_call, status, cx)?;
+        } else {
+            self.upsert_tool_call_inner(tool_call, status, cx)?;
+        }
         cx.emit(AcpThreadEvent::ToolAuthorizationRequested(
             tool_call_id.clone(),
         ));

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -4578,7 +4578,7 @@ mod tests {
                 )
                 .unwrap();
 
-            thread
+            let _ = thread
                 .request_tool_call_authorization(
                     acp::ToolCallUpdate::new(
                         "authorized-id",
@@ -4637,7 +4637,7 @@ mod tests {
                 )
                 .unwrap();
 
-            thread
+            let _ = thread
                 .request_tool_call_authorization(
                     acp::ToolCallUpdate::new(
                         "authorized-id",

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -4552,6 +4552,131 @@ mod tests {
         });
     }
 
+    #[gpui::test]
+    async fn test_permission_request_reuses_latest_placeholder_tool_call(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        thread.update(cx, |thread, cx| {
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new("placeholder-id", "Run permission checks")
+                            .kind(acp::ToolKind::Execute)
+                            .status(acp::ToolCallStatus::InProgress),
+                    ),
+                    cx,
+                )
+                .unwrap();
+
+            thread
+                .request_tool_call_authorization(
+                    acp::ToolCallUpdate::new(
+                        "authorized-id",
+                        acp::ToolCallUpdateFields::new()
+                            .title("Run permission checks")
+                            .kind(acp::ToolKind::Execute),
+                    ),
+                    PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                        acp::PermissionOptionId::new("allow"),
+                        "Allow",
+                        acp::PermissionOptionKind::AllowOnce,
+                    )]),
+                    cx,
+                )
+                .unwrap();
+
+            assert_eq!(thread.entries.len(), 1);
+
+            let AgentThreadEntry::ToolCall(tool_call) = &thread.entries[0] else {
+                panic!("Expected tool call entry");
+            };
+            assert_eq!(tool_call.id, acp::ToolCallId::new("authorized-id"));
+            assert_eq!(tool_call.label.read(cx).source(), "Run permission checks");
+            assert!(matches!(
+                tool_call.status,
+                ToolCallStatus::WaitingForConfirmation { .. }
+            ));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_tool_call_updates_follow_placeholder_alias_after_permission_request(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        thread.update(cx, |thread, cx| {
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new("placeholder-id", "Run permission checks")
+                            .kind(acp::ToolKind::Execute)
+                            .status(acp::ToolCallStatus::InProgress),
+                    ),
+                    cx,
+                )
+                .unwrap();
+
+            thread
+                .request_tool_call_authorization(
+                    acp::ToolCallUpdate::new(
+                        "authorized-id",
+                        acp::ToolCallUpdateFields::new()
+                            .title("Run permission checks")
+                            .kind(acp::ToolKind::Execute),
+                    ),
+                    PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                        acp::PermissionOptionId::new("allow"),
+                        "Allow",
+                        acp::PermissionOptionKind::AllowOnce,
+                    )]),
+                    cx,
+                )
+                .unwrap();
+
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate::new(
+                        acp::ToolCallId::new("placeholder-id"),
+                        acp::ToolCallUpdateFields::new()
+                            .status(acp::ToolCallStatus::Completed)
+                            .raw_output(serde_json::json!("done")),
+                    )),
+                    cx,
+                )
+                .unwrap();
+
+            assert_eq!(thread.entries.len(), 1);
+
+            let AgentThreadEntry::ToolCall(tool_call) = &thread.entries[0] else {
+                panic!("Expected tool call entry");
+            };
+            assert_eq!(tool_call.id, acp::ToolCallId::new("authorized-id"));
+            assert!(matches!(tool_call.status, ToolCallStatus::Completed));
+            assert_eq!(tool_call.raw_output, Some(serde_json::json!("done")));
+        });
+    }
+
     /// Tests that restoring a checkpoint properly cleans up terminals that were
     /// created after that checkpoint, and cancels any in-progress generation.
     ///

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1865,6 +1865,10 @@ impl AcpThread {
 
             cx.emit(AcpThreadEvent::EntryUpdated(ix));
         } else {
+            if let Some(ix) = self.index_for_tool_call(&id) {
+                self.entries.remove(ix);
+                cx.emit(AcpThreadEvent::EntriesRemoved(ix..ix + 1));
+            }
             self.insert_tool_call_entry(update, status, cx)?;
         };
 
@@ -2032,6 +2036,10 @@ impl AcpThread {
             .is_some_and(|ix| ix + 1 < self.entries.len());
 
         if should_insert_fresh_entry {
+            if let Some(ix) = self.index_for_tool_call(&tool_call_id) {
+                self.entries.remove(ix);
+                cx.emit(AcpThreadEvent::EntriesRemoved(ix..ix + 1));
+            }
             self.insert_tool_call_entry(tool_call, status, cx)?;
         } else {
             self.upsert_tool_call_inner(tool_call, status, cx)?;

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -5961,6 +5961,7 @@ impl ThreadView {
                 cx,
             ),
             PermissionOptions::Dropdown(choices) => self.render_permission_buttons_with_dropdown(
+                session_id,
                 is_first,
                 choices,
                 None,
@@ -5974,6 +5975,7 @@ impl ThreadView {
                 patterns,
                 tool_name,
             } => self.render_permission_buttons_with_dropdown(
+                session_id,
                 is_first,
                 choices,
                 Some((patterns, tool_name)),
@@ -5987,6 +5989,7 @@ impl ThreadView {
 
     fn render_permission_buttons_with_dropdown(
         &self,
+        session_id: acp::SessionId,
         is_first: bool,
         choices: &[PermissionOptionChoice],
         patterns: Option<(&[PermissionPattern], &str)>,
@@ -5996,6 +5999,14 @@ impl ThreadView {
         cx: &Context<Self>,
     ) -> Div {
         let selection = self.permission_selections.get(&tool_call_id);
+        let options = match patterns {
+            Some((patterns, tool_name)) => PermissionOptions::DropdownWithPatterns {
+                choices: choices.to_vec(),
+                patterns: patterns.to_vec(),
+                tool_name: tool_name.to_string(),
+            },
+            None => PermissionOptions::Dropdown(choices.to_vec()),
+        };
 
         let selected_index = selection
             .and_then(|s| s.choice_index())
@@ -6064,8 +6075,18 @@ impl ThreadView {
                                 )
                             })
                             .on_click(cx.listener({
+                                let session_id = session_id.clone();
+                                let tool_call_id = tool_call_id.clone();
+                                let options = options.clone();
                                 move |this, _, window, cx| {
-                                    this.authorize_pending_with_granularity(true, window, cx);
+                                    this.authorize_with_granularity(
+                                        session_id.clone(),
+                                        tool_call_id.clone(),
+                                        &options,
+                                        true,
+                                        window,
+                                        cx,
+                                    );
                                 }
                             })),
                     )
@@ -6088,8 +6109,18 @@ impl ThreadView {
                                 )
                             })
                             .on_click(cx.listener({
+                                let session_id = session_id.clone();
+                                let tool_call_id = tool_call_id.clone();
+                                let options = options.clone();
                                 move |this, _, window, cx| {
-                                    this.authorize_pending_with_granularity(false, window, cx);
+                                    this.authorize_with_granularity(
+                                        session_id.clone(),
+                                        tool_call_id.clone(),
+                                        &options,
+                                        false,
+                                        window,
+                                        cx,
+                                    );
                                 }
                             })),
                     ),


### PR DESCRIPTION
## Context

Fixes an ACP thread issue where inline permission prompts could become attached to the wrong tool-call card in long-running agent conversations.

When a permission request arrived after earlier command cards had already been rendered, ACP tool-call reconciliation could reuse stale tool-call entries or lose the relationship between related tool-call updates. In practice, that could make approvals appear on an older command higher in the thread, or create confusing duplicate command cards around the approval point.

This change tightens tool-call reconciliation in `acp_thread` so permission prompts stay attached to the active command card while preserving identity across subsequent ACP updates.

## How to Review

1. Start in [acp_thread.rs](E:/Temp/zed/crates/acp_thread/src/acp_thread.rs) around tool-call lookup and authorization handling.
2. Review the added placeholder matching and tool-call alias resolution logic.
3. Review `request_tool_call_authorization` to confirm that permission requests now attach to the active tool-call entry instead of surfacing on stale thread content.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed inline agent permission prompts attaching to the wrong command in long ACP threads.