### PR TITLE
terminal_view: Ensure terminal toggle shortcut appears in tooltip

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1646,7 +1646,7 @@ impl Panel for TerminalPanel {
     }
 
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
-        Box::new(ToggleFocus)
+        Box::new(Toggle)
     }
 
     fn pane(&self) -> Option<Entity<Pane>> {


### PR DESCRIPTION
Follow-up to the discussion in #51670.

@ConradIrwin, thanks for the review!

You're right about the other editors. VS Code and JetBrains use dedicated shortcuts for bottom panel tabs, which exactly mirrors how `ctrl-`` already behaves in Zed, so we don't need a new keybinding.

The reason I originally proposed `cmd-shift-j` was just to match the UI pattern of the Debugger, which clearly shows `cmd-shift-d` on hover. Because of a minor UI discoverability bug, the Terminal button's tooltip was completely blank, which made it look like it just lacked a shortcut entirely.

It turns out the Terminal button's internal `toggle_action()` method was just telling the UI to look up `ToggleFocus` instead of `terminal_panel::Toggle` (which is what `ctrl-`` is actually bound to).

I've updated this branch with a simple one-word fix that just points the `toggle_action` to the correct keymap. The existing `ctrl-`` shortcut now shows up perfectly in the hover tooltip. Good catch on the existing shortcuts, keeps this much cleaner.


Release Notes:

- Fixed the tooltip on the terminal dock icon