### PR TITLE
Fix double borrow when resizing bottom dock

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -837,16 +837,6 @@ impl Dock {
     pub fn resize_active_panel(
         &mut self,
         size: Option<Pixels>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let ratio = size.and_then(|size| self.flexible_size_ratio_for_pixels(size, window, cx));
-        self.resize_active_panel_with_ratio(size, ratio, window, cx);
-    }
-
-    pub fn resize_active_panel_with_ratio(
-        &mut self,
-        size: Option<Pixels>,
         ratio: Option<f32>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -878,16 +868,6 @@ impl Dock {
     }
 
     pub fn resize_all_panels(
-        &mut self,
-        size: Option<Pixels>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let ratio = size.and_then(|size| self.flexible_size_ratio_for_pixels(size, window, cx));
-        self.resize_all_panels_with_ratio(size, ratio, window, cx);
-    }
-
-    pub fn resize_all_panels_with_ratio(
         &mut self,
         size: Option<Pixels>,
         ratio: Option<f32>,
@@ -975,18 +955,6 @@ impl Dock {
             .unwrap_or_else(|| entry.panel.default_size(window, cx))
     }
 
-    fn flexible_size_ratio_for_pixels(
-        &self,
-        size: Pixels,
-        window: &Window,
-        cx: &App,
-    ) -> Option<f32> {
-        let workspace = self.workspace.upgrade()?;
-        workspace
-            .read(cx)
-            .flexible_dock_ratio_for_size(self.position, size, window, cx)
-    }
-
     pub(crate) fn load_persisted_size_state(
         workspace: &Workspace,
         panel_key: &'static str,
@@ -1059,7 +1027,7 @@ impl Render for Dock {
                         MouseButton::Left,
                         cx.listener(|dock, e: &MouseUpEvent, window, cx| {
                             if e.click_count == 2 {
-                                dock.resize_active_panel(None, window, cx);
+                                dock.resize_active_panel(None, None, window, cx);
                                 dock.workspace
                                     .update(cx, |workspace, cx| {
                                         workspace.serialize_workspace(window, cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7369,9 +7369,9 @@ impl Workspace {
                 .resize_all_panels_in_dock
                 .contains(&DockPosition::Left)
             {
-                left_dock.resize_all_panels_with_ratio(Some(size), ratio, window, cx);
+                left_dock.resize_all_panels(Some(size), ratio, window, cx);
             } else {
-                left_dock.resize_active_panel_with_ratio(Some(size), ratio, window, cx);
+                left_dock.resize_active_panel(Some(size), ratio, window, cx);
             }
         });
     }
@@ -7393,9 +7393,9 @@ impl Workspace {
                 .resize_all_panels_in_dock
                 .contains(&DockPosition::Right)
             {
-                right_dock.resize_all_panels_with_ratio(Some(size), ratio, window, cx);
+                right_dock.resize_all_panels(Some(size), ratio, window, cx);
             } else {
-                right_dock.resize_active_panel_with_ratio(Some(size), ratio, window, cx);
+                right_dock.resize_active_panel(Some(size), ratio, window, cx);
             }
         });
     }
@@ -7407,9 +7407,9 @@ impl Workspace {
                 .resize_all_panels_in_dock
                 .contains(&DockPosition::Bottom)
             {
-                bottom_dock.resize_all_panels(Some(size), window, cx);
+                bottom_dock.resize_all_panels(Some(size), None, window, cx);
             } else {
-                bottom_dock.resize_active_panel(Some(size), window, cx);
+                bottom_dock.resize_active_panel(Some(size), None, window, cx);
             }
         });
     }


### PR DESCRIPTION
Fixes a double borrow panic when resizing the bottom dock, introduced in #52276 

Release Notes:

- N/A
