### PR TITLE
gpui_wgpu: Allowlist `Apple Color Emoji` fonts for Linux systems

### DIFF
--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -226,19 +226,20 @@ impl CosmicTextSystemState {
             .collect::<SmallVec<[_; 4]>>();
 
         let mut loaded_font_ids = SmallVec::new();
+
+        // HACK: To let the storybook run and render Windows caption icons. We should actually do better font fallback.
+        let allowed_bad_font_names = [
+            "SegoeFluentIcons", // NOTE: Segoe fluent icons postscript name is inconsistent
+            "Segoe Fluent Icons",
+            "AppleColorEmoji",
+            "Apple Color Emoji",
+        ];
+
         for (font_id, postscript_name) in families {
             let font = self
                 .font_system
                 .get_font(font_id, cosmic_text::Weight::NORMAL)
                 .context("Could not load font")?;
-
-            // HACK: To let the storybook run and render Windows caption icons. We should actually do better font fallback.
-            let allowed_bad_font_names = [
-                "SegoeFluentIcons", // NOTE: Segoe fluent icons postscript name is inconsistent
-                "Segoe Fluent Icons",
-                "AppleColorEmoji",
-                "Apple Color Emoji",
-            ];
 
             if font.as_swash().charmap().map('m') == 0
                 && !allowed_bad_font_names.contains(&postscript_name.as_str())

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -236,6 +236,8 @@ impl CosmicTextSystemState {
             let allowed_bad_font_names = [
                 "SegoeFluentIcons", // NOTE: Segoe fluent icons postscript name is inconsistent
                 "Segoe Fluent Icons",
+                "AppleColorEmoji",
+                "Apple Color Emoji",
             ];
 
             if font.as_swash().charmap().map('m') == 0
@@ -641,5 +643,5 @@ fn face_info_into_properties(
 
 fn check_is_known_emoji_font(postscript_name: &str) -> bool {
     // TODO: Include other common emoji fonts
-    postscript_name == "NotoColorEmoji"
+    postscript_name == "NotoColorEmoji" || postscript_name == "AppleColorEmoji"
 }


### PR DESCRIPTION
## Context

The `.font_family("Apple Color Emoji")` call would not correctly assign the font family. This was caused by the known issue of emoji fonts failing the sanity check in the `load_family` implementation. It required the font name to be hard coded into a white list, as previously also done for `Segoe Fluent Icons`.  

I also moved the workaround out of the loop for efficiency reasons (see second commit).



Release Notes:

- N/A
