### PR TITLE
cloud_api_types: Add `is_personal` field to `Organization`

### DIFF
--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -47,6 +47,7 @@ pub struct OrganizationId(pub Arc<str>);
 pub struct Organization {
     pub id: OrganizationId,
     pub name: Arc<str>,
+    pub is_personal: bool,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR adds an `is_personal` field to the `Organization` DTO returned from Cloud.

We're already returning this field in production.

Part of CLO-569.

Release Notes:

- N/A
