### PR TITLE
agent: Make branch diff completion use same default branch as branch diff action

### DIFF
--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -874,7 +874,7 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
         let project = workspace.read(cx).project().clone();
         let repo = project.read(cx).active_repository(cx)?;
 
-        let default_branch_receiver = repo.update(cx, |repo, _| repo.default_branch(false));
+        let default_branch_receiver = repo.update(cx, |repo, _| repo.default_branch(true));
 
         Some(cx.spawn(async move |_cx| {
             let base_ref = default_branch_receiver


### PR DESCRIPTION
## Context

Before this change the branch diff would compare with local main instead of upstream main. This causes confusion because it's a different diff than the branch diff action would show users, and cause agents to potentially review a much larger diff then it has too. 

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
