### PR TITLE
tasks: Prioritize user-defined tasks and add auto_detected_tasks setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17387,6 +17387,7 @@ dependencies = [
  "project",
  "serde",
  "serde_json",
+ "settings",
  "task",
  "tree-sitter-rust",
  "tree-sitter-typescript",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1559,6 +1559,14 @@
   // 3. Don't load direnv configuration at all.
   //      "load_direnv": "disabled"
   "load_direnv": "direct",
+  // Controls the visibility of auto-detected tasks (e.g. npm scripts from
+  // package.json, tasks from language servers and extensions).
+  // Manually defined tasks from `.zed/tasks.json` and global tasks are
+  // always shown regardless of this setting.
+  //
+  // "all": Show all auto-detected tasks.
+  // "hidden": Hide all auto-detected tasks.
+  "auto_detected_tasks": "all",
   "edit_predictions": {
     // Which edit prediction provider to use.
     "provider": "zed",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1563,6 +1563,7 @@
   // package.json, tasks from language servers and extensions).
   // Manually defined tasks from `.zed/tasks.json` and global tasks are
   // always shown regardless of this setting.
+  // Note: changing this setting requires reloading the workspace.
   //
   // "all": Show all auto-detected tasks.
   // "deprioritized": Show auto-detected tasks, but sort them below user-defined tasks.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1565,6 +1565,7 @@
   // always shown regardless of this setting.
   //
   // "all": Show all auto-detected tasks.
+  // "deprioritized": Show auto-detected tasks, but sort them below user-defined tasks.
   // "hidden": Hide all auto-detected tasks.
   "auto_detected_tasks": "all",
   "edit_predictions": {

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -15,6 +15,8 @@ use project::LanguageServerToQuery;
 use project::LocationLink;
 use project::Project;
 use project::TaskSourceKind;
+use project::project_settings::{AutoDetectedTasks, ProjectSettings};
+use settings::Settings as _;
 use project::lsp_store::lsp_ext_command::GetLspRunnables;
 use smol::future::FutureExt as _;
 use task::ResolvedTask;
@@ -91,6 +93,13 @@ pub fn lsp_tasks(
     for_position: Option<text::Anchor>,
     cx: &mut App,
 ) -> Task<Vec<(TaskSourceKind, Vec<(Option<LocationLink>, ResolvedTask)>)>> {
+    if matches!(
+        ProjectSettings::get_global(cx).auto_detected_tasks,
+        AutoDetectedTasks::Hidden
+    ) {
+        return Task::ready(Vec::new());
+    }
+
     let lsp_task_sources = task_sources
         .iter()
         .filter_map(|(name, buffer_ids)| {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -18,6 +18,7 @@ use rpc::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+pub use settings::AutoDetectedTasks;
 pub use settings::BinarySettings;
 pub use settings::DirenvSettings;
 pub use settings::LspSettings;
@@ -79,6 +80,9 @@ pub struct ProjectSettings {
 
     /// Configuration for session-related features
     pub session: SessionSettings,
+
+    /// Controls the visibility of auto-detected tasks.
+    pub auto_detected_tasks: AutoDetectedTasks,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -730,6 +734,9 @@ impl Settings for ProjectSettings {
                 restore_unsaved_buffers: content.session.unwrap().restore_unsaved_buffers.unwrap(),
                 trust_all_worktrees: content.session.unwrap().trust_all_worktrees.unwrap(),
             },
+            auto_detected_tasks: project
+                .auto_detected_tasks
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -472,16 +472,14 @@ impl Inventory {
                     post_inc(&mut lru_score),
                 )
             })
-            .sorted_unstable_by(task_lru_comparator)
+            .sorted_unstable_by(task_lru_comparator(task_source_kind_preference))
             .map(|(kind, task, _)| (kind, task))
             .collect::<Vec<_>>();
 
         let not_used_score = post_inc(&mut lru_score);
         let global_tasks = self.global_templates_from_settings().collect::<Vec<_>>();
-        let show_auto_detected = matches!(
-            ProjectSettings::get_global(cx).auto_detected_tasks,
-            AutoDetectedTasks::All
-        );
+        let auto_detected_tasks_setting = ProjectSettings::get_global(cx).auto_detected_tasks;
+        let show_auto_detected = !matches!(auto_detected_tasks_setting, AutoDetectedTasks::Hidden);
         let associated_tasks = language
             .filter(|_| show_auto_detected)
             .filter(|language| {
@@ -498,6 +496,10 @@ impl Inventory {
             .into_iter()
             .flat_map(|worktree| self.worktree_templates_from_settings(worktree))
             .collect::<Vec<_>>();
+        let preference_fn = match auto_detected_tasks_setting {
+            AutoDetectedTasks::Deprioritized => deprioritized_task_source_kind_preference,
+            _ => task_source_kind_preference,
+        };
         let task_contexts = task_contexts.clone();
         cx.background_spawn(async move {
             let language_tasks = if let Some(task) = associated_tasks {
@@ -574,7 +576,7 @@ impl Inventory {
                         }
                     }
                 })
-                .sorted_unstable_by(task_lru_comparator)
+                .sorted_unstable_by(task_lru_comparator(preference_fn))
                 .map(|(kind, task, _)| (kind, task))
                 .collect::<Vec<_>>();
 
@@ -846,32 +848,45 @@ impl Inventory {
 }
 
 fn task_lru_comparator(
-    (kind_a, task_a, lru_score_a): &(TaskSourceKind, ResolvedTask, u32),
-    (kind_b, task_b, lru_score_b): &(TaskSourceKind, ResolvedTask, u32),
+    preference_fn: fn(&TaskSourceKind) -> u32,
+) -> impl Fn(
+    &(TaskSourceKind, ResolvedTask, u32),
+    &(TaskSourceKind, ResolvedTask, u32),
 ) -> cmp::Ordering {
-    lru_score_a
-        // First, display recently used templates above all.
-        .cmp(lru_score_b)
-        // Then, ensure more specific sources are displayed first.
-        .then(task_source_kind_preference(kind_a).cmp(&task_source_kind_preference(kind_b)))
-        // After that, display first more specific tasks, using more template variables.
-        // Bonus points for tasks with symbol variables.
-        .then(task_variables_preference(task_a).cmp(&task_variables_preference(task_b)))
-        // Finally, sort by the resolved label, but a bit more specifically, to avoid mixing letters and digits.
-        .then({
-            NumericPrefixWithSuffix::from_numeric_prefixed_str(&task_a.resolved_label)
-                .cmp(&NumericPrefixWithSuffix::from_numeric_prefixed_str(
-                    &task_b.resolved_label,
-                ))
-                .then(task_a.resolved_label.cmp(&task_b.resolved_label))
-                .then(kind_a.cmp(kind_b))
-        })
+    move |(kind_a, task_a, lru_score_a), (kind_b, task_b, lru_score_b)| {
+        lru_score_a
+            // First, display recently used templates above all.
+            .cmp(lru_score_b)
+            // Then, ensure more specific sources are displayed first.
+            .then(preference_fn(kind_a).cmp(&preference_fn(kind_b)))
+            // After that, display first more specific tasks, using more template variables.
+            // Bonus points for tasks with symbol variables.
+            .then(task_variables_preference(task_a).cmp(&task_variables_preference(task_b)))
+            // Finally, sort by the resolved label, but a bit more specifically, to avoid mixing letters and digits.
+            .then({
+                NumericPrefixWithSuffix::from_numeric_prefixed_str(&task_a.resolved_label)
+                    .cmp(&NumericPrefixWithSuffix::from_numeric_prefixed_str(
+                        &task_b.resolved_label,
+                    ))
+                    .then(task_a.resolved_label.cmp(&task_b.resolved_label))
+                    .then(kind_a.cmp(kind_b))
+            })
+    }
 }
 
-/// User-defined tasks (worktree, global, one-off commands) are ranked above
-/// auto-detected ones (LSP, language extension) because they represent explicit
-/// user intent.
 pub fn task_source_kind_preference(kind: &TaskSourceKind) -> u32 {
+    match kind {
+        TaskSourceKind::Lsp { .. } => 0,
+        TaskSourceKind::Language { .. } => 1,
+        TaskSourceKind::UserInput => 2,
+        TaskSourceKind::Worktree { .. } => 3,
+        TaskSourceKind::AbsPath { .. } => 4,
+    }
+}
+
+/// Alternative preference ordering that ranks user-defined tasks above
+/// auto-detected ones, used when `auto_detected_tasks` is set to `deprioritized`.
+pub fn deprioritized_task_source_kind_preference(kind: &TaskSourceKind) -> u32 {
     match kind {
         TaskSourceKind::Worktree { .. } => 0,
         TaskSourceKind::AbsPath { .. } => 1,

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -19,7 +19,9 @@ use language::{
 };
 use lsp::{LanguageServerId, LanguageServerName};
 use paths::{debug_task_file_name, task_file_name};
-use settings::{InvalidSettingsError, parse_json_with_comments};
+use settings::{InvalidSettingsError, Settings as _, parse_json_with_comments};
+
+use crate::project_settings::{AutoDetectedTasks, ProjectSettings};
 use task::{
     DebugScenario, ResolvedTask, SharedTaskContext, TaskContext, TaskId, TaskTemplate,
     TaskTemplates, TaskVariables, VariableName,
@@ -476,7 +478,12 @@ impl Inventory {
 
         let not_used_score = post_inc(&mut lru_score);
         let global_tasks = self.global_templates_from_settings().collect::<Vec<_>>();
+        let show_auto_detected = matches!(
+            ProjectSettings::get_global(cx).auto_detected_tasks,
+            AutoDetectedTasks::All
+        );
         let associated_tasks = language
+            .filter(|_| show_auto_detected)
             .filter(|language| {
                 language_settings(Some(language.name()), file.as_ref(), cx)
                     .tasks
@@ -861,13 +868,16 @@ fn task_lru_comparator(
         })
 }
 
+/// User-defined tasks (worktree, global, one-off commands) are ranked above
+/// auto-detected ones (LSP, language extension) because they represent explicit
+/// user intent.
 pub fn task_source_kind_preference(kind: &TaskSourceKind) -> u32 {
     match kind {
-        TaskSourceKind::Lsp { .. } => 0,
-        TaskSourceKind::Language { .. } => 1,
+        TaskSourceKind::Worktree { .. } => 0,
+        TaskSourceKind::AbsPath { .. } => 1,
         TaskSourceKind::UserInput => 2,
-        TaskSourceKind::Worktree { .. } => 3,
-        TaskSourceKind::AbsPath { .. } => 4,
+        TaskSourceKind::Lsp { .. } => 3,
+        TaskSourceKind::Language { .. } => 4,
     }
 }
 

--- a/crates/project/tests/integration/task_inventory.rs
+++ b/crates/project/tests/integration/task_inventory.rs
@@ -2,6 +2,7 @@ use gpui::{AppContext, Entity, Task, TestAppContext};
 use itertools::Itertools;
 use paths::tasks_file;
 use pretty_assertions::assert_eq;
+use project::project_settings::AutoDetectedTasks;
 use serde_json::json;
 use settings::SettingsLocation;
 use std::path::Path;
@@ -560,8 +561,12 @@ async fn test_inventory_static_task_filters(cx: &mut TestAppContext) {
     );
 }
 
-fn init_test(_cx: &mut TestAppContext) {
+fn init_test(cx: &mut TestAppContext) {
     zlog::init_test();
+    cx.update(|cx| {
+        let settings_store = settings::SettingsStore::test(cx);
+        cx.set_global(settings_store);
+    });
     TaskStore::init(None);
 }
 
@@ -623,4 +628,104 @@ async fn list_tasks_sorted_by_last_used(
         .map(|(source_kind, task)| (source_kind, task.resolved_label))
         .sorted_by_key(|(kind, label)| (task_source_kind_preference(kind), label.clone()))
         .collect()
+}
+
+#[test]
+fn test_task_source_kind_preference_ordering() {
+    let worktree_kind = TaskSourceKind::Worktree {
+        id: WorktreeId::from_usize(1),
+        directory_in_worktree: rel_path(".zed").into(),
+        id_base: "test".into(),
+    };
+    let abs_path_kind = TaskSourceKind::AbsPath {
+        id_base: "global".into(),
+        abs_path: paths::tasks_file().clone(),
+    };
+    let lsp_kind = TaskSourceKind::Lsp {
+        language_name: "Rust".into(),
+        server: lsp::LanguageServerId(0),
+    };
+    let language_kind = TaskSourceKind::Language {
+        name: "Rust".into(),
+    };
+    let user_input_kind = TaskSourceKind::UserInput;
+
+    assert!(
+        task_source_kind_preference(&worktree_kind) < task_source_kind_preference(&abs_path_kind),
+        "Worktree tasks should be preferred over global tasks"
+    );
+    assert!(
+        task_source_kind_preference(&abs_path_kind) < task_source_kind_preference(&user_input_kind),
+        "Global tasks should be preferred over user input tasks"
+    );
+    assert!(
+        task_source_kind_preference(&user_input_kind) < task_source_kind_preference(&lsp_kind),
+        "User input tasks should be preferred over LSP tasks"
+    );
+    assert!(
+        task_source_kind_preference(&lsp_kind) < task_source_kind_preference(&language_kind),
+        "LSP tasks should be preferred over language tasks"
+    );
+}
+
+#[test]
+fn test_auto_detected_tasks_deserialization() {
+    let all: AutoDetectedTasks = serde_json::from_str(r#""all""#).unwrap();
+    assert_eq!(all, AutoDetectedTasks::All);
+
+    let none: AutoDetectedTasks = serde_json::from_str(r#""hidden""#).unwrap();
+    assert_eq!(none, AutoDetectedTasks::Hidden);
+
+    assert_eq!(AutoDetectedTasks::default(), AutoDetectedTasks::All);
+}
+
+#[gpui::test]
+async fn test_auto_detected_tasks_setting(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let inventory = cx.update(|cx| Inventory::new(cx));
+    let worktree_1 = WorktreeId::from_usize(1);
+
+    inventory.update(cx, |inventory, _| {
+        inventory
+            .update_file_based_tasks(
+                TaskSettingsLocation::Worktree(SettingsLocation {
+                    worktree_id: worktree_1,
+                    path: rel_path(".zed"),
+                }),
+                Some(&mock_tasks_from_names(["worktree_task"])),
+            )
+            .unwrap();
+        inventory
+            .update_file_based_tasks(
+                TaskSettingsLocation::Global(tasks_file()),
+                Some(&mock_tasks_from_names(["global_task"])),
+            )
+            .unwrap();
+    });
+
+    let task_names_with_default =
+        resolved_task_names(&inventory, Some(worktree_1), cx).await;
+    assert_eq!(
+        task_names_with_default,
+        vec!["worktree_task", "global_task"],
+        "Both worktree and global tasks should appear with default setting"
+    );
+
+    cx.update(|cx| {
+        settings::SettingsStore::update(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.auto_detected_tasks = Some(AutoDetectedTasks::Hidden);
+            });
+        });
+    });
+
+    let task_names_after_disable =
+        resolved_task_names(&inventory, Some(worktree_1), cx).await;
+    assert_eq!(
+        task_names_after_disable,
+        vec!["worktree_task", "global_task"],
+        "Worktree and global tasks should still appear when auto_detected_tasks is hidden \
+         (only language/LSP tasks are filtered, which are not present in this test)"
+    );
 }

--- a/crates/project/tests/integration/task_inventory.rs
+++ b/crates/project/tests/integration/task_inventory.rs
@@ -650,21 +650,46 @@ fn test_task_source_kind_preference_ordering() {
     };
     let user_input_kind = TaskSourceKind::UserInput;
 
+    // Default ordering: LSP > Language > UserInput > Worktree > AbsPath
+    assert!(
+        task_source_kind_preference(&lsp_kind) < task_source_kind_preference(&language_kind),
+        "LSP tasks should be preferred over language tasks"
+    );
+    assert!(
+        task_source_kind_preference(&language_kind) < task_source_kind_preference(&user_input_kind),
+        "Language tasks should be preferred over user input tasks"
+    );
+    assert!(
+        task_source_kind_preference(&user_input_kind)
+            < task_source_kind_preference(&worktree_kind),
+        "User input tasks should be preferred over worktree tasks"
+    );
     assert!(
         task_source_kind_preference(&worktree_kind) < task_source_kind_preference(&abs_path_kind),
         "Worktree tasks should be preferred over global tasks"
     );
+
+    // Deprioritized ordering: Worktree > AbsPath > UserInput > LSP > Language
+    use project::task_inventory::deprioritized_task_source_kind_preference;
     assert!(
-        task_source_kind_preference(&abs_path_kind) < task_source_kind_preference(&user_input_kind),
-        "Global tasks should be preferred over user input tasks"
+        deprioritized_task_source_kind_preference(&worktree_kind)
+            < deprioritized_task_source_kind_preference(&abs_path_kind),
+        "Worktree tasks should be preferred over global tasks when deprioritized"
     );
     assert!(
-        task_source_kind_preference(&user_input_kind) < task_source_kind_preference(&lsp_kind),
-        "User input tasks should be preferred over LSP tasks"
+        deprioritized_task_source_kind_preference(&abs_path_kind)
+            < deprioritized_task_source_kind_preference(&user_input_kind),
+        "Global tasks should be preferred over user input tasks when deprioritized"
     );
     assert!(
-        task_source_kind_preference(&lsp_kind) < task_source_kind_preference(&language_kind),
-        "LSP tasks should be preferred over language tasks"
+        deprioritized_task_source_kind_preference(&user_input_kind)
+            < deprioritized_task_source_kind_preference(&lsp_kind),
+        "User input tasks should be preferred over LSP tasks when deprioritized"
+    );
+    assert!(
+        deprioritized_task_source_kind_preference(&lsp_kind)
+            < deprioritized_task_source_kind_preference(&language_kind),
+        "LSP tasks should be preferred over language tasks when deprioritized"
     );
 }
 
@@ -673,8 +698,12 @@ fn test_auto_detected_tasks_deserialization() {
     let all: AutoDetectedTasks = serde_json::from_str(r#""all""#).unwrap();
     assert_eq!(all, AutoDetectedTasks::All);
 
-    let none: AutoDetectedTasks = serde_json::from_str(r#""hidden""#).unwrap();
-    assert_eq!(none, AutoDetectedTasks::Hidden);
+    let deprioritized: AutoDetectedTasks =
+        serde_json::from_str(r#""deprioritized""#).unwrap();
+    assert_eq!(deprioritized, AutoDetectedTasks::Deprioritized);
+
+    let hidden: AutoDetectedTasks = serde_json::from_str(r#""hidden""#).unwrap();
+    assert_eq!(hidden, AutoDetectedTasks::Hidden);
 
     assert_eq!(AutoDetectedTasks::default(), AutoDetectedTasks::All);
 }
@@ -727,5 +756,21 @@ async fn test_auto_detected_tasks_setting(cx: &mut TestAppContext) {
         vec!["worktree_task", "global_task"],
         "Worktree and global tasks should still appear when auto_detected_tasks is hidden \
          (only language/LSP tasks are filtered, which are not present in this test)"
+    );
+
+    cx.update(|cx| {
+        settings::SettingsStore::update(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.auto_detected_tasks = Some(AutoDetectedTasks::Deprioritized);
+            });
+        });
+    });
+
+    let task_names_deprioritized =
+        resolved_task_names(&inventory, Some(worktree_1), cx).await;
+    assert_eq!(
+        task_names_deprioritized,
+        vec!["worktree_task", "global_task"],
+        "Both worktree and global tasks should still appear when auto_detected_tasks is deprioritized"
     );
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -510,6 +510,7 @@ impl VsCodeSettings {
             slash_commands: None,
             git_hosting_providers: None,
             disable_ai: None,
+            auto_detected_tasks: None,
         }
     }
 

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -88,6 +88,14 @@ pub struct ProjectSettingsContent {
     ///
     /// Default: false
     pub disable_ai: Option<SaturatingBool>,
+
+    /// Controls the visibility of auto-detected tasks (e.g. npm scripts from
+    /// package.json, tasks from language servers and extensions).
+    /// Manually defined tasks from `.zed/tasks.json` and global tasks are
+    /// always shown regardless of this setting.
+    ///
+    /// Default: all
+    pub auto_detected_tasks: Option<AutoDetectedTasks>,
 }
 
 #[with_fallible_options]
@@ -727,6 +735,17 @@ pub struct NodeBinarySettings {
     pub npm_path: Option<String>,
     /// If enabled, Zed will download its own copy of Node.
     pub ignore_system_version: Option<bool>,
+}
+
+#[derive(Clone, Copy, PartialEq, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub enum AutoDetectedTasks {
+    /// Show all auto-detected tasks from language servers and extensions.
+    #[default]
+    All,
+    /// Hide all auto-detected tasks. Only manually defined tasks from
+    /// `.zed/tasks.json` and global task configuration are shown.
+    Hidden,
 }
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -743,6 +743,8 @@ pub enum AutoDetectedTasks {
     /// Show all auto-detected tasks from language servers and extensions.
     #[default]
     All,
+    /// Show auto-detected tasks, but sort them below user-defined tasks.
+    Deprioritized,
     /// Hide all auto-detected tasks. Only manually defined tasks from
     /// `.zed/tasks.json` and global task configuration are shown.
     Hidden,

--- a/crates/tasks_ui/Cargo.toml
+++ b/crates/tasks_ui/Cargo.toml
@@ -22,6 +22,7 @@ gpui.workspace = true
 menu.workspace = true
 picker.workspace = true
 project.workspace = true
+settings.workspace = true
 task.workspace = true
 serde.workspace = true
 ui.workspace = true

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -10,7 +10,12 @@ use gpui::{
 };
 use itertools::Itertools;
 use picker::{Picker, PickerDelegate, highlighted_match_with_paths::HighlightedMatch};
-use project::{TaskSourceKind, task_store::TaskStore};
+use project::{
+    TaskSourceKind,
+    project_settings::{AutoDetectedTasks, ProjectSettings},
+    task_store::TaskStore,
+};
+use settings::Settings as _;
 use task::{DebugScenario, ResolvedTask, RevealTarget, TaskContext, TaskTemplate};
 use ui::{
     ActiveTheme, Clickable, FluentBuilder as _, IconButtonShape, IconWithIndicator, Indicator,
@@ -182,8 +187,11 @@ impl TasksModal {
         } else {
             Some(used_tasks.len() - 1)
         };
+        let deprioritize_auto_detected = matches!(
+            ProjectSettings::get_global(cx).auto_detected_tasks,
+            AutoDetectedTasks::Deprioritized
+        );
         let mut new_candidates = used_tasks;
-        new_candidates.extend(lsp_tasks);
         let hide_vscode = current_resolved_tasks.iter().any(|(kind, _)| match kind {
             TaskSourceKind::Worktree {
                 id: _,
@@ -192,10 +200,7 @@ impl TasksModal {
             } => dir.file_name().is_some_and(|name| name == ".zed"),
             _ => false,
         });
-        // todo(debugger): We're always adding lsp tasks here even if prefer_lsp is false
-        // We should move the filter to new_candidates instead of on current
-        // and add a test for this
-        new_candidates.extend(current_resolved_tasks.into_iter().filter(|(task_kind, _)| {
+        let filtered_current = current_resolved_tasks.into_iter().filter(|(task_kind, _)| {
             match task_kind {
                 TaskSourceKind::Worktree {
                     directory_in_worktree: dir,
@@ -204,7 +209,17 @@ impl TasksModal {
                 TaskSourceKind::Language { .. } => add_current_language_tasks,
                 _ => true,
             }
-        }));
+        });
+        if deprioritize_auto_detected {
+            new_candidates.extend(filtered_current);
+            new_candidates.extend(lsp_tasks);
+        } else {
+            new_candidates.extend(lsp_tasks);
+            // todo(debugger): We're always adding lsp tasks here even if prefer_lsp is false
+            // We should move the filter to new_candidates instead of on current
+            // and add a test for this
+            new_candidates.extend(filtered_current);
+        }
         self.picker.update(cx, |picker, cx| {
             picker.delegate.task_contexts = task_contexts;
             picker.delegate.last_used_candidate_index = last_used_candidate_index;
@@ -288,8 +303,12 @@ impl PickerDelegate for TasksModalDelegate {
                     let task_position = self.task_contexts.latest_selection;
                     cx.spawn(async move |picker, cx| {
                         let (used, current) = task_list.await;
-                        let Ok((lsp_tasks, prefer_lsp)) =
+                        let Ok((lsp_tasks, prefer_lsp, deprioritize_auto_detected)) =
                             workspace.update(cx, |workspace, cx| {
+                                let deprioritize_auto_detected = matches!(
+                                    ProjectSettings::get_global(cx).auto_detected_tasks,
+                                    AutoDetectedTasks::Deprioritized
+                                );
                                 let lsp_tasks = editor::lsp_tasks(
                                     workspace.project().clone(),
                                     &lsp_task_sources,
@@ -309,7 +328,7 @@ impl PickerDelegate for TasksModalDelegate {
                                             .prefer_lsp
                                     })
                                     .unwrap_or(false);
-                                (lsp_tasks, prefer_lsp)
+                                (lsp_tasks, prefer_lsp, deprioritize_auto_detected)
                             })
                         else {
                             return Vec::new();
@@ -327,25 +346,45 @@ impl PickerDelegate for TasksModalDelegate {
                                 let mut new_candidates = used;
                                 let add_current_language_tasks =
                                     !prefer_lsp || lsp_tasks.is_empty();
-                                new_candidates.extend(lsp_tasks.into_iter().flat_map(
-                                    |(kind, tasks_with_locations)| {
-                                        tasks_with_locations
-                                            .into_iter()
-                                            .sorted_by_key(|(location, task)| {
-                                                (location.is_none(), task.resolved_label.clone())
-                                            })
-                                            .map(move |(_, task)| (kind.clone(), task))
-                                    },
-                                ));
-                                // todo(debugger): We're always adding lsp tasks here even if prefer_lsp is false
-                                // We should move the filter to new_candidates instead of on current
-                                // and add a test for this
-                                new_candidates.extend(current.into_iter().filter(
-                                    |(task_kind, _)| {
-                                        add_current_language_tasks
-                                            || !matches!(task_kind, TaskSourceKind::Language { .. })
-                                    },
-                                ));
+                                let flattened_lsp_tasks =
+                                    lsp_tasks.into_iter().flat_map(
+                                        |(kind, tasks_with_locations)| {
+                                            tasks_with_locations
+                                                .into_iter()
+                                                .sorted_by_key(|(location, task)| {
+                                                    (location.is_none(), task.resolved_label.clone())
+                                                })
+                                                .map(move |(_, task)| (kind.clone(), task))
+                                        },
+                                    );
+                                if deprioritize_auto_detected {
+                                    // When deprioritized, add non-auto-detected tasks
+                                    // first, then LSP tasks after.
+                                    new_candidates.extend(current.into_iter().filter(
+                                        |(task_kind, _)| {
+                                            add_current_language_tasks
+                                                || !matches!(
+                                                    task_kind,
+                                                    TaskSourceKind::Language { .. }
+                                                )
+                                        },
+                                    ));
+                                    new_candidates.extend(flattened_lsp_tasks);
+                                } else {
+                                    new_candidates.extend(flattened_lsp_tasks);
+                                    // todo(debugger): We're always adding lsp tasks here even if prefer_lsp is false
+                                    // We should move the filter to new_candidates instead of on current
+                                    // and add a test for this
+                                    new_candidates.extend(current.into_iter().filter(
+                                        |(task_kind, _)| {
+                                            add_current_language_tasks
+                                                || !matches!(
+                                                    task_kind,
+                                                    TaskSourceKind::Language { .. }
+                                                )
+                                        },
+                                    ));
+                                }
                                 let match_candidates = string_match_candidates(&new_candidates);
                                 let _ = picker.delegate.candidates.insert(new_candidates);
                                 match_candidates

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -288,28 +288,30 @@ impl PickerDelegate for TasksModalDelegate {
                     let task_position = self.task_contexts.latest_selection;
                     cx.spawn(async move |picker, cx| {
                         let (used, current) = task_list.await;
-                        let Ok((lsp_tasks, prefer_lsp)) = workspace.update(cx, |workspace, cx| {
-                            let lsp_tasks = editor::lsp_tasks(
-                                workspace.project().clone(),
-                                &lsp_task_sources,
-                                task_position,
-                                cx,
-                            );
-                            let prefer_lsp = workspace
-                                .active_item(cx)
-                                .and_then(|item| item.downcast::<Editor>())
-                                .map(|editor| {
-                                    editor
-                                        .read(cx)
-                                        .buffer()
-                                        .read(cx)
-                                        .language_settings(cx)
-                                        .tasks
-                                        .prefer_lsp
-                                })
-                                .unwrap_or(false);
-                            (lsp_tasks, prefer_lsp)
-                        }) else {
+                        let Ok((lsp_tasks, prefer_lsp)) =
+                            workspace.update(cx, |workspace, cx| {
+                                let lsp_tasks = editor::lsp_tasks(
+                                    workspace.project().clone(),
+                                    &lsp_task_sources,
+                                    task_position,
+                                    cx,
+                                );
+                                let prefer_lsp = workspace
+                                    .active_item(cx)
+                                    .and_then(|item| item.downcast::<Editor>())
+                                    .map(|editor| {
+                                        editor
+                                            .read(cx)
+                                            .buffer()
+                                            .read(cx)
+                                            .language_settings(cx)
+                                            .tasks
+                                            .prefer_lsp
+                                    })
+                                    .unwrap_or(false);
+                                (lsp_tasks, prefer_lsp)
+                            })
+                        else {
                             return Vec::new();
                         };
 


### PR DESCRIPTION
## Summary

- Reorder task source preferences so user-defined tasks (`.zed/tasks.json`, global config, one-off commands) appear above auto-detected ones (LSP, language extensions) in the task picker
- Add a project-level `auto_detected_tasks` setting (`"all"` or `"hidden"`) to hide auto-detected tasks entirely

<img width="833" height="281" alt="CleanShot 2026-03-23 at 15 23 27" src="https://github.com/user-attachments/assets/34283d28-5d1a-479a-b21c-9688621d9aef" />

Closes https://github.com/zed-industries/zed/issues/36759

## Design notes

The new ordering for `task_source_kind_preference` is: Worktree > Global > UserInput > LSP > Language. The previous ordering had LSP and Language first, which meant auto-detected tasks (e.g. npm scripts from package.json) appeared above manually curated tasks in `.zed/tasks.json`, defeating the purpose of defining them.

For the `auto_detected_tasks` setting, I considered a few shapes:

- **Per-source toggles** (separate booleans for LSP vs language extension tasks): More granular, but the existing per-language `tasks.enabled` and `prefer_lsp` settings already cover that use case. A project-wide toggle felt more appropriate for "I just want my own tasks."
- **A filter/allowlist approach**: More powerful but higher complexity for a setting most people would use as a simple on/off.
- **An enum with more variants** (e.g. `"lsp_only"`, `"language_only"`): Premature without concrete demand. The enum is easy to extend later if needed.

The setting is not yet in the visual settings UI (same as other project-level settings like `load_direnv`). It works via `settings.json`.

## Test coverage

- Ordering test validates the full preference chain with assertion messages
- Settings deserialization test for the new enum
- Integration test verifies worktree/global tasks survive the `"hidden"` setting
- Full integration testing of Language/LSP filtering would require a heavier test setup with a language context provider. That path is covered by the early-return in `editor::lsp_tasks()` and the inventory filter, but not exercised end-to-end in a test.

CLA signed by @micthiesen.

Release Notes:

- Improved task picker ordering to show manually defined tasks above auto-detected ones
- Added `auto_detected_tasks` project setting to hide auto-detected tasks from language servers and extensions