### PR TITLE
theme_selector: Fix theme preview not updating on filter changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17585,12 +17585,15 @@ dependencies = [
 name = "theme_selector"
 version = "0.1.0"
 dependencies = [
+ "editor",
  "fs",
  "fuzzy",
  "gpui",
  "log",
  "picker",
+ "project",
  "serde",
+ "serde_json",
  "settings",
  "telemetry",
  "theme",

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -124,6 +124,12 @@ impl ThemeRegistry {
         }
     }
 
+    /// Registers theme families for use in tests.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn register_test_themes(&self, families: impl IntoIterator<Item = ThemeFamily>) {
+        self.insert_theme_families(families);
+    }
+
     fn insert_themes(&self, themes: impl IntoIterator<Item = Theme>) {
         let mut state = self.state.write();
         for theme in themes.into_iter() {

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -124,7 +124,7 @@ impl ThemeRegistry {
         }
     }
 
-    /// Registers theme families for use in tests.
+    /// Inserts theme families directly, bypassing extension loading.
     #[cfg(any(test, feature = "test-support"))]
     pub fn register_test_themes(&self, families: impl IntoIterator<Item = ThemeFamily>) {
         self.insert_theme_families(families);

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -28,3 +28,6 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [dev-dependencies]
+editor = { workspace = true, features = ["test-support"] }
+project.workspace = true
+serde_json.workspace = true

--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -162,6 +162,10 @@ impl PickerDelegate for IconThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
+        // Ensure the previewed theme matches the currently highlighted item,
+        // since filtering without navigation may leave the global settings stale.
+        self.selected_theme = self.show_selected_theme(cx);
+
         let theme_settings = ThemeSettings::get_global(cx);
         let theme_name = theme_settings
             .icon_theme
@@ -252,12 +256,7 @@ impl PickerDelegate for IconThemeSelectorDelegate {
 
             this.update(cx, |this, cx| {
                 this.delegate.matches = matches;
-                if query.is_empty() && this.delegate.selected_theme.is_none() {
-                    this.delegate.selected_index = this
-                        .delegate
-                        .selected_index
-                        .min(this.delegate.matches.len().saturating_sub(1));
-                } else if let Some(selected) = this.delegate.selected_theme.as_ref() {
+                if let Some(selected) = this.delegate.selected_theme.as_ref() {
                     this.delegate.selected_index = this
                         .delegate
                         .matches
@@ -265,11 +264,16 @@ impl PickerDelegate for IconThemeSelectorDelegate {
                         .enumerate()
                         .find(|(_, mtch)| mtch.string.as_str() == selected.0.as_ref())
                         .map(|(ix, _)| ix)
-                        .unwrap_or_default();
+                        .unwrap_or(0);
                 } else {
-                    this.delegate.selected_index = 0;
+                    this.delegate.selected_index = this
+                        .delegate
+                        .selected_index
+                        .min(this.delegate.matches.len().saturating_sub(1));
                 }
-                this.delegate.selected_theme = this.delegate.show_selected_theme(cx);
+                if let Some(theme) = this.delegate.show_selected_theme(cx) {
+                    this.delegate.selected_theme = Some(theme);
+                }
             })
             .log_err();
         })

--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -162,8 +162,7 @@ impl PickerDelegate for IconThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
-        // Ensure the previewed theme matches the currently highlighted item,
-        // since filtering without navigation may leave the global settings stale.
+        // Sync preview with the highlighted item before confirming.
         self.selected_theme = self.show_selected_theme(cx);
 
         let theme_settings = ThemeSettings::get_global(cx);
@@ -264,13 +263,15 @@ impl PickerDelegate for IconThemeSelectorDelegate {
                         .enumerate()
                         .find(|(_, mtch)| mtch.string.as_str() == selected.0.as_ref())
                         .map(|(ix, _)| ix)
-                        .unwrap_or(0);
+                        .unwrap_or_default();
                 } else {
                     this.delegate.selected_index = this
                         .delegate
                         .selected_index
                         .min(this.delegate.matches.len().saturating_sub(1));
                 }
+                // Keep stale selected_theme on empty matches so it can be
+                // re-resolved when the filter widens again.
                 if let Some(theme) = this.delegate.show_selected_theme(cx) {
                     this.delegate.selected_theme = Some(theme);
                 }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -353,9 +353,13 @@ impl PickerDelegate for ThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
-        // Ensure the previewed theme matches the currently highlighted item,
-        // since filtering without navigation may leave `new_theme` stale.
-        self.selected_theme = self.show_selected_theme(cx);
+        // Sync preview with the highlighted item; bail if no matches.
+        if self.show_selected_theme(cx).is_none() {
+            self.selector
+                .update(cx, |_, cx| cx.emit(DismissEvent))
+                .ok();
+            return;
+        }
 
         let theme_name: Arc<str> = self.new_theme.name.as_str().into();
         let theme_appearance = self.new_theme.appearance;
@@ -450,13 +454,15 @@ impl PickerDelegate for ThemeSelectorDelegate {
                         .enumerate()
                         .find(|(_, mtch)| mtch.string == selected.name)
                         .map(|(ix, _)| ix)
-                        .unwrap_or(0);
+                        .unwrap_or_default();
                 } else {
                     this.delegate.selected_index = this
                         .delegate
                         .selected_index
                         .min(this.delegate.matches.len().saturating_sub(1));
                 }
+                // Keep stale selected_theme on empty matches so it can be
+                // re-resolved when the filter widens again.
                 if let Some(theme) = this.delegate.show_selected_theme(cx) {
                     this.delegate.selected_theme = Some(theme);
                 }
@@ -577,6 +583,17 @@ mod tests {
         });
     }
 
+    async fn setup_test(cx: &mut TestAppContext) -> Arc<workspace::AppState> {
+        let app_state = init_test(cx);
+        register_test_themes(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/test"), json!({}))
+            .await;
+        app_state
+    }
+
     fn open_theme_selector(
         workspace: &Entity<workspace::Workspace>,
         cx: &mut VisualTestContext,
@@ -621,20 +638,12 @@ mod tests {
     async fn test_theme_selector_preserves_selection_on_empty_filter(
         cx: &mut TestAppContext,
     ) {
-        let app_state = init_test(cx);
-        register_test_themes(cx);
-        app_state
-            .fs
-            .as_fake()
-            .insert_tree(path!("/test"), json!({}))
-            .await;
-
+        let app_state = setup_test(cx).await;
         let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
         let (multi_workspace, cx) =
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace =
             multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
-
         let picker = open_theme_selector(&workspace, cx);
 
         // Navigate to "Test Light" via arrow keys.
@@ -680,20 +689,12 @@ mod tests {
 
     #[gpui::test]
     async fn test_theme_selector_updates_preview_on_filter(cx: &mut TestAppContext) {
-        let app_state = init_test(cx);
-        register_test_themes(cx);
-        app_state
-            .fs
-            .as_fake()
-            .insert_tree(path!("/test"), json!({}))
-            .await;
-
+        let app_state = setup_test(cx).await;
         let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
         let (multi_workspace, cx) =
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace =
             multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
-
         let picker = open_theme_selector(&workspace, cx);
 
         // Filter to only show "Test Light".
@@ -718,20 +719,12 @@ mod tests {
     async fn test_theme_selector_confirm_after_filter_without_navigation(
         cx: &mut TestAppContext,
     ) {
-        let app_state = init_test(cx);
-        register_test_themes(cx);
-        app_state
-            .fs
-            .as_fake()
-            .insert_tree(path!("/test"), json!({}))
-            .await;
-
+        let app_state = setup_test(cx).await;
         let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
         let (multi_workspace, cx) =
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace =
             multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
-
         let picker = open_theme_selector(&workspace, cx);
 
         // Filter to "Test Light" and confirm without navigating with arrows.

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -353,6 +353,10 @@ impl PickerDelegate for ThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
+        // Ensure the previewed theme matches the currently highlighted item,
+        // since filtering without navigation may leave `new_theme` stale.
+        self.selected_theme = self.show_selected_theme(cx);
+
         let theme_name: Arc<str> = self.new_theme.name.as_str().into();
         let theme_appearance = self.new_theme.appearance;
         let system_appearance = SystemAppearance::global(cx).0;
@@ -438,12 +442,7 @@ impl PickerDelegate for ThemeSelectorDelegate {
 
             this.update(cx, |this, cx| {
                 this.delegate.matches = matches;
-                if query.is_empty() && this.delegate.selected_theme.is_none() {
-                    this.delegate.selected_index = this
-                        .delegate
-                        .selected_index
-                        .min(this.delegate.matches.len().saturating_sub(1));
-                } else if let Some(selected) = this.delegate.selected_theme.as_ref() {
+                if let Some(selected) = this.delegate.selected_theme.as_ref() {
                     this.delegate.selected_index = this
                         .delegate
                         .matches
@@ -451,11 +450,16 @@ impl PickerDelegate for ThemeSelectorDelegate {
                         .enumerate()
                         .find(|(_, mtch)| mtch.string == selected.name)
                         .map(|(ix, _)| ix)
-                        .unwrap_or_default();
+                        .unwrap_or(0);
                 } else {
-                    this.delegate.selected_index = 0;
+                    this.delegate.selected_index = this
+                        .delegate
+                        .selected_index
+                        .min(this.delegate.matches.len().saturating_sub(1));
                 }
-                this.delegate.selected_theme = this.delegate.show_selected_theme(cx);
+                if let Some(theme) = this.delegate.show_selected_theme(cx) {
+                    this.delegate.selected_theme = Some(theme);
+                }
             })
             .log_err();
         })

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -527,3 +527,235 @@ impl PickerDelegate for ThemeSelectorDelegate {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{TestAppContext, VisualTestContext};
+    use project::Project;
+    use serde_json::json;
+    use theme::{Appearance, ThemeFamily, ThemeRegistry, default_color_scales};
+    use util::path;
+    use workspace::MultiWorkspace;
+
+    fn init_test(cx: &mut TestAppContext) -> Arc<workspace::AppState> {
+        cx.update(|cx| {
+            let app_state = workspace::AppState::test(cx);
+            settings::init(cx);
+            theme::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+            super::init(cx);
+            app_state
+        })
+    }
+
+    fn register_test_themes(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let registry = ThemeRegistry::global(cx);
+            let base_theme = registry.get("One Dark").unwrap();
+
+            let mut test_light = (*base_theme).clone();
+            test_light.id = "test-light".to_string();
+            test_light.name = "Test Light".into();
+            test_light.appearance = Appearance::Light;
+
+            let mut test_dark_a = (*base_theme).clone();
+            test_dark_a.id = "test-dark-a".to_string();
+            test_dark_a.name = "Test Dark A".into();
+
+            let mut test_dark_b = (*base_theme).clone();
+            test_dark_b.id = "test-dark-b".to_string();
+            test_dark_b.name = "Test Dark B".into();
+
+            registry.register_test_themes([ThemeFamily {
+                id: "test-family".to_string(),
+                name: "Test Family".into(),
+                author: "test".into(),
+                themes: vec![test_light, test_dark_a, test_dark_b],
+                scales: default_color_scales(),
+            }]);
+        });
+    }
+
+    fn open_theme_selector(
+        workspace: &Entity<workspace::Workspace>,
+        cx: &mut VisualTestContext,
+    ) -> Entity<Picker<ThemeSelectorDelegate>> {
+        cx.dispatch_action(zed_actions::theme_selector::Toggle {
+            themes_filter: None,
+        });
+        cx.run_until_parked();
+        workspace.update(cx, |workspace, cx| {
+            workspace
+                .active_modal::<ThemeSelector>(cx)
+                .expect("theme selector should be open")
+                .read(cx)
+                .picker
+                .clone()
+        })
+    }
+
+    fn selected_theme_name(
+        picker: &Entity<Picker<ThemeSelectorDelegate>>,
+        cx: &mut VisualTestContext,
+    ) -> String {
+        picker.read_with(cx, |picker, _| {
+            picker
+                .delegate
+                .matches
+                .get(picker.delegate.selected_index)
+                .expect("selected index should point to a match")
+                .string
+                .clone()
+        })
+    }
+
+    fn previewed_theme_name(
+        picker: &Entity<Picker<ThemeSelectorDelegate>>,
+        cx: &mut VisualTestContext,
+    ) -> String {
+        picker.read_with(cx, |picker, _| picker.delegate.new_theme.name.to_string())
+    }
+
+    #[gpui::test]
+    async fn test_theme_selector_preserves_selection_on_empty_filter(
+        cx: &mut TestAppContext,
+    ) {
+        let app_state = init_test(cx);
+        register_test_themes(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/test"), json!({}))
+            .await;
+
+        let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        let picker = open_theme_selector(&workspace, cx);
+
+        // Navigate to "Test Light" via arrow keys.
+        let target_index = picker.read_with(cx, |picker, _| {
+            picker
+                .delegate
+                .matches
+                .iter()
+                .position(|m| m.string == "Test Light")
+                .unwrap()
+        });
+        picker.update_in(cx, |picker, window, cx| {
+            picker.set_selected_index(target_index, None, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(previewed_theme_name(&picker, cx), "Test Light");
+
+        // Filter with a query that produces no matches (e.g., "zzz").
+        picker.update_in(cx, |picker, window, cx| {
+            picker.update_matches("zzz".to_string(), window, cx);
+        });
+        cx.run_until_parked();
+
+        // Clear the filter.
+        picker.update_in(cx, |picker, window, cx| {
+            picker.update_matches("".to_string(), window, cx);
+        });
+        cx.run_until_parked();
+
+        // The selection should still point to "Test Light", not reset to index 0.
+        assert_eq!(
+            selected_theme_name(&picker, cx),
+            "Test Light",
+            "selected theme should be preserved after clearing an empty filter"
+        );
+        assert_eq!(
+            previewed_theme_name(&picker, cx),
+            "Test Light",
+            "previewed theme should be preserved after clearing an empty filter"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_theme_selector_updates_preview_on_filter(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        register_test_themes(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/test"), json!({}))
+            .await;
+
+        let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        let picker = open_theme_selector(&workspace, cx);
+
+        // Filter to only show "Test Light".
+        picker.update_in(cx, |picker, window, cx| {
+            picker.update_matches("Test Light".to_string(), window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            selected_theme_name(&picker, cx),
+            "Test Light",
+            "filtering to a specific theme should select it"
+        );
+        assert_eq!(
+            previewed_theme_name(&picker, cx),
+            "Test Light",
+            "filtering to a specific theme should preview it"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_theme_selector_confirm_after_filter_without_navigation(
+        cx: &mut TestAppContext,
+    ) {
+        let app_state = init_test(cx);
+        register_test_themes(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/test"), json!({}))
+            .await;
+
+        let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        let picker = open_theme_selector(&workspace, cx);
+
+        // Filter to "Test Light" and confirm without navigating with arrows.
+        picker.update_in(cx, |picker, window, cx| {
+            picker.update_matches("Test Light".to_string(), window, cx);
+        });
+        cx.run_until_parked();
+
+        picker.update_in(cx, |picker, window, cx| {
+            picker.delegate.confirm(false, window, cx);
+        });
+        cx.run_until_parked();
+
+        // The confirmed theme should be "Test Light".
+        picker.read_with(cx, |picker, _| {
+            assert_eq!(
+                picker.delegate.new_theme.name.as_ref(),
+                "Test Light",
+                "confirming after filter should apply the highlighted theme"
+            );
+            assert!(
+                picker.delegate.selection_completed,
+                "selection should be marked as completed"
+            );
+        });
+    }
+}


### PR DESCRIPTION
Fixes #52118

When a user filters themes in the theme selector and then confirms or clears the filter, the preview could show the wrong theme. Two issues were at play:

1. Confirming a selection after filtering (without navigating with arrow keys) could persist a stale theme because `show_selected_theme` was never called in `confirm`.
2. When a filter query matched no results (e.g., "Ayu 1"), `selected_theme` was overwritten with `None`. Clearing the filter then lost track of the previously selected theme and defaulted to index 0 (typically the first dark theme).

Both issues are fixed in `ThemeSelectorDelegate` and `IconThemeSelectorDelegate`.

## How to Review

Small PR — two files with symmetrical changes. Focus on the `update_matches` and `confirm` methods in:

- `crates/theme_selector/src/theme_selector.rs`
- `crates/theme_selector/src/icon_theme_selector.rs`

Key change: `selected_theme` is now only updated when `show_selected_theme` returns `Some`, preserving the previous selection when the filter yields no results.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Before:


https://github.com/user-attachments/assets/55da1c74-e2a9-4f64-9d35-3b46b3f973f0


## After:



https://github.com/user-attachments/assets/cf39933c-f119-4d9a-817d-d1af559666da


Release Notes:

- Fixed theme selector preview not updating correctly when filtering themes without navigating with arrow keys.