### PR TITLE
Normalize extension relative paths to use forward slashes for cross-platform remote compatibility

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1579,7 +1579,7 @@ impl ExtensionStore {
                 })?;
                 let config = ::toml::from_str::<LanguageConfig>(&config)?;
 
-                let relative_path = relative_path.to_path_buf();
+                let relative_path = normalize_relative_path(relative_path);
                 if !extension_manifest.languages.contains(&relative_path) {
                     extension_manifest.languages.push(relative_path.clone());
                 }
@@ -1612,7 +1612,7 @@ impl ExtensionStore {
                     continue;
                 };
 
-                let relative_path = relative_path.to_path_buf();
+                let relative_path = normalize_relative_path(relative_path);
                 if !extension_manifest.themes.contains(&relative_path) {
                     extension_manifest.themes.push(relative_path.clone());
                 }
@@ -1644,7 +1644,7 @@ impl ExtensionStore {
                     continue;
                 };
 
-                let relative_path = relative_path.to_path_buf();
+                let relative_path = normalize_relative_path(relative_path);
                 if !extension_manifest.icon_themes.contains(&relative_path) {
                     extension_manifest.icon_themes.push(relative_path.clone());
                 }
@@ -1873,6 +1873,21 @@ impl ExtensionStore {
         self.remote_clients.push(client.downgrade());
         self.ssh_registered_tx.unbounded_send(()).ok();
     }
+}
+
+/// Normalizes a relative path to always use forward slashes as separators.
+///
+/// This is needed because on Windows, `Path::strip_prefix` returns paths with
+/// backslash separators, but these paths may be serialized into extension manifests
+/// and sent to remote hosts (e.g., Linux via SSH) where backslashes are not
+/// recognized as path separators.
+fn normalize_relative_path(path: &Path) -> PathBuf {
+    PathBuf::from(
+        path.components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/"),
+    )
 }
 
 fn load_plugin_queries(root_path: &Path) -> LanguageQueries {

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1890,6 +1890,38 @@ fn normalize_relative_path(path: &Path) -> PathBuf {
     )
 }
 
+#[cfg(test)]
+mod normalize_path_tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_forward_slashes_preserved() {
+        let path = Path::new("languages/agda");
+        assert_eq!(normalize_relative_path(path), PathBuf::from("languages/agda"));
+    }
+
+    #[test]
+    fn test_normalize_backslashes_converted() {
+        let path = PathBuf::from("languages\\agda");
+        assert_eq!(normalize_relative_path(&path), PathBuf::from("languages/agda"));
+    }
+
+    #[test]
+    fn test_normalize_nested_path() {
+        let path = PathBuf::from("themes\\subfolder\\theme.json");
+        assert_eq!(
+            normalize_relative_path(&path),
+            PathBuf::from("themes/subfolder/theme.json")
+        );
+    }
+
+    #[test]
+    fn test_normalize_single_component() {
+        let path = Path::new("languages");
+        assert_eq!(normalize_relative_path(path), PathBuf::from("languages"));
+    }
+}
+
 fn load_plugin_queries(root_path: &Path) -> LanguageQueries {
     let mut result = LanguageQueries::default();
     if let Some(entries) = std::fs::read_dir(root_path).log_err() {


### PR DESCRIPTION
Context

On Windows, `Path::strip_prefix` returns relative paths with backslash separators (e.g., `languages\agda`). These paths are stored in the extension manifest and index during extension indexing. When extensions are synced to a remote Linux host via SSH, the backslashes are treated as literal filename characters rather than path separators, resulting in broken paths like `languages\agda/config.toml` instead of `languages/agda/config.toml`.

This fix normalizes relative paths to always use forward slashes when storing them in the extension manifest and index. Forward slashes are valid path separators on all platforms, so local Windows behavior is unaffected.

Closes #51526

## How to Review

Small PR — single file change in `crates/extension_host/src/extension_host.rs`:
- A `normalize_relative_path()` helper function is added that joins path components with `/` instead of the OS-native separator.
- Three call sites in `add_extension_to_index` are updated: languages (line 1582), themes (line 1615), and icon_themes (line 1647), replacing `relative_path.to_path_buf()` with `normalize_relative_path(relative_path)`.
- Four unit tests covering forward slashes, backslashes, nested paths, and single components.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed extension paths using wrong separators when syncing from Windows to remote Linux hosts via SSH (#51526