### PR TITLE
editor: Defer rendering the git blame popover until after the markdown is parsed

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8696,6 +8696,10 @@ fn render_blame_entry_popover(
     window: &mut Window,
     cx: &mut App,
 ) -> Option<AnyElement> {
+    if markdown.read(cx).is_parsing() {
+        return None;
+    }
+
     let renderer = cx.global::<GlobalBlameRenderer>().0.clone();
     let blame = blame.read(cx);
     let repository = blame.repository(cx, buffer)?;


### PR DESCRIPTION
Fixes this single-frame glitch that sometimes occurs when the git blame popover is rendered before the markdown has been parsed.

https://github.com/user-attachments/assets/d5a322c3-e46f-4597-a10f-a676da57daa7

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a visual glitch where the git blame popover could briefly appear empty while its markdown content was being parsed
