### PR TITLE
Replace current notification system on Linux with DBus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "uuid",
  "watch",
  "workspace",
+ "zbus 4.4.0",
  "zed_actions",
 ]
 
@@ -770,7 +771,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -10961,6 +10962,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -11585,10 +11587,10 @@ dependencies = [
  "serde_bytes",
  "sha2",
  "subtle",
- "zbus",
- "zbus_macros",
+ "zbus 5.13.2",
+ "zbus_macros 5.13.2",
  "zeroize",
- "zvariant",
+ "zvariant 5.9.2",
 ]
 
 [[package]]
@@ -21679,6 +21681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xim-ctext"
 version = "0.3.0"
 source = "git+https://github.com/zed-industries/xim-rs.git?rev=16f35a2c881b815a2b6cdfd6687988e84f8447d8#16f35a2c881b815a2b6cdfd6687988e84f8447d8"
@@ -21877,6 +21889,44 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock 3.4.2",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
@@ -21905,9 +21955,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.13.2",
+ "zbus_names 4.3.1",
+ "zvariant 5.9.2",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -21920,9 +21983,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.9.2",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -21933,7 +22007,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow",
- "zvariant",
+ "zvariant 5.9.2",
 ]
 
 [[package]]
@@ -22552,6 +22626,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
@@ -22561,8 +22648,21 @@ dependencies = [
  "serde",
  "serde_bytes",
  "winnow",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.9.2",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -22575,7 +22675,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -116,6 +116,9 @@ image.workspace = true
 async-fs.workspace = true
 reqwest_client = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = "4"
+
 [dev-dependencies]
 acp_thread = { workspace = true, features = ["test-support"] }
 agent = { workspace = true, features = ["test-support"] }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1,3 +1,69 @@
+#[cfg(target_os = "linux")]
+fn should_use_linux_native_notifications() -> bool {
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn send_linux_freedesktop_notification(
+    app_name: &str,
+    summary: &SharedString,
+    body: &SharedString,
+) -> anyhow::Result<()> {
+    let connection = Connection::session().map_err(|error| {
+        anyhow::anyhow!("failed to connect to DBus session bus for notifications: {error}")
+    })?;
+
+    let proxy = Proxy::new(
+        &connection,
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+    )
+    .map_err(|error| anyhow::anyhow!("failed to create DBus notifications proxy: {error}"))?;
+
+    // Notify(
+    //   s app_name,
+    //   u replaces_id,
+    //   s app_icon,
+    //   s summary,
+    //   s body,
+    //   as actions,
+    //   a{sv} hints,
+    //   i expire_timeout
+    // ) -> u id
+    let actions: Vec<&str> = Vec::new();
+    let mut hints: std::collections::HashMap<&str, OwnedValue> = std::collections::HashMap::new();
+    hints.insert("urgency", OwnedValue::from(1u8));
+
+    let notify_result: ZbusResult<u32> = proxy.call(
+        "Notify",
+        &(
+            app_name,
+            0u32,
+            "",
+            summary.as_ref(),
+            body.as_ref(),
+            actions,
+            hints,
+            -1i32,
+        ),
+    );
+
+    notify_result
+        .map(|_| ())
+        .map_err(|error| anyhow::anyhow!("freedesktop DBus Notify call failed: {error}"))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_notification_tests {
+    use super::*;
+
+    #[test]
+    fn linux_native_notifications_enabled() {
+        assert!(should_use_linux_native_notifications());
+    }
+}
+
 use acp_thread::{
     AcpThread, AcpThreadEvent, AgentSessionInfo, AgentThreadEntry, AssistantMessage,
     AssistantMessageChunk, AuthRequired, LoadError, MentionUri, PermissionOptionChoice,
@@ -47,6 +113,12 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use std::{collections::BTreeMap, rc::Rc, time::Duration};
+#[cfg(target_os = "linux")]
+use zbus::blocking::{Connection, Proxy};
+#[cfg(target_os = "linux")]
+use zbus::zvariant::OwnedValue;
+#[cfg(target_os = "linux")]
+use zbus::Result as ZbusResult;
 use terminal_view::terminal_panel::TerminalPanel;
 use text::Anchor;
 use theme::AgentFontSize;
@@ -2300,15 +2372,23 @@ impl ConversationView {
 
         // TODO: Change this once we have title summarization for external agents.
         let title = self.agent.agent_id().0;
+        let caption = caption.into();
 
         match settings.notify_when_agent_waiting {
             NotifyWhenAgentWaiting::PrimaryScreen => {
+                if self.try_send_native_notification_on_linux(&title, &caption) {
+                    return;
+                }
+
                 if let Some(primary) = cx.primary_display() {
-                    self.pop_up(icon, caption.into(), title, window, primary, cx);
+                    self.pop_up(icon, caption, title, window, primary, cx);
                 }
             }
             NotifyWhenAgentWaiting::AllScreens => {
-                let caption = caption.into();
+                if self.try_send_native_notification_on_linux(&title, &caption) {
+                    return;
+                }
+
                 for screen in cx.displays() {
                     self.pop_up(icon, caption.clone(), title.clone(), window, screen, cx);
                 }
@@ -2317,6 +2397,39 @@ impl ConversationView {
                 // Don't show anything
             }
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn try_send_native_notification_on_linux(
+        &self,
+        title: &SharedString,
+        caption: &SharedString,
+    ) -> bool {
+        if !should_use_linux_native_notifications() {
+            return false;
+        }
+
+        match self.send_linux_native_notification(title, caption) {
+            Ok(()) => {
+                log::debug!("agent waiting notification sent using freedesktop DBus");
+                true
+            }
+            Err(error) => {
+                log::warn!(
+                    "failed to send freedesktop DBus agent waiting notification, falling back to popup: {error}"
+                );
+                false
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn try_send_native_notification_on_linux(
+        &self,
+        _title: &SharedString,
+        _caption: &SharedString,
+    ) -> bool {
+        false
     }
 
     fn pop_up(
@@ -2406,6 +2519,15 @@ impl ConversationView {
                     })
                 });
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn send_linux_native_notification(
+        &self,
+        title: &SharedString,
+        caption: &SharedString,
+    ) -> anyhow::Result<()> {
+        send_linux_freedesktop_notification("Zed", title, caption)
     }
 
     fn dismiss_notifications(&mut self, cx: &mut Context<Self>) {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6,6 +6,7 @@ fn should_use_linux_native_notifications() -> bool {
 #[cfg(target_os = "linux")]
 fn send_linux_freedesktop_notification(
     app_name: &str,
+    app_icon: &str,
     summary: &SharedString,
     body: &SharedString,
 ) -> anyhow::Result<()> {
@@ -40,7 +41,7 @@ fn send_linux_freedesktop_notification(
         &(
             app_name,
             0u32,
-            "",
+            app_icon,
             summary.as_ref(),
             body.as_ref(),
             actions,
@@ -2527,7 +2528,7 @@ impl ConversationView {
         title: &SharedString,
         caption: &SharedString,
     ) -> anyhow::Result<()> {
-        send_linux_freedesktop_notification("Zed", title, caption)
+        send_linux_freedesktop_notification("Zed", "zed", title, caption)
     }
 
     fn dismiss_notifications(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
## Context

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->


So this introduces the DBus into this project. We can use this to send better and a more standard way of sending desktop notifications for the agent window. 

There is a fallback implemented aswell, which is the current notification system that is implemented on the main branch.

Currently this was opening a new gpui window, on tiling window managers for example this  caused the main window to get divided in 2 or depending on your configuration. 

this closes #40656 

before: 

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d68bcc00-f5d5-47b2-bf46-0a38ea05602e" />


after:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ec5d483e-116f-40ee-bd36-dce67e0e6746" />


<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/5f8b85c4-e607-480f-bae9-041029e5ec58" />





## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->
     
This has been tested on a CachyOS + Hyprland system. The notification will look different depending on every configuration of the set notification deamon that you chose.  (swaync in this case)

DBus is the standard on linux, they have the org.freedesktop.Notifications system which is now implemented for linux users.


## Self-Review Checklist

<!-- Check before requesting review: -->
- [ x] I've reviewed my own diff for quality, security, and reliability
- [ x] Unsafe blocks (if any) have justifying comments
- [ x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ x] Tests cover the new/changed behavior
- [ x] Performance impact has been considered and is acceptable

Release Notes:

-  Introduce DBus notification system on Linux.
