### PR TITLE
workspace: Fix empty workspaces deleted by recent_workspaces_on_disk

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1853,6 +1853,12 @@ impl WorkspaceDb {
                 continue;
             }
 
+            // Empty workspaces (no folder paths) are identified by workspace_id, not paths.
+            // They must not be deleted here; they are restored separately via session_workspaces.
+            if paths.is_empty() {
+                continue;
+            }
+
             // Delete the workspace if any of the paths are WSL paths. If a
             // local workspace points to WSL, attempting to read its metadata
             // will wait for the WSL VM and file server to boot up. This can
@@ -5065,5 +5071,52 @@ mod tests {
                 "fallback should have found workspace_b, not the excluded workspace_a"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_empty_workspace_not_deleted_by_recent_workspaces_on_disk(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db = WorkspaceDb::open_test_db(
+            "test_empty_workspace_not_deleted_by_recent_workspaces_on_disk",
+        )
+        .await;
+
+        // Simulate an empty workspace with unsaved buffers saved with restore_unsaved_buffers=true.
+        // These are saved with paths="" and a session_id.
+        let empty_workspace_id = db.next_id().await.unwrap();
+        let workspace = SerializedWorkspace {
+            id: empty_workspace_id,
+            paths: PathList::new::<String>(&[]),
+            location: SerializedWorkspaceLocation::Local,
+            center_group: Default::default(),
+            window_bounds: None,
+            display: None,
+            docks: Default::default(),
+            breakpoints: Default::default(),
+            centered_layout: false,
+            session_id: Some("test-session".to_string()),
+            window_id: Some(1),
+            user_toolchains: Default::default(),
+        };
+        db.save_workspace(workspace).await;
+
+        // Verify it was saved
+        assert!(db.workspace_for_id(empty_workspace_id).is_some());
+
+        // recent_workspaces_on_disk must not delete this empty workspace
+        let _ = db.recent_workspaces_on_disk(fs.as_ref()).await.unwrap();
+
+        // The workspace should still exist after recent_workspaces_on_disk runs
+        assert!(
+            db.workspace_for_id(empty_workspace_id).is_some(),
+            "empty workspace was incorrectly deleted by recent_workspaces_on_disk"
+        );
+
+        // And session_workspaces should still find it
+        let session_ws = db.session_workspaces("test-session".to_string()).unwrap();
+        assert_eq!(session_ws.len(), 1);
+        assert_eq!(session_ws[0].0, empty_workspace_id);
     }
 }


### PR DESCRIPTION
Fixes #52038

## Problem

Empty workspaces (a Zed window with no folder open, containing only unsaved buffers) are saved to the database with `paths = ""`. On the next startup, `recent_workspaces_on_disk` is called early — via `HistoryManager::init` — and unconditionally **deletes** these workspaces.

The bug is in this check:

```rust
if !has_wsl_path
    && Self::all_paths_exist_with_a_directory(paths.paths(), fs, Some(timestamp)).await
{
    result.push(...);
} else {
    delete_tasks.push(self.delete_workspace_by_id(id)); // ← empty workspace deleted here
}
```

`all_paths_exist_with_a_directory` receives an empty slice, its loop never runs, `any_dir` stays `false`, and the workspace is queued for deletion.

This runs concurrently with session restoration. By the time restoration calls `workspace_for_id(N)`, the row is gone, producing:

```
ERROR [zed] Failed to restore workspace: Workspace WorkspaceId(N) not found
ERROR [zed] All workspace restorations failed. Opening fallback empty workspace.
```

The user's unsaved buffers are lost even though `restore_unsaved_buffers` is enabled.

## Fix

Skip empty-path workspaces in `recent_workspaces_on_disk`. They are identified by workspace ID rather than paths and are restored via `session_workspaces` — they must not appear in the "recent projects" list, and must not be deleted by this function.

```rust
// Empty workspaces (no folder paths) are identified by workspace_id, not paths.
// They must not be deleted here; they are restored separately via session_workspaces.
if paths.is_empty() {
    continue;
}
```

A regression test is included that saves an empty workspace with a session ID, calls `recent_workspaces_on_disk`, and asserts the workspace row and its session entry still exist afterwards.

Release Notes:

- Fixed `restore_unsaved_buffers` not restoring unsaved file contents when Zed was closed with an empty window (no folder open). The workspace was being incorrectly deleted during startup, causing a "Workspace not found" error and falling back to a blank window.