### PR TITLE
agent_ui: Fix full screen behavior on worktree creation

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2994,8 +2994,6 @@ impl AgentPanel {
                 }
 
                 // If we had an active buffer, remap its path and reopen it.
-                let should_zoom_agent_panel = active_file_path.is_none();
-
                 let remapped_active_path = active_file_path.and_then(|original_path| {
                     let best_match = path_remapping
                         .iter()
@@ -3018,7 +3016,7 @@ impl AgentPanel {
                     None
                 });
 
-                if !should_zoom_agent_panel && remapped_active_path.is_none() {
+                if remapped_active_path.is_none() {
                     log::warn!(
                         "Active file could not be remapped to the new worktree; it will not be reopened"
                     );

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3047,13 +3047,7 @@ impl AgentPanel {
                 // (equivalent to cmd-esc fullscreen behavior).
                 // This must happen after focus_panel, which activates
                 // and opens the panel in the dock.
-                if should_zoom_agent_panel {
-                    if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
-                        panel.update(cx, |_panel, cx| {
-                            cx.emit(PanelEvent::ZoomIn);
-                        });
-                    }
-                }
+
                 if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
                     panel.update(cx, |panel, cx| {
                         panel.external_thread(
@@ -4005,6 +3999,8 @@ impl AgentPanel {
 
         let is_text_thread = matches!(&self.active_view, ActiveView::TextThread { .. });
 
+        let is_full_screen = self.is_zoomed(window, cx);
+
         let use_v2_empty_toolbar =
             has_v2_flag && is_empty_state && !is_in_history_or_config && !is_text_thread;
 
@@ -4049,7 +4045,7 @@ impl AgentPanel {
                 .trigger_with_tooltip(agent_selector_button, {
                     move |_window, cx| {
                         Tooltip::for_action_in(
-                            "New Thread\u{2026}",
+                            "New Thread…",
                             &ToggleNewThreadMenu,
                             &focus_handle,
                             cx,
@@ -4092,6 +4088,20 @@ impl AgentPanel {
                                 Corner::TopRight,
                                 cx,
                             ))
+                        })
+                        .when(is_full_screen, |this| {
+                            this.child(
+                                IconButton::new("disable-full-screen", IconName::Minimize)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip(move |_, cx| {
+                                        Tooltip::for_action("Disable Full Screen", &ToggleZoom, cx)
+                                    })
+                                    .on_click({
+                                        cx.listener(move |_, _, window, cx| {
+                                            window.dispatch_action(ToggleZoom.boxed_clone(), cx);
+                                        })
+                                    }),
+                            )
                         })
                         .child(self.render_panel_options_menu(window, cx)),
                 )
@@ -4144,6 +4154,20 @@ impl AgentPanel {
                                 Corner::TopRight,
                                 cx,
                             ))
+                        })
+                        .when(is_full_screen, |this| {
+                            this.child(
+                                IconButton::new("disable-full-screen", IconName::Minimize)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip(move |_, cx| {
+                                        Tooltip::for_action("Disable Full Screen", &ToggleZoom, cx)
+                                    })
+                                    .on_click({
+                                        cx.listener(move |_, _, window, cx| {
+                                            window.dispatch_action(ToggleZoom.boxed_clone(), cx);
+                                        })
+                                    }),
+                            )
                         })
                         .child(self.render_panel_options_menu(window, cx)),
                 )

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2994,6 +2994,7 @@ impl AgentPanel {
                 }
 
                 // If we had an active buffer, remap its path and reopen it.
+                let had_active_file = active_file_path.is_some();
                 let remapped_active_path = active_file_path.and_then(|original_path| {
                     let best_match = path_remapping
                         .iter()
@@ -3016,7 +3017,7 @@ impl AgentPanel {
                     None
                 });
 
-                if remapped_active_path.is_none() {
+                if had_active_file && remapped_active_path.is_none() {
                     log::warn!(
                         "Active file could not be remapped to the new worktree; it will not be reopened"
                     );


### PR DESCRIPTION
## Context

This PR removes the behavior in which we turn the agent panel full screen on worktree creation, even if there aren't any files open. Changing the width behavior of the panel will ultimately solve this, and auto-full screening it turned out to be surprising. Also, in reaction to this, I've added an icon button in the agent panel's toolbar when in full screen so it's easier to get out of it. Eventually though, we can probably remove it (also because of the flexible width work).

## How to Review

- Create a new worktree from a thread and see the panel with the same width
- See the "disable full screen" icon button in the toolbar when you full screen it

--- 

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
