### PR TITLE
Use multibuffer to fix symbol search when diff is present

### DIFF
--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -1,4 +1,6 @@
-use editor::{Bias, Editor, SelectionEffects, scroll::Autoscroll, styled_runs_for_code_label};
+use editor::{
+    Anchor, Bias, Editor, SelectionEffects, scroll::Autoscroll, styled_runs_for_code_label,
+};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     App, Context, DismissEvent, Entity, HighlightStyle, ParentElement, StyledText, Task, TextStyle,
@@ -139,11 +141,19 @@ impl PickerDelegate for ProjectSymbolsDelegate {
                     );
 
                     editor.update(cx, |editor, cx| {
+                        let multibuffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+                        let Some((excerpt_id, _, buffer_snapshot)) =
+                            multibuffer_snapshot.as_singleton()
+                        else {
+                            return;
+                        };
+                        let text_anchor = buffer_snapshot.anchor_before(position);
+                        let anchor = Anchor::in_buffer(excerpt_id, text_anchor);
                         editor.change_selections(
                             SelectionEffects::scroll(Autoscroll::center()),
                             window,
                             cx,
-                            |s| s.select_ranges([position..position]),
+                            |s| s.select_ranges([anchor..anchor]),
                         );
                     });
                 })?;


### PR DESCRIPTION
## Context

<!-- What does this PR do, and why? How is it expected to impact users?
     Not just what changed, but what motivated it and why this approach.

     Link to Linear issue (e.g., ENG-123) or GitHub issue (e.g., Closes #456)
     if one exists — helps with traceability. -->
     
Fixes a bug where project symbol search navigates to the wrong position when diff hunks are expanded. The cursor would land offset by the number of lines added by the expanded diffs (Closes #51331). Now, users navigating to symbols via project symbol search will land on the correct position even when diff hunks are expanded in the editor.

The fix converts the buffer position to a `multi_buffer::Anchor` before passing it to `select_ranges`, so it resolves correctly through the diff transform layer instead of being interpreted as a literal MultiBuffer coordinate.

Previously, the symbol's position was passed as a raw coordinate to the editor, which interpreted it relative to what's displayed on screen (including expanded diff lines). The fix converts the position to an anchor, which is tied to the actual content in the file rather than a screen position.

## How to Review

<!-- Help reviewers focus their attention:
     - For small PRs: note what to focus on (e.g., "error handling in foo.rs")
     - For large PRs (>400 LOC): provide a guided tour — numbered list of
       files/commits to read in order. (The `large-pr` label is applied automatically.)
     - See the review process guidelines for comment conventions -->
     
- All changes are in `crates/project_symbols/src/project_symbols.rs`. Most of the changes are in `confirm()` method (Lines 142-154). 
  - There's also one change on the first line of the file.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a bug where project symbols did not take you to the correct location when diffs are expanded.