### PR TITLE
Always open microphone track on call join

### DIFF
--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -1773,7 +1773,12 @@ fn spawn_room_connection(
                 });
                 this.diagnostics = Some(cx.new(|cx| CallDiagnostics::new(weak_room, cx)));
 
-                if !muted_by_user && this.can_use_microphone() {
+                // Always open the microphone track on join, even when
+                // `muted_by_user` is set. `share_microphone` will still mute
+                // the track if `muted_by_user` is set. This avoids a Bluetooth
+                // profile switch (A2DP -> HFP) on first unmute, which can cause
+                // 1-2 seconds of audio silence on some Bluetooth headphones.
+                if this.can_use_microphone() {
                     this.share_microphone(cx)
                 } else {
                     Task::ready(Ok(()))

--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -1774,10 +1774,13 @@ fn spawn_room_connection(
                 this.diagnostics = Some(cx.new(|cx| CallDiagnostics::new(weak_room, cx)));
 
                 // Always open the microphone track on join, even when
-                // `muted_by_user` is set. `share_microphone` will still mute
-                // the track if `muted_by_user` is set. This avoids a Bluetooth
-                // profile switch (A2DP -> HFP) on first unmute, which can cause
-                // 1-2 seconds of audio silence on some Bluetooth headphones.
+                // `muted_by_user` is set. Note that the microphone will still
+                // be muted, as it is still gated in `share_microphone` by
+                // `muted_by_user`. For users that have `mute_on_join` enabled,
+                // this moves the Bluetooth profile switch (A2DP -> HFP) (which
+                // can cause 1-2 seconds of audio silence on some Bluetooth
+                // headphones) from first unmute to channel join, where
+                // instability is expected.
                 if this.can_use_microphone() {
                     this.share_microphone(cx)
                 } else {


### PR DESCRIPTION
## Context

This PR works around a 1-2 second audio silence that occurs when unmuting for the first time during a call for Bluetooth headphone users with `mute_on_join` enabled. Bluetooth headphones must switch from A2DP (listening-only) to HFP (microphone-enabled) mode when the mic is first activated, which interrupts audio output. Now the microphone track opens on join (still muted at the publication level), moving this switch to when users already expect a connection delay / audio instability. It should be noted that I expect that the OS microphone indicator will now appear on channel join rather than on first unmute, but I feel this is a justified side effect:

1. This is consistent with other apps—joining a Slack huddle with "Mute my microphone" enabled also shows the indicator immediately on join while muted. 
1. Zed users without `mute_on_join` already see the OS-level microphone indicator for the entire call (even after muting) and already experience the Bluetooth profile switch at join time—this change simply brings `mute_on_join` users in line with that existing behavior.

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

## Self-Review Checklist

<!-- Check before requesting review: -->
- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Fixed 1-2 seconds of audio silence when unmuting for the first time during a call with Bluetooth headphones when `mute_on_join` is enabled.
