### PR TITLE
Prevent panic on non-char-boundary FontRun.len in layout_line

### DIFF
--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -478,8 +478,14 @@ impl MacTextSystemState {
             let mut text = text;
             let mut break_ligature = true;
             for run in font_runs {
+                let split_ix = text.floor_char_boundary(run.len);
+                debug_assert_eq!(
+                    split_ix, run.len,
+                    "FontRun.len {} is not on a char boundary in {:?}",
+                    run.len, text
+                );
                 let text_run;
-                (text_run, text) = text.split_at(run.len);
+                (text_run, text) = text.split_at(split_ix);
 
                 let utf16_start = string.char_len(); // insert at end of string
                 // note: replace_str may silently ignore codepoints it dislikes (e.g., BOM at start of string)
@@ -839,5 +845,56 @@ mod tests {
         let layout = fonts.layout_line(text, px(16.), font_runs);
         assert_eq!(layout.len, 0);
         assert!(layout.runs.is_empty());
+    }
+
+    #[test]
+    fn test_layout_line_multibyte_utf8() {
+        let fonts = MacTextSystem::new();
+        let font_id = fonts.font_id(&font("Helvetica")).unwrap();
+
+        // 'ß' is 2 bytes in UTF-8, 'ü' is 2 bytes, 'ö' is 2 bytes
+        let text = "Grüße";
+        let font_runs = &[FontRun {
+            font_id,
+            len: text.len(),
+        }];
+        let layout = fonts.layout_line(text, px(16.), font_runs);
+        assert_eq!(layout.len, text.len());
+
+        for run in &layout.runs {
+            for glyph in &run.glyphs {
+                assert!(
+                    text.is_char_boundary(glyph.index),
+                    "Glyph index {} is not on a char boundary",
+                    glyph.index,
+                );
+            }
+        }
+
+        // Split multi-byte text across font runs at char boundaries
+        let text = "Rot Grün Blau";
+        let split = "Rot Gr".len(); // 6 bytes, on char boundary before 'ü'
+        let font_runs = &[
+            FontRun {
+                font_id,
+                len: split,
+            },
+            FontRun {
+                font_id,
+                len: text.len() - split,
+            },
+        ];
+        let layout = fonts.layout_line(text, px(16.), font_runs);
+        assert_eq!(layout.len, text.len());
+
+        for run in &layout.runs {
+            for glyph in &run.glyphs {
+                assert!(
+                    text.is_char_boundary(glyph.index),
+                    "Glyph index {} is not on a char boundary",
+                    glyph.index,
+                );
+            }
+        }
     }
 }

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -557,8 +557,16 @@ impl DirectWriteState {
                     f32::INFINITY,
                     f32::INFINITY,
                 )?;
-                let current_text = &text[utf8_offset..(utf8_offset + first_run.len)];
-                utf8_offset += first_run.len;
+                let end = text.floor_char_boundary(utf8_offset + first_run.len);
+                debug_assert_eq!(
+                    end,
+                    utf8_offset + first_run.len,
+                    "FontRun.len {} is not on a char boundary in {:?}",
+                    first_run.len,
+                    text
+                );
+                let current_text = &text[utf8_offset..end];
+                utf8_offset = end;
                 let current_text_utf16_length = current_text.encode_utf16().count() as u32;
                 let text_range = DWRITE_TEXT_RANGE {
                     startPosition: utf16_offset,
@@ -582,8 +590,17 @@ impl DirectWriteState {
             let mut break_ligatures = true;
             for run in &font_runs[1..] {
                 let font_info = &self.fonts[run.font_id.0];
-                let current_text = &text[utf8_offset..(utf8_offset + run.len)];
-                utf8_offset += run.len;
+
+                let end = text.floor_char_boundary(utf8_offset + run.len);
+                debug_assert_eq!(
+                    end,
+                    utf8_offset + run.len,
+                    "FontRun.len {} is not on a char boundary in {:?}",
+                    run.len,
+                    text
+                );
+                let current_text = &text[utf8_offset..end];
+                utf8_offset = end;
                 let current_text_utf16_length = current_text.encode_utf16().count() as u32;
 
                 let collection = &font_info.font_collection;


### PR DESCRIPTION
## Context

When a FontRun.len falls inside a multi-byte UTF-8 character (e.g. 'ß'), text.split_at() and string slicing panic with 'byte index N is not a char boundary'.

Use str::floor_char_boundary() to snap to the nearest valid boundary in release builds, preventing the panic. A debug_assert_eq! catches the root cause during development.

Applied to both the macOS (CoreText) and Windows (DirectWrite) text system backends. Added a test for multi-byte UTF-8 text layout.

## How to Review

The fix is motivated by a crash I observed in an application using the gpui 0.2.2 crate. A string containing multi-byte chars was dynamically truncated with an ellipsis. While enlarging the area for rendering the string, the app suddenly crashed.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a crash in the text layout sub-system when a font-run ended within a multi-byte char
