### PR TITLE
debugger: Fix debugger interrupts stealing editor focus

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -238,7 +238,7 @@ impl DebugPanel {
             let session = session.clone();
             async move |this, cx| {
                 let debug_session =
-                    Self::register_session(this.clone(), session.clone(), true, cx).await?;
+                    Self::register_session(this.clone(), session.clone(), true, true, cx).await?;
                 let definition = debug_session
                     .update_in(cx, |debug_session, window, cx| {
                         debug_session.running_state().update(cx, |running, cx| {
@@ -347,20 +347,23 @@ impl DebugPanel {
         this: WeakEntity<Self>,
         session: Entity<Session>,
         focus: bool,
+        activate_session: bool,
         cx: &mut AsyncWindowContext,
     ) -> Result<Entity<DebugSession>> {
         let debug_session = register_session_inner(&this, session, cx).await?;
 
         let workspace = this.update_in(cx, |this, window, cx| {
-            if focus {
-                this.activate_session(debug_session.clone(), window, cx);
+            if activate_session {
+                this.activate_session(debug_session.clone(), window, focus, cx);
             }
 
             this.workspace.clone()
         })?;
-        workspace.update_in(cx, |workspace, window, cx| {
-            workspace.focus_panel::<Self>(window, cx);
-        })?;
+        if focus {
+            workspace.update_in(cx, |workspace, window, cx| {
+                workspace.focus_panel::<Self>(window, cx);
+            })?;
+        }
         Ok(debug_session)
     }
 
@@ -404,7 +407,7 @@ impl DebugPanel {
                 });
                 (session, task)
             });
-            Self::register_session(this.clone(), session.clone(), true, cx).await?;
+            Self::register_session(this.clone(), session.clone(), true, true, cx).await?;
 
             if let Err(error) = task.await {
                 session
@@ -469,7 +472,7 @@ impl DebugPanel {
             // Focus child sessions if the parent has never emitted a stopped event;
             // this improves our JavaScript experience, as it always spawns a "main" session that then spawns subsessions.
             let parent_ever_stopped = parent_session.update(cx, |this, _| this.has_ever_stopped());
-            Self::register_session(this, session, !parent_ever_stopped, cx).await?;
+            Self::register_session(this, session, false, !parent_ever_stopped, cx).await?;
             task.await
         })
         .detach_and_log_err(cx);
@@ -1041,7 +1044,7 @@ impl DebugPanel {
             .keys()
             .find(|session| session.read(cx).session_id(cx) == session_id)
         {
-            self.activate_session(session.clone(), window, cx);
+            self.activate_session(session.clone(), window, true, cx);
         }
     }
 
@@ -1049,10 +1052,13 @@ impl DebugPanel {
         &mut self,
         session_item: Entity<DebugSession>,
         window: &mut Window,
+        focus: bool,
         cx: &mut Context<Self>,
     ) {
         debug_assert!(self.sessions_with_children.contains_key(&session_item));
-        session_item.focus_handle(cx).focus(window, cx);
+        if focus {
+            session_item.focus_handle(cx).focus(window, cx);
+        }
         session_item.update(cx, |this, cx| {
             this.running_state().update(cx, |this, cx| {
                 this.go_to_selected_stack_frame(window, cx);

--- a/crates/debugger_ui/src/dropdown_menus.rs
+++ b/crates/debugger_ui/src/dropdown_menus.rs
@@ -201,7 +201,7 @@ impl DebugPanel {
                             let leaf = session_entry.leaf.clone();
                             move |window, cx| {
                                 weak.update(cx, |panel, cx| {
-                                    panel.activate_session(leaf.clone(), window, cx);
+                                    panel.activate_session(leaf.clone(), window, true, cx);
                                 })
                                 .ok();
                             }

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -2598,7 +2598,10 @@ async fn test_handle_start_debugging_request_does_not_steal_editor_focus(
 
     let buffer = project
         .update(cx, |project, cx| {
-            let worktree = project.find_worktree(Path::new(path!("/project")), cx).unwrap().0;
+            let worktree = project
+                .find_worktree(Path::new(path!("/project")), cx)
+                .unwrap()
+                .0;
             project.open_buffer((worktree.read(cx).id(), rel_path("main.rs")), cx)
         })
         .await
@@ -2614,7 +2617,6 @@ async fn test_handle_start_debugging_request_does_not_steal_editor_focus(
         )
     });
 
-    
     editor.update_in(cx, |editor, window, cx| {
         window.focus(&editor.focus_handle(cx), cx);
         assert!(editor.is_focused(window));

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -18,7 +18,7 @@ use editor::{
     ActiveDebugLine, Editor, EditorMode, MultiBuffer,
     actions::{self},
 };
-use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
+use gpui::{BackgroundExecutor, Focusable, TestAppContext, VisualTestContext};
 use project::{
     FakeFs, Project,
     debugger::session::{ThreadId, ThreadStatus},
@@ -2554,4 +2554,92 @@ async fn test_restart_request_is_not_sent_more_than_once_until_response(
         2,
         "A second restart should be allowed after the first one completes"
     );
+}
+
+#[gpui::test]
+async fn test_handle_start_debugging_request_does_not_steal_editor_focus(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            "main.rs": "First line\nSecond line\nThird line\nFourth line",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+
+    let fake_config = json!({"one": "two"});
+    let launched_with = Arc::new(parking_lot::Mutex::new(None));
+    let _subscription = project::debugger::test::intercept_debug_sessions(cx, {
+        let launched_with = launched_with.clone();
+        move |client| {
+            let launched_with = launched_with.clone();
+            client.on_request::<dap::requests::Launch, _>(move |_, args| {
+                launched_with.lock().replace(args.raw);
+                Ok(())
+            });
+            client.on_request::<dap::requests::Attach, _>(move |_, _| {
+                assert!(false, "should not get attach request");
+                Ok(())
+            });
+        }
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            let worktree = project.find_worktree(Path::new(path!("/project")), cx).unwrap().0;
+            project.open_buffer((worktree.read(cx).id(), rel_path("main.rs")), cx)
+        })
+        .await
+        .unwrap();
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer, cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+
+    
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+        assert!(editor.is_focused(window));
+    });
+
+    client
+        .fake_reverse_request::<StartDebugging>(StartDebuggingRequestArguments {
+            request: StartDebuggingRequestArgumentsRequest::Launch,
+            configuration: fake_config.clone(),
+        })
+        .await;
+
+    cx.run_until_parked();
+
+    workspace
+        .update(cx, |workspace, window, cx| {
+            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+            let is_debug_panel_focused = debug_panel
+                .read(cx)
+                .active_session()
+                .unwrap()
+                .read(cx)
+                .focus_handle(cx)
+                .is_focused(window);
+            assert!(!is_debug_panel_focused);
+        })
+        .unwrap();
 }

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -2578,8 +2578,8 @@ async fn test_handle_start_debugging_request_does_not_steal_editor_focus(
 
     let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
     let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    let parent_session_id = session.read_with(cx, |session, _| session.session_id());
 
-    let fake_config = json!({"one": "two"});
     let launched_with = Arc::new(parking_lot::Mutex::new(None));
     let _subscription = project::debugger::test::intercept_debug_sessions(cx, {
         let launched_with = launched_with.clone();
@@ -2589,59 +2589,79 @@ async fn test_handle_start_debugging_request_does_not_steal_editor_focus(
                 launched_with.lock().replace(args.raw);
                 Ok(())
             });
-            client.on_request::<dap::requests::Attach, _>(move |_, _| {
-                assert!(false, "should not get attach request");
-                Ok(())
-            });
         }
     });
 
-    let buffer = project
-        .update(cx, |project, cx| {
-            let worktree = project
-                .find_worktree(Path::new(path!("/project")), cx)
-                .unwrap()
-                .0;
-            project.open_buffer((worktree.read(cx).id(), rel_path("main.rs")), cx)
+    // Let the parent session finish registering (which focuses the debug panel).
+    cx.run_until_parked();
+
+    let worktree_id = project.update(cx, |project, cx| {
+        project
+            .find_worktree(Path::new(path!("/project")), cx)
+            .unwrap()
+            .0
+            .read(cx)
+            .id()
+    });
+
+    // Open and focus an editor in the workspace, as if the user were editing
+    // code while the debug session is running.
+    let editor = workspace
+        .update(cx, |multi, window, cx| {
+            multi.workspace().update(cx, |workspace, cx| {
+                workspace.open_path((worktree_id, rel_path("main.rs")), None, true, window, cx)
+            })
         })
+        .unwrap()
         .await
+        .unwrap()
+        .downcast::<Editor>()
         .unwrap();
 
-    let (editor, cx) = cx.add_window_view(|window, cx| {
-        Editor::new(
-            EditorMode::full(),
-            MultiBuffer::build_from_buffer(buffer, cx),
-            Some(project.clone()),
-            window,
-            cx,
-        )
-    });
+    cx.run_until_parked();
 
-    editor.update_in(cx, |editor, window, cx| {
-        window.focus(&editor.focus_handle(cx), cx);
-        assert!(editor.is_focused(window));
-    });
+    workspace
+        .update(cx, |_, window, cx| {
+            assert!(
+                editor.focus_handle(cx).is_focused(window),
+                "editor should be focused before the child session starts"
+            );
+        })
+        .unwrap();
 
+    // The adapter spawns a child session via a reverse request, as e.g.
+    // hot-reload-capable adapters do while the user is editing code.
     client
         .fake_reverse_request::<StartDebugging>(StartDebuggingRequestArguments {
             request: StartDebuggingRequestArgumentsRequest::Launch,
-            configuration: fake_config.clone(),
+            configuration: json!({"one": "two"}),
         })
         .await;
 
     cx.run_until_parked();
 
+    assert!(
+        launched_with.lock().is_some(),
+        "child session should have been launched"
+    );
+
     workspace
         .update(cx, |workspace, window, cx| {
             let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-            let is_debug_panel_focused = debug_panel
-                .read(cx)
-                .active_session()
-                .unwrap()
-                .read(cx)
-                .focus_handle(cx)
-                .is_focused(window);
-            assert!(!is_debug_panel_focused);
+            let active_session = debug_panel.read(cx).active_session().unwrap();
+            assert_ne!(
+                active_session.read(cx).session_id(cx),
+                parent_session_id,
+                "child session should have been activated in the debug panel"
+            );
+            assert!(
+                !debug_panel.focus_handle(cx).contains_focused(window, cx),
+                "debug panel should not steal focus when a child session starts"
+            );
+            assert!(
+                editor.focus_handle(cx).is_focused(window),
+                "editor should remain focused when a child session starts"
+            );
         })
         .unwrap();
 }


### PR DESCRIPTION
## Context

Closes #34038 

When editing code during a debugging session within a hot-reload-capable application, the debugger panel steal the editor focus, which make it difficult to modify code.

## How to Review

`focus` argument was used for both activation and focus capability, so I created a new argument called `activate_session` to split the control of those capabilities.

I also condition the workspace panel focus by the `focus` argument, it looked like an oversight.


## Self-Review Checklist

<!-- Check before requesting review: -->
- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Fixed debugger interrupts stealing editor focus 

## PS

Thank you for the amazing work! 