### PR TITLE
Respect envFile property in debugpy for VSCode launch configuration

### DIFF
--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -1,4 +1,5 @@
 mod codelldb;
+mod env_file;
 mod gdb;
 mod go;
 mod javascript;

--- a/crates/dap_adapters/src/env_file.rs
+++ b/crates/dap_adapters/src/env_file.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use collections::HashMap;
+use fs::Fs;
+use log::warn;
+use serde_json::{Map, Value};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
+
+/// Expands a VS Code-style `envFile` into concrete environment variables.
+///
+/// Loaded values are merged into both the outgoing DAP configuration's `env` object and the
+/// adapter process environment map. Explicit values already present in `config["env"]` override
+/// values loaded from `envFile` in the DAP configuration.
+///
+/// Relative `envFile` paths are resolved against `cwd`. After processing, the raw `envFile`
+/// attribute is removed so adapters that do not support it do not receive it unchanged.
+pub(crate) async fn apply_env_file(
+    config: &mut Map<String, Value>,
+    envs: &mut HashMap<String, String>,
+    cwd: Option<&Path>,
+    fs: Arc<dyn Fs>,
+    adapter_name: &'static str,
+) -> Result<()> {
+    let Some(env_file) = config.get("envFile") else {
+        return Ok(());
+    };
+
+    let env_files = match env_file {
+        Value::Array(values) => values
+            .iter()
+            .map(|value| value.as_str())
+            .collect::<Vec<_>>(),
+        Value::String(value) => vec![Some(value.as_str())],
+        _ => return Ok(()),
+    };
+
+    let rebase_path = |path: PathBuf| {
+        if path.is_absolute() {
+            Some(path)
+        } else {
+            cwd.map(|base_path| base_path.join(path))
+        }
+    };
+
+    let mut env_file_vars = HashMap::default();
+    for path in env_files {
+        let Some(path) = path
+            .and_then(|value| PathBuf::from_str(value).ok())
+            .and_then(rebase_path)
+        else {
+            continue;
+        };
+
+        if let Ok(file) = fs.open_sync(&path).await {
+            let file_envs: HashMap<String, String> = dotenvy::from_read_iter(file)
+                .filter_map(Result::ok)
+                .collect();
+            envs.extend(
+                file_envs
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+            env_file_vars.extend(file_envs);
+        } else {
+            warn!("While starting {adapter_name} debug session: failed to read env file {path:?}");
+        }
+    }
+
+    let mut env_obj = serde_json::Map::new();
+    for (key, value) in env_file_vars {
+        env_obj.insert(key, Value::String(value));
+    }
+
+    if let Some(existing_env) = config.get("env").and_then(|value| value.as_object()) {
+        for (key, value) in existing_env {
+            env_obj.insert(key.clone(), value.clone());
+        }
+    }
+
+    if !env_obj.is_empty() {
+        config.insert("env".to_string(), Value::Object(env_obj));
+    }
+
+    config.remove("envFile");
+    Ok(())
+}

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -10,6 +10,7 @@ use dap::{
 use futures::StreamExt;
 use gpui::{AsyncApp, SharedString};
 use language::LanguageName;
+use log::warn;
 use task::TcpArgumentsTemplate;
 use util;
 

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -7,22 +7,13 @@ use dap::{
         latest_github_release,
     },
 };
-use fs::Fs;
 use futures::StreamExt;
 use gpui::{AsyncApp, SharedString};
 use language::LanguageName;
-use log::warn;
-use serde_json::{Map, Value};
 use task::TcpArgumentsTemplate;
 use util;
 
-use std::{
-    env::consts,
-    ffi::OsStr,
-    path::{Path, PathBuf},
-    str::FromStr,
-    sync::OnceLock,
-};
+use std::{env::consts, ffi::OsStr, path::PathBuf, sync::OnceLock};
 
 use crate::*;
 
@@ -505,13 +496,14 @@ impl DebugAdapter for GoDebugAdapter {
                 .entry("cwd")
                 .or_insert_with(|| delegate.worktree_root_path().to_string_lossy().into());
 
-            handle_envs(
+            crate::env_file::apply_env_file(
                 configuration,
                 &mut envs,
                 cwd.as_deref(),
                 delegate.fs().clone(),
+                Self::ADAPTER_NAME,
             )
-            .await;
+            .await?;
         }
 
         if let Some(connection_options) = &task_definition.tcp_connection {
@@ -562,66 +554,4 @@ impl DebugAdapter for GoDebugAdapter {
             },
         })
     }
-}
-
-// delve doesn't do anything with the envFile setting, so we intercept it
-async fn handle_envs(
-    config: &mut Map<String, Value>,
-    envs: &mut HashMap<String, String>,
-    cwd: Option<&Path>,
-    fs: Arc<dyn Fs>,
-) -> Option<()> {
-    let env_files = match config.get("envFile")? {
-        Value::Array(arr) => arr.iter().map(|v| v.as_str()).collect::<Vec<_>>(),
-        Value::String(s) => vec![Some(s.as_str())],
-        _ => return None,
-    };
-
-    let rebase_path = |path: PathBuf| {
-        if path.is_absolute() {
-            Some(path)
-        } else {
-            cwd.map(|p| p.join(path))
-        }
-    };
-
-    let mut env_vars = HashMap::default();
-    for path in env_files {
-        let Some(path) = path
-            .and_then(|s| PathBuf::from_str(s).ok())
-            .and_then(rebase_path)
-        else {
-            continue;
-        };
-
-        if let Ok(file) = fs.open_sync(&path).await {
-            let file_envs: HashMap<String, String> = dotenvy::from_read_iter(file)
-                .filter_map(Result::ok)
-                .collect();
-            envs.extend(file_envs.iter().map(|(k, v)| (k.clone(), v.clone())));
-            env_vars.extend(file_envs);
-        } else {
-            warn!("While starting Go debug session: failed to read env file {path:?}");
-        };
-    }
-
-    let mut env_obj: serde_json::Map<String, Value> = serde_json::Map::new();
-
-    for (k, v) in env_vars {
-        env_obj.insert(k, Value::String(v));
-    }
-
-    if let Some(existing_env) = config.get("env").and_then(|v| v.as_object()) {
-        for (k, v) in existing_env {
-            env_obj.insert(k.clone(), v.clone());
-        }
-    }
-
-    if !env_obj.is_empty() {
-        config.insert("env".to_string(), Value::Object(env_obj));
-    }
-
-    // remove envFile now that it's been handled
-    config.remove("envFile");
-    Some(())
 }

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -86,13 +86,12 @@ impl PythonDebugAdapter {
         Ok(args)
     }
 
-    async fn request_args(
+    async fn finalize_configuration(
         &self,
         delegate: &Arc<dyn DapDelegate>,
         task_definition: &DebugTaskDefinition,
-    ) -> Result<StartDebuggingRequestArguments> {
-        let request = self.request_kind(&task_definition.config).await?;
-
+        envs: &mut HashMap<String, String>,
+    ) -> Result<Value> {
         let mut configuration = task_definition.config.clone();
         if let Ok(console) = configuration.dot_get_mut("console") {
             // Use built-in Zed terminal if user did not explicitly provide a setting for console.
@@ -101,10 +100,32 @@ impl PythonDebugAdapter {
             }
         }
 
-        if let Some(obj) = configuration.as_object_mut() {
-            obj.entry("cwd")
-                .or_insert(delegate.worktree_root_path().to_string_lossy().into());
+        if let Some(config) = configuration.as_object_mut() {
+            let cwd_path = match config.get("cwd") {
+                Some(Value::String(cwd)) => PathBuf::from(cwd),
+                Some(_) => bail!("expected `cwd` to be a string"),
+                None => {
+                    let worktree_root = delegate.worktree_root_path().to_path_buf();
+                    config.insert("cwd".into(), worktree_root.to_string_lossy().into());
+                    worktree_root
+                }
+            };
+
+            crate::env_file::apply_env_file(
+                config,
+                envs,
+                Some(&cwd_path),
+                delegate.fs().clone(),
+                Self::LANGUAGE_NAME,
+            )
+            .await?;
         }
+
+        Ok(configuration)
+    }
+
+    async fn request_args(&self, configuration: Value) -> Result<StartDebuggingRequestArguments> {
+        let request = self.request_kind(&configuration).await?;
 
         Ok(StartDebuggingRequestArguments {
             configuration,
@@ -414,6 +435,12 @@ impl PythonDebugAdapter {
             arguments.join(" ")
         );
 
+        let mut envs = user_env.unwrap_or_default();
+        let configuration = self
+            .finalize_configuration(delegate, config, &mut envs)
+            .await?;
+        let request_args = self.request_args(configuration).await?;
+
         Ok(DebugAdapterBinary {
             command: Some(python_command),
             arguments,
@@ -423,8 +450,8 @@ impl PythonDebugAdapter {
                 timeout,
             }),
             cwd: Some(delegate.worktree_root_path().to_path_buf()),
-            envs: user_env.unwrap_or_default(),
-            request_args: self.request_args(delegate, config).await?,
+            envs,
+            request_args,
         })
     }
 }


### PR DESCRIPTION
## Context

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

The adapter for `debugpy` does not respect the `envFile` attribute in VSCode launch configuration.

https://github.com/zed-industries/zed/issues/32984 describes the same missing behavior for Delve adapter for Go. The corresponding PR https://github.com/zed-industries/zed/pull/33666 implemented a change where the location of the `envFile` was resolved and environment variables are injected both in the `env` of the DAP launch request and the process environment that launches Delve.

This workaround is necessary as Delve, debuypy and other DAP adapters do not support the `envFile` property.

However, this PR only implemented this for Delve and therefore only for Go. When I tried to start a debugging session for a VSCode-style python launch configuration, I ran into issues because the environment variables where missing.

This PR factors out the functionality for handling the `envFile` and uses it across the Delve and Debugpy implementation.

I considered implementing it for all other debuggers as well, but refrained from doing so to keep my first contribution small. If desired, I would implement it for the other debuggers as well.

If you wish for me to create an issue first for traceability, please tell me.

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

I have created a small reproduction repository with a sample Python application. The `main.py` file simply reads the `NAME` env variable and prints it to stdout. It contains a `.env` file with said env variable. The launch configuration wires everything together.

https://github.com/nick-lehmann/zed-python-debug-repro

With the latest version of Zed, the debug configuration will yield "Hello nobody", as the `NAME` env variable is not provided to debugpy. With the changes in this branch, the debug configuration will correctly yield "Hello nick".

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added support for the `envFile` attribute in VSCode style launch configuration for python
