### PR TITLE
Add browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
  "context_server",
  "ctor",
  "db",
- "derive_more",
+ "derive_more 2.1.1",
  "editor",
  "env_logger 0.11.8",
  "eval_utils",
@@ -235,7 +235,7 @@ dependencies = [
  "anyhow",
  "async-broadcast",
  "async-trait",
- "derive_more",
+ "derive_more 2.1.1",
  "futures 0.3.31",
  "log",
  "serde",
@@ -249,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0497b9a95a404e35799904835c57c6f8c69b9d08ccfd3cb5b7d746425cd6789"
 dependencies = [
  "anyhow",
- "derive_more",
+ "derive_more 2.1.1",
  "schemars",
  "serde",
  "serde_json",
@@ -551,7 +551,7 @@ version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
 dependencies = [
- "cssparser",
+ "cssparser 0.35.0",
  "html5ever 0.35.0",
  "maplit",
  "tendril",
@@ -788,7 +788,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "collections",
- "derive_more",
+ "derive_more 2.1.1",
  "extension",
  "futures 0.3.31",
  "gpui",
@@ -1232,6 +1232,29 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite",
+]
+
+[[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib 0.18.5",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2217,7 +2240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2450,6 +2473,31 @@ name = "cached_proc_macro_types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.10.0",
+ "cairo-sys-rs",
+ "glib 0.18.5",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys 0.18.1",
+ "libc",
+ "system-deps 6.2.2",
+]
 
 [[package]]
 name = "call"
@@ -2972,7 +3020,7 @@ dependencies = [
  "cloud_llm_client",
  "collections",
  "credentials_provider",
- "derive_more",
+ "derive_more 2.1.1",
  "feature_flags",
  "fs",
  "futures 0.3.31",
@@ -3386,7 +3434,7 @@ name = "command_palette_hooks"
 version = "0.1.0"
 dependencies = [
  "collections",
- "derive_more",
+ "derive_more 2.1.1",
  "gpui",
  "workspace",
 ]
@@ -3567,6 +3615,12 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
@@ -3590,6 +3644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -4282,6 +4346,23 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
+version = "0.29.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "matches",
+ "phf 0.10.1",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
@@ -4789,6 +4870,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -5103,6 +5197,12 @@ checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
 dependencies = [
  "phf 0.11.3",
 ]
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dtoa"
@@ -6263,6 +6363,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
+
+[[package]]
 name = "file_finder"
 version = "0.1.0"
 dependencies = [
@@ -6832,6 +6942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gaoya"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6843,7 +6962,7 @@ dependencies = [
  "itertools 0.10.5",
  "num-traits",
  "rand 0.8.5",
- "rand_pcg",
+ "rand_pcg 0.3.1",
  "random_choice",
  "rayon",
  "seahash",
@@ -6852,6 +6971,91 @@ dependencies = [
  "siphasher 0.3.11",
  "smallvec",
  "triomphe",
+]
+
+[[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib 0.18.5",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib 0.18.5",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gdkx11"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe"
+dependencies = [
+ "gdk",
+ "gdkx11-sys",
+ "gio",
+ "glib 0.18.5",
+ "libc",
+ "x11",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
+dependencies = [
+ "gdk-sys",
+ "glib-sys 0.18.1",
+ "libc",
+ "system-deps 6.2.2",
+ "x11",
 ]
 
 [[package]]
@@ -7127,6 +7331,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
@@ -7134,7 +7349,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -7171,7 +7386,7 @@ version = "0.8.0"
 source = "git+https://github.com/zed-industries/gh-workflow?rev=37f3c0575d379c218a9c455ee67585184e40d43f#37f3c0575d379c218a9c455ee67585184e40d43f"
 dependencies = [
  "async-trait",
- "derive_more",
+ "derive_more 2.1.1",
  "derive_setters",
  "gh-workflow-macros",
  "indexmap",
@@ -7220,13 +7435,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps 6.2.2",
+ "winapi",
+]
+
+[[package]]
 name = "gio-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.21.5",
+ "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.7",
  "windows-sys 0.61.2",
@@ -7240,7 +7487,7 @@ dependencies = [
  "askpass",
  "async-trait",
  "collections",
- "derive_more",
+ "derive_more 2.1.1",
  "futures 0.3.31",
  "git2",
  "gpui",
@@ -7406,6 +7653,29 @@ dependencies = [
 
 [[package]]
 name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.10.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys 0.18.1",
+ "glib-macros 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
@@ -7416,13 +7686,27 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.21.5",
+ "glib-macros 0.21.5",
+ "glib-sys 0.21.5",
+ "gobject-sys 0.21.5",
  "libc",
  "memchr",
  "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7432,10 +7716,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -7524,11 +7818,22 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys 0.18.1",
+ "libc",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gobject-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.21.5",
  "libc",
  "system-deps 7.0.7",
 ]
@@ -7615,7 +7920,7 @@ dependencies = [
  "core-text",
  "core-video",
  "ctor",
- "derive_more",
+ "derive_more 2.1.1",
  "embed-resource",
  "env_logger 0.11.8",
  "etagere",
@@ -7743,7 +8048,7 @@ dependencies = [
  "core-text",
  "core-video",
  "ctor",
- "derive_more",
+ "derive_more 2.1.1",
  "dispatch2",
  "etagere",
  "foreign-types 0.5.0",
@@ -7899,6 +8204,58 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib 0.18.5",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "pango-sys",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8228,13 +8585,25 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.1",
+ "match_token 0.1.0",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
  "markup5ever 0.35.0",
- "match_token",
+ "match_token 0.35.0",
 ]
 
 [[package]]
@@ -8320,7 +8689,7 @@ dependencies = [
  "async-fs",
  "async-tar",
  "bytes 1.11.1",
- "derive_more",
+ "derive_more 2.1.1",
  "futures 0.3.31",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -9024,6 +9393,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "javascriptcore-rs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "glib 0.18.5",
+ "javascriptcore-rs-sys",
+]
+
+[[package]]
+name = "javascriptcore-rs-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps 6.2.2",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9301,6 +9693,18 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kuchikiki"
+version = "0.8.8-speedreader"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
+dependencies = [
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
+ "indexmap",
+ "selectors",
 ]
 
 [[package]]
@@ -9778,7 +10182,7 @@ version = "0.3.26"
 source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=147fbca3d4b592d96d33f5e6a84b59fc0b5d9bf1#147fbca3d4b592d96d33f5e6a84b59fc0b5d9bf1"
 dependencies = [
  "cxx",
- "glib",
+ "glib 0.21.5",
  "jni",
  "js-sys",
  "lazy_static",
@@ -10282,7 +10686,21 @@ checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -10313,6 +10731,17 @@ dependencies = [
 
 [[package]]
 name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "match_token"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
@@ -10330,6 +10759,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -10650,7 +11085,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -10662,7 +11097,7 @@ checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -10884,6 +11319,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle",
  "thiserror 1.0.69",
 ]
 
@@ -10976,6 +11412,12 @@ dependencies = [
  "watch",
  "which 6.0.3",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -11267,7 +11709,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11324,6 +11766,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
+ "objc2-exception-helper",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -11394,6 +11849,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "objc2-exception-helper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11441,6 +11905,32 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -11895,6 +12385,31 @@ dependencies = [
  "gpui",
  "ui",
  "workspace",
+]
+
+[[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib 0.18.5",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -12592,6 +13107,26 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
@@ -12612,12 +13147,42 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -12638,6 +13203,20 @@ checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
  "fastrand 2.3.0",
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -12664,6 +13243,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -13063,6 +13660,25 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
@@ -13115,6 +13731,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -13805,6 +14427,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg 0.2.1",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -13822,6 +14458,16 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -13861,6 +14507,15 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -13885,6 +14540,24 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -15492,6 +16165,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
+dependencies = [
+ "bitflags 1.3.2",
+ "cssparser 0.29.6",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15677,6 +16368,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "session"
 version = "0.1.0"
 dependencies = [
@@ -15724,7 +16425,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
- "derive_more",
+ "derive_more 2.1.1",
  "gpui",
  "log",
  "schemars",
@@ -16223,6 +16924,32 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "soup3"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
+dependencies = [
+ "futures-channel",
+ "gio",
+ "glib 0.18.5",
+ "libc",
+ "soup3-sys",
+]
+
+[[package]]
+name = "soup3-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
+dependencies = [
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "libc",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -17305,6 +18032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17526,7 +18264,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
- "derive_more",
+ "derive_more 2.1.1",
  "fs",
  "futures 0.3.31",
  "gpui",
@@ -18017,7 +18755,7 @@ dependencies = [
  "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -18040,6 +18778,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -18049,7 +18809,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -18061,7 +18821,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 0.7.3",
  "toml_parser",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -18070,7 +18830,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -19298,6 +20058,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -20019,7 +20785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
 ]
@@ -20050,6 +20816,72 @@ dependencies = [
  "serde",
  "serde_json",
  "web_search",
+]
+
+[[package]]
+name = "web_view"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "editor",
+ "gdkx11",
+ "gpui",
+ "gtk",
+ "icons",
+ "log",
+ "menu",
+ "schemars",
+ "serde",
+ "ui",
+ "url",
+ "util",
+ "workspace",
+ "wry",
+ "x11-dl",
+]
+
+[[package]]
+name = "webkit2gtk"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "gdk",
+ "gdk-sys",
+ "gio",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "gtk",
+ "gtk-sys",
+ "javascriptcore-rs",
+ "libc",
+ "once_cell",
+ "soup3",
+ "webkit2gtk-sys",
+]
+
+[[package]]
+name = "webkit2gtk-sys"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-sys-rs",
+ "gdk-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
+ "gtk-sys",
+ "javascriptcore-rs-sys",
+ "libc",
+ "pkg-config",
+ "soup3-sys",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -20096,6 +20928,42 @@ dependencies = [
  "scratch",
  "semver",
  "zip 0.6.6",
+]
+
+[[package]]
+name = "webview2-com"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
+dependencies = [
+ "webview2-com-macros",
+ "webview2-com-sys",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+]
+
+[[package]]
+name = "webview2-com-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "webview2-com-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
+dependencies = [
+ "thiserror 2.0.17",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -20903,6 +21771,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21081,6 +21958,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -21588,6 +22474,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "wry"
+version = "0.54.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+dependencies = [
+ "base64 0.22.1",
+ "block2",
+ "cookie",
+ "crossbeam-channel",
+ "dirs 6.0.0",
+ "dpi",
+ "dunce",
+ "gdkx11",
+ "gtk",
+ "html5ever 0.29.1",
+ "http 1.3.1",
+ "javascriptcore-rs",
+ "jni",
+ "kuchikiki",
+ "libc",
+ "ndk",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "objc2-web-kit",
+ "once_cell",
+ "percent-encoding",
+ "raw-window-handle",
+ "sha2",
+ "soup3",
+ "tao-macros",
+ "thiserror 2.0.17",
+ "url",
+ "webkit2gtk",
+ "webkit2gtk-sys",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-version",
+ "x11-dl",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21614,6 +22545,17 @@ checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
 dependencies = [
  "libc",
  "x11rb",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -21899,7 +22841,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.13",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -21911,7 +22853,7 @@ version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -21927,7 +22869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.13",
  "zvariant",
 ]
 
@@ -22090,6 +23032,7 @@ dependencies = [
  "watch",
  "web_search",
  "web_search_providers",
+ "web_view",
  "which_key",
  "windows 0.61.3",
  "winresource",
@@ -22555,7 +23498,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "serde_bytes",
- "winnow",
+ "winnow 0.7.13",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -22566,7 +23509,7 @@ version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -22583,5 +23526,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow",
+ "winnow 0.7.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,6 +211,7 @@ members = [
     "crates/vim",
     "crates/vim_mode_setting",
     "crates/watch",
+    "crates/web_view",
     "crates/web_search",
     "crates/web_search_providers",
     "crates/which_key",
@@ -458,6 +459,7 @@ vim_mode_setting = { path = "crates/vim_mode_setting" }
 which_key = { path = "crates/which_key" }
 
 watch = { path = "crates/watch" }
+web_view = { path = "crates/web_view" }
 web_search = { path = "crates/web_search" }
 web_search_providers = { path = "crates/web_search_providers" }
 workspace = { path = "crates/workspace" }

--- a/crates/web_view/Cargo.toml
+++ b/crates/web_view/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "web_view"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/web_view.rs"
+
+[dependencies]
+anyhow.workspace = true
+editor.workspace = true
+gpui.workspace = true
+icons.workspace = true
+log.workspace = true
+menu.workspace = true
+schemars.workspace = true
+serde.workspace = true
+ui.workspace = true
+url.workspace = true
+util.workspace = true
+workspace.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+wry = "0.54"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"
+x11-dl = "2.21"
+gdkx11 = "0.18"

--- a/crates/web_view/src/element.rs
+++ b/crates/web_view/src/element.rs
@@ -1,0 +1,93 @@
+use gpui::{
+    App, Bounds, Element, ElementId, Entity, GlobalElementId, InspectorElementId, IntoElement,
+    LayoutId, Pixels, Style, Window, px, relative,
+};
+
+use crate::WebView;
+
+pub struct WebViewElement {
+    view: Entity<WebView>,
+}
+
+impl WebViewElement {
+    pub fn new(view: Entity<WebView>) -> Self {
+        Self { view }
+    }
+}
+
+impl IntoElement for WebViewElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for WebViewElement {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.size.width = relative(1.).into();
+        style.size.height = relative(1.).into();
+        style.min_size.width = px(1.).into();
+        style.min_size.height = px(1.).into();
+        style.flex_grow = 1.0;
+        let layout_id = window.request_layout(style, [], cx);
+        (layout_id, ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        #[cfg(target_os = "linux")]
+        while gtk::events_pending() {
+            gtk::main_iteration_do(false);
+        }
+
+        self.view.update(cx, |view, cx| {
+            view.paint_webview(bounds, window, cx);
+        });
+
+        #[cfg(target_os = "linux")]
+        {
+            while gtk::events_pending() {
+                gtk::main_iteration_do(false);
+            }
+            window.request_animation_frame();
+        }
+    }
+}

--- a/crates/web_view/src/toolbar.rs
+++ b/crates/web_view/src/toolbar.rs
@@ -1,0 +1,219 @@
+use editor::Editor;
+use gpui::{Context, Entity, EventEmitter, Focusable, Render, Subscription, Window};
+use menu::Confirm;
+use ui::{Tooltip, prelude::*};
+use workspace::item::ItemHandle;
+use workspace::{ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
+
+use crate::WebView;
+
+pub struct WebViewToolbar {
+    active_web_view: Option<Entity<WebView>>,
+    url_editor: Option<Entity<Editor>>,
+    validation_error: Option<SharedString>,
+    _observe_webview: Option<Subscription>,
+}
+
+impl Default for WebViewToolbar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WebViewToolbar {
+    pub fn new() -> Self {
+        Self {
+            active_web_view: None,
+            url_editor: None,
+            validation_error: None,
+            _observe_webview: None,
+        }
+    }
+
+    fn normalized_url(input: &str) -> Option<String> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if url::Url::parse(trimmed).is_ok() {
+            return Some(trimmed.to_string());
+        }
+
+        let prefixed = format!("https://{trimmed}");
+        url::Url::parse(&prefixed).ok()?;
+        Some(prefixed)
+    }
+
+    fn navigate(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if let (Some(web_view), Some(url_editor)) = (&self.active_web_view, &self.url_editor) {
+            let input = url_editor.read(cx).text(cx);
+            if let Some(url) = Self::normalized_url(&input) {
+                self.validation_error = None;
+                web_view.update(cx, |view, cx| view.navigate(url, cx));
+                web_view.read(cx).focus_webview();
+            } else {
+                self.validation_error = Some("Enter a valid URL".into());
+            }
+            cx.notify();
+        }
+    }
+
+    fn confirm(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        self.navigate(window, cx);
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for WebViewToolbar {}
+
+impl Render for WebViewToolbar {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(web_view) = &self.active_web_view else {
+            return div().into_any_element();
+        };
+        let Some(url_editor) = &self.url_editor else {
+            return div().into_any_element();
+        };
+
+        let should_focus_url_bar =
+            web_view.update(cx, |view, _cx| view.take_focus_url_bar_request());
+        if should_focus_url_bar {
+            url_editor.focus_handle(cx).focus(window, cx);
+        }
+
+        let (url, is_loading, can_go_back, can_go_forward) = {
+            let state = web_view.read(cx);
+            (
+                state.url().to_string(),
+                state.is_loading(),
+                state.can_go_back(),
+                state.can_go_forward(),
+            )
+        };
+
+        let is_url_editor_focused = url_editor.focus_handle(cx).is_focused(window);
+        url_editor.update(cx, |editor, cx| {
+            if !is_url_editor_focused && editor.text(cx) != url {
+                editor.set_text(url.as_str(), window, cx);
+            }
+        });
+
+        v_flex()
+            .child(
+                h_flex()
+                    .key_context("WebViewToolbar")
+                    .on_action(cx.listener(Self::confirm))
+                    .gap_1()
+                    .px_2()
+                    .py_1()
+                    .child(
+                        IconButton::new("back", IconName::ArrowLeft)
+                            .icon_size(IconSize::Small)
+                            .disabled(!can_go_back)
+                            .tooltip(Tooltip::text("Back"))
+                            .on_click({
+                                let web_view = web_view.clone();
+                                move |_event, _window, cx| {
+                                    web_view.read(cx).go_back();
+                                }
+                            }),
+                    )
+                    .child(
+                        IconButton::new("forward", IconName::ArrowRight)
+                            .icon_size(IconSize::Small)
+                            .disabled(!can_go_forward)
+                            .tooltip(Tooltip::text("Forward"))
+                            .on_click({
+                                let web_view = web_view.clone();
+                                move |_event, _window, cx| {
+                                    web_view.read(cx).go_forward();
+                                }
+                            }),
+                    )
+                    .child(
+                        IconButton::new("reload", IconName::RotateCw)
+                            .icon_size(IconSize::Small)
+                            .tooltip(Tooltip::text("Reload"))
+                            .on_click({
+                                let web_view = web_view.clone();
+                                move |_event, _window, cx| {
+                                    web_view.update(cx, |view, cx| view.reload_page(cx));
+                                }
+                            }),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_64()
+                            .h_7()
+                            .px_2()
+                            .py_1()
+                            .bg(cx.theme().colors().editor_background)
+                            .border_1()
+                            .border_color(cx.theme().colors().border)
+                            .rounded_md()
+                            .child(url_editor.clone()),
+                    )
+                    .when(is_loading, |this| {
+                        this.child(
+                            Icon::new(IconName::ArrowCircle)
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                        )
+                    })
+                    .when(!is_loading, |this| {
+                        this.child(
+                            IconButton::new("navigate", IconName::ArrowRight)
+                                .icon_size(IconSize::Small)
+                                .tooltip(Tooltip::text("Navigate"))
+                                .on_click(cx.listener(|this, _event, window, cx| {
+                                    this.navigate(window, cx);
+                                })),
+                        )
+                    }),
+            )
+            .when_some(self.validation_error.clone(), |this, message| {
+                this.child(
+                    h_flex()
+                        .px_2()
+                        .pb_1()
+                        .child(Label::new(message).color(Color::Error)),
+                )
+            })
+            .into_any_element()
+    }
+}
+
+impl ToolbarItemView for WebViewToolbar {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        self.active_web_view = active_pane_item
+            .and_then(|item| item.act_as::<WebView>(cx))
+            .map(|entity| entity.clone());
+        self.validation_error = None;
+        self._observe_webview = None;
+
+        if let Some(web_view) = &self.active_web_view {
+            self._observe_webview = Some(cx.observe(web_view, |_, _, cx| {
+                cx.notify();
+            }));
+
+            let url_editor = self.url_editor.get_or_insert_with(|| {
+                cx.new(|cx| {
+                    let mut editor = Editor::single_line(window, cx);
+                    editor.set_placeholder_text("https://example.com", window, cx);
+                    editor
+                })
+            });
+
+            let url = web_view.read(cx).url().to_string();
+            url_editor.update(cx, |editor, cx| editor.set_text(&*url, window, cx));
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+}

--- a/crates/web_view/src/web_view.rs
+++ b/crates/web_view/src/web_view.rs
@@ -16,6 +16,7 @@ use gdkx11::{
     X11Display,
     glib::{Cast, ObjectType},
 };
+
 #[cfg(not(target_arch = "wasm32"))]
 use std::cell::RefCell;
 #[cfg(not(target_arch = "wasm32"))]
@@ -85,7 +86,7 @@ pub struct WebView {
     #[cfg(not(target_arch = "wasm32"))]
     callback_state: Option<Rc<RefCell<WebViewCallbackState>>>,
     #[cfg(target_os = "linux")]
-    x11_parent_window: Option<XWindow>,
+    linux_backend: Option<LinuxBackend>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -93,6 +94,11 @@ pub struct WebView {
 struct WebViewCallbackState {
     pending_url: Option<String>,
     is_loading: bool,
+}
+
+#[cfg(target_os = "linux")]
+enum LinuxBackend {
+    X11 { parent_xid: XWindow },
 }
 
 #[cfg(target_os = "linux")]
@@ -120,10 +126,7 @@ impl LinuxX11WindowHandle {
                 window: handle.window,
                 visual_id: handle.visual_id,
             }),
-            RawWindowHandle::Wayland(_) => {
-                Err("Web views are not yet supported on Wayland. Please use X11.".to_string())
-            }
-            _ => Err("Web views are not supported for this Linux window backend.".to_string()),
+            _ => Err("Unsupported Linux window backend for X11 web view.".to_string()),
         }
     }
 }
@@ -136,6 +139,14 @@ impl HasWindowHandle for LinuxX11WindowHandle {
 
         Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::Xlib(handle)) })
     }
+}
+
+#[cfg(target_os = "linux")]
+fn is_wayland(window: &Window) -> bool {
+    matches!(
+        HasWindowHandle::window_handle(window).map(|h| h.as_raw()),
+        Ok(RawWindowHandle::Wayland(_))
+    )
 }
 
 impl WebView {
@@ -209,7 +220,7 @@ impl WebView {
             #[cfg(not(target_arch = "wasm32"))]
             callback_state: None,
             #[cfg(target_os = "linux")]
-            x11_parent_window: None,
+            linux_backend: None,
         }
     }
 
@@ -334,15 +345,24 @@ impl WebView {
         self.callback_state = Some(callback_state);
 
         #[cfg(target_os = "linux")]
-        let webview_result = match LinuxX11WindowHandle::from_window(window) {
-            Ok(x11_window_handle) => {
-                self.x11_parent_window = Some(x11_window_handle.window);
-                webview_builder.build_as_child(&x11_window_handle)
-            }
-            Err(message) => {
-                self.error = Some(message.into());
-                cx.notify();
-                return;
+        let webview_result = if is_wayland(window) {
+            open_url_in_system_browser(self.url.as_ref());
+            self.error = Some("Web view is not yet supported on Wayland. The URL has been opened in your default browser.".into());
+            cx.notify();
+            return;
+        } else {
+            match LinuxX11WindowHandle::from_window(window) {
+                Ok(x11_window_handle) => {
+                    self.linux_backend = Some(LinuxBackend::X11 {
+                        parent_xid: x11_window_handle.window,
+                    });
+                    webview_builder.build_as_child(&x11_window_handle)
+                }
+                Err(message) => {
+                    self.error = Some(message.into());
+                    cx.notify();
+                    return;
+                }
             }
         };
 
@@ -433,9 +453,12 @@ impl WebView {
                     )
                     .into(),
                 };
-                webview.set_bounds(rect).log_err();
+
                 #[cfg(target_os = "linux")]
-                self.lower_x11_children();
+                self.sync_linux_bounds(&rect);
+
+                #[cfg(not(target_os = "linux"))]
+                webview.set_bounds(rect).log_err();
             }
             self.set_visible(true);
         }
@@ -453,11 +476,20 @@ impl WebView {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn lower_x11_children(&self) {
-        let Some(parent_xid) = self.x11_parent_window else {
-            return;
-        };
+    fn sync_linux_bounds(&self, rect: &wry::Rect) {
+        match &self.linux_backend {
+            Some(LinuxBackend::X11 { parent_xid }) => {
+                if let Some(webview) = &self.wry_webview {
+                    webview.set_bounds(*rect).log_err();
+                }
+                self.lower_x11_children(*parent_xid);
+            }
+            None => {}
+        }
+    }
 
+    #[cfg(target_os = "linux")]
+    fn lower_x11_children(&self, parent_xid: XWindow) {
         let Some(gdk_display) = gtk::gdk::Display::default() else {
             return;
         };

--- a/crates/web_view/src/web_view.rs
+++ b/crates/web_view/src/web_view.rs
@@ -1,0 +1,622 @@
+mod element;
+pub mod toolbar;
+
+use gpui::{
+    Action, App, ClipboardItem, Context, Entity, EventEmitter, FocusHandle, Focusable, IntoElement,
+    ParentElement, Render, SharedString, Styled, Window, actions,
+};
+use schemars::JsonSchema;
+use ui::prelude::*;
+use util::ResultExt;
+use workspace::Workspace;
+use workspace::item::{Item, ItemEvent};
+
+#[cfg(target_os = "linux")]
+use gdkx11::{
+    X11Display,
+    glib::{Cast, ObjectType},
+};
+#[cfg(not(target_arch = "wasm32"))]
+use std::cell::RefCell;
+#[cfg(not(target_arch = "wasm32"))]
+use std::rc::Rc;
+#[cfg(not(target_arch = "wasm32"))]
+use wry::WebView as WryWebView;
+#[cfg(target_os = "linux")]
+use wry::raw_window_handle::{
+    HandleError, HasWindowHandle, RawWindowHandle, WindowHandle, XlibWindowHandle,
+};
+#[cfg(target_os = "linux")]
+use x11_dl::xlib::{Display, Window as XWindow, Xlib};
+
+actions!(
+    web_view,
+    [
+        /// Open a web view tab
+        Open,
+        /// Reload the current page
+        Reload,
+        /// Navigate back
+        GoBack,
+        /// Navigate forward
+        GoForward,
+        /// Focus the URL bar
+        FocusUrlBar,
+        /// Copy the current URL
+        CopyUrl,
+    ]
+);
+
+#[derive(Clone, serde::Deserialize, PartialEq, JsonSchema, Action)]
+#[action(namespace = web_view)]
+pub struct OpenUrl {
+    pub url: String,
+}
+
+pub fn init(cx: &mut App) {
+    #[cfg(target_os = "linux")]
+    {
+        if let Err(e) = gtk::init() {
+            log::error!("Failed to initialize GTK: {}", e);
+        }
+    }
+
+    cx.observe_new(|workspace: &mut Workspace, window, cx| {
+        let Some(window) = window else {
+            return;
+        };
+        WebView::register(workspace, window, cx);
+    })
+    .detach();
+}
+
+pub struct WebView {
+    url: SharedString,
+    title: Option<SharedString>,
+    is_loading: bool,
+    can_go_back: bool,
+    can_go_forward: bool,
+    request_focus_url_bar: bool,
+    focus_handle: FocusHandle,
+    error: Option<SharedString>,
+    visible: bool,
+    #[cfg(not(target_arch = "wasm32"))]
+    wry_webview: Option<WryWebView>,
+    #[cfg(not(target_arch = "wasm32"))]
+    callback_state: Option<Rc<RefCell<WebViewCallbackState>>>,
+    #[cfg(target_os = "linux")]
+    x11_parent_window: Option<XWindow>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct WebViewCallbackState {
+    pending_url: Option<String>,
+    is_loading: bool,
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxX11WindowHandle {
+    window: core::ffi::c_ulong,
+    visual_id: core::ffi::c_ulong,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxX11WindowHandle {
+    fn from_window(window: &Window) -> Result<Self, String> {
+        let raw_window_handle = HasWindowHandle::window_handle(window)
+            .map_err(|error| format!("Failed to access window handle: {error}"))?
+            .as_raw();
+
+        match raw_window_handle {
+            RawWindowHandle::Xcb(handle) => Ok(Self {
+                window: handle.window.get().into(),
+                visual_id: handle
+                    .visual_id
+                    .map(|visual_id| visual_id.get().into())
+                    .unwrap_or_default(),
+            }),
+            RawWindowHandle::Xlib(handle) => Ok(Self {
+                window: handle.window,
+                visual_id: handle.visual_id,
+            }),
+            RawWindowHandle::Wayland(_) => {
+                Err("Web views are not yet supported on Wayland. Please use X11.".to_string())
+            }
+            _ => Err("Web views are not supported for this Linux window backend.".to_string()),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl HasWindowHandle for LinuxX11WindowHandle {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        let mut handle = XlibWindowHandle::new(self.window);
+        handle.visual_id = self.visual_id;
+
+        Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::Xlib(handle)) })
+    }
+}
+
+impl WebView {
+    fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {
+        workspace.register_action(|workspace, action: &OpenUrl, window, cx| {
+            let web_view = cx.new(|cx| WebView::new(action.url.clone(), window, cx));
+            workspace.add_item_to_active_pane(Box::new(web_view), None, true, window, cx);
+        });
+
+        workspace.register_action(|workspace, _: &Open, window, cx| {
+            let web_view = cx.new(|cx| WebView::new("https://zed.dev".to_string(), window, cx));
+            workspace.add_item_to_active_pane(Box::new(web_view), None, true, window, cx);
+        });
+
+        workspace.register_action(|workspace, _: &Reload, _window, cx| {
+            if let Some(web_view) = Self::active_web_view(workspace, cx) {
+                web_view.update(cx, |view, cx| view.reload_page(cx));
+            }
+        });
+
+        workspace.register_action(|workspace, _: &GoBack, _window, cx| {
+            if let Some(web_view) = Self::active_web_view(workspace, cx) {
+                web_view.read(cx).go_back();
+            }
+        });
+
+        workspace.register_action(|workspace, _: &GoForward, _window, cx| {
+            if let Some(web_view) = Self::active_web_view(workspace, cx) {
+                web_view.read(cx).go_forward();
+            }
+        });
+
+        workspace.register_action(|workspace, _: &FocusUrlBar, _window, cx| {
+            if let Some(web_view) = Self::active_web_view(workspace, cx) {
+                web_view.update(cx, |view, cx| view.request_focus_url_bar(cx));
+            }
+        });
+
+        workspace.register_action(|workspace, _: &CopyUrl, _window, cx| {
+            if let Some(web_view) = Self::active_web_view(workspace, cx) {
+                cx.write_to_clipboard(ClipboardItem::new_string(
+                    web_view.read(cx).url().to_string(),
+                ));
+            }
+        });
+    }
+
+    fn active_web_view(
+        workspace: &Workspace,
+        cx: &mut Context<Workspace>,
+    ) -> Option<Entity<WebView>> {
+        workspace
+            .active_item(cx)
+            .and_then(|item| item.act_as::<WebView>(cx))
+    }
+
+    fn new(url: String, _window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let focus_handle = cx.focus_handle();
+        Self {
+            url: url.into(),
+            title: None,
+            is_loading: true,
+            can_go_back: false,
+            can_go_forward: false,
+            request_focus_url_bar: false,
+            focus_handle,
+            error: None,
+            visible: false,
+            #[cfg(not(target_arch = "wasm32"))]
+            wry_webview: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            callback_state: None,
+            #[cfg(target_os = "linux")]
+            x11_parent_window: None,
+        }
+    }
+
+    pub fn url(&self) -> &SharedString {
+        &self.url
+    }
+
+    pub fn title(&self) -> Option<&SharedString> {
+        self.title.as_ref()
+    }
+
+    pub fn is_loading(&self) -> bool {
+        self.is_loading
+    }
+
+    pub fn can_go_back(&self) -> bool {
+        self.can_go_back
+    }
+
+    pub fn can_go_forward(&self) -> bool {
+        self.can_go_forward
+    }
+
+    pub fn take_focus_url_bar_request(&mut self) -> bool {
+        std::mem::take(&mut self.request_focus_url_bar)
+    }
+
+    fn request_focus_url_bar(&mut self, cx: &mut Context<Self>) {
+        self.request_focus_url_bar = true;
+        cx.notify();
+    }
+
+    pub fn navigate(&mut self, url: String, cx: &mut Context<Self>) {
+        self.url = url.into();
+        self.is_loading = true;
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(webview) = &self.wry_webview {
+            webview.load_url(self.url.as_ref()).log_err();
+        }
+        cx.emit(ItemEvent::UpdateTab);
+        cx.notify();
+    }
+
+    pub fn reload_page(&mut self, cx: &mut Context<Self>) {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(webview) = &self.wry_webview {
+            webview.reload().log_err();
+        }
+        cx.notify();
+    }
+
+    pub fn go_back(&self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(webview) = &self.wry_webview {
+            webview.evaluate_script("history.back()").log_err();
+        }
+    }
+
+    pub fn go_forward(&self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(webview) = &self.wry_webview {
+            webview.evaluate_script("history.forward()").log_err();
+        }
+    }
+
+    fn set_visible(&mut self, visible: bool) {
+        if self.visible == visible {
+            return;
+        }
+        self.visible = visible;
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(webview) = &self.wry_webview {
+            webview.set_visible(visible).log_err();
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn ensure_webview(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.wry_webview.is_some() || self.error.is_some() {
+            return;
+        }
+
+        let callback_state = Rc::new(RefCell::new(WebViewCallbackState {
+            pending_url: None,
+            is_loading: true,
+        }));
+
+        let navigation_state = callback_state.clone();
+        let page_load_state = callback_state.clone();
+
+        let webview_builder = wry::WebViewBuilder::new()
+            .with_url(self.url.as_ref())
+            .with_transparent(true)
+            .with_visible(false)
+            .with_navigation_handler(move |url| {
+                if let Ok(mut state) = navigation_state.try_borrow_mut() {
+                    state.pending_url = Some(url);
+                    state.is_loading = true;
+                }
+                true
+            })
+            .with_on_page_load_handler(move |event, url| {
+                use wry::PageLoadEvent;
+                if let Ok(mut state) = page_load_state.try_borrow_mut() {
+                    match event {
+                        PageLoadEvent::Started => {
+                            state.is_loading = true;
+                            state.pending_url = Some(url);
+                        }
+                        PageLoadEvent::Finished => {
+                            state.is_loading = false;
+                            state.pending_url = Some(url);
+                        }
+                    }
+                }
+            })
+            .with_new_window_req_handler(|url, _features| {
+                open_url_in_system_browser(&url);
+                wry::NewWindowResponse::Deny
+            });
+
+        self.callback_state = Some(callback_state);
+
+        #[cfg(target_os = "linux")]
+        let webview_result = match LinuxX11WindowHandle::from_window(window) {
+            Ok(x11_window_handle) => {
+                self.x11_parent_window = Some(x11_window_handle.window);
+                webview_builder.build_as_child(&x11_window_handle)
+            }
+            Err(message) => {
+                self.error = Some(message.into());
+                cx.notify();
+                return;
+            }
+        };
+
+        #[cfg(not(target_os = "linux"))]
+        let webview_result = webview_builder.build_as_child(window);
+
+        match webview_result {
+            Ok(webview) => {
+                self.wry_webview = Some(webview);
+            }
+            Err(error) => {
+                log::error!("Failed to create web view: {}", error);
+                self.error = Some(format!("Failed to create web view: {error}").into());
+                cx.notify();
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn sync_callback_state(&mut self, cx: &mut Context<Self>) {
+        let Some(callback_state) = &self.callback_state else {
+            return;
+        };
+
+        let Ok(mut state) = callback_state.try_borrow_mut() else {
+            return;
+        };
+
+        let mut changed = false;
+
+        if let Some(url) = state.pending_url.take() {
+            if self.url.as_ref() != url {
+                self.url = url.into();
+                changed = true;
+            }
+        }
+
+        if self.is_loading != state.is_loading {
+            self.is_loading = state.is_loading;
+            changed = true;
+        }
+
+        if changed {
+            cx.emit(ItemEvent::UpdateTab);
+            cx.notify();
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn update_title_from_url(&mut self) {
+        if let Ok(parsed) = url::Url::parse(self.url.as_ref()) {
+            if let Some(host) = parsed.host_str() {
+                let title: SharedString = host.to_string().into();
+                if self.title.as_ref() != Some(&title) {
+                    self.title = Some(title);
+                }
+            }
+        }
+    }
+
+    pub fn paint_webview(
+        &mut self,
+        bounds: gpui::Bounds<gpui::Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.ensure_webview(window, cx);
+            self.sync_callback_state(cx);
+
+            if !self.is_loading {
+                self.update_title_from_url();
+                self.can_go_back = true;
+            }
+
+            if let Some(webview) = &self.wry_webview {
+                let device_bounds = bounds.to_device_pixels(window.scale_factor());
+                let rect = wry::Rect {
+                    position: wry::dpi::PhysicalPosition::new(
+                        device_bounds.origin.x.0,
+                        device_bounds.origin.y.0,
+                    )
+                    .into(),
+                    size: wry::dpi::PhysicalSize::new(
+                        device_bounds.size.width.0.max(0) as u32,
+                        device_bounds.size.height.0.max(0) as u32,
+                    )
+                    .into(),
+                };
+                webview.set_bounds(rect).log_err();
+                #[cfg(target_os = "linux")]
+                self.lower_x11_children();
+            }
+            self.set_visible(true);
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = (bounds, window, cx);
+        }
+    }
+
+    pub fn focus_webview(&self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(webview) = &self.wry_webview {
+            webview.focus().log_err();
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn lower_x11_children(&self) {
+        let Some(parent_xid) = self.x11_parent_window else {
+            return;
+        };
+
+        let Some(gdk_display) = gtk::gdk::Display::default() else {
+            return;
+        };
+
+        let gx11_display: &X11Display = match gdk_display.downcast_ref() {
+            Some(d) => d,
+            None => return,
+        };
+
+        let x11_display =
+            unsafe { gdkx11::ffi::gdk_x11_display_get_xdisplay(gx11_display.as_ptr()) };
+
+        if x11_display.is_null() {
+            return;
+        }
+
+        let xlib = match Xlib::open() {
+            Ok(xlib) => xlib,
+            Err(_) => return,
+        };
+
+        unsafe {
+            let mut root = 0;
+            let mut parent = 0;
+            let mut children: *mut XWindow = std::ptr::null_mut();
+            let mut nchildren = 0;
+
+            let status = (xlib.XQueryTree)(
+                x11_display as *mut Display,
+                parent_xid,
+                &mut root,
+                &mut parent,
+                &mut children,
+                &mut nchildren,
+            );
+
+            if status != 0 && !children.is_null() && nchildren > 0 {
+                let children_slice = std::slice::from_raw_parts(children, nchildren as usize);
+                for &child in children_slice {
+                    (xlib.XLowerWindow)(x11_display as *mut Display, child);
+                }
+                (xlib.XFree)(children as *mut _);
+            }
+
+            (xlib.XFlush)(x11_display as *mut Display);
+        }
+    }
+}
+
+impl EventEmitter<ItemEvent> for WebView {}
+
+impl Focusable for WebView {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for WebView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let view = cx.entity().clone();
+        if let Some(error) = &self.error {
+            return div()
+                .track_focus(&self.focus_handle)
+                .size_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(cx.theme().colors().editor_background)
+                .child(Label::new(error.clone()).color(Color::Error));
+        }
+
+        div()
+            .track_focus(&self.focus_handle)
+            .size_full()
+            .child(element::WebViewElement::new(view))
+    }
+}
+
+impl Item for WebView {
+    type Event = ItemEvent;
+
+    fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
+        self.title.clone().unwrap_or_else(|| self.url.clone())
+    }
+
+    fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
+        Some(Icon::new(IconName::ToolWeb))
+    }
+
+    fn to_item_events(event: &Self::Event, f: &mut dyn FnMut(ItemEvent)) {
+        f(*event)
+    }
+
+    fn deactivated(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        self.set_visible(false);
+        #[cfg(target_os = "linux")]
+        while gtk::events_pending() {
+            gtk::main_iteration_do(false);
+        }
+    }
+
+    fn workspace_deactivated(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        self.set_visible(false);
+        #[cfg(target_os = "linux")]
+        while gtk::events_pending() {
+            gtk::main_iteration_do(false);
+        }
+    }
+}
+
+impl Drop for WebView {
+    fn drop(&mut self) {
+        self.set_visible(false);
+        #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+        {
+            drop(self.wry_webview.take());
+            while gtk::events_pending() {
+                gtk::main_iteration_do(false);
+            }
+        }
+    }
+}
+
+/// Open a URL as a new tab in the workspace.
+pub fn open_url(
+    url: &str,
+    workspace: Entity<Workspace>,
+    window: &mut Window,
+    cx: &mut App,
+) -> Entity<WebView> {
+    let url = url.to_string();
+    let web_view = cx.new(|cx| WebView::new(url, window, cx));
+    workspace.update(cx, |workspace, cx| {
+        workspace.add_item_to_active_pane(Box::new(web_view.clone()), None, true, window, cx);
+    });
+    web_view
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn open_url_in_system_browser(url: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(url)
+            .spawn()
+            .log_err();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(url)
+            .spawn()
+            .log_err();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", url])
+            .spawn()
+            .log_err();
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -12,9 +12,11 @@ default-run = "zed"
 workspace = true
 
 [features]
+default = ["web-view"]
 tracy = ["ztracing/tracy"]
 # LEAK_BACKTRACE=1 cargo run --features zed/track-project-leak --profile release-fast
 track-project-leak = ["gpui/leak-detection"]
+web-view = ["dep:web_view"]
 test-support = [
     "gpui/test-support",
     "gpui_platform/screen-capture",
@@ -214,6 +216,7 @@ uuid.workspace = true
 vim.workspace = true
 vim_mode_setting.workspace = true
 watch.workspace = true
+web_view = { workspace = true, optional = true }
 web_search.workspace = true
 web_search_providers.workspace = true
 which_key.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -695,6 +695,8 @@ fn main() {
 
         editor::init(cx);
         image_viewer::init(cx);
+        #[cfg(feature = "web-view")]
+        web_view::init(cx);
         repl::notebook::init(cx);
         diagnostics::init(cx);
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1263,6 +1263,11 @@ fn initialize_pane(
             toolbar.add_item(basedpyright_banner, window, cx);
             let image_view_toolbar = cx.new(|_| image_viewer::ImageViewToolbarControls::new());
             toolbar.add_item(image_view_toolbar, window, cx);
+            #[cfg(feature = "web-view")]
+            {
+                let web_view_toolbar = cx.new(|_| web_view::toolbar::WebViewToolbar::new());
+                toolbar.add_item(web_view_toolbar, window, cx);
+            }
         })
     });
 }
@@ -5030,6 +5035,8 @@ mod tests {
                 cx,
             );
             image_viewer::init(cx);
+            #[cfg(feature = "web-view")]
+            web_view::init(cx);
             language_model::init(app_state.user_store.clone(), app_state.client.clone(), cx);
             language_models::init(app_state.user_store.clone(), app_state.client.clone(), cx);
             web_search::init(cx);


### PR DESCRIPTION
## Context

This PR proposes a lightweight browser tab using the system webview via https://github.com/tauri-apps/wry

The webview is composited by the OS as a native child view inside GPUI's window.

Related: https://github.com/zed-industries/zed/discussions/39885 https://github.com/zed-industries/zed/discussions/51251 Ialsopersonallyvote

---

Demo:

https://github.com/user-attachments/assets/4377f8e0-1a4a-4885-8cf5-964c9e35bff5

The experience is a bit jittery atm and it has to be improved.

The global menu at the start(cherry-picked for demo from https://github.com/zed-industries/zed/pull/51321) is important because with the editor-menu some of the dropdown options hide behind the webpage. As a workaround, I experimented with hiding the webview when dropdowns were opened, but this approach is not ideal. AFAIU there is no way to have both of them co-exist and give a higher z-index to dropdown options.

The demo was recorded on EndeavourOS KDE X11. It should work on MacOS and Windows as well. 

Wayland support would require GPUI to expose subsurface support so the webview's surface could be placed within Zed's window bounds.

Audio also works on the browser tab but was intentionally stripped out from the recording.

The lines of code may appear large, ~1k is just boilerplate: auto generated cargo.toml config only because this is adding a new feature

---

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Added web view