### PR TITLE
docs: Rework Elixir docs

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -100,7 +100,7 @@ Enable Next LS by adding the following to your settings file:
 
 Next LS can accept initialization options.
 
-Completions are an experimental feature within Next LS, but they are enabled by default in Zed. They can be disabled again by adding the following to your settings file:
+Completions are an experimental feature within Next LS, they are enabled by default in Zed. Disable them by adding the following to your settings file:
 
 ```json [settings]
   "lsp": {

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -7,7 +7,7 @@ description: "Configure Elixir language support in Zed, including language serve
 
 Elixir support is available through the [Elixir extension](https://github.com/zed-extensions/elixir).
 
-- Tree-sitter grammars:
+- Tree-sitter Grammars:
   - [elixir-lang/tree-sitter-elixir](https://github.com/elixir-lang/tree-sitter-elixir)
   - [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
 - Language Servers:
@@ -20,13 +20,15 @@ The Elixir extension also supports [EEx](https://hexdocs.pm/eex/EEx.html) (Embed
 
 ## Language Servers
 
-The Elixir extension offers language server support for `elixir-ls`, `expert`, `next-ls`, and `lexical`.
+The Elixir extension offers language server support for ElixirLS, Expert, Next LS, and Lexical. By default, ElixirLS is enabled, but this can be changed or disabled in Settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx, or directly in your settings file.
 
-### ElixirLS
+Some of the language servers can also accept initialization or workspace configuration options; what each one accepts is outlined in the sections below. These can be passed in your settings file via `lsp` > `initialization_options` and `lsp` > `settings` respectively.
 
-`elixir-ls` is enabled by default.
+See the [Configuring Zed](../configuring-zed.md#settings-files) guide for more information on how to edit your settings file.
 
-You can pass additional workspace configuration options to it via `lsp` > `settings` in your settings file ([how to edit](../configuring-zed.md#settings-files)).
+### Using ElixirLS
+
+ElixirLS can accept workspace configuration options.
 
 The following example disables [Dialyzer](https://github.com/elixir-lsp/elixir-ls#dialyzer-integration):
 
@@ -40,11 +42,11 @@ The following example disables [Dialyzer](https://github.com/elixir-lsp/elixir-l
   }
 ```
 
-See [ElixirLS configuration settings](https://github.com/elixir-lsp/elixir-ls#elixirls-configuration-settings) for more options.
+See the official list of [ElixirLS configuration settings](https://github.com/elixir-lsp/elixir-ls#elixirls-configuration-settings) for all available options.
 
-### Expert
+### Using Expert
 
-Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+Enable Expert by adding the following to your settings file:
 
 ```json [settings]
   "languages": {
@@ -60,7 +62,7 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
   }
 ```
 
-You can pass additional workspace configuration options to Expert via `lsp` > `settings` in your settings file.
+Expert can accept workspace configuration options.
 
 The following example sets the minimum number of characters required for a project symbols search to return results:
 
@@ -76,11 +78,11 @@ The following example sets the minimum number of characters required for a proje
   }
 ```
 
-See [Expert configuration](https://expert-lsp.org/docs/configuration/) for more options.
+See the [Expert configuration](https://expert-lsp.org/docs/configuration/) page for all available options.
 
-### Next LS
+### Using Next LS
 
-Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+Enable Next LS by adding the following to your settings file:
 
 ```json [settings]
   "languages": {
@@ -96,9 +98,9 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
   }
 ```
 
-You can pass additional initialization options to Next LS via `lsp` > `initialization_options` in your settings file.
+Next LS can accept initialization options.
 
-Next LS has completions enabled by default on Zed. This is an experimental feature, so it can be disabled by adding the following to your settings file:
+Completions are an experimental feature in Next LS, but they are enabled by default on Zed. They can be disabled again by adding the following to your settings file:
 
 ```json [settings]
   "lsp": {
@@ -114,7 +116,7 @@ Next LS has completions enabled by default on Zed. This is an experimental featu
   }
 ```
 
-Next LS also has [Credo](https://hexdocs.pm/credo/overview.html) detection support enabled by default. This can be disabled by adding the following to your settings file:
+Next LS also has an extension for [Credo](https://hexdocs.pm/credo/overview.html) detection; this is enabled by default, but can be disabled by adding the following to your settings file:
 
 ```json [settings]
   "lsp": {
@@ -146,9 +148,11 @@ It is also possible to pass CLI options to Credo. The following example passes `
   }
 ```
 
-### Lexical
+See the [Credo Command Line Switches](https://hexdocs.pm/credo/suggest_command.html#command-line-switches) page for more CLI options.
 
-Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+### Using Lexical
+
+Enable Lexical by adding the following to your settings file:
 
 ```json [settings]
   "languages": {
@@ -166,9 +170,7 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 
 ## Formatting without a language server
 
-If you prefer to work without a language server but would still like code formatting from [Mix](https://hexdocs.pm/mix/Mix.html), you can configure it as an external formatter.
-
-Configure formatting in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+If you prefer to work without a language server but would still like code formatting from [Mix](https://hexdocs.pm/mix/Mix.html), you can configure it as an external formatter by adding the following to your settings file:
 
 ```json [settings]
   "languages": {
@@ -207,7 +209,7 @@ Configure formatting in Settings ({#kb zed::OpenSettings}) under Languages > Eli
 
 ## Using the Tailwind CSS Language Server with HEEx templates
 
-To get all features (autocomplete, linting, and hover docs) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in HEEx templates, add the following to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+To get all features (autocomplete, linting, and hover docs) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in HEEx templates, add the following to your settings file:
 
 ```json [settings]
   "lsp": {

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -7,111 +7,28 @@ description: "Configure Elixir language support in Zed, including language serve
 
 Elixir support is available through the [Elixir extension](https://github.com/zed-extensions/elixir).
 
-- Tree-sitter:
+- Tree-sitters:
   - [elixir-lang/tree-sitter-elixir](https://github.com/elixir-lang/tree-sitter-elixir)
   - [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
-- Language servers:
+- Language Servers:
   - [elixir-lang/expert](https://github.com/elixir-lang/expert)
   - [elixir-lsp/elixir-ls](https://github.com/elixir-lsp/elixir-ls)
   - [elixir-tools/next-ls](https://github.com/elixir-tools/next-ls)
   - [lexical-lsp/lexical](https://github.com/lexical-lsp/lexical)
 
-## Choosing a language server
+The Elixir extension also supports [EEx](https://hexdocs.pm/eex/EEx.html) (Embedded Elixir) templates and [HEEx](https://hexdocs.pm/phoenix/components.html#heex) templates, a mix of HTML and EEx used by Phoenix LiveView applications.
 
-The Elixir extension offers language server support for `expert`, `elixir-ls`, `next-ls`, and `lexical`.
+## Language Servers
+
+The Elixir extension offers language server support for `elixir-ls`, `expert`, `next-ls`, and `lexical`.
+
+### ElixirLS
 
 `elixir-ls` is enabled by default.
 
-### Expert
+You can pass additional workspace configuration options to it via `lsp` > `settings` in your settings file ([how to edit](../configuring-zed.md#settings-files)).
 
-Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, or add to your settings file:
-
-```json [settings]
-  "languages": {
-    "Elixir": {
-      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
-    },
-    "HEEX": {
-      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
-    }
-  }
-```
-
-### Next LS
-
-Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, or add to your settings file:
-
-```json [settings]
-  "languages": {
-    "Elixir": {
-      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
-    },
-    "HEEX": {
-      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
-    }
-  }
-```
-
-### Lexical
-
-Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, or add to your settings file:
-
-```json [settings]
-  "languages": {
-    "Elixir": {
-      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
-    },
-    "HEEX": {
-      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
-    }
-  }
-```
-
-## Setting up `elixir-ls`
-
-1. Install `elixir`:
-
-```sh
-brew install elixir
-```
-
-2. Install `elixir-ls`:
-
-```sh
-brew install elixir-ls
-```
-
-3. Restart Zed
-
-> If `elixir-ls` is not running in an elixir project, check the error log via the command palette action `zed: open log`. If you find an error message mentioning: `invalid LSP message header "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\") [Yn]`, you might need to install [`Hex`](https://hex.pm). You run `elixir-ls` from the command line and accept the prompt to install `Hex`.
-
-### Formatting with Mix
-
-If you prefer to format your code with [Mix](https://hexdocs.pm/mix/Mix.html), configure it as an external formatter. Formatting will occur on file save.
-
-Configure formatting in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, or add to your settings file:
-
-```json [settings]
-{
-  "languages": {
-    "Elixir": {
-      "format_on_save": "on",
-      "formatter": {
-        "external": {
-          "command": "mix",
-          "arguments": ["format", "--stdin-filename", "{buffer_path}", "-"]
-        }
-      }
-    }
-  }
-}
-```
-
-### Additional workspace configuration options
-
-You can pass additional elixir-ls workspace configuration options via `lsp` settings in your settings file ([how to edit](../configuring-zed.md#settings-files)).
-
-The following example disables dialyzer:
+The following example disables [Dialyzer](https://github.com/elixir-lsp/elixir-ls#dialyzer-integration):
 
 ```json [settings]
   "lsp": {
@@ -125,23 +42,180 @@ The following example disables dialyzer:
 
 See [ElixirLS configuration settings](https://github.com/elixir-lsp/elixir-ls#elixirls-configuration-settings) for more options.
 
-### HEEx
+### Expert
 
-Zed also supports HEEx templates. HEEx is a mix of [EEx](https://hexdocs.pm/eex/1.12.3/EEx.html) (Embedded Elixir) and HTML, and is used in Phoenix LiveView applications.
-
-- Tree-sitter: [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
-
-#### Using the Tailwind CSS Language Server with HEEx
-
-To get all features (autocomplete, linting, and hover docs) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in HEEx files, add the following to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
 
 ```json [settings]
-{
+  "languages": {
+    "Elixir": {
+      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    },
+    "EEx": {
+      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    },
+    "HEEx": {
+      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    }
+  }
+```
+
+You can pass additional workspace configuration options to Expert via `lsp` > `settings` in your settings file.
+
+The following example sets the minimum number of characters required for a project symbols search to return results:
+
+```json [settings]
+  "lsp": {
+    "expert": {
+      "settings": {
+        "workspaceSymbols": {
+          "minQueryLength": 0
+        }
+      }
+    }
+  }
+```
+
+See [Expert configuration](https://expert-lsp.org/docs/configuration/) for more options.
+
+### Next LS
+
+Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+
+```json [settings]
+  "languages": {
+    "Elixir": {
+      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
+    },
+    "EEx": {
+      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
+    },
+    "HEEx": {
+      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
+    }
+  }
+```
+
+You can pass additional initialization options to Next LS via `lsp` > `initialization_options` in your settings file.
+
+Next LS has completions enabled by default on Zed. This is an experimental feature, so it can be disabled by adding the following to your settings file:
+
+```json [settings]
+  "lsp": {
+    "next-ls": {
+      "initialization_options": {
+        "experimental": {
+          "completions": {
+            "enable": false
+          }
+        }
+      }
+    }
+  }
+```
+
+Next LS also has [Credo](https://hexdocs.pm/credo/overview.html) detection support enabled by default. This can be disabled by adding the following to your settings file:
+
+```json [settings]
+  "lsp": {
+    "next-ls": {
+      "initialization_options": {
+        "extensions": {
+          "credo": {
+            "enable": false
+          }
+        }
+      }
+    }
+  }
+```
+
+It is also possible to pass CLI options to Credo. The following example passes `--min-priority high` to it:
+
+```json [settings]
+  "lsp": {
+    "next-ls": {
+      "initialization_options": {
+        "extensions": {
+          "credo": {
+            "cli_options": ["--min-priority high"]
+          }
+        }
+      }
+    }
+  }
+```
+
+### Lexical
+
+Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+
+```json [settings]
+  "languages": {
+    "Elixir": {
+      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
+    },
+    "EEx": {
+      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
+    },
+    "HEEx": {
+      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
+    }
+  }
+```
+
+## Formatting without a language server
+
+If you prefer to work without a language server but would still like code formatting from [Mix](https://hexdocs.pm/mix/Mix.html), you can configure it as an external formatter.
+
+Configure formatting in Settings ({#kb zed::OpenSettings}) under Languages > Elixir, Languages > EEx, and Languages > HEEx, or add to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+
+```json [settings]
+  "languages": {
+    "Elixir": {
+      "enable_language_server": false,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "mix",
+          "arguments": ["format", "--stdin-filename", "{buffer_path}", "-"]
+        }
+      }
+    },
+    "EEx": {
+      "enable_language_server": false,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "mix",
+          "arguments": ["format", "--stdin-filename", "{buffer_path}", "-"]
+        }
+      }
+    },
+    "HEEx": {
+      "enable_language_server": false,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "mix",
+          "arguments": ["format", "--stdin-filename", "{buffer_path}", "-"]
+        }
+      }
+    }
+  }
+```
+
+## Using the Tailwind CSS Language Server with HEEx templates
+
+To get all features (autocomplete, linting, and hover docs) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in HEEx templates, add the following to your settings file ([how to edit](../configuring-zed.md#settings-files)):
+
+```json [settings]
   "lsp": {
     "tailwindcss-language-server": {
       "settings": {
         "includeLanguages": {
-          "phoenix-heex": "html"
+          "elixir": "html",
+          "heex": "html"
         },
         "experimental": {
           "classRegex": ["class=\"([^\"]*)\"", "class='([^']*)'"]
@@ -149,10 +223,9 @@ To get all features (autocomplete, linting, and hover docs) from the [Tailwind C
       }
     }
   }
-}
 ```
 
-With these settings, you will get completions for Tailwind CSS classes in HEEx template files. Examples:
+With these settings, you will get completions for Tailwind CSS classes in HEEx templates. Examples:
 
 ```heex
 <%!-- Standard class attribute --%>
@@ -170,3 +243,8 @@ With these settings, you will get completions for Tailwind CSS classes in HEEx t
   Content
 </div>
 ```
+
+## See also
+
+- [Erlang](./erlang.md)
+- [Gleam](./gleam.md)

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -7,7 +7,7 @@ description: "Configure Elixir language support in Zed, including language serve
 
 Elixir support is available through the [Elixir extension](https://github.com/zed-extensions/elixir).
 
-- Tree-sitters:
+- Tree-sitter grammars:
   - [elixir-lang/tree-sitter-elixir](https://github.com/elixir-lang/tree-sitter-elixir)
   - [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
 - Language Servers:

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -16,15 +16,15 @@ Elixir support is available through the [Elixir extension](https://github.com/ze
   - [elixir-tools/next-ls](https://github.com/elixir-tools/next-ls)
   - [lexical-lsp/lexical](https://github.com/lexical-lsp/lexical)
 
-The Elixir extension also supports [EEx](https://hexdocs.pm/eex/EEx.html) (Embedded Elixir) templates and [HEEx](https://hexdocs.pm/phoenix/components.html#heex) templates, a mix of HTML and EEx used by Phoenix LiveView applications.
+Furthermore, the extension provides support for [EEx](https://hexdocs.pm/eex/EEx.html) (Embedded Elixir) templates and [HEEx](https://hexdocs.pm/phoenix/components.html#heex) templates, a mix of HTML and EEx used by Phoenix LiveView applications.
 
 ## Language Servers
 
-The Elixir extension offers language server support for ElixirLS, Expert, Next LS, and Lexical. By default, ElixirLS is enabled, but this can be changed or disabled in Settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx, or directly in your settings file.
+The Elixir extension offers language server support for ElixirLS, Expert, Next LS, and Lexical. By default, only ElixirLS is enabled. You can change or disable the enabled language servers in your settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx or directly within your settings file.
 
-Some of the language servers can also accept initialization or workspace configuration options; what each one accepts is outlined in the sections below. These can be passed in your settings file via `lsp` > `initialization_options` and `lsp` > `settings` respectively.
+Some of the language servers can also accept initialization or workspace configuration options. See the sections below for an outline of what each server supports. The configuration can be passed in your settings file via `lsp.{language-server-id}.initialization_options` and `lsp.{language-server-id}.settings` respectively.
 
-See the [Configuring Zed](../configuring-zed.md#settings-files) guide for more information on how to edit your settings file.
+Visit the [Configuring Zed](../configuring-zed.md#settings-files) guide for more information on how to edit your settings file.
 
 ### Using ElixirLS
 
@@ -64,7 +64,7 @@ Enable Expert by adding the following to your settings file:
 
 Expert can accept workspace configuration options.
 
-The following example sets the minimum number of characters required for a project symbols search to return results:
+The following example sets the minimum number of characters required for a project symbol search to return results:
 
 ```json [settings]
   "lsp": {
@@ -100,7 +100,7 @@ Enable Next LS by adding the following to your settings file:
 
 Next LS can accept initialization options.
 
-Completions are an experimental feature in Next LS, but they are enabled by default on Zed. They can be disabled again by adding the following to your settings file:
+Completions are an experimental feature within Next LS, but they are enabled by default in Zed. They can be disabled again by adding the following to your settings file:
 
 ```json [settings]
   "lsp": {
@@ -116,7 +116,7 @@ Completions are an experimental feature in Next LS, but they are enabled by defa
   }
 ```
 
-Next LS also has an extension for [Credo](https://hexdocs.pm/credo/overview.html) detection; this is enabled by default, but can be disabled by adding the following to your settings file:
+Next LS also has an extension for [Credo](https://hexdocs.pm/credo/overview.html) integration which is enabled by default. You can disable this by adding the following section to your settings file:
 
 ```json [settings]
   "lsp": {
@@ -132,7 +132,7 @@ Next LS also has an extension for [Credo](https://hexdocs.pm/credo/overview.html
   }
 ```
 
-It is also possible to pass CLI options to Credo. The following example passes `--min-priority high` to it:
+Next LS can also pass CLI options directly to Credo. The following example passes `--min-priority high` to it:
 
 ```json [settings]
   "lsp": {

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -15,7 +15,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [CSS](./css.md)
 - [ERB](./ruby.md#using-the-tailwind-css-language-server-with-ruby)
 - [Gleam](./gleam.md)
-- [HEEx](./elixir.md#using-the-tailwind-css-language-server-with-heex)
+- [HEEx](./elixir.md#using-the-tailwind-css-language-server-with-heex-templates)
 - [HTML](./html.md#using-the-tailwind-css-language-server-with-html)
 - [TypeScript](./typescript.md#using-the-tailwind-css-language-server-with-typescript)
 - [JavaScript](./javascript.md#using-the-tailwind-css-language-server-with-javascript)


### PR DESCRIPTION
## Context

- Mention support for EEx templates
- Rearranges a few sections (HEEx, `elixir-ls` workspace configuration)
- Corrects naming of HEEx and mention that language server configurations also need to be applied to it (and EEx)
- Removes unnecessary instructions for how to install `elixir-ls` - the extension has been able to do this on its own for a long time; additionally, these instructions were very macOS-specific
- Demonstrates how to pass initialization options to `next-ls` and workspace configuration options to `expert`
- Rewords the formatting with Mix section - all language servers already use Mix for code formatting, so these instructions are only useful if you work _without_ a language server
- Adjust Tailwind LSP configuration instructions

## How to Review

Check for typos and that the wording/structure of the new/reworded sections is also good.

Release Notes:

- N/A