### PR TITLE
Make tabs compact with shrink-to-fit behavior

### DIFF
--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -77,11 +77,11 @@ impl Tab {
     }
 
     pub fn content_height(cx: &App) -> Pixels {
-        DynamicSpacing::Base32.px(cx) - px(1.)
+        DynamicSpacing::Base24.px(cx) - px(1.)
     }
 
     pub fn container_height(cx: &App) -> Pixels {
-        DynamicSpacing::Base32.px(cx)
+        DynamicSpacing::Base24.px(cx)
     }
 }
 
@@ -143,6 +143,9 @@ impl RenderOnce for Tab {
 
         self.div
             .h(Tab::container_height(cx))
+            .max_w(px(180.))
+            .min_w(px(60.))
+            .flex_shrink()
             .bg(tab_bg)
             .border_color(cx.theme().colors().border)
             .map(|this| match self.position {
@@ -172,6 +175,8 @@ impl RenderOnce for Tab {
                     .h(Tab::content_height(cx))
                     .px(DynamicSpacing::Base04.px(cx))
                     .gap(DynamicSpacing::Base04.rems(cx))
+                    .overflow_hidden()
+                    .text_ellipsis()
                     .text_color(text_color)
                     .child(start_slot)
                     .children(self.children)


### PR DESCRIPTION
## Summary
- Reduce tab height from `Base32` (32px) to `Base24` (24px) for a more compact UI
- Add `max_w(180px)` / `min_w(60px)` + `flex_shrink()` so tabs compress as more are opened — similar to Chrome/Edge browser tabs
- Add `overflow_hidden()` + `text_ellipsis()` so long tab titles truncate gracefully

## Motivation
Zed's current tabs take up significant vertical and horizontal space. Users coming from Chrome, Edge, or Cursor expect tabs to be compact by default and shrink automatically as more tabs are opened, rather than expanding to fill available width.

## Changes
Single file change: `crates/ui/src/components/tab.rs`
- `container_height` / `content_height`: `Base32` → `Base24`
- Tab div: added `max_w(px(180.))`, `min_w(px(60.))`, `flex_shrink()`
- Tab content flex: added `overflow_hidden()`, `text_ellipsis()`

## Test plan
- [x] `cargo check -p ui` — compiles clean
- [x] `cargo check -p workspace` — compiles clean
- [ ] Visual verification with 1, 5, 10, 20+ tabs open
- [ ] Verify text truncation with long file names
- [ ] Verify tab bar scroll behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)