### PR TITLE
project_panel: Paste image from clipboard

### DIFF
--- a/crates/gpui_macos/src/pasteboard.rs
+++ b/crates/gpui_macos/src/pasteboard.rs
@@ -73,9 +73,20 @@ impl Pasteboard {
 
             // Next, check for a plain string.
             if let Some(string_entry) = self.read_string_from_pasteboard() {
-                return Some(ClipboardItem {
-                    entries: vec![string_entry],
-                });
+                let mut entries = vec![string_entry];
+
+                // Also check for image data that may coexist with text
+                // (e.g., copying an image from a browser puts both URL text
+                // and image data on the pasteboard). String goes first for
+                // backward compatibility.
+                for format in ImageFormat::iter() {
+                    if let Some(image_entry) = self.read_image_entry(format) {
+                        entries.push(image_entry);
+                        break;
+                    }
+                }
+
+                return Some(ClipboardItem { entries });
             }
 
             // Finally, try the various supported image types.
@@ -89,7 +100,7 @@ impl Pasteboard {
         None
     }
 
-    fn read_image(&self, format: ImageFormat) -> Option<ClipboardItem> {
+    fn read_image_entry(&self, format: ImageFormat) -> Option<ClipboardEntry> {
         let ut_type: UTType = format.into();
 
         unsafe {
@@ -98,15 +109,18 @@ impl Pasteboard {
                 self.data_for_type(ut_type.inner_mut()).map(|bytes| {
                     let bytes = bytes.to_vec();
                     let id = hash(&bytes);
-
-                    ClipboardItem {
-                        entries: vec![ClipboardEntry::Image(Image { format, bytes, id })],
-                    }
+                    ClipboardEntry::Image(Image { format, bytes, id })
                 })
             } else {
                 None
             }
         }
+    }
+
+    fn read_image(&self, format: ImageFormat) -> Option<ClipboardItem> {
+        self.read_image_entry(format).map(|entry| ClipboardItem {
+            entries: vec![entry],
+        })
     }
 
     unsafe fn read_string_from_pasteboard(&self) -> Option<ClipboardEntry> {
@@ -520,6 +534,65 @@ mod tests {
                 assert_eq!(img.bytes, png_bytes);
             }
             other => panic!("expected Image, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_read_text_and_image() {
+        let pasteboard = Pasteboard::unique();
+
+        let png_bytes: &[u8] = &[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+            0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9C, 0x62, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE5, 0x27, 0xDE, 0xFC, 0x00, 0x00,
+            0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+        ];
+
+        let url_text = "https://example.com/image.png";
+
+        unsafe {
+            let ns_png_type = NSPasteboardTypePNG;
+            let types_array =
+                NSArray::arrayWithObjects(nil, &[NSPasteboardTypeString, ns_png_type]);
+            pasteboard.inner.declareTypes_owner(types_array, nil);
+
+            let text_data = NSData::dataWithBytes_length_(
+                nil,
+                url_text.as_ptr() as *const c_void,
+                url_text.len() as u64,
+            );
+            pasteboard
+                .inner
+                .setData_forType(text_data, NSPasteboardTypeString);
+
+            let image_data = NSData::dataWithBytes_length_(
+                nil,
+                png_bytes.as_ptr() as *const c_void,
+                png_bytes.len() as u64,
+            );
+            pasteboard.inner.setData_forType(image_data, ns_png_type);
+        }
+
+        let item = pasteboard
+            .read()
+            .expect("should read clipboard with text and image");
+
+        assert_eq!(item.entries.len(), 2);
+
+        match &item.entries[0] {
+            ClipboardEntry::String(s) => {
+                assert_eq!(s.text(), url_text);
+            }
+            other => panic!("expected String first, got {:?}", other),
+        }
+
+        match &item.entries[1] {
+            ClipboardEntry::Image(img) => {
+                assert_eq!(img.format, ImageFormat::Png);
+                assert_eq!(img.bytes, png_bytes);
+            }
+            other => panic!("expected Image second, got {:?}", other),
         }
     }
 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -22,12 +22,12 @@ use git_ui::file_diff_view::FileDiffView;
 use gpui::{
     Action, AnyElement, App, AsyncWindowContext, Bounds, ClipboardEntry as GpuiClipboardEntry,
     ClipboardItem, Context, CursorStyle, DismissEvent, Div, DragMoveEvent, Entity, EventEmitter,
-    ExternalPaths, FocusHandle, Focusable, FontWeight, Hsla, InteractiveElement, KeyContext,
-    ListHorizontalSizingBehavior, ListSizingBehavior, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, ParentElement, PathPromptOptions, Pixels, Point, PromptLevel,
-    Render, ScrollStrategy, Stateful, Styled, Subscription, Task, UniformListScrollHandle,
-    WeakEntity, Window, actions, anchored, deferred, div, hsla, linear_color_stop, linear_gradient,
-    point, px, size, transparent_white, uniform_list,
+    ExternalPaths, FocusHandle, Focusable, FontWeight, Hsla, Image as GpuiImage,
+    InteractiveElement, KeyContext, ListHorizontalSizingBehavior, ListSizingBehavior, Modifiers,
+    ModifiersChangedEvent, MouseButton, MouseDownEvent, ParentElement, PathPromptOptions, Pixels,
+    Point, PromptLevel, Render, ScrollStrategy, Stateful, Styled, Subscription, Task,
+    UniformListScrollHandle, WeakEntity, Window, actions, anchored, deferred, div, hsla,
+    linear_color_stop, linear_gradient, point, px, size, transparent_white, uniform_list,
 };
 use language::DiagnosticSeverity;
 use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
@@ -3052,6 +3052,11 @@ impl ProjectPanel {
             return;
         }
 
+        if let Some(image) = self.image_from_system_clipboard(cx) {
+            self.paste_image(image, window, cx);
+            return;
+        }
+
         maybe!({
             let (worktree, entry) = self.selected_entry_handle(cx)?;
             let entry = entry.clone();
@@ -3835,6 +3840,16 @@ impl ProjectPanel {
         None
     }
 
+    fn image_from_system_clipboard(&self, cx: &App) -> Option<GpuiImage> {
+        let clipboard_item = cx.read_from_clipboard()?;
+        for entry in clipboard_item.entries() {
+            if let GpuiClipboardEntry::Image(image) = entry {
+                return Some(image.clone());
+            }
+        }
+        None
+    }
+
     fn has_pasteable_content(&self, cx: &App) -> bool {
         if self
             .clipboard
@@ -3843,7 +3858,10 @@ impl ProjectPanel {
         {
             return true;
         }
-        self.external_paths_from_system_clipboard(cx).is_some()
+        if self.external_paths_from_system_clipboard(cx).is_some() {
+            return true;
+        }
+        self.image_from_system_clipboard(cx).is_some()
     }
 
     fn selected_entry_handle<'a>(
@@ -4257,6 +4275,74 @@ impl ProjectPanel {
                 }
             }
         });
+    }
+
+    fn paste_image(&mut self, image: GpuiImage, window: &mut Window, cx: &mut Context<Self>) {
+        let target_entry_id = self
+            .selection
+            .map(|s| s.entry_id)
+            .or(self.state.last_worktree_root_id);
+        let Some(target_entry_id) = target_entry_id else {
+            return;
+        };
+
+        let Some((worktree, target_directory)) = maybe!({
+            let project = self.project.read(cx);
+            let worktree = project.worktree_for_entry(target_entry_id, cx)?;
+            let entry = worktree.read(cx).entry_for_id(target_entry_id)?;
+            let target_directory = if entry.is_dir() {
+                entry.path.clone()
+            } else {
+                entry.path.parent()?.into()
+            };
+            Some((worktree, target_directory))
+        }) else {
+            return;
+        };
+
+        let file_path = {
+            let worktree_ref = worktree.read(cx);
+            let mut candidate = target_directory.join(RelPath::unix("image.png").unwrap());
+            let mut counter = 1u32;
+            while worktree_ref.entry_for_path(&candidate).is_some() {
+                let next = format!("image {counter}.png");
+                candidate = target_directory.join(RelPath::unix(&next).unwrap());
+                counter += 1;
+            }
+            candidate
+        };
+
+        let worktree_id = worktree.read(cx).id();
+        let content = image.bytes;
+        let task = worktree.update(cx, |worktree, cx| {
+            worktree.create_entry(file_path, false, Some(content), cx)
+        });
+
+        cx.spawn_in(window, async move |this, cx| {
+            async move {
+                let entry = task.await?;
+                if let CreatedEntry::Included(entry) = entry {
+                    this.update_in(cx, |this, window, cx| {
+                        this.selection = Some(SelectedEntry {
+                            worktree_id,
+                            entry_id: entry.id,
+                        });
+                        this.marked_entries.clear();
+                        this.expand_entry(worktree_id, entry.id, cx);
+                        this.update_visible_entries(None, false, false, window, cx);
+
+                        let settings = ProjectPanelSettings::get_global(cx);
+                        if settings.auto_open.should_open_on_paste() {
+                            this.open_entry(entry.id, true, false, cx);
+                        }
+                    })?;
+                }
+                anyhow::Ok(())
+            }
+            .log_err()
+            .await
+        })
+        .detach();
     }
 
     fn drop_external_files(

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2603,6 +2603,127 @@ async fn test_paste_external_paths(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_paste_clipboard_image(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_auto_open_settings(
+        cx,
+        ProjectPanelAutoOpenSettings {
+            on_paste: Some(false),
+            ..Default::default()
+        },
+    );
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "subdir": {}
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    let png_bytes: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    cx.write_to_clipboard(ClipboardItem {
+        entries: vec![GpuiClipboardEntry::Image(GpuiImage::from_bytes(
+            gpui::ImageFormat::Png,
+            png_bytes.clone(),
+        ))],
+    });
+
+    select_path(&panel, "root/subdir", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.paste(&Default::default(), window, cx);
+    });
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    v subdir",
+            "          image.png  <== selected",
+        ],
+    );
+
+    let content = fs
+        .load_bytes(Path::new(path!("/root/subdir/image.png")))
+        .await
+        .unwrap();
+    assert_eq!(content, png_bytes);
+}
+
+#[gpui::test]
+async fn test_paste_clipboard_image_auto_increment(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_auto_open_settings(
+        cx,
+        ProjectPanelAutoOpenSettings {
+            on_paste: Some(false),
+            ..Default::default()
+        },
+    );
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "subdir": {
+                "image.png": "existing"
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    let png_bytes: Vec<u8> = vec![0x89, 0x50, 0x4E, 0x47];
+    cx.write_to_clipboard(ClipboardItem {
+        entries: vec![GpuiClipboardEntry::Image(GpuiImage::from_bytes(
+            gpui::ImageFormat::Png,
+            png_bytes.clone(),
+        ))],
+    });
+
+    select_path(&panel, "root/subdir", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.paste(&Default::default(), window, cx);
+    });
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    v subdir",
+            "          image.png",
+            "          image 1.png  <== selected",
+        ],
+    );
+
+    let content = fs
+        .load_bytes(Path::new(path!("/root/subdir/image 1.png")))
+        .await
+        .unwrap();
+    assert_eq!(content, png_bytes);
+}
+
+#[gpui::test]
 async fn test_copy_and_cut_write_to_system_clipboard(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
Part of #29026

https://github.com/user-attachments/assets/c0561b17-63b4-4535-ad3d-9dca16c97741

## Context

When copying an image from a browser (or any non-filesystem source like a screenshot tool), macOS places image data on the system pasteboard alongside text (e.g., the URL). Previously, the project panel only handled pasting file paths (`ExternalPaths`) from the system clipboard and ignored image data entirely. This meant copying an image and pasting in Zed's project panel did nothing.

This PR adds support for reading image data from the macOS system pasteboard and saving it as a `.png` file in the project panel. The file is created with auto-incrementing names (`image.png`, `image 1.png`, `image 2.png`, ...) to avoid conflicts.

> **Note:** Pasting clipboard images currently works best on macOS. The project panel changes are cross-platform, but the pasteboard fix that surfaces image data alongside text is only implemented for macOS. Windows and Linux would need equivalent changes in their respective clipboard implementations.

## How to Review

This is a small PR touching two files:

1. **`crates/gpui_macos/src/pasteboard.rs`** — When reading from the pasteboard, also check for image data alongside text (browsers put both URL text and image data on the pasteboard — without this, only the text was returned and the image was silently discarded). Extracts `read_image_entry()` from `read_image()` to allow reuse without wrapping in a `ClipboardItem`.

2. **`crates/project_panel/src/project_panel.rs`** — On paste, check the system clipboard for image data (after checking for external file paths) and create a `.png` file in the selected directory. Generates unique filenames with auto-incrementing (`image.png`, `image 1.png`, etc.). Updates the "Paste" context menu item to also be enabled when the system clipboard contains image data.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Test plan

- [ ] Copy an image from a browser (right-click → Copy Image), paste in the project panel — an `image.png` file should be created in the selected directory
- [ ] Paste again — `image 1.png` should be created (auto-increment)
- [ ] Copy files in Finder, paste in the project panel — existing file paste behavior is preserved
- [ ] Copy/cut within the project panel, paste — existing internal copy/paste behavior is preserved
- [ ] Right-click context menu shows "Paste" enabled when system clipboard has image data
- [ ] Right-click context menu shows "Paste" disabled when clipboard is empty
- [ ] Copy an image to clipboard, then Cmd+C a file in Zed's project panel, then paste — the file should be pasted (Cmd+C clears the previous image from the system clipboard)
- [ ] Cmd+C a file in Zed's project panel, then copy an image (e.g., screenshot), then paste — the image should be pasted (most recent copy wins)

Release Notes:

- Added support for pasting images from the system clipboard (e.g., copied from a browser) into the project panel as `.png` files (macOS only).