### PR TITLE
go: Add semantic token rule for format string interpolations

### DIFF
--- a/crates/languages/src/go/semantic_token_rules.json
+++ b/crates/languages/src/go/semantic_token_rules.json
@@ -3,5 +3,10 @@
     "token_type": "variable",
     "token_modifiers": ["readonly"],
     "style": ["constant"]
+  },
+  {
+    "token_type": "string",
+    "token_modifiers": ["format"],
+    "style": ["string.special"]
   }
 ]


### PR DESCRIPTION
## Context

Closes #52391

gopls sends semantic tokens for format args with [format] modifier. Without a simple support for there is no special highlighting for format args like `%s`. Its a simple change inside `go/semantic_token_rules.json` that makes this a default behavior.

Currently (on 0.229 preview):
<img width="1136" height="675" alt="Screenshot 2026-03-25 at 11 34 57" src="https://github.com/user-attachments/assets/cd3d9a52-6740-47b5-8f05-02514cb4f9df" />

After fix:

<img width="1136" height="675" alt="Screenshot 2026-03-25 at 11 58 37" src="https://github.com/user-attachments/assets/5ec4277b-39c1-4fe1-bed5-8a6fa63c18c9" />


## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- gopls: Add semantic token rule for format string interpolations
