### PR TITLE
Fix bracketed paste in terminal on middle click

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1940,7 +1940,7 @@ impl Terminal {
                 MouseButton::Middle => {
                     if let Some(item) = _cx.read_from_primary() {
                         let text = item.text().unwrap_or_default();
-                        self.input(text.into_bytes());
+                        self.paste(&text);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
## Context

**Current Behavior:** Middle click pastes multiple lines of text and runs each as an individual terminal command
**Expected Behavior:** On Linux middle click should use bracketed paste to paste multiple lines and wait for the user to hit "Enter" before running all commands together like when pressing Ctrl+Shift+V

Steps to reproduce old behavior: 
1. Open terminal 
2. Copy multiple lines of text from outside the terminal
3. Middle click to paste text in terminal


## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
Fixed multiple line paste behavior in terminal on middle click
