### PR TITLE
theme_selector: Fix theme preview not updating on filter changes

### DIFF
--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -162,6 +162,10 @@ impl PickerDelegate for IconThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
+        // Ensure the previewed theme matches the currently highlighted item,
+        // since filtering without navigation may leave the global settings stale.
+        self.selected_theme = self.show_selected_theme(cx);
+
         let theme_settings = ThemeSettings::get_global(cx);
         let theme_name = theme_settings
             .icon_theme
@@ -252,12 +256,7 @@ impl PickerDelegate for IconThemeSelectorDelegate {
 
             this.update(cx, |this, cx| {
                 this.delegate.matches = matches;
-                if query.is_empty() && this.delegate.selected_theme.is_none() {
-                    this.delegate.selected_index = this
-                        .delegate
-                        .selected_index
-                        .min(this.delegate.matches.len().saturating_sub(1));
-                } else if let Some(selected) = this.delegate.selected_theme.as_ref() {
+                if let Some(selected) = this.delegate.selected_theme.as_ref() {
                     this.delegate.selected_index = this
                         .delegate
                         .matches
@@ -265,11 +264,16 @@ impl PickerDelegate for IconThemeSelectorDelegate {
                         .enumerate()
                         .find(|(_, mtch)| mtch.string.as_str() == selected.0.as_ref())
                         .map(|(ix, _)| ix)
-                        .unwrap_or_default();
+                        .unwrap_or(0);
                 } else {
-                    this.delegate.selected_index = 0;
+                    this.delegate.selected_index = this
+                        .delegate
+                        .selected_index
+                        .min(this.delegate.matches.len().saturating_sub(1));
                 }
-                this.delegate.selected_theme = this.delegate.show_selected_theme(cx);
+                if let Some(theme) = this.delegate.show_selected_theme(cx) {
+                    this.delegate.selected_theme = Some(theme);
+                }
             })
             .log_err();
         })

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -353,6 +353,10 @@ impl PickerDelegate for ThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
+        // Ensure the previewed theme matches the currently highlighted item,
+        // since filtering without navigation may leave `new_theme` stale.
+        self.selected_theme = self.show_selected_theme(cx);
+
         let theme_name: Arc<str> = self.new_theme.name.as_str().into();
         let theme_appearance = self.new_theme.appearance;
         let system_appearance = SystemAppearance::global(cx).0;
@@ -438,12 +442,7 @@ impl PickerDelegate for ThemeSelectorDelegate {
 
             this.update(cx, |this, cx| {
                 this.delegate.matches = matches;
-                if query.is_empty() && this.delegate.selected_theme.is_none() {
-                    this.delegate.selected_index = this
-                        .delegate
-                        .selected_index
-                        .min(this.delegate.matches.len().saturating_sub(1));
-                } else if let Some(selected) = this.delegate.selected_theme.as_ref() {
+                if let Some(selected) = this.delegate.selected_theme.as_ref() {
                     this.delegate.selected_index = this
                         .delegate
                         .matches
@@ -451,11 +450,16 @@ impl PickerDelegate for ThemeSelectorDelegate {
                         .enumerate()
                         .find(|(_, mtch)| mtch.string == selected.name)
                         .map(|(ix, _)| ix)
-                        .unwrap_or_default();
+                        .unwrap_or(0);
                 } else {
-                    this.delegate.selected_index = 0;
+                    this.delegate.selected_index = this
+                        .delegate
+                        .selected_index
+                        .min(this.delegate.matches.len().saturating_sub(1));
                 }
-                this.delegate.selected_theme = this.delegate.show_selected_theme(cx);
+                if let Some(theme) = this.delegate.show_selected_theme(cx) {
+                    this.delegate.selected_theme = Some(theme);
+                }
             })
             .log_err();
         })


### PR DESCRIPTION
Context

Fixes #52118

When a user filters themes in the theme selector and then confirms or clears the filter, the preview could show the wrong theme. Two issues were at play:

1. Confirming a selection after filtering (without navigating with arrow keys) could persist a stale theme because `show_selected_theme` was never called in `confirm`.
2. When a filter query matched no results (e.g., "Ayu 1"), `selected_theme` was overwritten with `None`. Clearing the filter then lost track of the previously selected theme and defaulted to index 0 (typically the first dark theme).

Both issues are fixed in `ThemeSelectorDelegate` and `IconThemeSelectorDelegate`.

## How to Review

Small PR — two files with symmetrical changes. Focus on the `update_matches` and `confirm` methods in:
- `crates/theme_selector/src/theme_selector.rs`
- `crates/theme_selector/src/icon_theme_selector.rs`

Key change: `selected_theme` is now only updated when `show_selected_theme` returns `Some`, preserving the previous selection when the filter yields no results.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Before:

https://github.com/user-attachments/assets/5b2b5b7e-aafc-4f3e-a833-242ddf5ecacc


##After:


https://github.com/user-attachments/assets/7756180c-d8d2-401e-ba7b-31d2a6adb950


Release Notes:

- Fixed theme selector preview not updating correctly when filtering themes without navigating with arrow keys.


