### PR TITLE
collab: Add AuthProvider trait for extensible authentication

### DIFF
--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -1,21 +1,22 @@
-use crate::{AppState, Error, db::UserId, rpc::Principal};
-use anyhow::Context as _;
+pub mod provider;
+
+use crate::{AppState, Error, rpc::Principal};
+
 use axum::{
     http::{self, Request, StatusCode},
     middleware::Next,
     response::IntoResponse,
 };
-use cloud_api_types::GetAuthenticatedUserResponse;
 pub use rpc::auth::random_token;
 use std::sync::Arc;
 
-/// Validates the authorization header and adds an Extension<Principal> to the request.
-/// Authorization: <user-id> <token>
-///   <token> can be an access_token attached to that user, or an access token of an admin
-///   or (in development) the string ADMIN:<config.api_token>.
-/// Authorization: "dev-server-token" <token>
+/// Validates the authorization header using the configured `AuthProvider` and adds
+/// an `Extension<Principal>` to the request.
+///
+/// The actual authentication logic is delegated to `AppState::auth_provider`, allowing
+/// for different authentication mechanisms to be plugged in.
 pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl IntoResponse {
-    let mut auth_header = req
+    let auth_header = req
         .headers()
         .get(http::header::AUTHORIZATION)
         .and_then(|header| header.to_str().ok())
@@ -24,62 +25,20 @@ pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl Into
                 StatusCode::UNAUTHORIZED,
                 "missing authorization header".to_string(),
             )
-        })?
-        .split_whitespace();
+        })?;
 
     let state = req.extensions().get::<Arc<AppState>>().unwrap();
 
-    let first = auth_header.next().unwrap_or("");
-    if first == "dev-server-token" {
-        Err(Error::http(
+    let user_id = state.auth_provider.authenticate(auth_header).await?;
+
+    let user = state.db.get_user_by_id(user_id).await?.ok_or_else(|| {
+        Error::http(
             StatusCode::UNAUTHORIZED,
-            "Dev servers were removed in Zed 0.157 please upgrade to SSH remoting".to_string(),
-        ))?;
-    }
-
-    let user_id = UserId(first.parse().map_err(|_| {
-        Error::http(
-            StatusCode::BAD_REQUEST,
-            "missing user id in authorization header".to_string(),
-        )
-    })?);
-
-    let access_token = auth_header.next().ok_or_else(|| {
-        Error::http(
-            StatusCode::BAD_REQUEST,
-            "missing access token in authorization header".to_string(),
+            format!("user {user_id} not found"),
         )
     })?;
 
-    let http_client = state.http_client.clone().expect("no HTTP client");
+    req.extensions_mut().insert(Principal::User(user));
 
-    let response = http_client
-        .get(format!("{}/client/users/me", state.config.zed_cloud_url()))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("{user_id} {access_token}"))
-        .send()
-        .await
-        .context("failed to validate access token")?;
-    if let Ok(response) = response.error_for_status() {
-        let response_body: GetAuthenticatedUserResponse = response
-            .json()
-            .await
-            .context("failed to parse response body")?;
-
-        let user_id = UserId(response_body.user.id);
-
-        let user = state
-            .db
-            .get_user_by_id(user_id)
-            .await?
-            .with_context(|| format!("user {user_id} not found"))?;
-
-        req.extensions_mut().insert(Principal::User(user));
-        return Ok::<_, Error>(next.run(req).await);
-    }
-
-    Err(Error::http(
-        StatusCode::UNAUTHORIZED,
-        "invalid credentials".to_string(),
-    ))
+    return Ok::<_, Error>(next.run(req).await);
 }

--- a/crates/collab/src/auth/provider.rs
+++ b/crates/collab/src/auth/provider.rs
@@ -1,0 +1,84 @@
+use crate::{Error, db::UserId};
+use anyhow::Context as _;
+use async_trait::async_trait;
+use axum::http::StatusCode;
+use cloud_api_types::GetAuthenticatedUserResponse;
+
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    async fn authenticate(&self, header: &str) -> Result<UserId, Error>;
+    fn provider_name(&self) -> &'static str;
+}
+
+// -------------------------------- ZedCloud -------------------------------- //
+
+pub struct ZedCloudAuthProvider {
+    http_client: Option<reqwest::Client>,
+    zed_cloud_url: String,
+}
+
+impl ZedCloudAuthProvider {
+    pub fn new(http_client: Option<reqwest::Client>, zed_cloud_url: String) -> Self {
+        Self {
+            http_client,
+            zed_cloud_url,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for ZedCloudAuthProvider {
+    fn provider_name(&self) -> &'static str {
+        "zed_cloud"
+    }
+
+    async fn authenticate(&self, header: &str) -> Result<UserId, Error> {
+        let mut parts = header.split_whitespace();
+
+        let first = parts.next().unwrap_or("");
+        if first == "dev-server-token" {
+            Err(Error::http(
+                StatusCode::UNAUTHORIZED,
+                "Dev servers were removed in Zed 0.157 please upgrade to SSH remoting".to_string(),
+            ))?;
+        }
+
+        let user_id = UserId(first.parse().map_err(|_| {
+            Error::http(
+                StatusCode::BAD_REQUEST,
+                "missing user id in authorization header".to_string(),
+            )
+        })?);
+
+        let access_token = parts.next().ok_or_else(|| {
+            Error::http(
+                StatusCode::BAD_REQUEST,
+                "missing access token in authorization header".to_string(),
+            )
+        })?;
+
+        let http_client = self.http_client.clone().expect("no HTTP client");
+
+        let response = http_client
+            .get(format!("{}/client/users/me", self.zed_cloud_url))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("{user_id} {access_token}"))
+            .send()
+            .await
+            .context("failed to validate access token")?;
+
+        if let Ok(response) = response.error_for_status() {
+            let response_body: GetAuthenticatedUserResponse = response
+                .json()
+                .await
+                .context("failed to parse response body")?;
+
+            return Ok(UserId(response_body.user.id));
+        }
+
+        Err(Error::http(
+            StatusCode::UNAUTHORIZED,
+            "invalid credentials".to_string(),
+        ))
+    }
+}

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -18,6 +18,8 @@ use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};
 use util::ResultExt;
 
+use crate::auth::provider::{AuthProvider, ZedCloudAuthProvider};
+
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const REVISION: Option<&'static str> = option_env!("GITHUB_SHA");
 
@@ -210,12 +212,12 @@ impl ServiceMode {
 
 pub struct AppState {
     pub db: Arc<Database>,
-    pub http_client: Option<reqwest::Client>,
     pub livekit_client: Option<Arc<dyn livekit_api::Client>>,
     pub blob_store_client: Option<aws_sdk_s3::Client>,
     pub executor: Executor,
     pub kinesis_client: Option<::aws_sdk_kinesis::Client>,
     pub config: Config,
+    pub auth_provider: Arc<dyn AuthProvider>,
 }
 
 impl AppState {
@@ -247,9 +249,14 @@ impl AppState {
             .context("failed to construct HTTP client")?;
 
         let db = Arc::new(db);
+
+        let auth_provider: Arc<dyn AuthProvider> = Arc::new(ZedCloudAuthProvider::new(
+            Some(http_client),
+            config.zed_cloud_url().to_string(),
+        ));
+
         let this = Self {
             db: db.clone(),
-            http_client: Some(http_client),
             livekit_client,
             blob_store_client: build_blob_store_client(&config).await.log_err(),
             executor,
@@ -259,6 +266,7 @@ impl AppState {
                 None
             },
             config,
+            auth_provider,
         };
         Ok(Arc::new(this))
     }

--- a/crates/collab/tests/integration/test_server.rs
+++ b/crates/collab/tests/integration/test_server.rs
@@ -7,6 +7,7 @@ use client::{
     proto::PeerId,
 };
 use clock::FakeSystemClock;
+use collab::auth::provider::ZedCloudAuthProvider;
 use collab::{
     AppState, Config,
     db::{NewUserParams, UserId},
@@ -561,36 +562,43 @@ impl TestServer {
         livekit_test_server: &LivekitTestServer,
         executor: Executor,
     ) -> Arc<AppState> {
+        let config = Config {
+            http_port: 0,
+            database_url: "".into(),
+            database_max_connections: 0,
+            api_token: "".into(),
+            livekit_server: None,
+            livekit_key: None,
+            livekit_secret: None,
+            rust_log: None,
+            log_json: None,
+            zed_environment: "test".into(),
+            blob_store_url: None,
+            blob_store_region: None,
+            blob_store_access_key: None,
+            blob_store_secret_key: None,
+            blob_store_bucket: None,
+            zed_client_checksum_seed: None,
+            seed_path: None,
+            kinesis_region: None,
+            kinesis_stream: None,
+            kinesis_access_key: None,
+            kinesis_secret_key: None,
+        };
+
+        let auth_provider = Arc::new(ZedCloudAuthProvider::new(
+            None,
+            config.zed_cloud_url().to_string(),
+        ));
+
         Arc::new(AppState {
             db: test_db.db().clone(),
-            http_client: None,
             livekit_client: Some(Arc::new(livekit_test_server.create_api_client())),
             blob_store_client: None,
             executor,
             kinesis_client: None,
-            config: Config {
-                http_port: 0,
-                database_url: "".into(),
-                database_max_connections: 0,
-                api_token: "".into(),
-                livekit_server: None,
-                livekit_key: None,
-                livekit_secret: None,
-                rust_log: None,
-                log_json: None,
-                zed_environment: "test".into(),
-                blob_store_url: None,
-                blob_store_region: None,
-                blob_store_access_key: None,
-                blob_store_secret_key: None,
-                blob_store_bucket: None,
-                zed_client_checksum_seed: None,
-                seed_path: None,
-                kinesis_region: None,
-                kinesis_stream: None,
-                kinesis_access_key: None,
-                kinesis_secret_key: None,
-            },
+            config,
+            auth_provider,
         })
     }
 }


### PR DESCRIPTION
Refactors authentication into a pluggable `AuthProvider` trait. This extracts the authentication logic from `validate_header` into a dedicated `ZedCloudAuthProvider` implementation, allowing different authentication mechanisms to be plugged in without modifying the core auth middleware.

## How to Review

- **`crates/collab/src/auth/provider.rs`** - New file: The `AuthProvider` trait and `ZedCloudAuthProvider` implementation
- **`crates/collab/src/auth.rs`** - Refactored `validate_header` to delegate to `auth_provider.authenticate()`
- **`crates/collab/src/lib.rs`** - `AppState` now holds `auth_provider: Arc<dyn AuthProvider>` instead of `http_client`
- **`crates/collab/tests/integration/test_server.rs`** - Test fixture updated to construct `ZedCloudAuthProvider`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior (none)
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A

## References

This refactoring is a step toward enabling fully self-hosted collab servers without requiring ZedCloud as an authentication intermediary. The `AuthProvider` trait allows arbitrary authentication layers to be plugged in, enabling future implementations such as OIDC for independent deployments.

Kinda related:
- https://github.com/zed-industries/zed/discussions/13503
- https://github.com/zed-industries/zed/issues/8260#issuecomment-1965463519
- https://github.com/zed-industries/zed/discussions/50999

---

Note: This is my first PR to this codebase. I've done my best to ensure I've covered the necessary steps, but please let me know if there is anything I have missed or can improve on.