### PR TITLE
Fix wrong selection in commit panel

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -3392,9 +3392,12 @@ impl OutlinePanel {
                     selection_display_point - outline_range.end
                 };
 
+                let cursor_past_start = outline_range.start != selection_display_point;
                 (
+                    cursor_past_start,
                     cmp::Reverse(outline.depth),
-                    distance_from_start + distance_from_end,
+                    distance_from_start,
+                    distance_from_end,
                 )
             })
             .map(|(_, (_, outline))| *outline)
@@ -5360,7 +5363,7 @@ impl GenerationState {
 mod tests {
     use db::indoc;
     use gpui::{TestAppContext, UpdateGlobal, VisualTestContext, WindowHandle};
-    use language::{self, FakeLspAdapter, rust_lang};
+    use language::{self, FakeLspAdapter, markdown_lang, rust_lang};
     use pretty_assertions::assert_eq;
     use project::FakeFs;
     use search::{
@@ -8087,5 +8090,183 @@ outline: struct Foo  <==== selected
                 "Step 3: tree-sitter outlines should be restored"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_markdown_outline_selection_at_heading_boundaries(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/test",
+            json!({
+                "doc.md": indoc!("
+                    # Top Level
+
+                    Some content
+
+                    ## Sub Section A
+
+                    Sub content A
+
+                    ## Sub Section B
+
+                    Sub content B
+
+                    # Another Top
+
+                    More content
+                ")
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [Path::new("/test")], cx).await;
+        project.read_with(cx, |project, _| project.languages().add(markdown_lang()));
+        let (window, workspace) = add_outline_panel(&project, cx).await;
+        let cx = &mut VisualTestContext::from_window(window.into(), cx);
+        let outline_panel = outline_panel(&workspace, cx);
+        outline_panel.update_in(cx, |outline_panel, window, cx| {
+            outline_panel.set_active(true, window, cx)
+        });
+
+        let editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_abs_path(
+                    PathBuf::from("/test/doc.md"),
+                    OpenOptions {
+                        visible: Some(OpenVisible::All),
+                        ..Default::default()
+                    },
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+
+        cx.executor()
+            .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(500));
+        cx.run_until_parked();
+
+        outline_panel.update_in(cx, |panel, window, cx| {
+            panel.update_non_fs_items(window, cx);
+            panel.update_cached_entries(Some(UPDATE_DEBOUNCE), window, cx);
+        });
+        cx.executor()
+            .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(500));
+        cx.run_until_parked();
+
+        let all_entries = indoc!(
+            "
+            outline: # Top Level
+              outline: ## Sub Section A
+              outline: ## Sub Section B
+            outline: # Another Top"
+        );
+
+        // Verify outline entries are correct.
+        outline_panel.update(cx, |outline_panel, cx| {
+            assert_eq!(
+                display_entries(
+                    &project,
+                    &snapshot(outline_panel, cx),
+                    &outline_panel.cached_entries,
+                    None,
+                    cx,
+                ),
+                all_entries,
+                "Outline entries should match the markdown heading structure"
+            );
+        });
+
+        // Helper: move cursor to (row, 0), wait for debounce, return selected entry text.
+        let move_cursor_and_get_selection =
+            |row: u32, cx: &mut VisualTestContext| -> Option<String> {
+                cx.update(|window, cx| {
+                    editor.update(cx, |editor, cx| {
+                        editor.change_selections(
+                            SelectionEffects::no_scroll(),
+                            window,
+                            cx,
+                            |s| {
+                                s.select_ranges(Some(
+                                    language::Point::new(row, 0)..language::Point::new(row, 0),
+                                ))
+                            },
+                        );
+                    });
+                });
+                cx.executor()
+                    .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(100));
+                cx.run_until_parked();
+
+                outline_panel.read_with(cx, |panel, _cx| {
+                    panel.selected_entry().and_then(|entry| match entry {
+                        PanelEntry::Outline(OutlineEntry::Outline(outline)) => {
+                            Some(outline.outline.text.clone())
+                        }
+                        _ => None,
+                    })
+                })
+            };
+
+        // Case 1: Cursor at start of first heading (row 0).
+        assert_eq!(
+            move_cursor_and_get_selection(0, cx).as_deref(),
+            Some("# Top Level"),
+            "Cursor at row 0 should select '# Top Level'"
+        );
+
+        // Case 2: Cursor in content under first heading (row 2).
+        assert_eq!(
+            move_cursor_and_get_selection(2, cx).as_deref(),
+            Some("# Top Level"),
+            "Cursor at row 2 (content) should still select '# Top Level'"
+        );
+
+        // Case 3: Cursor at start of sub-heading A (row 4) — boundary case.
+        assert_eq!(
+            move_cursor_and_get_selection(4, cx).as_deref(),
+            Some("## Sub Section A"),
+            "Cursor at row 4 should select '## Sub Section A', not '# Top Level'"
+        );
+
+        // Case 4: Cursor in content under sub-heading A (row 6).
+        assert_eq!(
+            move_cursor_and_get_selection(6, cx).as_deref(),
+            Some("## Sub Section A"),
+            "Cursor at row 6 (content) should select '## Sub Section A'"
+        );
+
+        // Case 5: Cursor at start of sub-heading B (row 8) — sibling boundary.
+        assert_eq!(
+            move_cursor_and_get_selection(8, cx).as_deref(),
+            Some("## Sub Section B"),
+            "Cursor at row 8 should select '## Sub Section B', not '## Sub Section A'"
+        );
+
+        // Case 6: Cursor in content under sub-heading B (row 10).
+        assert_eq!(
+            move_cursor_and_get_selection(10, cx).as_deref(),
+            Some("## Sub Section B"),
+            "Cursor at row 10 (content) should select '## Sub Section B'"
+        );
+
+        // Case 7: Cursor at start of second top-level heading (row 12) — top-level boundary.
+        assert_eq!(
+            move_cursor_and_get_selection(12, cx).as_deref(),
+            Some("# Another Top"),
+            "Cursor at row 12 should select '# Another Top', not '## Sub Section B'"
+        );
+
+        // Case 8: Cursor in content under second top-level heading (row 14).
+        assert_eq!(
+            move_cursor_and_get_selection(14, cx).as_deref(),
+            Some("# Another Top"),
+            "Cursor at row 14 (content) should select '# Another Top'"
+        );
     }
 }


### PR DESCRIPTION
### Summary

Fix wrong outline selection at heading boundaries in Markdown files.

When clicking headings in the Outline Panel for Markdown, the selected item showed as N-1 (previous heading) instead of N. Root cause: the `outline_location()` function's sort key prioritized depth over cursor position, causing deeper sections to win even when the cursor was at the exact start of a shallower section.

### Fixes #52418

### How to Review

- `outline_panel.rs:3395` : Sort key change adding `cursor_past_start` as primary criterion
- `outline_panel.rs:8094` : New comprehensive test with 8 boundary/nesting cases

### Self-Review Checklist

- [x] Reviewed diff for quality and correctness
- [x] Tests cover the new/changed behavior (8 test cases added)
- [x] No unsafe code changes
- [x] All 12 tests pass (11 existing + 1 new)

### Video 

[Screencast from 2026-03-26 09-58-23.webm](https://github.com/user-attachments/assets/b2d51506-5041-40d7-aa7d-5769f48ddabd)


Release Notes:

- Fixed Outline Panel selection being off-by-one at Markdown heading boundaries
