### PR TITLE
ci: Bump runner size for extension CLI publishing job

### DIFF
--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish_job:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
-    runs-on: namespace-profile-2x4-ubuntu-2404
+    runs-on: namespace-profile-16x32-ubuntu-2204
     steps:
     - name: steps::checkout_repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/tooling/xtask/src/tasks/workflows/publish_extension_cli.rs
+++ b/tooling/xtask/src/tasks/workflows/publish_extension_cli.rs
@@ -42,7 +42,7 @@ fn publish_job() -> NamedJob {
     named::job(
         Job::default()
             .with_repository_owner_guard()
-            .runs_on(runners::LINUX_SMALL)
+            .runs_on(runners::LINUX_DEFAULT)
             .add_step(steps::checkout_repo())
             .add_step(steps::cache_rust_dependencies_namespace())
             .add_step(steps::setup_linux())


### PR DESCRIPTION
As of https://github.com/zed-industries/zed/pull/50750, the runner size for building the extension CLI is no longer sufficient due to the addition of the `settings_content` crate as a dependency. The [most recent workflow run](https://github.com/zed-industries/zed/actions/runs/23554506504/job/68577404831) fails while building that crate due to insufficient RAM availlable during the build. 

Removing the dependency is not an option, as we do want to have the validation here and need structs from the settings content crate to do so. 

Thus, changing the job here to a larger runner to fix the build and also build it faster. 

Release Notes:

- N/A
