### PR TITLE
agent: Set message editor language to markdown

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -14,7 +14,6 @@ use acp_thread::MentionUri;
 use agent::ThreadStore;
 use agent_client_protocol as acp;
 use anyhow::{Result, anyhow};
-use collections::HashSet;
 use editor::{
     Addon, AnchorRangeExt, ContextMenuOptions, Editor, EditorElement, EditorEvent, EditorMode,
     EditorStyle, Inlay, MultiBuffer, MultiBufferOffset, MultiBufferSnapshot, ToOffset,
@@ -25,7 +24,7 @@ use gpui::{
     AppContext, ClipboardEntry, Context, Entity, EventEmitter, FocusHandle, Focusable, ImageFormat,
     KeyContext, SharedString, Subscription, Task, TextStyle, WeakEntity,
 };
-use language::{Buffer, Language, language_settings::InlayHintKind};
+use language::{Buffer, language_settings::InlayHintKind};
 use parking_lot::RwLock;
 use project::AgentId;
 use project::{CompletionIntent, InlayHint, InlayHintLabel, InlayId, Project, Worktree};
@@ -172,16 +171,18 @@ impl MessageEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let language = Language::new(
-            language::LanguageConfig {
-                completion_query_characters: HashSet::from_iter(['.', '-', '_', '@']),
-                ..Default::default()
-            },
-            None,
-        );
+        let language_registry = project
+            .upgrade()
+            .map(|project| project.read(cx).languages().clone());
 
         let editor = cx.new(|cx| {
-            let buffer = cx.new(|cx| Buffer::local("", cx).with_language(Arc::new(language), cx));
+            let buffer = cx.new(|cx| {
+                let buffer = Buffer::local("", cx);
+                if let Some(language_registry) = language_registry.as_ref() {
+                    buffer.set_language_registry(language_registry.clone());
+                }
+                buffer
+            });
             let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
 
             let mut editor = Editor::new(mode, buffer, None, window, cx);
@@ -286,6 +287,22 @@ impl MessageEditor {
                 }
             }
         }));
+
+        if let Some(language_registry) = language_registry {
+            let editor = editor.clone();
+            cx.spawn(async move |_, cx| {
+                let markdown = language_registry.language_for_name("Markdown").await?;
+                editor.update(cx, |editor, cx| {
+                    if let Some(buffer) = editor.buffer().read(cx).as_singleton() {
+                        buffer.update(cx, |buffer, cx| {
+                            buffer.set_language(Some(markdown), cx);
+                        });
+                    }
+                });
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
 
         Self {
             editor,


### PR DESCRIPTION
Agent panel message editor highlighted as markdown

<img width="633" height="179" alt="image" src="https://github.com/user-attachments/assets/c9832393-9bae-4b9a-9a32-071d0e3e7a90" />


Release Notes:

- N/A or Added/Fixed/Improved ...
