### PR TITLE
editor: Fix stale multibuffer snippet completion crash

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6557,7 +6557,6 @@ impl Editor {
             .borrow()
             .get(candidate_id)?
             .clone();
-        cx.stop_propagation();
 
         let buffer_handle = completions_menu.buffer.clone();
 
@@ -6575,15 +6574,26 @@ impl Editor {
 
         let buffer = buffer_handle.read(cx);
         let snapshot = self.buffer.read(cx).snapshot(cx);
+        let completion_position = completions_menu.initial_position;
         let newest_anchor = self.selections.newest_anchor();
-        let replace_range_multibuffer = {
-            let mut excerpt = snapshot.excerpt_containing(newest_anchor.range()).unwrap();
-            excerpt.map_range_from_buffer(replace_range.clone())
-        };
-        if snapshot.buffer_id_for_anchor(newest_anchor.head()) != Some(buffer.remote_id()) {
+        if newest_anchor
+            .start
+            .cmp(&completion_position, &snapshot)
+            .is_ne()
+        {
             return None;
         }
-
+        if snapshot.buffer_id_for_anchor(completion_position) != Some(buffer.remote_id()) {
+            return None;
+        }
+        let replace_range_multibuffer = {
+            let Some(mut excerpt) =
+                snapshot.excerpt_containing(completion_position..completion_position)
+            else {
+                return None;
+            };
+            excerpt.map_range_from_buffer(replace_range.clone())
+        };
         let old_text = buffer
             .text_for_range(replace_range.clone())
             .collect::<String>();
@@ -6598,6 +6608,7 @@ impl Editor {
             .saturating_sub(newest_anchor.end.text_anchor.to_offset(buffer));
         let prefix = &old_text[..old_text.len().saturating_sub(lookahead)];
         let suffix = &old_text[lookbehind.min(old_text.len())..];
+        cx.stop_propagation();
 
         let selections = self
             .selections

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -16230,6 +16230,245 @@ async fn test_completion_in_multibuffer_with_replace_range(cx: &mut TestAppConte
 }
 
 #[gpui::test]
+async fn test_snippet_completion_in_multibuffer_after_selection_moves_to_earlier_excerpt(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let buffer_text = indoc! {"
+        fn main() {
+            10.satu;
+
+            //
+            // separate1
+            // separate2
+            // separate3
+            //
+
+            10.satu20;
+        }
+    "};
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "main.rs": buffer_text,
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                completion_provider: Some(lsp::CompletionOptions {
+                    resolve_provider: None,
+                    ..lsp::CompletionOptions::default()
+                }),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/a/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let multi_buffer = cx.new(|cx| {
+        let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
+        multi_buffer.set_excerpts_for_path(
+            PathKey::sorted(0),
+            buffer.clone(),
+            [
+                Point::zero()..Point::new(2, 0),
+                Point::new(7, 0)..buffer.read(cx).max_point(),
+            ],
+            0,
+            cx,
+        );
+        multi_buffer
+    });
+
+    let editor = workspace.update_in(cx, |_, window, cx| {
+        cx.new(|cx| {
+            Editor::new(
+                EditorMode::Full {
+                    scale_ui_elements_with_buffer_font_size: false,
+                    show_active_line_background: false,
+                    sizing_behavior: SizingBehavior::Default,
+                },
+                multi_buffer.clone(),
+                Some(project.clone()),
+                window,
+                cx,
+            )
+        })
+    });
+
+    let pane = workspace.update_in(cx, |workspace, _, _| workspace.active_pane().clone());
+    pane.update_in(cx, |pane, window, cx| {
+        pane.add_item(Box::new(editor.clone()), true, true, None, window, cx);
+    });
+
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.run_until_parked();
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_ranges([Point::new(5, 11)..Point::new(5, 11)])
+        });
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.show_completions(&ShowCompletions, window, cx);
+    });
+
+    fake_server
+        .set_request_handler::<lsp::request::Completion, _, _>(move |_, _| async move {
+            Ok(Some(lsp::CompletionResponse::Array(vec![
+                lsp::CompletionItem {
+                    label: "saturating_sub".into(),
+                    kind: Some(lsp::CompletionItemKind::SNIPPET),
+                    insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+                    text_edit: Some(lsp::CompletionTextEdit::InsertAndReplace(
+                        lsp::InsertReplaceEdit {
+                            insert: lsp::Range::new(
+                                lsp::Position::new(9, 7),
+                                lsp::Position::new(9, 11),
+                            ),
+                            replace: lsp::Range::new(
+                                lsp::Position::new(9, 7),
+                                lsp::Position::new(9, 13),
+                            ),
+                            new_text: "saturating_sub($0)".to_owned(),
+                        },
+                    )),
+                    ..lsp::CompletionItem::default()
+                },
+            ])))
+        })
+        .next()
+        .await
+        .unwrap();
+
+    cx.condition(&editor, |editor, _| editor.context_menu_visible())
+        .await;
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(
+            SelectionEffects::no_scroll().completions(false),
+            window,
+            cx,
+            |s| s.select_ranges([Point::new(1, 11)..Point::new(1, 11)]),
+        );
+
+        assert!(editor.context_menu_visible());
+    });
+
+    let confirm_completion_handled = editor.update_in(cx, |editor, window, cx| {
+        editor
+            .confirm_completion(&ConfirmCompletion::default(), window, cx)
+            .is_some()
+    });
+    assert!(
+        !confirm_completion_handled,
+        "stale completion confirms should propagate instead of being treated as handled"
+    );
+
+    editor.update(cx, |editor, cx| {
+        assert_text_with_selections(
+            editor,
+            indoc! {"
+                fn main() {
+                    10.satuˇ;
+
+                    //
+
+                    10.satu20;
+                }
+            "},
+            cx,
+        );
+        assert!(!editor.context_menu_visible());
+    });
+}
+
+#[gpui::test]
+async fn test_stale_completion_confirm_propagates_enter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            completion_provider: Some(lsp::CompletionOptions {
+                trigger_characters: Some(vec![".".to_string()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    cx.set_state(indoc! {"
+        oneˇ
+        two
+    "});
+    cx.simulate_keystroke(".");
+    handle_completion_request(
+        indoc! {"
+            one.|<>
+            two
+        "},
+        vec!["first_completion"],
+        true,
+        counter.clone(),
+        &mut cx,
+    )
+    .await;
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+    assert_eq!(counter.load(atomic::Ordering::Acquire), 1);
+
+    cx.update_editor(|editor, window, cx| {
+        editor.change_selections(
+            SelectionEffects::no_scroll().completions(false),
+            window,
+            cx,
+            |s| {
+                s.select_ranges([Point::new(1, 3)..Point::new(1, 3)]);
+            },
+        );
+
+        assert!(editor.context_menu_visible());
+    });
+
+    cx.simulate_keystroke("\n");
+    cx.run_until_parked();
+
+    cx.assert_editor_state(indoc! {"
+        one.
+        two
+        ˇ
+    "});
+    cx.update_editor(|editor, _, _| {
+        assert!(!editor.context_menu_visible());
+    });
+}
+
+#[gpui::test]
 async fn test_completion(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
## Context

Close https://github.com/zed-industries/zed/issues/52072

Release Notes:

- Fixed stale multibuffer snippet completion crash
