### PR TITLE
tab_switcher: Prevent tab switcher from closing on shift release

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -61,7 +61,7 @@ actions!(
 
 pub struct TabSwitcher {
     picker: Entity<Picker<TabSwitcherDelegate>>,
-    anchor_modifier: Option<AnchorModifier>,
+    anchor_modifiers: Vec<AnchorModifier>,
 }
 
 impl ModalView for TabSwitcher {}
@@ -172,19 +172,15 @@ impl TabSwitcher {
         is_global: bool,
         cx: &mut Context<Self>,
     ) -> Self {
-        let anchor_modifier = if is_global {
-            None
+        let anchor_modifiers = if is_global {
+            Vec::new()
         } else {
             let mods = window.modifiers();
-            if mods.platform {
-                Some(AnchorModifier::Platform)
-            } else if mods.control {
-                Some(AnchorModifier::Control)
-            } else if mods.alt {
-                Some(AnchorModifier::Alt)
-            } else {
-                None
-            }
+            let mut anchors = Vec::new();
+            if mods.platform { anchors.push(AnchorModifier::Platform); }
+            if mods.control { anchors.push(AnchorModifier::Control); }
+            if mods.alt { anchors.push(AnchorModifier::Alt); }
+            anchors
         };
         Self {
             picker: cx.new(|cx| {
@@ -194,7 +190,7 @@ impl TabSwitcher {
                     Picker::nonsearchable_list(delegate, window, cx)
                 }
             }),
-            anchor_modifier,
+            anchor_modifiers,
         }
     }
 
@@ -204,18 +200,18 @@ impl TabSwitcher {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(anchor) = self.anchor_modifier else {
+        if self.anchor_modifiers.is_empty() {
             return;
-        };
+        }
 
-        let released = match anchor {
+        let any_released = self.anchor_modifiers.iter().any(|anchor| match anchor {
             AnchorModifier::Platform => !event.platform,
-            AnchorModifier::Alt => !event.alt,
-            AnchorModifier::Control => !event.control,
-        };
+            AnchorModifier::Control  => !event.control,
+            AnchorModifier::Alt      => !event.alt,
+        });
 
-        if released {
-            self.anchor_modifier = None;
+        if any_released {
+            self.anchor_modifiers.clear();
             if self.picker.read(cx).delegate.matches.is_empty() {
                 cx.emit(DismissEvent)
             } else {

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -8,9 +8,10 @@ use editor::items::{
 use fuzzy_nucleo::StringMatchCandidate;
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EntityId, EventEmitter, FocusHandle,
-    Focusable, Modifiers, ModifiersChangedEvent, MouseButton, MouseUpEvent, ParentElement, Point,
+    Focusable, ModifiersChangedEvent, MouseButton, MouseUpEvent, ParentElement, Point,
     Render, Styled, Task, TaskExt, WeakEntity, Window, actions, rems,
 };
+// #[cfg(test)]
 use picker::{Picker, PickerDelegate};
 use project::Project;
 use schemars::JsonSchema;
@@ -29,6 +30,13 @@ use workspace::{
 };
 
 const PANEL_WIDTH_REMS: f32 = 28.;
+
+#[derive(Copy, Clone, PartialEq)]
+enum AnchorModifier {
+    Platform,
+    Control,
+    Alt,
+}
 
 /// Toggles the tab switcher interface.
 #[derive(PartialEq, Clone, Deserialize, JsonSchema, Default, Action)]
@@ -53,7 +61,7 @@ actions!(
 
 pub struct TabSwitcher {
     picker: Entity<Picker<TabSwitcherDelegate>>,
-    init_modifiers: Option<Modifiers>,
+    anchor_modifier: Option<AnchorModifier>,
 }
 
 impl ModalView for TabSwitcher {}
@@ -164,10 +172,19 @@ impl TabSwitcher {
         is_global: bool,
         cx: &mut Context<Self>,
     ) -> Self {
-        let init_modifiers = if is_global {
+        let anchor_modifier = if is_global {
             None
         } else {
-            window.modifiers().modified().then_some(window.modifiers())
+            let mods = window.modifiers();
+            if mods.platform {
+                Some(AnchorModifier::Platform)
+            } else if mods.control {
+                Some(AnchorModifier::Control)
+            } else if mods.alt {
+                Some(AnchorModifier::Alt)
+            } else {
+                None
+            }
         };
         Self {
             picker: cx.new(|cx| {
@@ -177,7 +194,7 @@ impl TabSwitcher {
                     Picker::nonsearchable_list(delegate, window, cx)
                 }
             }),
-            init_modifiers,
+            anchor_modifier,
         }
     }
 
@@ -187,11 +204,18 @@ impl TabSwitcher {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(init_modifiers) = self.init_modifiers else {
+        let Some(anchor) = self.anchor_modifier else {
             return;
         };
-        if !event.modified() || !init_modifiers.is_subset_of(event) {
-            self.init_modifiers = None;
+
+        let released = match anchor {
+            AnchorModifier::Platform => !event.platform,
+            AnchorModifier::Alt => !event.alt,
+            AnchorModifier::Control => !event.control,
+        };
+
+        if released {
+            self.anchor_modifier = None;
             if self.picker.read(cx).delegate.matches.is_empty() {
                 cx.emit(DismissEvent)
             } else {

--- a/crates/tab_switcher/src/tab_switcher_tests.rs
+++ b/crates/tab_switcher/src/tab_switcher_tests.rs
@@ -605,3 +605,56 @@ async fn test_toggle_all_stays_open_after_closing_last_tab_in_active_pane(
         let _ = cx;
     });
 }
+
+#[gpui::test]
+async fn test_ignore_shift_modifier_release(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/root"),
+            json!({
+                "1.txt": "First file",
+                "2.txt": "Second file",
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let _tab_1 = open_buffer("1.txt", &workspace, cx).await;
+    let _tab_2 = open_buffer("2.txt", &workspace, cx).await;
+
+    cx.simulate_modifiers_change(gpui::Modifiers {
+        control: true,
+        shift: true,
+        ..Default::default()
+    });
+
+    let tab_switcher = open_tab_switcher(false, &workspace, cx);
+    tab_switcher.update(cx, |tab_switcher, _| {
+        assert_eq!(tab_switcher.delegate.matches.len(), 2);
+    });
+
+    cx.simulate_modifiers_change(gpui::Modifiers {
+        control: true,
+        shift: false,
+        ..Default::default()
+    });
+
+    workspace.update(cx, |workspace, cx| {
+        assert!(
+            workspace.active_modal::<TabSwitcher>(cx).is_some(),
+            "tab switcher closed prematurely when shift was released"
+        );
+    });
+
+    cx.simulate_modifiers_change(gpui::Modifiers::none());
+
+    assert_tab_switcher_is_closed(workspace, cx);
+}


### PR DESCRIPTION
## What

In the default keybindings, holding `ctrl` and pressing `tab` or `shift` + `tab` toggles the tab switcher and it should remain open as long as `ctrl` is held.

However, if `ctrl` + `shift` is held when tab switcher appears, releasing `shift` will close tab switcher even if `ctrl` is held down.

## Why

When the tab switcher is toggled, it tracks all modifier keys that are held at that moment and is closed when at least one of them is released. Because `ctrl` and `shift` were held down when tab switcher was opened, releasing `shift` triggers the closing of tab switcher.

## Fix

- `crates/tab_switcher/src/tab_switcher.rs`: Update to only close when the primary modifier (`ctrl`, `cmd`/`win` or `alt`/`option`) is released.
- `crates/tab_switcher/src/tab_switcher_tests.rs`: Added a regression test (`test_ignore_shift_modifier_release`) to simulate user holding `ctrl` + `shift` and pressing `tab`, then release `shift` and ensure tab switcher stays open.

Closes #44853

## Self-Review Checklist

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fixed the tab switcher closing prematurely when the `Shift` key is released while cycling backwards.
