### PR TITLE
Simplify sidebar internals

### DIFF
--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -228,6 +228,12 @@ impl SidebarThreadMetadataStore {
         self.threads.iter().map(|thread| thread.session_id.clone())
     }
 
+    pub fn has_entries_for_path(&self, path_list: &PathList) -> bool {
+        self.threads_by_paths
+            .get(path_list)
+            .is_some_and(|entries| !entries.is_empty())
+    }
+
     pub fn entries_for_path(
         &self,
         path_list: &PathList,
@@ -408,12 +414,13 @@ impl ThreadMetadataDb {
             .map(|counts| counts.into_iter().next().unwrap_or_default() == 0)
     }
 
-    /// List all sidebar thread metadata, ordered by updated_at descending.
+    /// Returns all thread metadata, sorted by most recently created first.
+    /// When `created_at` is NULL, falls back to `updated_at`.
     pub fn list(&self) -> anyhow::Result<Vec<ThreadMetadata>> {
         self.select::<ThreadMetadata>(
             "SELECT session_id, agent_id, title, updated_at, created_at, folder_paths, folder_paths_order \
              FROM sidebar_threads \
-             ORDER BY updated_at DESC"
+             ORDER BY COALESCE(created_at, updated_at) DESC"
         )?()
     }
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -654,12 +654,9 @@ impl Sidebar {
 
         let query = self.filter_editor.read(cx).text(cx);
 
-        // Derive active_entry from the active workspace's agent panel.
-        // Thread when the panel has a non-draft thread, Draft when the
-        // workspace has no active thread (or no panel at all).
-        // Only overwrite with Thread on a positive signal — if the panel
-        // transiently returns None while loading, keep the previous value
-        // so eager writes from user actions survive.
+        // Update active_entry to reflect the focused thread in the
+        // agent panel. If the panel has no focused thread, leave
+        // active_entry alone to preserve optimistic UI set by user actions.
         let panel_focused = active_workspace
             .as_ref()
             .and_then(|ws| ws.read(cx).panel::<AgentPanel>(cx))
@@ -2443,7 +2440,7 @@ impl Sidebar {
 
         // Delete from the store and clean up empty worktree workspaces.
         let delete_task = SidebarThreadMetadataStore::global(cx)
-            .update(cx, |store, cx| store.delete(session_id, cx));
+            .update(cx, |store, cx| store.delete(session_id.clone(), cx));
 
         cx.spawn_in(window, async move |this, cx| {
             delete_task.await?;

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -96,7 +96,7 @@ impl From<&ActiveThreadInfo> for acp_thread::AgentSessionInfo {
 enum ThreadEntryWorkspace {
     Main(Entity<Workspace>),
     LinkedOpen {
-        worktree: Entity<Workspace>,
+        workspace: Entity<Workspace>,
         parent: Entity<Workspace>,
     },
     LinkedClosed {
@@ -108,8 +108,7 @@ enum ThreadEntryWorkspace {
 impl ThreadEntryWorkspace {
     fn workspace(&self) -> Option<&Entity<Workspace>> {
         match self {
-            Self::Main(ws) => Some(ws),
-            Self::LinkedOpen { worktree, .. } => Some(worktree),
+            Self::Main(workspace) | Self::LinkedOpen { workspace, .. } => Some(workspace),
             Self::LinkedClosed { .. } => None,
         }
     }
@@ -890,7 +889,7 @@ impl Sidebar {
                                         cx,
                                     ));
                                     ThreadEntryWorkspace::LinkedOpen {
-                                        worktree: workspaces[idx].clone(),
+                                        workspace: workspaces[idx].clone(),
                                         parent: workspace.clone(),
                                     }
                                 }
@@ -1965,9 +1964,9 @@ impl Sidebar {
                 let session_info = thread.session_info.clone();
                 let workspace = thread.workspace.clone();
                 match &workspace {
-                    ThreadEntryWorkspace::Main(ws)
-                    | ThreadEntryWorkspace::LinkedOpen { worktree: ws, .. } => {
-                        self.activate_thread(agent, session_info, ws, window, cx);
+                    ThreadEntryWorkspace::Main(workspace)
+                    | ThreadEntryWorkspace::LinkedOpen { workspace, .. } => {
+                        self.activate_thread(agent, session_info, workspace, window, cx);
                     }
                     ThreadEntryWorkspace::LinkedClosed { path_list, .. } => {
                         self.open_workspace_and_activate_thread(
@@ -2599,12 +2598,12 @@ impl Sidebar {
                 cx.listener(move |this, _, window, cx| {
                     this.selection = None;
                     match &thread_workspace {
-                        ThreadEntryWorkspace::Main(ws)
-                        | ThreadEntryWorkspace::LinkedOpen { worktree: ws, .. } => {
+                        ThreadEntryWorkspace::Main(workspace)
+                        | ThreadEntryWorkspace::LinkedOpen { workspace, .. } => {
                             this.activate_thread(
                                 agent.clone(),
                                 session_info.clone(),
-                                ws,
+                                workspace,
                                 window,
                                 cx,
                             );

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -116,6 +116,18 @@ struct ThreadEntry {
     diff_stats: DiffStats,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+enum ActiveEntry {
+    Thread(acp::SessionId),
+    Draft(Entity<Workspace>),
+}
+
+impl ActiveEntry {
+    fn is_draft(&self) -> bool {
+        matches!(self, ActiveEntry::Draft(_))
+    }
+}
+
 #[derive(Clone)]
 enum ListEntry {
     ProjectHeader {
@@ -135,7 +147,6 @@ enum ListEntry {
     NewThread {
         path_list: PathList,
         workspace: Entity<Workspace>,
-        is_active_draft: bool,
     },
 }
 
@@ -237,17 +248,11 @@ pub struct Sidebar {
     filter_editor: Entity<Editor>,
     list_state: ListState,
     contents: SidebarContents,
-    /// The index of the list item that currently has the keyboard focus
-    ///
-    /// Note: This is NOT the same as the active item.
+    /// The index of the list item that currently has the keyboard focus.
     selection: Option<usize>,
-    /// Derived from the active panel's thread in `rebuild_contents`.
-    /// Only updated when the panel returns `Some` — never cleared by
-    /// derivation, since the panel may transiently return `None` while
-    /// loading. User actions may write directly for immediate feedback.
-    focused_thread: Option<acp::SessionId>,
-    agent_panel_visible: bool,
-    active_thread_is_draft: bool,
+    /// Tracks which entry is "active" — the thread or draft the user is
+    /// currently working with.
+    active_entry: Option<ActiveEntry>,
     hovered_thread_index: Option<usize>,
     collapsed_groups: HashSet<PathList>,
     expanded_groups: HashMap<PathList, usize>,
@@ -280,6 +285,7 @@ impl Sidebar {
             window,
             |this, _multi_workspace, event: &MultiWorkspaceEvent, window, cx| match event {
                 MultiWorkspaceEvent::ActiveWorkspaceChanged => {
+                    this.active_entry = None;
                     this.observe_draft_editor(cx);
                     this.update_entries(cx);
                 }
@@ -337,9 +343,7 @@ impl Sidebar {
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
             contents: SidebarContents::default(),
             selection: None,
-            focused_thread: None,
-            agent_panel_visible: false,
-            active_thread_is_draft: false,
+            active_entry: None,
             hovered_thread_index: None,
             collapsed_groups: HashSet::new(),
             expanded_groups: HashMap::new(),
@@ -349,6 +353,12 @@ impl Sidebar {
             _subscriptions: Vec::new(),
             _draft_observation: None,
         }
+    }
+
+    fn is_agent_panel_visible(&self, cx: &App) -> bool {
+        self.multi_workspace.upgrade().map_or(false, |mw| {
+            AgentPanel::is_visible(mw.read(cx).workspace(), cx)
+        })
     }
 
     fn is_active_workspace(&self, workspace: &Entity<Workspace>, cx: &App) -> bool {
@@ -415,9 +425,6 @@ impl Sidebar {
 
         if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
             self.subscribe_to_agent_panel(&agent_panel, window, cx);
-            if self.is_active_workspace(workspace, cx) {
-                self.agent_panel_visible = AgentPanel::is_visible(workspace, cx);
-            }
             self.observe_draft_editor(cx);
         }
     }
@@ -438,7 +445,10 @@ impl Sidebar {
                         .active_conversation_view()
                         .is_some_and(|cv| cv.read(cx).parent_id(cx).is_none());
                     if is_new_draft {
-                        this.focused_thread = None;
+                        if let Some(multi_workspace) = this.multi_workspace.upgrade() {
+                            let workspace = multi_workspace.read(cx).workspace().clone();
+                            this.active_entry = Some(ActiveEntry::Draft(workspace));
+                        }
                     }
                     this.observe_draft_editor(cx);
                     this.update_entries(cx);
@@ -465,14 +475,7 @@ impl Sidebar {
                 let Some(workspace) = workspace.upgrade() else {
                     return;
                 };
-                if !this.is_active_workspace(&workspace, cx) {
-                    return;
-                }
-
-                let is_visible = AgentPanel::is_visible(&workspace, cx);
-
-                if this.agent_panel_visible != is_visible {
-                    this.agent_panel_visible = is_visible;
+                if this.is_active_workspace(&workspace, cx) {
                     cx.notify();
                 }
             })
@@ -614,23 +617,12 @@ impl Sidebar {
 
         let query = self.filter_editor.read(cx).text(cx);
 
-        // Re-derive agent_panel_visible from the active workspace so it stays
-        // correct after workspace switches.
-        self.agent_panel_visible = active_workspace
-            .as_ref()
-            .map_or(false, |ws| AgentPanel::is_visible(ws, cx));
-
-        // Derive active_thread_is_draft BEFORE focused_thread so we can
-        // use it as a guard below.
-        self.active_thread_is_draft = active_workspace
-            .as_ref()
-            .and_then(|ws| ws.read(cx).panel::<AgentPanel>(cx))
-            .map_or(false, |panel| panel.read(cx).active_thread_is_draft(cx));
-
-        // Derive focused_thread from the active workspace's agent panel.
-        // Only update when the panel gives us a positive signal — if the
-        // panel returns None (e.g. still loading after a thread activation),
-        // keep the previous value so eager writes from user actions survive.
+        // Derive active_entry from the active workspace's agent panel.
+        // Thread when the panel has a non-draft thread, Draft when the
+        // workspace has no active thread (or no panel at all).
+        // Only overwrite with Thread on a positive signal — if the panel
+        // transiently returns None while loading, keep the previous value
+        // so eager writes from user actions survive.
         let panel_focused = active_workspace
             .as_ref()
             .and_then(|ws| ws.read(cx).panel::<AgentPanel>(cx))
@@ -640,8 +632,12 @@ impl Sidebar {
                     .active_conversation_view()
                     .and_then(|cv| cv.read(cx).parent_id(cx))
             });
-        if panel_focused.is_some() && !self.active_thread_is_draft {
-            self.focused_thread = panel_focused;
+        if let Some(session_id) = panel_focused {
+            self.active_entry = Some(ActiveEntry::Thread(session_id));
+        } else if self.active_entry.is_none() {
+            if let Some(workspace) = active_workspace.as_ref() {
+                self.active_entry = Some(ActiveEntry::Draft(workspace.clone()));
+            }
         }
 
         let previous = mem::take(&mut self.contents);
@@ -1033,9 +1029,8 @@ impl Sidebar {
                 }
             } else {
                 let thread_count = threads.len();
-                let is_draft_for_workspace = self.agent_panel_visible
-                    && self.active_thread_is_draft
-                    && self.focused_thread.is_none()
+                let is_draft_for_workspace = self.is_agent_panel_visible(cx)
+                    && self.active_entry.as_ref().is_some_and(|e| e.is_draft())
                     && is_active;
 
                 let show_new_thread_entry = thread_count == 0 || is_draft_for_workspace;
@@ -1059,7 +1054,6 @@ impl Sidebar {
                     entries.push(ListEntry::NewThread {
                         path_list: path_list.clone(),
                         workspace: workspace.clone(),
-                        is_active_draft: is_draft_for_workspace,
                     });
                 }
 
@@ -1084,10 +1078,9 @@ impl Sidebar {
                         let is_promoted = thread.status == AgentThreadStatus::Running
                             || thread.status == AgentThreadStatus::WaitingForConfirmation
                             || notified_threads.contains(session_id)
-                            || self
-                                .focused_thread
-                                .as_ref()
-                                .is_some_and(|id| id == session_id);
+                            || self.active_entry.as_ref().is_some_and(|entry| {
+                                entry == &ActiveEntry::Thread(session_id.clone())
+                            });
                         if is_promoted {
                             promoted_threads.insert(session_id.clone());
                         }
@@ -1211,10 +1204,7 @@ impl Sidebar {
             ListEntry::NewThread {
                 path_list,
                 workspace,
-                is_active_draft,
-            } => {
-                self.render_new_thread(ix, path_list, workspace, *is_active_draft, is_selected, cx)
-            }
+            } => self.render_new_thread(ix, path_list, workspace, is_selected, cx),
         };
 
         if is_group_header_after_first {
@@ -1253,13 +1243,6 @@ impl Sidebar {
         } else {
             IconName::ChevronDown
         };
-
-        let has_new_thread_entry = self
-            .contents
-            .entries
-            .get(ix + 1)
-            .is_some_and(|entry| matches!(entry, ListEntry::NewThread { .. }));
-        let show_new_thread_button = !has_new_thread_entry && !self.has_filter_query(cx);
 
         let workspace_for_remove = workspace.clone();
         let workspace_for_menu = workspace.clone();
@@ -1397,7 +1380,7 @@ impl Sidebar {
                             .tooltip(Tooltip::text("Activate Workspace"))
                             .on_click(cx.listener({
                                 move |this, _, window, cx| {
-                                    this.focused_thread = None;
+                                    this.active_entry = None;
                                     if let Some(multi_workspace) = this.multi_workspace.upgrade() {
                                         multi_workspace.update(cx, |multi_workspace, cx| {
                                             multi_workspace
@@ -1413,7 +1396,7 @@ impl Sidebar {
                             })),
                         )
                     })
-                    .when(show_new_thread_button, |this| {
+                    .when(!self.has_filter_query(cx), |this| {
                         this.child(
                             IconButton::new(
                                 SharedString::from(format!(
@@ -2062,10 +2045,10 @@ impl Sidebar {
             return;
         };
 
-        // Set focused_thread eagerly so the sidebar highlight updates
+        // Set active_entry eagerly so the sidebar highlight updates
         // immediately, rather than waiting for a deferred AgentPanel
         // event which can race with ActiveWorkspaceChanged clearing it.
-        self.focused_thread = Some(session_info.session_id.clone());
+        self.active_entry = Some(ActiveEntry::Thread(session_info.session_id.clone()));
 
         multi_workspace.update(cx, |multi_workspace, cx| {
             multi_workspace.activate(workspace.clone(), cx);
@@ -2105,7 +2088,7 @@ impl Sidebar {
                 .and_then(|sidebar| sidebar.downcast::<Self>().ok())
             {
                 target_sidebar.update(cx, |sidebar, cx| {
-                    sidebar.focused_thread = Some(target_session_id);
+                    sidebar.active_entry = Some(ActiveEntry::Thread(target_session_id));
                     sidebar.update_entries(cx);
                 });
             }
@@ -2382,7 +2365,7 @@ impl Sidebar {
         // nearest thread within the same project group. We never cross group
         // boundaries — if the group has no other threads, clear focus and open
         // a blank new thread in the panel instead.
-        if self.focused_thread.as_ref() == Some(session_id) {
+        if self.active_entry.as_ref() == Some(&ActiveEntry::Thread(session_id.clone())) {
             let current_pos = self.contents.entries.iter().position(|entry| {
                 matches!(entry, ListEntry::Thread(t) if &t.session_info.session_id == session_id)
             });
@@ -2436,7 +2419,8 @@ impl Sidebar {
             });
 
             if let Some(next) = next_thread {
-                self.focused_thread = Some(next.session_info.session_id.clone());
+                self.active_entry =
+                    Some(ActiveEntry::Thread(next.session_info.session_id.clone()));
 
                 // Use the thread's own workspace when it has one open (e.g. an absorbed
                 // linked worktree thread that appears under the main workspace's header
@@ -2464,7 +2448,7 @@ impl Sidebar {
                     }
                 }
             } else {
-                self.focused_thread = None;
+                self.active_entry = None;
                 if let Some(workspace) = &group_workspace {
                     if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
                         agent_panel.update(cx, |panel, cx| {
@@ -2519,8 +2503,9 @@ impl Sidebar {
         let thread_workspace = thread.workspace.clone();
 
         let is_hovered = self.hovered_thread_index == Some(ix);
-        let is_selected = self.agent_panel_visible
-            && self.focused_thread.as_ref() == Some(&session_info.session_id);
+        let is_selected = self.is_agent_panel_visible(cx)
+            && self.active_entry.as_ref()
+                == Some(&ActiveEntry::Thread(session_info.session_id.clone()));
         let is_running = matches!(
             thread.status,
             AgentThreadStatus::Running | AgentThreadStatus::WaitingForConfirmation
@@ -2789,11 +2774,11 @@ impl Sidebar {
             return;
         };
 
-        // Clear focused_thread immediately so no existing thread stays
+        // Set active_entry to Draft immediately so no existing thread stays
         // highlighted while the new blank thread is being shown. Without this,
         // if the target workspace is already active (so ActiveWorkspaceChanged
         // never fires), the previous thread's highlight would linger.
-        self.focused_thread = None;
+        self.active_entry = Some(ActiveEntry::Draft(workspace.clone()));
 
         multi_workspace.update(cx, |multi_workspace, cx| {
             multi_workspace.activate(workspace.clone(), cx);
@@ -2814,11 +2799,13 @@ impl Sidebar {
         ix: usize,
         _path_list: &PathList,
         workspace: &Entity<Workspace>,
-        is_active_draft: bool,
         is_selected: bool,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        let is_active = is_active_draft && self.agent_panel_visible && self.active_thread_is_draft;
+        let is_active = self
+            .active_entry
+            .as_ref()
+            .is_some_and(|entry| entry == &ActiveEntry::Draft(workspace.clone()));
 
         let label: SharedString = if is_active {
             self.active_draft_text(cx)
@@ -3613,6 +3600,86 @@ mod tests {
         );
     }
 
+    #[gpui::test]
+    async fn test_activate_empty_workspace_marks_new_thread_active(cx: &mut TestAppContext) {
+        let project_a = init_test_project("/project-a", cx).await;
+        let (multi_workspace, cx) = cx
+            .add_window_view(|window, cx| MultiWorkspace::test_new(project_a.clone(), window, cx));
+        let sidebar = setup_sidebar(&multi_workspace, cx);
+
+        let path_list_a = PathList::new(&[std::path::PathBuf::from("/project-a")]);
+
+        // Workspace A has a thread.
+        save_thread_metadata(
+            acp::SessionId::new(Arc::from("thread-a1")),
+            "Thread A1".into(),
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+            path_list_a.clone(),
+            cx,
+        )
+        .await;
+        cx.run_until_parked();
+
+        // Add workspace B with no threads.
+        let fs = cx.update(|_, cx| <dyn fs::Fs>::global(cx));
+        fs.as_fake()
+            .insert_tree("/project-b", serde_json::json!({ "src": {} }))
+            .await;
+        let project_b = project::Project::test(fs, ["/project-b".as_ref()], cx).await;
+        let _workspace_b = multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project_b.clone(), window, cx)
+        });
+        cx.run_until_parked();
+
+        // After adding workspace B, it becomes active. Its new-thread entry
+        // should be marked active since it has no threads.
+        assert_eq!(
+            visible_entries_as_strings(&sidebar, cx),
+            vec![
+                "v [project-a]",
+                "  Thread A1",
+                "v [project-b]",
+                "  [+ New Thread]",
+            ]
+        );
+
+        // Switch back to workspace A.
+        multi_workspace.update_in(cx, |mw, _window, cx| {
+            let workspace_a = mw.workspaces()[0].clone();
+            mw.activate(workspace_a, cx);
+        });
+        cx.run_until_parked();
+
+        // Workspace A is now active; workspace B's new-thread should no
+        // longer be marked active.
+        assert_eq!(
+            visible_entries_as_strings(&sidebar, cx),
+            vec![
+                "v [project-a]",
+                "  Thread A1",
+                "v [project-b]",
+                "  [+ New Thread]",
+            ]
+        );
+
+        // Switch back to workspace B.
+        multi_workspace.update_in(cx, |mw, _window, cx| {
+            let workspace_b = mw.workspaces()[1].clone();
+            mw.activate(workspace_b, cx);
+        });
+        cx.run_until_parked();
+
+        // Workspace B is active again; its new-thread entry should be active.
+        assert_eq!(
+            visible_entries_as_strings(&sidebar, cx),
+            vec![
+                "v [project-a]",
+                "  Thread A1",
+                "v [project-b]",
+                "  [+ New Thread]",
+            ]
+        );
+    }
     #[gpui::test]
     async fn test_view_more_pagination(cx: &mut TestAppContext) {
         let project = init_test_project("/my-project", cx).await;
@@ -5102,7 +5169,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_focused_thread_tracks_user_intent(cx: &mut TestAppContext) {
+    async fn test_active_entry_tracks_user_intent(cx: &mut TestAppContext) {
         let project_a = init_test_project_with_agent_panel("/project-a", cx).await;
         let (multi_workspace, cx) = cx
             .add_window_view(|window, cx| MultiWorkspace::test_new(project_a.clone(), window, cx));
@@ -5134,12 +5201,11 @@ mod tests {
 
         let workspace_a = multi_workspace.read_with(cx, |mw, _cx| mw.workspaces()[0].clone());
 
-        // ── 1. Initial state: focused thread derived from active panel ─────
+        // ── 1. Initial state: workspace_b is active (no threads) so Draft ────
         sidebar.read_with(cx, |sidebar, _cx| {
-            assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_a),
-                "The active panel's thread should be focused on startup"
+            assert!(
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
+                "Workspace B is active with no threads, so active_entry should be Draft"
             );
         });
 
@@ -5163,8 +5229,8 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_a),
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_a.clone())),
                 "After clicking a thread, it should be the focused thread"
             );
             assert!(
@@ -5218,8 +5284,8 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_b),
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_b.clone())),
                 "Clicking a thread in another workspace should focus that thread"
             );
             assert!(
@@ -5235,9 +5301,9 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_a),
-                "Switching workspace should seed focused_thread from the new active panel"
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_a.clone())),
+                "Switching workspace should seed active_entry from the new active panel"
             );
             assert!(
                 has_thread_entry(sidebar, &session_id_a),
@@ -5256,14 +5322,14 @@ mod tests {
         cx.run_until_parked();
 
         // Panel B is not the active workspace's panel (workspace A is
-        // active), so opening a thread there should not change focused_thread.
+        // active), so opening a thread there should not change active_entry.
         // This prevents running threads in background workspaces from causing
         // the selection highlight to jump around.
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_a),
-                "Opening a thread in a non-active panel should not change focused_thread"
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_a.clone())),
+                "Opening a thread in a non-active panel should not change active_entry"
             );
         });
 
@@ -5274,14 +5340,14 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_a),
-                "Defocusing the sidebar should not change focused_thread"
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_a.clone())),
+                "Defocusing the sidebar should not change active_entry"
             );
         });
 
         // Switching workspaces via the multi_workspace (simulates clicking
-        // a workspace header) should clear focused_thread.
+        // a workspace header) should clear active_entry.
         multi_workspace.update_in(cx, |mw, window, cx| {
             if let Some(index) = mw.workspaces().iter().position(|w| w == &workspace_b) {
                 mw.activate_index(index, window, cx);
@@ -5291,9 +5357,9 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_b2),
-                "Switching workspace should seed focused_thread from the new active panel"
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_b2.clone())),
+                "Switching workspace should seed active_entry from the new active panel"
             );
             assert!(
                 has_thread_entry(sidebar, &session_id_b2),
@@ -5301,10 +5367,10 @@ mod tests {
             );
         });
 
-        // ── 8. Focusing the agent panel thread keeps focused_thread ────
+        // ── 8. Focusing the agent panel thread keeps active_entry ────
         // Workspace B still has session_id_b2 loaded in the agent panel.
         // Clicking into the thread (simulated by focusing its view) should
-        // keep focused_thread since it was already seeded on workspace switch.
+        // keep active_entry since it was already seeded on workspace switch.
         panel_b.update_in(cx, |panel, window, cx| {
             if let Some(thread_view) = panel.active_conversation_view() {
                 thread_view.read(cx).focus_handle(cx).focus(window, cx);
@@ -5314,9 +5380,9 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id_b2),
-                "Focusing the agent panel thread should set focused_thread"
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id_b2.clone())),
+                "Focusing the agent panel thread should set active_entry"
             );
             assert!(
                 has_thread_entry(sidebar, &session_id_b2),
@@ -5356,8 +5422,8 @@ mod tests {
         // because the panel has a thread with messages.
         sidebar.read_with(cx, |sidebar, _cx| {
             assert!(
-                !sidebar.active_thread_is_draft,
-                "Panel has a thread with messages, so it should not be a draft"
+                !sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
+                "Panel has a thread with messages, so active_entry should not be a draft"
             );
         });
 
@@ -5384,13 +5450,13 @@ mod tests {
         );
 
         // The "New Thread" button must still be clickable (not stuck in
-        // "active/draft" state). Verify that `active_thread_is_draft` is
-        // false — the panel still has the old thread with messages.
+        // "active/draft" state). Verify that `active_entry` is not a
+        // draft — the panel still has the old thread with messages.
         sidebar.read_with(cx, |sidebar, _cx| {
             assert!(
-                !sidebar.active_thread_is_draft,
+                !sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
                 "After adding a folder the panel still has a thread with messages, \
-                 so active_thread_is_draft should be false"
+                 so active_entry should not be a draft"
             );
         });
 
@@ -5406,7 +5472,7 @@ mod tests {
         // state (no messages on the new thread).
         sidebar.read_with(cx, |sidebar, _cx| {
             assert!(
-                sidebar.active_thread_is_draft,
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
                 "After creating a new thread the panel should be in draft state"
             );
         });
@@ -5460,11 +5526,11 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert!(
-                sidebar.focused_thread.is_none(),
-                "focused_thread should be cleared after Cmd-N"
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
+                "active_entry should be a Draft after Cmd-N"
             );
             assert!(
-                sidebar.active_thread_is_draft,
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
                 "the new blank thread should be a draft"
             );
         });
@@ -5592,11 +5658,11 @@ mod tests {
 
         sidebar.read_with(cx, |sidebar, _cx| {
             assert!(
-                sidebar.focused_thread.is_none(),
-                "focused_thread should be cleared after Cmd-N"
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
+                "active_entry should be a Draft after Cmd-N"
             );
             assert!(
-                sidebar.active_thread_is_draft,
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
                 "the new blank thread should be a draft"
             );
         });
@@ -6749,9 +6815,9 @@ mod tests {
             "should activate the window that already owns the matching workspace"
         );
         sidebar.read_with(cx_a, |sidebar, _| {
-            assert_eq!(
-                sidebar.focused_thread, None,
-                "source window's sidebar should not eagerly claim focus for a thread opened in another window"
+            assert!(
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
+                "source window's sidebar should show Draft for its own workspace, not claim a thread from another window"
             );
         });
     }
@@ -6825,15 +6891,15 @@ mod tests {
             "should activate the window that already owns the matching workspace"
         );
         sidebar_a.read_with(cx_a, |sidebar, _| {
-            assert_eq!(
-                sidebar.focused_thread, None,
-                "source window's sidebar should not eagerly claim focus for a thread opened in another window"
+            assert!(
+                sidebar.active_entry.as_ref().is_some_and(|e| e.is_draft()),
+                "source window's sidebar should show Draft for its own workspace, not claim a thread from another window"
             );
         });
         sidebar_b.read_with(cx_b, |sidebar, _| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id),
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id.clone())),
                 "target window's sidebar should eagerly focus the activated archived thread"
             );
         });
@@ -6887,8 +6953,8 @@ mod tests {
         );
         sidebar_a.read_with(cx_a, |sidebar, _| {
             assert_eq!(
-                sidebar.focused_thread.as_ref(),
-                Some(&session_id),
+                sidebar.active_entry.as_ref(),
+                Some(&ActiveEntry::Thread(session_id.clone())),
                 "current window's sidebar should eagerly focus the activated archived thread"
             );
         });
@@ -7044,11 +7110,11 @@ mod tests {
 
         // The sidebar should track T2 as the focused thread (derived from the
         // main panel's active view).
-        let focused = sidebar.read_with(cx, |s, _| s.focused_thread.clone());
+        let focused = sidebar.read_with(cx, |s, _| s.active_entry.clone());
         assert_eq!(
             focused,
-            Some(thread2_session_id.clone()),
-            "focused thread should be Thread 2 before archiving: {:?}",
+            Some(ActiveEntry::Thread(thread2_session_id.clone())),
+            "focused entry should be Thread 2 before archiving: {:?}",
             focused
         );
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -94,8 +94,36 @@ impl From<&ActiveThreadInfo> for acp_thread::AgentSessionInfo {
 
 #[derive(Clone)]
 enum ThreadEntryWorkspace {
-    Open(Entity<Workspace>),
-    Closed(PathList),
+    Main(Entity<Workspace>),
+    LinkedOpen {
+        worktree: Entity<Workspace>,
+        parent: Entity<Workspace>,
+    },
+    LinkedClosed {
+        path_list: PathList,
+        parent: Entity<Workspace>,
+    },
+}
+
+impl ThreadEntryWorkspace {
+    fn workspace(&self) -> Option<&Entity<Workspace>> {
+        match self {
+            Self::Main(ws) => Some(ws),
+            Self::LinkedOpen { worktree, .. } => Some(worktree),
+            Self::LinkedClosed { .. } => None,
+        }
+    }
+
+    fn is_open_worktree(&self) -> bool {
+        matches!(self, Self::LinkedOpen { .. })
+    }
+
+    fn parent_workspace(&self) -> &Entity<Workspace> {
+        match self {
+            Self::Main(ws) => ws,
+            Self::LinkedOpen { parent, .. } | Self::LinkedClosed { parent, .. } => parent,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -159,6 +187,7 @@ impl From<ThreadEntry> for ListEntry {
 #[derive(Default)]
 struct SidebarContents {
     entries: Vec<ListEntry>,
+    thread_indices: HashMap<acp::SessionId, usize>,
     notified_threads: HashSet<acp::SessionId>,
     project_header_indices: Vec<usize>,
     has_open_projects: bool,
@@ -167,6 +196,14 @@ struct SidebarContents {
 impl SidebarContents {
     fn is_thread_notified(&self, session_id: &acp::SessionId) -> bool {
         self.notified_threads.contains(session_id)
+    }
+
+    fn thread_entry(&self, session_id: &acp::SessionId) -> Option<(usize, &ThreadEntry)> {
+        let &ix = self.thread_indices.get(session_id)?;
+        match &self.entries[ix] {
+            ListEntry::Thread(t) => Some((ix, t)),
+            _ => None,
+        }
     }
 }
 
@@ -654,8 +691,8 @@ impl Sidebar {
             .collect();
 
         let mut entries = Vec::new();
+        let mut thread_indices: HashMap<acp::SessionId, usize> = HashMap::default();
         let mut notified_threads = previous.notified_threads;
-        let mut current_session_ids: HashSet<acp::SessionId> = HashSet::new();
         let mut project_header_indices: Vec<usize> = Vec::new();
 
         // Identify absorbed workspaces in a single pass. A workspace is
@@ -810,7 +847,7 @@ impl Sidebar {
                         icon,
                         icon_from_external_svg,
                         status: AgentThreadStatus::default(),
-                        workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+                        workspace: ThreadEntryWorkspace::Main(workspace.clone()),
                         is_live: false,
                         is_background: false,
                         is_title_generating: false,
@@ -855,9 +892,15 @@ impl Sidebar {
                                         &workspaces[idx],
                                         cx,
                                     ));
-                                    ThreadEntryWorkspace::Open(workspaces[idx].clone())
+                                    ThreadEntryWorkspace::LinkedOpen {
+                                        worktree: workspaces[idx].clone(),
+                                        parent: workspace.clone(),
+                                    }
                                 }
-                                None => ThreadEntryWorkspace::Closed(worktree_path_list.clone()),
+                                None => ThreadEntryWorkspace::LinkedClosed {
+                                    path_list: worktree_path_list.clone(),
+                                    parent: workspace.clone(),
+                                },
                             };
 
                         let worktree_rows: Vec<_> = thread_store
@@ -943,12 +986,10 @@ impl Sidebar {
                         thread.diff_stats = info.diff_stats;
                     }
 
-                    let is_thread_workspace_active = match &thread.workspace {
-                        ThreadEntryWorkspace::Open(thread_workspace) => active_workspace
-                            .as_ref()
-                            .is_some_and(|active| active == thread_workspace),
-                        ThreadEntryWorkspace::Closed(_) => false,
-                    };
+                    let is_thread_workspace_active = thread
+                        .workspace
+                        .workspace()
+                        .is_some_and(|ws| active_workspace.as_ref() == Some(ws));
 
                     if thread.status == AgentThreadStatus::Completed
                         && !is_thread_workspace_active
@@ -961,12 +1002,6 @@ impl Sidebar {
                         notified_threads.remove(session_id);
                     }
                 }
-
-                threads.sort_by(|a, b| {
-                    let a_time = a.session_info.created_at.or(a.session_info.updated_at);
-                    let b_time = b.session_info.created_at.or(b.session_info.updated_at);
-                    b_time.cmp(&a_time)
-                });
             } else {
                 for info in &live_infos {
                     if info.status == AgentThreadStatus::Running {
@@ -1024,7 +1059,7 @@ impl Sidebar {
                 });
 
                 for thread in matched_threads {
-                    current_session_ids.insert(thread.session_info.session_id.clone());
+                    thread_indices.insert(thread.session_info.session_id.clone(), entries.len());
                     entries.push(thread.into());
                 }
             } else {
@@ -1089,7 +1124,7 @@ impl Sidebar {
                         }
                     }
 
-                    current_session_ids.insert(session_id.clone());
+                    thread_indices.insert(thread.session_info.session_id.clone(), entries.len());
                     entries.push(thread.into());
                 }
 
@@ -1107,10 +1142,11 @@ impl Sidebar {
 
         // Prune stale notifications using the session IDs we collected during
         // the build pass (no extra scan needed).
-        notified_threads.retain(|id| current_session_ids.contains(id));
+        notified_threads.retain(|id| thread_indices.contains_key(id));
 
         self.contents = SidebarContents {
             entries,
+            thread_indices,
             notified_threads,
             project_header_indices,
             has_open_projects,
@@ -1928,21 +1964,17 @@ impl Sidebar {
                 self.toggle_collapse(&path_list, window, cx);
             }
             ListEntry::Thread(thread) => {
+                let agent = thread.agent.clone();
                 let session_info = thread.session_info.clone();
-                match &thread.workspace {
-                    ThreadEntryWorkspace::Open(workspace) => {
-                        let workspace = workspace.clone();
-                        self.activate_thread(
-                            thread.agent.clone(),
-                            session_info,
-                            &workspace,
-                            window,
-                            cx,
-                        );
+                let workspace = thread.workspace.clone();
+                match &workspace {
+                    ThreadEntryWorkspace::Main(ws)
+                    | ThreadEntryWorkspace::LinkedOpen { worktree: ws, .. } => {
+                        self.activate_thread(agent, session_info, ws, window, cx);
                     }
-                    ThreadEntryWorkspace::Closed(path_list) => {
+                    ThreadEntryWorkspace::LinkedClosed { path_list, .. } => {
                         self.open_workspace_and_activate_thread(
-                            thread.agent.clone(),
+                            agent,
                             session_info,
                             path_list.clone(),
                             window,
@@ -2361,78 +2393,29 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // If we're archiving the currently focused thread, move focus to the
-        // nearest thread within the same project group. We never cross group
-        // boundaries — if the group has no other threads, clear focus and open
-        // a blank new thread in the panel instead.
+        let Some((pos, current_thread)) = self.contents.thread_entry(session_id) else {
+            return;
+        };
+        let current_workspace = current_thread.workspace.clone();
+
+        // Move focus to the nearest adjacent thread, or open a new draft.
         if self.active_entry.as_ref() == Some(&ActiveEntry::Thread(session_id.clone())) {
-            let current_pos = self.contents.entries.iter().position(|entry| {
-                matches!(entry, ListEntry::Thread(t) if &t.session_info.session_id == session_id)
+            let below = self.contents.entries.get(pos + 1).and_then(|e| match e {
+                ListEntry::Thread(t) => Some(t),
+                _ => None,
             });
-
-            // Find the workspace that owns this thread's project group by
-            // walking backwards to the nearest ProjectHeader. We must use
-            // *this* workspace (not the active workspace) because the user
-            // might be archiving a thread in a non-active group.
-            let group_workspace = current_pos.and_then(|pos| {
-                self.contents.entries[..pos]
-                    .iter()
-                    .rev()
-                    .find_map(|e| match e {
-                        ListEntry::ProjectHeader { workspace, .. } => Some(workspace.clone()),
-                        _ => None,
-                    })
-            });
-
-            let next_thread = current_pos.and_then(|pos| {
-                let group_start = self.contents.entries[..pos]
-                    .iter()
-                    .rposition(|e| matches!(e, ListEntry::ProjectHeader { .. }))
-                    .map_or(0, |i| i + 1);
-                let group_end = self.contents.entries[pos + 1..]
-                    .iter()
-                    .position(|e| matches!(e, ListEntry::ProjectHeader { .. }))
-                    .map_or(self.contents.entries.len(), |i| pos + 1 + i);
-
-                let above = self.contents.entries[group_start..pos]
-                    .iter()
-                    .rev()
-                    .find_map(|entry| {
-                        if let ListEntry::Thread(t) = entry {
-                            Some(t)
-                        } else {
-                            None
-                        }
-                    });
-
-                above.or_else(|| {
-                    self.contents.entries[pos + 1..group_end]
-                        .iter()
-                        .find_map(|entry| {
-                            if let ListEntry::Thread(t) = entry {
-                                Some(t)
-                            } else {
-                                None
-                            }
-                        })
-                })
-            });
+            let above = pos
+                .checked_sub(1)
+                .and_then(|i| match &self.contents.entries[i] {
+                    ListEntry::Thread(t) => Some(t),
+                    _ => None,
+                });
+            let next_thread = below.or(above);
 
             if let Some(next) = next_thread {
-                self.active_entry =
-                    Some(ActiveEntry::Thread(next.session_info.session_id.clone()));
+                self.active_entry = Some(ActiveEntry::Thread(next.session_info.session_id.clone()));
 
-                // Use the thread's own workspace when it has one open (e.g. an absorbed
-                // linked worktree thread that appears under the main workspace's header
-                // but belongs to its own workspace). Loading into the wrong panel binds
-                // the thread to the wrong project, which corrupts its stored folder_paths
-                // when metadata is saved via ThreadMetadata::from_thread.
-                let target_workspace = match &next.workspace {
-                    ThreadEntryWorkspace::Open(ws) => Some(ws.clone()),
-                    ThreadEntryWorkspace::Closed(_) => group_workspace,
-                };
-
-                if let Some(workspace) = target_workspace {
+                if let Some(workspace) = next.workspace.workspace() {
                     if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
                         agent_panel.update(cx, |panel, cx| {
                             panel.load_agent_thread(
@@ -2449,19 +2432,37 @@ impl Sidebar {
                 }
             } else {
                 self.active_entry = None;
-                if let Some(workspace) = &group_workspace {
-                    if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
-                        agent_panel.update(cx, |panel, cx| {
-                            panel.new_thread(&NewThread, window, cx);
-                        });
-                    }
+                let parent = current_workspace.parent_workspace();
+                if let Some(agent_panel) = parent.read(cx).panel::<AgentPanel>(cx) {
+                    agent_panel.update(cx, |panel, cx| {
+                        panel.new_thread(&NewThread, window, cx);
+                    });
                 }
             }
         }
 
-        SidebarThreadMetadataStore::global(cx)
-            .update(cx, |store, cx| store.delete(session_id.clone(), cx))
-            .detach_and_log_err(cx);
+        // Delete from the store and clean up empty worktree workspaces.
+        let delete_task = SidebarThreadMetadataStore::global(cx)
+            .update(cx, |store, cx| store.delete(session_id, cx));
+
+        cx.spawn_in(window, async move |this, cx| {
+            delete_task.await?;
+            if current_workspace.is_open_worktree() {
+                if let Some(ws) = current_workspace.workspace() {
+                    this.update_in(cx, |sidebar, window, cx| {
+                        let path_list = workspace_path_list(ws, cx);
+                        let has_remaining = SidebarThreadMetadataStore::global(cx)
+                            .read(cx)
+                            .has_entries_for_path(&path_list);
+                        if !has_remaining {
+                            sidebar.remove_workspace(ws, window, cx);
+                        }
+                    })?;
+                }
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
     }
 
     fn remove_selected_thread(
@@ -2601,16 +2602,17 @@ impl Sidebar {
                 cx.listener(move |this, _, window, cx| {
                     this.selection = None;
                     match &thread_workspace {
-                        ThreadEntryWorkspace::Open(workspace) => {
+                        ThreadEntryWorkspace::Main(ws)
+                        | ThreadEntryWorkspace::LinkedOpen { worktree: ws, .. } => {
                             this.activate_thread(
                                 agent.clone(),
                                 session_info.clone(),
-                                workspace,
+                                ws,
                                 window,
                                 cx,
                             );
                         }
-                        ThreadEntryWorkspace::Closed(path_list) => {
+                        ThreadEntryWorkspace::LinkedClosed { path_list, .. } => {
                             this.open_workspace_and_activate_thread(
                                 agent.clone(),
                                 session_info.clone(),
@@ -3860,7 +3862,7 @@ mod tests {
                     icon: IconName::ZedAgent,
                     icon_from_external_svg: None,
                     status: AgentThreadStatus::Completed,
-                    workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+                    workspace: ThreadEntryWorkspace::Main(workspace.clone()),
                     is_live: false,
                     is_background: false,
                     is_title_generating: false,
@@ -3884,7 +3886,7 @@ mod tests {
                     icon: IconName::ZedAgent,
                     icon_from_external_svg: None,
                     status: AgentThreadStatus::Running,
-                    workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+                    workspace: ThreadEntryWorkspace::Main(workspace.clone()),
                     is_live: true,
                     is_background: false,
                     is_title_generating: false,
@@ -3908,7 +3910,7 @@ mod tests {
                     icon: IconName::ZedAgent,
                     icon_from_external_svg: None,
                     status: AgentThreadStatus::Error,
-                    workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+                    workspace: ThreadEntryWorkspace::Main(workspace.clone()),
                     is_live: true,
                     is_background: false,
                     is_title_generating: false,
@@ -3932,7 +3934,7 @@ mod tests {
                     icon: IconName::ZedAgent,
                     icon_from_external_svg: None,
                     status: AgentThreadStatus::WaitingForConfirmation,
-                    workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+                    workspace: ThreadEntryWorkspace::Main(workspace.clone()),
                     is_live: false,
                     is_background: false,
                     is_title_generating: false,
@@ -3956,7 +3958,7 @@ mod tests {
                     icon: IconName::ZedAgent,
                     icon_from_external_svg: None,
                     status: AgentThreadStatus::Completed,
-                    workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+                    workspace: ThreadEntryWorkspace::Main(workspace.clone()),
                     is_live: true,
                     is_background: true,
                     is_title_generating: false,
@@ -7146,6 +7148,113 @@ mod tests {
             entries_after.iter().any(|s| s.contains("{wt-feature-a}")),
             "T1 should still carry its linked-worktree chip after archiving T2: {:?}",
             entries_after
+        );
+    }
+
+    #[gpui::test]
+    async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppContext) {
+        agent_ui::test_support::init_test(cx);
+        cx.update(|cx| {
+            cx.update_flags(false, vec!["agent-v2".into()]);
+            ThreadStore::init_global(cx);
+            SidebarThreadMetadataStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            prompt_store::init(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            serde_json::json!({
+                ".git": {
+                    "worktrees": {
+                        "feature-a": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature-a",
+                        },
+                    },
+                },
+                "src": {},
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            "/wt-feature-a",
+            serde_json::json!({
+                ".git": "gitdir: /project/.git/worktrees/feature-a",
+                "src": {},
+            }),
+        )
+        .await;
+        fs.with_git_state(std::path::Path::new("/project/.git"), false, |state| {
+            state.worktrees.push(git::repository::Worktree {
+                path: std::path::PathBuf::from("/wt-feature-a"),
+                ref_name: Some("refs/heads/feature-a".into()),
+                sha: "aaa".into(),
+            });
+        })
+        .unwrap();
+        cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+        let main_project = project::Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+        let worktree_project =
+            project::Project::test(fs.clone(), ["/wt-feature-a".as_ref()], cx).await;
+        main_project
+            .update(cx, |p, cx| p.git_scans_complete(cx))
+            .await;
+        worktree_project
+            .update(cx, |p, cx| p.git_scans_complete(cx))
+            .await;
+
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            MultiWorkspace::test_new(main_project.clone(), window, cx)
+        });
+        let worktree_workspace = multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(worktree_project.clone(), window, cx)
+        });
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_index(0, window, cx);
+        });
+
+        let sidebar = setup_sidebar(&multi_workspace, cx);
+        let main_workspace = multi_workspace.read_with(cx, |mw, _| mw.workspaces()[0].clone());
+        let _main_panel = add_agent_panel(&main_workspace, &main_project, cx);
+        let _worktree_panel = add_agent_panel(&worktree_workspace, &worktree_project, cx);
+
+        // Save a single thread for the worktree.
+        let thread_id = acp::SessionId::new(Arc::from("wt-thread"));
+        save_thread_metadata(
+            thread_id.clone(),
+            "Worktree Thread".into(),
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+            PathList::new(&[std::path::PathBuf::from("/wt-feature-a")]),
+            cx,
+        )
+        .await;
+        cx.run_until_parked();
+
+        assert_eq!(
+            multi_workspace.read_with(cx, |mw, _| mw.workspaces().len()),
+            2,
+            "should have main + worktree workspaces"
+        );
+
+        // Archive the only worktree thread.
+        sidebar.update_in(cx, |sidebar, _window, cx| {
+            sidebar.active_entry = Some(ActiveEntry::Thread(thread_id.clone()));
+            cx.notify();
+        });
+        cx.run_until_parked();
+        sidebar.update_in(cx, |sidebar, window, cx| {
+            sidebar.archive_thread(&thread_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        // The worktree workspace should have been removed.
+        assert_eq!(
+            multi_workspace.read_with(cx, |mw, _| mw.workspaces().len()),
+            1,
+            "worktree workspace should be removed after archiving its last thread"
         );
     }
 }


### PR DESCRIPTION
## Context

Commit 1:  This commit simplifies the sidebar internals by removing state that could be derived live, and unifying the two separate concepts of "active" (draft or focused) with a new enum. I also renamed "focused" to "active", to match "active workspace" more than "keyboard focus".

Commit 2: I simplified the sidebar a bit more, by doing the thread metadata sorting in sqlite rather than on the sidebar.  Then I also simplified the implementation of the "archive" action by:
- Adjusting our derivation to cache the "parent" workspaces in the thread entries
- Caching a `Map<Session ID, ThreadEntryIndex>` so that we can look up the visual entries quickly
- Simplify the group traversal to only check the thread immediately below, then immediately above the current thread entry. This relies on the fact that all groups are visually bounded by project headers, so we we're guaranteed to either get a valid thread entry OR a non-entry.

Finally, I fixed the bug I set out to start with: once a thread deletion goes through, we drop the workspace it's associated with from the multiworkspace. I also added a test demonstrating this.

Subsequent Commits: Getting the PR ready for merging.


## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
- [ ] I've sufficient done manual testing

Release Notes:

- N/A