### PR TITLE
helix: Add support for line length in reflow command

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1869,6 +1869,9 @@ pub enum MultibufferSelectionMode {
 pub struct RewrapOptions {
     pub override_language_settings: bool,
     pub preserve_existing_whitespace: bool,
+    // TODO!: Better name to make it obvious this is meant to be an optional
+    // override?
+    pub line_length: Option<usize>,
 }
 
 impl Editor {
@@ -5119,6 +5122,7 @@ impl Editor {
                         RewrapOptions {
                             override_language_settings: true,
                             preserve_existing_whitespace: true,
+                            line_length: None,
                         },
                         cx,
                     )
@@ -13704,7 +13708,7 @@ impl Editor {
                 continue;
             };
 
-            let wrap_column = self.hard_wrap.unwrap_or_else(|| {
+            let wrap_column = options.line_length.or(self.hard_wrap).unwrap_or_else(|| {
                 buffer
                     .language_settings_at(Point::new(start_row, 0), cx)
                     .preferred_line_length as usize

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1869,8 +1869,6 @@ pub enum MultibufferSelectionMode {
 pub struct RewrapOptions {
     pub override_language_settings: bool,
     pub preserve_existing_whitespace: bool,
-    // TODO!: Better name to make it obvious this is meant to be an optional
-    // override?
     pub line_length: Option<usize>,
 }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2276,6 +2276,7 @@ impl GitPanel {
                 RewrapOptions {
                     override_language_settings: false,
                     preserve_existing_whitespace: true,
+                    line_length: None,
                 },
                 cx,
             );

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1726,7 +1726,17 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         )
         .range(wrap_count),
         VimCommand::new(("j", "oin"), JoinLines).range(select_range),
-        VimCommand::new(("reflow", ""), Rewrap).range(select_range),
+        VimCommand::new(("reflow", ""), Rewrap { line_length: None })
+            .range(select_range)
+            .args(|_action, args| {
+                if let Ok(length) = args.parse::<usize>() {
+                    Some(Box::new(Rewrap {
+                        line_length: Some(length),
+                    }))
+                } else {
+                    Some(Box::new(Rewrap { line_length: None }))
+                }
+            }),
         VimCommand::new(("fo", "ld"), editor::actions::FoldSelectedRanges).range(act_on_range),
         VimCommand::new(("foldo", "pen"), editor::actions::UnfoldLines)
             .bang(editor::actions::UnfoldRecursive)
@@ -3550,7 +3560,7 @@ mod test {
 
         cx.set_state(
             indoc! {"
-                ˇ0123456789 0123456789 0123456789 0123456789
+                ˇ0123456789 0123456789
             "},
             Mode::Normal,
         );
@@ -3560,8 +3570,6 @@ mod test {
 
         cx.assert_state(
             indoc! {"
-                0123456789
-                0123456789
                 0123456789
                 ˇ0123456789
             "},
@@ -3570,20 +3578,38 @@ mod test {
 
         cx.set_state(
             indoc! {"
-                «0123456789 0123456789ˇ»
-                0123456789 0123456789
+                ˇ0123456789 0123456789
             "},
             Mode::VisualLine,
         );
 
-        cx.simulate_keystrokes(": reflow");
+        cx.simulate_keystrokes("shift-v : reflow");
         cx.simulate_keystrokes("enter");
 
         cx.assert_state(
             indoc! {"
-                ˇ0123456789
                 0123456789
-                0123456789 0123456789
+                ˇ0123456789
+            "},
+            Mode::Normal,
+        );
+
+        cx.set_state(
+            indoc! {"
+                ˇ0123 4567 0123 4567
+            "},
+            Mode::VisualLine,
+        );
+
+        cx.simulate_keystrokes(": reflow space 7");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇ0123
+                4567
+                0123
+                4567
             "},
             Mode::Normal,
         );

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1734,7 +1734,7 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
                         line_length: Some(length),
                     }))
                 } else {
-                    Some(Box::new(Rewrap { line_length: None }))
+                    None
                 }
             }),
         VimCommand::new(("fo", "ld"), editor::actions::FoldSelectedRanges).range(act_on_range),
@@ -3612,6 +3612,25 @@ mod test {
                 4567
             "},
             Mode::Normal,
+        );
+
+        // Assert that, if `:reflow` is invoked with an invalid argument, it
+        // does not actually have any effect in the buffer's contents.
+        cx.set_state(
+            indoc! {"
+                ˇ0123 4567 0123 4567
+            "},
+            Mode::VisualLine,
+        );
+
+        cx.simulate_keystrokes(": reflow space a");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇ0123 4567 0123 4567
+            "},
+            Mode::VisualLine,
         );
     }
 }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1729,13 +1729,11 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("reflow", ""), Rewrap { line_length: None })
             .range(select_range)
             .args(|_action, args| {
-                if let Ok(length) = args.parse::<usize>() {
+                args.parse::<usize>().map_or(None, |length| {
                     Some(Box::new(Rewrap {
                         line_length: Some(length),
                     }))
-                } else {
-                    None
-                }
+                })
             }),
         VimCommand::new(("fo", "ld"), editor::actions::FoldSelectedRanges).range(act_on_range),
         VimCommand::new(("foldo", "pen"), editor::actions::UnfoldLines)

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -10,8 +10,6 @@ use serde::Deserialize;
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 pub(crate) struct Rewrap {
-    // TODO!: Should this just be a tuple? Not sure if that would not require
-    // updating the keymap file too.
     pub line_length: Option<usize>,
 }
 

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -1,19 +1,22 @@
 use crate::{Vim, motion::Motion, object::Object, state::Mode};
 use collections::HashMap;
 use editor::{Bias, Editor, RewrapOptions, SelectionEffects, display_map::ToDisplayPoint};
-use gpui::{Context, Window, actions};
+use gpui::{Action, Context, Window};
 use language::SelectionGoal;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
-actions!(
-    vim,
-    [
-        /// Rewraps the selected text to fit within the line width.
-        Rewrap
-    ]
-);
+/// Rewraps the selected text to fit within the line width.
+#[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
+#[action(namespace = vim)]
+pub(crate) struct Rewrap {
+    // TODO!: Should this just be a tuple? Not sure if that would not require
+    // updating the keymap file too.
+    pub line_length: Option<usize>,
+}
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
-    Vim::action(editor, cx, |vim, _: &Rewrap, window, cx| {
+    Vim::action(editor, cx, |vim, action: &Rewrap, window, cx| {
         vim.record_current_action(cx);
         Vim::take_count(cx);
         Vim::take_forced_motion(cx);
@@ -24,6 +27,7 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
                 editor.rewrap_impl(
                     RewrapOptions {
                         override_language_settings: true,
+                        line_length: action.line_length,
                         ..Default::default()
                     },
                     cx,


### PR DESCRIPTION
## Context

Continue the work from https://github.com/zed-industries/zed/pull/51788 and adds support for a line length argument to be provided to the `:reflow` command.

## How to Review

1. Added `RewrapOptions::line_length`
2. Updated `Editor::rewrap_impl` to leverage `RewrapOptions::line_length`, when set
3. Added `line_length` field to `vim::rewrap::Rewrap` action
4. Updated `Rewrap` action handler with `vim::command::VimCommand::args`, to allow attempting to parse arguments as `usize`

## Self-Review Checklist

<!-- Check before requesting review: -->
- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
