### PR TITLE
deepseek: Fix empty text segments causing issues

### DIFF
--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -331,15 +331,25 @@ pub fn into_deepseek(
     for message in request.messages {
         for content in message.content {
             match content {
-                MessageContent::Text(text) => messages.push(match message.role {
-                    Role::User => deepseek::RequestMessage::User { content: text },
-                    Role::Assistant => deepseek::RequestMessage::Assistant {
-                        content: Some(text),
-                        tool_calls: Vec::new(),
-                        reasoning_content: current_reasoning.take(),
-                    },
-                    Role::System => deepseek::RequestMessage::System { content: text },
-                }),
+                MessageContent::Text(text) => {
+                    let should_add = if message.role == Role::User {
+                        !text.trim().is_empty()
+                    } else {
+                        !text.is_empty()
+                    };
+
+                    if should_add {
+                        messages.push(match message.role {
+                            Role::User => deepseek::RequestMessage::User { content: text },
+                            Role::Assistant => deepseek::RequestMessage::Assistant {
+                                content: Some(text),
+                                tool_calls: Vec::new(),
+                                reasoning_content: current_reasoning.take(),
+                            },
+                            Role::System => deepseek::RequestMessage::System { content: text },
+                        });
+                    }
+                }
                 MessageContent::Thinking { text, .. } => {
                     // Accumulate reasoning content for next assistant message
                     current_reasoning.get_or_insert_default().push_str(&text);

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -395,6 +395,8 @@ pub fn into_deepseek(
         }
     }
 
+    dbg!(&messages[1..]);
+
     deepseek::Request {
         model: model.id().to_string(),
         messages,
@@ -455,7 +457,9 @@ impl DeepSeekEventMapper {
         };
 
         let mut events = Vec::new();
-        if let Some(content) = choice.delta.content.clone() {
+        if let Some(content) = choice.delta.content.clone()
+            && !content.is_empty()
+        {
             events.push(Ok(LanguageModelCompletionEvent::Text(content)));
         }
 

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -395,8 +395,6 @@ pub fn into_deepseek(
         }
     }
 
-    dbg!(&messages[1..]);
-
     deepseek::Request {
         model: model.id().to_string(),
         messages,


### PR DESCRIPTION
## Context

Deepseek seems to have started to return empty text deltas, which causes issues cause their upstream API does not like empty text blocks to be included in their request.

In practice this caused issues like `An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'..., because the payload looked like this:

```
User {
    content: "Call the now tool a bunch of times",
},
Assistant {
    content: Some(
        "",
    ),
},
Tool {
    content: "The current datetime is 2026-03-23T13:21:24.084848+00:00.",
    tool_call_id: "call_00_iozCfHXJAPR13XwHiAwJ9OEw",
},
```

Now we filter out that empty text, which seems to fix the issue. This matches our implementation for OpenAI

Closes #51854

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- deepseek: Fixed issue with tool calling (`An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'...`) 
