### PR TITLE
languages: Capture function calls as `function.call` for C/C++

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -119,11 +119,11 @@
   (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (call_expression
   function: (field_expression
-    field: (field_identifier) @function))
+    field: (field_identifier) @function.call))
 
 (function_declarator
   declarator: (identifier) @function)

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -29,7 +29,7 @@
 
 (call_expression
   function: (qualified_identifier
-    name: (identifier) @function))
+    name: (identifier) @function.call))
 
 (call_expression
   (qualified_identifier
@@ -54,11 +54,11 @@
   (#has-ancestor? @_parent call_expression))
 
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (call_expression
   function: (field_expression
-    field: (field_identifier) @function))
+    field: (field_identifier) @function.call))
 
 (preproc_function_def
   name: (identifier) @function.special)


### PR DESCRIPTION
## Context

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

Add `@function.call` to highlight C/C++ function calls differently from defintions. This vastly improves reading experience and is a feature of many IDEs (ex. CLion).

### Without Specifying `@function.call` (Behavior Unchanged)
<img width="618" height="550" alt="image" src="https://github.com/user-attachments/assets/d1631692-9d35-46f7-bc56-ef5d75d80f95" />


### Specifying  `@function.call`
<img width="631" height="463" alt="image" src="https://github.com/user-attachments/assets/13ac3046-f605-44a2-b935-ea3ec2305818" />

```
{
  "experimental.theme_overrides": {
    "syntax": {
      "function.call": {
        "color": "#000000",
        "font_style": "italic",
      },
    },
  },
}
```


## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

- Verifying unchanged behavior without specifying `@function.call`
- Verify function call highlighting when `@function.call` specified

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A or Added/Fixed/Improved ...
