### PR TITLE
Revert "Add ctrl-enter keybind (macOS) to type newline in search bars"

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -480,13 +480,6 @@
     },
   },
   {
-    "context": "BufferSearchBar || ProjectSearchBar",
-    "use_key_equivalents": true,
-    "bindings": {
-      "ctrl-enter": "editor::Newline",
-    },
-  },
-  {
     "context": "ProjectSearchBar",
     "use_key_equivalents": true,
     "bindings": {


### PR DESCRIPTION
Reverts #50420

This was made redundant by https://github.com/zed-industries/zed/pull/50783.

According to [this comment](https://github.com/zed-industries/zed/pull/50783#issuecomment-4002827488), the ctrl-enter keybind from the `Editor && mode == auto_height` context applies to the search bars now.

Release Notes:

- N/A