### PR TITLE
Fix workspace-absolute paths in markdown images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10286,6 +10286,7 @@ dependencies = [
  "pulldown-cmark 0.13.0",
  "settings",
  "stacksafe",
+ "tempfile",
  "theme",
  "ui",
  "urlencoding",

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -41,3 +41,4 @@ mermaid-rs-renderer.workspace = true
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
+tempfile = { workspace = true }

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -293,7 +293,7 @@ pub enum Link {
 }
 
 impl Link {
-    pub fn identify(file_location_directory: Option<PathBuf>, text: String) -> Option<Link> {
+    pub fn identify(file_location_directory: Option<PathBuf>, workspace_directory: Option<PathBuf>, text: String) -> Option<Link> {
         if text.starts_with("http") {
             return Some(Link::Web { url: text });
         }
@@ -304,6 +304,19 @@ impl Link {
             .unwrap_or(text);
 
         let path = PathBuf::from(&decoded_text);
+
+        if let Ok(relative_path) = path.strip_prefix("/") {
+            if let Some(root) = &workspace_directory {
+                let absolute_path = root.join(relative_path);
+                if absolute_path.exists() {
+                    return Some(Link::Path {
+                        display_path: path.clone(),
+                        path : absolute_path
+                    });
+                }
+            }
+        }
+
         if path.is_absolute() && path.exists() {
             return Some(Link::Path {
                 display_path: path.clone(),
@@ -348,8 +361,9 @@ impl Image {
         text: String,
         source_range: Range<usize>,
         file_location_directory: Option<PathBuf>,
+        workspace_directory: Option<PathBuf>,
     ) -> Option<Self> {
-        let link = Link::identify(file_location_directory, text)?;
+        let link = Link::identify(file_location_directory, workspace_directory, text)?;
         Some(Self {
             source_range,
             link,

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -19,12 +19,14 @@ use ui::SharedString;
 pub async fn parse_markdown(
     markdown_input: &str,
     file_location_directory: Option<PathBuf>,
+    workspace_directory: Option<PathBuf>,
     language_registry: Option<Arc<LanguageRegistry>>,
 ) -> ParsedMarkdown {
     let parser = Parser::new_ext(markdown_input, PARSE_OPTIONS);
     let parser = MarkdownParser::new(
         parser.into_offset_iter().collect(),
         file_location_directory,
+        workspace_directory,
         language_registry,
     );
     let renderer = parser.parse_document().await;
@@ -58,6 +60,7 @@ struct MarkdownParser<'a> {
     /// The blocks that we have successfully parsed so far
     parsed: Vec<ParsedMarkdownElement>,
     file_location_directory: Option<PathBuf>,
+    workspace_directory: Option<PathBuf>,
     language_registry: Option<Arc<LanguageRegistry>>,
 }
 
@@ -90,11 +93,13 @@ impl<'a> MarkdownParser<'a> {
     fn new(
         tokens: Vec<(Event<'a>, Range<usize>)>,
         file_location_directory: Option<PathBuf>,
+        workspace_directory: Option<PathBuf>,
         language_registry: Option<Arc<LanguageRegistry>>,
     ) -> Self {
         Self {
             tokens,
             file_location_directory,
+            workspace_directory,
             language_registry,
             cursor: 0,
             parsed: vec![],
@@ -393,6 +398,7 @@ impl<'a> MarkdownParser<'a> {
                     Tag::Link { dest_url, .. } => {
                         link = Link::identify(
                             self.file_location_directory.clone(),
+                            self.workspace_directory.clone(),
                             dest_url.to_string(),
                         );
                     }
@@ -410,6 +416,7 @@ impl<'a> MarkdownParser<'a> {
                             dest_url.to_string(),
                             source_range.clone(),
                             self.file_location_directory.clone(),
+                            self.workspace_directory.clone(),
                         );
                     }
                     _ => {
@@ -1114,7 +1121,10 @@ impl<'a> MarkdownParser<'a> {
                 } else if local_name!("a") == name.local {
                     if let Some(url) = Self::attr_value(attrs, local_name!("href"))
                         && let Some(link) =
-                            Link::identify(self.file_location_directory.clone(), url)
+                            Link::identify(
+                                self.file_location_directory.clone(),
+                                self.workspace_directory.clone(),
+                                url)
                     {
                         highlights.push(MarkdownHighlight::Style(MarkdownHighlightStyle {
                             link: true,
@@ -1342,7 +1352,12 @@ impl<'a> MarkdownParser<'a> {
     ) -> Option<Image> {
         let src = Self::attr_value(attrs, local_name!("src"))?;
 
-        let mut image = Image::identify(src, source_range, self.file_location_directory.clone())?;
+        let mut image = Image::identify(
+            src,
+            source_range,
+            self.file_location_directory.clone(),
+            self.workspace_directory.clone()
+        )?;
 
         if let Some(alt) = Self::attr_value(attrs, local_name!("alt")) {
             image.set_alt_text(alt.into());
@@ -1524,7 +1539,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     async fn parse(input: &str) -> ParsedMarkdown {
-        parse_markdown(input, None, None).await
+        parse_markdown(input, None, None, None).await
     }
 
     #[gpui::test]
@@ -1840,6 +1855,71 @@ mod tests {
                         width: None,
                     },)
                 );
+    }
+
+    #[gpui::test]
+    async fn test_workspace_absolute_path_resolution() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace_root = temp_dir.path();
+
+        let dummy_image_path = workspace_root.join("test_image.png");
+        std::fs::write(&dummy_image_path, "mock data").unwrap();
+ 
+        let parsed = parse_markdown(
+            "![Alt text](/test_image.png)\n",
+            None,
+            Some(workspace_root.to_path_buf()),
+            None
+        ).await;
+
+        let paragraph = if let ParsedMarkdownElement::Paragraph(text) = &parsed.children[0] {
+            text
+        } else {
+            panic!("Expected a paragraph");
+        };
+
+        assert_eq!(
+            paragraph[0],
+            MarkdownParagraphChunk::Image(Image {
+                source_range: 0..29,
+                link: Link::Path {
+                    display_path: std::path::PathBuf::from("/test_image.png"),
+                    path: dummy_image_path
+                },
+                alt_text: Some("Alt text".into()),
+                height: None,
+                width: None,
+            })
+        );
+    }
+
+    #[gpui::test]
+    async fn test_workspace_absolute_path_missing_file_fallback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace_root = temp_dir.path();
+
+        let parsed = parse_markdown(
+            "![Alt text](/missing_image.png)\n",
+            None,
+            Some(workspace_root.to_path_buf()),
+            None
+        ).await;
+
+        let paragraph = if let ParsedMarkdownElement::Paragraph(text) = &parsed.children[0] {
+            text
+        } else {
+            panic!("Expected a paragraph");
+        };
+
+        assert_eq!(
+            paragraph[0],
+            MarkdownParagraphChunk::Text(ParsedMarkdownText {
+                source_range: 0..32,
+                contents: "Alt text".into(),
+                highlights: [].to_vec(),
+                regions: [].to_vec(),
+            })
+        );
     }
 
     #[gpui::test]
@@ -3163,6 +3243,7 @@ fn main() {
 }
 ```
 ",
+            None,
             None,
             Some(language_registry),
         )

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -341,15 +341,26 @@ impl MarkdownPreviewView {
                 cx.background_executor().timer(REPARSE_DEBOUNCE).await;
             }
 
-            let (contents, file_location) = view.update(cx, |_, cx| {
+            let (contents, file_location, workspace_root) = view.update(cx, |this, cx| {
                 let editor = editor.read(cx);
                 let contents = editor.buffer().read(cx).snapshot(cx).text();
                 let file_location = MarkdownPreviewView::get_folder_for_active_editor(editor, cx);
-                (contents, file_location)
+
+                let mut workspace_root = None;
+
+                if let Some(workspace) = this.workspace.upgrade() {
+                    let project = workspace.read(cx).project();
+
+                    if let Some(tree) = project.read(cx).worktrees(cx).next() {
+                        workspace_root = Some(tree.read(cx).abs_path().to_path_buf());
+                    }
+                }
+
+                (contents, file_location, workspace_root)
             })?;
 
             let parsing_task = cx.background_spawn(async move {
-                parse_markdown(&contents, file_location, Some(language_registry)).await
+                parse_markdown(&contents, file_location, workspace_root, Some(language_registry)).await
             });
             let contents = parsing_task.await;
 


### PR DESCRIPTION
## Context

Previously, markdown images failed to load workspace-absolute paths. This fix updates the parser, making it able to identify the active workspace root directory. Paths which are workspace absolute are correctly resolved and rendered. 

Closes #46924 

## How to Review

Small PR - focus on three changes in three different files:
- In `crates/markdown_preview/src/markdown_elements.rs` - `identify()` (~line 296-337): added workplace_directory variable, and a verification to create the full path when a path is workplace-absolute
- In `crates/markdown_preview/src/markdown_parser.rs` - `parse_markdown()` (~line 22): added workplace_directory variable to function's arguments
- In `crates/markdown_preview/src/markdown_preview_view.rs` - `parse_markdown_in_background()` (~line 344-359): added logic to determine the worplace_directory

Two tests were added, one covering a successful resolution (`test_workspace_absolute_path_resolution`) and another testing the fallback behaviour when given a path of a file that does not exist within the workspace (`test_workspace_absolute_path_missing_file_fallback`). Both tests are implemented in the file `crates/markdown_preview/src/markdown_parser.rs`.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added workspace-absolute path detection in markdown files
