### PR TITLE
Prevent subagents from consuming additional premium requests with Github Copilot subscription

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1885,7 +1885,17 @@ impl Thread {
         cx: &mut AsyncApp,
     ) -> Result<()> {
         let mut attempt = 0;
-        let mut intent = CompletionIntent::UserPrompt;
+        // Subagent turns are agent-initiated: using SubagentPrompt causes the Copilot Chat
+        // provider to send `X-Initiator: agent`, so these requests do not consume the
+        // user's premium request quota
+        let initial_intent = this.read_with(cx, |this, _| {
+            if this.is_subagent() {
+                CompletionIntent::SubagentPrompt
+            } else {
+                CompletionIntent::UserPrompt
+            }
+        })?;
+        let mut intent = initial_intent;
         loop {
             // Re-read the model and refresh tools on each iteration so that
             // mid-turn changes (e.g. the user switches model, toggles tools,
@@ -2066,7 +2076,7 @@ impl Thread {
                 this.update(cx, |this, _cx| {
                     if let Some(Message::Agent(message)) = this.messages.last() {
                         if message.tool_results.is_empty() {
-                            intent = CompletionIntent::UserPrompt;
+                            intent = initial_intent;
                             this.messages.push(Message::Resume);
                         }
                     }

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -197,6 +197,7 @@ pub enum EditPredictionRejectReason {
 #[serde(rename_all = "snake_case")]
 pub enum CompletionIntent {
     UserPrompt,
+    SubagentPrompt,
     ToolResults,
     ThreadSummarization,
     ThreadContextSummarization,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -357,7 +357,11 @@ impl LanguageModel for CopilotChatLanguageModel {
             | CompletionIntent::TerminalInlineAssist
             | CompletionIntent::GenerateGitCommitMessage => true,
 
-            CompletionIntent::ToolResults
+            // Subagent requests are agent-initiated: Copilot will send
+            // `X-Initiator: agent` so they do not consume the user's
+            // premium request quota.
+            CompletionIntent::SubagentPrompt
+            | CompletionIntent::ToolResults
             | CompletionIntent::ThreadSummarization
             | CompletionIntent::CreateFile
             | CompletionIntent::EditFile => false,
@@ -1072,6 +1076,7 @@ fn compute_thinking_budget(
 fn intent_to_chat_location(intent: Option<CompletionIntent>) -> ChatLocation {
     match intent {
         Some(CompletionIntent::UserPrompt) => ChatLocation::Agent,
+        Some(CompletionIntent::SubagentPrompt) => ChatLocation::Agent,
         Some(CompletionIntent::ToolResults) => ChatLocation::Agent,
         Some(CompletionIntent::ThreadSummarization) => ChatLocation::Panel,
         Some(CompletionIntent::ThreadContextSummarization) => ChatLocation::Panel,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -350,22 +350,7 @@ impl LanguageModel for CopilotChatLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        let is_user_initiated = request.intent.is_none_or(|intent| match intent {
-            CompletionIntent::UserPrompt
-            | CompletionIntent::ThreadContextSummarization
-            | CompletionIntent::InlineAssist
-            | CompletionIntent::TerminalInlineAssist
-            | CompletionIntent::GenerateGitCommitMessage => true,
-
-            // Subagent requests are agent-initiated: Copilot will send
-            // `X-Initiator: agent` so they do not consume the user's
-            // premium request quota.
-            CompletionIntent::SubagentPrompt
-            | CompletionIntent::ToolResults
-            | CompletionIntent::ThreadSummarization
-            | CompletionIntent::CreateFile
-            | CompletionIntent::EditFile => false,
-        });
+        let is_user_initiated = is_user_initiated_intent(request.intent);
 
         if self.model.supports_messages() {
             let location = intent_to_chat_location(request.intent);
@@ -1073,6 +1058,29 @@ fn compute_thinking_budget(
     )
 }
 
+/// Returns `true` when the request should be billed against the user's premium
+/// quota.  Agent-initiated intents (e.g. subagent turns, tool results) return
+/// `false`, causing Copilot to send `X-Initiator: agent` and skip quota
+/// consumption.
+fn is_user_initiated_intent(intent: Option<CompletionIntent>) -> bool {
+    intent.is_none_or(|intent| match intent {
+        CompletionIntent::UserPrompt
+        | CompletionIntent::ThreadContextSummarization
+        | CompletionIntent::InlineAssist
+        | CompletionIntent::TerminalInlineAssist
+        | CompletionIntent::GenerateGitCommitMessage => true,
+
+        // Subagent requests are agent-initiated: Copilot will send
+        // `X-Initiator: agent` so they do not consume the user's
+        // premium request quota.
+        CompletionIntent::SubagentPrompt
+        | CompletionIntent::ToolResults
+        | CompletionIntent::ThreadSummarization
+        | CompletionIntent::CreateFile
+        | CompletionIntent::EditFile => false,
+    })
+}
+
 fn intent_to_chat_location(intent: Option<CompletionIntent>) -> ChatLocation {
     match intent {
         Some(CompletionIntent::UserPrompt) => ChatLocation::Agent,
@@ -1653,6 +1661,44 @@ mod tests {
             reasoning_text_value,
             Some("Let me check the directory".to_string()),
             "Should capture reasoning_text"
+        );
+    }
+
+    #[test]
+    fn test_subagent_prompt_chat_location() {
+        // SubagentPrompt must map to the Agent chat location, just like
+        // UserPrompt and ToolResults, so the request is routed correctly.
+        assert_eq!(
+            intent_to_chat_location(Some(CompletionIntent::SubagentPrompt)),
+            ChatLocation::Agent,
+        );
+    }
+
+    #[test]
+    fn test_subagent_prompt_is_not_user_initiated() {
+        // SubagentPrompt must NOT be user-initiated so that Copilot sends
+        // `X-Initiator: agent` and does not consume the user's premium quota.
+        assert!(
+            !is_user_initiated_intent(Some(CompletionIntent::SubagentPrompt)),
+            "SubagentPrompt should not be user-initiated"
+        );
+
+        // Sanity-check the positive case: UserPrompt IS user-initiated.
+        assert!(
+            is_user_initiated_intent(Some(CompletionIntent::UserPrompt)),
+            "UserPrompt should be user-initiated"
+        );
+
+        // ToolResults are also agent-initiated and must not consume quota.
+        assert!(
+            !is_user_initiated_intent(Some(CompletionIntent::ToolResults)),
+            "ToolResults should not be user-initiated"
+        );
+
+        // A request with no intent defaults to user-initiated.
+        assert!(
+            is_user_initiated_intent(None),
+            "None intent should default to user-initiated"
         );
     }
 }


### PR DESCRIPTION
This pull request introduces a new `SubagentPrompt` intent to distinguish between user-initiated and agent-initiated requests, ensuring that subagent turns do not consume the user's premium quota. 

**Intent handling improvements:**

* Added `SubagentPrompt` to the `CompletionIntent` enum to represent agent-initiated subagent turns, ensuring these requests are not billed against the user's quota.
* Updated the `Thread` logic to set the intent to `SubagentPrompt` for subagent turns, so that Copilot Chat recognizes these as agent-initiated. 

**Copilot Chat provider logic:**

* Refactored user-initiated intent detection into a new `is_user_initiated_intent` function, which now treats `SubagentPrompt` as agent-initiated (not user-initiated), ensuring correct quota handling and header setting (`X-Initiator: agent`). 
* Ensured `SubagentPrompt` maps to the correct chat location (`ChatLocation::Agent`) for proper request routing.

**Testing:**

* Added tests to verify that `SubagentPrompt` is agent-initiated, does not consume user quota, and maps to the correct chat location.