### PR TITLE
sidebar: Ensure the projects menu is dismissed

### DIFF
--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -403,8 +403,8 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
 
         Some(
             v_flex()
-                .flex_1()
                 .p_1p5()
+                .flex_1()
                 .gap_1()
                 .border_t_1()
                 .border_color(cx.theme().colors().border_variant)
@@ -414,9 +414,10 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                     };
                     Button::new("open_local_folder", "Add Local Project")
                         .key_binding(KeyBinding::for_action_in(&open_action, &focus_handle, cx))
-                        .on_click(move |_, window, cx| {
+                        .on_click(cx.listener(move |_, _, window, cx| {
+                            cx.emit(DismissEvent);
                             window.dispatch_action(open_action.boxed_clone(), cx)
-                        })
+                        }))
                 })
                 .into_any(),
         )


### PR DESCRIPTION
Specifically the "Add Local Project" button was missing emitting a dismiss event. Regular list items within the picker match entries are covered because the picker already handles that, but using that standalone button would sometimes not dismiss the menu properly.

Release Notes:

- N/A
