### PR TITLE
ep: Follow-ups for binding changes

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -796,7 +796,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       "tab": "editor::AcceptEditPrediction",
     },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -858,7 +858,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       "tab": "editor::AcceptEditPrediction",
     },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -790,7 +790,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptEditPrediction",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1060,7 +1060,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to
       // "vim::Tab" shadow it, so it needs to be bound again.

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -304,3 +304,9 @@ pub(crate) mod m_2026_02_25 {
 
     pub(crate) use settings::migrate_builtin_agent_servers_to_registry;
 }
+
+pub(crate) mod m_2026_03_23 {
+    mod keymap;
+
+    pub(crate) use keymap::replace_edit_prediction_conflict_with_expanded_version;
+}

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -308,5 +308,5 @@ pub(crate) mod m_2026_02_25 {
 pub(crate) mod m_2026_03_23 {
     mod keymap;
 
-    pub(crate) use keymap::replace_edit_prediction_conflict_with_expanded_version;
+    pub(crate) use keymap::KEYMAP_PATTERNS;
 }

--- a/crates/migrator/src/migrations/m_2026_03_23/keymap.rs
+++ b/crates/migrator/src/migrations/m_2026_03_23/keymap.rs
@@ -1,0 +1,58 @@
+use std::ops::Range;
+
+use anyhow::Result;
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+
+pub fn replace_edit_prediction_conflict_with_expanded_version(
+    json: &mut serde_json::Value,
+) -> Result<()> {
+    let Some(bindings) = json.as_array_mut() else {
+        anyhow::bail!("Expected an array of key bindings")
+    };
+
+    for binding in bindings {
+        let Some(context) = binding.get_mut("context") else {
+            continue;
+        };
+        let Some(context_str) = context.as_str() else {
+            continue;
+        };
+        if !context_str.contains("edit_prediction_conflict") {
+            continue;
+        }
+        *context = serde_json::Value::String(context_str.replace(
+            "edit_prediction_conflict",
+            "(edit_prediction && (showing_completions || in_leading_whitespace))",
+        ));
+    }
+
+    return Ok(());
+}
+
+pub const KEYMAP_PATTERNS: MigrationPatterns =
+    &[(crate::patterns::KEYMAP_CONTEXT_PATTERN, rename_context_key)];
+
+fn rename_context_key(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let context_predicate_ix = query.capture_index_for_name("context_predicate")?;
+    let context_predicate_range = mat
+        .nodes_for_capture_index(context_predicate_ix)
+        .next()?
+        .byte_range();
+    let old_predicate = contents.get(context_predicate_range.clone())?.to_string();
+    let new_predicate = old_predicate.replace(
+        "edit_prediction_conflict",
+        "(edit_prediction && (showing_completions || in_leading_whitespace))",
+    );
+
+    if new_predicate != old_predicate {
+        Some((context_predicate_range, new_predicate))
+    } else {
+        None
+    }
+}

--- a/crates/migrator/src/migrations/m_2026_03_23/keymap.rs
+++ b/crates/migrator/src/migrations/m_2026_03_23/keymap.rs
@@ -1,35 +1,8 @@
 use std::ops::Range;
 
-use anyhow::Result;
 use tree_sitter::{Query, QueryMatch};
 
 use crate::MigrationPatterns;
-
-pub fn replace_edit_prediction_conflict_with_expanded_version(
-    json: &mut serde_json::Value,
-) -> Result<()> {
-    let Some(bindings) = json.as_array_mut() else {
-        anyhow::bail!("Expected an array of key bindings")
-    };
-
-    for binding in bindings {
-        let Some(context) = binding.get_mut("context") else {
-            continue;
-        };
-        let Some(context_str) = context.as_str() else {
-            continue;
-        };
-        if !context_str.contains("edit_prediction_conflict") {
-            continue;
-        }
-        *context = serde_json::Value::String(context_str.replace(
-            "edit_prediction_conflict",
-            "(edit_prediction && (showing_completions || in_leading_whitespace))",
-        ));
-    }
-
-    return Ok(());
-}
 
 pub const KEYMAP_PATTERNS: MigrationPatterns =
     &[(crate::patterns::KEYMAP_CONTEXT_PATTERN, rename_context_key)];
@@ -45,10 +18,26 @@ fn rename_context_key(
         .next()?
         .byte_range();
     let old_predicate = contents.get(context_predicate_range.clone())?.to_string();
-    let new_predicate = old_predicate.replace(
-        "edit_prediction_conflict",
-        "(edit_prediction && (showing_completions || in_leading_whitespace))",
-    );
+    let mut new_predicate = old_predicate.clone();
+
+    const REPLACEMENTS: &[(&str, &str)] = &[
+        (
+            "edit_prediction_conflict && !showing_completions",
+            "(edit_prediction && in_leading_whitespace)",
+        ),
+        (
+            "edit_prediction_conflict && showing_completions",
+            "(edit_prediction && showing_completions)",
+        ),
+        (
+            "edit_prediction_conflict",
+            "(edit_prediction && (showing_completions || in_leading_whitespace))",
+        ),
+    ];
+
+    for (old, new) in REPLACEMENTS {
+        new_predicate = new_predicate.replace(old, new);
+    }
 
     if new_predicate != old_predicate {
         Some((context_predicate_range, new_predicate))

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -143,6 +143,9 @@ pub fn migrate_keymap(text: &str) -> Result<Option<String>> {
             migrations::m_2025_12_08::KEYMAP_PATTERNS,
             &KEYMAP_QUERY_2025_12_08,
         ),
+        MigrationType::Json(
+            migrations::m_2026_03_23::replace_edit_prediction_conflict_with_expanded_version,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -400,6 +403,7 @@ mod tests {
         }
     }
 
+    #[track_caller]
     fn assert_migrate_keymap(input: &str, output: Option<&str>) {
         let migrated = migrate_keymap(input).unwrap();
         pretty_assertions::assert_eq!(migrated.as_deref(), output);
@@ -418,7 +422,7 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_migrate_settings_with_migrations(
+    fn assert_migrate_with_migrations(
         migrations: &[MigrationType],
         input: &str,
         output: Option<&str>,
@@ -966,7 +970,7 @@ mod tests {
 
     #[test]
     fn test_mcp_settings_migration() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::TreeSitter(
                 migrations::m_2025_06_16::SETTINGS_PATTERNS,
                 &SETTINGS_QUERY_2025_06_16,
@@ -1155,7 +1159,7 @@ mod tests {
         }
     }
 }"#;
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::TreeSitter(
                 migrations::m_2025_06_16::SETTINGS_PATTERNS,
                 &SETTINGS_QUERY_2025_06_16,
@@ -1167,7 +1171,7 @@ mod tests {
 
     #[test]
     fn test_custom_agent_server_settings_migration() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::TreeSitter(
                 migrations::m_2025_11_20::SETTINGS_PATTERNS,
                 &SETTINGS_QUERY_2025_11_20,
@@ -1383,7 +1387,7 @@ mod tests {
 
     #[test]
     fn test_flatten_code_action_formatters_basic_array() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1417,7 +1421,7 @@ mod tests {
 
     #[test]
     fn test_flatten_code_action_formatters_basic_object() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1574,7 +1578,7 @@ mod tests {
     #[test]
     fn test_flatten_code_action_formatters_array_with_multiple_action_blocks_in_defaults_and_multiple_languages()
      {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1700,7 +1704,7 @@ mod tests {
 
     #[test]
     fn test_flatten_code_action_formatters_array_with_format_on_save_and_multiple_languages() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1887,7 +1891,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_basic() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1907,7 +1911,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_array() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1932,7 +1936,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_on_off_unchanged() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1943,7 +1947,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1957,7 +1961,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_in_languages() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1995,7 +1999,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_mixed_global_and_languages() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -2032,7 +2036,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_no_migration_when_no_format_on_save() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -2046,7 +2050,7 @@ mod tests {
 
     #[test]
     fn test_restore_code_actions_on_format() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2067,7 +2071,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2081,7 +2085,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2108,7 +2112,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2137,7 +2141,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2155,7 +2159,7 @@ mod tests {
 
     #[test]
     fn test_make_file_finder_include_ignored_an_enum() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2163,7 +2167,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2183,7 +2187,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2203,7 +2207,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2224,7 +2228,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "linux" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2253,7 +2257,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2288,7 +2292,7 @@ mod tests {
 
     #[test]
     fn test_make_relative_line_numbers_an_enum() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2296,7 +2300,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2312,7 +2316,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2329,7 +2333,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "macos" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2354,7 +2358,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2431,7 +2435,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "linux" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_11_25::remove_context_server_source,
             )],
@@ -2469,7 +2473,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_11_25::remove_context_server_source,
             )],
@@ -2610,7 +2614,7 @@ mod tests {
     #[test]
     fn test_make_auto_indent_an_enum() {
         // Empty settings should not change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2619,7 +2623,7 @@ mod tests {
         );
 
         // true should become "syntax_aware"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2636,7 +2640,7 @@ mod tests {
         );
 
         // false should become "none"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2653,7 +2657,7 @@ mod tests {
         );
 
         // Already valid enum values should not change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2665,7 +2669,7 @@ mod tests {
         );
 
         // Should also work inside languages
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2694,7 +2698,7 @@ mod tests {
 
     #[test]
     fn test_move_edit_prediction_provider_to_edit_predictions() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2702,7 +2706,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2726,7 +2730,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2754,7 +2758,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2781,7 +2785,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2798,7 +2802,7 @@ mod tests {
 
         // Non-object edit_predictions (e.g. true) should gracefully skip
         // instead of bail!-ing and aborting the entire migration chain.
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2822,7 +2826,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "macos" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2851,7 +2855,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2884,7 +2888,7 @@ mod tests {
         );
 
         // Combined: root + platform + profile should all be migrated simultaneously
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2935,7 +2939,7 @@ mod tests {
 
     #[test]
     fn test_migrate_experimental_sweep_mercury() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -2943,7 +2947,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -2969,7 +2973,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -2995,7 +2999,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3021,7 +3025,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3036,7 +3040,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3054,7 +3058,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "linux" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3085,7 +3089,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3120,7 +3124,7 @@ mod tests {
         );
 
         // Combined: root + platform + profile should all be migrated simultaneously
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3178,7 +3182,7 @@ mod tests {
     #[test]
     fn test_migrate_always_allow_tool_actions_to_default() {
         // No agent settings - no change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3187,7 +3191,7 @@ mod tests {
         );
 
         // always_allow_tool_actions: true -> tool_permissions.default: "allow"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3214,7 +3218,7 @@ mod tests {
         );
 
         // always_allow_tool_actions: false -> just remove it
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3233,7 +3237,7 @@ mod tests {
         );
 
         // Preserve existing tool_permissions.tools when migrating
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3272,7 +3276,7 @@ mod tests {
         );
 
         // Don't override existing default (and migrate default_mode to default)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3302,7 +3306,7 @@ mod tests {
         );
 
         // Migrate existing default_mode to default (no always_allow_tool_actions)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3331,7 +3335,7 @@ mod tests {
         );
 
         // No migration needed if already using new format with "default"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3349,7 +3353,7 @@ mod tests {
         );
 
         // Migrate default_mode to default in tool-specific rules
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3388,7 +3392,7 @@ mod tests {
         );
 
         // When tool_permissions is null, replace it so always_allow is preserved
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3416,7 +3420,7 @@ mod tests {
         );
 
         // Platform-specific agent migration
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3447,7 +3451,7 @@ mod tests {
         );
 
         // Channel-specific agent migration
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3488,7 +3492,7 @@ mod tests {
         );
 
         // Profile-level migration
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3526,7 +3530,7 @@ mod tests {
         );
 
         // Platform-specific agent with profiles
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3571,7 +3575,7 @@ mod tests {
         );
 
         // Root-level profile with always_allow_tool_actions
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3606,7 +3610,7 @@ mod tests {
         );
 
         // Root-level profile with default_mode
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3643,7 +3647,7 @@ mod tests {
         );
 
         // Root-level profile + root-level agent both migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3689,7 +3693,7 @@ mod tests {
 
         // Non-boolean always_allow_tool_actions (string "true") is left in place
         // so the schema validator can report it, rather than silently dropping user data.
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3705,7 +3709,7 @@ mod tests {
         );
 
         // null always_allow_tool_actions is removed (treated as false)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3722,7 +3726,7 @@ mod tests {
 
         // Project-local settings (.zed/settings.json) with always_allow_tool_actions
         // These files have no platform/channel overrides or root-level profiles.
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3763,7 +3767,7 @@ mod tests {
         );
 
         // Project-local settings with only default_mode (no always_allow_tool_actions)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3792,7 +3796,7 @@ mod tests {
         );
 
         // Project-local settings with no agent section at all - no change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3807,7 +3811,7 @@ mod tests {
         );
 
         // Existing agent_servers are left untouched
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3850,7 +3854,7 @@ mod tests {
         );
 
         // Existing agent_servers are left untouched even with partial entries
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3887,7 +3891,7 @@ mod tests {
         );
 
         // always_allow_tool_actions: false leaves agent_servers untouched
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3910,7 +3914,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_to_registry_simple() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -3950,7 +3954,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_empty_entries() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -3981,7 +3985,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_with_command() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4019,7 +4023,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_gemini_with_command() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4047,7 +4051,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_gemini_ignore_system_version_false() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4075,7 +4079,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_gemini_ignore_system_version_true() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4102,7 +4106,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_already_typed_unchanged() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4124,7 +4128,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_preserves_custom_entries() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4158,7 +4162,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_target_already_exists() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4188,7 +4192,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_no_agent_servers_key() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4203,7 +4207,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_all_fields() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4251,7 +4255,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_codex_with_command() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4283,7 +4287,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_mixed_migrated_and_not() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4315,6 +4319,37 @@ mod tests {
         }
     }
 }"#,
+            ),
+        );
+    }
+
+    #[test]
+    fn test_migrate_edit_prediction_conflict_context() {
+        assert_migrate_with_migrations(
+            &[MigrationType::Json(
+                migrations::m_2026_03_23::replace_edit_prediction_conflict_with_expanded_version,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction_conflict",
+                    "bindings": {
+                        "ctrl-enter": "editor::AcceptEditPrediction" // Example of a modified keybinding
+                    }
+                }
+            ]
+            "#.unindent(),
+            Some(
+                &r#"
+                [
+                    {
+                        "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
+                        "bindings": {
+                            "ctrl-enter": "editor::AcceptEditPrediction" Example of a modified keybinding
+                        }
+                    }
+                ]
+                "#.unindent(),
             ),
         );
     }

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -143,8 +143,9 @@ pub fn migrate_keymap(text: &str) -> Result<Option<String>> {
             migrations::m_2025_12_08::KEYMAP_PATTERNS,
             &KEYMAP_QUERY_2025_12_08,
         ),
-        MigrationType::Json(
-            migrations::m_2026_03_23::replace_edit_prediction_conflict_with_expanded_version,
+        MigrationType::TreeSitter(
+            migrations::m_2026_03_23::KEYMAP_PATTERNS,
+            &KEYMAP_QUERY_2026_03_23,
         ),
     ];
     run_migrations(text, migrations)
@@ -375,6 +376,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_12_15,
     migrations::m_2025_12_15::SETTINGS_PATTERNS
+);
+define_query!(
+    KEYMAP_QUERY_2026_03_23,
+    migrations::m_2026_03_23::KEYMAP_PATTERNS
 );
 
 // custom query
@@ -4326,8 +4331,9 @@ mod tests {
     #[test]
     fn test_migrate_edit_prediction_conflict_context() {
         assert_migrate_with_migrations(
-            &[MigrationType::Json(
-                migrations::m_2026_03_23::replace_edit_prediction_conflict_with_expanded_version,
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
             )],
             &r#"
             [
@@ -4345,11 +4351,124 @@ mod tests {
                     {
                         "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
                         "bindings": {
-                            "ctrl-enter": "editor::AcceptEditPrediction" Example of a modified keybinding
+                            "ctrl-enter": "editor::AcceptEditPrediction" // Example of a modified keybinding
                         }
                     }
                 ]
                 "#.unindent(),
+            ),
+        );
+
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction_conflict && !showing_completions",
+                    "bindings": {
+                        // Here we don't require a modifier unless there's a language server completion
+                        "tab": "editor::AcceptEditPrediction"
+                    }
+                }
+            ]
+            "#.unindent(),
+            Some(
+                &r#"
+                [
+                    {
+                        "context": "Editor && (edit_prediction && in_leading_whitespace)",
+                        "bindings": {
+                            // Here we don't require a modifier unless there's a language server completion
+                            "tab": "editor::AcceptEditPrediction"
+                        }
+                    }
+                ]
+                "#.unindent(),
+            ),
+        );
+
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction_conflict && showing_completions",
+                    "bindings": {
+                        "tab": "editor::AcceptEditPrediction"
+                    }
+                }
+            ]
+            "#
+            .unindent(),
+            Some(
+                &r#"
+                [
+                    {
+                        "context": "Editor && (edit_prediction && showing_completions)",
+                        "bindings": {
+                            "tab": "editor::AcceptEditPrediction"
+                        }
+                    }
+                ]
+                "#
+                .unindent(),
+            ),
+        );
+
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction",
+                    "bindings": {
+                        "tab": "editor::AcceptEditPrediction",
+                        // Optional: This makes the default `alt-l` binding do nothing.
+                        "alt-l": null
+                    }
+                },
+                {
+                    "context": "Editor && edit_prediction_conflict",
+                    "bindings": {
+                        "alt-tab": "editor::AcceptEditPrediction",
+                        // Optional: This makes the default `alt-l` binding do nothing.
+                        "alt-l": null
+                    }
+                },
+            ]
+            "#
+            .unindent(),
+            Some(
+                &r#"
+                    [
+                        {
+                            "context": "Editor && edit_prediction",
+                            "bindings": {
+                                "tab": "editor::AcceptEditPrediction",
+                                // Optional: This makes the default `alt-l` binding do nothing.
+                                "alt-l": null
+                            }
+                        },
+                        {
+                            "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
+                            "bindings": {
+                                "alt-tab": "editor::AcceptEditPrediction",
+                                // Optional: This makes the default `alt-l` binding do nothing.
+                                "alt-l": null
+                            }
+                        },
+                    ]
+                "#
+                .unindent(),
             ),
         );
     }


### PR DESCRIPTION
## Context

- Updates docs for how to update edit prediction bindings
- Walks back how often we use tab to accept prediction where we previously didn't; now just when in leading whitespace, tab does not accept completion when completions menu is open
- migration for keymaps using the old `edit_prediction_conflict` key context

## How to Review

The only code worth reviewing is the migration
<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A or Added/Fixed/Improved ...
