### PR TITLE
Change the default panel layout

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3184,7 +3184,7 @@ impl Panel for AgentPanel {
     }
 
     fn activation_priority(&self) -> u32 {
-        3
+        8
     }
 
     fn enabled(&self, cx: &App) -> bool {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -426,6 +426,7 @@ pub fn init(
                     defaults.collaboration_panel.get_or_insert_default().dock =
                         Some(DockPosition::Right);
                     defaults.git_panel.get_or_insert_default().dock = Some(DockPosition::Right);
+                    defaults.notification_panel.get_or_insert_default().button = Some(false);
                 } else {
                     defaults.agent.get_or_insert_default().dock = Some(DockPosition::Right);
                     defaults.project_panel.get_or_insert_default().dock = Some(DockSide::Left);
@@ -433,6 +434,7 @@ pub fn init(
                     defaults.collaboration_panel.get_or_insert_default().dock =
                         Some(DockPosition::Left);
                     defaults.git_panel.get_or_insert_default().dock = Some(DockPosition::Left);
+                    defaults.notification_panel.get_or_insert_default().button = Some(true);
                 }
             });
         });

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -47,7 +47,7 @@ use client::Client;
 use command_palette_hooks::CommandPaletteFilter;
 use feature_flags::{AgentV2FeatureFlag, FeatureFlagAppExt as _};
 use fs::Fs;
-use gpui::{Action, App, Context, Entity, SharedString, Window, actions};
+use gpui::{Action, App, Context, Entity, SharedString, UpdateGlobal, Window, actions};
 use language::{
     LanguageRegistry,
     language_settings::{AllLanguageSettings, EditPredictionProvider},
@@ -59,7 +59,7 @@ use project::{AgentId, DisableAiSettings};
 use prompt_store::PromptBuilder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{LanguageModelSelection, Settings as _, SettingsStore};
+use settings::{DockPosition, DockSide, LanguageModelSelection, Settings as _, SettingsStore};
 use std::any::TypeId;
 use workspace::Workspace;
 
@@ -413,6 +413,29 @@ pub fn init(
 
     cx.on_flags_ready(|_, cx| {
         update_command_palette_filter(cx);
+    })
+    .detach();
+
+    cx.observe_flag::<AgentV2FeatureFlag, _>(|is_enabled, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_default_settings(cx, |defaults| {
+                if is_enabled {
+                    defaults.agent.get_or_insert_default().dock = Some(DockPosition::Left);
+                    defaults.project_panel.get_or_insert_default().dock = Some(DockSide::Right);
+                    defaults.outline_panel.get_or_insert_default().dock = Some(DockSide::Right);
+                    defaults.collaboration_panel.get_or_insert_default().dock =
+                        Some(DockPosition::Right);
+                    defaults.git_panel.get_or_insert_default().dock = Some(DockPosition::Right);
+                } else {
+                    defaults.agent.get_or_insert_default().dock = Some(DockPosition::Right);
+                    defaults.project_panel.get_or_insert_default().dock = Some(DockSide::Left);
+                    defaults.outline_panel.get_or_insert_default().dock = Some(DockSide::Left);
+                    defaults.collaboration_panel.get_or_insert_default().dock =
+                        Some(DockPosition::Left);
+                    defaults.git_panel.get_or_insert_default().dock = Some(DockPosition::Left);
+                }
+            });
+        });
     })
     .detach();
 }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -3229,7 +3229,7 @@ impl Panel for CollabPanel {
     }
 
     fn activation_priority(&self) -> u32 {
-        6
+        5
     }
 }
 

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -690,7 +690,7 @@ impl Panel for NotificationPanel {
     }
 
     fn activation_priority(&self) -> u32 {
-        8
+        3
     }
 }
 

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -5069,7 +5069,7 @@ impl Panel for OutlinePanel {
     }
 
     fn activation_priority(&self) -> u32 {
-        5
+        6
     }
 }
 

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -793,6 +793,17 @@ impl SettingsStore {
         edits
     }
 
+    /// Mutates the default settings in place and recomputes all setting values.
+    pub fn update_default_settings(
+        &mut self,
+        cx: &mut App,
+        update: impl FnOnce(&mut SettingsContent),
+    ) {
+        let default_settings = Rc::make_mut(&mut self.default_settings);
+        update(default_settings);
+        self.recompute_values(None, cx);
+    }
+
     /// Sets the default settings via a JSON string.
     ///
     /// The string should contain a JSON object with a default value for every setting.

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -911,7 +911,7 @@ impl Render for PanelButtons {
             DockPosition::Bottom | DockPosition::Right => (Corner::BottomRight, Corner::TopRight),
         };
 
-        let buttons: Vec<_> = dock
+        let mut buttons: Vec<_> = dock
             .panel_entries
             .iter()
             .enumerate()
@@ -1004,6 +1004,10 @@ impl Render for PanelButtons {
             })
             .collect();
 
+        if dock_position == DockPosition::Right {
+            buttons.reverse();
+        }
+
         let has_buttons = !buttons.is_empty();
 
         h_flex()
@@ -1013,6 +1017,10 @@ impl Render for PanelButtons {
                 |this| this.child(Divider::vertical().color(DividerColor::Border)),
             )
             .children(buttons)
+            .when(
+                has_buttons && dock.position == DockPosition::Right,
+                |this| this.child(Divider::vertical().color(DividerColor::Border)),
+            )
             .when(has_buttons && dock.position == DockPosition::Left, |this| {
                 this.child(Divider::vertical().color(DividerColor::Border))
             })

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1013,14 +1013,12 @@ impl Render for PanelButtons {
         h_flex()
             .gap_1()
             .when(
-                has_buttons && dock.position == DockPosition::Bottom,
+                has_buttons
+                    && (dock.position == DockPosition::Bottom
+                        || dock.position == DockPosition::Right),
                 |this| this.child(Divider::vertical().color(DividerColor::Border)),
             )
             .children(buttons)
-            .when(
-                has_buttons && dock.position == DockPosition::Right,
-                |this| this.child(Divider::vertical().color(DividerColor::Border)),
-            )
             .when(has_buttons && dock.position == DockPosition::Left, |this| {
                 this.child(Divider::vertical().color(DividerColor::Border))
             })

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -577,8 +577,6 @@ fn main() {
         let installation_id = cx.foreground_executor().block_on(installation_id).ok();
         let session = cx.foreground_executor().block_on(session);
 
-        migrate_panel_positions(system_id.as_ref(), fs.clone(), cx);
-
         let telemetry = client.telemetry();
         telemetry.start(
             system_id.as_ref().map(|id| id.to_string()),
@@ -1340,79 +1338,6 @@ async fn installation_id(db: KeyValueStore) -> Result<IdType> {
     db.write_kvp(key_name, installation_id.clone()).await?;
 
     Ok(IdType::New(installation_id))
-}
-
-/// Pins current panel dock positions into settings.json for existing users.
-///
-/// This runs once at startup for users who aren't brand new. It writes the
-/// current default positions into the user's settings file for any panel
-/// position they haven't explicitly customized. This is a no-op in practice
-/// (writing values that already match the defaults), but ensures that when
-/// the AgentV2 feature flag later overrides the defaults at runtime,
-/// existing users' layouts aren't silently rearranged.
-fn migrate_panel_positions(system_id: Option<&IdType>, fs: Arc<dyn Fs>, cx: &mut App) {
-    // New users get whatever defaults are active — no pinning needed.
-    if matches!(system_id, Some(IdType::New(_)) | None) {
-        return;
-    }
-
-    let db = KeyValueStore::global(cx);
-    if db
-        .read_kvp("agent_layout_migrated")
-        .ok()
-        .flatten()
-        .is_some()
-    {
-        return;
-    }
-
-    // Pin the current defaults into settings.json for any position the user
-    // has not explicitly set.
-    settings::update_settings_file(fs, cx, |settings, _| {
-        use settings::{DockPosition, DockSide};
-
-        if settings
-            .project_panel
-            .as_ref()
-            .and_then(|p| p.dock)
-            .is_none()
-        {
-            settings.project_panel.get_or_insert_default().dock = Some(DockSide::Left);
-        }
-        if settings
-            .outline_panel
-            .as_ref()
-            .and_then(|p| p.dock)
-            .is_none()
-        {
-            settings.outline_panel.get_or_insert_default().dock = Some(DockSide::Left);
-        }
-        if settings
-            .collaboration_panel
-            .as_ref()
-            .and_then(|p| p.dock)
-            .is_none()
-        {
-            settings.collaboration_panel.get_or_insert_default().dock = Some(DockPosition::Left);
-        }
-        if settings.git_panel.as_ref().and_then(|p| p.dock).is_none() {
-            settings.git_panel.get_or_insert_default().dock = Some(DockPosition::Left);
-        }
-        if settings.agent.as_ref().and_then(|a| a.dock).is_none() {
-            settings
-                .agent
-                .get_or_insert_default()
-                .set_dock(DockPosition::Right);
-        }
-    });
-
-    // Record that we've done this migration.
-    cx.background_spawn(async move {
-        db.write_kvp("agent_layout_migrated".to_string(), "true".to_string())
-            .await
-            .log_err();
-    })
-    .detach();
 }
 
 pub(crate) async fn restore_or_create_workspace(

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -577,6 +577,8 @@ fn main() {
         let installation_id = cx.foreground_executor().block_on(installation_id).ok();
         let session = cx.foreground_executor().block_on(session);
 
+        migrate_panel_positions(system_id.as_ref(), fs.clone(), cx);
+
         let telemetry = client.telemetry();
         telemetry.start(
             system_id.as_ref().map(|id| id.to_string()),
@@ -1338,6 +1340,79 @@ async fn installation_id(db: KeyValueStore) -> Result<IdType> {
     db.write_kvp(key_name, installation_id.clone()).await?;
 
     Ok(IdType::New(installation_id))
+}
+
+/// Pins current panel dock positions into settings.json for existing users.
+///
+/// This runs once at startup for users who aren't brand new. It writes the
+/// current default positions into the user's settings file for any panel
+/// position they haven't explicitly customized. This is a no-op in practice
+/// (writing values that already match the defaults), but ensures that when
+/// the AgentV2 feature flag later overrides the defaults at runtime,
+/// existing users' layouts aren't silently rearranged.
+fn migrate_panel_positions(system_id: Option<&IdType>, fs: Arc<dyn Fs>, cx: &mut App) {
+    // New users get whatever defaults are active — no pinning needed.
+    if matches!(system_id, Some(IdType::New(_)) | None) {
+        return;
+    }
+
+    let db = KeyValueStore::global(cx);
+    if db
+        .read_kvp("agent_layout_migrated")
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return;
+    }
+
+    // Pin the current defaults into settings.json for any position the user
+    // has not explicitly set.
+    settings::update_settings_file(fs, cx, |settings, _| {
+        use settings::{DockPosition, DockSide};
+
+        if settings
+            .project_panel
+            .as_ref()
+            .and_then(|p| p.dock)
+            .is_none()
+        {
+            settings.project_panel.get_or_insert_default().dock = Some(DockSide::Left);
+        }
+        if settings
+            .outline_panel
+            .as_ref()
+            .and_then(|p| p.dock)
+            .is_none()
+        {
+            settings.outline_panel.get_or_insert_default().dock = Some(DockSide::Left);
+        }
+        if settings
+            .collaboration_panel
+            .as_ref()
+            .and_then(|p| p.dock)
+            .is_none()
+        {
+            settings.collaboration_panel.get_or_insert_default().dock = Some(DockPosition::Left);
+        }
+        if settings.git_panel.as_ref().and_then(|p| p.dock).is_none() {
+            settings.git_panel.get_or_insert_default().dock = Some(DockPosition::Left);
+        }
+        if settings.agent.as_ref().and_then(|a| a.dock).is_none() {
+            settings
+                .agent
+                .get_or_insert_default()
+                .set_dock(DockPosition::Right);
+        }
+    });
+
+    // Record that we've done this migration.
+    cx.background_spawn(async move {
+        db.write_kvp("agent_layout_migrated".to_string(), "true".to_string())
+            .await
+            .log_err();
+    })
+    .detach();
 }
 
 pub(crate) async fn restore_or_create_workspace(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2461,7 +2461,7 @@ mod tests {
             .update(cx, |multi_workspace, window, cx| {
                 multi_workspace.workspace().update(cx, |workspace, cx| {
                     assert_eq!(workspace.worktrees(cx).count(), 2);
-                    assert!(workspace.left_dock().read(cx).is_open());
+                    assert!(workspace.right_dock().read(cx).is_open());
                     assert!(
                         workspace
                             .active_pane()
@@ -2520,7 +2520,7 @@ mod tests {
                         .collect::<Vec<_>>(),
                     &[Path::new(path!("/root/e")).into()]
                 );
-                assert!(workspace.left_dock().read(cx).is_open());
+                assert!(workspace.right_dock().read(cx).is_open());
                 assert!(workspace.active_pane().focus_handle(cx).is_focused(window));
             })
             .unwrap();


### PR DESCRIPTION
This PR adjusts the default panel layout for anyone on the agent v2 feature flag.

Note that this changes the right status bar items to show in reverse priority order, and then adjusts priorities so that the "project management" buttons appear to the right, and the outline panel appears to the far left. The reversal "cancels out" most of the priority changes, except the outline panel and the collab panel.


## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Swapped the order of the collab and outline status bar buttons
