### PR TITLE
Reload debug.json on Rerun Session

### DIFF
--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1766,6 +1766,18 @@ impl RunningState {
             } = context;
             let active_buffer = active_buffer.and_then(|buffer| buffer.upgrade());
 
+            let scenario = self
+                .project
+                .upgrade()
+                .and_then(|project| {
+                    let task_store = project.read(cx).task_store().clone();
+                    let inventory = task_store.read(cx).task_inventory()?.clone();
+                    inventory
+                        .read(cx)
+                        .scenario_by_label(&scenario.label, worktree_id)
+                })
+                .unwrap_or(scenario);
+
             self.workspace
                 .update(cx, |workspace, cx| {
                     workspace.start_debug_session(

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -663,6 +663,26 @@ impl Inventory {
         self.scenarios_from_settings.worktree_scenarios(worktree)
     }
 
+    /// Looks up a debug scenario by label from the current file-based settings.
+    pub fn scenario_by_label(
+        &self,
+        label: &str,
+        worktree_id: Option<WorktreeId>,
+    ) -> Option<DebugScenario> {
+        if let Some(worktree_id) = worktree_id {
+            if let Some(scenario) = self
+                .worktree_scenarios_from_settings(worktree_id)
+                .find(|(_, s)| s.label.as_ref() == label)
+                .map(|(_, s)| s)
+            {
+                return Some(scenario);
+            }
+        }
+        self.global_debug_scenarios_from_settings()
+            .find(|(_, s)| s.label.as_ref() == label)
+            .map(|(_, s)| s)
+    }
+
     fn worktree_templates_from_settings(
         &self,
         worktree: WorktreeId,


### PR DESCRIPTION
Fixes #52379

When clicking "Rerun Session", the debugger reused the `DebugScenario` cached at session start. If `debug.json` was modified after the session launched, those changes were ignored until a full restart.

This re-reads the scenario from the task inventory's current file-based settings before starting the new session. The task inventory already tracks file changes to `debug.json` via `update_file_based_scenarios`, so the fresh config is always available.

Release Notes:

- Fixed debug configuration not reloading when using "Rerun Session" after modifying `.zed/debug.json`.
