### PR TITLE
editor: Don’t autoclose brackets when preceded by a backslash in regex search

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4789,10 +4789,11 @@ impl Editor {
                                     .reversed_chars_at(selection.start)
                                     .next()
                                     .is_none_or(|c| {
-                                        bracket_pair.start != bracket_pair.end
-                                            || !snapshot
-                                                .char_classifier_at(selection.start)
-                                                .is_word(c)
+                                        c != '\\'
+                                            && (bracket_pair.start != bracket_pair.end
+                                                || !snapshot
+                                                    .char_classifier_at(selection.start)
+                                                    .is_word(c))
                                     });
 
                             let is_closing_quote = if bracket_pair.end == bracket_pair.start


### PR DESCRIPTION
## Context


When typing `\[` in regex search, the editor incorrectly auto-inserts a closing `]`. Since the backslash escapes the bracket, auto-closing shouldn't trigger.

Closes #52124

## How to Review

Small change — one condition added at line ~4790 in `editor.rs`. Focus on the `is_none_or` closure logic.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
- Fixed auto-closing `]` when typing `\[` in regex search
