### PR TITLE
extension_api: Add support for setting the working dir for `Command`

### DIFF
--- a/crates/extension/src/types.rs
+++ b/crates/extension/src/types.rs
@@ -23,6 +23,8 @@ pub struct Command {
     pub args: Vec<String>,
     /// The environment variables to set for the command.
     pub env: EnvVars,
+    /// The working directory for the command
+    pub working_dir: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for Command {
@@ -37,6 +39,7 @@ impl std::fmt::Debug for Command {
             .field("command", &self.command)
             .field("args", &self.args)
             .field("env", &filtered_env)
+            .field("working_dir", &self.working_dir)
             .finish()
     }
 }

--- a/crates/extension_api/src/process.rs
+++ b/crates/extension_api/src/process.rs
@@ -9,6 +9,7 @@ impl Command {
             command: program.into(),
             args: Vec::new(),
             env: Vec::new(),
+            working_dir: None,
         }
     }
 
@@ -35,6 +36,11 @@ impl Command {
             envs.into_iter()
                 .map(|(key, value)| (key.into(), value.into())),
         );
+        self
+    }
+
+    pub fn working_dir(mut self, dir: impl Into<String>) -> Self {
+        self.working_dir = Some(dir.into());
         self
     }
 

--- a/crates/extension_api/wit/since_v0.0.1/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.1/extension.wit
@@ -52,6 +52,7 @@ world extension {
         command: string,
         args: list<string>,
         env: env-vars,
+        working-dir: option<string>,
     }
 
     resource worktree {

--- a/crates/extension_api/wit/since_v0.0.4/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.4/extension.wit
@@ -54,6 +54,7 @@ world extension {
         command: string,
         args: list<string>,
         env: env-vars,
+        working-dir: option<string>,
     }
 
     resource worktree {

--- a/crates/extension_api/wit/since_v0.0.6/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.6/extension.wit
@@ -64,6 +64,8 @@ world extension {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// A Zed worktree.

--- a/crates/extension_api/wit/since_v0.1.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.1.0/extension.wit
@@ -67,6 +67,8 @@ world extension {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// A Zed worktree.

--- a/crates/extension_api/wit/since_v0.2.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.2.0/extension.wit
@@ -67,6 +67,8 @@ world extension {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// A Zed worktree.

--- a/crates/extension_api/wit/since_v0.3.0/process.wit
+++ b/crates/extension_api/wit/since_v0.3.0/process.wit
@@ -9,6 +9,8 @@ interface process {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// The output of a finished process.

--- a/crates/extension_api/wit/since_v0.4.0/process.wit
+++ b/crates/extension_api/wit/since_v0.4.0/process.wit
@@ -9,6 +9,8 @@ interface process {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// The output of a finished process.

--- a/crates/extension_api/wit/since_v0.5.0/process.wit
+++ b/crates/extension_api/wit/since_v0.5.0/process.wit
@@ -9,6 +9,8 @@ interface process {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// The output of a finished process.

--- a/crates/extension_api/wit/since_v0.6.0/process.wit
+++ b/crates/extension_api/wit/since_v0.6.0/process.wit
@@ -9,6 +9,8 @@ interface process {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// The output of a finished process.

--- a/crates/extension_api/wit/since_v0.8.0/process.wit
+++ b/crates/extension_api/wit/since_v0.8.0/process.wit
@@ -9,6 +9,8 @@ interface process {
         args: list<string>,
         /// The environment variables to set for the command.
         env: env-vars,
+        /// The working directory of the command.
+        working-dir: option<string>,
     }
 
     /// The output of a finished process.

--- a/crates/extension_host/src/wasm_host/wit/since_v0_0_1.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_0_1.rs
@@ -63,6 +63,7 @@ impl From<Command> for latest::Command {
             command: value.command,
             args: value.args,
             env: value.env,
+            working_dir: value.working_dir,
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_0_4.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_0_4.rs
@@ -71,6 +71,7 @@ impl From<Command> for latest::Command {
             command: value.command,
             args: value.args,
             env: value.env,
+            working_dir: value.working_dir,
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_0_6.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_0_6.rs
@@ -48,6 +48,7 @@ impl From<Command> for latest::Command {
             command: value.command,
             args: value.args,
             env: value.env,
+            working_dir: value.working_dir,
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -69,6 +69,7 @@ impl From<Command> for latest::Command {
             command: value.command,
             args: value.args,
             env: value.env,
+            working_dir: value.working_dir,
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
@@ -57,6 +57,7 @@ impl From<Command> for latest::Command {
             command: value.command,
             args: value.args,
             env: value.env,
+            working_dir: value.working_dir,
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -90,6 +90,7 @@ impl From<Command> for extension::Command {
             command: value.command.into(),
             args: value.args,
             env: value.env,
+            working_dir: value.working_dir.map(PathBuf::from),
         }
     }
 }
@@ -872,6 +873,10 @@ impl process::Host for WasmState {
         &mut self,
         command: process::Command,
     ) -> wasmtime::Result<Result<process::Output, String>> {
+        let working_dir = command
+            .working_dir
+            .unwrap_or_else(|| self.work_dir().to_string_lossy().to_string());
+
         maybe!(async {
             self.capability_granter
                 .grant_exec(&command.command, &command.args)?;
@@ -879,6 +884,7 @@ impl process::Host for WasmState {
             let output = util::command::new_command(command.command.as_str())
                 .args(&command.args)
                 .envs(command.env)
+                .current_dir(&working_dir)
                 .output()
                 .await?;
 


### PR DESCRIPTION
Adds an optional `working-dir` field to the `Command` type across the extension API.

## Context

Extensions that use the `Command` sometimes need to run commands in a specific directory, for example, in a worktree root. Without this, the CWD was uncontrolled/implicit.

This makes it explicit and overridable.
If `working_dir` is not set, it defaults to the extension's work directory. This is the current behavior.

## How to Review

I think the most important bit is extension API compatibility.  
I tried to keep the existing extensions that rely on the `Command` API
working in the same way as they do currently.

Not sure if a bump is requires but happy to do that.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Add support for setting the working dir for `Command` in Extension API
