### PR TITLE
settings_ui: Fix open settings keybind always taking precedence

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -31,7 +31,6 @@
       "ctrl-+": ["zed::IncreaseBufferFontSize", { "persist": false }],
       "ctrl--": ["zed::DecreaseBufferFontSize", { "persist": false }],
       "ctrl-0": ["zed::ResetBufferFontSize", { "persist": false }],
-      "ctrl-,": "zed::OpenSettings",
       "ctrl-alt-,": "zed::OpenSettingsFile",
       "ctrl-q": "zed::Quit",
       "f4": "debugger::Start",
@@ -1338,6 +1337,15 @@
       "ctrl-space": "git::WorktreeFromDefault",
       "ctrl-shift-backspace": "git::DeleteWorktree",
     },
+  },
+  {
+    // Handled under a more specific context to avoid conflicts with the
+    // `OpenCurrentFile` keybind from the settings UI
+    "context": "!SettingsWindow",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-,": "zed::OpenSettings",
+    }
   },
   {
     "context": "SettingsWindow",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -39,7 +39,6 @@
       "cmd-+": ["zed::IncreaseBufferFontSize", { "persist": false }],
       "cmd--": ["zed::DecreaseBufferFontSize", { "persist": false }],
       "cmd-0": ["zed::ResetBufferFontSize", { "persist": false }],
-      "cmd-,": "zed::OpenSettings",
       "cmd-alt-,": "zed::OpenSettingsFile",
       "cmd-q": "zed::Quit",
       "cmd-h": "zed::Hide",
@@ -1440,6 +1439,15 @@
       "ctrl-space": "git::WorktreeFromDefault",
       "cmd-shift-backspace": "git::DeleteWorktree",
     },
+  },
+  {
+    // Handled under a more specific context to avoid conflicts with the
+    // `OpenCurrentFile` keybind from the settings UI
+    "context": "!SettingsWindow",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-,": "zed::OpenSettings",
+    }
   },
   {
     "context": "SettingsWindow",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -30,7 +30,6 @@
       "ctrl-shift-=": ["zed::IncreaseBufferFontSize", { "persist": false }],
       "ctrl--": ["zed::DecreaseBufferFontSize", { "persist": false }],
       "ctrl-0": ["zed::ResetBufferFontSize", { "persist": false }],
-      "ctrl-,": "zed::OpenSettings",
       "ctrl-alt-,": "zed::OpenSettingsFile",
       "ctrl-q": "zed::Quit",
       "f4": "debugger::Start",
@@ -1356,6 +1355,15 @@
       "ctrl-space": "git::WorktreeFromDefault",
       "ctrl-shift-backspace": "git::DeleteWorktree",
     },
+  },
+  {
+    // Handled under a more specific context to avoid conflicts with the
+    // `OpenCurrentFile` keybind from the settings UI
+    "context": "!SettingsWindow",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-,": "zed::OpenSettings",
+    }
   },
   {
     "context": "SettingsWindow",


### PR DESCRIPTION
Solves an issue introduced by https://github.com/zed-industries/zed/pull/49527 until we land https://github.com/zed-industries/zed/pull/52275.

No release notes since this is only on Nightly.

Release Notes:

- N/A