### PR TITLE
title_bar: Display the org name in the user avatar trigger when not the personal

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1152,6 +1152,7 @@ impl TitleBar {
         let has_organization = user_store_read.current_organization().is_some();
 
         let current_organization = user_store_read.current_organization();
+        let is_business_org = current_organization.as_ref().filter(|org| !org.is_personal);
         let organizations: Vec<_> = user_store_read
             .organizations()
             .iter()
@@ -1178,7 +1179,14 @@ impl TitleBar {
                 }
             });
 
-            ButtonLike::new("user-menu").children(avatar)
+            ButtonLike::new("user-menu").child(
+                h_flex()
+                    .when_some(is_business_org, |this, org| {
+                        this.gap_2()
+                            .child(Label::new(&org.name).size(LabelSize::Small))
+                    })
+                    .children(avatar),
+            )
         } else {
             ButtonLike::new("user-menu")
                 .child(Icon::new(IconName::ChevronDown).size(IconSize::Small))

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1152,7 +1152,9 @@ impl TitleBar {
         let has_organization = user_store_read.current_organization().is_some();
 
         let current_organization = user_store_read.current_organization();
-        let is_business_org = current_organization.as_ref().filter(|org| !org.is_personal);
+        let business_organization = current_organization
+            .as_ref()
+            .filter(|organization| !organization.is_personal);
         let organizations: Vec<_> = user_store_read
             .organizations()
             .iter()
@@ -1181,9 +1183,9 @@ impl TitleBar {
 
             ButtonLike::new("user-menu").child(
                 h_flex()
-                    .when_some(is_business_org, |this, org| {
+                    .when_some(business_organization, |this, organization| {
                         this.gap_2()
-                            .child(Label::new(&org.name).size(LabelSize::Small))
+                            .child(Label::new(&organization.name).size(LabelSize::Small))
                     })
                     .children(avatar),
             )


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/52343

We'll be experimenting showing the org name in the avatar trigger button when that's not the personal one.

Release Notes:

- N/A
