### PR TITLE
windows: Preserve launch environment for forwarded CLI opens

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -611,9 +611,12 @@ fn run() -> Result<()> {
 
         #[cfg(target_os = "windows")]
         {
-            // On Windows, by default, a child process inherits a copy of the environment block of the parent process.
-            // So we don't need to pass env vars explicitly.
-            None
+            use collections::HashMap;
+
+            // Child-process inheritance does not help when the request is forwarded into an
+            // already-running Zed instance. In that case we need to serialize the launching
+            // process environment explicitly.
+            Some(std::env::vars().collect::<HashMap<_, _>>())
         }
 
         #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "windows")))]

--- a/crates/zed/src/zed/windows_only_instance.rs
+++ b/crates/zed/src/zed/windows_only_instance.rs
@@ -159,7 +159,7 @@ fn send_args_to_instance(args: &Args) -> anyhow::Result<()> {
             wait: false,
             wsl: args.wsl.clone(),
             open_behavior: Default::default(),
-            env: None,
+            env: Some(std::env::vars().collect()),
             user_data_dir: args.user_data_dir.clone(),
             dev_container: args.dev_container,
             cwd: std::env::current_dir().ok(),


### PR DESCRIPTION
Closes #47306

## Summary
 • preserve the launching process env when Windows forwards a CLI open into an already running Zed instance
 • make the Windows CLI path serialize the launch environment explicitly, so both request producers stay consistent
 • keep the downstream environment plumbing unchanged, since `CliRequest::Open`, `open_listener`, and `ProjectEnvironment` already handle per-open CLI env correctly

### Why
The bug was in the Windows request producers, not in the receiver side. On Windows, both `crates/zed/src/zed/windows_only_instance.rs` and `crates/cli/src/main.rs` were constructing `CliRequest::Open` with `env: None`. That assumption only works when a fresh child process is doing the work. It breaks when a later launch forwards into an already running Zed process, which is the exact single instance path this issue describes.

The only way for the later window to see the later launch environment is to serialize it in the request.

## Verification
 • `cargo fmt --all --check`
 • `./script/check-keymaps`
 • `./script/clippy -p cli -p zed`
 • `cargo test -p cli -- --nocapture`
 • `cargo test -p cli -p zed -- --nocapture`

Release Notes:

 - Fixed Windows CLI-opened workspaces to preserve the launch envs when forwarding to an already running Zed instance.