### PR TITLE
repl: Retry iopub connection on failure

### DIFF
--- a/crates/repl/src/kernels/ssh_kernel.rs
+++ b/crates/repl/src/kernels/ssh_kernel.rs
@@ -160,8 +160,9 @@ impl SshRunningKernel {
                             attempt + 1
                         );
                         // giving the tunnel a moment to fully establish forwarding
+                        // waiting same as WSL
                         cx.background_executor()
-                            .timer(std::time::Duration::from_millis(500))
+                            .timer(std::time::Duration::from_secs(2))
                             .await;
                         break;
                     }
@@ -209,13 +210,35 @@ impl SshRunningKernel {
                 serde_json::from_value(local_connection_info)?;
             let session_id = uuid::Uuid::new_v4().to_string();
 
-            let output_socket = runtimelib::create_client_iopub_connection(
-                &connection_info_struct,
-                "",
-                &session_id,
-            )
-            .await
-            .context("failed to create iopub connection")?;
+            let output_socket = {
+                let max_retries = 5;
+                let mut retry = 0;
+                loop {
+                    match runtimelib::create_client_iopub_connection(
+                        &connection_info_struct,
+                        "",
+                        &session_id,
+                    )
+                    .await
+                    {
+                        Ok(socket) => break socket,
+                        Err(err) => {
+                            if retry >= max_retries {
+                                anyhow::bail!("failed to create iopub connection: {}", err);
+                            }
+                            log::debug!(
+                                "Retrying iopub connection (attempt {}/{})",
+                                retry + 1,
+                                max_retries
+                            );
+                            cx.background_executor()
+                                .timer(std::time::Duration::from_millis(200 << retry))
+                                .await;
+                            retry += 1;
+                        }
+                    }
+                }
+            };
 
             let peer_identity = runtimelib::peer_identity_for_session(&session_id)?;
             let shell_socket = runtimelib::create_client_shell_connection_with_identity(


### PR DESCRIPTION
## Context
 
Based on #51834 , iopub might fail the first time or in 500 millisecond, so changed that to 2 seconds like WSL and allowed for retries. This fixed iopub failures on unstable internet when using repl via remote. 

## How to Review

- allowed for same time as wsl_kernel.rs and allowed retrying for failure until 5 times with each try, time increasing exponentially to allow for network failures.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A 