### PR TITLE
git_ui: Fix Git Graph button flicker in Git panel

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -20,6 +20,7 @@ use editor::{
     actions::ExpandAllDiffHunks,
 };
 use editor::{EditorStyle, RewrapOptions};
+use feature_flags::{FeatureFlagAppExt as _, GitGraphFeatureFlag};
 use file_icons::FileIcons;
 use futures::StreamExt as _;
 use git::commit::ParsedCommitMessage;
@@ -4528,7 +4529,7 @@ impl GitPanel {
 
     fn render_previous_commit(
         &self,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<impl IntoElement> {
         let active_repository = self.active_repository.as_ref()?;
@@ -4536,6 +4537,7 @@ impl GitPanel {
         let commit = branch.most_recent_commit.as_ref()?.clone();
         let workspace = self.workspace.clone();
         let this = cx.entity();
+        let can_open_git_graph = cx.has_flag::<GitGraphFeatureFlag>();
 
         Some(
             h_flex()
@@ -4613,7 +4615,7 @@ impl GitPanel {
                                     ),
                             )
                         })
-                        .when(window.is_action_available(&Open, cx), |this| {
+                        .when(can_open_git_graph, |this| {
                             this.child(
                                 panel_icon_button("git-graph-button", IconName::GitGraph)
                                     .icon_size(IconSize::Small)


### PR DESCRIPTION
Release Notes:

- Fixed Git Graph button flicker in Git panel

Replace the Git Graph button visibility check with a stable feature-flag gate instead of querying action availability from the current window focus path, which could briefly remove the button during initial panel render and after opening Git Graph.

before:


https://github.com/user-attachments/assets/0af38a49-b28d-4b50-9d63-a4676fd229f7




after:




https://github.com/user-attachments/assets/fcdf8245-bd34-45d0-9ea3-8671fc99a7c2

