### PR TITLE
Reload debug.json config on session rerun

### DIFF
--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1756,9 +1756,24 @@ impl RunningState {
     }
 
     pub fn rerun_session(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some((scenario, context)) = self.scenario.take().zip(self.scenario_context.take())
-            && scenario.build.is_some()
+        if let Some((cached_scenario, context)) =
+            self.scenario.take().zip(self.scenario_context.take())
+            && cached_scenario.build.is_some()
         {
+            let scenario = self
+                .workspace
+                .upgrade()
+                .and_then(|workspace| {
+                    let project = workspace.read(cx).project().read(cx);
+                    let task_store = project.task_store().read(cx);
+                    let inventory = task_store.task_inventory()?;
+                    inventory
+                        .read(cx)
+                        .scheduled_scenario_by_label(&cached_scenario.label)
+                        .map(|(s, _)| s.clone())
+                })
+                .unwrap_or(cached_scenario);
+
             let DebugScenarioContext {
                 task_context,
                 active_buffer,

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -285,6 +285,15 @@ impl Inventory {
         self.last_scheduled_scenarios.back()
     }
 
+    pub fn scheduled_scenario_by_label(
+        &self,
+        label: &str,
+    ) -> Option<&(DebugScenario, DebugScenarioContext)> {
+        self.last_scheduled_scenarios
+            .iter()
+            .find(|(s, _)| s.label.as_ref() == label)
+    }
+
     pub fn list_debug_scenarios(
         &self,
         task_contexts: &TaskContexts,


### PR DESCRIPTION
Rerun Session was using the cached debug scenario from the original launch
instead of the current definition. The task inventory already updates its
stored scenarios when debug.json changes on disk, so this change makes
rerun look up the latest version by label before starting a new session.

Closes #52379

Release Notes:

- Fixed debug.json changes not being picked up by "Rerun Session"