### PR TITLE
zed_agent: Pick rules file in order described in docs

### DIFF
--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -26,9 +26,9 @@ pub const RULES_FILE_NAMES: &[&str] = &[
     ".windsurfrules",
     ".clinerules",
     ".github/copilot-instructions.md",
-    "CLAUDE.md",
     "AGENT.md",
     "AGENTS.md",
+    "CLAUDE.md",
     "GEMINI.md",
 ];
 


### PR DESCRIPTION
## Context

This makes zed-agent prioritize rules files in the same order as is described in the docs. My order of experience was
- saw in my zed agent thread `Using project "CLAUDE.md" file.
- went to settings to see if I can make it use `AGENTS.md` instead.
- went to [the docs](https://zed.dev/docs/ai/rules) where it specifies that AGENTS.md is be picked over CLAUDE.md.
- went to source to see what went wrong

## How to Review

I'm changing the order of filenames in an array - the only two places where the order matters is when picking which rules file to use. The last place it's used with an `.iter().any()`.

## Self-Review Checklist
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
  - If you want the behavior tested I can, but I think it's equally hard keeping docs and tests and docs and this codepath in sync.
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed agent rules files are prioritized as described in docs
