### PR TITLE
Agent speech to text dictation feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "util",
  "uuid",
  "watch",
+ "which 6.0.3",
  "workspace",
  "zed_actions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "language_model",
  "language_models",
  "languages",
+ "livekit_client",
  "log",
  "lsp",
  "markdown",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -332,6 +332,7 @@
       // `alt-l` is provided as an alternative to `alt-tab` as the latter breaks on Linux under the `AcpThread > Editor` context
       "alt-l": "agent::CycleFavoriteModels",
       "ctrl-;": "agent::OpenAddContextMenu",
+      "ctrl-alt-v": "agent::ToggleVoiceRecording",
       "ctrl-alt-k": "agent::ToggleThinkingMode",
       "ctrl-alt-'": "agent::ToggleThinkingEffortMenu",
       "ctrl-'": "agent::CycleThinkingEffort",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -376,6 +376,7 @@
       "shift-tab": "agent::CycleModeSelector",
       "alt-tab": "agent::CycleFavoriteModels",
       "ctrl-;": "agent::OpenAddContextMenu",
+      "cmd-alt-v": "agent::ToggleVoiceRecording",
       "cmd-alt-k": "agent::ToggleThinkingMode",
       "cmd-alt-'": "agent::ToggleThinkingEffortMenu",
       "ctrl-'": "agent::CycleThinkingEffort",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -334,6 +334,7 @@
       "alt-tab": "agent::CycleFavoriteModels",
       "alt-l": "agent::CycleFavoriteModels",
       "ctrl-;": "agent::OpenAddContextMenu",
+      "ctrl-alt-v": "agent::ToggleVoiceRecording",
       "ctrl-alt-k": "agent::ToggleThinkingMode",
       "ctrl-alt-'": "agent::ToggleThinkingEffortMenu",
       "ctrl-'": "agent::CycleThinkingEffort",

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -596,6 +596,7 @@ mod tests {
             tool_permissions,
             show_turn_stats: false,
             new_thread_location: Default::default(),
+            speech_to_text: Default::default(),
         }
     }
 

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -17,6 +17,7 @@ use settings::{
 use std::path::PathBuf;
 
 pub use crate::agent_profile::*;
+pub use settings::settings_content::SpeechToTextTriggerMode;
 
 pub const SUMMARIZE_THREAD_PROMPT: &str = include_str!("prompts/summarize_thread_prompt.txt");
 pub const SUMMARIZE_THREAD_DETAILED_PROMPT: &str =
@@ -95,6 +96,7 @@ impl AgentSettings {
 pub struct SpeechToTextSettings {
     pub whisper_cpp_executable_path: Option<PathBuf>,
     pub whisper_cpp_model_path: Option<PathBuf>,
+    pub trigger_mode: SpeechToTextTriggerMode,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]
@@ -457,6 +459,11 @@ impl Settings for AgentSettings {
                     .speech_to_text
                     .as_ref()
                     .and_then(|speech_to_text| speech_to_text.whisper_cpp_model_path.clone()),
+                trigger_mode: agent
+                    .speech_to_text
+                    .as_ref()
+                    .and_then(|speech_to_text| speech_to_text.trigger_mode)
+                    .unwrap_or_default(),
             },
         }
     }

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -94,6 +94,7 @@ impl AgentSettings {
 
 #[derive(Clone, Debug, Default)]
 pub struct SpeechToTextSettings {
+    pub enabled: bool,
     pub whisper_cpp_executable_path: Option<PathBuf>,
     pub whisper_cpp_model_path: Option<PathBuf>,
     pub trigger_mode: SpeechToTextTriggerMode,
@@ -451,6 +452,11 @@ impl Settings for AgentSettings {
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
             new_thread_location: agent.new_thread_location.unwrap_or_default(),
             speech_to_text: SpeechToTextSettings {
+                enabled: agent
+                    .speech_to_text
+                    .as_ref()
+                    .and_then(|speech_to_text| speech_to_text.enabled)
+                    .unwrap_or(false),
                 whisper_cpp_executable_path: agent
                     .speech_to_text
                     .as_ref()

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -14,6 +14,7 @@ use settings::{
     DefaultAgentView, DockPosition, LanguageModelParameters, LanguageModelSelection,
     NewThreadLocation, NotifyWhenAgentWaiting, RegisterSetting, Settings, ToolPermissionMode,
 };
+use std::path::PathBuf;
 
 pub use crate::agent_profile::*;
 
@@ -52,6 +53,7 @@ pub struct AgentSettings {
     pub show_turn_stats: bool,
     pub tool_permissions: ToolPermissions,
     pub new_thread_location: NewThreadLocation,
+    pub speech_to_text: SpeechToTextSettings,
 }
 
 impl AgentSettings {
@@ -87,6 +89,12 @@ impl AgentSettings {
             .map(|sel| ModelId::new(format!("{}/{}", sel.provider.0, sel.model)))
             .collect()
     }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SpeechToTextSettings {
+    pub whisper_cpp_executable_path: Option<PathBuf>,
+    pub whisper_cpp_model_path: Option<PathBuf>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]
@@ -440,6 +448,16 @@ impl Settings for AgentSettings {
             show_turn_stats: agent.show_turn_stats.unwrap(),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
             new_thread_location: agent.new_thread_location.unwrap_or_default(),
+            speech_to_text: SpeechToTextSettings {
+                whisper_cpp_executable_path: agent
+                    .speech_to_text
+                    .as_ref()
+                    .and_then(|speech_to_text| speech_to_text.whisper_cpp_executable_path.clone()),
+                whisper_cpp_model_path: agent
+                    .speech_to_text
+                    .as_ref()
+                    .and_then(|speech_to_text| speech_to_text.whisper_cpp_model_path.clone()),
+            },
         }
     }
 }

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -112,6 +112,7 @@ util.workspace = true
 uuid.workspace = true
 watch.workspace = true
 workspace.workspace = true
+which.workspace = true
 zed_actions.workspace = true
 image.workspace = true
 reqwest_client = { workspace = true, optional = true }

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -70,6 +70,7 @@ jsonschema.workspace = true
 language.workspace = true
 language_model.workspace = true
 language_models.workspace = true
+livekit_client.workspace = true
 log.workspace = true
 lsp.workspace = true
 markdown.workspace = true

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -51,7 +51,7 @@ use crate::{
 };
 use crate::{ManageProfiles, ThreadHistoryViewEvent};
 use crate::{ThreadHistory, agent_connection_store::AgentConnectionStore};
-use agent_settings::AgentSettings;
+use agent_settings::{AgentSettings, SpeechToTextTriggerMode};
 use ai_onboarding::AgentPanelOnboarding;
 use anyhow::{Context as _, Result, anyhow};
 use assistant_slash_command::SlashCommandWorkingSet;
@@ -79,7 +79,8 @@ use settings::{Settings, update_settings_file};
 use theme::ThemeSettings;
 use ui::{
     Button, Callout, CommonAnimationExt, ContextMenu, ContextMenuEntry, DocumentationSide,
-    KeyBinding, PopoverMenu, PopoverMenuHandle, Tab, Tooltip, prelude::*, utils::WithRemSize,
+    IconPosition, KeyBinding, PopoverMenu, PopoverMenuHandle, Tab, Tooltip, prelude::*,
+    utils::WithRemSize,
 };
 use util::{ResultExt as _, debug_panic};
 use workspace::{
@@ -3391,6 +3392,10 @@ impl AgentPanel {
             ActiveView::AgentThread { conversation_view } => Some(conversation_view.clone()),
             _ => None,
         };
+        let speech_to_text_settings = AgentSettings::get_global(cx).speech_to_text.clone();
+        let voice_input_enabled = speech_to_text_settings.enabled;
+        let voice_input_trigger_mode = speech_to_text_settings.trigger_mode;
+        let fs = self.fs.clone();
         let thread_with_messages = match &self.active_view {
             ActiveView::AgentThread { conversation_view } => {
                 conversation_view.read(cx).has_user_submitted_prompt(cx)
@@ -3474,6 +3479,83 @@ impl AgentPanel {
                             .separator()
                             .action("Rules", Box::new(OpenRulesLibrary::default()))
                             .action("Profiles", Box::new(ManageProfiles::default()))
+                            .separator()
+                            .header("Voice Input")
+                            .item(
+                                ContextMenuEntry::new("Enable Voice Input")
+                                    .toggleable(IconPosition::End, voice_input_enabled)
+                                    .handler({
+                                        let fs = fs.clone();
+                                        let voice_input_enabled = voice_input_enabled;
+                                        move |_window, cx| {
+                                            update_settings_file(
+                                                fs.clone(),
+                                                cx,
+                                                move |settings, _| {
+                                                    settings
+                                                        .agent
+                                                        .get_or_insert_default()
+                                                        .set_speech_to_text_enabled(
+                                                            !voice_input_enabled,
+                                                        );
+                                                },
+                                            );
+                                        }
+                                    }),
+                            )
+                            .item(
+                                ContextMenuEntry::new("Toggle to Record")
+                                    .toggleable(
+                                        IconPosition::End,
+                                        voice_input_trigger_mode == SpeechToTextTriggerMode::Toggle,
+                                    )
+                                    .disabled(!voice_input_enabled)
+                                    .handler({
+                                        let fs = fs.clone();
+                                        let trigger_mode = SpeechToTextTriggerMode::Toggle;
+                                        move |_window, cx| {
+                                            update_settings_file(
+                                                fs.clone(),
+                                                cx,
+                                                move |settings, _| {
+                                                    settings
+                                                        .agent
+                                                        .get_or_insert_default()
+                                                        .set_speech_to_text_trigger_mode(
+                                                            trigger_mode,
+                                                        );
+                                                },
+                                            );
+                                        }
+                                    }),
+                            )
+                            .item(
+                                ContextMenuEntry::new("Hold to Record")
+                                    .toggleable(
+                                        IconPosition::End,
+                                        voice_input_trigger_mode == SpeechToTextTriggerMode::Hold,
+                                    )
+                                    .disabled(!voice_input_enabled)
+                                    .handler({
+                                        let fs = fs.clone();
+                                        let trigger_mode = SpeechToTextTriggerMode::Hold;
+                                        move |_window, cx| {
+                                            update_settings_file(
+                                                fs.clone(),
+                                                cx,
+                                                move |settings, _| {
+                                                    settings
+                                                        .agent
+                                                        .get_or_insert_default()
+                                                        .set_speech_to_text_trigger_mode(
+                                                            trigger_mode,
+                                                        );
+                                                },
+                                            );
+                                        }
+                                    }),
+                            )
+                            .separator()
                             .action("Settings", Box::new(OpenSettings))
                             .separator()
                             .action("Toggle Threads Sidebar", Box::new(ToggleWorkspaceSidebar))

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -667,6 +667,7 @@ mod tests {
             tool_permissions: Default::default(),
             show_turn_stats: false,
             new_thread_location: Default::default(),
+            speech_to_text: Default::default(),
         };
 
         cx.update(|cx| {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -179,6 +179,10 @@ actions!(
         ToggleThinkingEffortMenu,
         /// Toggles fast mode for models that support it.
         ToggleFastMode,
+        /// Toggles the voice input recording UI state for the active thread.
+        ToggleVoiceRecording,
+        /// Toggles the microphone selection menu for the active thread.
+        ToggleMicrophoneMenu,
     ]
 );
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -85,7 +85,8 @@ use crate::{
     CycleThinkingEffort, EditFirstQueuedMessage, ExpandMessageEditor, Follow, KeepAll, NewThread,
     OpenAddContextMenu, OpenAgentDiff, OpenHistory, RejectAll, RejectOnce,
     RemoveFirstQueuedMessage, SendImmediately, SendNextQueuedMessage, ToggleFastMode,
-    ToggleProfileSelector, ToggleThinkingEffortMenu, ToggleThinkingMode, UndoLastReject,
+    ToggleMicrophoneMenu, ToggleProfileSelector, ToggleThinkingEffortMenu, ToggleThinkingMode,
+    ToggleVoiceRecording, UndoLastReject,
 };
 
 const STOPWATCH_THRESHOLD: Duration = Duration::from_secs(30);

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3216,7 +3216,7 @@ impl ThreadView {
                             .gap_1()
                             .items_center()
                             .children(self.render_token_usage(cx))
-                            .child(self.render_microphone_control(window, cx))
+                            .children(self.render_microphone_control(window, cx))
                             .children(self.profile_selector.clone())
                             .map(|this| {
                                 // Either config_options_view OR (mode_selector + model_selector)
@@ -8324,6 +8324,10 @@ impl ThreadView {
     }
 
     fn start_voice_recording(&mut self, cx: &mut Context<Self>) -> anyhow::Result<()> {
+        if !AgentSettings::get_global(cx).speech_to_text.enabled {
+            anyhow::bail!("Voice input is disabled in agent settings.");
+        }
+
         self.resolve_whisper_cpp_configuration(cx)?;
         audio::ensure_devices_initialized(cx);
         let available_devices = cx.default_global::<AvailableAudioDevices>().0.clone();
@@ -8719,7 +8723,11 @@ impl ThreadView {
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> Option<AnyElement> {
+        if !AgentSettings::get_global(cx).speech_to_text.enabled {
+            return None;
+        }
+
         audio::ensure_devices_initialized(cx);
         let available_devices = cx.default_global::<AvailableAudioDevices>().0.clone();
         let mut microphone_options = vec![MicrophoneOption {
@@ -8923,16 +8931,19 @@ impl ThreadView {
         })
         .render(window, cx);
 
-        div()
-            .relative()
-            .child(
-                h_flex()
-                    .items_center()
-                    .gap_px()
-                    .child(voice_recording_button)
-                    .child(microphone_menu),
-            )
-            .when_some(indicator, |this, indicator| this.child(indicator))
+        Some(
+            div()
+                .relative()
+                .child(
+                    h_flex()
+                        .items_center()
+                        .gap_px()
+                        .child(voice_recording_button)
+                        .child(microphone_menu),
+                )
+                .when_some(indicator, |this, indicator| this.child(indicator))
+                .into_any_element(),
+        )
     }
 }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 
 use acp_thread::ContentBlock;
+use agent_settings::SpeechToTextTriggerMode;
 use audio::{AudioDeviceInfo, AudioSettings, AvailableAudioDevices};
 use chrono::Local;
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
@@ -12,7 +13,7 @@ use picker::{Picker, PickerDelegate, popover_menu::PickerPopoverMenu};
 
 use crate::StartThreadIn;
 use crate::message_editor::SharedSessionCapabilities;
-use gpui::{Corner, DismissEvent, List};
+use gpui::{Corner, DismissEvent, List, MouseButton, MouseDownEvent, MouseUpEvent};
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
 use settings::update_settings_file;
@@ -8297,6 +8298,31 @@ impl ThreadView {
         }
     }
 
+    fn start_voice_recording_from_press(&mut self, cx: &mut Context<Self>) {
+        if !matches!(self.voice_recording_state, VoiceRecordingState::Idle) {
+            return;
+        }
+
+        if let Err(error) = self.start_voice_recording(cx) {
+            self.voice_recording_state = VoiceRecordingState::Idle;
+            self.show_voice_recording_error(
+                format!("Failed to start voice recording: {error:#}"),
+                cx,
+            );
+            cx.notify();
+        }
+    }
+
+    fn stop_voice_recording_from_release(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let VoiceRecordingState::Recording { capture_input } =
+            std::mem::replace(&mut self.voice_recording_state, VoiceRecordingState::Idle)
+        else {
+            return;
+        };
+
+        self.finish_voice_recording(capture_input, window, cx);
+    }
+
     fn start_voice_recording(&mut self, cx: &mut Context<Self>) -> anyhow::Result<()> {
         self.resolve_whisper_cpp_configuration(cx)?;
         audio::ensure_devices_initialized(cx);
@@ -8504,12 +8530,7 @@ impl ThreadView {
             );
         }
 
-        let transcript = Self::extract_whisper_transcript(&output.stdout)?;
-        if transcript.is_empty() {
-            anyhow::bail!("whisper.cpp returned an empty transcript");
-        }
-
-        Ok(transcript)
+        Self::extract_whisper_transcript(&output.stdout)
     }
 
     fn extract_whisper_transcript(stdout: &[u8]) -> anyhow::Result<String> {
@@ -8545,7 +8566,7 @@ impl ThreadView {
         cx: &mut Context<Self>,
     ) {
         let transcript = transcript.trim();
-        if transcript.is_empty() {
+        if transcript.is_empty() || transcript == "[BLANK_AUDIO]" {
             return;
         }
 
@@ -8717,6 +8738,7 @@ impl ThreadView {
         let microphone_picker = self.ensure_microphone_picker(window, microphone_options, cx);
 
         let focus_handle = self.message_editor.focus_handle(cx);
+        let trigger_mode = AgentSettings::get_global(cx).speech_to_text.trigger_mode;
         let is_recording = self.voice_recording_state.is_recording();
         let is_saving = self.voice_recording_state.is_saving();
         let is_transcribing = self.voice_recording_state.is_transcribing();
@@ -8829,21 +8851,50 @@ impl ThreadView {
             } else if is_transcribing {
                 Tooltip::text("Transcribing recording")(window, cx)
             } else {
-                Tooltip::for_action_in(
-                    if is_recording {
-                        "Stop Voice Input"
-                    } else {
-                        "Start Voice Input"
-                    },
-                    &ToggleVoiceRecording,
-                    &focus_handle,
-                    cx,
-                )
+                let label = match trigger_mode {
+                    SpeechToTextTriggerMode::Toggle => {
+                        if is_recording {
+                            "Stop Voice Input"
+                        } else {
+                            "Start Voice Input"
+                        }
+                    }
+                    SpeechToTextTriggerMode::Hold => "Hold to Record Voice Input",
+                };
+
+                Tooltip::for_action_in(label, &ToggleVoiceRecording, &focus_handle, cx)
             }
-        })
-        .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
-            this.flip_voice_recording(window, cx);
-        }));
+        });
+        let voice_recording_button = match trigger_mode {
+            SpeechToTextTriggerMode::Toggle => voice_recording_button
+                .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                    this.flip_voice_recording(window, cx);
+                }))
+                .into_any_element(),
+            SpeechToTextTriggerMode::Hold => div()
+                .child(voice_recording_button)
+                .when(!microphone_control_disabled, |this| {
+                    this.on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseDownEvent, _window, cx| {
+                            this.start_voice_recording_from_press(cx);
+                        }),
+                    )
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, window, cx| {
+                            this.stop_voice_recording_from_release(window, cx);
+                        }),
+                    )
+                    .on_mouse_up_out(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, window, cx| {
+                            this.stop_voice_recording_from_release(window, cx);
+                        }),
+                    )
+                })
+                .into_any_element(),
+        };
 
         let microphone_menu = PickerPopoverMenu::new(
             microphone_picker,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -172,7 +172,8 @@ impl ThreadFeedbackState {
 enum VoiceRecordingState {
     Idle,
     Recording { capture_input: CaptureInput },
-    Saving,
+    SavingAudio,
+    Transcribing,
 }
 
 impl Default for VoiceRecordingState {
@@ -187,12 +188,24 @@ impl VoiceRecordingState {
     }
 
     fn is_saving(&self) -> bool {
-        matches!(self, Self::Saving)
+        matches!(self, Self::SavingAudio)
+    }
+
+    fn is_transcribing(&self) -> bool {
+        matches!(self, Self::Transcribing)
+    }
+
+    fn is_processing(&self) -> bool {
+        matches!(self, Self::SavingAudio | Self::Transcribing)
     }
 }
 
-struct VoiceRecordingSavedToast;
 struct VoiceRecordingErrorToast;
+
+struct WhisperCppConfiguration {
+    executable_path: PathBuf,
+    model_path: PathBuf,
+}
 
 #[derive(Clone)]
 struct MicrophoneOption {
@@ -8278,13 +8291,14 @@ impl ThreadView {
             VoiceRecordingState::Recording { capture_input } => {
                 self.finish_voice_recording(capture_input, window, cx);
             }
-            VoiceRecordingState::Saving => {
-                self.voice_recording_state = VoiceRecordingState::Saving;
+            VoiceRecordingState::SavingAudio | VoiceRecordingState::Transcribing => {
+                self.voice_recording_state = VoiceRecordingState::Transcribing;
             }
         }
     }
 
     fn start_voice_recording(&mut self, cx: &mut Context<Self>) -> anyhow::Result<()> {
+        self.resolve_whisper_cpp_configuration(cx)?;
         audio::ensure_devices_initialized(cx);
         let available_devices = cx.default_global::<AvailableAudioDevices>().0.clone();
         let selected_microphone =
@@ -8304,7 +8318,17 @@ impl ThreadView {
         cx: &mut Context<Self>,
     ) {
         let save_path = Self::next_voice_recording_path();
-        self.voice_recording_state = VoiceRecordingState::Saving;
+        let whisper_configuration = match self.resolve_whisper_cpp_configuration(cx) {
+            Ok(configuration) => configuration,
+            Err(error) => {
+                self.voice_recording_state = VoiceRecordingState::Idle;
+                self.show_voice_recording_error(error.to_string(), cx);
+                cx.notify();
+                return;
+            }
+        };
+
+        self.voice_recording_state = VoiceRecordingState::SavingAudio;
         cx.notify();
 
         cx.spawn_in(window, async move |this, cx| {
@@ -8312,15 +8336,46 @@ impl ThreadView {
                 .background_spawn(async move { capture_input.finish_to_path(save_path) })
                 .await;
 
-            this.update_in(cx, |this, _window, cx| {
+            let saved_path = match save_result {
+                Ok(saved_path) => {
+                    this.update_in(cx, |this, _window, cx| {
+                        this.voice_recording_state = VoiceRecordingState::Transcribing;
+                        cx.notify();
+                    })?;
+                    saved_path
+                }
+                Err(error) => {
+                    this.update_in(cx, |this, _window, cx| {
+                        this.voice_recording_state = VoiceRecordingState::Idle;
+                        this.show_voice_recording_error(
+                            format!("Failed to save voice recording: {error:#}"),
+                            cx,
+                        );
+                        cx.notify();
+                    })?;
+                    return anyhow::Ok(());
+                }
+            };
+
+            let transcribe_result = cx
+                .background_spawn(async move {
+                    Self::transcribe_voice_recording(saved_path, whisper_configuration)
+                })
+                .await;
+
+            this.update_in(cx, |this, window, cx| {
                 this.voice_recording_state = VoiceRecordingState::Idle;
 
-                match save_result {
-                    Ok(saved_path) => this.show_voice_recording_saved(&saved_path, cx),
-                    Err(error) => this.show_voice_recording_error(
-                        format!("Failed to save voice recording: {error:#}"),
-                        cx,
-                    ),
+                match transcribe_result {
+                    Ok(transcript) => {
+                        this.insert_voice_transcript(&transcript, window, cx);
+                    }
+                    Err(error) => {
+                        this.show_voice_recording_error(
+                            format!("Failed to transcribe voice recording: {error:#}"),
+                            cx,
+                        );
+                    }
                 }
 
                 cx.notify();
@@ -8333,29 +8388,9 @@ impl ThreadView {
 
     fn next_voice_recording_path() -> PathBuf {
         let timestamp = Local::now().format("%Y-%m-%dT%H-%M-%S-%3f");
-        util::paths::home_dir()
-            .join("Projects")
-            .join("random")
-            .join("recordings")
+        paths::temp_dir()
+            .join("agent_voice")
             .join(format!("agent-voice-{timestamp}.wav"))
-    }
-
-    fn show_voice_recording_saved(&self, saved_path: &std::path::Path, cx: &mut Context<Self>) {
-        let Some(workspace) = self.workspace.upgrade() else {
-            return;
-        };
-
-        let compact_path = saved_path.compact();
-        workspace.update(cx, |workspace, cx| {
-            workspace.show_toast(
-                Toast::new(
-                    NotificationId::unique::<VoiceRecordingSavedToast>(),
-                    format!("Saved voice recording to {}", compact_path.display()),
-                )
-                .autohide(),
-                cx,
-            );
-        });
     }
 
     fn show_voice_recording_error(&self, message: String, cx: &mut Context<Self>) {
@@ -8375,12 +8410,176 @@ impl ThreadView {
         });
     }
 
+    fn resolve_whisper_cpp_configuration(
+        &self,
+        cx: &App,
+    ) -> anyhow::Result<WhisperCppConfiguration> {
+        let settings = AgentSettings::get_global(cx);
+        let executable_path = settings
+            .speech_to_text
+            .whisper_cpp_executable_path
+            .clone()
+            .or_else(|| which::which("whisper-cli").ok())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Voice input requires a whisper.cpp executable path or whisper-cli on PATH."
+                )
+            })?;
+        let model_path = settings
+            .speech_to_text
+            .whisper_cpp_model_path
+            .clone()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Voice input requires a configured whisper.cpp model path.")
+            })?;
+
+        if !executable_path.is_file() {
+            anyhow::bail!(
+                "whisper.cpp executable not found at {}",
+                executable_path.compact().display()
+            );
+        }
+
+        if !model_path.is_file() {
+            anyhow::bail!(
+                "whisper.cpp model not found at {}",
+                model_path.compact().display()
+            );
+        }
+
+        Ok(WhisperCppConfiguration {
+            executable_path,
+            model_path,
+        })
+    }
+
+    fn transcribe_voice_recording(
+        audio_path: PathBuf,
+        whisper_configuration: WhisperCppConfiguration,
+    ) -> anyhow::Result<String> {
+        let mut command = util::command::new_std_command(&whisper_configuration.executable_path);
+        command
+            .arg("-m")
+            .arg(&whisper_configuration.model_path)
+            .arg("-f")
+            .arg(&audio_path);
+
+        let output = match command.output() {
+            Ok(output) => output,
+            Err(error) => {
+                if let Err(remove_error) = std::fs::remove_file(&audio_path) {
+                    log::warn!(
+                        "failed to remove temporary voice recording {}: {remove_error:#}",
+                        audio_path.display()
+                    );
+                }
+
+                return Err(anyhow::anyhow!(
+                    "failed to run whisper.cpp at {}: {}",
+                    whisper_configuration.executable_path.compact().display(),
+                    error
+                ));
+            }
+        };
+
+        if let Err(error) = std::fs::remove_file(&audio_path) {
+            log::warn!(
+                "failed to remove temporary voice recording {}: {error:#}",
+                audio_path.display()
+            );
+        }
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let details = if !stderr.is_empty() { stderr } else { stdout };
+            anyhow::bail!(
+                "whisper.cpp exited with status {}{}",
+                output.status,
+                if details.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {details}")
+                }
+            );
+        }
+
+        let transcript = Self::extract_whisper_transcript(&output.stdout)?;
+        if transcript.is_empty() {
+            anyhow::bail!("whisper.cpp returned an empty transcript");
+        }
+
+        Ok(transcript)
+    }
+
+    fn extract_whisper_transcript(stdout: &[u8]) -> anyhow::Result<String> {
+        let stdout = String::from_utf8(stdout.to_vec())
+            .map_err(|error| anyhow::anyhow!("whisper.cpp returned invalid UTF-8: {error}"))?;
+        let transcript = stdout
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() {
+                    return None;
+                }
+
+                if let Some((_, remainder)) = line.split_once(']')
+                    && line.starts_with('[')
+                {
+                    let remainder = remainder.trim();
+                    return (!remainder.is_empty()).then_some(remainder.to_string());
+                }
+
+                None
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        Ok(transcript.trim().to_string())
+    }
+
+    fn insert_voice_transcript(
+        &mut self,
+        transcript: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let transcript = transcript.trim();
+        if transcript.is_empty() {
+            return;
+        }
+
+        let needs_leading_space = self
+            .message_editor
+            .read(cx)
+            .text(cx)
+            .chars()
+            .last()
+            .is_some_and(|character| !character.is_whitespace());
+        let text = if needs_leading_space {
+            format!(" {transcript}")
+        } else {
+            transcript.to_string()
+        };
+
+        self.message_editor.update(cx, |message_editor, cx| {
+            message_editor.insert_text(&text, window, cx);
+        });
+        self.message_editor.focus_handle(cx).focus(window, cx);
+    }
+
     fn toggle_microphone_menu(
         &mut self,
         _: &ToggleMicrophoneMenu,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.voice_recording_state.is_processing()
+            || self.resolve_whisper_cpp_configuration(cx).is_err()
+        {
+            return;
+        }
+
         let menu_handle = self.microphone_menu_handle.clone();
         window.defer(cx, move |window, cx| {
             menu_handle.toggle(window, cx);
@@ -8520,6 +8719,15 @@ impl ThreadView {
         let focus_handle = self.message_editor.focus_handle(cx);
         let is_recording = self.voice_recording_state.is_recording();
         let is_saving = self.voice_recording_state.is_saving();
+        let is_transcribing = self.voice_recording_state.is_transcribing();
+        let is_processing = self.voice_recording_state.is_processing();
+        let whisper_configuration_error = self
+            .resolve_whisper_cpp_configuration(cx)
+            .err()
+            .map(|error| error.to_string());
+        let button_whisper_configuration_error = whisper_configuration_error.clone();
+        let menu_whisper_configuration_error = whisper_configuration_error.clone();
+        let microphone_control_disabled = is_processing || whisper_configuration_error.is_some();
         let microphone_menu_open = self.microphone_menu_handle.is_deployed();
         let microphone_name =
             resolve_selected_microphone(self.selected_microphone_id.as_deref(), &available_devices)
@@ -8565,7 +8773,7 @@ impl ThreadView {
                     )
                     .into_any_element(),
             ),
-            VoiceRecordingState::Saving => Some(
+            VoiceRecordingState::SavingAudio => Some(
                 h_flex()
                     .justify_center()
                     .items_center()
@@ -8579,6 +8787,18 @@ impl ThreadView {
                             .size(IconSize::XSmall)
                             .color(Color::Accent),
                     )
+                    .child(loading_contents_spinner(IconSize::XSmall))
+                    .into_any_element(),
+            ),
+            VoiceRecordingState::Transcribing => Some(
+                h_flex()
+                    .justify_center()
+                    .items_center()
+                    .w_full()
+                    .gap_0p5()
+                    .absolute()
+                    .top(px(-8.0))
+                    .left(px(0.0))
                     .child(loading_contents_spinner(IconSize::XSmall))
                     .into_any_element(),
             ),
@@ -8598,12 +8818,16 @@ impl ThreadView {
         } else {
             Color::Muted
         })
-        .disabled(is_saving)
+        .disabled(microphone_control_disabled)
         .toggle_state(is_recording)
         .selected_style(ButtonStyle::Tinted(TintColor::Accent))
         .tooltip(move |window, cx| {
-            if is_saving {
+            if let Some(error) = button_whisper_configuration_error.clone() {
+                Tooltip::text(error)(window, cx)
+            } else if is_saving {
                 Tooltip::text("Saving recording")(window, cx)
+            } else if is_transcribing {
+                Tooltip::text("Transcribing recording")(window, cx)
             } else {
                 Tooltip::for_action_in(
                     if is_recording {
@@ -8626,9 +8850,17 @@ impl ThreadView {
             IconButton::new("select-microphone", chevron_icon)
                 .icon_size(IconSize::XSmall)
                 .icon_color(Color::Muted)
-                .disabled(is_saving),
-            move |_window, cx| {
-                Tooltip::with_meta("Select Microphone", None, microphone_name.clone(), cx)
+                .disabled(microphone_control_disabled),
+            move |window, cx| {
+                if let Some(error) = menu_whisper_configuration_error.clone() {
+                    Tooltip::text(error)(window, cx)
+                } else if is_saving {
+                    Tooltip::text("Saving recording")(window, cx)
+                } else if is_transcribing {
+                    Tooltip::text("Transcribing recording")(window, cx)
+                } else {
+                    Tooltip::with_meta("Select Microphone", None, microphone_name.clone(), cx)
+                }
             },
             Corner::BottomLeft,
             cx,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2,6 +2,7 @@ use crate::{DEFAULT_THREAD_TITLE, SelectPermissionGranularity};
 use std::cell::RefCell;
 
 use acp_thread::ContentBlock;
+use audio::{AudioDeviceInfo, AudioSettings, AvailableAudioDevices};
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
 use editor::actions::OpenExcerpts;
 
@@ -11,7 +12,7 @@ use gpui::{Corner, List};
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
 use settings::update_settings_file;
-use ui::{ButtonLike, SplitButton, SplitButtonStyle, Tab};
+use ui::{ButtonLike, IconPosition, SplitButton, SplitButtonStyle, Tab};
 use workspace::SERIALIZATION_THROTTLE_TIME;
 
 use super::*;
@@ -217,6 +218,22 @@ impl PermissionSelection {
     }
 }
 
+fn resolve_selected_microphone(
+    preferred_device: Option<&str>,
+    available_devices: &[AudioDeviceInfo],
+) -> Option<AudioDeviceInfo> {
+    let Some(preferred_device) = preferred_device else {
+        return None;
+    };
+
+    available_devices
+        .iter()
+        .find(|device| {
+            device.desc.supports_input() && device.id.to_string().as_str() == preferred_device
+        })
+        .cloned()
+}
+
 pub struct ThreadView {
     pub id: acp::SessionId,
     pub parent_id: Option<acp::SessionId>,
@@ -279,12 +296,15 @@ pub struct ThreadView {
     pub _subscriptions: Vec<Subscription>,
     pub message_editor: Entity<MessageEditor>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
+    pub microphone_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub thinking_effort_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub project: WeakEntity<Project>,
     pub recent_history_entries: Vec<AgentSessionInfo>,
     pub hovered_recent_history_item: Option<usize>,
     pub show_external_source_prompt_warning: bool,
     pub show_codex_windows_warning: bool,
+    pub selected_microphone_id: Option<String>,
+    pub is_voice_recording: bool,
     pub history: Option<Entity<ThreadHistory>>,
     pub _history_subscription: Option<Subscription>,
 }
@@ -337,6 +357,7 @@ impl ThreadView {
         cx: &mut Context<Self>,
     ) -> Self {
         let id = thread.read(cx).session_id().clone();
+        audio::ensure_devices_initialized(cx);
 
         let placeholder = placeholder_text(agent_display_name.as_ref(), false);
 
@@ -457,6 +478,10 @@ impl ThreadView {
             .as_ref()
             .map(|h| h.read(cx).get_recent_sessions(3))
             .unwrap_or_default();
+        let preferred_microphone = AudioSettings::get_global(cx)
+            .input_audio_device
+            .as_ref()
+            .map(ToString::to_string);
 
         let mut this = Self {
             id,
@@ -517,6 +542,7 @@ impl ThreadView {
             in_flight_prompt: None,
             message_editor,
             add_context_menu_handle: PopoverMenuHandle::default(),
+            microphone_menu_handle: PopoverMenuHandle::default(),
             thinking_effort_menu_handle: PopoverMenuHandle::default(),
             project,
             recent_history_entries,
@@ -525,6 +551,8 @@ impl ThreadView {
             history,
             _history_subscription: history_subscription,
             show_codex_windows_warning,
+            selected_microphone_id: preferred_microphone,
+            is_voice_recording: false,
         };
         let list_state_for_scroll = this.list_state.clone();
         let thread_view = cx.entity().downgrade();
@@ -2966,6 +2994,7 @@ impl ThreadView {
                         h_flex()
                             .gap_1()
                             .children(self.render_token_usage(cx))
+                            .child(self.render_microphone_control(cx))
                             .children(self.profile_selector.clone())
                             .map(|this| {
                                 // Either config_options_view OR (mode_selector + model_selector)
@@ -8016,6 +8045,32 @@ impl ThreadView {
         });
     }
 
+    fn toggle_voice_recording(
+        &mut self,
+        _: &ToggleVoiceRecording,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.flip_voice_recording(cx);
+    }
+
+    fn flip_voice_recording(&mut self, cx: &mut Context<Self>) {
+        self.is_voice_recording = !self.is_voice_recording;
+        cx.notify();
+    }
+
+    fn toggle_microphone_menu(
+        &mut self,
+        _: &ToggleMicrophoneMenu,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let menu_handle = self.microphone_menu_handle.clone();
+        window.defer(cx, move |window, cx| {
+            menu_handle.toggle(window, cx);
+        });
+    }
+
     fn toggle_fast_mode(&mut self, cx: &mut Context<Self>) {
         if !self.fast_mode_available(cx) {
             return;
@@ -8091,6 +8146,177 @@ impl ThreadView {
             menu_handle.toggle(window, cx);
         });
     }
+
+    fn build_microphone_menu(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<ContextMenu> {
+        audio::ensure_devices_initialized(cx);
+        let devices = cx.default_global::<AvailableAudioDevices>().0.clone();
+        let selected_microphone_id = self.selected_microphone_id.clone();
+        let weak_self = cx.weak_entity();
+
+        ContextMenu::build(window, cx, move |mut menu, _window, _cx| {
+            menu = menu.header("Select Microphone");
+
+            let is_system_default = selected_microphone_id.is_none();
+            menu = menu.toggleable_entry(
+                "System Default",
+                is_system_default,
+                IconPosition::Start,
+                None,
+                {
+                    let weak_self = weak_self.clone();
+                    move |_window, cx| {
+                        weak_self
+                            .update(cx, |this, cx| {
+                                this.selected_microphone_id = None;
+                                cx.notify();
+                            })
+                            .ok();
+                    }
+                },
+            );
+
+            let input_devices = devices
+                .iter()
+                .filter(|device| device.desc.supports_input())
+                .cloned()
+                .collect::<Vec<_>>();
+
+            if input_devices.is_empty() {
+                menu = menu.entry("No input devices available", None, |_window, _cx| {});
+                return menu;
+            }
+
+            for device in input_devices {
+                let is_selected = selected_microphone_id
+                    .as_ref()
+                    .is_some_and(|selected_id| selected_id == &device.id.to_string());
+                let label = device.desc.name().to_string();
+
+                menu = menu.toggleable_entry(label, is_selected, IconPosition::Start, None, {
+                    let weak_self = weak_self.clone();
+                    let device = device.clone();
+                    move |_window, cx| {
+                        weak_self
+                            .update(cx, |this, cx| {
+                                this.selected_microphone_id = Some(device.id.to_string());
+                                cx.notify();
+                            })
+                            .ok();
+                    }
+                });
+            }
+
+            menu
+        })
+    }
+
+    fn render_microphone_control(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        audio::ensure_devices_initialized(cx);
+        let available_devices = cx.default_global::<AvailableAudioDevices>().0.clone();
+
+        let focus_handle = self.message_editor.focus_handle(cx);
+        let weak_self = cx.weak_entity();
+        let is_recording = self.is_voice_recording;
+        let microphone_menu_open = self.microphone_menu_handle.is_deployed();
+        let microphone_name =
+            resolve_selected_microphone(self.selected_microphone_id.as_deref(), &available_devices)
+                .map(|device| device.desc.name().to_string())
+                .unwrap_or_else(|| {
+                    if self.selected_microphone_id.is_some() {
+                        "Configured Input Device".to_string()
+                    } else {
+                        "System Default".to_string()
+                    }
+                });
+        let chevron_icon = if microphone_menu_open {
+            IconName::ChevronUp
+        } else {
+            IconName::ChevronDown
+        };
+
+        let indicator = div()
+            .h(px(2.0))
+            .w_full()
+            .rounded_full()
+            .bg(cx.theme().colors().text_accent)
+            .with_animation(
+                "voice-recording-indicator",
+                Animation::new(Duration::from_secs(1))
+                    .repeat()
+                    .with_easing(pulsating_between(0.25, 1.0)),
+                move |indicator, delta| {
+                    if is_recording {
+                        indicator.opacity(delta)
+                    } else {
+                        indicator.opacity(0.0)
+                    }
+                },
+            );
+
+        let voice_recording_button = IconButton::new(
+            "toggle-voice-recording",
+            if is_recording {
+                IconName::Mic
+            } else {
+                IconName::MicMute
+            },
+        )
+        .icon_size(IconSize::Small)
+        .icon_color(if is_recording {
+            Color::Accent
+        } else {
+            Color::Muted
+        })
+        .toggle_state(is_recording)
+        .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+        .tooltip(move |_window, cx| {
+            Tooltip::for_action_in(
+                if is_recording {
+                    "Stop Voice Input"
+                } else {
+                    "Start Voice Input"
+                },
+                &ToggleVoiceRecording,
+                &focus_handle,
+                cx,
+            )
+        })
+        .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| {
+            this.flip_voice_recording(cx);
+        }));
+
+        let microphone_menu = PopoverMenu::new("microphone-input-menu")
+            .trigger_with_tooltip(
+                IconButton::new("select-microphone", chevron_icon)
+                    .icon_size(IconSize::XSmall)
+                    .icon_color(Color::Muted),
+                move |_window, cx| {
+                    Tooltip::with_meta("Select Microphone", None, microphone_name.clone(), cx)
+                },
+            )
+            .anchor(Corner::BottomLeft)
+            .with_handle(self.microphone_menu_handle.clone())
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-2.0),
+            })
+            .menu(move |window, cx| {
+                weak_self
+                    .update(cx, |this, cx| this.build_microphone_menu(window, cx))
+                    .ok()
+            });
+
+        v_flex().gap_0p5().child(indicator).child(
+            h_flex()
+                .gap_px()
+                .child(voice_recording_button)
+                .child(microphone_menu),
+        )
+    }
 }
 
 impl Render for ThreadView {
@@ -8144,6 +8370,8 @@ impl Render for ThreadView {
             .on_action(cx.listener(Self::handle_toggle_command_pattern))
             .on_action(cx.listener(Self::open_permission_dropdown))
             .on_action(cx.listener(Self::open_add_context_menu))
+            .on_action(cx.listener(Self::toggle_voice_recording))
+            .on_action(cx.listener(Self::toggle_microphone_menu))
             .on_action(cx.listener(|this, _: &ToggleFastMode, _window, cx| {
                 this.toggle_fast_mode(cx);
             }))

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -8867,7 +8867,7 @@ impl ThreadView {
                             "Start Voice Input"
                         }
                     }
-                    SpeechToTextTriggerMode::Hold => "Hold to Record Voice Input",
+                    SpeechToTextTriggerMode::Hold => "Hold to Record Dictation",
                 };
 
                 Tooltip::for_action_in(label, &ToggleVoiceRecording, &focus_handle, cx)

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1,18 +1,25 @@
 use crate::{DEFAULT_THREAD_TITLE, SelectPermissionGranularity};
 use std::cell::RefCell;
+use std::path::PathBuf;
 
 use acp_thread::ContentBlock;
 use audio::{AudioDeviceInfo, AudioSettings, AvailableAudioDevices};
+use chrono::Local;
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
 use editor::actions::OpenExcerpts;
+use livekit_client::CaptureInput;
+use picker::{Picker, PickerDelegate, popover_menu::PickerPopoverMenu};
 
 use crate::StartThreadIn;
 use crate::message_editor::SharedSessionCapabilities;
-use gpui::{Corner, List};
+use gpui::{Corner, DismissEvent, List};
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
 use settings::update_settings_file;
-use ui::{ButtonLike, IconPosition, SplitButton, SplitButtonStyle, Tab};
+use ui::{
+    ButtonLike, HighlightedLabel, IconPosition, ListItem, SplitButton, SplitButtonStyle, Tab,
+};
+use util::paths::PathExt;
 use workspace::SERIALIZATION_THROTTLE_TIME;
 
 use super::*;
@@ -162,6 +169,204 @@ impl ThreadFeedbackState {
     }
 }
 
+enum VoiceRecordingState {
+    Idle,
+    Recording { capture_input: CaptureInput },
+    Saving,
+}
+
+impl Default for VoiceRecordingState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl VoiceRecordingState {
+    fn is_recording(&self) -> bool {
+        matches!(self, Self::Recording { .. })
+    }
+
+    fn is_saving(&self) -> bool {
+        matches!(self, Self::Saving)
+    }
+}
+
+struct VoiceRecordingSavedToast;
+struct VoiceRecordingErrorToast;
+
+#[derive(Clone)]
+struct MicrophoneOption {
+    device_id: Option<String>,
+    name: SharedString,
+}
+
+struct MicrophonePickerDelegate {
+    thread_view: WeakEntity<ThreadView>,
+    options: Vec<MicrophoneOption>,
+    filtered_options: Vec<MicrophoneOption>,
+    selected_microphone_id: Option<String>,
+    selected_index: usize,
+    query: String,
+}
+
+impl MicrophonePickerDelegate {
+    fn new(
+        thread_view: WeakEntity<ThreadView>,
+        options: Vec<MicrophoneOption>,
+        selected_microphone_id: Option<String>,
+    ) -> Self {
+        let mut this = Self {
+            thread_view,
+            options: Vec::new(),
+            filtered_options: Vec::new(),
+            selected_microphone_id: None,
+            selected_index: 0,
+            query: String::new(),
+        };
+        this.refresh_options(options, selected_microphone_id);
+        this
+    }
+
+    fn refresh_options(
+        &mut self,
+        options: Vec<MicrophoneOption>,
+        selected_microphone_id: Option<String>,
+    ) {
+        self.options = options;
+        self.selected_microphone_id = selected_microphone_id;
+        self.filtered_options = self.options_for_query(&self.query);
+        self.selected_index = self
+            .index_of_selected()
+            .unwrap_or_else(|| self.first_selectable_index().unwrap_or(0));
+    }
+
+    fn options_for_query(&self, query: &str) -> Vec<MicrophoneOption> {
+        let normalized_query = query.trim().to_ascii_lowercase();
+        if normalized_query.is_empty() {
+            return self.options.clone();
+        }
+
+        self.options
+            .iter()
+            .filter(|option| option.name.to_ascii_lowercase().contains(&normalized_query))
+            .cloned()
+            .collect()
+    }
+
+    fn first_selectable_index(&self) -> Option<usize> {
+        (!self.filtered_options.is_empty()).then_some(0)
+    }
+
+    fn index_of_selected(&self) -> Option<usize> {
+        self.filtered_options
+            .iter()
+            .position(|option| option.device_id == self.selected_microphone_id)
+    }
+}
+
+impl PickerDelegate for MicrophonePickerDelegate {
+    type ListItem = AnyElement;
+
+    fn match_count(&self) -> usize {
+        self.filtered_options.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(&mut self, ix: usize, _: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.selected_index = ix.min(self.filtered_options.len().saturating_sub(1));
+        cx.notify();
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Select microphone…".into()
+    }
+
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("No microphones match your search.".into())
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        self.query = query;
+        self.filtered_options = self.options_for_query(&self.query);
+        self.selected_index = self
+            .index_of_selected()
+            .unwrap_or_else(|| self.first_selectable_index().unwrap_or(0));
+        cx.notify();
+        Task::ready(())
+    }
+
+    fn confirm(&mut self, _: bool, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        let Some(option) = self.filtered_options.get(self.selected_index).cloned() else {
+            return;
+        };
+
+        self.thread_view
+            .update(cx, |thread_view, cx| {
+                thread_view.selected_microphone_id = option.device_id.clone();
+                cx.notify();
+            })
+            .ok();
+
+        self.selected_microphone_id = option.device_id;
+        cx.emit(DismissEvent);
+    }
+
+    fn dismissed(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        cx.defer_in(window, |picker, window, cx| {
+            picker.set_query("", window, cx);
+        });
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let option = self.filtered_options.get(ix)?;
+        let is_active = option.device_id == self.selected_microphone_id;
+        let query = self.query.trim().to_ascii_lowercase();
+        let highlight_positions = if query.is_empty() {
+            Vec::new()
+        } else {
+            option
+                .name
+                .to_ascii_lowercase()
+                .find(&query)
+                .map(|start| (start..start + query.len()).collect())
+                .unwrap_or_default()
+        };
+
+        Some(
+            ListItem::new(("microphone-picker-item", ix))
+                .inset(true)
+                .spacing(ui::ListItemSpacing::Sparse)
+                .toggle_state(selected)
+                .child(HighlightedLabel::new(
+                    option.name.clone(),
+                    highlight_positions,
+                ))
+                .when(is_active, |this| {
+                    this.end_slot(
+                        div()
+                            .pr_2()
+                            .child(Icon::new(IconName::Check).color(Color::Accent)),
+                    )
+                })
+                .into_any_element(),
+        )
+    }
+}
+
 pub enum AcpThreadViewEvent {
     FirstSendRequested { content: Vec<acp::ContentBlock> },
 }
@@ -296,7 +501,7 @@ pub struct ThreadView {
     pub _subscriptions: Vec<Subscription>,
     pub message_editor: Entity<MessageEditor>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
-    pub microphone_menu_handle: PopoverMenuHandle<ContextMenu>,
+    microphone_menu_handle: PopoverMenuHandle<Picker<MicrophonePickerDelegate>>,
     pub thinking_effort_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub project: WeakEntity<Project>,
     pub recent_history_entries: Vec<AgentSessionInfo>,
@@ -304,7 +509,8 @@ pub struct ThreadView {
     pub show_external_source_prompt_warning: bool,
     pub show_codex_windows_warning: bool,
     pub selected_microphone_id: Option<String>,
-    pub is_voice_recording: bool,
+    microphone_picker: Option<Entity<Picker<MicrophonePickerDelegate>>>,
+    voice_recording_state: VoiceRecordingState,
     pub history: Option<Entity<ThreadHistory>>,
     pub _history_subscription: Option<Subscription>,
 }
@@ -552,7 +758,8 @@ impl ThreadView {
             _history_subscription: history_subscription,
             show_codex_windows_warning,
             selected_microphone_id: preferred_microphone,
-            is_voice_recording: false,
+            microphone_picker: None,
+            voice_recording_state: VoiceRecordingState::Idle,
         };
         let list_state_for_scroll = this.list_state.clone();
         let thread_view = cx.entity().downgrade();
@@ -2993,8 +3200,9 @@ impl ThreadView {
                     .child(
                         h_flex()
                             .gap_1()
+                            .items_center()
                             .children(self.render_token_usage(cx))
-                            .child(self.render_microphone_control(cx))
+                            .child(self.render_microphone_control(window, cx))
                             .children(self.profile_selector.clone())
                             .map(|this| {
                                 // Either config_options_view OR (mode_selector + model_selector)
@@ -8048,15 +8256,123 @@ impl ThreadView {
     fn toggle_voice_recording(
         &mut self,
         _: &ToggleVoiceRecording,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.flip_voice_recording(cx);
+        self.flip_voice_recording(window, cx);
     }
 
-    fn flip_voice_recording(&mut self, cx: &mut Context<Self>) {
-        self.is_voice_recording = !self.is_voice_recording;
+    fn flip_voice_recording(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match std::mem::replace(&mut self.voice_recording_state, VoiceRecordingState::Idle) {
+            VoiceRecordingState::Idle => match self.start_voice_recording(cx) {
+                Ok(()) => {}
+                Err(error) => {
+                    self.voice_recording_state = VoiceRecordingState::Idle;
+                    self.show_voice_recording_error(
+                        format!("Failed to start voice recording: {error:#}"),
+                        cx,
+                    );
+                    cx.notify();
+                }
+            },
+            VoiceRecordingState::Recording { capture_input } => {
+                self.finish_voice_recording(capture_input, window, cx);
+            }
+            VoiceRecordingState::Saving => {
+                self.voice_recording_state = VoiceRecordingState::Saving;
+            }
+        }
+    }
+
+    fn start_voice_recording(&mut self, cx: &mut Context<Self>) -> anyhow::Result<()> {
+        audio::ensure_devices_initialized(cx);
+        let available_devices = cx.default_global::<AvailableAudioDevices>().0.clone();
+        let selected_microphone =
+            resolve_selected_microphone(self.selected_microphone_id.as_deref(), &available_devices);
+
+        let capture_input =
+            CaptureInput::start(selected_microphone.map(|device| device.id.clone()))?;
+        self.voice_recording_state = VoiceRecordingState::Recording { capture_input };
         cx.notify();
+        Ok(())
+    }
+
+    fn finish_voice_recording(
+        &mut self,
+        capture_input: CaptureInput,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let save_path = Self::next_voice_recording_path();
+        self.voice_recording_state = VoiceRecordingState::Saving;
+        cx.notify();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let save_result = cx
+                .background_spawn(async move { capture_input.finish_to_path(save_path) })
+                .await;
+
+            this.update_in(cx, |this, _window, cx| {
+                this.voice_recording_state = VoiceRecordingState::Idle;
+
+                match save_result {
+                    Ok(saved_path) => this.show_voice_recording_saved(&saved_path, cx),
+                    Err(error) => this.show_voice_recording_error(
+                        format!("Failed to save voice recording: {error:#}"),
+                        cx,
+                    ),
+                }
+
+                cx.notify();
+            })?;
+
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn next_voice_recording_path() -> PathBuf {
+        let timestamp = Local::now().format("%Y-%m-%dT%H-%M-%S-%3f");
+        util::paths::home_dir()
+            .join("Projects")
+            .join("random")
+            .join("recordings")
+            .join(format!("agent-voice-{timestamp}.wav"))
+    }
+
+    fn show_voice_recording_saved(&self, saved_path: &std::path::Path, cx: &mut Context<Self>) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+
+        let compact_path = saved_path.compact();
+        workspace.update(cx, |workspace, cx| {
+            workspace.show_toast(
+                Toast::new(
+                    NotificationId::unique::<VoiceRecordingSavedToast>(),
+                    format!("Saved voice recording to {}", compact_path.display()),
+                )
+                .autohide(),
+                cx,
+            );
+        });
+    }
+
+    fn show_voice_recording_error(&self, message: String, cx: &mut Context<Self>) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+
+        workspace.update(cx, |workspace, cx| {
+            workspace.show_toast(
+                Toast::new(
+                    NotificationId::unique::<VoiceRecordingErrorToast>(),
+                    message,
+                )
+                .autohide(),
+                cx,
+            );
+        });
     }
 
     fn toggle_microphone_menu(
@@ -8147,80 +8463,63 @@ impl ThreadView {
         });
     }
 
-    fn build_microphone_menu(
-        &self,
+    fn ensure_microphone_picker(
+        &mut self,
         window: &mut Window,
+        options: Vec<MicrophoneOption>,
         cx: &mut Context<Self>,
-    ) -> Entity<ContextMenu> {
-        audio::ensure_devices_initialized(cx);
-        let devices = cx.default_global::<AvailableAudioDevices>().0.clone();
-        let selected_microphone_id = self.selected_microphone_id.clone();
-        let weak_self = cx.weak_entity();
-
-        ContextMenu::build(window, cx, move |mut menu, _window, _cx| {
-            menu = menu.header("Select Microphone");
-
-            let is_system_default = selected_microphone_id.is_none();
-            menu = menu.toggleable_entry(
-                "System Default",
-                is_system_default,
-                IconPosition::Start,
-                None,
-                {
-                    let weak_self = weak_self.clone();
-                    move |_window, cx| {
-                        weak_self
-                            .update(cx, |this, cx| {
-                                this.selected_microphone_id = None;
-                                cx.notify();
-                            })
-                            .ok();
-                    }
-                },
+    ) -> Entity<Picker<MicrophonePickerDelegate>> {
+        if self.microphone_picker.is_none() {
+            let delegate = MicrophonePickerDelegate::new(
+                cx.weak_entity(),
+                options.clone(),
+                self.selected_microphone_id.clone(),
             );
+            let picker = cx.new(|cx| {
+                Picker::list(delegate, window, cx)
+                    .show_scrollbar(true)
+                    .width(rems(18.))
+                    .max_height(Some(rems(16.).into()))
+            });
+            self.microphone_picker = Some(picker);
+        }
 
-            let input_devices = devices
-                .iter()
-                .filter(|device| device.desc.supports_input())
-                .cloned()
-                .collect::<Vec<_>>();
-
-            if input_devices.is_empty() {
-                menu = menu.entry("No input devices available", None, |_window, _cx| {});
-                return menu;
-            }
-
-            for device in input_devices {
-                let is_selected = selected_microphone_id
-                    .as_ref()
-                    .is_some_and(|selected_id| selected_id == &device.id.to_string());
-                let label = device.desc.name().to_string();
-
-                menu = menu.toggleable_entry(label, is_selected, IconPosition::Start, None, {
-                    let weak_self = weak_self.clone();
-                    let device = device.clone();
-                    move |_window, cx| {
-                        weak_self
-                            .update(cx, |this, cx| {
-                                this.selected_microphone_id = Some(device.id.to_string());
-                                cx.notify();
-                            })
-                            .ok();
-                    }
-                });
-            }
-
-            menu
-        })
+        let picker = self.microphone_picker.as_ref().unwrap().clone();
+        let selected_microphone_id = self.selected_microphone_id.clone();
+        picker.update(cx, |picker, cx| {
+            picker
+                .delegate
+                .refresh_options(options, selected_microphone_id);
+            cx.notify();
+        });
+        picker
     }
 
-    fn render_microphone_control(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_microphone_control(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         audio::ensure_devices_initialized(cx);
         let available_devices = cx.default_global::<AvailableAudioDevices>().0.clone();
+        let mut microphone_options = vec![MicrophoneOption {
+            device_id: None,
+            name: "System Default".into(),
+        }];
+        microphone_options.extend(
+            available_devices
+                .iter()
+                .filter(|device| device.desc.supports_input())
+                .map(|device| MicrophoneOption {
+                    device_id: Some(device.id.to_string()),
+                    name: SharedString::from(device.desc.name().to_string()),
+                }),
+        );
+        let microphone_picker = self.ensure_microphone_picker(window, microphone_options, cx);
 
         let focus_handle = self.message_editor.focus_handle(cx);
-        let weak_self = cx.weak_entity();
-        let is_recording = self.is_voice_recording;
+        let is_recording = self.voice_recording_state.is_recording();
+        let is_saving = self.voice_recording_state.is_saving();
         let microphone_menu_open = self.microphone_menu_handle.is_deployed();
         let microphone_name =
             resolve_selected_microphone(self.selected_microphone_id.as_deref(), &available_devices)
@@ -8238,24 +8537,52 @@ impl ThreadView {
             IconName::ChevronDown
         };
 
-        let indicator = div()
-            .h(px(2.0))
-            .w_full()
-            .rounded_full()
-            .bg(cx.theme().colors().text_accent)
-            .with_animation(
-                "voice-recording-indicator",
-                Animation::new(Duration::from_secs(1))
-                    .repeat()
-                    .with_easing(pulsating_between(0.25, 1.0)),
-                move |indicator, delta| {
-                    if is_recording {
-                        indicator.opacity(delta)
-                    } else {
-                        indicator.opacity(0.0)
-                    }
-                },
-            );
+        let indicator = match &self.voice_recording_state {
+            VoiceRecordingState::Idle => None,
+            VoiceRecordingState::Recording { .. } => Some(
+                h_flex()
+                    .justify_center()
+                    .items_center()
+                    .w_full()
+                    .gap_0p5()
+                    .absolute()
+                    .top(px(-8.0))
+                    .left(px(0.0))
+                    .child(
+                        div()
+                            .child(
+                                Icon::new(IconName::Circle)
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Accent),
+                            )
+                            .with_animation(
+                                "voice-recording-indicator",
+                                Animation::new(Duration::from_secs(1))
+                                    .repeat()
+                                    .with_easing(pulsating_between(0.25, 1.0)),
+                                |indicator, delta| indicator.opacity(delta),
+                            ),
+                    )
+                    .into_any_element(),
+            ),
+            VoiceRecordingState::Saving => Some(
+                h_flex()
+                    .justify_center()
+                    .items_center()
+                    .w_full()
+                    .gap_0p5()
+                    .absolute()
+                    .top(px(-8.0))
+                    .left(px(0.0))
+                    .child(
+                        Icon::new(IconName::Circle)
+                            .size(IconSize::XSmall)
+                            .color(Color::Accent),
+                    )
+                    .child(loading_contents_spinner(IconSize::XSmall))
+                    .into_any_element(),
+            ),
+        };
 
         let voice_recording_button = IconButton::new(
             "toggle-voice-recording",
@@ -8271,51 +8598,58 @@ impl ThreadView {
         } else {
             Color::Muted
         })
+        .disabled(is_saving)
         .toggle_state(is_recording)
         .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-        .tooltip(move |_window, cx| {
-            Tooltip::for_action_in(
-                if is_recording {
-                    "Stop Voice Input"
-                } else {
-                    "Start Voice Input"
-                },
-                &ToggleVoiceRecording,
-                &focus_handle,
-                cx,
-            )
+        .tooltip(move |window, cx| {
+            if is_saving {
+                Tooltip::text("Saving recording")(window, cx)
+            } else {
+                Tooltip::for_action_in(
+                    if is_recording {
+                        "Stop Voice Input"
+                    } else {
+                        "Start Voice Input"
+                    },
+                    &ToggleVoiceRecording,
+                    &focus_handle,
+                    cx,
+                )
+            }
         })
-        .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| {
-            this.flip_voice_recording(cx);
+        .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+            this.flip_voice_recording(window, cx);
         }));
 
-        let microphone_menu = PopoverMenu::new("microphone-input-menu")
-            .trigger_with_tooltip(
-                IconButton::new("select-microphone", chevron_icon)
-                    .icon_size(IconSize::XSmall)
-                    .icon_color(Color::Muted),
-                move |_window, cx| {
-                    Tooltip::with_meta("Select Microphone", None, microphone_name.clone(), cx)
-                },
-            )
-            .anchor(Corner::BottomLeft)
-            .with_handle(self.microphone_menu_handle.clone())
-            .offset(gpui::Point {
-                x: px(0.0),
-                y: px(-2.0),
-            })
-            .menu(move |window, cx| {
-                weak_self
-                    .update(cx, |this, cx| this.build_microphone_menu(window, cx))
-                    .ok()
-            });
-
-        v_flex().gap_0p5().child(indicator).child(
-            h_flex()
-                .gap_px()
-                .child(voice_recording_button)
-                .child(microphone_menu),
+        let microphone_menu = PickerPopoverMenu::new(
+            microphone_picker,
+            IconButton::new("select-microphone", chevron_icon)
+                .icon_size(IconSize::XSmall)
+                .icon_color(Color::Muted)
+                .disabled(is_saving),
+            move |_window, cx| {
+                Tooltip::with_meta("Select Microphone", None, microphone_name.clone(), cx)
+            },
+            Corner::BottomLeft,
+            cx,
         )
+        .with_handle(self.microphone_menu_handle.clone())
+        .offset(gpui::Point {
+            x: px(0.0),
+            y: px(-2.0),
+        })
+        .render(window, cx);
+
+        div()
+            .relative()
+            .child(
+                h_flex()
+                    .items_center()
+                    .gap_px()
+                    .child(voice_recording_button)
+                    .child(microphone_menu),
+            )
+            .when_some(indicator, |this, indicator| this.child(indicator))
     }
 }
 

--- a/crates/livekit_client/src/record.rs
+++ b/crates/livekit_client/src/record.rs
@@ -42,9 +42,18 @@ impl CaptureInput {
     }
 
     pub fn finish(self) -> Result<PathBuf> {
-        let name = self.name;
         let mut path = env::current_dir().context("Could not get current dir")?;
-        path.push(&format!("test_recording_{name}.wav"));
+        path.push(format!("test_recording_{}.wav", self.name.as_str()));
+        self.finish_to_path(path)
+    }
+
+    pub fn finish_to_path(self, path: impl Into<PathBuf>) -> Result<PathBuf> {
+        let path = path.into();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create recording directory {}", parent.display())
+            })?;
+        }
         log::info!("Test recording written to: {}", path.display());
         write_out(self.samples, self.config, &path)?;
         Ok(path)

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -180,6 +180,14 @@ impl AgentSettingsContent {
         self.new_thread_location = Some(value);
     }
 
+    pub fn set_speech_to_text_enabled(&mut self, enabled: bool) {
+        self.speech_to_text.get_or_insert_default().enabled = Some(enabled);
+    }
+
+    pub fn set_speech_to_text_trigger_mode(&mut self, trigger_mode: SpeechToTextTriggerMode) {
+        self.speech_to_text.get_or_insert_default().trigger_mode = Some(trigger_mode);
+    }
+
     pub fn add_favorite_model(&mut self, model: LanguageModelSelection) {
         if !self.favorite_models.contains(&model) {
             self.favorite_models.push(model);
@@ -233,11 +241,17 @@ impl AgentSettingsContent {
 #[with_fallible_options]
 #[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, Default)]
 pub struct SpeechToTextContent {
+    /// Whether voice input controls should be shown in the agent panel.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
     /// Path to the whisper.cpp executable to run for transcription.
     pub whisper_cpp_executable_path: Option<PathBuf>,
     /// Path to the whisper.cpp model file to use for transcription.
     pub whisper_cpp_model_path: Option<PathBuf>,
     /// Whether the microphone button toggles recording or records only while held.
+    ///
+    /// Default: "toggle"
     pub trigger_mode: Option<SpeechToTextTriggerMode>,
 }
 

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -237,6 +237,31 @@ pub struct SpeechToTextContent {
     pub whisper_cpp_executable_path: Option<PathBuf>,
     /// Path to the whisper.cpp model file to use for transcription.
     pub whisper_cpp_model_path: Option<PathBuf>,
+    /// Whether the microphone button toggles recording or records only while held.
+    pub trigger_mode: Option<SpeechToTextTriggerMode>,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SpeechToTextTriggerMode {
+    /// Click once to start recording and click again to stop.
+    #[default]
+    Toggle,
+    /// Record only while the microphone button is held down.
+    Hold,
 }
 
 #[with_fallible_options]

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -150,6 +150,8 @@ pub struct AgentSettingsContent {
     /// `always_confirm`) match against the tool's text input (command, path,
     /// URL, etc.).
     pub tool_permissions: Option<ToolPermissionsContent>,
+    /// Local speech-to-text settings for voice input in the agent panel.
+    pub speech_to_text: Option<SpeechToTextContent>,
 }
 
 impl AgentSettingsContent {
@@ -226,6 +228,15 @@ impl AgentSettingsContent {
             });
         }
     }
+}
+
+#[with_fallible_options]
+#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, Default)]
+pub struct SpeechToTextContent {
+    /// Path to the whisper.cpp executable to run for transcription.
+    pub whisper_cpp_executable_path: Option<PathBuf>,
+    /// Path to the whisper.cpp model file to use for transcription.
+    pub whisper_cpp_model_path: Option<PathBuf>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -22,6 +22,12 @@ const DEFAULT_STRING: String = String::new();
 /// A default empty string reference. Useful in `pick` functions for cases either in dynamic item fields, or when dealing with `settings::Maybe`
 /// to avoid the "NO DEFAULT" case.
 const DEFAULT_EMPTY_STRING: Option<&String> = Some(&DEFAULT_STRING);
+const DEFAULT_FALSE: bool = false;
+const DEFAULT_FALSE_BOOL: Option<&bool> = Some(&DEFAULT_FALSE);
+const DEFAULT_SPEECH_TO_TEXT_TRIGGER_MODE: settings::SpeechToTextTriggerMode =
+    settings::SpeechToTextTriggerMode::Toggle;
+const DEFAULT_SPEECH_TO_TEXT_TRIGGER_MODE_VALUE: Option<&settings::SpeechToTextTriggerMode> =
+    Some(&DEFAULT_SPEECH_TO_TEXT_TRIGGER_MODE);
 
 const DEFAULT_AUDIO_OUTPUT: AudioOutputDeviceName = AudioOutputDeviceName(None);
 const DEFAULT_EMPTY_AUDIO_OUTPUT: Option<&AudioOutputDeviceName> = Some(&DEFAULT_AUDIO_OUTPUT);
@@ -5606,7 +5612,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn agent_panel_section() -> [SettingsPageItem; 5] {
+    fn agent_panel_section() -> [SettingsPageItem; 7] {
         [
             SettingsPageItem::SectionHeader("Agent Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5645,6 +5651,52 @@ fn panels_page() -> SettingsPage {
                     },
                     write: |settings_content, value| {
                         settings_content.agent.get_or_insert_default().default_width = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Enable Voice Input",
+                description: "Whether to show dictation controls in the agent composer.",
+                field: Box::new(SettingField {
+                    json_path: Some("agent.speech_to_text.enabled"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()
+                            .and_then(|agent| agent.speech_to_text.as_ref())
+                            .and_then(|speech_to_text| speech_to_text.enabled.as_ref())
+                            .or(DEFAULT_FALSE_BOOL)
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .set_speech_to_text_enabled(value.unwrap_or(false));
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Voice Input Trigger Mode",
+                description: "Whether the dictation button records until clicked again or only while held down.",
+                field: Box::new(SettingField {
+                    json_path: Some("agent.speech_to_text.trigger_mode"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()
+                            .and_then(|agent| agent.speech_to_text.as_ref())
+                            .and_then(|speech_to_text| speech_to_text.trigger_mode.as_ref())
+                            .or(DEFAULT_SPEECH_TO_TEXT_TRIGGER_MODE_VALUE)
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .set_speech_to_text_trigger_mode(value.unwrap_or_default());
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -523,6 +523,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::VimInsertModeCursorShape>(render_dropdown)
         .add_basic_renderer::<settings::SteppingGranularity>(render_dropdown)
         .add_basic_renderer::<settings::NotifyWhenAgentWaiting>(render_dropdown)
+        .add_basic_renderer::<settings::SpeechToTextTriggerMode>(render_dropdown)
         .add_basic_renderer::<settings::NewThreadLocation>(render_dropdown)
         .add_basic_renderer::<settings::ImageFileSizeUnit>(render_dropdown)
         .add_basic_renderer::<settings::StatusStyle>(render_dropdown)


### PR DESCRIPTION
I've added a speech to text dictation tool for the agent tool. I believe this belongs in zed for a few reasons:
1. speed. talking is way faster than typing. it's also very natural for prompting since LLMs are relatively conversational.
2. accessibility + convenience. vibe coding has made software development more accessible by closing knowledge gaps, but voice typing can assist users who struggle to use keyboards.
3. competitiveness. both cursor and claude code now have voice modes, so adding it to zed will assist in growing the community of zed users.
I have implemented it in a way that minimizes bloat for the regular user but keeps feature parity for those who choose to use it.
How it works:
By default, voice mode is disabled. I've added a setting in the agent panel menu:
<img width="670" height="483" alt="image" src="https://github.com/user-attachments/assets/8859e18c-f699-4ead-84c8-f89e758c83a7" />
Once enabled, the agent panel gains this minimal mic icon with the dropdown menu:
<img width="817" height="1070" alt="image" src="https://github.com/user-attachments/assets/ec7652c9-2043-4632-b1bf-ef298ec60a3b" />
However right now it's grayed out as it's not configured yet:
<img width="306" height="70" alt="image" src="https://github.com/user-attachments/assets/bea54cd0-9f10-468c-883f-93ca1bc953ce" />
Now in settings under "agent":
    "speech_to_text": {
          "enabled": true,
          "whisper_cpp_executable_path": "{your binary path}",
          "whisper_cpp_model_path": "{your model path}",
          "trigger_mode": "hold",
    },
The transcription powered by [whisper.cpp](ttps://github.com/ggml-org/whisper.cpp) running locally. By having the user install it and set the path themselves, it ensures that users who don't want the feature don't have to install a whole voice dictation model along with Zed.

Once that's in, it stops being gray and will work when used. you can hit the dropdown menu to select a mic (by default set to System Default):
<img width="822" height="397" alt="image" src="https://github.com/user-attachments/assets/d0b064a0-85d2-4603-a6de-d485e7d88d1c" />

The user can set between hold and toggle options in settings for the mouse. There is also a keybind for toggling by default set to ctrl + alt + v.
<img width="294" height="74" alt="image" src="https://github.com/user-attachments/assets/ec76501b-196a-4661-bf74-73f89e1b8cdc" />

While active, there's this flashing dot indicator on the mic icon:
<img width="42" height="37" alt="image" src="https://github.com/user-attachments/assets/9e7bfeea-edc8-4c4c-9653-835f22f3ce93" />

While whisper is processing it, it has this loading buffer icon:
<img width="47" height="47" alt="image" src="https://github.com/user-attachments/assets/7a15743c-0c3f-4fb5-a3ad-43bf8d4beb52" />

Then when you're done speaking, the text is inserted wherever your cursor is in the text box.

The flow of processing is
toggle on = start recording -> toggle off = stop recording -> saves .wav file to an audio folder in zed's set caching directory -> whispr processes it into text -> text inserts into agent panel -> audio file is deleted.

I encourage you to try it out yourself in the fork, it's pretty fun to talk to the LLM! This is also my first time contributing to zed so I would appreciate feedback.
Also - I understand for features it's recommended I start a discussion first. I opted to just do this since I had the free time.