### PR TITLE
Fix slow Tree-sitter parsing on broken code

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -25,6 +25,7 @@ use tree_sitter::{
 };
 
 pub const MAX_BYTES_TO_QUERY: usize = 16 * 1024;
+const CAPTURE_CONTAINING_CONTEXT_BYTES: usize = 3 * 1024;
 
 pub struct SyntaxMap {
     snapshot: SyntaxSnapshot,
@@ -1117,6 +1118,7 @@ impl<'a> SyntaxMapCaptures<'a> {
             };
 
             cursor.set_byte_range(range.clone());
+            cursor.set_containing_byte_range(containing_byte_range_for_captures(&range));
             let captures = cursor.captures(query, layer.node(), TextProvider(text));
             let grammar_index = result
                 .grammars
@@ -1206,6 +1208,19 @@ impl<'a> SyntaxMapCaptures<'a> {
             .position(|layer| layer.next_capture.is_none())
             .unwrap_or(self.layers.len());
     }
+}
+
+fn containing_byte_range_for_captures(query_range: &Range<usize>) -> Range<usize> {
+    let desired_window = query_range
+        .len()
+        .saturating_add(CAPTURE_CONTAINING_CONTEXT_BYTES.saturating_mul(2));
+    let containing_window_len = desired_window.min(MAX_BYTES_TO_QUERY);
+    let midpoint = query_range
+        .start
+        .saturating_add(query_range.len().saturating_div(2));
+    let containing_start = midpoint.saturating_sub(containing_window_len / 2);
+    let containing_end = containing_start.saturating_add(containing_window_len);
+    containing_start..containing_end
 }
 
 #[derive(Default)]

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -84,6 +84,68 @@ fn test_splice_included_ranges() {
 }
 
 #[gpui::test]
+fn test_captures_on_large_error_node(cx: &mut App) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    let language = rust_lang();
+    registry.add(language.clone());
+
+    // Build a large file with broken syntax that produces a massive ERROR node.
+    let mut source = String::from("fn main() {\n");
+    for i in 0..5000 {
+        source.push_str(&format!("    ({i}),\n"));
+    }
+    // Deliberately omit the closing brace to produce a large ERROR subtree.
+    source.push_str("    unexpected_token\n");
+
+    let buffer = Buffer::new(ReplicaId::LOCAL, BufferId::new(1).unwrap(), source.clone());
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(language, &buffer);
+
+    // Verify the tree contains an ERROR node.
+    let layers = syntax_map.layers(&buffer);
+    assert!(
+        layers.first().expect("expected at least one layer").node().has_error(),
+        "expected the parse tree to contain an ERROR node"
+    );
+
+    // Query highlights for small visible windows at various positions in the file,
+    // simulating scrolling. Each should complete without hanging or taking excessive time.
+    let total_bytes = source.len();
+    let window_size = 800; // ~25 lines visible
+    let query_positions = [
+        0,
+        total_bytes / 4,
+        total_bytes / 2,
+        total_bytes * 3 / 4,
+        total_bytes.saturating_sub(window_size),
+    ];
+
+    for &start in &query_positions {
+        let end = (start + window_size).min(total_bytes);
+        let captures: Vec<_> = syntax_map
+            .captures(
+                start..end,
+                &buffer,
+                |grammar| grammar.highlights_config.as_ref().map(|c| &c.query),
+            )
+            .collect();
+
+        // The captures should be limited to nodes relevant to the visible window,
+        // not the entire ERROR subtree.
+        for capture in &captures {
+            assert!(
+                capture.node.start_byte() < end + MAX_BYTES_TO_QUERY,
+                "capture at byte {} is too far past the query range end {}",
+                capture.node.start_byte(),
+                end,
+            );
+        }
+    }
+}
+
+#[gpui::test]
 fn test_syntax_map_layers_for_range(cx: &mut App) {
     let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let language = rust_lang();


### PR DESCRIPTION
#### Context

When tree-sitter parses a file with broken syntax (e.g. a large partial SQL `VALUES` clause, or any language where a large chunk becomes invalid), it can produce a single `ERROR` node spanning thousands of lines. On every render frame, Zed queries this tree for syntax highlights via `SyntaxMapCaptures`. Previously, only `set_byte_range` was applied to the query cursor - this limits which captures are *returned*, but tree-sitter still had to *traverse* the entire ERROR subtree to find them, causing O(file size) work per frame and making scrolling/editing visibly laggy.

The fix applies `set_containing_byte_range` to the highlight query cursor, mirroring what `SyntaxMapMatches` already does for indentation and bracket queries. This tells tree-sitter to skip subtrees that extend far beyond the visible window, reducing traversal to the visible range only.

**Note:** This fix eliminates the main freeze/stall caused by full-tree traversal.  A small amount of lag may still occur on very large broken files, as tree-sitter still needs to parse the error-recovery structure. Further improvements would require deeper changes to tree-sitter's query execution or incremental parsing.


#### Closes #52390

#### How to Review

Small change — focus on [syntax_map.rs:1119-1123](crates/language/src/syntax_map.rs#L1119) (the fix) and the `containing_byte_range_for_captures` helper below it. Compare with the existing `SyntaxMapMatches::new` path (line ~1255) which uses the same pattern.

#### Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

#### Video 
[Screencast from 2026-03-26 14-19-19.webm](https://github.com/user-attachments/assets/6628492a-f013-438a-836a-2740f6e2f266)


Release Notes:

- Fixed laggy scrolling and editing in files with large broken syntax regions (e.g. incomplete SQL `VALUES` clauses or large invalid blocks in any language)
