### PR TITLE
project: Exclude deleted buffers from project search

### DIFF
--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -164,6 +164,8 @@ impl Search {
             let buffer = handle.read(cx);
             if !buffers.is_searchable(&buffer.remote_id()) {
                 continue;
+            } else if Self::buffer_has_deleted_file(&buffer) {
+                continue;
             } else if let Some(entry_id) = buffer.entry_id(cx) {
                 open_buffers.insert(entry_id);
             } else {
@@ -585,6 +587,9 @@ impl Search {
             .flatten()
             .filter(|buffer| {
                 let b = buffer.read(cx);
+                if Self::buffer_has_deleted_file(&b) {
+                    return false;
+                }
                 if let Some(file) = b.file() {
                     if !search_query.match_path(file.path()) {
                         return false;
@@ -614,6 +619,12 @@ impl Search {
         });
 
         buffers
+    }
+
+    fn buffer_has_deleted_file(buffer: &Buffer) -> bool {
+        buffer
+            .file()
+            .is_some_and(|file| file.disk_state().is_deleted())
     }
 }
 

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -337,6 +337,93 @@ async fn test_remote_project_search_single_cpu(
 }
 
 #[gpui::test]
+async fn test_remote_project_search_excludes_deleted_open_buffers(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(
+        path!("/code"),
+        json!({
+            "project1": {
+                ".git": {},
+                "README.md": "# project 1",
+                "src": {
+                    "deleted.rs": "const DELETED_SEARCH_NEEDLE: &str = \"deleted-search-needle\";",
+                }
+            },
+        }),
+    )
+    .await;
+
+    let (project, headless) = init_test(&fs, cx, server_cx).await;
+
+    let worktree_id = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/code/project1"), true, cx)
+        })
+        .await
+        .unwrap()
+        .0
+        .read_with(cx, |worktree, _| worktree.id());
+
+    cx.run_until_parked();
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, rel_path("src/deleted.rs")), cx)
+        })
+        .await
+        .unwrap();
+    let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
+
+    cx.run_until_parked();
+    server_cx.run_until_parked();
+
+    fs.remove_file(
+        path!("/code/project1/src/deleted.rs").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    server_cx.run_until_parked();
+    cx.run_until_parked();
+    server_cx.run_until_parked();
+    cx.run_until_parked();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert!(buffer.file().unwrap().disk_state().is_deleted());
+    });
+    server_cx.read(|cx| {
+        let server_buffer = headless
+            .read(cx)
+            .buffer_store
+            .read(cx)
+            .get(buffer_id)
+            .unwrap();
+        assert!(
+            server_buffer
+                .read(cx)
+                .file()
+                .unwrap()
+                .disk_state()
+                .is_deleted()
+        );
+    });
+
+    do_search_and_assert(
+        &project,
+        "deleted-search-needle",
+        Default::default(),
+        false,
+        &[],
+        cx.clone(),
+    )
+    .await;
+}
+
+#[gpui::test]
 async fn test_remote_project_search_inclusion(
     cx: &mut TestAppContext,
     server_cx: &mut TestAppContext,


### PR DESCRIPTION
Skip buffers whose file is in DiskState::Deleted when building project search candidates, including the opened-buffers-only path.

## Context

After opening the remote folder, deleting a file, and then searching for content within the files, the content of the already deleted file is still found. The expectation is that deleted files should not be within the search scope.

Release Notes:

- Added Exclude deleted buffers from project search
