### PR TITLE
Upgrade tree-sitter-rust, de-list bsn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18551,9 +18551,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+checksum = "f715f73a0687261ddb686f0d64a1e5af57bd199c4d12be5fdda6676ce1885bf9"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -752,7 +752,7 @@ tree-sitter-md = { git = "https://github.com/tree-sitter-grammars/tree-sitter-ma
 tree-sitter-python = "0.25"
 tree-sitter-regex = "0.24"
 tree-sitter-ruby = "0.23"
-tree-sitter-rust = "0.24"
+tree-sitter-rust = "0.24.1"
 tree-sitter-typescript = { git = "https://github.com/zed-industries/tree-sitter-typescript", rev = "e2c53597d6a5d9cf7bbe8dccde576fe1e46c5899" } # https://github.com/tree-sitter/tree-sitter-typescript/pull/347
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a" }
 tracing = "0.1.40"

--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -10,7 +10,7 @@
     (scoped_identifier
       (identifier) @_macro_name .)
   ]
-  (#not-any-of? @_macro_name "view" "html" "bsn")
+  (#not-any-of? @_macro_name "view" "html")
   (token_tree) @injection.content
   (#set! injection.language "rust"))
 


### PR DESCRIPTION
## Context

Recently, we put bsn in the list of "macros to not reparse as rust" (#51353).

We have since updated tree-sitter-rust to better handle the `@"string"`, `:"string"`, etc cases, and can un-list bsn from the special casing.

on main, the highlighting currently looks like this for `bsn` and for `not` (represents "other macros"). Note the `:"player.bsn"` string is re-parsed as rust tokens.

<img width="1728" height="1084" alt="Screenshot 2026-03-23 at 9 33 35 AM" src="https://github.com/user-attachments/assets/94ea5a6d-228b-44dd-857b-c41edcbd9af0" />

This pr, plus the tree-sitter-rust updates results in better handling by default.

<img width="1728" height="1084" alt="Screenshot 2026-03-23 at 11 38 47 AM" src="https://github.com/user-attachments/assets/fb6f71e3-7bcf-4c06-8e84-ce0823010b2e" />

Release Notes:

- N/A