### PR TITLE
sidebar: Use last used agent when creating a new thread from it

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1179,7 +1179,8 @@ impl AgentPanel {
     }
 
     pub fn new_thread(&mut self, _action: &NewThread, window: &mut Window, cx: &mut Context<Self>) {
-        self.new_agent_thread(AgentType::NativeAgent, window, cx);
+        self.reset_start_thread_in_to_default(cx);
+        self.external_thread(None, None, None, None, None, true, window, cx);
     }
 
     fn new_native_agent_thread_from_summary(


### PR DESCRIPTION
The "new thread" buttons as well as the `cmd-n` keybinding were resetting the agent to the Zed one instead of following the agent panel's behavior to use whatever agent was recently selected, as per the key-value store.

Release Notes:

- N/A
