### PR TITLE
Allow PRs to not have a newline before the first release note

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -12,7 +12,7 @@ prHygiene({
   },
 });
 
-const RELEASE_NOTES_PATTERN = /Release Notes:\r?\n\s+-/gm;
+const RELEASE_NOTES_PATTERN = /Release Notes:(\r?\n)+- /gm;
 const body = danger.github.pr.body;
 
 const hasReleaseNotes = RELEASE_NOTES_PATTERN.test(body);


### PR DESCRIPTION
Release Notes:

- N/A or Added/Fixed/Improved ...
