### PR TITLE
Add configurable double-click action for terminal and clarify '+' button behavior

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1881,6 +1881,11 @@
     "path_hyperlink_timeout_ms": 1,
     // Whether to show a badge on the terminal panel icon with the count of open terminals.
     "show_count_badge": false,
+    // Action to perform on double-clicking the terminal header.
+    // "new_terminal" opens a new terminal, "toggle_zoom" toggles zoom.
+    //
+    // Default: new_terminal
+    "double_click_action": "new_terminal",
   },
   "code_actions_on_format": {},
   // Settings related to running tasks.

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -877,6 +877,7 @@ impl VsCodeSettings {
             scrollbar: None,
             scroll_multiplier: None,
             toolbar: None,
+            double_click_action: None,
             show_count_badge: None,
         })
     }

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -175,6 +175,9 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: false
     pub show_count_badge: Option<bool>,
+    /// Action to perform on double-clicking the terminal header.
+    /// "new_terminal" opens a new terminal, "toggle_zoom" toggles zoom.
+    pub double_click_action: Option<TerminalHeaderDoubleClickAction>,
 }
 
 /// Shell configuration to open the terminal with.
@@ -476,6 +479,14 @@ pub enum TerminalDockPosition {
     Left,
     Bottom,
     Right,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalHeaderDoubleClickAction {
+    #[default]
+    NewTerminal,
+    ToggleZoom,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -481,7 +481,19 @@ pub enum TerminalDockPosition {
     Right,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum TerminalHeaderDoubleClickAction {
     #[default]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6268,7 +6268,7 @@ fn terminal_page() -> SettingsPage {
         ]
     }
 
-    fn behavior_settings_section() -> [SettingsPageItem; 4] {
+    fn behavior_settings_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("Behavior Settings"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -6324,6 +6324,29 @@ fn terminal_page() -> SettingsPage {
                             .terminal
                             .get_or_insert_default()
                             .keep_selection_on_copy = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            // New double-click action setting
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Double-Click Action",
+                description: "Action when double-clicking the terminal header (new_terminal or toggle_zoom).",
+                field: Box::new(SettingField {
+                    json_path: Some("terminal.double_click_action"),
+                    pick: |settings_content| {
+                        settings_content
+                            .terminal
+                            .as_ref()?
+                            .double_click_action
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .terminal
+                            .get_or_insert_default()
+                            .double_click_action = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -480,6 +480,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::DiagnosticSeverityContent>(render_dropdown)
         .add_basic_renderer::<settings::SeedQuerySetting>(render_dropdown)
         .add_basic_renderer::<settings::DoubleClickInMultibuffer>(render_dropdown)
+        .add_basic_renderer::<settings::TerminalHeaderDoubleClickAction>(render_dropdown)
         .add_basic_renderer::<settings::GoToDefinitionFallback>(render_dropdown)
         .add_basic_renderer::<settings::ActivateOnClose>(render_dropdown)
         .add_basic_renderer::<settings::ShowDiagnostics>(render_dropdown)

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -10,8 +10,8 @@ pub use settings::AlternateScroll;
 
 use settings::{
     IntoGpui, PathHyperlinkRegex, RegisterSetting, ShowScrollbar, TerminalBlink,
-    TerminalDockPosition, TerminalLineHeight, VenvSettings, WorkingDirectory,
-    merge_from::MergeFrom,
+    TerminalDockPosition, TerminalHeaderDoubleClickAction, TerminalLineHeight, VenvSettings,
+    WorkingDirectory, merge_from::MergeFrom,
 };
 use task::Shell;
 use theme::FontFamilyName;
@@ -23,6 +23,7 @@ pub struct Toolbar {
 
 #[derive(Clone, Debug, Deserialize, RegisterSetting)]
 pub struct TerminalSettings {
+    pub double_click_action: TerminalHeaderDoubleClickAction,
     pub shell: Shell,
     pub working_directory: WorkingDirectory,
     pub font_size: Option<Pixels>, // todo(settings_refactor) can be non-optional...
@@ -130,6 +131,7 @@ impl settings::Settings for TerminalSettings {
                 })
                 .collect(),
             path_hyperlink_timeout_ms: project_content.path_hyperlink_timeout_ms.unwrap(),
+            double_click_action: user_content.double_click_action.unwrap_or_default(),
             show_count_badge: user_content.show_count_badge.unwrap(),
         }
     }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -18,6 +18,7 @@ use gpui::{
 use itertools::Itertools;
 use project::{Fs, Project};
 
+use settings::TerminalHeaderDoubleClickAction;
 use settings::{Settings, TerminalDockPosition};
 use task::{RevealStrategy, RevealTarget, Shell, ShellBuilder, SpawnInTerminal, TaskId};
 use terminal::{Terminal, terminal_settings::TerminalSettings};
@@ -1194,12 +1195,18 @@ pub fn new_terminal_pane(
 ) -> Entity<Pane> {
     let terminal_panel = cx.entity();
     let pane = cx.new(|cx| {
+        let double_click_action = match TerminalSettings::get_global(cx).double_click_action {
+            TerminalHeaderDoubleClickAction::ToggleZoom => {
+                workspace::ToggleZoom::default().boxed_clone()
+            }
+            _ => workspace::NewTerminal::default().boxed_clone(),
+        };
         let mut pane = Pane::new(
             workspace.clone(),
             project.clone(),
             Default::default(),
             None,
-            workspace::NewTerminal::default().boxed_clone(),
+            double_click_action,
             false,
             window,
             cx,


### PR DESCRIPTION
## Purpose

- Introduce a user‑configurable  setting that can be set to  (default) or .
- Adjust the double‑click handling logic in  to respect this setting.
- Ensure the '+' button in the pane tab bar continues to create a new terminal rather than toggling zoom.

## Future Work

- Add UI controls in the Settings panel to let users toggle this option via a dropdown.
- Provide documentation in the settings schema and a short tooltip for the new option.
