### PR TITLE
git_hosting_providers: Add Hugging Face support

### DIFF
--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -26,6 +26,7 @@ pub fn init(cx: &mut App) {
     provider_registry.register_hosting_provider(Arc::new(Gitea::public_instance()));
     provider_registry.register_hosting_provider(Arc::new(Gitee));
     provider_registry.register_hosting_provider(Arc::new(Github::public_instance()));
+    provider_registry.register_hosting_provider(Arc::new(HuggingFace));
     provider_registry.register_hosting_provider(Arc::new(Gitlab::public_instance()));
     provider_registry.register_hosting_provider(Arc::new(SourceHut::public_instance()));
 }

--- a/crates/git_hosting_providers/src/providers.rs
+++ b/crates/git_hosting_providers/src/providers.rs
@@ -6,6 +6,7 @@ mod gitea;
 mod gitee;
 mod github;
 mod gitlab;
+mod huggingface;
 mod sourcehut;
 
 pub use azure::*;
@@ -16,4 +17,5 @@ pub use gitea::*;
 pub use gitee::*;
 pub use github::*;
 pub use gitlab::*;
+pub use huggingface::*;
 pub use sourcehut::*;

--- a/crates/git_hosting_providers/src/providers/huggingface.rs
+++ b/crates/git_hosting_providers/src/providers/huggingface.rs
@@ -1,6 +1,11 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
+use anyhow::{Context as _, Result, bail};
 use async_trait::async_trait;
+use futures::AsyncReadExt;
+use gpui::SharedString;
+use http_client::{AsyncBody, HttpClient, HttpRequestExt, Request};
+use serde::Deserialize;
 use url::Url;
 
 use git::{
@@ -8,9 +13,82 @@ use git::{
     RemoteUrl,
 };
 
+#[derive(Debug, Deserialize)]
+struct CommitEntry {
+    authors: Vec<CommitAuthor>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitAuthor {
+    avatar: Option<String>,
+}
+
 pub struct HuggingFace;
 
 impl HuggingFace {
+    fn api_url(&self, repo_owner: &str, repo: &str) -> String {
+        // The owner may be prefixed with a repo type (e.g. "datasets/squad").
+        // Map to the correct API path: /api/models/, /api/datasets/, or /api/spaces/.
+        if let Some(owner) = repo_owner.strip_prefix("datasets/") {
+            format!("https://huggingface.co/api/datasets/{owner}/{repo}")
+        } else if let Some(owner) = repo_owner.strip_prefix("spaces/") {
+            format!("https://huggingface.co/api/spaces/{owner}/{repo}")
+        } else {
+            format!("https://huggingface.co/api/models/{repo_owner}/{repo}")
+        }
+    }
+
+    async fn fetch_commit_author_avatar(
+        &self,
+        repo_owner: &str,
+        repo: &str,
+        commit: &str,
+        client: &Arc<dyn HttpClient>,
+    ) -> Result<Option<Url>> {
+        let url = format!("{}/commits/{commit}?limit=1", self.api_url(repo_owner, repo));
+
+        let request = Request::get(&url)
+            .header("Content-Type", "application/json")
+            .follow_redirects(http_client::RedirectPolicy::FollowAll);
+
+        let mut response = client
+            .send(request.body(AsyncBody::default())?)
+            .await
+            .with_context(|| format!("error fetching Hugging Face commit details at {:?}", url))?;
+
+        let mut body = Vec::new();
+        response.body_mut().read_to_end(&mut body).await?;
+
+        if response.status().is_client_error() {
+            let text = String::from_utf8_lossy(body.as_slice());
+            bail!(
+                "status error {}, response: {text:?}",
+                response.status().as_u16()
+            );
+        }
+
+        let body_str = std::str::from_utf8(&body)?;
+        let commits: Vec<CommitEntry> = serde_json::from_str(body_str)
+            .context("failed to deserialize Hugging Face commit details")?;
+
+        let avatar = commits
+            .first()
+            .and_then(|entry| entry.authors.first())
+            .and_then(|author| author.avatar.as_deref());
+
+        let Some(avatar) = avatar else {
+            return Ok(None);
+        };
+
+        if avatar.starts_with('/') {
+            Ok(Some(Url::parse(&format!(
+                "https://huggingface.co{avatar}"
+            ))?))
+        } else {
+            Ok(Some(Url::parse(avatar)?))
+        }
+    }
+
     fn parse_remote_url_inner(&self, url: &str) -> Option<ParsedGitRemote> {
         let url = RemoteUrl::from_str(url).ok()?;
 
@@ -55,7 +133,7 @@ impl GitHostingProvider for HuggingFace {
     }
 
     fn supports_avatars(&self) -> bool {
-        false
+        true
     }
 
     fn format_line_number(&self, line: u32) -> String {
@@ -81,6 +159,18 @@ impl GitHostingProvider for HuggingFace {
         self.base_url()
             .join(&format!("{owner}/{repo}/commit/{sha}"))
             .unwrap()
+    }
+
+    async fn commit_author_avatar_url(
+        &self,
+        repo_owner: &str,
+        repo: &str,
+        commit: SharedString,
+        _author_email: Option<SharedString>,
+        http_client: Arc<dyn HttpClient>,
+    ) -> Result<Option<Url>> {
+        self.fetch_commit_author_avatar(repo_owner, repo, &commit, &http_client)
+            .await
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {

--- a/crates/git_hosting_providers/src/providers/huggingface.rs
+++ b/crates/git_hosting_providers/src/providers/huggingface.rs
@@ -247,11 +247,11 @@ mod tests {
             BuildPermalinkParams::new(
                 "80f73ce5ee059377ce0662ec5c45b592c3025ae5",
                 &repo_path("config.json"),
-                Some(23..47),
+                Some(13..18),
             ),
         );
 
-        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/80f73ce5ee059377ce0662ec5c45b592c3025ae5/config.json#L24-L48";
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/80f73ce5ee059377ce0662ec5c45b592c3025ae5/config.json#L14-L19";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 

--- a/crates/git_hosting_providers/src/providers/huggingface.rs
+++ b/crates/git_hosting_providers/src/providers/huggingface.rs
@@ -1,0 +1,292 @@
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use url::Url;
+
+use git::{
+    BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,
+    RemoteUrl,
+};
+
+pub struct HuggingFace;
+
+impl HuggingFace {
+    fn parse_remote_url_inner(&self, url: &str) -> Option<ParsedGitRemote> {
+        let url = RemoteUrl::from_str(url).ok()?;
+
+        let host = url.host_str()?;
+        if host != "huggingface.co" && host != "hf.co" {
+            return None;
+        }
+
+        let mut path_segments = url.path_segments()?;
+        let first = path_segments.next()?;
+
+        // Repos can be prefixed with a type: datasets/ or spaces/
+        let (owner, repo) = if first == "datasets" || first == "spaces" {
+            let owner = path_segments.next()?;
+            let repo = path_segments.next()?.trim_end_matches(".git");
+            let prefixed_owner = format!("{first}/{owner}");
+            (prefixed_owner, repo.to_string())
+        } else {
+            let repo = path_segments.next()?.trim_end_matches(".git");
+            (first.to_string(), repo.to_string())
+        };
+
+        if owner.is_empty() || repo.is_empty() {
+            return None;
+        }
+
+        Some(ParsedGitRemote {
+            owner: owner.into(),
+            repo: repo.into(),
+        })
+    }
+}
+
+#[async_trait]
+impl GitHostingProvider for HuggingFace {
+    fn name(&self) -> String {
+        "Hugging Face".to_string()
+    }
+
+    fn base_url(&self) -> Url {
+        Url::parse("https://huggingface.co").unwrap()
+    }
+
+    fn supports_avatars(&self) -> bool {
+        false
+    }
+
+    fn format_line_number(&self, line: u32) -> String {
+        format!("L{line}")
+    }
+
+    fn format_line_numbers(&self, start_line: u32, end_line: u32) -> String {
+        format!("L{start_line}-L{end_line}")
+    }
+
+    fn parse_remote_url(&self, url: &str) -> Option<ParsedGitRemote> {
+        self.parse_remote_url_inner(url)
+    }
+
+    fn build_commit_permalink(
+        &self,
+        remote: &ParsedGitRemote,
+        params: BuildCommitPermalinkParams,
+    ) -> Url {
+        let BuildCommitPermalinkParams { sha } = params;
+        let ParsedGitRemote { owner, repo } = remote;
+
+        self.base_url()
+            .join(&format!("{owner}/{repo}/commit/{sha}"))
+            .unwrap()
+    }
+
+    fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
+        let ParsedGitRemote { owner, repo } = remote;
+        let BuildPermalinkParams {
+            sha,
+            path,
+            selection,
+        } = params;
+
+        let mut permalink = self
+            .base_url()
+            .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
+            .unwrap();
+        permalink.set_fragment(
+            selection
+                .map(|selection| self.line_fragment(&selection))
+                .as_deref(),
+        );
+        permalink
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use git::repository::repo_path;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = HuggingFace
+            .parse_remote_url("https://huggingface.co/zed-industries/zeta")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_https_url_with_dotgit() {
+        let parsed_remote = HuggingFace
+            .parse_remote_url("https://huggingface.co/zed-industries/zeta.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = HuggingFace
+            .parse_remote_url("git@hf.co:zed-industries/zeta.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_ssh_url_huggingface_host() {
+        let parsed_remote = HuggingFace
+            .parse_remote_url("git@huggingface.co:zed-industries/zeta.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_dataset_https_url() {
+        let parsed_remote = HuggingFace
+            .parse_remote_url("https://huggingface.co/datasets/squad/squad")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "datasets/squad".into(),
+                repo: "squad".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_space_ssh_url() {
+        let parsed_remote = HuggingFace
+            .parse_remote_url("git@hf.co:spaces/user/my-app.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "spaces/user".into(),
+                repo: "my-app".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_huggingface_permalink() {
+        let permalink = HuggingFace.build_permalink(
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            },
+            BuildPermalinkParams::new(
+                "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+                &repo_path("src/main.py"),
+                None,
+            ),
+        );
+
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/src/main.py";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_huggingface_permalink_with_single_line_selection() {
+        let permalink = HuggingFace.build_permalink(
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            },
+            BuildPermalinkParams::new(
+                "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+                &repo_path("src/main.py"),
+                Some(6..6),
+            ),
+        );
+
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/src/main.py#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_huggingface_permalink_with_multi_line_selection() {
+        let permalink = HuggingFace.build_permalink(
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            },
+            BuildPermalinkParams::new(
+                "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+                &repo_path("src/main.py"),
+                Some(23..47),
+            ),
+        );
+
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/src/main.py#L24-L48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_huggingface_permalink_dataset() {
+        let permalink = HuggingFace.build_permalink(
+            ParsedGitRemote {
+                owner: "datasets/squad".into(),
+                repo: "squad".into(),
+            },
+            BuildPermalinkParams::new(
+                "abc123",
+                &repo_path("README.md"),
+                None,
+            ),
+        );
+
+        let expected_url =
+            "https://huggingface.co/datasets/squad/squad/blob/abc123/README.md";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_huggingface_commit_permalink() {
+        let permalink = HuggingFace.build_commit_permalink(
+            &ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zeta".into(),
+            },
+            BuildCommitPermalinkParams {
+                sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            },
+        );
+
+        let expected_url = "https://huggingface.co/zed-industries/zeta/commit/e5fe811d7ad0fc26934edd76f891d20bdc3bb194";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+}

--- a/crates/git_hosting_providers/src/providers/huggingface.rs
+++ b/crates/git_hosting_providers/src/providers/huggingface.rs
@@ -209,13 +209,13 @@ mod tests {
                 repo: "zeta".into(),
             },
             BuildPermalinkParams::new(
-                "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-                &repo_path("src/main.py"),
+                "80f73ce5ee059377ce0662ec5c45b592c3025ae5",
+                &repo_path("config.json"),
                 None,
             ),
         );
 
-        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/src/main.py";
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/80f73ce5ee059377ce0662ec5c45b592c3025ae5/config.json";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
@@ -227,13 +227,13 @@ mod tests {
                 repo: "zeta".into(),
             },
             BuildPermalinkParams::new(
-                "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-                &repo_path("src/main.py"),
+                "80f73ce5ee059377ce0662ec5c45b592c3025ae5",
+                &repo_path("config.json"),
                 Some(6..6),
             ),
         );
 
-        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/src/main.py#L7";
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/80f73ce5ee059377ce0662ec5c45b592c3025ae5/config.json#L7";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
@@ -245,13 +245,13 @@ mod tests {
                 repo: "zeta".into(),
             },
             BuildPermalinkParams::new(
-                "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-                &repo_path("src/main.py"),
+                "80f73ce5ee059377ce0662ec5c45b592c3025ae5",
+                &repo_path("config.json"),
                 Some(23..47),
             ),
         );
 
-        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/src/main.py#L24-L48";
+        let expected_url = "https://huggingface.co/zed-industries/zeta/blob/80f73ce5ee059377ce0662ec5c45b592c3025ae5/config.json#L24-L48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
@@ -282,11 +282,11 @@ mod tests {
                 repo: "zeta".into(),
             },
             BuildCommitPermalinkParams {
-                sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+                sha: "80f73ce5ee059377ce0662ec5c45b592c3025ae5",
             },
         );
 
-        let expected_url = "https://huggingface.co/zed-industries/zeta/commit/e5fe811d7ad0fc26934edd76f891d20bdc3bb194";
+        let expected_url = "https://huggingface.co/zed-industries/zeta/commit/80f73ce5ee059377ce0662ec5c45b592c3025ae5";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }

--- a/crates/git_hosting_providers/src/providers/huggingface.rs
+++ b/crates/git_hosting_providers/src/providers/huggingface.rs
@@ -48,7 +48,6 @@ impl HuggingFace {
         let url = format!("{}/commits/{commit}?limit=1", self.api_url(repo_owner, repo));
 
         let request = Request::get(&url)
-            .header("Content-Type", "application/json")
             .follow_redirects(http_client::RedirectPolicy::FollowAll);
 
         let mut response = client

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -269,8 +269,9 @@ Zed currently supports links to the hosted versions of
 [GitHub](https://github.com),
 [GitLab](https://gitlab.com),
 [Bitbucket](https://bitbucket.org),
-[SourceHut](https://sr.ht) and
-[Codeberg](https://codeberg.org).
+[SourceHut](https://sr.ht),
+[Codeberg](https://codeberg.org) and
+[Hugging Face](https://huggingface.co).
 
 ### Self-Hosted Instances
 


### PR DESCRIPTION
## Summary

- Add a `HuggingFace` Git hosting provider so that commit hashes and file references become clickable links to `huggingface.co`
- Supports both `huggingface.co` and `hf.co` (SSH shorthand) hosts, HTTPS and SSH remote URLs, and model/dataset/space repository types
- Add Hugging Face to the docs list of supported Git hosting services

## Test plan

- [x] All 11 unit tests pass (`cargo test -p git_hosting_providers --lib providers::huggingface`)
- [x] `cargo clippy -p git_hosting_providers` passes with no warnings
- [ ] Manual: clone a Hugging Face repo and verify commit hashes render as clickable links

Release Notes:

- Added support for Hugging Face as a Git hosting provider, making commit hashes and file references clickable links to huggingface.co.