### PR TITLE
gpui: Fix scrollbar drag position inversion in bottom-aligned lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3476,7 @@ version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
 dependencies = [
+ "bzip2 0.6.1",
  "compression-core",
  "deflate64",
  "flate2",
@@ -9669,6 +9679,12 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
@@ -22348,7 +22364,7 @@ checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
  "aes",
  "byteorder",
- "bzip2",
+ "bzip2 0.4.4",
  "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -491,7 +491,7 @@ ashpd = { version = "0.13", default-features = false, features = [
 ] }
 async-channel = "2.5.0"
 async-compat = "0.2.1"
-async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
+async-compression = { version = "0.4", features = ["bzip2", "gzip", "futures-io"] }
 async-dispatcher = "0.1"
 async-fs = "2.1"
 async-lock = "2.1"

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -775,7 +775,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       "tab": "editor::AcceptEditPrediction",
     },

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -776,15 +776,6 @@
     },
   },
   {
-    "context": "Editor && edit_prediction_conflict",
-    "bindings": {
-      "alt-tab": "editor::AcceptEditPrediction",
-      "alt-l": "editor::AcceptEditPrediction",
-      "alt-k": "editor::AcceptNextWordEditPrediction",
-      "alt-j": "editor::AcceptNextLineEditPrediction",
-    },
-  },
-  {
     "context": "Editor && showing_code_actions",
     "bindings": {
       "enter": "editor::ConfirmCodeAction",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -770,9 +770,14 @@
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
-      "tab": "editor::AcceptEditPrediction",
       "alt-k": "editor::AcceptNextWordEditPrediction",
       "alt-j": "editor::AcceptNextLineEditPrediction",
+    },
+  },
+  {
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "bindings": {
+      "tab": "editor::AcceptEditPrediction",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -839,7 +839,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       "tab": "editor::AcceptEditPrediction",
     },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -840,15 +840,6 @@
     },
   },
   {
-    "context": "Editor && edit_prediction_conflict",
-    "use_key_equivalents": true,
-    "bindings": {
-      "alt-tab": "editor::AcceptEditPrediction",
-      "ctrl-cmd-right": "editor::AcceptNextWordEditPrediction",
-      "ctrl-cmd-down": "editor::AcceptNextLineEditPrediction",
-    },
-  },
-  {
     "context": "Editor && showing_code_actions",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -834,9 +834,14 @@
     "context": "Editor && edit_prediction",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
-      "tab": "editor::AcceptEditPrediction",
       "ctrl-cmd-right": "editor::AcceptNextWordEditPrediction",
       "ctrl-cmd-down": "editor::AcceptNextLineEditPrediction",
+    },
+  },
+  {
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "bindings": {
+      "tab": "editor::AcceptEditPrediction",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -771,7 +771,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptEditPrediction",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -772,16 +772,6 @@
     },
   },
   {
-    "context": "Editor && edit_prediction_conflict",
-    "use_key_equivalents": true,
-    "bindings": {
-      "alt-tab": "editor::AcceptEditPrediction",
-      "alt-l": "editor::AcceptEditPrediction",
-      "alt-k": "editor::AcceptNextWordEditPrediction",
-      "alt-j": "editor::AcceptNextLineEditPrediction",
-    },
-  },
-  {
     "context": "Editor && showing_code_actions",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -766,9 +766,15 @@
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
-      "tab": "editor::AcceptEditPrediction",
       "alt-k": "editor::AcceptNextWordEditPrediction",
       "alt-j": "editor::AcceptNextLineEditPrediction",
+    },
+  },
+  {
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": "editor::AcceptEditPrediction",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1073,15 +1073,7 @@
       "enter": "agent::Chat",
     },
   },
-  {
-    "context": "os != macos && Editor && edit_prediction_conflict",
-    "bindings": {
-      // alt-l is provided as an alternative to tab/alt-tab. and will be displayed in the UI. This
-      // is because alt-tab may not be available, as it is often used for window switching on Linux
-      // and Windows.
-      "alt-l": "editor::AcceptEditPrediction",
-    },
-  },
+
   {
     "context": "SettingsWindow > NavigationMenu && !search",
     "bindings": {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1060,7 +1060,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to
       // "vim::Tab" shadow it, so it needs to be bound again.

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1060,7 +1060,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to
       // "vim::Tab" shadow it, so it needs to be bound again.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2040,6 +2040,9 @@
       "remove_trailing_whitespace_on_save": false,
       "ensure_final_newline_on_save": false,
     },
+    "EEx": {
+      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
+    },
     "Elixir": {
       "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
     },
@@ -2066,7 +2069,7 @@
         "allowed": true,
       },
     },
-    "HEEX": {
+    "HEEx": {
       "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
     },
     "HTML": {

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -5039,6 +5039,11 @@ async fn test_subagent_thread_inherits_parent_thread_properties(cx: &mut TestApp
             subagent_thread.parent_thread_id(),
             Some(parent_thread.read(cx).id().clone())
         );
+
+        let request = subagent_thread
+            .build_completion_request(CompletionIntent::UserPrompt, cx)
+            .unwrap();
+        assert_eq!(request.intent, Some(CompletionIntent::Subagent));
     });
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2646,6 +2646,13 @@ impl Thread {
         completion_intent: CompletionIntent,
         cx: &App,
     ) -> Result<LanguageModelRequest> {
+        let completion_intent =
+            if self.is_subagent() && completion_intent == CompletionIntent::UserPrompt {
+                CompletionIntent::Subagent
+            } else {
+                completion_intent
+            };
+
         let model = self.model().context("No language model configured")?;
         let tools = if let Some(turn) = self.running_turn.as_ref() {
             turn.tools

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -193,6 +193,7 @@ pub enum EditPredictionRejectReason {
 #[serde(rename_all = "snake_case")]
 pub enum CompletionIntent {
     UserPrompt,
+    Subagent,
     ToolResults,
     ThreadSummarization,
     ThreadContextSummarization,

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -1,13 +1,17 @@
 use edit_prediction_types::{
     EditPredictionDelegate, EditPredictionIconSet, PredictedCursorPosition,
 };
-use gpui::{Entity, KeyBinding, Modifiers, prelude::*};
+use gpui::{
+    Entity, KeyBinding, KeybindingKeystroke, Keystroke, Modifiers, NoAction, Task, prelude::*,
+};
 use indoc::indoc;
-use language::Buffer;
 use language::EditPredictionsMode;
-use multi_buffer::{Anchor, MultiBufferSnapshot, ToPoint};
+use language::{Buffer, CodeLabel};
+use multi_buffer::{Anchor, ExcerptId, MultiBufferSnapshot, ToPoint};
+use project::{Completion, CompletionResponse, CompletionSource};
 use std::{
     ops::Range,
+    rc::Rc,
     sync::{
         Arc,
         atomic::{self, AtomicUsize},
@@ -17,8 +21,9 @@ use text::{Point, ToOffset};
 use ui::prelude::*;
 
 use crate::{
-    AcceptEditPrediction, EditPrediction, EditPredictionKeybindAction,
-    EditPredictionKeybindSurface, MenuEditPredictionsPolicy,
+    AcceptEditPrediction, CompletionContext, CompletionProvider, EditPrediction,
+    EditPredictionKeybindAction, EditPredictionKeybindSurface, MenuEditPredictionsPolicy,
+    ShowCompletions,
     editor_tests::{init_test, update_test_language_settings},
     test::editor_test_context::EditorTestContext,
 };
@@ -482,6 +487,56 @@ async fn test_edit_prediction_preview_cleanup_on_toggle_off(cx: &mut gpui::TestA
     });
 }
 
+#[gpui::test]
+async fn test_edit_prediction_preview_activates_when_prediction_arrives_with_modifier_held(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+    update_test_language_settings(cx, &|settings| {
+        settings.edit_predictions.get_or_insert_default().mode = Some(EditPredictionsMode::Subtle);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    cx.editor(|editor, _, _| {
+        assert!(!editor.has_active_edit_prediction());
+        assert!(!editor.edit_prediction_preview_is_active());
+    });
+
+    let preview_modifiers = cx.update_editor(|editor, window, cx| {
+        *editor
+            .preview_edit_prediction_keystroke(window, cx)
+            .unwrap()
+            .modifiers()
+    });
+
+    cx.simulate_modifiers_change(preview_modifiers);
+    cx.run_until_parked();
+
+    cx.editor(|editor, _, _| {
+        assert!(!editor.has_active_edit_prediction());
+        assert!(editor.edit_prediction_preview_is_active());
+    });
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| {
+        editor.set_menu_edit_predictions_policy(MenuEditPredictionsPolicy::ByProvider);
+        editor.update_visible_edit_prediction(window, cx)
+    });
+
+    cx.editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(
+            editor.edit_prediction_preview_is_active(),
+            "prediction preview should activate immediately when the prediction arrives while the preview modifier is still held",
+        );
+    });
+}
+
 fn load_default_keymap(cx: &mut gpui::TestAppContext) {
     cx.update(|cx| {
         cx.bind_keys(
@@ -495,123 +550,272 @@ fn load_default_keymap(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_tab_is_preferred_accept_binding_over_alt_tab(cx: &mut gpui::TestAppContext) {
+async fn test_inline_edit_prediction_keybind_selection_cases(cx: &mut gpui::TestAppContext) {
+    enum InlineKeybindState {
+        Normal,
+        ShowingCompletions,
+        InLeadingWhitespace,
+        ShowingCompletionsAndLeadingWhitespace,
+    }
+
+    enum ExpectedKeystroke {
+        DefaultAccept,
+        DefaultPreview,
+        Literal(&'static str),
+    }
+
+    struct InlineKeybindCase {
+        name: &'static str,
+        use_default_keymap: bool,
+        mode: EditPredictionsMode,
+        extra_bindings: Vec<KeyBinding>,
+        state: InlineKeybindState,
+        expected_accept_keystroke: ExpectedKeystroke,
+        expected_preview_keystroke: ExpectedKeystroke,
+        expected_displayed_keystroke: ExpectedKeystroke,
+    }
+
     init_test(cx, |_| {});
     load_default_keymap(cx);
+    let mut default_cx = EditorTestContext::new(cx).await;
+    let provider = default_cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut default_cx);
+    default_cx.set_state("let x = ˇ;");
+    propose_edits(&provider, vec![(8..8, "42")], &mut default_cx);
+    default_cx
+        .update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
 
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
+    let (default_accept_keystroke, default_preview_keystroke) =
+        default_cx.update_editor(|editor, window, cx| {
+            let keybind_display = editor.edit_prediction_keybind_display(
+                EditPredictionKeybindSurface::Inline,
+                window,
+                cx,
+            );
+            let accept_keystroke = keybind_display
+                .accept_keystroke
+                .as_ref()
+                .expect("default inline edit prediction should have an accept binding")
+                .clone();
+            let preview_keystroke = keybind_display
+                .preview_keystroke
+                .as_ref()
+                .expect("default inline edit prediction should have a preview binding")
+                .clone();
+            (accept_keystroke, preview_keystroke)
+        });
 
-    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    let cases = [
+        InlineKeybindCase {
+            name: "default setup prefers tab over alt-tab for accept",
+            use_default_keymap: true,
+            mode: EditPredictionsMode::Eager,
+            extra_bindings: Vec::new(),
+            state: InlineKeybindState::Normal,
+            expected_accept_keystroke: ExpectedKeystroke::DefaultAccept,
+            expected_preview_keystroke: ExpectedKeystroke::DefaultPreview,
+            expected_displayed_keystroke: ExpectedKeystroke::DefaultAccept,
+        },
+        InlineKeybindCase {
+            name: "subtle mode displays preview binding inline",
+            use_default_keymap: true,
+            mode: EditPredictionsMode::Subtle,
+            extra_bindings: Vec::new(),
+            state: InlineKeybindState::Normal,
+            expected_accept_keystroke: ExpectedKeystroke::DefaultPreview,
+            expected_preview_keystroke: ExpectedKeystroke::DefaultPreview,
+            expected_displayed_keystroke: ExpectedKeystroke::DefaultPreview,
+        },
+        InlineKeybindCase {
+            name: "removing default tab binding still displays tab",
+            use_default_keymap: true,
+            mode: EditPredictionsMode::Eager,
+            extra_bindings: vec![KeyBinding::new(
+                "tab",
+                NoAction,
+                Some("Editor && edit_prediction && edit_prediction_mode == eager"),
+            )],
+            state: InlineKeybindState::Normal,
+            expected_accept_keystroke: ExpectedKeystroke::DefaultPreview,
+            expected_preview_keystroke: ExpectedKeystroke::DefaultPreview,
+            expected_displayed_keystroke: ExpectedKeystroke::DefaultPreview,
+        },
+        InlineKeybindCase {
+            name: "custom-only rebound accept key uses replacement key",
+            use_default_keymap: true,
+            mode: EditPredictionsMode::Eager,
+            extra_bindings: vec![KeyBinding::new(
+                "ctrl-enter",
+                AcceptEditPrediction,
+                Some("Editor && edit_prediction"),
+            )],
+            state: InlineKeybindState::Normal,
+            expected_accept_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_preview_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_displayed_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+        },
+        InlineKeybindCase {
+            name: "showing completions restores conflict-context binding",
+            use_default_keymap: true,
+            mode: EditPredictionsMode::Eager,
+            extra_bindings: vec![KeyBinding::new(
+                "ctrl-enter",
+                AcceptEditPrediction,
+                Some("Editor && edit_prediction && showing_completions"),
+            )],
+            state: InlineKeybindState::ShowingCompletions,
+            expected_accept_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_preview_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_displayed_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+        },
+        InlineKeybindCase {
+            name: "leading whitespace restores conflict-context binding",
+            use_default_keymap: false,
+            mode: EditPredictionsMode::Eager,
+            extra_bindings: vec![KeyBinding::new(
+                "ctrl-enter",
+                AcceptEditPrediction,
+                Some("Editor && edit_prediction && in_leading_whitespace"),
+            )],
+            state: InlineKeybindState::InLeadingWhitespace,
+            expected_accept_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_preview_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_displayed_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+        },
+        InlineKeybindCase {
+            name: "showing completions and leading whitespace restore combined conflict binding",
+            use_default_keymap: false,
+            mode: EditPredictionsMode::Eager,
+            extra_bindings: vec![KeyBinding::new(
+                "ctrl-enter",
+                AcceptEditPrediction,
+                Some("Editor && edit_prediction && showing_completions && in_leading_whitespace"),
+            )],
+            state: InlineKeybindState::ShowingCompletionsAndLeadingWhitespace,
+            expected_accept_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_preview_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+            expected_displayed_keystroke: ExpectedKeystroke::Literal("ctrl-enter"),
+        },
+    ];
 
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::Inline,
-            window,
-            cx,
-        );
-        let keystroke = keybind_display
-            .accept_keystroke
-            .as_ref()
-            .expect("should have an accept binding");
-        assert!(
-            !keystroke.modifiers().modified(),
-            "preferred accept binding should be unmodified (tab), got modifiers: {:?}",
-            keystroke.modifiers()
-        );
-        assert_eq!(
-            keystroke.key(),
-            "tab",
-            "preferred accept binding should be tab"
-        );
-    });
-}
+    for case in cases {
+        init_test(cx, |_| {});
+        if case.use_default_keymap {
+            load_default_keymap(cx);
+        }
+        update_test_language_settings(cx, &|settings| {
+            settings.edit_predictions.get_or_insert_default().mode = Some(case.mode);
+        });
 
-#[gpui::test]
-async fn test_subtle_in_code_indicator_prefers_preview_binding(cx: &mut gpui::TestAppContext) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
-    update_test_language_settings(cx, &|settings| {
-        settings.edit_predictions.get_or_insert_default().mode = Some(EditPredictionsMode::Subtle);
-    });
+        if !case.extra_bindings.is_empty() {
+            cx.update(|cx| cx.bind_keys(case.extra_bindings.clone()));
+        }
 
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
+        let mut cx = EditorTestContext::new(cx).await;
+        let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+        assign_editor_completion_provider(provider.clone(), &mut cx);
 
-    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+        match case.state {
+            InlineKeybindState::Normal | InlineKeybindState::ShowingCompletions => {
+                cx.set_state("let x = ˇ;");
+            }
+            InlineKeybindState::InLeadingWhitespace
+            | InlineKeybindState::ShowingCompletionsAndLeadingWhitespace => {
+                cx.set_state(indoc! {"
+                    fn main() {
+                        ˇ
+                    }
+                "});
+            }
+        }
 
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
-        assert!(
-            editor.edit_prediction_requires_modifier(),
-            "subtle mode should require a modifier"
-        );
+        propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+        cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
 
-        let inline_keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::Inline,
-            window,
-            cx,
-        );
-        let compact_keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverCompact,
-            window,
-            cx,
-        );
+        if matches!(
+            case.state,
+            InlineKeybindState::ShowingCompletions
+                | InlineKeybindState::ShowingCompletionsAndLeadingWhitespace
+        ) {
+            assign_editor_completion_menu_provider(&mut cx);
+            cx.update_editor(|editor, window, cx| {
+                editor.show_completions(&ShowCompletions, window, cx);
+            });
+            cx.run_until_parked();
+        }
 
-        let accept_keystroke = inline_keybind_display
-            .accept_keystroke
-            .as_ref()
-            .expect("should have an accept binding");
-        let preview_keystroke = inline_keybind_display
-            .preview_keystroke
-            .as_ref()
-            .expect("should have a preview binding");
-        let in_code_keystroke = inline_keybind_display
-            .displayed_keystroke
-            .as_ref()
-            .expect("should have an in-code binding");
-        let compact_cursor_popover_keystroke = compact_keybind_display
-            .displayed_keystroke
-            .as_ref()
-            .expect("should have a compact cursor popover binding");
+        cx.update_editor(|editor, window, cx| {
+            assert!(
+                editor.has_active_edit_prediction(),
+                "case '{}' should have an active edit prediction",
+                case.name
+            );
 
-        assert_eq!(accept_keystroke.key(), "tab");
-        assert!(
-            !editor.has_visible_completions_menu(),
-            "compact cursor-popover branch should be used without a completions menu"
-        );
-        assert!(
-            preview_keystroke.modifiers().modified(),
-            "preview binding should use modifiers in subtle mode"
-        );
-        assert_eq!(
-            compact_cursor_popover_keystroke.key(),
-            preview_keystroke.key(),
-            "subtle compact cursor popover should prefer the preview binding"
-        );
-        assert_eq!(
-            compact_cursor_popover_keystroke.modifiers(),
-            preview_keystroke.modifiers(),
-            "subtle compact cursor popover should use the preview binding modifiers"
-        );
-        assert_eq!(
-            in_code_keystroke.key(),
-            preview_keystroke.key(),
-            "subtle in-code indicator should prefer the preview binding"
-        );
-        assert_eq!(
-            in_code_keystroke.modifiers(),
-            preview_keystroke.modifiers(),
-            "subtle in-code indicator should use the preview binding modifiers"
-        );
-    });
+            let keybind_display = editor.edit_prediction_keybind_display(
+                EditPredictionKeybindSurface::Inline,
+                window,
+                cx,
+            );
+            let accept_keystroke = keybind_display
+                .accept_keystroke
+                .as_ref()
+                .unwrap_or_else(|| panic!("case '{}' should have an accept binding", case.name));
+            let preview_keystroke = keybind_display
+                .preview_keystroke
+                .as_ref()
+                .unwrap_or_else(|| panic!("case '{}' should have a preview binding", case.name));
+            let displayed_keystroke = keybind_display
+                .displayed_keystroke
+                .as_ref()
+                .unwrap_or_else(|| panic!("case '{}' should have a displayed binding", case.name));
+
+            let expected_accept_keystroke = match case.expected_accept_keystroke {
+                ExpectedKeystroke::DefaultAccept => default_accept_keystroke.clone(),
+                ExpectedKeystroke::DefaultPreview => default_preview_keystroke.clone(),
+                ExpectedKeystroke::Literal(keystroke) => KeybindingKeystroke::from_keystroke(
+                    Keystroke::parse(keystroke).expect("expected test keystroke to parse"),
+                ),
+            };
+            let expected_preview_keystroke = match case.expected_preview_keystroke {
+                ExpectedKeystroke::DefaultAccept => default_accept_keystroke.clone(),
+                ExpectedKeystroke::DefaultPreview => default_preview_keystroke.clone(),
+                ExpectedKeystroke::Literal(keystroke) => KeybindingKeystroke::from_keystroke(
+                    Keystroke::parse(keystroke).expect("expected test keystroke to parse"),
+                ),
+            };
+            let expected_displayed_keystroke = match case.expected_displayed_keystroke {
+                ExpectedKeystroke::DefaultAccept => default_accept_keystroke.clone(),
+                ExpectedKeystroke::DefaultPreview => default_preview_keystroke.clone(),
+                ExpectedKeystroke::Literal(keystroke) => KeybindingKeystroke::from_keystroke(
+                    Keystroke::parse(keystroke).expect("expected test keystroke to parse"),
+                ),
+            };
+
+            assert_eq!(
+                accept_keystroke, &expected_accept_keystroke,
+                "case '{}' selected the wrong accept binding",
+                case.name
+            );
+            assert_eq!(
+                preview_keystroke, &expected_preview_keystroke,
+                "case '{}' selected the wrong preview binding",
+                case.name
+            );
+            assert_eq!(
+                displayed_keystroke, &expected_displayed_keystroke,
+                "case '{}' selected the wrong displayed binding",
+                case.name
+            );
+
+            if matches!(case.mode, EditPredictionsMode::Subtle) {
+                assert!(
+                    editor.edit_prediction_requires_modifier(),
+                    "case '{}' should require a modifier",
+                    case.name
+                );
+            }
+        });
+    }
 }
 
 #[gpui::test]
@@ -639,265 +843,179 @@ async fn test_tab_accepts_edit_prediction_over_completion(cx: &mut gpui::TestApp
 }
 
 #[gpui::test]
-async fn test_single_line_prediction_uses_accept_cursor_popover_action(
-    cx: &mut gpui::TestAppContext,
-) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
+async fn test_cursor_popover_edit_prediction_keybind_cases(cx: &mut gpui::TestAppContext) {
+    enum CursorPopoverPredictionKind {
+        SingleLine,
+        MultiLine,
+        SingleLineWithPreview,
+        MultiLineWithPreview,
+        DeleteSingleNewline,
+        StaleSingleLineAfterMultiLine,
+    }
 
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
+    struct CursorPopoverCase {
+        name: &'static str,
+        prediction_kind: CursorPopoverPredictionKind,
+        expected_action: EditPredictionKeybindAction,
+    }
 
-    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    let cases = [
+        CursorPopoverCase {
+            name: "single line prediction uses accept action",
+            prediction_kind: CursorPopoverPredictionKind::SingleLine,
+            expected_action: EditPredictionKeybindAction::Accept,
+        },
+        CursorPopoverCase {
+            name: "multi line prediction uses preview action",
+            prediction_kind: CursorPopoverPredictionKind::MultiLine,
+            expected_action: EditPredictionKeybindAction::Preview,
+        },
+        CursorPopoverCase {
+            name: "single line prediction with preview still uses accept action",
+            prediction_kind: CursorPopoverPredictionKind::SingleLineWithPreview,
+            expected_action: EditPredictionKeybindAction::Accept,
+        },
+        CursorPopoverCase {
+            name: "multi line prediction with preview uses preview action",
+            prediction_kind: CursorPopoverPredictionKind::MultiLineWithPreview,
+            expected_action: EditPredictionKeybindAction::Preview,
+        },
+        CursorPopoverCase {
+            name: "single line newline deletion uses accept action",
+            prediction_kind: CursorPopoverPredictionKind::DeleteSingleNewline,
+            expected_action: EditPredictionKeybindAction::Accept,
+        },
+        CursorPopoverCase {
+            name: "stale multi line prediction does not force preview action",
+            prediction_kind: CursorPopoverPredictionKind::StaleSingleLineAfterMultiLine,
+            expected_action: EditPredictionKeybindAction::Accept,
+        },
+    ];
 
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
+    for case in cases {
+        init_test(cx, |_| {});
+        load_default_keymap(cx);
 
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverExpanded,
-            window,
-            cx,
-        );
+        let mut cx = EditorTestContext::new(cx).await;
+        let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+        assign_editor_completion_provider(provider.clone(), &mut cx);
 
-        let accept_keystroke = keybind_display
-            .accept_keystroke
-            .as_ref()
-            .expect("should have an accept binding");
-        let preview_keystroke = keybind_display
-            .preview_keystroke
-            .as_ref()
-            .expect("should have a preview binding");
+        match case.prediction_kind {
+            CursorPopoverPredictionKind::SingleLine => {
+                cx.set_state("let x = ˇ;");
+                propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+            }
+            CursorPopoverPredictionKind::MultiLine => {
+                cx.set_state("let x = ˇ;");
+                propose_edits(&provider, vec![(8..8, "42\n43")], &mut cx);
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+            }
+            CursorPopoverPredictionKind::SingleLineWithPreview => {
+                cx.set_state("let x = ˇ;");
+                propose_edits_with_preview(&provider, vec![(8..8, "42")], &mut cx).await;
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+            }
+            CursorPopoverPredictionKind::MultiLineWithPreview => {
+                cx.set_state("let x = ˇ;");
+                propose_edits_with_preview(&provider, vec![(8..8, "42\n43")], &mut cx).await;
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+            }
+            CursorPopoverPredictionKind::DeleteSingleNewline => {
+                cx.set_state(indoc! {"
+                    fn main() {
+                        let value = 1;
+                        ˇprintln!(\"done\");
+                    }
+                "});
+                propose_edits(
+                    &provider,
+                    vec![(Point::new(1, 18)..Point::new(2, 17), "")],
+                    &mut cx,
+                );
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+            }
+            CursorPopoverPredictionKind::StaleSingleLineAfterMultiLine => {
+                cx.set_state("let x = ˇ;");
+                propose_edits(&provider, vec![(8..8, "42\n43")], &mut cx);
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+                cx.update_editor(|editor, _window, cx| {
+                    assert!(editor.active_edit_prediction.is_some());
+                    assert!(editor.stale_edit_prediction_in_menu.is_none());
+                    editor.take_active_edit_prediction(cx);
+                    assert!(editor.active_edit_prediction.is_none());
+                    assert!(editor.stale_edit_prediction_in_menu.is_some());
+                });
 
-        assert_eq!(
-            keybind_display.action,
-            EditPredictionKeybindAction::Accept,
-            "single-line prediction should show the accept action"
-        );
-        assert_eq!(accept_keystroke.key(), "tab");
-        assert!(preview_keystroke.modifiers().modified());
-    });
-}
-
-#[gpui::test]
-async fn test_multi_line_prediction_uses_preview_cursor_popover_action(
-    cx: &mut gpui::TestAppContext,
-) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
-
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
-
-    propose_edits(&provider, vec![(8..8, "42\n43")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
-
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverExpanded,
-            window,
-            cx,
-        );
-        let preview_keystroke = keybind_display
-            .preview_keystroke
-            .as_ref()
-            .expect("should have a preview binding");
-
-        assert_eq!(
-            keybind_display.action,
-            EditPredictionKeybindAction::Preview,
-            "multi-line prediction should show the preview action"
-        );
-        assert!(preview_keystroke.modifiers().modified());
-    });
-}
-
-#[gpui::test]
-async fn test_single_line_prediction_with_preview_uses_accept_cursor_popover_action(
-    cx: &mut gpui::TestAppContext,
-) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
-
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
-
-    propose_edits_with_preview(&provider, vec![(8..8, "42")], &mut cx).await;
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
-
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverExpanded,
-            window,
-            cx,
-        );
-
-        let accept_keystroke = keybind_display
-            .accept_keystroke
-            .as_ref()
-            .expect("should have an accept binding");
-        let preview_keystroke = keybind_display
-            .preview_keystroke
-            .as_ref()
-            .expect("should have a preview binding");
-
-        assert_eq!(
-            keybind_display.action,
-            EditPredictionKeybindAction::Accept,
-            "single-line prediction should show the accept action even with edit_preview"
-        );
-        assert_eq!(accept_keystroke.key(), "tab");
-        assert!(preview_keystroke.modifiers().modified());
-    });
-}
-
-#[gpui::test]
-async fn test_multi_line_prediction_with_preview_uses_preview_cursor_popover_action(
-    cx: &mut gpui::TestAppContext,
-) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
-
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
-
-    propose_edits_with_preview(&provider, vec![(8..8, "42\n43")], &mut cx).await;
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
-
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverExpanded,
-            window,
-            cx,
-        );
-        let preview_keystroke = keybind_display
-            .preview_keystroke
-            .as_ref()
-            .expect("should have a preview binding");
-
-        assert_eq!(
-            keybind_display.action,
-            EditPredictionKeybindAction::Preview,
-            "multi-line prediction should show the preview action with edit_preview"
-        );
-        assert!(preview_keystroke.modifiers().modified());
-    });
-}
-
-#[gpui::test]
-async fn test_single_line_deletion_of_newline_uses_accept_cursor_popover_action(
-    cx: &mut gpui::TestAppContext,
-) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
-
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state(indoc! {"
-        fn main() {
-            let value = 1;
-            ˇprintln!(\"done\");
+                propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+                cx.update_editor(|editor, window, cx| {
+                    editor.update_visible_edit_prediction(window, cx)
+                });
+            }
         }
-    "});
 
-    propose_edits(
-        &provider,
-        vec![(Point::new(1, 18)..Point::new(2, 17), "")],
-        &mut cx,
-    );
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+        cx.update_editor(|editor, window, cx| {
+            assert!(
+                editor.has_active_edit_prediction(),
+                "case '{}' should have an active edit prediction",
+                case.name
+            );
 
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
+            let keybind_display = editor.edit_prediction_keybind_display(
+                EditPredictionKeybindSurface::CursorPopoverExpanded,
+                window,
+                cx,
+            );
+            let accept_keystroke = keybind_display
+                .accept_keystroke
+                .as_ref()
+                .unwrap_or_else(|| panic!("case '{}' should have an accept binding", case.name));
+            let preview_keystroke = keybind_display
+                .preview_keystroke
+                .as_ref()
+                .unwrap_or_else(|| panic!("case '{}' should have a preview binding", case.name));
 
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverExpanded,
-            window,
-            cx,
-        );
+            assert_eq!(
+                keybind_display.action, case.expected_action,
+                "case '{}' selected the wrong cursor popover action",
+                case.name
+            );
+            assert_eq!(
+                accept_keystroke.key(),
+                "tab",
+                "case '{}' selected the wrong accept binding",
+                case.name
+            );
+            assert!(
+                preview_keystroke.modifiers().modified(),
+                "case '{}' should use a modified preview binding",
+                case.name
+            );
 
-        let accept_keystroke = keybind_display
-            .accept_keystroke
-            .as_ref()
-            .expect("should have an accept binding");
-        let preview_keystroke = keybind_display
-            .preview_keystroke
-            .as_ref()
-            .expect("should have a preview binding");
-
-        assert_eq!(
-            keybind_display.action,
-            EditPredictionKeybindAction::Accept,
-            "deleting one newline plus adjacent text should show the accept action"
-        );
-        assert_eq!(accept_keystroke.key(), "tab");
-        assert!(preview_keystroke.modifiers().modified());
-    });
-}
-
-#[gpui::test]
-async fn test_stale_single_line_prediction_does_not_force_preview_cursor_popover_action(
-    cx: &mut gpui::TestAppContext,
-) {
-    init_test(cx, |_| {});
-    load_default_keymap(cx);
-
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-    cx.set_state("let x = ˇ;");
-
-    propose_edits(&provider, vec![(8..8, "42\n43")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-    cx.update_editor(|editor, _window, cx| {
-        assert!(editor.active_edit_prediction.is_some());
-        assert!(editor.stale_edit_prediction_in_menu.is_none());
-        editor.take_active_edit_prediction(cx);
-        assert!(editor.active_edit_prediction.is_none());
-        assert!(editor.stale_edit_prediction_in_menu.is_some());
-    });
-
-    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-
-    cx.update_editor(|editor, window, cx| {
-        assert!(editor.has_active_edit_prediction());
-
-        let keybind_display = editor.edit_prediction_keybind_display(
-            EditPredictionKeybindSurface::CursorPopoverExpanded,
-            window,
-            cx,
-        );
-        let accept_keystroke = keybind_display
-            .accept_keystroke
-            .as_ref()
-            .expect("should have an accept binding");
-
-        assert_eq!(
-            keybind_display.action,
-            EditPredictionKeybindAction::Accept,
-            "single-line active prediction should show the accept action"
-        );
-        assert!(
-            editor.stale_edit_prediction_in_menu.is_none(),
-            "refreshing the visible prediction should clear stale menu state"
-        );
-        assert_eq!(accept_keystroke.key(), "tab");
-    });
+            if matches!(
+                case.prediction_kind,
+                CursorPopoverPredictionKind::StaleSingleLineAfterMultiLine
+            ) {
+                assert!(
+                    editor.stale_edit_prediction_in_menu.is_none(),
+                    "case '{}' should clear stale menu state",
+                    case.name
+                );
+            }
+        });
+    }
 }
 
 fn assert_editor_active_edit_completion(
@@ -1054,6 +1172,12 @@ fn assign_editor_completion_provider(
     })
 }
 
+fn assign_editor_completion_menu_provider(cx: &mut EditorTestContext) {
+    cx.update_editor(|editor, _, _| {
+        editor.set_completion_provider(Some(Rc::new(FakeCompletionMenuProvider)));
+    });
+}
+
 fn propose_edits_non_zed<T: ToOffset>(
     provider: &Entity<FakeNonZedEditPredictionDelegate>,
     edits: Vec<(Range<T>, &str)>,
@@ -1084,6 +1208,54 @@ fn assign_editor_completion_provider_non_zed(
     cx.update_editor(|editor, window, cx| {
         editor.set_edit_prediction_provider(Some(provider), window, cx);
     })
+}
+
+struct FakeCompletionMenuProvider;
+
+impl CompletionProvider for FakeCompletionMenuProvider {
+    fn completions(
+        &self,
+        _excerpt_id: ExcerptId,
+        _buffer: &Entity<Buffer>,
+        _buffer_position: text::Anchor,
+        _trigger: CompletionContext,
+        _window: &mut Window,
+        _cx: &mut Context<crate::Editor>,
+    ) -> Task<anyhow::Result<Vec<CompletionResponse>>> {
+        let completion = Completion {
+            replace_range: text::Anchor::MIN..text::Anchor::MAX,
+            new_text: "fake_completion".to_string(),
+            label: CodeLabel::plain("fake_completion".to_string(), None),
+            documentation: None,
+            source: CompletionSource::Custom,
+            icon_path: None,
+            match_start: None,
+            snippet_deduplication_key: None,
+            insert_text_mode: None,
+            confirm: None,
+        };
+
+        Task::ready(Ok(vec![CompletionResponse {
+            completions: vec![completion],
+            display_options: Default::default(),
+            is_incomplete: false,
+        }]))
+    }
+
+    fn is_completion_trigger(
+        &self,
+        _buffer: &Entity<Buffer>,
+        _position: language::Anchor,
+        _text: &str,
+        _trigger_in_words: bool,
+        _cx: &mut Context<crate::Editor>,
+    ) -> bool {
+        false
+    }
+
+    fn filter_completions(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Default, Clone)]

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -3,6 +3,8 @@ use edit_prediction_types::{
 };
 use gpui::{Entity, KeyBinding, Modifiers, prelude::*};
 use indoc::indoc;
+use language::Buffer;
+use language::EditPredictionsMode;
 use multi_buffer::{Anchor, MultiBufferSnapshot, ToPoint};
 use std::{
     ops::Range,
@@ -15,7 +17,9 @@ use text::{Point, ToOffset};
 use ui::prelude::*;
 
 use crate::{
-    AcceptEditPrediction, EditPrediction, MenuEditPredictionsPolicy, editor_tests::init_test,
+    AcceptEditPrediction, EditPrediction, EditPredictionKeybindAction,
+    EditPredictionKeybindSurface, MenuEditPredictionsPolicy,
+    editor_tests::{init_test, update_test_language_settings},
     test::editor_test_context::EditorTestContext,
 };
 use rpc::proto::PeerId;
@@ -478,6 +482,424 @@ async fn test_edit_prediction_preview_cleanup_on_toggle_off(cx: &mut gpui::TestA
     });
 }
 
+fn load_default_keymap(cx: &mut gpui::TestAppContext) {
+    cx.update(|cx| {
+        cx.bind_keys(
+            settings::KeymapFile::load_asset_allow_partial_failure(
+                settings::DEFAULT_KEYMAP_PATH,
+                cx,
+            )
+            .expect("failed to load default keymap"),
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_tab_is_preferred_accept_binding_over_alt_tab(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::Inline,
+            window,
+            cx,
+        );
+        let keystroke = keybind_display
+            .accept_keystroke
+            .as_ref()
+            .expect("should have an accept binding");
+        assert!(
+            !keystroke.modifiers().modified(),
+            "preferred accept binding should be unmodified (tab), got modifiers: {:?}",
+            keystroke.modifiers()
+        );
+        assert_eq!(
+            keystroke.key(),
+            "tab",
+            "preferred accept binding should be tab"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_subtle_in_code_indicator_prefers_preview_binding(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+    update_test_language_settings(cx, &|settings| {
+        settings.edit_predictions.get_or_insert_default().mode = Some(EditPredictionsMode::Subtle);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(
+            editor.edit_prediction_requires_modifier(),
+            "subtle mode should require a modifier"
+        );
+
+        let inline_keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::Inline,
+            window,
+            cx,
+        );
+        let compact_keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverCompact,
+            window,
+            cx,
+        );
+
+        let accept_keystroke = inline_keybind_display
+            .accept_keystroke
+            .as_ref()
+            .expect("should have an accept binding");
+        let preview_keystroke = inline_keybind_display
+            .preview_keystroke
+            .as_ref()
+            .expect("should have a preview binding");
+        let in_code_keystroke = inline_keybind_display
+            .displayed_keystroke
+            .as_ref()
+            .expect("should have an in-code binding");
+        let compact_cursor_popover_keystroke = compact_keybind_display
+            .displayed_keystroke
+            .as_ref()
+            .expect("should have a compact cursor popover binding");
+
+        assert_eq!(accept_keystroke.key(), "tab");
+        assert!(
+            !editor.has_visible_completions_menu(),
+            "compact cursor-popover branch should be used without a completions menu"
+        );
+        assert!(
+            preview_keystroke.modifiers().modified(),
+            "preview binding should use modifiers in subtle mode"
+        );
+        assert_eq!(
+            compact_cursor_popover_keystroke.key(),
+            preview_keystroke.key(),
+            "subtle compact cursor popover should prefer the preview binding"
+        );
+        assert_eq!(
+            compact_cursor_popover_keystroke.modifiers(),
+            preview_keystroke.modifiers(),
+            "subtle compact cursor popover should use the preview binding modifiers"
+        );
+        assert_eq!(
+            in_code_keystroke.key(),
+            preview_keystroke.key(),
+            "subtle in-code indicator should prefer the preview binding"
+        );
+        assert_eq!(
+            in_code_keystroke.modifiers(),
+            preview_keystroke.modifiers(),
+            "subtle in-code indicator should use the preview binding modifiers"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_tab_accepts_edit_prediction_over_completion(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    assert_editor_active_edit_completion(&mut cx, |_, edits| {
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].1.as_ref(), "42");
+    });
+
+    cx.simulate_keystroke("tab");
+    cx.run_until_parked();
+
+    cx.assert_editor_state("let x = 42ˇ;");
+}
+
+#[gpui::test]
+async fn test_single_line_prediction_uses_accept_cursor_popover_action(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
+
+        let accept_keystroke = keybind_display
+            .accept_keystroke
+            .as_ref()
+            .expect("should have an accept binding");
+        let preview_keystroke = keybind_display
+            .preview_keystroke
+            .as_ref()
+            .expect("should have a preview binding");
+
+        assert_eq!(
+            keybind_display.action,
+            EditPredictionKeybindAction::Accept,
+            "single-line prediction should show the accept action"
+        );
+        assert_eq!(accept_keystroke.key(), "tab");
+        assert!(preview_keystroke.modifiers().modified());
+    });
+}
+
+#[gpui::test]
+async fn test_multi_line_prediction_uses_preview_cursor_popover_action(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42\n43")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
+        let preview_keystroke = keybind_display
+            .preview_keystroke
+            .as_ref()
+            .expect("should have a preview binding");
+
+        assert_eq!(
+            keybind_display.action,
+            EditPredictionKeybindAction::Preview,
+            "multi-line prediction should show the preview action"
+        );
+        assert!(preview_keystroke.modifiers().modified());
+    });
+}
+
+#[gpui::test]
+async fn test_single_line_prediction_with_preview_uses_accept_cursor_popover_action(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits_with_preview(&provider, vec![(8..8, "42")], &mut cx).await;
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
+
+        let accept_keystroke = keybind_display
+            .accept_keystroke
+            .as_ref()
+            .expect("should have an accept binding");
+        let preview_keystroke = keybind_display
+            .preview_keystroke
+            .as_ref()
+            .expect("should have a preview binding");
+
+        assert_eq!(
+            keybind_display.action,
+            EditPredictionKeybindAction::Accept,
+            "single-line prediction should show the accept action even with edit_preview"
+        );
+        assert_eq!(accept_keystroke.key(), "tab");
+        assert!(preview_keystroke.modifiers().modified());
+    });
+}
+
+#[gpui::test]
+async fn test_multi_line_prediction_with_preview_uses_preview_cursor_popover_action(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits_with_preview(&provider, vec![(8..8, "42\n43")], &mut cx).await;
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
+        let preview_keystroke = keybind_display
+            .preview_keystroke
+            .as_ref()
+            .expect("should have a preview binding");
+
+        assert_eq!(
+            keybind_display.action,
+            EditPredictionKeybindAction::Preview,
+            "multi-line prediction should show the preview action with edit_preview"
+        );
+        assert!(preview_keystroke.modifiers().modified());
+    });
+}
+
+#[gpui::test]
+async fn test_single_line_deletion_of_newline_uses_accept_cursor_popover_action(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        fn main() {
+            let value = 1;
+            ˇprintln!(\"done\");
+        }
+    "});
+
+    propose_edits(
+        &provider,
+        vec![(Point::new(1, 18)..Point::new(2, 17), "")],
+        &mut cx,
+    );
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
+
+        let accept_keystroke = keybind_display
+            .accept_keystroke
+            .as_ref()
+            .expect("should have an accept binding");
+        let preview_keystroke = keybind_display
+            .preview_keystroke
+            .as_ref()
+            .expect("should have a preview binding");
+
+        assert_eq!(
+            keybind_display.action,
+            EditPredictionKeybindAction::Accept,
+            "deleting one newline plus adjacent text should show the accept action"
+        );
+        assert_eq!(accept_keystroke.key(), "tab");
+        assert!(preview_keystroke.modifiers().modified());
+    });
+}
+
+#[gpui::test]
+async fn test_stale_single_line_prediction_does_not_force_preview_cursor_popover_action(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    load_default_keymap(cx);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42\n43")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx.update_editor(|editor, _window, cx| {
+        assert!(editor.active_edit_prediction.is_some());
+        assert!(editor.stale_edit_prediction_in_menu.is_none());
+        editor.take_active_edit_prediction(cx);
+        assert!(editor.active_edit_prediction.is_none());
+        assert!(editor.stale_edit_prediction_in_menu.is_some());
+    });
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, window, cx| {
+        assert!(editor.has_active_edit_prediction());
+
+        let keybind_display = editor.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
+        let accept_keystroke = keybind_display
+            .accept_keystroke
+            .as_ref()
+            .expect("should have an accept binding");
+
+        assert_eq!(
+            keybind_display.action,
+            EditPredictionKeybindAction::Accept,
+            "single-line active prediction should show the accept action"
+        );
+        assert!(
+            editor.stale_edit_prediction_in_menu.is_none(),
+            "refreshing the visible prediction should clear stale menu state"
+        );
+        assert_eq!(accept_keystroke.key(), "tab");
+    });
+}
+
 fn assert_editor_active_edit_completion(
     cx: &mut EditorTestContext,
     assert: impl FnOnce(MultiBufferSnapshot, &Vec<(Range<Anchor>, Arc<str>)>),
@@ -526,6 +948,44 @@ fn propose_edits<T: ToOffset>(
     cx: &mut EditorTestContext,
 ) {
     propose_edits_with_cursor_position(provider, edits, None, cx);
+}
+
+async fn propose_edits_with_preview<T: ToOffset + Clone>(
+    provider: &Entity<FakeEditPredictionDelegate>,
+    edits: Vec<(Range<T>, &str)>,
+    cx: &mut EditorTestContext,
+) {
+    let snapshot = cx.buffer_snapshot();
+    let edits = edits
+        .into_iter()
+        .map(|(range, text)| {
+            let anchor_range =
+                snapshot.anchor_after(range.start.clone())..snapshot.anchor_before(range.end);
+            (anchor_range, Arc::<str>::from(text))
+        })
+        .collect::<Vec<_>>();
+
+    let preview_edits = edits
+        .iter()
+        .map(|(range, text)| (range.clone(), text.clone()))
+        .collect::<Arc<[_]>>();
+
+    let edit_preview = cx
+        .buffer(|buffer: &Buffer, app| buffer.preview_edits(preview_edits, app))
+        .await;
+
+    let provider_edits = edits.into_iter().collect();
+
+    cx.update(|_, cx| {
+        provider.update(cx, |provider, _| {
+            provider.set_edit_prediction(Some(edit_prediction_types::EditPrediction::Local {
+                id: None,
+                edits: provider_edits,
+                cursor_position: None,
+                edit_preview: Some(edit_preview),
+            }))
+        })
+    });
 }
 
 fn propose_edits_with_cursor_position<T: ToOffset>(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -105,7 +105,7 @@ use edit_prediction_types::{
     EditPredictionGranularity, SuggestionDisplayType,
 };
 use editor_settings::{GoToDefinitionFallback, Minimap as MinimapSettings};
-use element::{AcceptEditPredictionBinding, LineWithInvisibles, PositionMap, layout_line};
+use element::{LineWithInvisibles, PositionMap, layout_line};
 use futures::{
     FutureExt,
     future::{self, Shared, join},
@@ -256,7 +256,6 @@ pub(crate) const SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT: Duration = Duration:
 pub const LSP_REQUEST_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(50);
 
 pub(crate) const EDIT_PREDICTION_KEY_CONTEXT: &str = "edit_prediction";
-pub(crate) const EDIT_PREDICTION_CONFLICT_KEY_CONTEXT: &str = "edit_prediction_conflict";
 pub(crate) const MINIMAP_FONT_SIZE: AbsoluteLength = AbsoluteLength::Pixels(px(2.));
 
 pub type RenderDiffHunkControlsFn = Arc<
@@ -699,6 +698,30 @@ pub enum EditPredictionPreview {
         since: Instant,
         previous_scroll_position: Option<SharedScrollAnchor>,
     },
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum EditPredictionKeybindSurface {
+    Inline,
+    CursorPopoverCompact,
+    CursorPopoverExpanded,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum EditPredictionKeybindAction {
+    Accept,
+    Preview,
+}
+
+struct EditPredictionKeybindDisplay {
+    #[cfg(test)]
+    accept_keystroke: Option<gpui::KeybindingKeystroke>,
+    #[cfg(test)]
+    preview_keystroke: Option<gpui::KeybindingKeystroke>,
+    displayed_keystroke: Option<gpui::KeybindingKeystroke>,
+    action: EditPredictionKeybindAction,
+    missing_accept_keystroke: bool,
+    show_hold_label: bool,
 }
 
 impl EditPredictionPreview {
@@ -1225,8 +1248,7 @@ pub struct Editor {
     show_completions_on_input_override: Option<bool>,
     menu_edit_predictions_policy: MenuEditPredictionsPolicy,
     edit_prediction_preview: EditPredictionPreview,
-    edit_prediction_indent_conflict: bool,
-    edit_prediction_requires_modifier_in_indent_conflict: bool,
+    in_leading_whitespace: bool,
     next_inlay_id: usize,
     next_color_inlay_id: usize,
     _subscriptions: Vec<Subscription>,
@@ -2473,8 +2495,7 @@ impl Editor {
             show_completions_on_input_override: None,
             menu_edit_predictions_policy: MenuEditPredictionsPolicy::ByProvider,
             edit_prediction_settings: EditPredictionSettings::Disabled,
-            edit_prediction_indent_conflict: false,
-            edit_prediction_requires_modifier_in_indent_conflict: true,
+            in_leading_whitespace: false,
             custom_context_menu: None,
             show_git_blame_gutter: false,
             show_git_blame_inline: false,
@@ -2856,12 +2877,12 @@ impl Editor {
         }
 
         if has_active_edit_prediction {
-            if self.edit_prediction_in_conflict() {
-                key_context.add(EDIT_PREDICTION_CONFLICT_KEY_CONTEXT);
-            } else {
-                key_context.add(EDIT_PREDICTION_KEY_CONTEXT);
-                key_context.add("copilot_suggestion");
-            }
+            key_context.add(EDIT_PREDICTION_KEY_CONTEXT);
+            key_context.add("copilot_suggestion");
+        }
+
+        if self.in_leading_whitespace {
+            key_context.add("in_leading_whitespace");
         }
 
         if self.selection_mark_mode {
@@ -2915,32 +2936,13 @@ impl Editor {
         }
     }
 
-    pub fn edit_prediction_in_conflict(&self) -> bool {
-        if !self.show_edit_predictions_in_menu() {
-            return false;
-        }
-
-        let showing_completions = self
-            .context_menu
-            .borrow()
-            .as_ref()
-            .is_some_and(|context| matches!(context, CodeContextMenu::Completions(_)));
-
-        showing_completions
-            || self.edit_prediction_requires_modifier()
-            // Require modifier key when the cursor is on leading whitespace, to allow `tab`
-            // bindings to insert tab characters.
-            || (self.edit_prediction_requires_modifier_in_indent_conflict && self.edit_prediction_indent_conflict)
-    }
-
-    pub fn accept_edit_prediction_keybind(
+    fn accept_edit_prediction_keystroke(
         &self,
         granularity: EditPredictionGranularity,
         window: &mut Window,
         cx: &mut App,
-    ) -> AcceptEditPredictionBinding {
-        let key_context = self.key_context_internal(true, window, cx);
-        let in_conflict = self.edit_prediction_in_conflict();
+    ) -> Option<gpui::KeybindingKeystroke> {
+        let key_context = self.key_context_internal(self.has_active_edit_prediction(), window, cx);
 
         let bindings =
             match granularity {
@@ -2953,13 +2955,131 @@ impl Editor {
                 }
             };
 
-        AcceptEditPredictionBinding(bindings.into_iter().rev().find(|binding| {
-            !in_conflict
-                || binding
-                    .keystrokes()
-                    .first()
-                    .is_some_and(|keystroke| keystroke.modifiers().modified())
-        }))
+        bindings
+            .into_iter()
+            .rev()
+            .find_map(|binding| match binding.keystrokes() {
+                [keystroke, ..] => Some(keystroke.clone()),
+                _ => None,
+            })
+    }
+
+    fn preview_edit_prediction_keystroke(
+        &self,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<gpui::KeybindingKeystroke> {
+        let key_context = self.key_context_internal(self.has_active_edit_prediction(), window, cx);
+        let bindings = window.bindings_for_action_in_context(&AcceptEditPrediction, key_context);
+        bindings
+            .into_iter()
+            .rev()
+            .find_map(|binding| match binding.keystrokes() {
+                [keystroke, ..] if keystroke.modifiers().modified() => Some(keystroke.clone()),
+                _ => None,
+            })
+    }
+
+    fn edit_prediction_cursor_popover_prefers_preview(
+        &self,
+        completion: &EditPredictionState,
+    ) -> bool {
+        match &completion.completion {
+            EditPrediction::Edit {
+                edits, snapshot, ..
+            } => {
+                let mut start_row: Option<u32> = None;
+                let mut end_row: Option<u32> = None;
+
+                for (range, text) in edits {
+                    let edit_start_row = range.start.text_anchor.to_point(snapshot).row;
+                    let old_end_row = range.end.text_anchor.to_point(snapshot).row;
+                    let inserted_newline_count = text
+                        .as_ref()
+                        .chars()
+                        .filter(|character| *character == '\n')
+                        .count() as u32;
+                    let deleted_newline_count = old_end_row - edit_start_row;
+                    let preview_end_row = edit_start_row + inserted_newline_count;
+
+                    start_row =
+                        Some(start_row.map_or(edit_start_row, |row| row.min(edit_start_row)));
+                    end_row = Some(end_row.map_or(preview_end_row, |row| row.max(preview_end_row)));
+
+                    if deleted_newline_count > 1 {
+                        end_row = Some(end_row.map_or(old_end_row, |row| row.max(old_end_row)));
+                    }
+                }
+
+                start_row
+                    .zip(end_row)
+                    .is_some_and(|(start_row, end_row)| end_row > start_row)
+            }
+            EditPrediction::MoveWithin { .. } | EditPrediction::MoveOutside { .. } => false,
+        }
+    }
+
+    fn edit_prediction_keybind_display(
+        &self,
+        surface: EditPredictionKeybindSurface,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> EditPredictionKeybindDisplay {
+        let accept_keystroke =
+            self.accept_edit_prediction_keystroke(EditPredictionGranularity::Full, window, cx);
+        let preview_keystroke = self.preview_edit_prediction_keystroke(window, cx);
+
+        let action = match surface {
+            EditPredictionKeybindSurface::Inline
+            | EditPredictionKeybindSurface::CursorPopoverCompact => {
+                if self.edit_prediction_requires_modifier() {
+                    EditPredictionKeybindAction::Preview
+                } else {
+                    EditPredictionKeybindAction::Accept
+                }
+            }
+            EditPredictionKeybindSurface::CursorPopoverExpanded => self
+                .active_edit_prediction
+                .as_ref()
+                .filter(|completion| {
+                    self.edit_prediction_cursor_popover_prefers_preview(completion)
+                })
+                .map_or(EditPredictionKeybindAction::Accept, |_| {
+                    EditPredictionKeybindAction::Preview
+                }),
+        };
+        #[cfg(test)]
+        let preview_copy = preview_keystroke.clone();
+        #[cfg(test)]
+        let accept_copy = accept_keystroke.clone();
+
+        let displayed_keystroke = match surface {
+            EditPredictionKeybindSurface::Inline => match action {
+                EditPredictionKeybindAction::Accept => accept_keystroke,
+                EditPredictionKeybindAction::Preview => preview_keystroke,
+            },
+            EditPredictionKeybindSurface::CursorPopoverCompact
+            | EditPredictionKeybindSurface::CursorPopoverExpanded => match action {
+                EditPredictionKeybindAction::Accept => accept_keystroke,
+                EditPredictionKeybindAction::Preview => {
+                    preview_keystroke.or_else(|| accept_keystroke.clone())
+                }
+            },
+        };
+
+        let missing_accept_keystroke = displayed_keystroke.is_none();
+
+        EditPredictionKeybindDisplay {
+            #[cfg(test)]
+            accept_keystroke: accept_copy,
+            #[cfg(test)]
+            preview_keystroke: preview_copy,
+            displayed_keystroke,
+            action,
+            missing_accept_keystroke,
+            show_hold_label: matches!(surface, EditPredictionKeybindSurface::CursorPopoverCompact)
+                && self.edit_prediction_preview.released_too_fast(),
+        }
     }
 
     pub fn new_file(
@@ -3596,7 +3716,6 @@ impl Editor {
             self.refresh_matching_bracket_highlights(&display_map, cx);
             self.refresh_outline_symbols_at_cursor(cx);
             self.update_visible_edit_prediction(window, cx);
-            self.edit_prediction_requires_modifier_in_indent_conflict = true;
             self.inline_blame_popover.take();
             if self.git_blame_inline_enabled {
                 self.start_inline_blame_timer(window, cx);
@@ -8216,8 +8335,6 @@ impl Editor {
                 }
             }
         }
-
-        self.edit_prediction_requires_modifier_in_indent_conflict = false;
     }
 
     pub fn accept_next_word_edit_prediction(
@@ -8466,21 +8583,20 @@ impl Editor {
     ) {
         let mut modifiers_held = false;
 
-        // Check bindings for all granularities.
-        // If the user holds the key for Word, Line, or Full, we want to show the preview.
-        let granularities = [
-            EditPredictionGranularity::Full,
-            EditPredictionGranularity::Line,
-            EditPredictionGranularity::Word,
+        let key_context = self.key_context_internal(self.has_active_edit_prediction(), window, cx);
+        let actions: [&dyn Action; 3] = [
+            &AcceptEditPrediction,
+            &AcceptNextWordEditPrediction,
+            &AcceptNextLineEditPrediction,
         ];
 
-        for granularity in granularities {
-            if let Some(keystroke) = self
-                .accept_edit_prediction_keybind(granularity, window, cx)
-                .keystroke()
-            {
-                modifiers_held = modifiers_held
-                    || (keystroke.modifiers() == modifiers && keystroke.modifiers().modified());
+        for action in actions {
+            let bindings = window.bindings_for_action_in_context(action, key_context.clone());
+            for binding in bindings {
+                if let Some(keystroke) = binding.keystrokes().first() {
+                    modifiers_held = modifiers_held
+                        || (keystroke.modifiers() == modifiers && keystroke.modifiers().modified());
+                }
             }
         }
 
@@ -8580,9 +8696,9 @@ impl Editor {
         self.edit_prediction_settings =
             self.edit_prediction_settings_at_position(&buffer, cursor_buffer_position, cx);
 
-        self.edit_prediction_indent_conflict = multibuffer.is_line_whitespace_upto(cursor);
+        self.in_leading_whitespace = multibuffer.is_line_whitespace_upto(cursor);
 
-        if self.edit_prediction_indent_conflict {
+        if self.in_leading_whitespace {
             let cursor_point = cursor.to_point(&multibuffer);
             let mut suggested_indent = None;
             multibuffer.suggested_indents_callback(
@@ -8597,7 +8713,7 @@ impl Editor {
             if let Some(indent) = suggested_indent
                 && indent.len == cursor_point.column
             {
-                self.edit_prediction_indent_conflict = false;
+                self.in_leading_whitespace = false;
             }
         }
 
@@ -9610,7 +9726,7 @@ impl Editor {
 
         const BORDER_WIDTH: Pixels = px(1.);
 
-        let keybind = self.render_edit_prediction_accept_keybind(window, cx);
+        let keybind = self.render_edit_prediction_keybind(window, cx);
         let has_keybind = keybind.is_some();
 
         let mut element = h_flex()
@@ -9766,22 +9882,13 @@ impl Editor {
         }
     }
 
-    fn render_edit_prediction_accept_keybind(
+    fn render_edit_prediction_inline_keystroke(
         &self,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> Option<AnyElement> {
-        let accept_binding =
-            self.accept_edit_prediction_keybind(EditPredictionGranularity::Full, window, cx);
-        let accept_keystroke = accept_binding.keystroke()?;
-
+        keystroke: &gpui::KeybindingKeystroke,
+        modifiers_color: Color,
+        cx: &App,
+    ) -> AnyElement {
         let is_platform_style_mac = PlatformStyle::platform() == PlatformStyle::Mac;
-
-        let modifiers_color = if *accept_keystroke.modifiers() == window.modifiers() {
-            Color::Accent
-        } else {
-            Color::Muted
-        };
 
         h_flex()
             .px_0p5()
@@ -9789,26 +9896,67 @@ impl Editor {
             .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
             .text_size(TextSize::XSmall.rems(cx))
             .child(h_flex().children(ui::render_modifiers(
-                accept_keystroke.modifiers(),
+                keystroke.modifiers(),
                 PlatformStyle::platform(),
                 Some(modifiers_color),
                 Some(IconSize::XSmall.rems().into()),
                 true,
             )))
             .when(is_platform_style_mac, |parent| {
-                parent.child(accept_keystroke.key().to_string())
+                parent.child(keystroke.key().to_string())
             })
             .when(!is_platform_style_mac, |parent| {
                 parent.child(
-                    Key::new(
-                        util::capitalize(accept_keystroke.key()),
-                        Some(Color::Default),
-                    )
-                    .size(Some(IconSize::XSmall.rems().into())),
+                    Key::new(util::capitalize(keystroke.key()), Some(Color::Default))
+                        .size(Some(IconSize::XSmall.rems().into())),
                 )
             })
             .into_any()
-            .into()
+    }
+
+    fn render_edit_prediction_popover_keystroke(
+        &self,
+        keystroke: &gpui::KeybindingKeystroke,
+        color: Color,
+        cx: &App,
+    ) -> AnyElement {
+        let is_platform_style_mac = PlatformStyle::platform() == PlatformStyle::Mac;
+
+        if keystroke.modifiers().modified() {
+            h_flex()
+                .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
+                .when(is_platform_style_mac, |parent| parent.gap_1())
+                .child(h_flex().children(ui::render_modifiers(
+                    keystroke.modifiers(),
+                    PlatformStyle::platform(),
+                    Some(color),
+                    None,
+                    false,
+                )))
+                .into_any()
+        } else {
+            Key::new(util::capitalize(keystroke.key()), Some(color))
+                .size(Some(IconSize::XSmall.rems().into()))
+                .into_any_element()
+        }
+    }
+
+    fn render_edit_prediction_keybind(
+        &self,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let keybind_display =
+            self.edit_prediction_keybind_display(EditPredictionKeybindSurface::Inline, window, cx);
+        let keystroke = keybind_display.displayed_keystroke.as_ref()?;
+
+        let modifiers_color = if *keystroke.modifiers() == window.modifiers() {
+            Color::Accent
+        } else {
+            Color::Muted
+        };
+
+        Some(self.render_edit_prediction_inline_keystroke(keystroke, modifiers_color, cx))
     }
 
     fn render_edit_prediction_line_popover(
@@ -9820,7 +9968,7 @@ impl Editor {
     ) -> Stateful<Div> {
         let padding_right = if icon.is_some() { px(4.) } else { px(8.) };
 
-        let keybind = self.render_edit_prediction_accept_keybind(window, cx);
+        let keybind = self.render_edit_prediction_keybind(window, cx);
         let has_keybind = keybind.is_some();
         let icons = Self::get_prediction_provider_icons(&self.edit_prediction_provider, cx);
 
@@ -9879,7 +10027,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut App,
     ) -> Stateful<Div> {
-        let keybind = self.render_edit_prediction_accept_keybind(window, cx);
+        let keybind = self.render_edit_prediction_keybind(window, cx);
         let has_keybind = keybind.is_some();
         let icons = Self::get_prediction_provider_icons(&self.edit_prediction_provider, cx);
 
@@ -9962,8 +10110,7 @@ impl Editor {
         max_width: Pixels,
         cursor_point: Point,
         style: &EditorStyle,
-        accept_keystroke: Option<&gpui::KeybindingKeystroke>,
-        _window: &Window,
+        window: &mut Window,
         cx: &mut Context<Editor>,
     ) -> Option<AnyElement> {
         let provider = self.edit_prediction_provider.as_ref()?;
@@ -9980,13 +10127,18 @@ impl Editor {
                 if !self.has_visible_completions_menu() {
                     const RADIUS: Pixels = px(6.);
                     const BORDER_WIDTH: Pixels = px(1.);
+                    let keybind_display = self.edit_prediction_keybind_display(
+                        EditPredictionKeybindSurface::CursorPopoverCompact,
+                        window,
+                        cx,
+                    );
 
                     return Some(
                         h_flex()
                             .elevation_2(cx)
                             .border(BORDER_WIDTH)
                             .border_color(cx.theme().colors().border)
-                            .when(accept_keystroke.is_none(), |el| {
+                            .when(keybind_display.missing_accept_keystroke, |el| {
                                 el.border_color(cx.theme().status().error)
                             })
                             .rounded(RADIUS)
@@ -10017,18 +10169,19 @@ impl Editor {
                                     .border_l_1()
                                     .border_color(cx.theme().colors().border)
                                     .bg(Self::edit_prediction_line_popover_bg_color(cx))
-                                    .when(self.edit_prediction_preview.released_too_fast(), |el| {
+                                    .when(keybind_display.show_hold_label, |el| {
                                         el.child(
                                             Label::new("Hold")
                                                 .size(LabelSize::Small)
-                                                .when(accept_keystroke.is_none(), |el| {
-                                                    el.strikethrough()
-                                                })
+                                                .when(
+                                                    keybind_display.missing_accept_keystroke,
+                                                    |el| el.strikethrough(),
+                                                )
                                                 .line_height_style(LineHeightStyle::UiLabel),
                                         )
                                     })
                                     .id("edit_prediction_cursor_popover_keybind")
-                                    .when(accept_keystroke.is_none(), |el| {
+                                    .when(keybind_display.missing_accept_keystroke, |el| {
                                         let status_colors = cx.theme().status();
 
                                         el.bg(status_colors.error_background)
@@ -10041,15 +10194,13 @@ impl Editor {
                                             })
                                     })
                                     .when_some(
-                                        accept_keystroke.as_ref(),
-                                        |el, accept_keystroke| {
-                                            el.child(h_flex().children(ui::render_modifiers(
-                                                accept_keystroke.modifiers(),
-                                                PlatformStyle::platform(),
-                                                Some(Color::Default),
-                                                Some(IconSize::XSmall.rems().into()),
-                                                false,
-                                            )))
+                                        keybind_display.displayed_keystroke.as_ref(),
+                                        |el, compact_keystroke| {
+                                            el.child(self.render_edit_prediction_popover_keystroke(
+                                                compact_keystroke,
+                                                Color::Default,
+                                                cx,
+                                            ))
                                         },
                                     ),
                             )
@@ -10096,8 +10247,12 @@ impl Editor {
         };
 
         let has_completion = self.active_edit_prediction.is_some();
+        let keybind_display = self.edit_prediction_keybind_display(
+            EditPredictionKeybindSurface::CursorPopoverExpanded,
+            window,
+            cx,
+        );
 
-        let is_platform_style_mac = PlatformStyle::platform() == PlatformStyle::Mac;
         Some(
             h_flex()
                 .min_w(min_width)
@@ -10113,41 +10268,51 @@ impl Editor {
                         .overflow_hidden()
                         .child(completion),
                 )
-                .when_some(accept_keystroke, |el, accept_keystroke| {
-                    if !accept_keystroke.modifiers().modified() {
-                        return el;
-                    }
+                .when_some(
+                    keybind_display.displayed_keystroke.as_ref(),
+                    |el, keystroke| {
+                        let key_color = if !has_completion {
+                            Color::Muted
+                        } else {
+                            Color::Default
+                        };
 
-                    el.child(
-                        h_flex()
-                            .h_full()
-                            .border_l_1()
-                            .rounded_r_lg()
-                            .border_color(cx.theme().colors().border)
-                            .bg(Self::edit_prediction_line_popover_bg_color(cx))
-                            .gap_1()
-                            .py_1()
-                            .px_2()
-                            .child(
+                        if keybind_display.action == EditPredictionKeybindAction::Preview {
+                            el.child(
                                 h_flex()
-                                    .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
-                                    .when(is_platform_style_mac, |parent| parent.gap_1())
-                                    .child(h_flex().children(ui::render_modifiers(
-                                        accept_keystroke.modifiers(),
-                                        PlatformStyle::platform(),
-                                        Some(if !has_completion {
-                                            Color::Muted
-                                        } else {
-                                            Color::Default
-                                        }),
-                                        None,
-                                        false,
-                                    ))),
+                                    .h_full()
+                                    .border_l_1()
+                                    .rounded_r_lg()
+                                    .border_color(cx.theme().colors().border)
+                                    .bg(Self::edit_prediction_line_popover_bg_color(cx))
+                                    .gap_1()
+                                    .py_1()
+                                    .px_2()
+                                    .child(self.render_edit_prediction_popover_keystroke(
+                                        keystroke, key_color, cx,
+                                    ))
+                                    .child(Label::new("Preview").into_any_element())
+                                    .opacity(if has_completion { 1.0 } else { 0.4 }),
                             )
-                            .child(Label::new("Preview").into_any_element())
-                            .opacity(if has_completion { 1.0 } else { 0.4 }),
-                    )
-                })
+                        } else {
+                            el.child(
+                                h_flex()
+                                    .h_full()
+                                    .border_l_1()
+                                    .rounded_r_lg()
+                                    .border_color(cx.theme().colors().border)
+                                    .bg(Self::edit_prediction_line_popover_bg_color(cx))
+                                    .gap_1()
+                                    .py_1()
+                                    .px_2()
+                                    .child(self.render_edit_prediction_popover_keystroke(
+                                        keystroke, key_color, cx,
+                                    ))
+                                    .opacity(if has_completion { 1.0 } else { 0.4 }),
+                            )
+                        }
+                    },
+                )
                 .into_any(),
         )
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2884,6 +2884,11 @@ impl Editor {
         if self.in_leading_whitespace {
             key_context.add("in_leading_whitespace");
         }
+        if self.edit_prediction_requires_modifier() {
+            key_context.set("edit_prediction_mode", "subtle")
+        } else {
+            key_context.set("edit_prediction_mode", "eager");
+        }
 
         if self.selection_mark_mode {
             key_context.add("selection_mode");
@@ -2942,7 +2947,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<gpui::KeybindingKeystroke> {
-        let key_context = self.key_context_internal(self.has_active_edit_prediction(), window, cx);
+        let key_context = self.key_context_internal(true, window, cx);
 
         let bindings =
             match granularity {
@@ -2969,7 +2974,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<gpui::KeybindingKeystroke> {
-        let key_context = self.key_context_internal(self.has_active_edit_prediction(), window, cx);
+        let key_context = self.key_context_internal(true, window, cx);
         let bindings = window.bindings_for_action_in_context(&AcceptEditPrediction, key_context);
         bindings
             .into_iter()
@@ -2978,6 +2983,32 @@ impl Editor {
                 [keystroke, ..] if keystroke.modifiers().modified() => Some(keystroke.clone()),
                 _ => None,
             })
+    }
+
+    fn edit_prediction_preview_modifiers_held(
+        &self,
+        modifiers: &Modifiers,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> bool {
+        let key_context = self.key_context_internal(true, window, cx);
+        let actions: [&dyn Action; 3] = [
+            &AcceptEditPrediction,
+            &AcceptNextWordEditPrediction,
+            &AcceptNextLineEditPrediction,
+        ];
+
+        actions.into_iter().any(|action| {
+            window
+                .bindings_for_action_in_context(action, key_context.clone())
+                .into_iter()
+                .rev()
+                .any(|binding| {
+                    binding.keystrokes().first().is_some_and(|keystroke| {
+                        keystroke.modifiers().modified() && keystroke.modifiers() == modifiers
+                    })
+                })
+        })
     }
 
     fn edit_prediction_cursor_popover_prefers_preview(
@@ -8486,9 +8517,12 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.update_edit_prediction_settings(cx);
+
         // Ensure that the edit prediction preview is updated, even when not
         // enabled, if there's an active edit prediction preview.
         if self.show_edit_predictions_in_menu()
+            || self.edit_prediction_requires_modifier()
             || matches!(
                 self.edit_prediction_preview,
                 EditPredictionPreview::Active { .. }
@@ -8581,24 +8615,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let mut modifiers_held = false;
-
-        let key_context = self.key_context_internal(self.has_active_edit_prediction(), window, cx);
-        let actions: [&dyn Action; 3] = [
-            &AcceptEditPrediction,
-            &AcceptNextWordEditPrediction,
-            &AcceptNextLineEditPrediction,
-        ];
-
-        for action in actions {
-            let bindings = window.bindings_for_action_in_context(action, key_context.clone());
-            for binding in bindings {
-                if let Some(keystroke) = binding.keystrokes().first() {
-                    modifiers_held = modifiers_held
-                        || (keystroke.modifiers() == modifiers && keystroke.modifiers().modified());
-                }
-            }
-        }
+        let modifiers_held = self.edit_prediction_preview_modifiers_held(modifiers, window, cx);
 
         if modifiers_held {
             if matches!(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8820,6 +8820,7 @@ impl Editor {
             let target = first_edit_start;
             EditPrediction::MoveWithin { target, snapshot }
         } else {
+            let show_completions_in_menu = self.has_visible_completions_menu();
             let show_completions_in_buffer = !self.edit_prediction_visible_in_cursor_popover(true)
                 && !self.edit_predictions_hidden_for_vim_mode;
 
@@ -8833,16 +8834,26 @@ impl Editor {
                 EditDisplayMode::DiffPopover
             };
 
-            if show_completions_in_buffer {
-                if let Some(provider) = &self.edit_prediction_provider {
-                    let suggestion_display_type = match display_mode {
-                        EditDisplayMode::DiffPopover => SuggestionDisplayType::DiffPopover,
-                        EditDisplayMode::Inline | EditDisplayMode::TabAccept => {
-                            SuggestionDisplayType::GhostText
-                        }
-                    };
-                    provider.provider.did_show(suggestion_display_type, cx);
+            let report_shown = match display_mode {
+                EditDisplayMode::DiffPopover | EditDisplayMode::Inline => {
+                    show_completions_in_buffer || show_completions_in_menu
                 }
+                EditDisplayMode::TabAccept => {
+                    show_completions_in_menu || self.edit_prediction_preview_is_active()
+                }
+            };
+
+            if report_shown && let Some(provider) = &self.edit_prediction_provider {
+                let suggestion_display_type = match display_mode {
+                    EditDisplayMode::DiffPopover => SuggestionDisplayType::DiffPopover,
+                    EditDisplayMode::Inline | EditDisplayMode::TabAccept => {
+                        SuggestionDisplayType::GhostText
+                    }
+                };
+                provider.provider.did_show(suggestion_display_type, cx);
+            }
+
+            if show_completions_in_buffer {
                 if edits
                     .iter()
                     .all(|(range, _)| range.to_offset(&multibuffer).is_empty())

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -43,13 +43,12 @@ use gpui::{
     Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle,
     DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, Font, FontId,
     FontWeight, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement,
-    IsZero, KeybindingKeystroke, Length, Modifiers, ModifiersChangedEvent, MouseButton,
-    MouseClickEvent, MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad,
-    ParentElement, Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine,
-    SharedString, Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun,
-    TextStyleRefinement, WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop,
-    linear_gradient, outline, pattern_slash, point, px, quad, relative, size, solid_background,
-    transparent_black,
+    IsZero, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent,
+    MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels,
+    PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Size,
+    StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyleRefinement,
+    WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop, linear_gradient, outline,
+    pattern_slash, point, px, quad, relative, size, solid_background, transparent_black,
 };
 use itertools::Itertools;
 use language::{HighlightedText, IndentGuideSettings, language_settings::ShowWhitespaceSetting};
@@ -58,8 +57,6 @@ use multi_buffer::{
     Anchor, ExcerptId, ExcerptInfo, ExpandExcerptDirection, ExpandInfo, MultiBufferPoint,
     MultiBufferRow, RowInfo,
 };
-
-use edit_prediction_types::EditPredictionGranularity;
 
 use project::{
     DisableAiSettings, Entry, ProjectPath,
@@ -4838,17 +4835,11 @@ impl EditorElement {
 
                 let edit_prediction = if edit_prediction_popover_visible {
                     self.editor.update(cx, move |editor, cx| {
-                        let accept_binding = editor.accept_edit_prediction_keybind(
-                            EditPredictionGranularity::Full,
-                            window,
-                            cx,
-                        );
                         let mut element = editor.render_edit_prediction_cursor_popover(
                             min_width,
                             max_width,
                             cursor_point,
                             style,
-                            accept_binding.keystroke(),
                             window,
                             cx,
                         )?;
@@ -8616,21 +8607,6 @@ pub(crate) fn render_buffer_header(
                 menu.context(menu_context)
             })
         })
-}
-
-pub struct AcceptEditPredictionBinding(pub(crate) Option<gpui::KeyBinding>);
-
-impl AcceptEditPredictionBinding {
-    pub fn keystroke(&self) -> Option<&KeybindingKeystroke> {
-        if let Some(binding) = self.0.as_ref() {
-            match &binding.keystrokes() {
-                [keystroke, ..] => Some(keystroke),
-                _ => None,
-            }
-        } else {
-            None
-        }
-    }
 }
 
 fn prepaint_gutter_button(

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -21,7 +21,7 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("dart", &["dart"]),
     ("dockerfile", &["Dockerfile"]),
     ("elisp", &["el"]),
-    ("elixir", &["ex", "exs", "heex"]),
+    ("elixir", &["eex", "ex", "exs", "heex", "leex", "neex"]),
     ("elm", &["elm"]),
     ("erlang", &["erl", "hrl"]),
     ("fish", &["fish"]),

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 use language::{Anchor, Buffer, BufferId};
 use project::{
-    ConflictRegion, ConflictSet, ConflictSetUpdate, ProjectItem as _,
+    ConflictRegion, ConflictSet, ConflictSetUpdate, Project, ProjectItem as _,
     git_store::{GitStoreEvent, RepositoryEvent},
 };
 use settings::Settings;
@@ -497,8 +497,7 @@ fn render_conflict_buttons(
         .into_any()
 }
 
-fn collect_conflicted_file_paths(workspace: &Workspace, cx: &App) -> Vec<String> {
-    let project = workspace.project().read(cx);
+fn collect_conflicted_file_paths(project: &Project, cx: &App) -> Vec<String> {
     let git_store = project.git_store().read(cx);
     let mut paths = Vec::new();
 
@@ -534,7 +533,11 @@ pub(crate) fn register_conflict_notification(
             GitStoreEvent::ConflictsUpdated
                 | GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::StatusesChanged, _)
         );
-        if !AgentSettings::get_global(cx).enabled || !conflicts_changed {
+        if !AgentSettings::get_global(cx).enabled(cx) || !conflicts_changed {
+            return;
+        }
+        let project = workspace.project().read(cx);
+        if project.is_via_collab() {
             return;
         }
 
@@ -542,7 +545,7 @@ pub(crate) fn register_conflict_notification(
             return;
         }
 
-        let paths = collect_conflicted_file_paths(workspace, cx);
+        let paths = collect_conflicted_file_paths(project, cx);
         let notification_id = workspace::merge_conflict_notification_id();
         let current_paths_set: HashSet<String> = paths.iter().cloned().collect();
 
@@ -556,11 +559,10 @@ pub(crate) fn register_conflict_notification(
             let file_count = paths.len();
             workspace.show_notification(notification_id, cx, |cx| {
                 cx.new(|cx| {
-                    let message = if file_count == 1 {
-                        "1 file has unresolved merge conflicts".to_string()
-                    } else {
-                        format!("{file_count} files have unresolved merge conflicts")
-                    };
+                    let message = format!(
+                        "{file_count} file{} have unresolved merge conflicts",
+                        if file_count == 1 { "" } else { "s" }
+                    );
 
                     MessageNotification::new(message, cx)
                         .primary_message("Resolve with Agent")

--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result};
 use collections::HashMap;
 pub use gpui_macros::Action;
-pub use no_action::{NoAction, is_no_action};
+pub use no_action::{NoAction, Unbind, is_no_action, is_unbind};
 use serde_json::json;
 use std::{
     any::{Any, TypeId},
@@ -290,19 +290,6 @@ impl ActionRegistry {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn load_action<A: Action>(&mut self) {
-        self.insert_action(MacroActionData {
-            name: A::name_for_type(),
-            type_id: TypeId::of::<A>(),
-            build: A::build,
-            json_schema: A::action_json_schema,
-            deprecated_aliases: A::deprecated_aliases(),
-            deprecation_message: A::deprecation_message(),
-            documentation: A::documentation(),
-        });
-    }
-
     fn insert_action(&mut self, action: MacroActionData) {
         let name = action.name;
         if self.by_name.contains_key(name) {
@@ -432,7 +419,8 @@ pub fn generate_list_of_all_registered_actions() -> impl Iterator<Item = MacroAc
 
 mod no_action {
     use crate as gpui;
-    use std::any::Any as _;
+    use schemars::JsonSchema;
+    use serde::Deserialize;
 
     actions!(
         zed,
@@ -443,8 +431,23 @@ mod no_action {
         ]
     );
 
+    /// Action with special handling which unbinds later bindings for the same keystrokes when they
+    /// dispatch the named action, regardless of that action's context.
+    ///
+    /// In keymap JSON this is written as:
+    ///
+    /// `["zed::Unbind", "editor::NewLine"]`
+    #[derive(Clone, Debug, PartialEq, Deserialize, JsonSchema, gpui::Action)]
+    #[action(namespace = zed)]
+    pub struct Unbind(pub gpui::SharedString);
+
     /// Returns whether or not this action represents a removed key binding.
     pub fn is_no_action(action: &dyn gpui::Action) -> bool {
-        action.as_any().type_id() == (NoAction {}).type_id()
+        action.as_any().is::<NoAction>()
+    }
+
+    /// Returns whether or not this action represents an unbind marker.
+    pub fn is_unbind(action: &dyn gpui::Action) -> bool {
+        action.as_any().is::<Unbind>()
     }
 }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -579,21 +579,13 @@ impl GpuiMode {
 pub struct App {
     pub(crate) this: Weak<AppCell>,
     pub(crate) platform: Rc<dyn Platform>,
-    pub(crate) mode: GpuiMode,
     text_system: Arc<TextSystem>,
-    flushing_effects: bool,
-    pending_updates: usize,
+
     pub(crate) actions: Rc<ActionRegistry>,
     pub(crate) active_drag: Option<AnyDrag>,
     pub(crate) background_executor: BackgroundExecutor,
     pub(crate) foreground_executor: ForegroundExecutor,
-    pub(crate) loading_assets: FxHashMap<(TypeId, u64), Box<dyn Any>>,
-    asset_source: Arc<dyn AssetSource>,
-    pub(crate) svg_renderer: SvgRenderer,
-    http_client: Arc<dyn HttpClient>,
-    pub(crate) globals_by_type: FxHashMap<TypeId, Box<dyn Any>>,
     pub(crate) entities: EntityMap,
-    pub(crate) window_update_stack: Vec<WindowId>,
     pub(crate) new_entity_observers: SubscriberSet<TypeId, NewEntityListener>,
     pub(crate) windows: SlotMap<WindowId, Option<Box<Window>>>,
     pub(crate) window_handles: FxHashMap<WindowId, AnyWindowHandle>,
@@ -604,10 +596,8 @@ pub struct App {
     pub(crate) global_action_listeners:
         FxHashMap<TypeId, Vec<Rc<dyn Fn(&dyn Any, DispatchPhase, &mut Self)>>>,
     pending_effects: VecDeque<Effect>,
-    pub(crate) pending_notifications: FxHashSet<EntityId>,
-    pub(crate) pending_global_notifications: FxHashSet<TypeId>,
+
     pub(crate) observers: SubscriberSet<EntityId, Handler>,
-    // TypeId is the type of the event that the listener callback expects
     pub(crate) event_listeners: SubscriberSet<EntityId, (TypeId, Listener)>,
     pub(crate) keystroke_observers: SubscriberSet<(), KeystrokeObserver>,
     pub(crate) keystroke_interceptors: SubscriberSet<(), KeystrokeObserver>,
@@ -617,8 +607,30 @@ pub struct App {
     pub(crate) global_observers: SubscriberSet<TypeId, Handler>,
     pub(crate) quit_observers: SubscriberSet<(), QuitHandler>,
     pub(crate) restart_observers: SubscriberSet<(), Handler>,
-    pub(crate) restart_path: Option<PathBuf>,
     pub(crate) window_closed_observers: SubscriberSet<(), WindowClosedHandler>,
+
+    /// Per-App element arena. This isolates element allocations between different
+    /// App instances (important for tests where multiple Apps run concurrently).
+    pub(crate) element_arena: RefCell<Arena>,
+    /// Per-App event arena.
+    pub(crate) event_arena: Arena,
+
+    // Drop globals last. We need to ensure all tasks owned by entities and
+    // callbacks are marked cancelled at this point as this will also shutdown
+    // the tokio runtime. As any task attempting to spawn a blocking tokio task,
+    // might panic.
+    pub(crate) globals_by_type: FxHashMap<TypeId, Box<dyn Any>>,
+
+    // assets
+    pub(crate) loading_assets: FxHashMap<(TypeId, u64), Box<dyn Any>>,
+    asset_source: Arc<dyn AssetSource>,
+    pub(crate) svg_renderer: SvgRenderer,
+    http_client: Arc<dyn HttpClient>,
+
+    // below is plain data, the drop order is insignificant here
+    pub(crate) pending_notifications: FxHashSet<EntityId>,
+    pub(crate) pending_global_notifications: FxHashSet<TypeId>,
+    pub(crate) restart_path: Option<PathBuf>,
     pub(crate) layout_id_buffer: Vec<LayoutId>, // We recycle this memory across layout requests.
     pub(crate) propagate_event: bool,
     pub(crate) prompt_builder: Option<PromptBuilder>,
@@ -632,13 +644,18 @@ pub struct App {
     #[cfg(any(test, feature = "test-support", debug_assertions))]
     pub(crate) name: Option<&'static str>,
     pub(crate) text_rendering_mode: Rc<Cell<TextRenderingMode>>,
+
+    pub(crate) window_update_stack: Vec<WindowId>,
+    pub(crate) mode: GpuiMode,
+    flushing_effects: bool,
+    pending_updates: usize,
     quit_mode: QuitMode,
     quitting: bool,
-    /// Per-App element arena. This isolates element allocations between different
-    /// App instances (important for tests where multiple Apps run concurrently).
-    pub(crate) element_arena: RefCell<Arena>,
-    /// Per-App event arena.
-    pub(crate) event_arena: Arena,
+
+    // We need to ensure the leak detector drops last, after all tasks, callbacks and things have been dropped.
+    // Otherwise it may report false positives.
+    #[cfg(any(test, feature = "leak-detection"))]
+    _ref_counts: Arc<RwLock<EntityRefCounts>>,
 }
 
 impl App {
@@ -659,6 +676,9 @@ impl App {
         let entities = EntityMap::new();
         let keyboard_layout = platform.keyboard_layout();
         let keyboard_mapper = platform.keyboard_mapper();
+
+        #[cfg(any(test, feature = "leak-detection"))]
+        let _ref_counts = entities.ref_counts_drop_handle();
 
         let app = Rc::new_cyclic(|this| AppCell {
             app: RefCell::new(App {
@@ -719,6 +739,9 @@ impl App {
                 name: None,
                 element_arena: RefCell::new(Arena::new(1024 * 1024)),
                 event_arena: Arena::new(1024 * 1024),
+
+                #[cfg(any(test, feature = "leak-detection"))]
+                _ref_counts,
             }),
         });
 

--- a/crates/gpui/src/app/entity_map.rs
+++ b/crates/gpui/src/app/entity_map.rs
@@ -59,7 +59,8 @@ pub(crate) struct EntityMap {
     ref_counts: Arc<RwLock<EntityRefCounts>>,
 }
 
-struct EntityRefCounts {
+#[doc(hidden)]
+pub(crate) struct EntityRefCounts {
     counts: SlotMap<EntityId, AtomicUsize>,
     dropped_entity_ids: Vec<EntityId>,
     #[cfg(any(test, feature = "leak-detection"))]
@@ -84,7 +85,7 @@ impl EntityMap {
     }
 
     #[doc(hidden)]
-    pub fn ref_counts_drop_handle(&self) -> impl Sized + use<> {
+    pub fn ref_counts_drop_handle(&self) -> Arc<RwLock<EntityRefCounts>> {
         self.ref_counts.clone()
     }
 

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -949,7 +949,7 @@ impl StateInner {
         let drag_offset =
             // if dragging the scrollbar, we want to offset the point if the height changed
             content_height - self.scrollbar_drag_start_height.unwrap_or(content_height);
-        let new_scroll_top = (point.y - drag_offset).abs().max(px(0.)).min(scroll_max);
+        let new_scroll_top = (-point.y).max(px(0.)).min(scroll_max);
 
         if self.alignment == ListAlignment::Bottom && new_scroll_top == scroll_max {
             self.logical_scroll_top = None;

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -629,57 +629,29 @@ mod tests {
     use std::{cell::RefCell, ops::Range, rc::Rc};
 
     use crate::{
-        Action, ActionRegistry, App, Bounds, Context, DispatchTree, FocusHandle, InputHandler,
-        IntoElement, KeyBinding, KeyContext, Keymap, Pixels, Point, Render, Subscription,
-        TestAppContext, UTF16Selection, Window,
+        ActionRegistry, App, Bounds, Context, DispatchTree, FocusHandle, InputHandler, IntoElement,
+        KeyBinding, KeyContext, Keymap, Pixels, Point, Render, Subscription, TestAppContext,
+        UTF16Selection, Unbind, Window,
     };
 
-    #[derive(PartialEq, Eq)]
-    struct TestAction;
+    actions!(dispatch_test, [TestAction, SecondaryTestAction]);
 
-    impl Action for TestAction {
-        fn name(&self) -> &'static str {
-            "test::TestAction"
-        }
+    fn test_dispatch_tree(bindings: Vec<KeyBinding>) -> DispatchTree {
+        let registry = ActionRegistry::default();
 
-        fn name_for_type() -> &'static str
-        where
-            Self: ::std::marker::Sized,
-        {
-            "test::TestAction"
-        }
-
-        fn partial_eq(&self, action: &dyn Action) -> bool {
-            action.as_any().downcast_ref::<Self>() == Some(self)
-        }
-
-        fn boxed_clone(&self) -> std::boxed::Box<dyn Action> {
-            Box::new(TestAction)
-        }
-
-        fn build(_value: serde_json::Value) -> anyhow::Result<Box<dyn Action>>
-        where
-            Self: Sized,
-        {
-            Ok(Box::new(TestAction))
-        }
+        DispatchTree::new(
+            Rc::new(RefCell::new(Keymap::new(bindings))),
+            Rc::new(registry),
+        )
     }
 
     #[test]
     fn test_keybinding_for_action_bounds() {
-        let keymap = Keymap::new(vec![KeyBinding::new(
+        let tree = test_dispatch_tree(vec![KeyBinding::new(
             "cmd-n",
             TestAction,
             Some("ProjectPanel"),
         )]);
-
-        let mut registry = ActionRegistry::default();
-
-        registry.load_action::<TestAction>();
-
-        let keymap = Rc::new(RefCell::new(keymap));
-
-        let tree = DispatchTree::new(keymap, Rc::new(registry));
 
         let contexts = vec![
             KeyContext::parse("Workspace").unwrap(),
@@ -692,16 +664,74 @@ mod tests {
     }
 
     #[test]
+    fn test_bindings_for_action_hides_targeted_unbind_in_active_context() {
+        let tree = test_dispatch_tree(vec![
+            KeyBinding::new("tab", TestAction, Some("Editor")),
+            KeyBinding::new(
+                "tab",
+                Unbind("dispatch_test::TestAction".into()),
+                Some("Editor && edit_prediction"),
+            ),
+            KeyBinding::new(
+                "tab",
+                SecondaryTestAction,
+                Some("Editor && showing_completions"),
+            ),
+        ]);
+
+        let contexts = vec![
+            KeyContext::parse("Workspace").unwrap(),
+            KeyContext::parse("Editor showing_completions edit_prediction").unwrap(),
+        ];
+
+        let bindings = tree.bindings_for_action(&TestAction, &contexts);
+        assert!(bindings.is_empty());
+
+        let highest = tree.highest_precedence_binding_for_action(&TestAction, &contexts);
+        assert!(highest.is_none());
+
+        let fallback_bindings = tree.bindings_for_action(&SecondaryTestAction, &contexts);
+        assert_eq!(fallback_bindings.len(), 1);
+        assert!(fallback_bindings[0].action.partial_eq(&SecondaryTestAction));
+    }
+
+    #[test]
+    fn test_bindings_for_action_keeps_targeted_binding_outside_unbind_context() {
+        let tree = test_dispatch_tree(vec![
+            KeyBinding::new("tab", TestAction, Some("Editor")),
+            KeyBinding::new(
+                "tab",
+                Unbind("dispatch_test::TestAction".into()),
+                Some("Editor && edit_prediction"),
+            ),
+            KeyBinding::new(
+                "tab",
+                SecondaryTestAction,
+                Some("Editor && showing_completions"),
+            ),
+        ]);
+
+        let contexts = vec![
+            KeyContext::parse("Workspace").unwrap(),
+            KeyContext::parse("Editor").unwrap(),
+        ];
+
+        let bindings = tree.bindings_for_action(&TestAction, &contexts);
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].action.partial_eq(&TestAction));
+
+        let highest = tree.highest_precedence_binding_for_action(&TestAction, &contexts);
+        assert!(highest.is_some_and(|binding| binding.action.partial_eq(&TestAction)));
+    }
+
+    #[test]
     fn test_pending_has_binding_state() {
         let bindings = vec![
             KeyBinding::new("ctrl-b h", TestAction, None),
             KeyBinding::new("space", TestAction, Some("ContextA")),
             KeyBinding::new("space f g", TestAction, Some("ContextB")),
         ];
-        let keymap = Rc::new(RefCell::new(Keymap::new(bindings)));
-        let mut registry = ActionRegistry::default();
-        registry.load_action::<TestAction>();
-        let mut tree = DispatchTree::new(keymap, Rc::new(registry));
+        let mut tree = test_dispatch_tree(bindings);
 
         type DispatchPath = SmallVec<[super::DispatchNodeId; 32]>;
         fn dispatch(

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -4,7 +4,7 @@ mod context;
 pub use binding::*;
 pub use context::*;
 
-use crate::{Action, AsKeystroke, Keystroke, is_no_action};
+use crate::{Action, AsKeystroke, Keystroke, Unbind, is_no_action, is_unbind};
 use collections::{HashMap, HashSet};
 use smallvec::SmallVec;
 use std::any::TypeId;
@@ -19,13 +19,33 @@ pub struct KeymapVersion(usize);
 pub struct Keymap {
     bindings: Vec<KeyBinding>,
     binding_indices_by_action_id: HashMap<TypeId, SmallVec<[usize; 3]>>,
-    no_action_binding_indices: Vec<usize>,
+    disabled_binding_indices: Vec<usize>,
     version: KeymapVersion,
 }
 
 /// Index of a binding within a keymap.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BindingIndex(usize);
+
+fn disabled_binding_matches_context(disabled_binding: &KeyBinding, binding: &KeyBinding) -> bool {
+    match (
+        &disabled_binding.context_predicate,
+        &binding.context_predicate,
+    ) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(disabled_predicate), Some(predicate)) => disabled_predicate.is_superset(predicate),
+    }
+}
+
+fn binding_is_unbound(disabled_binding: &KeyBinding, binding: &KeyBinding) -> bool {
+    disabled_binding.keystrokes == binding.keystrokes
+        && disabled_binding
+            .action()
+            .as_any()
+            .downcast_ref::<Unbind>()
+            .is_some_and(|unbind| unbind.0.as_ref() == binding.action.name())
+}
 
 impl Keymap {
     /// Create a new keymap with the given bindings.
@@ -44,8 +64,8 @@ impl Keymap {
     pub fn add_bindings<T: IntoIterator<Item = KeyBinding>>(&mut self, bindings: T) {
         for binding in bindings {
             let action_id = binding.action().as_any().type_id();
-            if is_no_action(&*binding.action) {
-                self.no_action_binding_indices.push(self.bindings.len());
+            if is_no_action(&*binding.action) || is_unbind(&*binding.action) {
+                self.disabled_binding_indices.push(self.bindings.len());
             } else {
                 self.binding_indices_by_action_id
                     .entry(action_id)
@@ -62,7 +82,7 @@ impl Keymap {
     pub fn clear(&mut self) {
         self.bindings.clear();
         self.binding_indices_by_action_id.clear();
-        self.no_action_binding_indices.clear();
+        self.disabled_binding_indices.clear();
         self.version.0 += 1;
     }
 
@@ -90,21 +110,22 @@ impl Keymap {
                 return None;
             }
 
-            for null_ix in &self.no_action_binding_indices {
-                if null_ix > ix {
-                    let null_binding = &self.bindings[*null_ix];
-                    if null_binding.keystrokes == binding.keystrokes {
-                        let null_binding_matches =
-                            match (&null_binding.context_predicate, &binding.context_predicate) {
-                                (None, _) => true,
-                                (Some(_), None) => false,
-                                (Some(null_predicate), Some(predicate)) => {
-                                    null_predicate.is_superset(predicate)
-                                }
-                            };
-                        if null_binding_matches {
+            for disabled_ix in &self.disabled_binding_indices {
+                if disabled_ix > ix {
+                    let disabled_binding = &self.bindings[*disabled_ix];
+                    if disabled_binding.keystrokes != binding.keystrokes {
+                        continue;
+                    }
+
+                    if is_no_action(&*disabled_binding.action) {
+                        if disabled_binding_matches_context(disabled_binding, binding) {
                             return None;
                         }
+                    } else if is_unbind(&*disabled_binding.action)
+                        && disabled_binding_matches_context(disabled_binding, binding)
+                        && binding_is_unbound(disabled_binding, binding)
+                    {
+                        return None;
                     }
                 }
             }
@@ -170,6 +191,7 @@ impl Keymap {
 
         let mut bindings: SmallVec<[_; 1]> = SmallVec::new();
         let mut first_binding_index = None;
+        let mut unbound_bindings: Vec<&KeyBinding> = Vec::new();
 
         for (_, ix, binding) in matched_bindings {
             if is_no_action(&*binding.action) {
@@ -186,6 +208,19 @@ impl Keymap {
                 // For non-user NoAction bindings, continue searching for user overrides
                 continue;
             }
+
+            if is_unbind(&*binding.action) {
+                unbound_bindings.push(binding);
+                continue;
+            }
+
+            if unbound_bindings
+                .iter()
+                .any(|disabled_binding| binding_is_unbound(disabled_binding, binding))
+            {
+                continue;
+            }
+
             bindings.push(binding.clone());
             first_binding_index.get_or_insert(ix);
         }
@@ -197,7 +232,7 @@ impl Keymap {
             {
                 continue;
             }
-            if is_no_action(&*binding.action) {
+            if is_no_action(&*binding.action) || is_unbind(&*binding.action) {
                 pending.remove(&&binding.keystrokes);
                 continue;
             }
@@ -232,7 +267,10 @@ impl Keymap {
                 match pending {
                     None => None,
                     Some(is_pending) => {
-                        if !is_pending || is_no_action(&*binding.action) {
+                        if !is_pending
+                            || is_no_action(&*binding.action)
+                            || is_unbind(&*binding.action)
+                        {
                             return None;
                         }
                         Some((depth, BindingIndex(ix), binding))
@@ -256,7 +294,7 @@ impl Keymap {
 mod tests {
     use super::*;
     use crate as gpui;
-    use gpui::NoAction;
+    use gpui::{NoAction, Unbind};
 
     actions!(
         test_only,
@@ -718,6 +756,76 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(actual, expected, "{:?}", action);
         }
+    }
+
+    #[test]
+    fn test_targeted_unbind_ignores_target_context() {
+        let bindings = [
+            KeyBinding::new("tab", ActionAlpha {}, Some("Editor")),
+            KeyBinding::new("tab", ActionBeta {}, Some("Editor && showing_completions")),
+            KeyBinding::new(
+                "tab",
+                Unbind("test_only::ActionAlpha".into()),
+                Some("Editor && edit_prediction"),
+            ),
+        ];
+
+        let mut keymap = Keymap::default();
+        keymap.add_bindings(bindings);
+
+        let (result, pending) = keymap.bindings_for_input(
+            &[Keystroke::parse("tab").unwrap()],
+            &[KeyContext::parse("Editor showing_completions edit_prediction").unwrap()],
+        );
+
+        assert!(!pending);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].action.partial_eq(&ActionBeta {}));
+    }
+
+    #[test]
+    fn test_bindings_for_action_keeps_binding_for_narrower_targeted_unbind() {
+        let bindings = [
+            KeyBinding::new("tab", ActionAlpha {}, Some("Editor")),
+            KeyBinding::new(
+                "tab",
+                Unbind("test_only::ActionAlpha".into()),
+                Some("Editor && edit_prediction"),
+            ),
+            KeyBinding::new("tab", ActionBeta {}, Some("Editor && showing_completions")),
+        ];
+
+        let mut keymap = Keymap::default();
+        keymap.add_bindings(bindings);
+
+        assert_bindings(&keymap, &ActionAlpha {}, &["tab"]);
+        assert_bindings(&keymap, &ActionBeta {}, &["tab"]);
+
+        #[track_caller]
+        fn assert_bindings(keymap: &Keymap, action: &dyn Action, expected: &[&str]) {
+            let actual = keymap
+                .bindings_for_action(action)
+                .map(|binding| binding.keystrokes[0].inner().unparse())
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected, "{:?}", action);
+        }
+    }
+
+    #[test]
+    fn test_bindings_for_action_removes_binding_for_broader_targeted_unbind() {
+        let bindings = [
+            KeyBinding::new("tab", ActionAlpha {}, Some("Editor && edit_prediction")),
+            KeyBinding::new(
+                "tab",
+                Unbind("test_only::ActionAlpha".into()),
+                Some("Editor"),
+            ),
+        ];
+
+        let mut keymap = Keymap::default();
+        keymap.add_bindings(bindings);
+
+        assert!(keymap.bindings_for_action(&ActionAlpha {}).next().is_none());
     }
 
     #[test]

--- a/crates/gpui_macos/src/metal_atlas.rs
+++ b/crates/gpui_macos/src/metal_atlas.rs
@@ -61,7 +61,7 @@ impl PlatformAtlas for MetalAtlas {
 
     fn remove(&self, key: &AtlasKey) {
         let mut lock = self.0.lock();
-        let Some(id) = lock.tiles_by_key.get(key).map(|v| v.texture_id) else {
+        let Some(id) = lock.tiles_by_key.remove(key).map(|v| v.texture_id) else {
             return;
         };
 
@@ -81,10 +81,8 @@ impl PlatformAtlas for MetalAtlas {
 
         if let Some(mut texture) = texture_slot.take() {
             texture.decrement_ref_count();
-
             if texture.is_unreferenced() {
                 textures.free_list.push(id.index as usize);
-                lock.tiles_by_key.remove(key);
             } else {
                 *texture_slot = Some(texture);
             }
@@ -271,3 +269,81 @@ fn point_from_etagere(value: etagere::Point) -> Point<DevicePixels> {
 struct AssertSend<T>(T);
 
 unsafe impl<T> Send for AssertSend<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::PlatformAtlas;
+    use std::borrow::Cow;
+
+    fn create_atlas() -> Option<MetalAtlas> {
+        let device = metal::Device::system_default()?;
+        Some(MetalAtlas::new(device, true))
+    }
+
+    fn make_image_key(image_id: usize, frame_index: usize) -> AtlasKey {
+        AtlasKey::Image(gpui::RenderImageParams {
+            image_id: gpui::ImageId(image_id),
+            frame_index,
+        })
+    }
+
+    fn insert_tile(atlas: &MetalAtlas, key: &AtlasKey, size: Size<DevicePixels>) -> AtlasTile {
+        atlas
+            .get_or_insert_with(key, &mut || {
+                let byte_count = (size.width.0 as usize) * (size.height.0 as usize) * 4;
+                Ok(Some((size, Cow::Owned(vec![0u8; byte_count]))))
+            })
+            .expect("allocation should succeed")
+            .expect("callback returns Some")
+    }
+
+    #[test]
+    fn test_remove_clears_stale_keys_from_tiles_by_key() {
+        let Some(atlas) = create_atlas() else {
+            return;
+        };
+
+        let small = Size {
+            width: DevicePixels(64),
+            height: DevicePixels(64),
+        };
+
+        let key_a = make_image_key(1, 0);
+        let key_b = make_image_key(2, 0);
+        let key_c = make_image_key(3, 0);
+
+        let tile_a = insert_tile(&atlas, &key_a, small);
+        let tile_b = insert_tile(&atlas, &key_b, small);
+        let tile_c = insert_tile(&atlas, &key_c, small);
+
+        assert_eq!(tile_a.texture_id, tile_b.texture_id);
+        assert_eq!(tile_b.texture_id, tile_c.texture_id);
+
+        // Remove A: texture still has B and C, so it stays.
+        // The key for A must be removed from tiles_by_key.
+        atlas.remove(&key_a);
+
+        // Remove B: texture still has C.
+        atlas.remove(&key_b);
+
+        // Remove C: texture becomes unreferenced and is deleted.
+        atlas.remove(&key_c);
+
+        // Re-inserting A must allocate a fresh tile on a new texture,
+        // NOT return a stale tile referencing the deleted texture.
+        let tile_a2 = insert_tile(&atlas, &key_a, small);
+
+        // The texture must actually exist — this would panic before the fix.
+        let _texture = atlas.metal_texture(tile_a2.texture_id);
+    }
+
+    #[test]
+    fn test_remove_nonexistent_key_is_noop() {
+        let Some(atlas) = create_atlas() else {
+            return;
+        };
+        let key = make_image_key(999, 0);
+        atlas.remove(&key);
+    }
+}

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -55,7 +55,10 @@ use std::{
     path::PathBuf,
     ptr::{self, NonNull},
     rc::Rc,
-    sync::{Arc, Weak},
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 use util::ResultExt;
@@ -440,6 +443,7 @@ struct MacWindowState {
     select_previous_tab_callback: Option<Box<dyn FnMut()>>,
     toggle_tab_bar_callback: Option<Box<dyn FnMut()>>,
     activated_least_once: bool,
+    closed: Arc<AtomicBool>,
     // The parent window if this window is a sheet (Dialog kind)
     sheet_parent: Option<id>,
 }
@@ -764,6 +768,7 @@ impl MacWindow {
                 select_previous_tab_callback: None,
                 toggle_tab_bar_callback: None,
                 activated_least_once: false,
+                closed: Arc::new(AtomicBool::new(false)),
                 sheet_parent: None,
             })));
 
@@ -1020,6 +1025,17 @@ impl Drop for MacWindow {
     }
 }
 
+/// Calls `f` if the window is not closed.
+///
+/// This should be used when spawning foreground tasks interacting with the
+/// window, as some messages will end hard faulting if dispatched to no longer
+/// valid window handles.
+fn if_window_not_closed(closed: Arc<AtomicBool>, f: impl FnOnce()) {
+    if !closed.load(Ordering::Acquire) {
+        f();
+    }
+}
+
 impl PlatformWindow for MacWindow {
     fn bounds(&self) -> Bounds<Pixels> {
         self.0.as_ref().lock().bounds()
@@ -1040,14 +1056,15 @@ impl PlatformWindow for MacWindow {
     fn resize(&mut self, size: Size<Pixels>) {
         let this = self.0.lock();
         let window = this.native_window;
+        let closed = this.closed.clone();
         this.foreground_executor
             .spawn(async move {
-                unsafe {
+                if_window_not_closed(closed, || unsafe {
                     window.setContentSize_(NSSize {
                         width: size.width.as_f32() as f64,
                         height: size.height.as_f32() as f64,
                     });
-                }
+                })
             })
             .detach();
     }
@@ -1260,15 +1277,21 @@ impl PlatformWindow for MacWindow {
                 }
             });
             let block = block.copy();
-            let native_window = self.0.lock().native_window;
-            let executor = self.0.lock().foreground_executor.clone();
+            let lock = self.0.lock();
+            let native_window = lock.native_window;
+            let closed = lock.closed.clone();
+            let executor = lock.foreground_executor.clone();
             executor
                 .spawn(async move {
-                    let _: () = msg_send![
-                        alert,
-                        beginSheetModalForWindow: native_window
-                        completionHandler: block
-                    ];
+                    if !closed.load(Ordering::Acquire) {
+                        let _: () = msg_send![
+                            alert,
+                            beginSheetModalForWindow: native_window
+                            completionHandler: block
+                        ];
+                    } else {
+                        let _: () = msg_send![alert, release];
+                    }
                 })
                 .detach();
 
@@ -1277,12 +1300,16 @@ impl PlatformWindow for MacWindow {
     }
 
     fn activate(&self) {
-        let window = self.0.lock().native_window;
-        let executor = self.0.lock().foreground_executor.clone();
+        let lock = self.0.lock();
+        let window = lock.native_window;
+        let closed = lock.closed.clone();
+        let executor = lock.foreground_executor.clone();
         executor
             .spawn(async move {
-                unsafe {
-                    let _: () = msg_send![window, makeKeyAndOrderFront: nil];
+                if !closed.load(Ordering::Acquire) {
+                    unsafe {
+                        let _: () = msg_send![window, makeKeyAndOrderFront: nil];
+                    }
                 }
             })
             .detach();
@@ -1420,11 +1447,12 @@ impl PlatformWindow for MacWindow {
     fn zoom(&self) {
         let this = self.0.lock();
         let window = this.native_window;
+        let closed = this.closed.clone();
         this.foreground_executor
             .spawn(async move {
-                unsafe {
+                if_window_not_closed(closed, || unsafe {
                     window.zoom_(nil);
-                }
+                })
             })
             .detach();
     }
@@ -1432,11 +1460,12 @@ impl PlatformWindow for MacWindow {
     fn toggle_fullscreen(&self) {
         let this = self.0.lock();
         let window = this.native_window;
+        let closed = this.closed.clone();
         this.foreground_executor
             .spawn(async move {
-                unsafe {
+                if_window_not_closed(closed, || unsafe {
                     window.toggleFullScreen_(nil);
-                }
+                })
             })
             .detach();
     }
@@ -1577,45 +1606,48 @@ impl PlatformWindow for MacWindow {
     fn titlebar_double_click(&self) {
         let this = self.0.lock();
         let window = this.native_window;
+        let closed = this.closed.clone();
         this.foreground_executor
             .spawn(async move {
-                unsafe {
-                    let defaults: id = NSUserDefaults::standardUserDefaults();
-                    let domain = ns_string("NSGlobalDomain");
-                    let key = ns_string("AppleActionOnDoubleClick");
+                if_window_not_closed(closed, || {
+                    unsafe {
+                        let defaults: id = NSUserDefaults::standardUserDefaults();
+                        let domain = ns_string("NSGlobalDomain");
+                        let key = ns_string("AppleActionOnDoubleClick");
 
-                    let dict: id = msg_send![defaults, persistentDomainForName: domain];
-                    let action: id = if !dict.is_null() {
-                        msg_send![dict, objectForKey: key]
-                    } else {
-                        nil
-                    };
+                        let dict: id = msg_send![defaults, persistentDomainForName: domain];
+                        let action: id = if !dict.is_null() {
+                            msg_send![dict, objectForKey: key]
+                        } else {
+                            nil
+                        };
 
-                    let action_str = if !action.is_null() {
-                        CStr::from_ptr(NSString::UTF8String(action)).to_string_lossy()
-                    } else {
-                        "".into()
-                    };
+                        let action_str = if !action.is_null() {
+                            CStr::from_ptr(NSString::UTF8String(action)).to_string_lossy()
+                        } else {
+                            "".into()
+                        };
 
-                    match action_str.as_ref() {
-                        "None" => {
-                            // "Do Nothing" selected, so do no action
-                        }
-                        "Minimize" => {
-                            window.miniaturize_(nil);
-                        }
-                        "Maximize" => {
-                            window.zoom_(nil);
-                        }
-                        "Fill" => {
-                            // There is no documented API for "Fill" action, so we'll just zoom the window
-                            window.zoom_(nil);
-                        }
-                        _ => {
-                            window.zoom_(nil);
+                        match action_str.as_ref() {
+                            "None" => {
+                                // "Do Nothing" selected, so do no action
+                            }
+                            "Minimize" => {
+                                window.miniaturize_(nil);
+                            }
+                            "Maximize" => {
+                                window.zoom_(nil);
+                            }
+                            "Fill" => {
+                                // There is no documented API for "Fill" action, so we'll just zoom the window
+                                window.zoom_(nil);
+                            }
+                            _ => {
+                                window.zoom_(nil);
+                            }
                         }
                     }
-                }
+                })
             })
             .detach();
     }
@@ -2185,6 +2217,7 @@ extern "C" fn close_window(this: &Object, _: Sel) {
         let close_callback = {
             let window_state = get_window_state(this);
             let mut lock = window_state.as_ref().lock();
+            lock.closed.store(true, Ordering::Release);
             lock.close_callback.take()
         };
 

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -116,7 +116,6 @@ impl PlatformAtlas for DirectXAtlas {
             texture.decrement_ref_count();
             if texture.is_unreferenced() {
                 textures.free_list.push(texture.id.index as usize);
-                lock.tiles_by_key.remove(key);
             } else {
                 *texture_slot = Some(texture);
             }

--- a/crates/http_client/src/github.rs
+++ b/crates/http_client/src/github.rs
@@ -144,6 +144,7 @@ pub async fn get_release_by_tag_name(
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AssetKind {
     TarGz,
+    TarBz2,
     Gz,
     Zip,
 }
@@ -158,6 +159,7 @@ pub fn build_asset_url(repo_name_with_owner: &str, tag: &str, kind: AssetKind) -
         "{tag}.{extension}",
         extension = match kind {
             AssetKind::TarGz => "tar.gz",
+            AssetKind::TarBz2 => "tar.bz2",
             AssetKind::Gz => "gz",
             AssetKind::Zip => "zip",
         }

--- a/crates/http_client/src/github_download.rs
+++ b/crates/http_client/src/github_download.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use async_compression::futures::bufread::GzipDecoder;
+use async_compression::futures::bufread::{BzDecoder, GzipDecoder};
 use futures::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, io::BufReader};
 use sha2::{Digest, Sha256};
 
@@ -119,7 +119,7 @@ async fn extract_to_staging(
 
 fn staging_path(parent: &Path, asset_kind: AssetKind) -> Result<PathBuf> {
     match asset_kind {
-        AssetKind::TarGz | AssetKind::Zip => {
+        AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Zip => {
             let dir = tempfile::Builder::new()
                 .prefix(".tmp-github-download-")
                 .tempdir_in(parent)
@@ -141,7 +141,7 @@ fn staging_path(parent: &Path, asset_kind: AssetKind) -> Result<PathBuf> {
 
 async fn cleanup_staging_path(staging_path: &Path, asset_kind: AssetKind) {
     match asset_kind {
-        AssetKind::TarGz | AssetKind::Zip => {
+        AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Zip => {
             if let Err(err) = async_fs::remove_dir_all(staging_path).await {
                 log::warn!("failed to remove staging directory {staging_path:?}: {err:?}");
             }
@@ -170,6 +170,7 @@ async fn stream_response_archive(
 ) -> Result<()> {
     match asset_kind {
         AssetKind::TarGz => extract_tar_gz(destination_path, url, response).await?,
+        AssetKind::TarBz2 => extract_tar_bz2(destination_path, url, response).await?,
         AssetKind::Gz => extract_gz(destination_path, url, response).await?,
         AssetKind::Zip => {
             util::archive::extract_zip(destination_path, response).await?;
@@ -186,6 +187,7 @@ async fn stream_file_archive(
 ) -> Result<()> {
     match asset_kind {
         AssetKind::TarGz => extract_tar_gz(destination_path, url, file_archive).await?,
+        AssetKind::TarBz2 => extract_tar_bz2(destination_path, url, file_archive).await?,
         AssetKind::Gz => extract_gz(destination_path, url, file_archive).await?,
         #[cfg(not(windows))]
         AssetKind::Zip => {
@@ -205,6 +207,20 @@ async fn extract_tar_gz(
     from: impl AsyncRead + Unpin,
 ) -> Result<(), anyhow::Error> {
     let decompressed_bytes = GzipDecoder::new(BufReader::new(from));
+    let archive = async_tar::Archive::new(decompressed_bytes);
+    archive
+        .unpack(&destination_path)
+        .await
+        .with_context(|| format!("extracting {url} to {destination_path:?}"))?;
+    Ok(())
+}
+
+async fn extract_tar_bz2(
+    destination_path: &Path,
+    url: &str,
+    from: impl AsyncRead + Unpin,
+) -> Result<(), anyhow::Error> {
+    let decompressed_bytes = BzDecoder::new(BufReader::new(from));
     let archive = async_tar::Archive::new(decompressed_bytes);
     archive
         .unpack(&destination_path)

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -500,6 +500,40 @@ fn keystrokes_match_exactly(
         })
 }
 
+fn disabled_binding_matches_context(
+    disabled_binding: &gpui::KeyBinding,
+    binding: &gpui::KeyBinding,
+) -> bool {
+    match (
+        disabled_binding.predicate().as_deref(),
+        binding.predicate().as_deref(),
+    ) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(disabled_predicate), Some(predicate)) => disabled_predicate.is_superset(predicate),
+    }
+}
+
+fn binding_is_unbound_by_unbind(
+    binding: &gpui::KeyBinding,
+    binding_index: usize,
+    all_bindings: &[&gpui::KeyBinding],
+) -> bool {
+    all_bindings[binding_index + 1..]
+        .iter()
+        .rev()
+        .any(|disabled_binding| {
+            gpui::is_unbind(disabled_binding.action())
+                && keystrokes_match_exactly(disabled_binding.keystrokes(), binding.keystrokes())
+                && disabled_binding
+                    .action()
+                    .as_any()
+                    .downcast_ref::<gpui::Unbind>()
+                    .is_some_and(|unbind| unbind.0.as_ref() == binding.action().name())
+                && disabled_binding_matches_context(disabled_binding, binding)
+        })
+}
+
 impl KeymapEditor {
     fn new(workspace: WeakEntity<Workspace>, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let _keymap_subscription =
@@ -729,13 +763,8 @@ impl KeymapEditor {
                 SearchMode::Normal => {}
             }
 
-            // Filter out NoAction suppression bindings by default. These are internal
-            // markers created when a user deletes a default binding (to suppress the
-            // default at the GPUI level), not real bindings the user should usually see.
             if !this.show_no_action_bindings {
-                matches.retain(|item| {
-                    this.keybindings[item.candidate_id].action().name != gpui::NoAction.name()
-                });
+                matches.retain(|item| !this.keybindings[item.candidate_id].is_no_action());
             }
 
             if action_query.is_empty() {
@@ -772,7 +801,7 @@ impl KeymapEditor {
     ) {
         let key_bindings_ptr = cx.key_bindings();
         let lock = key_bindings_ptr.borrow();
-        let key_bindings = lock.bindings();
+        let key_bindings = lock.bindings().collect::<Vec<_>>();
         let mut unmapped_action_names = HashSet::from_iter(cx.all_action_names().iter().copied());
         let action_documentation = cx.action_documentation();
         let mut generator = KeymapFile::action_schema_generator();
@@ -785,13 +814,20 @@ impl KeymapEditor {
         let mut processed_bindings = Vec::new();
         let mut string_match_candidates = Vec::new();
 
-        for key_binding in key_bindings {
+        for (binding_index, &key_binding) in key_bindings.iter().enumerate() {
+            if gpui::is_unbind(key_binding.action()) {
+                continue;
+            }
+
             let source = key_binding
                 .meta()
                 .map(KeybindSource::from_meta)
                 .unwrap_or(KeybindSource::Unknown);
 
             let keystroke_text = ui::text_for_keybinding_keystrokes(key_binding.keystrokes(), cx);
+            let is_no_action = gpui::is_no_action(key_binding.action());
+            let is_unbound_by_unbind =
+                binding_is_unbound_by_unbind(key_binding, binding_index, &key_bindings);
             let binding = KeyBinding::new(key_binding, source);
 
             let context = key_binding
@@ -826,6 +862,8 @@ impl KeymapEditor {
                 binding,
                 context,
                 source,
+                is_no_action,
+                is_unbound_by_unbind,
                 action_information,
             ));
             string_match_candidates.push(string_match_candidate);
@@ -1019,20 +1057,23 @@ impl KeymapEditor {
                 .and_then(KeybindContextString::local)
                 .is_none();
 
-            let selected_binding_is_unbound = selected_binding.is_unbound();
+            let selected_binding_is_unmapped = selected_binding.is_unbound();
+            let selected_binding_is_suppressed = selected_binding.is_unbound_by_unbind();
+            let selected_binding_is_non_interactable =
+                selected_binding_is_unmapped || selected_binding_is_suppressed;
 
             let context_menu = ContextMenu::build(window, cx, |menu, _window, _cx| {
                 menu.context(self.focus_handle.clone())
-                    .when(selected_binding_is_unbound, |this| {
+                    .when(selected_binding_is_unmapped, |this| {
                         this.action("Create", Box::new(CreateBinding))
                     })
                     .action_disabled_when(
-                        selected_binding_is_unbound,
+                        selected_binding_is_non_interactable,
                         "Edit",
                         Box::new(EditBinding),
                     )
                     .action_disabled_when(
-                        selected_binding_is_unbound,
+                        selected_binding_is_non_interactable,
                         "Delete",
                         Box::new(DeleteBinding),
                     )
@@ -1080,9 +1121,15 @@ impl KeymapEditor {
         &self,
         index: usize,
         conflict: Option<ConflictOrigin>,
+        is_unbound_by_unbind: bool,
         cx: &mut Context<Self>,
     ) -> IconButton {
-        if self.filter_state != FilterState::Conflicts
+        if is_unbound_by_unbind {
+            base_button_style(index, IconName::Warning)
+                .icon_color(Color::Warning)
+                .disabled(true)
+                .tooltip(Tooltip::text("This action is unbound"))
+        } else if self.filter_state != FilterState::Conflicts
             && let Some(conflict) = conflict
         {
             if conflict.is_user_keybind_conflict() {
@@ -1242,6 +1289,9 @@ impl KeymapEditor {
         let Some((keybind, keybind_index)) = self.selected_keybind_and_index() else {
             return;
         };
+        if !create && keybind.is_unbound_by_unbind() {
+            return;
+        }
         let keybind = keybind.clone();
         let keymap_editor = cx.entity();
 
@@ -1348,6 +1398,9 @@ impl KeymapEditor {
         let Some(to_remove) = self.selected_binding().cloned() else {
             return;
         };
+        if to_remove.is_unbound_by_unbind() {
+            return;
+        }
 
         let std::result::Result::Ok(fs) = self
             .workspace
@@ -1677,6 +1730,8 @@ struct KeybindInformation {
     binding: KeyBinding,
     context: KeybindContextString,
     source: KeybindSource,
+    is_no_action: bool,
+    is_unbound_by_unbind: bool,
 }
 
 impl KeybindInformation {
@@ -1727,6 +1782,8 @@ impl ProcessedBinding {
         binding: KeyBinding,
         context: KeybindContextString,
         source: KeybindSource,
+        is_no_action: bool,
+        is_unbound_by_unbind: bool,
         action_information: ActionInformation,
     ) -> Self {
         Self::Mapped(
@@ -1735,6 +1792,8 @@ impl ProcessedBinding {
                 binding,
                 context,
                 source,
+                is_no_action,
+                is_unbound_by_unbind,
             },
             action_information,
         )
@@ -1771,6 +1830,16 @@ impl ProcessedBinding {
 
     fn key_binding(&self) -> Option<&KeyBinding> {
         self.keybind_information().map(|keybind| &keybind.binding)
+    }
+
+    fn is_no_action(&self) -> bool {
+        self.keybind_information()
+            .is_some_and(|keybind| keybind.is_no_action)
+    }
+
+    fn is_unbound_by_unbind(&self) -> bool {
+        self.keybind_information()
+            .is_some_and(|keybind| keybind.is_unbound_by_unbind)
     }
 
     fn keystroke_text(&self) -> Option<&SharedString> {
@@ -2054,11 +2123,18 @@ impl Render for KeymapEditor {
                                     let binding = &this.keybindings[candidate_id];
                                     let action_name = binding.action().name;
                                     let conflict = this.get_conflict(index);
+                                    let is_unbound_by_unbind = binding.is_unbound_by_unbind();
                                     let is_overridden = conflict.is_some_and(|conflict| {
                                         !conflict.is_user_keybind_conflict()
                                     });
+                                    let is_dimmed = is_overridden || is_unbound_by_unbind;
 
-                                    let icon = this.create_row_button(index, conflict, cx);
+                                    let icon = this.create_row_button(
+                                        index,
+                                        conflict,
+                                        is_unbound_by_unbind,
+                                        cx,
+                                    );
 
                                     let action = div()
                                         .id(("keymap action", index))
@@ -2079,7 +2155,7 @@ impl Render for KeymapEditor {
                                         .when(
                                             !context_menu_deployed
                                                 && this.show_hover_menus
-                                                && !is_overridden,
+                                                && !is_dimmed,
                                             |this| {
                                                 this.tooltip({
                                                     let action_name = binding.action().name;
@@ -2132,7 +2208,7 @@ impl Render for KeymapEditor {
                                                 .when(
                                                     is_local
                                                         && !context_menu_deployed
-                                                        && !is_overridden
+                                                        && !is_dimmed
                                                         && this.show_hover_menus,
                                                     |this| {
                                                         this.tooltip(Tooltip::element({
@@ -2167,6 +2243,10 @@ impl Render for KeymapEditor {
                     .map_row(cx.processor(
                         |this, (row_index, row): (usize, Stateful<Div>), _window, cx| {
                         let conflict = this.get_conflict(row_index);
+                            let candidate_id = this.matches.get(row_index).map(|candidate| candidate.candidate_id);
+                            let is_unbound_by_unbind = candidate_id
+                                .and_then(|candidate_id| this.keybindings.get(candidate_id))
+                                .is_some_and(ProcessedBinding::is_unbound_by_unbind);
                             let is_selected = this.selected_index == Some(row_index);
 
                             let row_id = row_group_id(row_index);
@@ -2175,38 +2255,43 @@ impl Render for KeymapEditor {
                                 .id(("keymap-row-wrapper", row_index))
                                 .child(
                                     row.id(row_id.clone())
-                                        .on_any_mouse_down(cx.listener(
-                                            move |this,
-                                                  mouse_down_event: &gpui::MouseDownEvent,
-                                                  window,
-                                                  cx| {
-                                                if mouse_down_event.button == MouseButton::Right {
-                                                    this.select_index(
-                                                        row_index, None, window, cx,
-                                                    );
-                                                    this.create_context_menu(
-                                                        mouse_down_event.position,
-                                                        window,
-                                                        cx,
-                                                    );
-                                                }
-                                            },
-                                        ))
-                                        .on_click(cx.listener(
-                                            move |this, event: &ClickEvent, window, cx| {
-                                                this.select_index(row_index, None, window, cx);
-                                                if event.click_count() == 2 {
-                                                    this.open_edit_keybinding_modal(
-                                                        false, window, cx,
-                                                    );
-                                                }
-                                            },
-                                        ))
+                                        .when(!is_unbound_by_unbind, |row| {
+                                            row.on_any_mouse_down(cx.listener(
+                                                move |this,
+                                                      mouse_down_event: &gpui::MouseDownEvent,
+                                                      window,
+                                                      cx| {
+                                                    if mouse_down_event.button == MouseButton::Right {
+                                                        this.select_index(
+                                                            row_index, None, window, cx,
+                                                        );
+                                                        this.create_context_menu(
+                                                            mouse_down_event.position,
+                                                            window,
+                                                            cx,
+                                                        );
+                                                    }
+                                                },
+                                            ))
+                                        })
+                                        .when(!is_unbound_by_unbind, |row| {
+                                            row.on_click(cx.listener(
+                                                move |this, event: &ClickEvent, window, cx| {
+                                                    this.select_index(row_index, None, window, cx);
+                                                    if event.click_count() == 2 {
+                                                        this.open_edit_keybinding_modal(
+                                                            false, window, cx,
+                                                        );
+                                                    }
+                                                },
+                                            ))
+                                        })
                                         .group(row_id)
                                         .when(
-                                            conflict.is_some_and(|conflict| {
-                                                !conflict.is_user_keybind_conflict()
-                                            }),
+                                            is_unbound_by_unbind
+                                                || conflict.is_some_and(|conflict| {
+                                                    !conflict.is_user_keybind_conflict()
+                                                }),
                                             |row| {
                                                 const OVERRIDDEN_OPACITY: f32 = 0.5;
                                                 row.opacity(OVERRIDDEN_OPACITY)
@@ -2214,7 +2299,8 @@ impl Render for KeymapEditor {
                                         )
                                         .when_some(
                                             conflict.filter(|conflict| {
-                                                !this.context_menu_deployed() &&
+                                                !is_unbound_by_unbind
+                                                    && !this.context_menu_deployed() &&
                                                 !conflict.is_user_keybind_conflict()
                                             }),
                                             |row, conflict| {
@@ -2231,8 +2317,12 @@ impl Render for KeymapEditor {
                                                     }.map(|source| format!("This keybinding is overridden by the '{}' binding from {}.", binding.action().humanized_name, source))
                                                 }).unwrap_or_else(|| "This binding is overridden.".to_string());
 
-                                                row.tooltip(Tooltip::text(context))},
-                                        ),
+                                                row.tooltip(Tooltip::text(context))
+                                            },
+                                        )
+                                        .when(is_unbound_by_unbind, |row| {
+                                            row.tooltip(Tooltip::text("This action is unbound"))
+                                        }),
                                 )
                                 .border_2()
                                 .when(
@@ -4061,5 +4151,26 @@ mod tests {
         assert!(cmp("a", "!(!a)"));
         assert!(cmp("!(!(!a))", "!a"));
         assert!(cmp("!(!(!(!a)))", "a"));
+    }
+
+    #[test]
+    fn binding_is_unbound_by_unbind_respects_precedence() {
+        let binding = gpui::KeyBinding::new("tab", zed_actions::OpenKeymap, None);
+        let unbind =
+            gpui::KeyBinding::new("tab", gpui::Unbind(binding.action().name().into()), None);
+
+        let unbind_then_binding = vec![&unbind, &binding];
+        assert!(!binding_is_unbound_by_unbind(
+            &binding,
+            1,
+            &unbind_then_binding,
+        ));
+
+        let binding_then_unbind = vec![&binding, &unbind];
+        assert!(binding_is_unbound_by_unbind(
+            &binding,
+            0,
+            &binding_then_unbind,
+        ));
     }
 }

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -357,7 +357,8 @@ impl LanguageModel for CopilotChatLanguageModel {
             | CompletionIntent::TerminalInlineAssist
             | CompletionIntent::GenerateGitCommitMessage => true,
 
-            CompletionIntent::ToolResults
+            CompletionIntent::Subagent
+            | CompletionIntent::ToolResults
             | CompletionIntent::ThreadSummarization
             | CompletionIntent::CreateFile
             | CompletionIntent::EditFile => false,
@@ -1072,6 +1073,7 @@ fn compute_thinking_budget(
 fn intent_to_chat_location(intent: Option<CompletionIntent>) -> ChatLocation {
     match intent {
         Some(CompletionIntent::UserPrompt) => ChatLocation::Agent,
+        Some(CompletionIntent::Subagent) => ChatLocation::Agent,
         Some(CompletionIntent::ToolResults) => ChatLocation::Agent,
         Some(CompletionIntent::ThreadSummarization) => ChatLocation::Panel,
         Some(CompletionIntent::ThreadContextSummarization) => ChatLocation::Panel,

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -331,15 +331,25 @@ pub fn into_deepseek(
     for message in request.messages {
         for content in message.content {
             match content {
-                MessageContent::Text(text) => messages.push(match message.role {
-                    Role::User => deepseek::RequestMessage::User { content: text },
-                    Role::Assistant => deepseek::RequestMessage::Assistant {
-                        content: Some(text),
-                        tool_calls: Vec::new(),
-                        reasoning_content: current_reasoning.take(),
-                    },
-                    Role::System => deepseek::RequestMessage::System { content: text },
-                }),
+                MessageContent::Text(text) => {
+                    let should_add = if message.role == Role::User {
+                        !text.trim().is_empty()
+                    } else {
+                        !text.is_empty()
+                    };
+
+                    if should_add {
+                        messages.push(match message.role {
+                            Role::User => deepseek::RequestMessage::User { content: text },
+                            Role::Assistant => deepseek::RequestMessage::Assistant {
+                                content: Some(text),
+                                tool_calls: Vec::new(),
+                                reasoning_content: current_reasoning.take(),
+                            },
+                            Role::System => deepseek::RequestMessage::System { content: text },
+                        });
+                    }
+                }
                 MessageContent::Thinking { text, .. } => {
                     // Accumulate reasoning content for next assistant message
                     current_reasoning.get_or_insert_default().push_str(&text);
@@ -445,7 +455,9 @@ impl DeepSeekEventMapper {
         };
 
         let mut events = Vec::new();
-        if let Some(content) = choice.delta.content.clone() {
+        if let Some(content) = choice.delta.content.clone()
+            && !content.is_empty()
+        {
             events.push(Ok(LanguageModelCompletionEvent::Text(content)));
         }
 

--- a/crates/language_tools/src/highlights_tree_view.rs
+++ b/crates/language_tools/src/highlights_tree_view.rs
@@ -209,20 +209,32 @@ impl HighlightsTreeView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(editor) = active_item
-            .filter(|item| item.item_id() != cx.entity_id())
-            .and_then(|item| item.downcast::<Editor>())
-        else {
-            self.clear(cx);
-            return;
+        let active_editor = match active_item {
+            Some(active_item) => {
+                if active_item.item_id() == cx.entity_id() {
+                    return;
+                } else {
+                    match active_item.downcast::<Editor>() {
+                        Some(active_editor) => active_editor,
+                        None => {
+                            self.clear(cx);
+                            return;
+                        }
+                    }
+                }
+            }
+            None => {
+                self.clear(cx);
+                return;
+            }
         };
 
         let is_different_editor = self
             .editor
             .as_ref()
-            .is_none_or(|state| state.editor != editor);
+            .is_none_or(|state| state.editor != active_editor);
         if is_different_editor {
-            self.set_editor(editor, window, cx);
+            self.set_editor(active_editor, window, cx);
         }
     }
 

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -298,7 +298,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         "CSS",
         "ERB",
         "HTML+ERB",
-        "HEEX",
+        "HEEx",
         "HTML",
         "JavaScript",
         "TypeScript",

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -437,7 +437,7 @@ impl LspInstaller for TyLspAdapter {
         async_fs::create_dir_all(&destination_path).await?;
 
         let server_path = match Self::GITHUB_ASSET_KIND {
-            AssetKind::TarGz | AssetKind::Gz => destination_path
+            AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Gz => destination_path
                 .join(Self::build_asset_name()?.0)
                 .join("ty"),
             AssetKind::Zip => destination_path.clone().join("ty.exe"),
@@ -527,7 +527,7 @@ impl LspInstaller for TyLspAdapter {
 
             let path = last.context("no cached binary")?;
             let path = match TyLspAdapter::GITHUB_ASSET_KIND {
-                AssetKind::TarGz | AssetKind::Gz => {
+                AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Gz => {
                     path.join(Self::build_asset_name()?.0).join("ty")
                 }
                 AssetKind::Zip => path.join("ty.exe"),
@@ -2508,7 +2508,7 @@ impl LspInstaller for RuffLspAdapter {
         } = latest_version;
         let destination_path = container_dir.join(format!("ruff-{name}"));
         let server_path = match Self::GITHUB_ASSET_KIND {
-            AssetKind::TarGz | AssetKind::Gz => destination_path
+            AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Gz => destination_path
                 .join(Self::build_asset_name()?.0)
                 .join("ruff"),
             AssetKind::Zip => destination_path.clone().join("ruff.exe"),
@@ -2598,7 +2598,7 @@ impl LspInstaller for RuffLspAdapter {
 
             let path = last.context("no cached binary")?;
             let path = match Self::GITHUB_ASSET_KIND {
-                AssetKind::TarGz | AssetKind::Gz => {
+                AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Gz => {
                     path.join(Self::build_asset_name()?.0).join("ruff")
                 }
                 AssetKind::Zip => path.join("ruff.exe"),

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -202,6 +202,7 @@ impl RustLspAdapter {
     async fn build_asset_name() -> String {
         let extension = match Self::GITHUB_ASSET_KIND {
             AssetKind::TarGz => "tar.gz",
+            AssetKind::TarBz2 => "tar.bz2",
             AssetKind::Gz => "gz",
             AssetKind::Zip => "zip",
         };
@@ -706,7 +707,7 @@ impl LspInstaller for RustLspAdapter {
         } = version;
         let destination_path = container_dir.join(format!("rust-analyzer-{name}"));
         let server_path = match Self::GITHUB_ASSET_KIND {
-            AssetKind::TarGz | AssetKind::Gz => destination_path.clone(), // Tar and gzip extract in place.
+            AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Gz => destination_path.clone(), // Tar and gzip extract in place.
             AssetKind::Zip => destination_path.clone().join("rust-analyzer.exe"), // zip contains a .exe
         };
 
@@ -1280,8 +1281,8 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
             None => return Ok(None),
         };
         let path = match RustLspAdapter::GITHUB_ASSET_KIND {
-            AssetKind::TarGz | AssetKind::Gz => path, // Tar and gzip extract in place.
-            AssetKind::Zip => path.join("rust-analyzer.exe"), // zip contains a .exe
+            AssetKind::TarGz | AssetKind::TarBz2 | AssetKind::Gz => path, // Tar and gzip extract in place.
+            AssetKind::Zip => path.join("rust-analyzer.exe"),             // zip contains a .exe
         };
 
         anyhow::Ok(Some(LanguageServerBinary {

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -197,11 +197,8 @@ impl LspAdapter for TailwindLspAdapter {
                 "typescriptreact".to_string(),
             ),
             (LanguageName::new_static("Svelte"), "svelte".to_string()),
-            (
-                LanguageName::new_static("Elixir"),
-                "phoenix-heex".to_string(),
-            ),
-            (LanguageName::new_static("HEEX"), "phoenix-heex".to_string()),
+            (LanguageName::new_static("Elixir"), "elixir".to_string()),
+            (LanguageName::new_static("HEEx"), "heex".to_string()),
             (LanguageName::new_static("ERB"), "erb".to_string()),
             (LanguageName::new_static("HTML+ERB"), "erb".to_string()),
             (LanguageName::new_static("PHP"), "php".to_string()),

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -310,3 +310,9 @@ pub(crate) mod m_2026_03_16 {
 
     pub(crate) use settings::SETTINGS_PATTERNS;
 }
+
+pub(crate) mod m_2026_03_23 {
+    mod keymap;
+
+    pub(crate) use keymap::KEYMAP_PATTERNS;
+}

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -304,3 +304,9 @@ pub(crate) mod m_2026_02_25 {
 
     pub(crate) use settings::migrate_builtin_agent_servers_to_registry;
 }
+
+pub(crate) mod m_2026_03_16 {
+    mod settings;
+
+    pub(crate) use settings::SETTINGS_PATTERNS;
+}

--- a/crates/migrator/src/migrations/m_2026_03_16/settings.rs
+++ b/crates/migrator/src/migrations/m_2026_03_16/settings.rs
@@ -1,0 +1,50 @@
+use std::ops::Range;
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+use crate::patterns::SETTINGS_NESTED_KEY_VALUE_PATTERN;
+
+pub const SETTINGS_PATTERNS: MigrationPatterns =
+    &[(SETTINGS_NESTED_KEY_VALUE_PATTERN, rename_heex_settings)];
+
+fn rename_heex_settings(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    if !is_heex_settings(contents, mat, query) {
+        return None;
+    }
+
+    let setting_name_ix = query.capture_index_for_name("setting_name")?;
+    let setting_name_range = mat
+        .nodes_for_capture_index(setting_name_ix)
+        .next()?
+        .byte_range();
+
+    Some((setting_name_range, "HEEx".to_string()))
+}
+
+fn is_heex_settings(contents: &str, mat: &QueryMatch, query: &Query) -> bool {
+    let parent_key_ix = match query.capture_index_for_name("parent_key") {
+        Some(ix) => ix,
+        None => return false,
+    };
+    let parent_range = match mat.nodes_for_capture_index(parent_key_ix).next() {
+        Some(node) => node.byte_range(),
+        None => return false,
+    };
+    if contents.get(parent_range) != Some("languages") {
+        return false;
+    }
+
+    let setting_name_ix = match query.capture_index_for_name("setting_name") {
+        Some(ix) => ix,
+        None => return false,
+    };
+    let setting_name_range = match mat.nodes_for_capture_index(setting_name_ix).next() {
+        Some(node) => node.byte_range(),
+        None => return false,
+    };
+    contents.get(setting_name_range) == Some("HEEX")
+}

--- a/crates/migrator/src/migrations/m_2026_03_23/keymap.rs
+++ b/crates/migrator/src/migrations/m_2026_03_23/keymap.rs
@@ -1,0 +1,47 @@
+use std::ops::Range;
+
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+
+pub const KEYMAP_PATTERNS: MigrationPatterns =
+    &[(crate::patterns::KEYMAP_CONTEXT_PATTERN, rename_context_key)];
+
+fn rename_context_key(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let context_predicate_ix = query.capture_index_for_name("context_predicate")?;
+    let context_predicate_range = mat
+        .nodes_for_capture_index(context_predicate_ix)
+        .next()?
+        .byte_range();
+    let old_predicate = contents.get(context_predicate_range.clone())?.to_string();
+    let mut new_predicate = old_predicate.clone();
+
+    const REPLACEMENTS: &[(&str, &str)] = &[
+        (
+            "edit_prediction_conflict && !showing_completions",
+            "(edit_prediction && in_leading_whitespace)",
+        ),
+        (
+            "edit_prediction_conflict && showing_completions",
+            "(edit_prediction && showing_completions)",
+        ),
+        (
+            "edit_prediction_conflict",
+            "(edit_prediction && (showing_completions || in_leading_whitespace))",
+        ),
+    ];
+
+    for (old, new) in REPLACEMENTS {
+        new_predicate = new_predicate.replace(old, new);
+    }
+
+    if new_predicate != old_predicate {
+        Some((context_predicate_range, new_predicate))
+    } else {
+        None
+    }
+}

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -143,6 +143,10 @@ pub fn migrate_keymap(text: &str) -> Result<Option<String>> {
             migrations::m_2025_12_08::KEYMAP_PATTERNS,
             &KEYMAP_QUERY_2025_12_08,
         ),
+        MigrationType::TreeSitter(
+            migrations::m_2026_03_23::KEYMAP_PATTERNS,
+            &KEYMAP_QUERY_2026_03_23,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -381,6 +385,10 @@ define_query!(
     SETTINGS_QUERY_2026_03_16,
     migrations::m_2026_03_16::SETTINGS_PATTERNS
 );
+define_query!(
+    KEYMAP_QUERY_2026_03_23,
+    migrations::m_2026_03_23::KEYMAP_PATTERNS
+);
 
 // custom query
 static EDIT_PREDICTION_SETTINGS_MIGRATION_QUERY: LazyLock<Query> = LazyLock::new(|| {
@@ -408,6 +416,7 @@ mod tests {
         }
     }
 
+    #[track_caller]
     fn assert_migrate_keymap(input: &str, output: Option<&str>) {
         let migrated = migrate_keymap(input).unwrap();
         pretty_assertions::assert_eq!(migrated.as_deref(), output);
@@ -426,7 +435,7 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_migrate_settings_with_migrations(
+    fn assert_migrate_with_migrations(
         migrations: &[MigrationType],
         input: &str,
         output: Option<&str>,
@@ -974,7 +983,7 @@ mod tests {
 
     #[test]
     fn test_mcp_settings_migration() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::TreeSitter(
                 migrations::m_2025_06_16::SETTINGS_PATTERNS,
                 &SETTINGS_QUERY_2025_06_16,
@@ -1163,7 +1172,7 @@ mod tests {
         }
     }
 }"#;
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::TreeSitter(
                 migrations::m_2025_06_16::SETTINGS_PATTERNS,
                 &SETTINGS_QUERY_2025_06_16,
@@ -1175,7 +1184,7 @@ mod tests {
 
     #[test]
     fn test_custom_agent_server_settings_migration() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::TreeSitter(
                 migrations::m_2025_11_20::SETTINGS_PATTERNS,
                 &SETTINGS_QUERY_2025_11_20,
@@ -1391,7 +1400,7 @@ mod tests {
 
     #[test]
     fn test_flatten_code_action_formatters_basic_array() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1425,7 +1434,7 @@ mod tests {
 
     #[test]
     fn test_flatten_code_action_formatters_basic_object() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1582,7 +1591,7 @@ mod tests {
     #[test]
     fn test_flatten_code_action_formatters_array_with_multiple_action_blocks_in_defaults_and_multiple_languages()
      {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1708,7 +1717,7 @@ mod tests {
 
     #[test]
     fn test_flatten_code_action_formatters_array_with_format_on_save_and_multiple_languages() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
@@ -1895,7 +1904,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_basic() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1915,7 +1924,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_array() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1940,7 +1949,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_on_off_unchanged() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1951,7 +1960,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -1965,7 +1974,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_in_languages() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -2003,7 +2012,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_formatter_migration_mixed_global_and_languages() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -2040,7 +2049,7 @@ mod tests {
 
     #[test]
     fn test_format_on_save_no_migration_when_no_format_on_save() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
@@ -2054,7 +2063,7 @@ mod tests {
 
     #[test]
     fn test_restore_code_actions_on_format() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2075,7 +2084,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2089,7 +2098,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2116,7 +2125,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2145,7 +2154,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
@@ -2163,7 +2172,7 @@ mod tests {
 
     #[test]
     fn test_make_file_finder_include_ignored_an_enum() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2171,7 +2180,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2191,7 +2200,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2211,7 +2220,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2232,7 +2241,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "linux" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2261,7 +2270,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
@@ -2296,7 +2305,7 @@ mod tests {
 
     #[test]
     fn test_make_relative_line_numbers_an_enum() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2304,7 +2313,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2320,7 +2329,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2337,7 +2346,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "macos" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2362,7 +2371,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
@@ -2439,7 +2448,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "linux" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_11_25::remove_context_server_source,
             )],
@@ -2477,7 +2486,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_11_25::remove_context_server_source,
             )],
@@ -2618,7 +2627,7 @@ mod tests {
     #[test]
     fn test_make_auto_indent_an_enum() {
         // Empty settings should not change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2627,7 +2636,7 @@ mod tests {
         );
 
         // true should become "syntax_aware"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2644,7 +2653,7 @@ mod tests {
         );
 
         // false should become "none"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2661,7 +2670,7 @@ mod tests {
         );
 
         // Already valid enum values should not change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2673,7 +2682,7 @@ mod tests {
         );
 
         // Should also work inside languages
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
@@ -2702,7 +2711,7 @@ mod tests {
 
     #[test]
     fn test_move_edit_prediction_provider_to_edit_predictions() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2710,7 +2719,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2734,7 +2743,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2762,7 +2771,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2789,7 +2798,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2806,7 +2815,7 @@ mod tests {
 
         // Non-object edit_predictions (e.g. true) should gracefully skip
         // instead of bail!-ing and aborting the entire migration chain.
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2830,7 +2839,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "macos" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2859,7 +2868,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2892,7 +2901,7 @@ mod tests {
         );
 
         // Combined: root + platform + profile should all be migrated simultaneously
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
@@ -2943,7 +2952,7 @@ mod tests {
 
     #[test]
     fn test_migrate_experimental_sweep_mercury() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -2951,7 +2960,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -2977,7 +2986,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3003,7 +3012,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3029,7 +3038,7 @@ mod tests {
             ),
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3044,7 +3053,7 @@ mod tests {
             None,
         );
 
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3062,7 +3071,7 @@ mod tests {
         );
 
         // Platform key: settings nested inside "linux" should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3093,7 +3102,7 @@ mod tests {
         );
 
         // Profile: settings nested inside profiles should be migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3128,7 +3137,7 @@ mod tests {
         );
 
         // Combined: root + platform + profile should all be migrated simultaneously
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
@@ -3186,7 +3195,7 @@ mod tests {
     #[test]
     fn test_migrate_always_allow_tool_actions_to_default() {
         // No agent settings - no change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3195,7 +3204,7 @@ mod tests {
         );
 
         // always_allow_tool_actions: true -> tool_permissions.default: "allow"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3222,7 +3231,7 @@ mod tests {
         );
 
         // always_allow_tool_actions: false -> just remove it
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3241,7 +3250,7 @@ mod tests {
         );
 
         // Preserve existing tool_permissions.tools when migrating
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3280,7 +3289,7 @@ mod tests {
         );
 
         // Don't override existing default (and migrate default_mode to default)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3310,7 +3319,7 @@ mod tests {
         );
 
         // Migrate existing default_mode to default (no always_allow_tool_actions)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3339,7 +3348,7 @@ mod tests {
         );
 
         // No migration needed if already using new format with "default"
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3357,7 +3366,7 @@ mod tests {
         );
 
         // Migrate default_mode to default in tool-specific rules
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3396,7 +3405,7 @@ mod tests {
         );
 
         // When tool_permissions is null, replace it so always_allow is preserved
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3424,7 +3433,7 @@ mod tests {
         );
 
         // Platform-specific agent migration
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3455,7 +3464,7 @@ mod tests {
         );
 
         // Channel-specific agent migration
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3496,7 +3505,7 @@ mod tests {
         );
 
         // Profile-level migration
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3534,7 +3543,7 @@ mod tests {
         );
 
         // Platform-specific agent with profiles
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3579,7 +3588,7 @@ mod tests {
         );
 
         // Root-level profile with always_allow_tool_actions
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3614,7 +3623,7 @@ mod tests {
         );
 
         // Root-level profile with default_mode
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3651,7 +3660,7 @@ mod tests {
         );
 
         // Root-level profile + root-level agent both migrated
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3697,7 +3706,7 @@ mod tests {
 
         // Non-boolean always_allow_tool_actions (string "true") is left in place
         // so the schema validator can report it, rather than silently dropping user data.
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3713,7 +3722,7 @@ mod tests {
         );
 
         // null always_allow_tool_actions is removed (treated as false)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3730,7 +3739,7 @@ mod tests {
 
         // Project-local settings (.zed/settings.json) with always_allow_tool_actions
         // These files have no platform/channel overrides or root-level profiles.
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3771,7 +3780,7 @@ mod tests {
         );
 
         // Project-local settings with only default_mode (no always_allow_tool_actions)
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3800,7 +3809,7 @@ mod tests {
         );
 
         // Project-local settings with no agent section at all - no change
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3815,7 +3824,7 @@ mod tests {
         );
 
         // Existing agent_servers are left untouched
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3858,7 +3867,7 @@ mod tests {
         );
 
         // Existing agent_servers are left untouched even with partial entries
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3895,7 +3904,7 @@ mod tests {
         );
 
         // always_allow_tool_actions: false leaves agent_servers untouched
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
@@ -3918,7 +3927,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_to_registry_simple() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -3958,7 +3967,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_empty_entries() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -3989,7 +3998,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_with_command() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4027,7 +4036,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_gemini_with_command() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4055,7 +4064,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_gemini_ignore_system_version_false() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4083,7 +4092,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_gemini_ignore_system_version_true() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4110,7 +4119,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_already_typed_unchanged() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4132,7 +4141,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_preserves_custom_entries() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4166,7 +4175,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_target_already_exists() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4196,7 +4205,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_no_agent_servers_key() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4211,7 +4220,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_all_fields() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4259,7 +4268,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_codex_with_command() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4291,7 +4300,7 @@ mod tests {
 
     #[test]
     fn test_migrate_builtin_agent_servers_mixed_migrated_and_not() {
-        assert_migrate_settings_with_migrations(
+        assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
             )],
@@ -4323,6 +4332,151 @@ mod tests {
         }
     }
 }"#,
+            ),
+        );
+    }
+
+    #[test]
+    fn test_migrate_edit_prediction_conflict_context() {
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction_conflict",
+                    "bindings": {
+                        "ctrl-enter": "editor::AcceptEditPrediction" // Example of a modified keybinding
+                    }
+                }
+            ]
+            "#.unindent(),
+            Some(
+                &r#"
+                [
+                    {
+                        "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
+                        "bindings": {
+                            "ctrl-enter": "editor::AcceptEditPrediction" // Example of a modified keybinding
+                        }
+                    }
+                ]
+                "#.unindent(),
+            ),
+        );
+
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction_conflict && !showing_completions",
+                    "bindings": {
+                        // Here we don't require a modifier unless there's a language server completion
+                        "tab": "editor::AcceptEditPrediction"
+                    }
+                }
+            ]
+            "#.unindent(),
+            Some(
+                &r#"
+                [
+                    {
+                        "context": "Editor && (edit_prediction && in_leading_whitespace)",
+                        "bindings": {
+                            // Here we don't require a modifier unless there's a language server completion
+                            "tab": "editor::AcceptEditPrediction"
+                        }
+                    }
+                ]
+                "#.unindent(),
+            ),
+        );
+
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction_conflict && showing_completions",
+                    "bindings": {
+                        "tab": "editor::AcceptEditPrediction"
+                    }
+                }
+            ]
+            "#
+            .unindent(),
+            Some(
+                &r#"
+                [
+                    {
+                        "context": "Editor && (edit_prediction && showing_completions)",
+                        "bindings": {
+                            "tab": "editor::AcceptEditPrediction"
+                        }
+                    }
+                ]
+                "#
+                .unindent(),
+            ),
+        );
+
+        assert_migrate_with_migrations(
+            &[MigrationType::TreeSitter(
+                migrations::m_2026_03_23::KEYMAP_PATTERNS,
+                &KEYMAP_QUERY_2026_03_23,
+            )],
+            &r#"
+            [
+                {
+                    "context": "Editor && edit_prediction",
+                    "bindings": {
+                        "tab": "editor::AcceptEditPrediction",
+                        // Optional: This makes the default `alt-l` binding do nothing.
+                        "alt-l": null
+                    }
+                },
+                {
+                    "context": "Editor && edit_prediction_conflict",
+                    "bindings": {
+                        "alt-tab": "editor::AcceptEditPrediction",
+                        // Optional: This makes the default `alt-l` binding do nothing.
+                        "alt-l": null
+                    }
+                },
+            ]
+            "#
+            .unindent(),
+            Some(
+                &r#"
+                    [
+                        {
+                            "context": "Editor && edit_prediction",
+                            "bindings": {
+                                "tab": "editor::AcceptEditPrediction",
+                                // Optional: This makes the default `alt-l` binding do nothing.
+                                "alt-l": null
+                            }
+                        },
+                        {
+                            "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
+                            "bindings": {
+                                "alt-tab": "editor::AcceptEditPrediction",
+                                // Optional: This makes the default `alt-l` binding do nothing.
+                                "alt-l": null
+                            }
+                        },
+                    ]
+                "#
+                .unindent(),
             ),
         );
     }

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -239,6 +239,10 @@ pub fn migrate_settings(text: &str) -> Result<Option<String>> {
         MigrationType::Json(migrations::m_2026_02_03::migrate_experimental_sweep_mercury),
         MigrationType::Json(migrations::m_2026_02_04::migrate_tool_permission_defaults),
         MigrationType::Json(migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry),
+        MigrationType::TreeSitter(
+            migrations::m_2026_03_16::SETTINGS_PATTERNS,
+            &SETTINGS_QUERY_2026_03_16,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -372,6 +376,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_12_15,
     migrations::m_2025_12_15::SETTINGS_PATTERNS
+);
+define_query!(
+    SETTINGS_QUERY_2026_03_16,
+    migrations::m_2026_03_16::SETTINGS_PATTERNS
 );
 
 // custom query

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1102,6 +1102,8 @@ impl ExternalAgentServer for LocalExtensionArchiveAgent {
                     AssetKind::Zip
                 } else if archive_url.ends_with(".tar.gz") || archive_url.ends_with(".tgz") {
                     AssetKind::TarGz
+                } else if archive_url.ends_with(".tar.bz2") || archive_url.ends_with(".tbz2") {
+                    AssetKind::TarBz2
                 } else {
                     anyhow::bail!("unsupported archive type in URL: {}", archive_url);
                 };
@@ -1288,6 +1290,8 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
                     AssetKind::Zip
                 } else if archive_url.ends_with(".tar.gz") || archive_url.ends_with(".tgz") {
                     AssetKind::TarGz
+                } else if archive_url.ends_with(".tar.bz2") || archive_url.ends_with(".tbz2") {
+                    AssetKind::TarBz2
                 } else {
                     anyhow::bail!("unsupported archive type in URL: {}", archive_url);
                 };

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -304,7 +304,7 @@ enum ProjectClientState {
     /// Multi-player mode but still a local project.
     Shared { remote_id: u64 },
     /// Multi-player mode but working on a remote project.
-    Remote {
+    Collab {
         sharing_has_stopped: bool,
         capability: Capability,
         remote_id: u64,
@@ -1813,7 +1813,7 @@ impl Project {
                 client_subscriptions: Default::default(),
                 _subscriptions: vec![cx.on_release(Self::release)],
                 collab_client: client.clone(),
-                client_state: ProjectClientState::Remote {
+                client_state: ProjectClientState::Collab {
                     sharing_has_stopped: false,
                     capability: Capability::ReadWrite,
                     remote_id,
@@ -1931,7 +1931,7 @@ impl Project {
             ProjectClientState::Shared { .. } => {
                 let _ = self.unshare_internal(cx);
             }
-            ProjectClientState::Remote { remote_id, .. } => {
+            ProjectClientState::Collab { remote_id, .. } => {
                 let _ = self.collab_client.send(proto::LeaveProject {
                     project_id: *remote_id,
                 });
@@ -2157,7 +2157,7 @@ impl Project {
         match self.client_state {
             ProjectClientState::Local => None,
             ProjectClientState::Shared { remote_id, .. }
-            | ProjectClientState::Remote { remote_id, .. } => Some(remote_id),
+            | ProjectClientState::Collab { remote_id, .. } => Some(remote_id),
         }
     }
 
@@ -2211,7 +2211,7 @@ impl Project {
     #[inline]
     pub fn replica_id(&self) -> ReplicaId {
         match self.client_state {
-            ProjectClientState::Remote { replica_id, .. } => replica_id,
+            ProjectClientState::Collab { replica_id, .. } => replica_id,
             _ => {
                 if self.remote_client.is_some() {
                     ReplicaId::REMOTE_SERVER
@@ -2725,7 +2725,7 @@ impl Project {
             } else {
                 Capability::ReadOnly
             };
-        if let ProjectClientState::Remote { capability, .. } = &mut self.client_state {
+        if let ProjectClientState::Collab { capability, .. } = &mut self.client_state {
             if *capability == new_capability {
                 return;
             }
@@ -2738,7 +2738,7 @@ impl Project {
     }
 
     fn disconnected_from_host_internal(&mut self, cx: &mut App) {
-        if let ProjectClientState::Remote {
+        if let ProjectClientState::Collab {
             sharing_has_stopped,
             ..
         } = &mut self.client_state
@@ -2765,7 +2765,7 @@ impl Project {
     #[inline]
     pub fn is_disconnected(&self, cx: &App) -> bool {
         match &self.client_state {
-            ProjectClientState::Remote {
+            ProjectClientState::Collab {
                 sharing_has_stopped,
                 ..
             } => *sharing_has_stopped,
@@ -2787,7 +2787,7 @@ impl Project {
     #[inline]
     pub fn capability(&self) -> Capability {
         match &self.client_state {
-            ProjectClientState::Remote { capability, .. } => *capability,
+            ProjectClientState::Collab { capability, .. } => *capability,
             ProjectClientState::Shared { .. } | ProjectClientState::Local => Capability::ReadWrite,
         }
     }
@@ -2803,7 +2803,7 @@ impl Project {
             ProjectClientState::Local | ProjectClientState::Shared { .. } => {
                 self.remote_client.is_none()
             }
-            ProjectClientState::Remote { .. } => false,
+            ProjectClientState::Collab { .. } => false,
         }
     }
 
@@ -2814,7 +2814,7 @@ impl Project {
             ProjectClientState::Local | ProjectClientState::Shared { .. } => {
                 self.remote_client.is_some()
             }
-            ProjectClientState::Remote { .. } => false,
+            ProjectClientState::Collab { .. } => false,
         }
     }
 
@@ -2823,7 +2823,7 @@ impl Project {
     pub fn is_via_collab(&self) -> bool {
         match &self.client_state {
             ProjectClientState::Local | ProjectClientState::Shared { .. } => false,
-            ProjectClientState::Remote { .. } => true,
+            ProjectClientState::Collab { .. } => true,
         }
     }
 
@@ -4496,7 +4496,7 @@ impl Project {
         match &self.client_state {
             ProjectClientState::Shared { .. } => true,
             ProjectClientState::Local => false,
-            ProjectClientState::Remote { .. } => true,
+            ProjectClientState::Collab { .. } => true,
         }
     }
 
@@ -5621,7 +5621,7 @@ impl Project {
 
     fn synchronize_remote_buffers(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
         let project_id = match self.client_state {
-            ProjectClientState::Remote {
+            ProjectClientState::Collab {
                 sharing_has_stopped,
                 remote_id,
                 ..

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -858,41 +858,32 @@ impl KeymapFile {
         tab_size: usize,
         keyboard_mapper: &dyn gpui::PlatformKeyboardMapper,
     ) -> Result<String> {
-        // When replacing a non-user binding's keystroke, we need to also suppress the old
-        // default so it doesn't continue showing under the old keystroke.
-        let mut old_keystroke_suppression: Option<(Option<String>, String)> = None;
+        // When replacing or removing a non-user binding, we may need to write an unbind entry
+        // to suppress the original default binding.
+        let mut suppression_unbind: Option<KeybindUpdateTarget<'_>> = None;
 
-        match operation {
+        match &operation {
             // if trying to replace a keybinding that is not user-defined, treat it as an add operation
             KeybindUpdateOperation::Replace {
                 target_keybind_source: target_source,
                 source,
                 target,
-            } if target_source != KeybindSource::User => {
+            } if *target_source != KeybindSource::User => {
                 if target.keystrokes_unparsed() != source.keystrokes_unparsed() {
-                    old_keystroke_suppression = Some((
-                        target.context.map(String::from),
-                        target.keystrokes_unparsed(),
-                    ));
+                    suppression_unbind = Some(target.clone());
                 }
                 operation = KeybindUpdateOperation::Add {
-                    source,
-                    from: Some(target),
+                    source: source.clone(),
+                    from: Some(target.clone()),
                 };
             }
-            // if trying to remove a keybinding that is not user-defined, treat it as creating a binding
-            // that binds it to `zed::NoAction`
+            // if trying to remove a keybinding that is not user-defined, treat it as creating an
+            // unbind entry for the removed action
             KeybindUpdateOperation::Remove {
                 target,
                 target_keybind_source,
-            } if target_keybind_source != KeybindSource::User => {
-                let mut source = target.clone();
-                source.action_name = gpui::NoAction.name();
-                source.action_arguments.take();
-                operation = KeybindUpdateOperation::Add {
-                    source,
-                    from: Some(target),
-                };
+            } if *target_keybind_source != KeybindSource::User => {
+                suppression_unbind = Some(target.clone());
             }
             _ => {}
         }
@@ -901,34 +892,41 @@ impl KeymapFile {
         // We don't want to modify the file if it's invalid.
         let keymap = Self::parse(&keymap_contents).context("Failed to parse keymap")?;
 
-        if let KeybindUpdateOperation::Remove { target, .. } = operation {
-            let target_action_value = target
-                .action_value()
-                .context("Failed to generate target action JSON value")?;
-            let Some((index, keystrokes_str)) =
-                find_binding(&keymap, &target, &target_action_value, keyboard_mapper)
-            else {
-                anyhow::bail!("Failed to find keybinding to remove");
-            };
-            let is_only_binding = keymap.0[index]
-                .bindings
-                .as_ref()
-                .is_none_or(|bindings| bindings.len() == 1);
-            let key_path: &[&str] = if is_only_binding {
-                &[]
-            } else {
-                &["bindings", keystrokes_str]
-            };
-            let (replace_range, replace_value) = replace_top_level_array_value_in_json_text(
-                &keymap_contents,
-                key_path,
-                None,
-                None,
-                index,
-                tab_size,
-            );
-            keymap_contents.replace_range(replace_range, &replace_value);
-            return Ok(keymap_contents);
+        if let KeybindUpdateOperation::Remove {
+            target,
+            target_keybind_source,
+        } = &operation
+        {
+            if *target_keybind_source == KeybindSource::User {
+                let target_action_value = target
+                    .action_value()
+                    .context("Failed to generate target action JSON value")?;
+                let Some(binding_location) =
+                    find_binding(&keymap, target, &target_action_value, keyboard_mapper)
+                else {
+                    anyhow::bail!("Failed to find keybinding to remove");
+                };
+                let is_only_binding = binding_location.is_only_entry_in_section(&keymap);
+                let key_path: &[&str] = if is_only_binding {
+                    &[]
+                } else {
+                    &[
+                        binding_location.kind.key_path(),
+                        binding_location.keystrokes_str,
+                    ]
+                };
+                let (replace_range, replace_value) = replace_top_level_array_value_in_json_text(
+                    &keymap_contents,
+                    key_path,
+                    None,
+                    None,
+                    binding_location.index,
+                    tab_size,
+                );
+                keymap_contents.replace_range(replace_range, &replace_value);
+
+                return Ok(keymap_contents);
+            }
         }
 
         if let KeybindUpdateOperation::Replace { source, target, .. } = operation {
@@ -939,7 +937,7 @@ impl KeymapFile {
                 .action_value()
                 .context("Failed to generate source action JSON value")?;
 
-            if let Some((index, keystrokes_str)) =
+            if let Some(binding_location) =
                 find_binding(&keymap, &target, &target_action_value, keyboard_mapper)
             {
                 if target.context == source.context {
@@ -948,30 +946,32 @@ impl KeymapFile {
 
                     let (replace_range, replace_value) = replace_top_level_array_value_in_json_text(
                         &keymap_contents,
-                        &["bindings", keystrokes_str],
+                        &[
+                            binding_location.kind.key_path(),
+                            binding_location.keystrokes_str,
+                        ],
                         Some(&source_action_value),
                         Some(&source.keystrokes_unparsed()),
-                        index,
+                        binding_location.index,
                         tab_size,
                     );
                     keymap_contents.replace_range(replace_range, &replace_value);
 
                     return Ok(keymap_contents);
-                } else if keymap.0[index]
-                    .bindings
-                    .as_ref()
-                    .is_none_or(|bindings| bindings.len() == 1)
-                {
+                } else if binding_location.is_only_entry_in_section(&keymap) {
                     // if we are replacing the only binding in the section,
                     // just update the section in place, updating the context
                     // and the binding
 
                     let (replace_range, replace_value) = replace_top_level_array_value_in_json_text(
                         &keymap_contents,
-                        &["bindings", keystrokes_str],
+                        &[
+                            binding_location.kind.key_path(),
+                            binding_location.keystrokes_str,
+                        ],
                         Some(&source_action_value),
                         Some(&source.keystrokes_unparsed()),
-                        index,
+                        binding_location.index,
                         tab_size,
                     );
                     keymap_contents.replace_range(replace_range, &replace_value);
@@ -981,7 +981,7 @@ impl KeymapFile {
                         &["context"],
                         source.context.map(Into::into).as_ref(),
                         None,
-                        index,
+                        binding_location.index,
                         tab_size,
                     );
                     keymap_contents.replace_range(replace_range, &replace_value);
@@ -994,10 +994,13 @@ impl KeymapFile {
 
                     let (replace_range, replace_value) = replace_top_level_array_value_in_json_text(
                         &keymap_contents,
-                        &["bindings", keystrokes_str],
+                        &[
+                            binding_location.kind.key_path(),
+                            binding_location.keystrokes_str,
+                        ],
                         None,
                         None,
-                        index,
+                        binding_location.index,
                         tab_size,
                     );
                     keymap_contents.replace_range(replace_range, &replace_value);
@@ -1032,8 +1035,9 @@ impl KeymapFile {
             }
             let use_key_equivalents = from.and_then(|from| {
                 let action_value = from.action_value().context("Failed to serialize action value. `use_key_equivalents` on new keybinding may be incorrect.").log_err()?;
-                let (index, _) = find_binding(&keymap, &from, &action_value, keyboard_mapper)?;
-                Some(keymap.0[index].use_key_equivalents)
+                let binding_location =
+                    find_binding(&keymap, &from, &action_value, keyboard_mapper)?;
+                Some(keymap.0[binding_location.index].use_key_equivalents)
             }).unwrap_or(false);
             if use_key_equivalents {
                 value.insert("use_key_equivalents".to_string(), true.into());
@@ -1054,18 +1058,18 @@ impl KeymapFile {
             keymap_contents.replace_range(replace_range, &replace_value);
         }
 
-        // If we converted a Replace to Add because the target was a non-user binding,
-        // and the keystroke changed, suppress the old default keystroke with a NoAction
-        // binding so it doesn't continue appearing under the old keystroke.
-        if let Some((context, old_keystrokes)) = old_keystroke_suppression {
+        if let Some(suppression_unbind) = suppression_unbind {
             let mut value = serde_json::Map::with_capacity(2);
-            if let Some(context) = context {
+            if let Some(context) = suppression_unbind.context {
                 value.insert("context".to_string(), context.into());
             }
-            value.insert("bindings".to_string(), {
-                let mut bindings = serde_json::Map::new();
-                bindings.insert(old_keystrokes, Value::Null);
-                bindings.into()
+            value.insert("unbind".to_string(), {
+                let mut unbind = serde_json::Map::new();
+                unbind.insert(
+                    suppression_unbind.keystrokes_unparsed(),
+                    suppression_unbind.action_value()?,
+                );
+                unbind.into()
             });
             let (replace_range, replace_value) = append_top_level_array_value_in_json_text(
                 &keymap_contents,
@@ -1082,7 +1086,7 @@ impl KeymapFile {
             target: &KeybindUpdateTarget<'a>,
             target_action_value: &Value,
             keyboard_mapper: &dyn gpui::PlatformKeyboardMapper,
-        ) -> Option<(usize, &'b str)> {
+        ) -> Option<BindingLocation<'b>> {
             let target_context_parsed =
                 KeyBindingContextPredicate::parse(target.context.unwrap_or("")).ok();
             for (index, section) in keymap.sections().enumerate() {
@@ -1091,39 +1095,107 @@ impl KeymapFile {
                 if section_context_parsed != target_context_parsed {
                     continue;
                 }
-                let Some(bindings) = &section.bindings else {
-                    continue;
-                };
-                for (keystrokes_str, action) in bindings {
-                    let Ok(keystrokes) = keystrokes_str
-                        .split_whitespace()
-                        .map(|source| {
-                            let keystroke = Keystroke::parse(source)?;
-                            Ok(KeybindingKeystroke::new_with_mapper(
-                                keystroke,
-                                false,
-                                keyboard_mapper,
-                            ))
-                        })
-                        .collect::<Result<Vec<_>, InvalidKeystrokeError>>()
-                    else {
-                        continue;
-                    };
-                    if keystrokes.len() != target.keystrokes.len()
-                        || !keystrokes
-                            .iter()
-                            .zip(target.keystrokes)
-                            .all(|(a, b)| a.inner().should_match(b))
-                    {
-                        continue;
-                    }
-                    if &action.0 != target_action_value {
-                        continue;
-                    }
-                    return Some((index, keystrokes_str));
+
+                if let Some(binding_location) = find_binding_in_entries(
+                    section.bindings.as_ref(),
+                    BindingKind::Binding,
+                    index,
+                    target,
+                    target_action_value,
+                    keyboard_mapper,
+                    |action| &action.0,
+                ) {
+                    return Some(binding_location);
+                }
+
+                if let Some(binding_location) = find_binding_in_entries(
+                    section.unbind.as_ref(),
+                    BindingKind::Unbind,
+                    index,
+                    target,
+                    target_action_value,
+                    keyboard_mapper,
+                    |action| &action.0,
+                ) {
+                    return Some(binding_location);
                 }
             }
             None
+        }
+
+        fn find_binding_in_entries<'a, 'b, T>(
+            entries: Option<&'b IndexMap<String, T>>,
+            kind: BindingKind,
+            index: usize,
+            target: &KeybindUpdateTarget<'a>,
+            target_action_value: &Value,
+            keyboard_mapper: &dyn gpui::PlatformKeyboardMapper,
+            action_value: impl Fn(&T) -> &Value,
+        ) -> Option<BindingLocation<'b>> {
+            let entries = entries?;
+            for (keystrokes_str, action) in entries {
+                let Ok(keystrokes) = keystrokes_str
+                    .split_whitespace()
+                    .map(|source| {
+                        let keystroke = Keystroke::parse(source)?;
+                        Ok(KeybindingKeystroke::new_with_mapper(
+                            keystroke,
+                            false,
+                            keyboard_mapper,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, InvalidKeystrokeError>>()
+                else {
+                    continue;
+                };
+                if keystrokes.len() != target.keystrokes.len()
+                    || !keystrokes
+                        .iter()
+                        .zip(target.keystrokes)
+                        .all(|(a, b)| a.inner().should_match(b))
+                {
+                    continue;
+                }
+                if action_value(action) != target_action_value {
+                    continue;
+                }
+                return Some(BindingLocation {
+                    index,
+                    kind,
+                    keystrokes_str,
+                });
+            }
+            None
+        }
+
+        #[derive(Copy, Clone)]
+        enum BindingKind {
+            Binding,
+            Unbind,
+        }
+
+        impl BindingKind {
+            fn key_path(self) -> &'static str {
+                match self {
+                    Self::Binding => "bindings",
+                    Self::Unbind => "unbind",
+                }
+            }
+        }
+
+        struct BindingLocation<'a> {
+            index: usize,
+            kind: BindingKind,
+            keystrokes_str: &'a str,
+        }
+
+        impl BindingLocation<'_> {
+            fn is_only_entry_in_section(&self, keymap: &KeymapFile) -> bool {
+                let section = &keymap.0[self.index];
+                let binding_count = section.bindings.as_ref().map_or(0, IndexMap::len);
+                let unbind_count = section.unbind.as_ref().map_or(0, IndexMap::len);
+                binding_count + unbind_count == 1
+            }
         }
     }
 }
@@ -1858,8 +1930,8 @@ mod tests {
                     }
                 },
                 {
-                    "bindings": {
-                        "ctrl-a": null
+                    "unbind": {
+                        "ctrl-a": "zed::SomeAction"
                     }
                 }
             ]"#
@@ -1867,7 +1939,7 @@ mod tests {
         );
 
         // Replacing a non-user binding without changing the keystroke should
-        // not produce a NoAction suppression entry.
+        // not produce an unbind suppression entry.
         check_keymap_update(
             r#"[
                 {
@@ -1949,8 +2021,8 @@ mod tests {
                 },
                 {
                     "context": "SomeContext",
-                    "bindings": {
-                        "ctrl-a": null
+                    "unbind": {
+                        "ctrl-a": "zed::SomeAction"
                     }
                 }
             ]"#
@@ -2447,8 +2519,11 @@ mod tests {
                 },
                 {
                     "context": "SomeContext",
-                    "bindings": {
-                        "a": null
+                    "unbind": {
+                        "a": [
+                            "foo::baz",
+                            true
+                        ]
                     }
                 }
             ]"#

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -4,7 +4,7 @@ use fs::Fs;
 use gpui::{
     Action, ActionBuildError, App, InvalidKeystrokeError, KEYSTROKE_PARSE_EXPECTED_MESSAGE,
     KeyBinding, KeyBindingContextPredicate, KeyBindingMetaIndex, KeybindingKeystroke, Keystroke,
-    NoAction, SharedString, generate_list_of_all_registered_actions, register_action,
+    NoAction, SharedString, Unbind, generate_list_of_all_registered_actions, register_action,
 };
 use schemars::{JsonSchema, json_schema};
 use serde::Deserialize;
@@ -73,6 +73,10 @@ pub struct KeymapSection {
     /// on macOS. See the documentation for more details.
     #[serde(default)]
     use_key_equivalents: bool,
+    /// This keymap section's unbindings, as a JSON object mapping keystrokes to actions. These are
+    /// parsed before `bindings`, so bindings later in the same section can still take precedence.
+    #[serde(default)]
+    unbind: Option<IndexMap<String, UnbindTargetAction>>,
     /// This keymap section's bindings, as a JSON object mapping keystrokes to actions. The
     /// keystrokes key is a string representing a sequence of keystrokes to type, where the
     /// keystrokes are separated by whitespace. Each keystroke is a sequence of modifiers (`ctrl`,
@@ -130,6 +134,20 @@ impl JsonSchema for KeymapAction {
 
     /// This schema will be replaced with the full action schema in
     /// `KeymapFile::generate_json_schema`.
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!(true)
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(transparent)]
+pub struct UnbindTargetAction(Value);
+
+impl JsonSchema for UnbindTargetAction {
+    fn schema_name() -> Cow<'static, str> {
+        "UnbindTargetAction".into()
+    }
+
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         json_schema!(true)
     }
@@ -231,6 +249,7 @@ impl KeymapFile {
         for KeymapSection {
             context,
             use_key_equivalents,
+            unbind,
             bindings,
             unrecognized_fields,
         } in keymap_file.0.iter()
@@ -244,7 +263,7 @@ impl KeymapFile {
                         // Leading space is to separate from the message indicating which section
                         // the error occurred in.
                         errors.push((
-                            context,
+                            context.clone(),
                             format!(" Parse error in section `context` field: {}", err),
                         ));
                         continue;
@@ -261,6 +280,38 @@ impl KeymapFile {
                     MarkdownInlineCode(&format!("{:?}", unrecognized_fields.keys()))
                 )
                 .unwrap();
+            }
+
+            if let Some(unbind) = unbind {
+                for (keystrokes, action) in unbind {
+                    let result = Self::load_unbinding(
+                        keystrokes,
+                        action,
+                        context_predicate.clone(),
+                        *use_key_equivalents,
+                        cx,
+                    );
+                    match result {
+                        Ok(key_binding) => {
+                            key_bindings.push(key_binding);
+                        }
+                        Err(err) => {
+                            let mut lines = err.lines();
+                            let mut indented_err = lines.next().unwrap().to_string();
+                            for line in lines {
+                                indented_err.push_str("  ");
+                                indented_err.push_str(line);
+                                indented_err.push_str("\n");
+                            }
+                            write!(
+                                section_errors,
+                                "\n\n- In unbind {}, {indented_err}",
+                                MarkdownInlineCode(&format!("\"{}\"", keystrokes))
+                            )
+                            .unwrap();
+                        }
+                    }
+                }
             }
 
             if let Some(bindings) = bindings {
@@ -296,7 +347,7 @@ impl KeymapFile {
             }
 
             if !section_errors.is_empty() {
-                errors.push((context, section_errors))
+                errors.push((context.clone(), section_errors))
             }
         }
 
@@ -332,7 +383,17 @@ impl KeymapFile {
         use_key_equivalents: bool,
         cx: &App,
     ) -> std::result::Result<KeyBinding, String> {
-        let (action, action_input_string) = Self::build_keymap_action(action, cx)?;
+        Self::load_keybinding_action_value(keystrokes, &action.0, context, use_key_equivalents, cx)
+    }
+
+    fn load_keybinding_action_value(
+        keystrokes: &str,
+        action: &Value,
+        context: Option<Rc<KeyBindingContextPredicate>>,
+        use_key_equivalents: bool,
+        cx: &App,
+    ) -> std::result::Result<KeyBinding, String> {
+        let (action, action_input_string) = Self::build_keymap_action_value(action, cx)?;
 
         let key_binding = match KeyBinding::load(
             keystrokes,
@@ -362,23 +423,70 @@ impl KeymapFile {
         }
     }
 
+    fn load_unbinding(
+        keystrokes: &str,
+        action: &UnbindTargetAction,
+        context: Option<Rc<KeyBindingContextPredicate>>,
+        use_key_equivalents: bool,
+        cx: &App,
+    ) -> std::result::Result<KeyBinding, String> {
+        let key_binding = Self::load_keybinding_action_value(
+            keystrokes,
+            &action.0,
+            context,
+            use_key_equivalents,
+            cx,
+        )?;
+
+        if key_binding.action().partial_eq(&NoAction) {
+            return Err("expected action name string or [name, input] array.".to_string());
+        }
+
+        if key_binding.action().name() == Unbind::name_for_type() {
+            return Err(format!(
+                "can't use {} as an unbind target.",
+                MarkdownInlineCode(&format!("\"{}\"", Unbind::name_for_type()))
+            ));
+        }
+
+        KeyBinding::load(
+            keystrokes,
+            Box::new(Unbind(key_binding.action().name().into())),
+            key_binding.predicate(),
+            use_key_equivalents,
+            key_binding.action_input(),
+            cx.keyboard_mapper().as_ref(),
+        )
+        .map_err(|InvalidKeystrokeError { keystroke }| {
+            format!(
+                "invalid keystroke {}. {}",
+                MarkdownInlineCode(&format!("\"{}\"", &keystroke)),
+                KEYSTROKE_PARSE_EXPECTED_MESSAGE
+            )
+        })
+    }
+
     pub fn parse_action(
         action: &KeymapAction,
     ) -> Result<Option<(&String, Option<&Value>)>, String> {
-        let name_and_input = match &action.0 {
+        Self::parse_action_value(&action.0)
+    }
+
+    fn parse_action_value(action: &Value) -> Result<Option<(&String, Option<&Value>)>, String> {
+        let name_and_input = match action {
             Value::Array(items) => {
                 if items.len() != 2 {
                     return Err(format!(
                         "expected two-element array of `[name, input]`. \
                         Instead found {}.",
-                        MarkdownInlineCode(&action.0.to_string())
+                        MarkdownInlineCode(&action.to_string())
                     ));
                 }
                 let serde_json::Value::String(ref name) = items[0] else {
                     return Err(format!(
                         "expected two-element array of `[name, input]`, \
                         but the first element is not a string in {}.",
-                        MarkdownInlineCode(&action.0.to_string())
+                        MarkdownInlineCode(&action.to_string())
                     ));
                 };
                 Some((name, Some(&items[1])))
@@ -389,7 +497,7 @@ impl KeymapFile {
                 return Err(format!(
                     "expected two-element array of `[name, input]`. \
                     Instead found {}.",
-                    MarkdownInlineCode(&action.0.to_string())
+                    MarkdownInlineCode(&action.to_string())
                 ));
             }
         };
@@ -400,7 +508,14 @@ impl KeymapFile {
         action: &KeymapAction,
         cx: &App,
     ) -> std::result::Result<(Box<dyn Action>, Option<String>), String> {
-        let (build_result, action_input_string) = match Self::parse_action(action)? {
+        Self::build_keymap_action_value(&action.0, cx)
+    }
+
+    fn build_keymap_action_value(
+        action: &Value,
+        cx: &App,
+    ) -> std::result::Result<(Box<dyn Action>, Option<String>), String> {
+        let (build_result, action_input_string) = match Self::parse_action_value(action)? {
             Some((name, action_input)) if name.as_str() == ActionSequence::name_for_type() => {
                 match action_input {
                     Some(action_input) => (
@@ -583,15 +698,24 @@ impl KeymapFile {
             "minItems": 2,
             "maxItems": 2
         });
-        let mut keymap_action_alternatives = vec![empty_action_name, empty_action_name_with_input];
+        let mut keymap_action_alternatives = vec![
+            empty_action_name.clone(),
+            empty_action_name_with_input.clone(),
+        ];
+        let mut unbind_target_action_alternatives =
+            vec![empty_action_name, empty_action_name_with_input];
 
         let mut empty_schema_action_names = vec![];
+        let mut empty_schema_unbind_target_action_names = vec![];
         for (name, action_schema) in action_schemas.into_iter() {
             let deprecation = if name == NoAction.name() {
                 Some("null")
             } else {
                 deprecations.get(name).copied()
             };
+
+            let include_in_unbind_target_schema =
+                name != NoAction.name() && name != Unbind::name_for_type();
 
             // Add an alternative for plain action names.
             let mut plain_action = json_schema!({
@@ -607,7 +731,10 @@ impl KeymapFile {
             if let Some(description) = &description {
                 add_description(&mut plain_action, description);
             }
-            keymap_action_alternatives.push(plain_action);
+            keymap_action_alternatives.push(plain_action.clone());
+            if include_in_unbind_target_schema {
+                unbind_target_action_alternatives.push(plain_action);
+            }
 
             // Add an alternative for actions with data specified as a [name, data] array.
             //
@@ -633,9 +760,15 @@ impl KeymapFile {
                     "minItems": 2,
                     "maxItems": 2
                 });
-                keymap_action_alternatives.push(action_with_input);
+                keymap_action_alternatives.push(action_with_input.clone());
+                if include_in_unbind_target_schema {
+                    unbind_target_action_alternatives.push(action_with_input);
+                }
             } else {
                 empty_schema_action_names.push(name);
+                if include_in_unbind_target_schema {
+                    empty_schema_unbind_target_action_names.push(name);
+                }
             }
         }
 
@@ -659,18 +792,42 @@ impl KeymapFile {
             keymap_action_alternatives.push(actions_with_empty_input);
         }
 
+        if !empty_schema_unbind_target_action_names.is_empty() {
+            let action_names = json_schema!({ "enum": empty_schema_unbind_target_action_names });
+            let no_properties_allowed = json_schema!({
+                "type": "object",
+                "additionalProperties": false
+            });
+            let mut actions_with_empty_input = json_schema!({
+                "type": "array",
+                "items": [action_names, no_properties_allowed],
+                "minItems": 2,
+                "maxItems": 2
+            });
+            add_deprecation(
+                &mut actions_with_empty_input,
+                "This action does not take input - just the action name string should be used."
+                    .to_string(),
+            );
+            unbind_target_action_alternatives.push(actions_with_empty_input);
+        }
+
         // Placing null first causes json-language-server to default assuming actions should be
         // null, so place it last.
         keymap_action_alternatives.push(json_schema!({
             "type": "null"
         }));
 
-        // The `KeymapSection` schema will reference the `KeymapAction` schema by name, so setting
-        // the definition of `KeymapAction` results in the full action schema being used.
         generator.definitions_mut().insert(
             KeymapAction::schema_name().to_string(),
             json!({
                 "anyOf": keymap_action_alternatives
+            }),
+        );
+        generator.definitions_mut().insert(
+            UnbindTargetAction::schema_name().to_string(),
+            json!({
+                "anyOf": unbind_target_action_alternatives
             }),
         );
 
@@ -1260,13 +1417,16 @@ impl Action for ActionSequence {
 
 #[cfg(test)]
 mod tests {
-    use gpui::{DummyKeyboardMapper, KeybindingKeystroke, Keystroke};
+    use gpui::{Action, App, DummyKeyboardMapper, KeybindingKeystroke, Keystroke, Unbind};
+    use serde_json::Value;
     use unindent::Unindent;
 
     use crate::{
         KeybindSource, KeymapFile,
         keymap_file::{KeybindUpdateOperation, KeybindUpdateTarget},
     };
+
+    gpui::actions!(test_keymap_file, [StringAction, InputAction]);
 
     #[test]
     fn can_deserialize_keymap_with_trailing_comma() {
@@ -1281,6 +1441,191 @@ mod tests {
                   "
         };
         KeymapFile::parse(json).unwrap();
+    }
+
+    #[gpui::test]
+    fn keymap_section_unbinds_are_loaded_before_bindings(cx: &mut App) {
+        let key_bindings = match KeymapFile::load(
+            indoc::indoc! {r#"
+                [
+                    {
+                        "unbind": {
+                            "ctrl-a": "test_keymap_file::StringAction",
+                            "ctrl-b": ["test_keymap_file::InputAction", {}]
+                        },
+                        "bindings": {
+                            "ctrl-c": "test_keymap_file::StringAction"
+                        }
+                    }
+                ]
+            "#},
+            cx,
+        ) {
+            crate::keymap_file::KeymapFileLoadResult::Success { key_bindings } => key_bindings,
+            crate::keymap_file::KeymapFileLoadResult::SomeFailedToLoad {
+                error_message, ..
+            } => {
+                panic!("{error_message}");
+            }
+            crate::keymap_file::KeymapFileLoadResult::JsonParseFailure { error } => {
+                panic!("JSON parse error: {error}");
+            }
+        };
+
+        assert_eq!(key_bindings.len(), 3);
+        assert!(
+            key_bindings[0]
+                .action()
+                .partial_eq(&Unbind("test_keymap_file::StringAction".into()))
+        );
+        assert_eq!(key_bindings[0].action_input(), None);
+        assert!(
+            key_bindings[1]
+                .action()
+                .partial_eq(&Unbind("test_keymap_file::InputAction".into()))
+        );
+        assert_eq!(
+            key_bindings[1]
+                .action_input()
+                .as_ref()
+                .map(ToString::to_string),
+            Some("{}".to_string())
+        );
+        assert_eq!(
+            key_bindings[2].action().name(),
+            "test_keymap_file::StringAction"
+        );
+    }
+
+    #[gpui::test]
+    fn keymap_unbind_loads_valid_target_action_with_input(cx: &mut App) {
+        let key_bindings = match KeymapFile::load(
+            indoc::indoc! {r#"
+                [
+                    {
+                        "unbind": {
+                            "ctrl-a": ["test_keymap_file::InputAction", {}]
+                        }
+                    }
+                ]
+            "#},
+            cx,
+        ) {
+            crate::keymap_file::KeymapFileLoadResult::Success { key_bindings } => key_bindings,
+            other => panic!("expected Success, got {other:?}"),
+        };
+
+        assert_eq!(key_bindings.len(), 1);
+        assert!(
+            key_bindings[0]
+                .action()
+                .partial_eq(&Unbind("test_keymap_file::InputAction".into()))
+        );
+        assert_eq!(
+            key_bindings[0]
+                .action_input()
+                .as_ref()
+                .map(ToString::to_string),
+            Some("{}".to_string())
+        );
+    }
+
+    #[gpui::test]
+    fn keymap_unbind_rejects_null(cx: &mut App) {
+        match KeymapFile::load(
+            indoc::indoc! {r#"
+                [
+                    {
+                        "unbind": {
+                            "ctrl-a": null
+                        }
+                    }
+                ]
+            "#},
+            cx,
+        ) {
+            crate::keymap_file::KeymapFileLoadResult::SomeFailedToLoad {
+                key_bindings,
+                error_message,
+            } => {
+                assert!(key_bindings.is_empty());
+                assert!(
+                    error_message
+                        .0
+                        .contains("expected action name string or [name, input] array.")
+                );
+            }
+            other => panic!("expected SomeFailedToLoad, got {other:?}"),
+        }
+    }
+
+    #[gpui::test]
+    fn keymap_unbind_rejects_unbind_action(cx: &mut App) {
+        match KeymapFile::load(
+            indoc::indoc! {r#"
+                [
+                    {
+                        "unbind": {
+                            "ctrl-a": ["zed::Unbind", "test_keymap_file::StringAction"]
+                        }
+                    }
+                ]
+            "#},
+            cx,
+        ) {
+            crate::keymap_file::KeymapFileLoadResult::SomeFailedToLoad {
+                key_bindings,
+                error_message,
+            } => {
+                assert!(key_bindings.is_empty());
+                assert!(
+                    error_message
+                        .0
+                        .contains("can't use `\"zed::Unbind\"` as an unbind target.")
+                );
+            }
+            other => panic!("expected SomeFailedToLoad, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn keymap_schema_for_unbind_excludes_null_and_unbind_action() {
+        fn schema_allows(schema: &Value, expected: &Value) -> bool {
+            match schema {
+                Value::Object(object) => {
+                    if object.get("const") == Some(expected) {
+                        return true;
+                    }
+                    if object.get("type") == Some(&Value::String("null".to_string()))
+                        && expected == &Value::Null
+                    {
+                        return true;
+                    }
+                    object.values().any(|value| schema_allows(value, expected))
+                }
+                Value::Array(items) => items.iter().any(|value| schema_allows(value, expected)),
+                _ => false,
+            }
+        }
+
+        let schema = KeymapFile::generate_json_schema_from_inventory();
+        let unbind_schema = schema
+            .pointer("/$defs/UnbindTargetAction")
+            .expect("missing UnbindTargetAction schema");
+
+        assert!(!schema_allows(unbind_schema, &Value::Null));
+        assert!(!schema_allows(
+            unbind_schema,
+            &Value::String(Unbind::name_for_type().to_string())
+        ));
+        assert!(schema_allows(
+            unbind_schema,
+            &Value::String("test_keymap_file::StringAction".to_string())
+        ));
+        assert!(schema_allows(
+            unbind_schema,
+            &Value::String("test_keymap_file::InputAction".to_string())
+        ));
     }
 
     #[track_caller]

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -115,7 +115,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
             "xlsx",
         ],
     ),
-    ("elixir", &["eex", "ex", "exs", "heex"]),
+    ("elixir", &["eex", "ex", "exs", "heex", "leex", "neex"]),
     ("elm", &["elm"]),
     (
         "erlang",

--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-preview
+stable

--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-dev
+preview

--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -26,6 +26,7 @@ accepted = [
     "OpenSSL",
     "Zlib",
     "BSL-1.0",
+    "bzip2-1.0.6",
 ]
 
 [procinfo.clarify]


### PR DESCRIPTION
## Context

The scrollbar drag handler in `list.rs` uses `.abs()` to normalize the scroll
position, which causes scroll position inversion when content is actively growing
(e.g., in a streaming chat view or terminal output).

The current code at line 952:

    let new_scroll_top = (point.y - drag_offset).abs().max(px(0.)).min(scroll_max);

The scrollbar always passes negative `point.y` values (representing downward offset
from the top of the content area). The `drag_offset` compensates for content height
changes during drag by subtracting `(current_height - frozen_height)`.

The problem: when content grows during a drag, `drag_offset` becomes positive and
can exceed `-point.y`. This makes `(point.y - drag_offset)` a large negative number,
and `.abs()` flips it to a large positive number -- mapping to a scroll position near
the *top* of the list instead of the intended position. The user drags the scrollbar
thumb down, but the viewport jumps upward.

The fix replaces the `.abs()` approach with direct negation:

    let new_scroll_top = (-point.y).max(px(0.)).min(scroll_max);

Since `point.y` is always negative (downward offset), `-point.y` gives the correct
positive scroll-top value. The `.max(px(0.)).min(scroll_max)` clamp handles edge
cases.

The `drag_offset` compensation is also removed because during a drag operation, both
the scrollbar position mapping and `scroll_max` should use the same frozen content
height (`scrollbar_drag_start_height`). The `drag_offset` was double-compensating:
the scrollbar already maps the thumb position relative to the content height at drag
start, so adjusting the result for content growth introduces drift.

I discovered this while building a bottom-aligned list view with streaming content
(new items appending while the user interacts with the scrollbar). The inversion is
reproducible in any `ListAlignment::Bottom` list where content height increases during
a scrollbar drag.

## How to Review

Focus on `set_offset_from_scrollbar` in `crates/gpui/src/elements/list.rs` (line ~940).
The change is small:

1. `content_height` now uses `scrollbar_drag_start_height` (frozen at drag start)
   instead of live `items.summary().height`
2. `drag_offset` calculation removed entirely
3. `.abs()` replaced with `-point.y`

The corresponding read path `scroll_px_offset_for_scrollbar` also removes the
`drag_offset` for consistency -- both sides of the scrollbar mapping now use the
same offset basis.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- gpui: Fixed scrollbar drag position inversion in bottom-aligned lists when content height changes during drag