### PR TITLE
Gemini CLI sandbox startup

### DIFF
--- a/crates/acp_tools/Cargo.toml
+++ b/crates/acp_tools/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 publish.workspace = true
 license = "GPL-3.0-or-later"
 
+[features]
+test-support = ["workspace/test-support"]
 
 [lints]
 workspace = true

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -6,7 +6,7 @@ publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [features]
-test-support = ["acp_thread/test-support", "gpui/test-support", "project/test-support", "dep:env_logger", "client/test-support", "dep:gpui_tokio", "reqwest_client/test-support"]
+test-support = ["acp_thread/test-support", "acp_tools/test-support", "gpui/test-support", "project/test-support", "dep:env_logger", "client/test-support", "dep:gpui_tokio", "reqwest_client/test-support"]
 e2e = []
 
 [lints]
@@ -59,6 +59,7 @@ libc.workspace = true
 nix.workspace = true
 
 [dev-dependencies]
+acp_tools = { workspace = true, features = ["test-support"] }
 client = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 fs.workspace = true

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -22,6 +22,7 @@ use util::process::Child;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::rc::Rc;
+use std::time::Duration;
 use std::{any::Any, cell::RefCell};
 use thiserror::Error;
 
@@ -35,6 +36,7 @@ use terminal::terminal_settings::{AlternateScroll, CursorShape, TerminalSettings
 use crate::GEMINI_ID;
 
 pub const GEMINI_TERMINAL_AUTH_METHOD_ID: &str = "spawn-gemini-cli";
+const ACP_INITIALIZE_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Error)]
 #[error("Unsupported version")]
@@ -293,28 +295,39 @@ impl AcpConnection {
             });
         });
 
-        let response = connection
-            .initialize(
-                acp::InitializeRequest::new(acp::ProtocolVersion::V1)
-                    .client_capabilities(
-                        acp::ClientCapabilities::new()
-                            .fs(acp::FileSystemCapabilities::new()
-                                .read_text_file(true)
-                                .write_text_file(true))
-                            .terminal(true)
-                            .auth(acp::AuthCapabilities::new().terminal(true))
-                            // Experimental: Allow for rendering terminal output from the agents
-                            .meta(acp::Meta::from_iter([
-                                ("terminal_output".into(), true.into()),
-                                ("terminal-auth".into(), true.into()),
-                            ])),
-                    )
-                    .client_info(
-                        acp::Implementation::new("zed", version)
-                            .title(release_channel.map(ToOwned::to_owned)),
-                    ),
-            )
-            .await?;
+        let initialize = connection.initialize(
+            acp::InitializeRequest::new(acp::ProtocolVersion::V1)
+                .client_capabilities(
+                    acp::ClientCapabilities::new()
+                        .fs(acp::FileSystemCapabilities::new()
+                            .read_text_file(true)
+                            .write_text_file(true))
+                        .terminal(true)
+                        .auth(acp::AuthCapabilities::new().terminal(true))
+                        // Experimental: Allow for rendering terminal output from the agents
+                        .meta(acp::Meta::from_iter([
+                            ("terminal_output".into(), true.into()),
+                            ("terminal-auth".into(), true.into()),
+                        ])),
+                )
+                .client_info(
+                    acp::Implementation::new("zed", version)
+                        .title(release_channel.map(ToOwned::to_owned)),
+                ),
+        );
+        let timeout = cx.background_executor().timer(ACP_INITIALIZE_TIMEOUT);
+        let response = match futures::future::select(Box::pin(initialize), Box::pin(timeout)).await
+        {
+            futures::future::Either::Left((Ok(response), _)) => response,
+            futures::future::Either::Left((Err(err), _)) => {
+                child.kill().log_err();
+                return Err(err.into());
+            }
+            futures::future::Either::Right(_) => {
+                child.kill().log_err();
+                return Err(anyhow!(initialize_timeout_error(&agent_id)));
+            }
+        };
 
         if response.protocol_version < MINIMUM_SUPPORTED_VERSION {
             return Err(UnsupportedVersion.into());
@@ -477,6 +490,21 @@ impl AcpConnection {
             }
         }
     }
+}
+
+fn initialize_timeout_error(agent_id: &AgentId) -> LoadError {
+    let mut message = format!(
+        "Timed out waiting for {} to respond to ACP initialize.",
+        agent_id
+    );
+
+    if agent_id.0.as_ref() == GEMINI_ID {
+        message.push_str(
+            " If Gemini sandboxing is enabled in `.gemini/settings.json` via `tools.sandbox`, disable it and retry until Gemini fixes ACP sandbox startup.",
+        );
+    }
+
+    LoadError::Other(message.into())
 }
 
 impl Drop for AcpConnection {
@@ -1210,6 +1238,19 @@ mod tests {
             ])
         );
         assert_eq!(terminal_auth_task.label, "Login");
+    }
+
+    #[test]
+    fn initialize_timeout_error_includes_gemini_hint() {
+        let error = initialize_timeout_error(&AgentId::new(GEMINI_ID));
+
+        match error {
+            LoadError::Other(message) => {
+                assert!(message.contains("Timed out waiting for gemini"));
+                assert!(message.contains("tools.sandbox"));
+            }
+            _ => unreachable!(),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #51333

## Summary
• Add a timeout for external ACP agent initialization so stalled startups fail with an error instead of hanging forever.
• Kill the child process if ACP init times out.
• Surface a targeted Gemini hint when startup stalls with sandboxing enabled.
• Propagate `test-support` through `acp_tools` so the `agent_servers` validation graph compiles cleanly - this was required to run the tests/checks locally, unless I'm missing something?

## Root Cause
Gemini CLI hangs before ACP initialization when its own sandboxing is enabled and stdin is piped.

Local repro showed:
• with `tools.sandbox = false`, Gemini responds to ACP initialize over piped stdio
• with `tools.sandbox = "sandbox-exec"`, Gemini never responds to ACP initialize
• this reproduces both with Zed’s shell-wrapped launch shape and with a direct piped launch

So, Zed’s shell wrapper isn't the root cause here, IMO.

This is an upstream issue in the Gemini CLI startup. When sandboxing is enabled and stdin is not a TTY, Gemini reads stdin before entering ACP mode. In ACP mode stdin is the protocol transport, so that waits for EOF forever and Gemini never starts its ACP server.

Zed still owns the UX here, so this change makes the failure explicit instead of leaving the thread in `Loading...`.

## Verification
• `./script/check-keymaps`
• `./script/clippy -p agent_servers`
• `cargo test -p agent_servers -- --nocapture`

## Manual Testing
• Repro’d Gemini ACP startup locally with Gemini CLI `0.35.0`
• Confirmed `initialize` succeeds with `tools.sandbox = false`
• Confirmed `initialize` times out with `tools.sandbox = "sandbox-exec"`
• Confirmed the timeout reproduces both with a direct piped launch and a Zed-like shell-wrapped piped launch

Release Notes:

 - Fixed external agent startup to fail with an error instead of hanging forever when ACP init stalls.