### PR TITLE
Remove search_on_input from docs

### DIFF
--- a/docs/src/finding-navigating.md
+++ b/docs/src/finding-navigating.md
@@ -23,14 +23,6 @@ Search across all files with {#kb pane::DeploySearch}. Start typing in the searc
 
 Results appear in a [multibuffer](./multibuffers.md), letting you edit matches in place.
 
-To disable automatic search and require pressing Enter instead, open the Settings Editor ({#kb zed::OpenSettings}), search for "search on input", and toggle the setting off. Or add this to your settings.json:
-
-```json
-{
-  "search_on_input": false
-}
-```
-
 ## Go to Definition
 
 Jump to where a symbol is defined with {#kb editor::GoToDefinition} (or `Cmd+Click` / `Ctrl+Click`). If there are multiple definitions, they open in a multibuffer.

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3454,12 +3454,6 @@ Non-negative `integer` values
 - Setting: `regex`
 - Default: `false`
 
-### Search On Input
-
-- Description: Whether to search on input in project search.
-- Setting: `search_on_input`
-- Default: `true`
-
 ### Center On Match
 
 - Description: Whether to center the cursor on each search match when navigating.


### PR DESCRIPTION
## Context

<img width="1610" height="394" alt="CleanShot 2026-03-25 at 15 32 24@2x" src="https://github.com/user-attachments/assets/704753d5-17c0-4857-8599-718b310211c8" />


Although search_on_input is a merged feature, it doesn't look like it's live yet. As a result, some people might be trying to activate the feature without success.

This commit removes its reference from the docs.

## How to Review

- Check if the feature is live before merging

## Self-Review Checklist

<!-- Check before requesting review: -->
- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
