### PR TITLE
editor: Go to file from multibuffer in multibuffer pane, not in the active pane

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24757,6 +24757,7 @@ impl Editor {
         Self::open_buffers_in_workspace(
             workspace.downgrade(),
             new_selections_by_buffer,
+            Some(cx.entity().entity_id()),
             split,
             window,
             cx,
@@ -24769,6 +24770,7 @@ impl Editor {
             Entity<language::Buffer>,
             (Vec<Range<BufferOffset>>, Option<u32>),
         >,
+        pane_item_id: Option<EntityId>,
         split: bool,
         window: &mut Window,
         cx: &mut App,
@@ -24782,7 +24784,9 @@ impl Editor {
                     let pane = if split {
                         workspace.adjacent_pane(window, cx)
                     } else {
-                        workspace.active_pane().clone()
+                        pane_item_id
+                            .and_then(|id| workspace.pane_for_item_id(id))
+                            .unwrap_or_else(|| workspace.active_pane().clone())
                     };
 
                     for (buffer, (ranges, scroll_offset)) in new_selections_by_buffer {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -67,7 +67,7 @@ use util::{
 };
 use workspace::{
     CloseActiveItem, CloseAllItems, CloseOtherItems, MultiWorkspace, NavigationEntry, OpenOptions,
-    ViewId,
+    SplitDirection, ViewId,
     item::{FollowEvent, FollowableItem, Item, ItemHandle, SaveOptions},
     register_project_item,
 };
@@ -22311,6 +22311,121 @@ async fn test_multibuffer_in_navigation_history(cx: &mut TestAppContext) {
             "Should navigate back from the 3rd buffer to the multi buffer"
         );
         assert_eq!(active_item.buffer_kind(cx), ItemBufferKind::Multibuffer);
+    });
+}
+
+#[gpui::test]
+async fn test_multibuffer_go_to_file_uses_multibuffer_pane(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "left.rs": sample_text(6, 6, 'm'),
+            "main.rs": sample_text(6, 6, 'a'),
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+
+    let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+        workspace.project().update(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        })
+    });
+
+    let left_pane = workspace.update(cx, |workspace, _| workspace.active_pane().clone());
+    workspace
+        .update_in(cx, |workspace, window, cx| {
+            workspace.open_path(
+                (worktree_id, rel_path("left.rs")),
+                Some(left_pane.downgrade()),
+                true,
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    let left_item_id = left_pane.read_with(cx, |pane, _| pane.active_item().unwrap().item_id());
+
+    let right_pane = workspace.update_in(cx, |workspace, window, cx| {
+        workspace.split_pane(left_pane.clone(), SplitDirection::Right, window, cx)
+    });
+
+    let main_buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, rel_path("main.rs")), cx)
+        })
+        .await
+        .unwrap();
+    let multi_buffer = cx.new(|cx| {
+        let mut multi_buffer = MultiBuffer::new(ReadWrite);
+        multi_buffer.set_excerpts_for_path(
+            PathKey::sorted(0),
+            main_buffer,
+            [Point::new(0, 0)..Point::new(2, 0)],
+            0,
+            cx,
+        );
+        multi_buffer
+    });
+    let right_editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            multi_buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    let right_multibuffer_item_id = right_pane.update_in(cx, |pane, window, cx| {
+        pane.add_item(Box::new(right_editor.clone()), true, true, None, window, cx);
+        pane.active_item().unwrap().item_id()
+    });
+
+    left_pane.update_in(cx, |pane, window, cx| {
+        pane.activate_item(0, true, true, window, cx);
+    });
+    cx.run_until_parked();
+
+    workspace.read_with(cx, |workspace, _| {
+        assert_eq!(workspace.active_pane().entity_id(), left_pane.entity_id());
+    });
+
+    right_editor.update_in(cx, |editor, window, cx| {
+        editor.open_excerpts_common(
+            Some(JumpData::MultiBufferRow {
+                row: MultiBufferRow(0),
+                line_offset_from_top: 0,
+            }),
+            false,
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    left_pane.read_with(cx, |pane, _cx| {
+        assert_eq!(
+            pane.active_item().unwrap().item_id(),
+            left_item_id,
+            "navigating to a file from the right pane should not replace the left pane item",
+        );
+    });
+    right_pane.read_with(cx, |pane, _cx| {
+        assert_ne!(
+            pane.active_item().unwrap().item_id(),
+            right_multibuffer_item_id,
+            "navigating to a file should replace the multibuffer with the opened excerpt",
+        );
     });
 }
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -599,7 +599,7 @@ impl SplittableEditor {
                             let workspace = this.workspace.clone();
                             let split = *split;
                             Editor::open_buffers_in_workspace(
-                                workspace, translated, split, window, cx,
+                                workspace, translated, None, split, window, cx,
                             );
                         }
                     }


### PR DESCRIPTION
Fixes a bug that caused multibuffer go-to-file actions (clicking a file name in an excerpt header, (double) clicking a line number) to open the file in the active pane, not necessarily in the multibuffer pane itself. The after behavior is more consistent with e.g. cmd-click to Go to Definition in a pane that isn't the active one.

Before:

https://github.com/user-attachments/assets/0f9a0166-b318-4bdd-9b30-0f77fb150172

After:

https://github.com/user-attachments/assets/edf9c80e-c668-4afe-a343-80a6d2d03552

I went with the minimal change, but it might make sense to merge the `pane_item_id: Option<EntityId>` and `split: bool` parameters, since the former is only relevant when `split` is `false`.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a bug that caused multibuffer go-to-file actions to open the file in the active pane, not necessarily in the multibuffer pane itself
