### PR TITLE
gpui: Retry present after wgpu surface Outdated/Lost

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -488,7 +488,11 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_hit_test_window_control(&self, callback: Box<dyn FnMut() -> Option<WindowControlArea>>);
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
-    fn draw(&self, scene: &Scene);
+    /// Draw the scene to the window surface.
+    /// Returns `true` if the frame was successfully submitted for presentation.
+    /// Returns `false` if the frame was skipped due to a surface error (e.g.
+    /// `Outdated` or `Lost`) and a retry on the next frame is needed.
+    fn draw(&self, scene: &Scene) -> bool;
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -285,7 +285,9 @@ impl PlatformWindow for TestWindow {
 
     fn on_appearance_changed(&self, _callback: Box<dyn FnMut()>) {}
 
-    fn draw(&self, _scene: &Scene) {}
+    fn draw(&self, _scene: &Scene) -> bool {
+        true
+    }
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {
         self.0.lock().sprite_atlas.clone()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2310,8 +2310,15 @@ impl Window {
 
     #[profiling::function]
     fn present(&self) {
-        self.platform_window.draw(&self.rendered_frame.scene);
-        self.needs_present.set(false);
+        let frame_presented = self.platform_window.draw(&self.rendered_frame.scene);
+        // Only clear needs_present if the frame was actually submitted for display.
+        // If the GPU surface was outdated/lost and needed reconfiguring, the renderer
+        // returns false and we keep needs_present=true so the next frame callback
+        // will retry presentation. This fixes UI freezes on Wayland/NVIDIA when
+        // switching windows via Alt+Tab causes a Vulkan swapchain Outdated error.
+        if frame_presented {
+            self.needs_present.set(false);
+        }
         profiling::finish_frame!();
     }
 

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1335,7 +1335,7 @@ impl PlatformWindow for WaylandWindow {
         self.0.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene) -> bool {
         let mut state = self.borrow_mut();
 
         if state.renderer.device_lost() {
@@ -1359,10 +1359,10 @@ impl PlatformWindow for WaylandWindow {
 
             // The current scene references atlas textures that were cleared during recovery.
             // Skip this frame and let the next frame rebuild the scene with fresh textures.
-            return;
+            return false;
         }
 
-        state.renderer.draw(scene);
+        state.renderer.draw(scene)
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -1602,7 +1602,7 @@ impl PlatformWindow for X11Window {
         self.0.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene) -> bool {
         let mut inner = self.0.state.borrow_mut();
 
         if inner.renderer.device_lost() {
@@ -1624,10 +1624,10 @@ impl PlatformWindow for X11Window {
 
             // The current scene references atlas textures that were cleared during recovery.
             // Skip this frame and let the next frame rebuild the scene with fresh textures.
-            return;
+            return false;
         }
 
-        inner.renderer.draw(scene);
+        inner.renderer.draw(scene)
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1545,9 +1545,10 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().toggle_tab_bar_callback = Some(callback);
     }
 
-    fn draw(&self, scene: &gpui::Scene) {
+    fn draw(&self, scene: &gpui::Scene) -> bool {
         let mut this = self.0.lock();
         this.renderer.draw(scene);
+        true
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -663,7 +663,7 @@ impl PlatformWindow for WebWindow {
         self.inner.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene) -> bool {
         if let Some((width, height)) = self.inner.pending_physical_size.take() {
             if self.inner.canvas.width() != width || self.inner.canvas.height() != height {
                 self.inner.canvas.set_width(width);
@@ -678,7 +678,7 @@ impl PlatformWindow for WebWindow {
             drop(state);
         }
 
-        self.inner.state.borrow_mut().renderer.draw(scene);
+        self.inner.state.borrow_mut().renderer.draw(scene)
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1036,7 +1036,7 @@ impl WgpuRenderer {
         self.max_texture_size
     }
 
-    pub fn draw(&mut self, scene: &Scene) {
+    pub fn draw(&mut self, scene: &Scene) -> bool {
         let last_error = self.last_error.lock().unwrap().take();
         if let Some(error) = last_error {
             self.failed_frame_count += 1;
@@ -1063,7 +1063,9 @@ impl WgpuRenderer {
                 resources
                     .surface
                     .configure(&resources.device, &surface_config);
-                return;
+                // Surface was reconfigured but no frame was submitted — caller
+                // should retry on the next frame callback.
+                return false;
             }
             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
                 let surface_config = self.surface_config.clone();
@@ -1071,15 +1073,19 @@ impl WgpuRenderer {
                 resources
                     .surface
                     .configure(&resources.device, &surface_config);
-                return;
+                // Surface was reconfigured but no frame was submitted — caller
+                // should retry on the next frame callback.
+                return false;
             }
             wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
-                return;
+                // Window is hidden or timed out — no retry needed; the frame
+                // loop will resume naturally when the compositor requests it.
+                return true;
             }
             wgpu::CurrentSurfaceTexture::Validation => {
                 *self.last_error.lock().unwrap() =
                     Some("Surface texture validation error".to_string());
-                return;
+                return true;
             }
         };
 
@@ -1269,7 +1275,7 @@ impl WgpuRenderer {
                 .queue
                 .submit(std::iter::once(encoder.finish()));
             frame.present();
-            return;
+            return true;
         }
     }
 

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -914,12 +914,13 @@ impl PlatformWindow for WindowsWindow {
             .set(Some(callback));
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene) -> bool {
         self.state
             .renderer
             .borrow_mut()
             .draw(scene, self.state.background_appearance.get())
             .log_err();
+        true
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {


### PR DESCRIPTION
When switching windows via Alt+Tab on Wayland with NVIDIA GPUs, the Vulkan swapchain becomes Outdated. The wgpu renderer correctly reconfigures the surface and returns early, but `Window::present()` was unconditionally setting `needs_present=false` afterward — even when no frame was actually submitted.

This caused a freeze: the next frame callback found `is_dirty=false` and `needs_present=false`, so it skipped rendering entirely. The window appeared frozen (but was still interactive since event handling is separate).

Fix: change `PlatformWindow::draw()` to return bool indicating whether the frame was actually submitted for display. `Window::present()` now only clears needs_present if the frame was successfully presented. For Outdated/Lost/ Suboptimal cases, needs_present stays true so the next frame callback retries.

For Occluded/Timeout cases, we return true (no retry) since the compositor controls when to resume rendering for hidden windows.

Fixes #52009
Related: #50195, #51397, #50734

## Context

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed UI freeze when switching windows via Alt+Tab on Wayland with NVIDIA GPUs