### PR TITLE
feat: Add reasoning split support for OpenAI compatible models

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2186,6 +2186,26 @@ impl Thread {
             }
             RedactedThinking { data } => self.handle_redacted_thinking_event(data),
             ReasoningDetails(details) => {
+                if let serde_json::Value::Array(arr) = &details {
+                    for item in arr {
+                        let is_reasoning_text = item
+                            .get("type")
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|t| t == "reasoning.text");
+                        if is_reasoning_text {
+                            if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                                if !text.is_empty() {
+                                    self.handle_thinking_event(
+                                        text.to_string(),
+                                        None,
+                                        event_stream,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let last_message = self.pending_message();
                 // Store the last non-empty reasoning_details (overwrites earlier ones)
                 // This ensures we keep the encrypted reasoning with signatures, not the early text reasoning

--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -104,6 +104,7 @@ struct ModelCapabilityToggles {
     pub supports_parallel_tool_calls: ToggleState,
     pub supports_prompt_cache_key: ToggleState,
     pub supports_chat_completions: ToggleState,
+    pub supports_reasoning_split: ToggleState,
 }
 
 struct ModelInput {
@@ -157,6 +158,7 @@ impl ModelInput {
             parallel_tool_calls,
             prompt_cache_key,
             chat_completions,
+            reasoning_split,
         } = ModelCapabilities::default();
 
         Self {
@@ -170,6 +172,7 @@ impl ModelInput {
                 supports_parallel_tool_calls: parallel_tool_calls.into(),
                 supports_prompt_cache_key: prompt_cache_key.into(),
                 supports_chat_completions: chat_completions.into(),
+                supports_reasoning_split: reasoning_split.into(),
             },
         }
     }
@@ -208,6 +211,7 @@ impl ModelInput {
                 parallel_tool_calls: self.capabilities.supports_parallel_tool_calls.selected(),
                 prompt_cache_key: self.capabilities.supports_prompt_cache_key.selected(),
                 chat_completions: self.capabilities.supports_chat_completions.selected(),
+                reasoning_split: self.capabilities.supports_reasoning_split.selected(),
             },
         })
     }
@@ -441,6 +445,20 @@ impl AddLlmProviderModal {
                         .on_click(cx.listener(
                             move |this, checked, _window, cx| {
                                 this.input.models[ix].capabilities.supports_chat_completions =
+                                    *checked;
+                                cx.notify();
+                            },
+                        )),
+                    )
+                    .child(
+                        Checkbox::new(
+                            ("supports-reasoning-split", ix),
+                            model.capabilities.supports_reasoning_split,
+                        )
+                        .label("Supports reasoning_split")
+                        .on_click(cx.listener(
+                            move |this, checked, _window, cx| {
+                                this.input.models[ix].capabilities.supports_reasoning_split =
                                     *checked;
                                 cx.notify();
                             },

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -146,6 +146,7 @@ impl Mercury {
                 tools: vec![],
                 prompt_cache_key: None,
                 reasoning_effort: None,
+                reasoning_split: None,
             };
 
             let buf = serde_json::to_vec(&request_body)?;

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -856,6 +856,7 @@ impl LanguageModel for CloudLanguageModel {
                     &self.model.id.0,
                     self.model.supports_parallel_tool_calls,
                     true,
+                    false,
                     None,
                     None,
                 );
@@ -902,6 +903,7 @@ impl LanguageModel for CloudLanguageModel {
                     request,
                     &self.model.id.0,
                     self.model.supports_parallel_tool_calls,
+                    false,
                     false,
                     None,
                     None,

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -381,6 +381,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.id(),
                 self.model.supports_parallel_tool_calls(),
                 self.model.supports_prompt_cache_key(),
+                false,
                 self.max_output_tokens(),
                 self.model.reasoning_effort(),
             );
@@ -396,6 +397,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.id(),
                 self.model.supports_parallel_tool_calls(),
                 self.model.supports_prompt_cache_key(),
+                false,
                 self.max_output_tokens(),
                 self.model.reasoning_effort(),
             );
@@ -414,6 +416,7 @@ pub fn into_open_ai(
     model_id: &str,
     supports_parallel_tool_calls: bool,
     supports_prompt_cache_key: bool,
+    supports_reasoning_split: bool,
     max_output_tokens: Option<u64>,
     reasoning_effort: Option<ReasoningEffort>,
 ) -> open_ai::Request {
@@ -540,6 +543,11 @@ pub fn into_open_ai(
             LanguageModelToolChoice::None => open_ai::ToolChoice::None,
         }),
         reasoning_effort,
+        reasoning_split: if supports_reasoning_split {
+            Some(true)
+        } else {
+            None
+        },
     }
 }
 
@@ -548,6 +556,7 @@ pub fn into_open_ai_response(
     model_id: &str,
     supports_parallel_tool_calls: bool,
     supports_prompt_cache_key: bool,
+    supports_reasoning_split: bool,
     max_output_tokens: Option<u64>,
     reasoning_effort: Option<ReasoningEffort>,
 ) -> ResponseRequest {
@@ -609,6 +618,11 @@ pub fn into_open_ai_response(
             effort,
             summary: Some(open_ai::responses::ReasoningSummaryMode::Auto),
         }),
+        reasoning_split: if supports_reasoning_split {
+            Some(true)
+        } else {
+            None
+        },
     }
 }
 
@@ -808,6 +822,9 @@ impl OpenAiEventMapper {
                         signature: None,
                     }));
                 }
+            }
+            if let Some(details) = delta.reasoning_details.clone() {
+                events.push(Ok(LanguageModelCompletionEvent::ReasoningDetails(details)));
             }
             if let Some(content) = delta.content.clone() {
                 if !content.is_empty() {
@@ -1649,6 +1666,7 @@ mod tests {
             "custom-model",
             true,
             true,
+            false,
             Some(2048),
             Some(ReasoningEffort::Low),
         );

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -380,6 +380,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 &self.model.name,
                 self.model.capabilities.parallel_tool_calls,
                 self.model.capabilities.prompt_cache_key,
+                self.model.capabilities.reasoning_split,
                 self.max_output_tokens(),
                 None,
             );
@@ -395,6 +396,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 &self.model.name,
                 self.model.capabilities.parallel_tool_calls,
                 self.model.capabilities.prompt_cache_key,
+                self.model.capabilities.reasoning_split,
                 self.max_output_tokens(),
                 None,
             );

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -465,6 +465,7 @@ impl LanguageModel for OpenCodeLanguageModel {
                     self.model.id(),
                     false,
                     false,
+                    false,
                     self.model.max_output_tokens(),
                     None,
                 );
@@ -479,6 +480,7 @@ impl LanguageModel for OpenCodeLanguageModel {
                 let response_request = into_open_ai_response(
                     request,
                     self.model.id(),
+                    false,
                     false,
                     false,
                     self.model.max_output_tokens(),

--- a/crates/language_models/src/provider/vercel.rs
+++ b/crates/language_models/src/provider/vercel.rs
@@ -299,6 +299,7 @@ impl LanguageModel for VercelLanguageModel {
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
+            false,
             self.max_output_tokens(),
             None,
         );

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -442,6 +442,7 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
             &self.model.name,
             self.model.capabilities.parallel_tool_calls,
             self.model.capabilities.prompt_cache_key,
+            self.model.capabilities.reasoning_split,
             self.max_output_tokens(),
             None,
         );
@@ -574,6 +575,7 @@ async fn list_models(
                 parallel_tool_calls,
                 prompt_cache_key,
                 chat_completions: true,
+                reasoning_split: false,
             },
         });
     }

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -319,6 +319,7 @@ impl LanguageModel for XAiLanguageModel {
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
+            false,
             self.max_output_tokens(),
             None,
         );

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -332,6 +332,8 @@ pub struct Request {
     pub prompt_cache_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_split: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -475,6 +477,8 @@ pub struct ResponseMessageDelta {
     pub tool_calls: Option<Vec<ToolCallChunk>>,
     #[serde(default, skip_serializing_if = "is_none_or_empty")]
     pub reasoning_content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_details: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -617,7 +621,7 @@ pub async fn stream_completion(
                         if line == "[DONE]" {
                             None
                         } else {
-                            match serde_json::from_str(line) {
+                            match serde_json::from_str::<ResponseStreamResult>(line) {
                                 Ok(ResponseStreamResult::Ok(response)) => Some(Ok(response)),
                                 Ok(ResponseStreamResult::Err { error }) => {
                                     Some(Err(anyhow!(error.message)))

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -29,6 +29,8 @@ pub struct Request {
     pub prompt_cache_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_split: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -291,6 +291,8 @@ pub struct OpenAiCompatibleModelCapabilities {
     pub prompt_cache_key: bool,
     #[serde(default = "default_true")]
     pub chat_completions: bool,
+    #[serde(default)]
+    pub reasoning_split: bool,
 }
 
 impl Default for OpenAiCompatibleModelCapabilities {
@@ -301,6 +303,7 @@ impl Default for OpenAiCompatibleModelCapabilities {
             parallel_tool_calls: false,
             prompt_cache_key: false,
             chat_completions: default_true(),
+            reasoning_split: false,
         }
     }
 }


### PR DESCRIPTION
# Add reasoning_split support for OpenAI compatible models

- Add reasoning_split field to OpenAI Request and ResponseRequest structs
- Add support for reasoning_details events in agent thread handling  
- Extract thinking text from reasoning_details when reasoning_split is enabled
- Add reasoning_split capability to model configuration UI
- Wire through reasoning_split support across all OpenAI-compatible providers
- Handle ReasoningDetails events in language model completion stream

## Context

This PR adds support for OpenAI compatible model's `reasoning_split` parameter, which allows reasoning models (like `MiniMax-M2.7`) to send their thinking process as separate `reasoning_details` events rather than inline `<think>`. When enabled, the model's reasoning is delivered as structured JSON containing reasoning text and metadata, providing better separation between the model's internal reasoning and its final response.

This feature enhances the user experience for reasoning-capable models by:
- Providing cleaner separation between reasoning and response content
- Enabling better handling of reasoning metadata and signatures
- Supporting future reasoning format improvements from OpenAI

The implementation adds the capability as an optional feature in the model configuration UI, allowing users to enable it for compatible providers and models.

## Test

Using MiniMax-M2.7

### Before
<img width="505" height="163" alt="image" src="https://github.com/user-attachments/assets/6232fd55-53a8-4011-acd3-ba80f925a5bb" />

### After
<img width="461" height="162" alt="image" src="https://github.com/user-attachments/assets/4486df3b-f1bb-4270-a3c0-6ed95d5a3470" />



## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added support for OpenAI compatible model's `reasoning_split` parameter for improved reasoning model interaction