### PR TITLE
ui: Add accent bottom border to selected tabs

### DIFF
--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -164,6 +164,10 @@ impl RenderOnce for Tab {
                 TabPosition::Middle(Ordering::Less) => this.border_l_1().pr_px().border_b_1(),
                 TabPosition::Middle(Ordering::Greater) => this.border_r_1().pl_px().border_b_1(),
             })
+            .when(self.selected, |this| {
+                this.border_b_2()
+                    .border_color(cx.theme().colors().border_focused)
+            })
             .cursor_pointer()
             .child(
                 h_flex()


### PR DESCRIPTION
Selected tabs currently have no visual distinction beyond their background color change. This makes it harder to tell at a glance which tab is active, especially with themes where the contrast is subtle.

Add a 2px bottom border using `border_focused` from the active theme color palette to selected tabs, giving a clear and theme-consistent active indicator.

**Changes:**

- `crates/ui/src/components/tab.rs`: Apply `.border_b_2().border_color(cx.theme().colors().border_focused)` when `self.selected` is true.

Release Notes:

- Improved visual clarity of active tabs by adding a themed accent bottom border to the selected tab.