### PR TITLE
Add "Fork Thread" to branch conversations from an earlier point

### DIFF
--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -1,7 +1,9 @@
-use crate::{DbThread, DbThreadMetadata, ThreadsDatabase};
+use crate::{DbThread, DbThreadMetadata, Message, ThreadsDatabase};
+use acp_thread::UserMessageId;
 use agent_client_protocol as acp;
 use anyhow::{Result, anyhow};
-use gpui::{App, Context, Entity, Global, Task, prelude::*};
+use chrono::Utc;
+use gpui::{App, Context, Entity, Global, SharedString, Task, prelude::*};
 use util::path_list::PathList;
 
 struct GlobalThreadStore(Entity<ThreadStore>);
@@ -62,6 +64,66 @@ impl ThreadStore {
             let database = database_future.await.map_err(|err| anyhow!(err))?;
             database.save_thread(id, thread, folder_paths).await?;
             this.update(cx, |this, cx| this.reload(cx))
+        })
+    }
+
+    /// Forks a thread at the given user message, creating a new thread
+    /// with conversation history up to (but not including) that message.
+    pub fn fork_thread(
+        &mut self,
+        source_id: acp::SessionId,
+        message_id: UserMessageId,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<(acp::SessionId, SharedString)>> {
+        let folder_paths = self
+            .thread_from_session_id(&source_id)
+            .map(|meta| meta.folder_paths.clone())
+            .unwrap_or_default();
+
+        let database_future = ThreadsDatabase::connect(cx);
+
+        cx.spawn(async move |this, cx| {
+            let database = database_future.await.map_err(|err| anyhow!(err))?;
+
+            let mut thread = database
+                .load_thread(source_id)
+                .await?
+                .ok_or_else(|| anyhow!("Thread not found"))?;
+
+            let position = thread
+                .messages
+                .iter()
+                .position(|msg| {
+                    matches!(msg, Message::User(user_msg) if user_msg.id == message_id)
+                })
+                .ok_or_else(|| anyhow!("Message not found"))?;
+
+            // Remove token usage entries for messages being dropped.
+            for msg in &thread.messages[position..] {
+                if let Message::User(user_msg) = msg {
+                    thread.request_token_usage.remove(&user_msg.id);
+                }
+            }
+
+            thread.messages.truncate(position);
+
+            let new_id = acp::SessionId::new(uuid::Uuid::new_v4().to_string());
+
+            thread.title = SharedString::from(format!("Fork of {}", thread.title));
+            thread.updated_at = Utc::now();
+            thread.detailed_summary = None;
+            thread.draft_prompt = None;
+            thread.ui_scroll_position = None;
+
+            let title = thread.title.clone();
+
+            database
+                .save_thread(new_id.clone(), thread, folder_paths)
+                .await?;
+
+            this.update(cx, |this, cx| this.reload(cx))?;
+
+            Ok((new_id, title))
         })
     }
 
@@ -146,6 +208,33 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
         }
+    }
+
+    fn make_thread_with_messages(
+        title: &str,
+        updated_at: DateTime<Utc>,
+        messages: Vec<Message>,
+    ) -> DbThread {
+        let mut thread = make_thread(title, updated_at);
+        thread.messages = messages;
+        thread
+    }
+
+    fn user_message() -> (UserMessageId, Message) {
+        let id = UserMessageId::new();
+        let msg = Message::User(crate::UserMessage {
+            id: id.clone(),
+            content: vec![crate::UserMessageContent::Text("user text".to_string())],
+        });
+        (id, msg)
+    }
+
+    fn agent_message() -> Message {
+        Message::Agent(crate::AgentMessage {
+            content: vec![crate::AgentMessageContent::Text("agent text".to_string())],
+            tool_results: Default::default(),
+            reasoning_details: None,
+        })
     }
 
     #[gpui::test]
@@ -287,5 +376,117 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].id, first_id);
         assert_eq!(entries[1].id, second_id);
+    }
+
+    #[gpui::test]
+    async fn test_fork_thread_creates_truncated_copy(cx: &mut TestAppContext) {
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        cx.run_until_parked();
+
+        let original_id = session_id("thread-a");
+        let (_, msg1) = user_message();
+        let (_, msg2) = user_message();
+        let (msg3_id, msg3) = user_message();
+        let messages = vec![
+            msg1,
+            agent_message(),
+            msg2,
+            agent_message(),
+            msg3,
+            agent_message(),
+        ];
+        let original_thread = make_thread_with_messages(
+            "My Thread",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+            messages,
+        );
+
+        let save_task = thread_store.update(cx, |store, cx| {
+            store.save_thread(original_id.clone(), original_thread, PathList::default(), cx)
+        });
+        save_task.await.unwrap();
+        cx.run_until_parked();
+
+        // Fork at msg3, which should keep messages before it (msg1, response, msg2, response).
+        let (new_id, new_title) = thread_store
+            .update(cx, |store, cx| {
+                store.fork_thread(original_id.clone(), msg3_id, cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        assert_ne!(new_id, original_id);
+        assert_eq!(new_title.as_ref(), "Fork of My Thread");
+
+        let entries: Vec<_> = thread_store.read_with(cx, |store, _cx| store.entries().collect());
+        assert_eq!(entries.len(), 2);
+        // The fork has a newer updated_at, so it should sort first.
+        assert_eq!(entries[0].id, new_id);
+        assert_eq!(entries[1].id, original_id);
+
+        // Load the forked thread and verify it has only the first 4 messages.
+        let forked = thread_store
+            .update(cx, |store, cx| store.load_thread(new_id, cx))
+            .await
+            .unwrap()
+            .expect("forked thread should exist");
+
+        assert_eq!(forked.messages.len(), 4);
+        assert_eq!(forked.title.as_ref(), "Fork of My Thread");
+    }
+
+    #[gpui::test]
+    async fn test_fork_thread_preserves_original(cx: &mut TestAppContext) {
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        cx.run_until_parked();
+
+        let original_id = session_id("thread-a");
+        let original_time = Utc.with_ymd_and_hms(2024, 6, 15, 12, 0, 0).unwrap();
+        let (_, msg1) = user_message();
+        let (msg2_id, msg2) = user_message();
+        let messages = vec![
+            msg1,
+            agent_message(),
+            msg2,
+            agent_message(),
+        ];
+        let original_thread =
+            make_thread_with_messages("Important Chat", original_time, messages);
+
+        let save_task = thread_store.update(cx, |store, cx| {
+            store.save_thread(original_id.clone(), original_thread, PathList::default(), cx)
+        });
+        save_task.await.unwrap();
+        cx.run_until_parked();
+
+        // Fork at msg2, keeping only msg1 and its response.
+        let (new_id, _) = thread_store
+            .update(cx, |store, cx| {
+                store.fork_thread(original_id.clone(), msg2_id, cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // Load both threads and verify the original is untouched.
+        let original_loaded = thread_store
+            .update(cx, |store, cx| store.load_thread(original_id.clone(), cx))
+            .await
+            .unwrap()
+            .expect("original thread should exist");
+        let forked_loaded = thread_store
+            .update(cx, |store, cx| store.load_thread(new_id, cx))
+            .await
+            .unwrap()
+            .expect("forked thread should exist");
+
+        assert_eq!(original_loaded.title.as_ref(), "Important Chat");
+        assert_eq!(original_loaded.updated_at, original_time);
+        assert_eq!(original_loaded.messages.len(), 4);
+
+        assert_eq!(forked_loaded.title.as_ref(), "Fork of Important Chat");
+        assert!(forked_loaded.updated_at > original_time);
+        assert_eq!(forked_loaded.messages.len(), 2);
     }
 }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1749,6 +1749,50 @@ impl AgentPanel {
         }
     }
 
+    fn fork_thread(
+        &mut self,
+        session_id: acp::SessionId,
+        message_id: acp_thread::UserMessageId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let thread_store = self.thread_store.clone();
+        let workspace = self.workspace.clone();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let (new_session_id, title) = thread_store
+                .update(&mut cx.clone(), |store, cx| {
+                    store.fork_thread(session_id, message_id, cx)
+                })
+                .await?;
+
+            this.update_in(cx, |this, window, cx| {
+                this.open_thread(new_session_id, None, Some(title), window, cx);
+            })?;
+
+            this.update_in(cx, |_, _window, cx| {
+                if let Some(workspace) = workspace.upgrade() {
+                    workspace.update(cx, |workspace, cx| {
+                        struct ThreadForkedToast;
+                        workspace.show_toast(
+                            workspace::Toast::new(
+                                workspace::notifications::NotificationId::unique::<
+                                    ThreadForkedToast,
+                                >(),
+                                "Thread forked",
+                            )
+                            .autohide(),
+                            cx,
+                        );
+                    });
+                }
+            })?;
+
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
+
     fn copy_thread_to_clipboard(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(thread) = self.active_native_agent_thread(cx) else {
             Self::show_deferred_toast(&self.workspace, "No active native thread to copy", cx);
@@ -2230,6 +2274,17 @@ impl AgentPanel {
                 |this, view, event: &AcpThreadViewEvent, window, cx| match event {
                     AcpThreadViewEvent::FirstSendRequested { content } => {
                         this.handle_first_send_requested(view.clone(), content.clone(), window, cx);
+                    }
+                    AcpThreadViewEvent::ForkRequested {
+                        session_id,
+                        message_id,
+                    } => {
+                        this.fork_thread(
+                            session_id.clone(),
+                            message_id.clone(),
+                            window,
+                            cx,
+                        );
                     }
                 },
             )

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3849,7 +3849,6 @@ impl ThreadView {
                     .children(rules_item)
                     .when(is_editable && (has_checkpoint_button || entry_ix > 0), |this| {
                         this.children(message.id.clone().map(|message_id| {
-                            let fork_message_id = message_id.clone();
                             h_flex()
                                 .px_3()
                                 .gap_2()
@@ -3868,6 +3867,7 @@ impl ThreadView {
                                     )
                                 })
                                 .when(entry_ix > 0, |this| {
+                                    let fork_message_id = message_id.clone();
                                     this.child(
                                         Button::new("fork-thread", "Fork Thread")
                                             .start_icon(Icon::new(IconName::GitBranch).size(IconSize::XSmall).color(Color::Muted))

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -158,6 +158,10 @@ impl ThreadFeedbackState {
 
 pub enum AcpThreadViewEvent {
     FirstSendRequested { content: Vec<acp::ContentBlock> },
+    ForkRequested {
+        session_id: acp::SessionId,
+        message_id: acp_thread::UserMessageId,
+    },
 }
 
 impl EventEmitter<AcpThreadViewEvent> for ThreadView {}
@@ -1828,6 +1832,14 @@ impl ThreadView {
                 thread.restore_checkpoint(message_id.clone(), cx)
             })
             .detach_and_log_err(cx);
+    }
+
+    pub fn fork_at_message(&mut self, message_id: &UserMessageId, cx: &mut Context<Self>) {
+        let session_id = self.thread.read(cx).session_id().clone();
+        cx.emit(AcpThreadViewEvent::ForkRequested {
+            session_id,
+            message_id: message_id.clone(),
+        });
     }
 
     pub fn clear_thread_error(&mut self, cx: &mut Context<Self>) {
@@ -3835,22 +3847,38 @@ impl ThreadView {
                     .gap_1p5()
                     .w_full()
                     .children(rules_item)
-                    .when(is_editable && has_checkpoint_button, |this| {
+                    .when(is_editable && (has_checkpoint_button || entry_ix > 0), |this| {
                         this.children(message.id.clone().map(|message_id| {
+                            let fork_message_id = message_id.clone();
                             h_flex()
                                 .px_3()
                                 .gap_2()
                                 .child(Divider::horizontal())
-                                .child(
-                                    Button::new("restore-checkpoint", "Restore Checkpoint")
-                                        .start_icon(Icon::new(IconName::Undo).size(IconSize::XSmall).color(Color::Muted))
-                                        .label_size(LabelSize::XSmall)
-                                        .color(Color::Muted)
-                                        .tooltip(Tooltip::text("Restores all files in the project to the content they had at this point in the conversation."))
-                                        .on_click(cx.listener(move |this, _, _window, cx| {
-                                            this.restore_checkpoint(&message_id, cx);
-                                        }))
-                                )
+                                .when(has_checkpoint_button, |this| {
+                                    let restore_message_id = message_id.clone();
+                                    this.child(
+                                        Button::new("restore-checkpoint", "Restore Checkpoint")
+                                            .start_icon(Icon::new(IconName::Undo).size(IconSize::XSmall).color(Color::Muted))
+                                            .label_size(LabelSize::XSmall)
+                                            .color(Color::Muted)
+                                            .tooltip(Tooltip::text("Restores all files in the project to the content they had at this point in the conversation."))
+                                            .on_click(cx.listener(move |this, _, _window, cx| {
+                                                this.restore_checkpoint(&restore_message_id, cx);
+                                            }))
+                                    )
+                                })
+                                .when(entry_ix > 0, |this| {
+                                    this.child(
+                                        Button::new("fork-thread", "Fork Thread")
+                                            .start_icon(Icon::new(IconName::GitBranch).size(IconSize::XSmall).color(Color::Muted))
+                                            .label_size(LabelSize::XSmall)
+                                            .color(Color::Muted)
+                                            .tooltip(Tooltip::text("Creates a new thread with the conversation history up to this point."))
+                                            .on_click(cx.listener(move |this, _, _window, cx| {
+                                                this.fork_at_message(&fork_message_id, cx);
+                                            }))
+                                    )
+                                })
                                 .child(Divider::horizontal())
                         }))
                     })


### PR DESCRIPTION
## Context

_Reworked from https://github.com/zed-industries/zed/pull/51903_

Adds a "Fork Thread" button to agent conversations, allowing users to branch off from any point in a conversation into a new thread.

When running long agent conversations, users frequently hit context window limits and want to resume from an earlier point. Currently, rewinding overwrites the existing conversation. This feature lets users fork instead — creating a new thread with the history up to that point while leaving the original intact.

A "Fork Thread" button (with a git branch icon) appears between messages on every user message except the first. Clicking it creates a new thread titled "Fork of {original}", containing all messages before the fork point, and opens it immediately.

See discussion: https://github.com/zed-industries/zed/discussions/47047

## How to Review

Small PR, four files — start from the data layer and work up to the UI:

1. **`crates/agent/src/thread_store.rs`** — Core logic. `fork_thread` loads a thread from the DB, truncates messages at a `UserMessageId`, cleans up token usage for removed messages, and saves the copy with a new session ID. Two tests cover the truncation and original preservation.
2. **`crates/agent_ui/src/conversation_view/thread_view.rs`** — UI additions. A `ForkRequested` event variant and `fork_at_message` method, plus the "Fork Thread" button rendered alongside "Restore Checkpoint" on user messages.
3. **`crates/agent_ui/src/agent_panel.rs`** — Wiring. Handles the `ForkRequested` event, calls `fork_thread` on the store, opens the new thread, and shows a toast.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added "Fork Thread" button to agent conversations, allowing users to branch off from any point into a new thread while preserving the original conversation history.