### PR TITLE
project: Use path-scoped language server selection for buffer registration

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2808,6 +2808,22 @@ impl LocalLspStore {
                 }
             })
             .collect::<Vec<_>>();
+        // Partial registration (e.g. restart selected servers) must not drop
+        // existing bindings for non-targeted servers.
+        if only_register_servers.is_empty() {
+            let desired_server_ids = servers_and_adapters
+                .iter()
+                .map(|(server, _)| server.server_id())
+                .collect::<HashSet<_>>();
+            self.unregister_buffer_from_obsolete_language_servers(
+                buffer_handle,
+                buffer_id,
+                &uri,
+                &desired_server_ids,
+                cx,
+            );
+        }
+
         for (server, adapter) in servers_and_adapters {
             buffer_handle.update(cx, |buffer, cx| {
                 buffer.set_completion_triggers(
@@ -2865,6 +2881,58 @@ impl LocalLspStore {
                     ),
                 });
             }
+        }
+    }
+
+    fn unregister_buffer_from_obsolete_language_servers(
+        &mut self,
+        buffer_handle: &Entity<Buffer>,
+        buffer_id: BufferId,
+        file_url: &lsp::Uri,
+        desired_server_ids: &HashSet<LanguageServerId>,
+        cx: &mut Context<LspStore>,
+    ) {
+        let Some(opened_in_servers) = self.buffers_opened_in_servers.get(&buffer_id).cloned()
+        else {
+            return;
+        };
+        let servers_to_unregister = opened_in_servers
+            .difference(desired_server_ids)
+            .copied()
+            .collect::<Vec<_>>();
+        for server_id in servers_to_unregister {
+            buffer_handle.update(cx, |buffer, cx| {
+                buffer.update_diagnostics(server_id, DiagnosticSet::new([], buffer), cx);
+                buffer.set_completion_triggers(server_id, Default::default(), cx);
+            });
+
+            let had_snapshot = self
+                .buffer_snapshots
+                .get_mut(&buffer_id)
+                .and_then(|snapshots| snapshots.remove(&server_id))
+                .is_some();
+
+            if had_snapshot
+                && let Some(LanguageServerState::Running { server, .. }) =
+                    self.language_servers.get(&server_id)
+            {
+                server.unregister_buffer(file_url.clone());
+            }
+
+            if let Some(opened_in_servers) = self.buffers_opened_in_servers.get_mut(&buffer_id) {
+                opened_in_servers.remove(&server_id);
+                if opened_in_servers.is_empty() {
+                    self.buffers_opened_in_servers.remove(&buffer_id);
+                }
+            }
+        }
+
+        if self
+            .buffer_snapshots
+            .get(&buffer_id)
+            .is_some_and(|snapshots| snapshots.is_empty())
+        {
+            self.buffer_snapshots.remove(&buffer_id);
         }
     }
 
@@ -5288,8 +5356,23 @@ impl LspStore {
         for message in messages_to_report {
             cx.emit(message);
         }
+        let servers_to_stop = to_stop.into_keys().collect::<Vec<_>>();
         local.lsp_tree = new_tree;
-        for (id, _) in to_stop {
+        let registered_buffer_ids = local
+            .registered_buffers
+            .keys()
+            .copied()
+            .collect::<HashSet<_>>();
+        let buffers_to_reconcile = buffer_store
+            .read(cx)
+            .buffers()
+            .filter(|buffer| registered_buffer_ids.contains(&buffer.read(cx).remote_id()))
+            .collect::<Vec<_>>();
+        for buffer in buffers_to_reconcile {
+            local.register_buffer_with_language_servers(&buffer, HashSet::default(), cx);
+        }
+        let _ = local;
+        for id in servers_to_stop {
             self.stop_local_language_server(id, cx).detach();
         }
     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11898,9 +11898,13 @@ impl LspStore {
             }
         }
         for (path, _, _) in changes {
-            if let Some(file_name) = path.file_name()
-                && local.watched_manifest_filenames.contains(file_name)
-            {
+            let should_refresh_for_manifest = path
+                .file_name()
+                .is_some_and(|file_name| local.watched_manifest_filenames.contains(file_name));
+            let should_refresh_for_local_settings =
+                path.ends_with(paths::local_settings_file_relative_path());
+
+            if should_refresh_for_manifest || should_refresh_for_local_settings {
                 self.request_workspace_config_refresh();
                 break;
             }

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -8,6 +8,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
 
@@ -33,7 +34,7 @@ use super::ManifestTree;
 pub(crate) struct ServersForWorktree {
     pub(crate) roots: BTreeMap<
         Arc<RelPath>,
-        BTreeMap<LanguageServerName, (Arc<InnerTreeNode>, BTreeSet<LanguageName>)>,
+        BTreeMap<ServerInstanceKey, (Arc<InnerTreeNode>, BTreeSet<LanguageName>)>,
     >,
 }
 
@@ -143,9 +144,9 @@ impl LanguageServerTree {
         delegate: &Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> impl Iterator<Item = LanguageServerId> + 'a {
-        let manifest_location = self.manifest_location_for_path(&path, manifest_name, delegate, cx);
-        let adapters = self.adapters_for_language(&manifest_location, &language_name, cx);
-        self.get_with_adapters(manifest_location, adapters)
+        let query_paths = self.query_paths_for_project_path(&path, manifest_name, delegate, cx);
+        let adapters = self.adapters_for_language(&query_paths, &language_name, cx);
+        self.get_with_adapters(query_paths.root_path, adapters)
     }
 
     /// Get all language server root points for a given path and language; the language servers might already be initialized at a given path.
@@ -157,9 +158,9 @@ impl LanguageServerTree {
         delegate: &Arc<dyn ManifestDelegate>,
         cx: &'a mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
-        let manifest_location = self.manifest_location_for_path(&path, manifest_name, delegate, cx);
-        let adapters = self.adapters_for_language(&manifest_location, &language_name, cx);
-        self.init_with_adapters(manifest_location, language_name, adapters, cx)
+        let query_paths = self.query_paths_for_project_path(&path, manifest_name, delegate, cx);
+        let adapters = self.adapters_for_language(&query_paths, &language_name, cx);
+        self.init_with_adapters(query_paths.root_path, language_name, adapters, cx)
     }
 
     fn init_with_adapters<'a>(
@@ -178,7 +179,7 @@ impl LanguageServerTree {
                 .roots
                 .entry(root_path.path.clone())
                 .or_default()
-                .entry(adapter.name());
+                .entry(ServerInstanceKey::new(adapter.name(), &settings));
             let (node, languages) = inner_node.or_insert_with(|| {
                 let toolchain = self.toolchains.read(cx).active_toolchain(
                     root_path.worktree_id,
@@ -206,41 +207,46 @@ impl LanguageServerTree {
         root_path: ProjectPath,
         adapters: IndexMap<LanguageServerName, (LspSettings, Arc<CachedLspAdapter>)>,
     ) -> impl Iterator<Item = LanguageServerId> + 'a {
-        adapters.into_iter().filter_map(move |(_, (_, adapter))| {
+        adapters.into_iter().filter_map(move |(_, (settings, adapter))| {
             let root_path = root_path.clone();
             let inner_node = self
                 .instances
                 .get(&root_path.worktree_id)?
                 .roots
                 .get(&root_path.path)?
-                .get(&adapter.name())?;
+                .get(&ServerInstanceKey::new(adapter.name(), &settings))?;
             inner_node.0.id.get().copied()
         })
     }
 
-    fn manifest_location_for_path(
+    fn query_paths_for_project_path(
         &self,
         path: &ProjectPath,
         manifest_name: Option<&ManifestName>,
         delegate: &Arc<dyn ManifestDelegate>,
         cx: &mut App,
-    ) -> ProjectPath {
-        // Find out what the root location of our subproject is.
-        // That's where we'll look for language settings (that include a set of language servers).
-        self.manifest_tree.update(cx, |this, cx| {
+    ) -> ServerQueryPaths {
+        // Keep server identity rooted at manifest/worktree root.
+        let root_path = self.manifest_tree.update(cx, |this, cx| {
             this.root_for_path_or_worktree_root(path, manifest_name, delegate, cx)
-        })
+        });
+        // Resolve language server selection with settings scoped to the current buffer path.
+        let settings_path = path.clone();
+        ServerQueryPaths {
+            root_path,
+            settings_path,
+        }
     }
 
     fn adapters_for_language(
         &self,
-        manifest_location: &ProjectPath,
+        query_paths: &ServerQueryPaths,
         language_name: &LanguageName,
         cx: &App,
     ) -> IndexMap<LanguageServerName, (LspSettings, Arc<CachedLspAdapter>)> {
         let settings_location = SettingsLocation {
-            worktree_id: manifest_location.worktree_id,
-            path: &manifest_location.path,
+            worktree_id: query_paths.settings_path.worktree_id,
+            path: &query_paths.settings_path.path,
         };
         let settings = AllLanguageSettings::get(Some(settings_location), cx).language(
             Some(settings_location),
@@ -340,7 +346,10 @@ impl LanguageServerTree {
             .roots
             .entry(RelPath::empty().into())
             .or_default()
-            .entry(node.disposition.server_name.clone())
+            .entry(ServerInstanceKey::new(
+                node.disposition.server_name.clone(),
+                node.disposition.settings.as_ref(),
+            ))
             .or_insert_with(|| (node, BTreeSet::new()))
             .1
             .insert(language_name);
@@ -396,15 +405,15 @@ impl ServerTreeRebase {
         delegate: Arc<dyn ManifestDelegate>,
         cx: &'a mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
-        let manifest =
+        let query_paths =
             self.new_tree
-                .manifest_location_for_path(&path, manifest_name, &delegate, cx);
+                .query_paths_for_project_path(&path, manifest_name, &delegate, cx);
         let adapters = self
             .new_tree
-            .adapters_for_language(&manifest, &language_name, cx);
+            .adapters_for_language(&query_paths, &language_name, cx);
 
         self.new_tree
-            .init_with_adapters(manifest, language_name, adapters, cx)
+            .init_with_adapters(query_paths.root_path, language_name, adapters, cx)
             .filter_map(|node| {
                 // Inspect result of the query and initialize it ourselves before
                 // handing it off to the caller.
@@ -419,15 +428,14 @@ impl ServerTreeRebase {
                     .old_contents
                     .get(&disposition.path.worktree_id)
                     .and_then(|worktree_nodes| worktree_nodes.roots.get(&disposition.path.path))
-                    .and_then(|roots| roots.get(&disposition.server_name))
+                    .and_then(|roots| {
+                        roots.get(&ServerInstanceKey::new(
+                            disposition.server_name.clone(),
+                            disposition.settings.as_ref(),
+                        ))
+                    })
                     .filter(|(old_node, _)| {
-                        // Only compare settings that require server restart.
-                        // Dynamic settings (settings.settings) can be updated via DidChangeConfiguration
-                        // without restarting the server.
                         disposition.toolchain == old_node.disposition.toolchain
-                            && disposition.settings.binary == old_node.disposition.settings.binary
-                            && disposition.settings.initialization_options
-                                == old_node.disposition.settings.initialization_options
                     })
                 else {
                     return Some(node);
@@ -459,5 +467,39 @@ impl ServerTreeRebase {
 
     pub(crate) fn server_tree(&mut self) -> &mut LanguageServerTree {
         &mut self.new_tree
+    }
+}
+
+struct ServerQueryPaths {
+    root_path: ProjectPath,
+    settings_path: ProjectPath,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ServerInstanceKey {
+    name: LanguageServerName,
+    settings_fingerprint: u64,
+}
+
+impl ServerInstanceKey {
+    fn new(name: LanguageServerName, settings: &LspSettings) -> Self {
+        // Server identity should only split on settings that require restart.
+        // Dynamic settings are handled through DidChangeConfiguration.
+        let settings_fingerprint = serde_json::to_string(&(
+            settings.binary.clone(),
+            settings.initialization_options.clone(),
+        ))
+            .ok()
+            .map(|serialized| {
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                serialized.hash(&mut hasher);
+                hasher.finish()
+            })
+            .unwrap_or_default();
+
+        Self {
+            name,
+            settings_fingerprint,
+        }
     }
 }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -49,8 +49,8 @@ use language::{
 };
 use lsp::{
     CodeActionKind, DEFAULT_LSP_REQUEST_TIMEOUT, DiagnosticSeverity, DocumentChanges,
-    FileOperationFilter, LanguageServerId, LanguageServerName, NumberOrString, TextDocumentEdit,
-    Uri, WillRenameFiles, notification::DidRenameFiles,
+    FileOperationFilter, LanguageServerId, LanguageServerName, LanguageServerSelector,
+    NumberOrString, TextDocumentEdit, Uri, WillRenameFiles, notification::DidRenameFiles,
 };
 use parking_lot::Mutex;
 use paths::{config_dir, global_gitignore_path, tasks_file};
@@ -1579,6 +1579,310 @@ async fn test_running_multiple_instances_of_a_single_server_in_one_worktree(
     assert_eq!(adapter.name(), LanguageServerName::new_static("ty"));
     // There's a new language server in town.
     assert_eq!(server.server_id(), LanguageServerId(1));
+}
+
+#[gpui::test]
+async fn test_typescript_language_server_selection_is_scoped_by_buffer_path(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/repo"),
+        json!({
+            ".zed": {
+                "settings.json": r#"{
+                    "languages": {
+                        "TypeScript": {
+                            "language_servers": ["vtsls"]
+                        }
+                    }
+                }"#
+            },
+            "src": {
+                "app.ts": "export const app = 1;"
+            },
+            "supabase": {
+                "functions": {
+                    ".zed": {
+                        "settings.json": r#"{
+                            "languages": {
+                                "TypeScript": {
+                                    "language_servers": ["deno"]
+                                }
+                            }
+                        }"#
+                    },
+                    "edge.ts": "export const edge = 1;"
+                }
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/repo").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(typescript_lang());
+    let _fake_vtsls = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "vtsls",
+            ..Default::default()
+        },
+    );
+    let _fake_deno = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "deno",
+            ..Default::default()
+        },
+    );
+
+    let (root_buffer, _root_handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/repo/src/app.ts"), cx)
+        })
+        .await
+        .unwrap();
+    let (supabase_buffer, _supabase_handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/repo/supabase/functions/edge.ts"), cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let root_servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            root_buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, _)| adapter.name())
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    let supabase_servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            supabase_buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, _)| adapter.name())
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+
+    assert_eq!(root_servers, vec![LanguageServerName::new_static("vtsls")],);
+    assert_eq!(
+        supabase_servers,
+        vec![LanguageServerName::new_static("deno")],
+    );
+}
+
+#[gpui::test]
+async fn test_typescript_language_server_selection_rebinds_after_local_settings_change(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/repo"),
+        json!({
+            ".zed": {
+                "settings.json": r#"{
+                    "languages": {
+                        "TypeScript": {
+                            "language_servers": ["vtsls"]
+                        }
+                    }
+                }"#
+            },
+            "supabase": {
+                "functions": {
+                    "edge.ts": "export const edge = 1;"
+                }
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/repo").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(typescript_lang());
+    let _fake_vtsls = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "vtsls",
+            ..Default::default()
+        },
+    );
+    let _fake_deno = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "deno",
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/repo/supabase/functions/edge.ts"), cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let servers_before = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, _)| adapter.name())
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    assert_eq!(
+        servers_before,
+        vec![LanguageServerName::new_static("vtsls")]
+    );
+
+    fs.insert_tree(
+        path!("/repo/supabase/functions/.zed"),
+        json!({
+            "settings.json": r#"{
+                "languages": {
+                    "TypeScript": {
+                        "language_servers": ["deno"]
+                    }
+                }
+            }"#
+        }),
+    )
+    .await;
+    cx.run_until_parked();
+
+    let servers_after = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, _)| adapter.name())
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    assert_eq!(servers_after, vec![LanguageServerName::new_static("deno")]);
+}
+
+#[gpui::test]
+async fn test_restarting_subset_of_servers_keeps_other_server_registrations(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/repo"),
+        json!({
+            ".zed": {
+                "settings.json": r#"{
+                    "languages": {
+                        "TypeScript": {
+                            "language_servers": ["vtsls", "deno"]
+                        }
+                    }
+                }"#
+            },
+            "src": {
+                "app.ts": "export const app = 1;"
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/repo").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(typescript_lang());
+    let _fake_vtsls = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "vtsls",
+            ..Default::default()
+        },
+    );
+    let _fake_deno = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "deno",
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/repo/src/app.ts"), cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let servers_before = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, server)| (adapter.name(), server.server_id()))
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    assert_eq!(servers_before.len(), 2);
+    let vtsls_server_id_before = servers_before
+        .iter()
+        .find_map(|(name, server_id)| {
+            (name == &LanguageServerName::new_static("vtsls")).then_some(*server_id)
+        })
+        .unwrap();
+    let deno_server_id_before = servers_before
+        .iter()
+        .find_map(|(name, server_id)| {
+            (name == &LanguageServerName::new_static("deno")).then_some(*server_id)
+        })
+        .unwrap();
+
+    project.update(cx, |project, cx| {
+        project.restart_language_servers_for_buffers(
+            vec![buffer.clone()],
+            HashSet::from_iter([LanguageServerSelector::Name(
+                LanguageServerName::new_static("deno"),
+            )]),
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    let servers_after = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, server)| (adapter.name(), server.server_id()))
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    let vtsls_server_id_after = servers_after
+        .iter()
+        .find_map(|(name, server_id)| {
+            (name == &LanguageServerName::new_static("vtsls")).then_some(*server_id)
+        })
+        .unwrap();
+    let deno_server_id_after = servers_after
+        .iter()
+        .find_map(|(name, server_id)| {
+            (name == &LanguageServerName::new_static("deno")).then_some(*server_id)
+        })
+        .unwrap();
+    assert_eq!(vtsls_server_id_after, vtsls_server_id_before);
+    assert_ne!(deno_server_id_after, deno_server_id_before);
 }
 
 #[gpui::test]


### PR DESCRIPTION
## Summary

(Might be related to #21990.) I want to enable the Deno language server for one directory in my monorepo and turn off all other TS language servers. With this change, language server routing respects directory-level settings so irrelevant language servers don't contribute to directories where they aren't welcome.

This change solves the problem for my use case, but if it isn't the way to go, feel free to close and consider this a vote for support in some other way! The change seems clean and in line with existing abstractions though to me.

- make language-server adapter selection path-scoped (buffer path) while preserving manifest/worktree-rooted server identity
- rebind buffer-to-server registrations when settings-driven adapter selection changes
- reconcile stale buffer registrations so deselected servers receive buffer unregister without forcing process churn
- add integration coverage for path-scoped TypeScript/Deno selection and dynamic rebind behavior

## Why
Zed already supports directory-scoped `.zed/settings.json`, but server selection in this flow was effectively resolved from manifest/worktree root. In monorepos that mix Deno and TypeScript by directory, this can cause both servers to attach to files where only one should run.

This change keeps server process rooting unchanged (good workspace semantics), but makes adapter selection and buffer registration path-aware so each file is attached only to the servers selected for that file path.

Release Notes:

- Fixed language server selection in monorepos to respect path-scoped `.zed/settings.json` so files can attach to different servers by directory.
