### PR TITLE
agent: Fix issues when editing thread title

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -663,15 +663,18 @@ impl NativeAgent {
             return;
         };
 
-        if let Some(title) = thread.read(cx).title() {
-            let acp_thread = session.acp_thread.downgrade();
-            cx.spawn(async move |_, cx| {
+        let thread = thread.downgrade();
+        let acp_thread = session.acp_thread.downgrade();
+        cx.spawn(async move |_, cx| {
+            let title = thread.read_with(cx, |thread, _| thread.title())?;
+            if let Some(title) = title {
                 let task =
                     acp_thread.update(cx, |acp_thread, cx| acp_thread.set_title(title, cx))?;
-                task.await
-            })
-            .detach_and_log_err(cx);
-        }
+                task.await?;
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
     }
 
     fn handle_thread_token_usage_updated(


### PR DESCRIPTION
## Context

Follow up to #52193

We changed this code in #52193, but moving the thread title read outside of the spawn, causes a loop of title updated events

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
