### PR TITLE
acp_thread: Mark in progress plan items as pending

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -924,6 +924,7 @@ impl Plan {
                 }
                 acp::PlanEntryStatus::InProgress => {
                     stats.in_progress_entry = stats.in_progress_entry.or(Some(entry));
+                    stats.pending += 1;
                 }
                 acp::PlanEntryStatus::Completed => {
                     stats.completed += 1;


### PR DESCRIPTION
## Context

We were seeing some off by one errors because we weren't counting in progress as either pending or completed.

Release Notes:

- acp: Fix plan stats showing all tasks as done when items were still in progress.
