### PR TITLE
workspace: Always open projects in a new window

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -652,28 +652,9 @@ impl MultiWorkspace {
     ) -> Task<Result<Entity<Workspace>>> {
         let workspace = self.workspace().clone();
 
-        if self.multi_workspace_enabled(cx) {
-            workspace.update(cx, |workspace, cx| {
-                workspace.open_workspace_for_paths(true, paths, window, cx)
-            })
-        } else {
-            cx.spawn_in(window, async move |_this, cx| {
-                let should_continue = workspace
-                    .update_in(cx, |workspace, window, cx| {
-                        workspace.prepare_to_close(crate::CloseIntent::ReplaceWindow, window, cx)
-                    })?
-                    .await?;
-                if should_continue {
-                    workspace
-                        .update_in(cx, |workspace, window, cx| {
-                            workspace.open_workspace_for_paths(true, paths, window, cx)
-                        })?
-                        .await
-                } else {
-                    Ok(workspace)
-                }
-            })
-        }
+        workspace.update(cx, |workspace, cx| {
+            workspace.open_workspace_for_paths(false, paths, window, cx)
+        })
     }
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3134,23 +3134,12 @@ impl Workspace {
 
     pub fn open_workspace_for_paths(
         &mut self,
-        replace_current_window: bool,
+        _replace_current_window: bool,
         paths: Vec<PathBuf>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Workspace>>> {
-        let window_handle = window.window_handle().downcast::<MultiWorkspace>();
-        let is_remote = self.project.read(cx).is_via_collab();
-        let has_worktree = self.project.read(cx).worktrees(cx).next().is_some();
-        let has_dirty_items = self.items(cx).any(|item| item.is_dirty(cx));
-
-        let window_to_replace = if replace_current_window {
-            window_handle
-        } else if is_remote || has_worktree || has_dirty_items {
-            None
-        } else {
-            window_handle
-        };
+        let window_to_replace: Option<WindowHandle<MultiWorkspace>> = None;
         let app_state = self.app_state.clone();
 
         cx.spawn(async move |_, cx| {


### PR DESCRIPTION
Currently, opening a project replaces the current workspace window when certain conditions are met (no dirty items, no remote session, no existing worktree). This can be surprising — users expect their current window to stay open.

This change makes Zed always open a new window when opening a project, regardless of the current window state.

**Changes:**

- `workspace/src/workspace.rs`: `open_workspace_for_paths` always sets `window_to_replace = None`, ignoring the `replace_current_window` parameter.
- `workspace/src/multi_workspace.rs`: Simplify `open_paths` to always pass `replace_current_window: false`, removing the conditional branch that previously closed the current window.

Release Notes:

- Changed project opening to always create a new window instead of replacing the current workspace.