### PR TITLE
workspace: Prompt before closing pane or window with running terminal process

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2123,6 +2123,38 @@ impl Terminal {
         }
     }
 
+    /// Returns the foreground process info if a non-shell process is running.
+    /// Returns None if the terminal is idle (only shell running).
+    pub fn foreground_process_name(&self) -> Option<String> {
+        match &self.terminal_type {
+            TerminalType::Pty { info, .. } => {
+                let process_info = info.current.read();
+                let fpi = process_info.as_ref()?;
+                let shells = [
+                    "bash",
+                    "zsh",
+                    "fish",
+                    "sh",
+                    "nu",
+                    "pwsh",
+                    "powershell",
+                    "cmd",
+                ];
+                if shells.iter().any(|s| fpi.name.eq_ignore_ascii_case(s)) {
+                    None
+                } else {
+                    let args = if fpi.argv.len() > 1 {
+                        format!(" {}", fpi.argv[1..].join(" "))
+                    } else {
+                        String::new()
+                    };
+                    Some(format!("{}{}", fpi.name, args))
+                }
+            }
+            TerminalType::DisplayOnly => None,
+        }
+    }
+
     pub fn title(&self, truncate: bool) -> String {
         const MAX_CHARS: usize = 25;
         match &self.task {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1624,10 +1624,19 @@ impl Item for TerminalView {
     }
 
     fn is_dirty(&self, cx: &App) -> bool {
-        match self.terminal.read(cx).task() {
+        let terminal = self.terminal.read(cx);
+        match terminal.task() {
             Some(task) => task.status == TaskStatus::Running,
-            None => self.has_bell(),
+            None => terminal.foreground_process_name().is_some() || self.has_bell(),
         }
+    }
+
+    fn running_process_name(&self, cx: &App) -> Option<String> {
+        let terminal = self.terminal.read(cx);
+        if terminal.task().is_some() {
+            return None;
+        }
+        terminal.foreground_process_name()
     }
 
     fn has_conflict(&self, _cx: &App) -> bool {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -255,6 +255,9 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
     fn is_dirty(&self, _: &App) -> bool {
         false
     }
+    fn running_process_name(&self, _: &App) -> Option<String> {
+        None
+    }
     fn capability(&self, _: &App) -> Capability {
         Capability::ReadWrite
     }
@@ -504,6 +507,7 @@ pub trait ItemHandle: 'static + Send {
     fn item_id(&self) -> EntityId;
     fn to_any_view(&self) -> AnyView;
     fn is_dirty(&self, cx: &App) -> bool;
+    fn running_process_name(&self, cx: &App) -> Option<String>;
     fn capability(&self, cx: &App) -> Capability;
     fn toggle_read_only(&self, window: &mut Window, cx: &mut App);
     fn has_deleted_file(&self, cx: &App) -> bool;
@@ -1015,6 +1019,10 @@ impl<T: Item> ItemHandle for Entity<T> {
 
     fn is_dirty(&self, cx: &App) -> bool {
         self.read(cx).is_dirty(cx)
+    }
+
+    fn running_process_name(&self, cx: &App) -> Option<String> {
+        self.read(cx).running_process_name(cx)
     }
 
     fn capability(&self, cx: &App) -> Capability {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1955,6 +1955,23 @@ impl Pane {
             }
 
             for item_to_close in items_to_close {
+                let process_name = cx.update(|_, cx| item_to_close.running_process_name(cx))?;
+                if let Some(name) = process_name {
+                    let answer = pane.update_in(cx, |_, window, cx| {
+                        window.prompt(
+                            PromptLevel::Warning,
+                            &format!("Terminal is running: {name}"),
+                            Some("Closing will terminate this process."),
+                            &["Close", "Cancel"],
+                            cx,
+                        )
+                    })?;
+                    match answer.await {
+                        Ok(0) => {}
+                        _ => return Ok(()),
+                    }
+                }
+
                 let mut should_close = true;
                 let mut should_save = true;
                 if save_intent == SaveIntent::Close {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2939,6 +2939,15 @@ impl Workspace {
                         }
                     }
                 }
+                for dock in this.all_docks() {
+                    for pane in dock.read(cx).panes(cx) {
+                        for item in pane.read(cx).items() {
+                            if let Some(name) = item.running_process_name(cx) {
+                                processes.push(name);
+                            }
+                        }
+                    }
+                }
                 processes
             })?;
 
@@ -2955,8 +2964,9 @@ impl Workspace {
                     )
                 })?;
 
-                if answer.await.log_err() == Some(1) {
-                    return anyhow::Ok(false);
+                match answer.await.log_err() {
+                    Some(0) => {} // "Force Close" — proceed
+                    _ => return anyhow::Ok(false), // "Cancel" or dialog dismissed
                 }
             }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2930,6 +2930,36 @@ impl Workspace {
                 }
             }
 
+            let running_processes = this.update(cx, |this, cx| {
+                let mut processes = Vec::new();
+                for pane in &this.panes {
+                    for item in pane.read(cx).items() {
+                        if let Some(name) = item.running_process_name(cx) {
+                            processes.push(name);
+                        }
+                    }
+                }
+                processes
+            })?;
+
+            if !running_processes.is_empty() {
+                this.update(cx, |_, cx| cx.emit(Event::Activate))?;
+                let process_list = running_processes.join("\n");
+                let answer = cx.update(|window, cx| {
+                    window.prompt(
+                        PromptLevel::Warning,
+                        "Terminals have running processes. Close anyway?",
+                        Some(&process_list),
+                        &["Force Close", "Cancel"],
+                        cx,
+                    )
+                })?;
+
+                if answer.await.log_err() == Some(1) {
+                    return anyhow::Ok(false);
+                }
+            }
+
             let save_result = this
                 .update_in(cx, |this, window, cx| {
                     this.save_all_internal(SaveIntent::Close, window, cx)


### PR DESCRIPTION
When a terminal tab has a foreground process running, closing it now prompts the user for confirmation instead of silently killing the process.

**Changes:**

- `workspace/pane.rs`: Before closing an individual item, check `running_process_name`. If a process is active, show a warning prompt with "Close" / "Cancel". The user must explicitly confirm to terminate the process.
- `workspace/workspace.rs`: Extend the existing window-close check to also scan terminals open in dock panels (bottom/left/right), not only center panes. Fix the dialog response check so that dismissing the dialog (e.g. pressing Escape) is treated as "Cancel" rather than "Force Close".
- `terminal/terminal.rs`, `terminal_view/terminal_view.rs`, `workspace/item.rs`: Foundation — `foreground_process_name()` on `Terminal` and the `running_process_name` method on the `Item` trait, implemented by `TerminalView`.

Release Notes:

- Added a confirmation prompt when closing a terminal pane or window that has a foreground process running, preventing accidental process termination.