### PR TITLE
open_router: Fix incorrect rate limit enforcement after reset had already expired

### DIFF
--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -7,7 +7,6 @@ use futures::{
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::convert::TryFrom;
 
 pub const DEEPSEEK_API_URL: &str = "https://api.deepseek.com/v1";
 
@@ -18,31 +17,6 @@ pub enum Role {
     Assistant,
     System,
     Tool,
-}
-
-impl TryFrom<String> for Role {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self> {
-        match value.as_str() {
-            "user" => Ok(Self::User),
-            "assistant" => Ok(Self::Assistant),
-            "system" => Ok(Self::System),
-            "tool" => Ok(Self::Tool),
-            _ => anyhow::bail!("invalid role '{value}'"),
-        }
-    }
-}
-
-impl From<Role> for String {
-    fn from(val: Role) -> Self {
-        match val {
-            Role::User => "user".to_owned(),
-            Role::Assistant => "assistant".to_owned(),
-            Role::System => "system".to_owned(),
-            Role::Tool => "tool".to_owned(),
-        }
-    }
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -241,13 +241,13 @@ pub async fn stream_completion(
     request: Request,
 ) -> Result<BoxStream<'static, Result<StreamResponse>>> {
     let uri = format!("{api_url}/chat/completions");
-    let request_builder = HttpRequest::builder()
+    let request = HttpRequest::builder()
         .method(Method::POST)
         .uri(uri)
         .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", api_key.trim()));
+        .header("Authorization", format!("Bearer {}", api_key.trim()))
+        .body(AsyncBody::from(serde_json::to_string(&request)?))?;
 
-    let request = request_builder.body(AsyncBody::from(serde_json::to_string(&request)?))?;
     let mut response = client.send(request).await?;
 
     if response.status().is_success() {

--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -453,7 +453,7 @@ pub async fn get_models(
         .uri(uri)
         .header("Accept", "application/json")
         .when_some(api_key, |builder, api_key| {
-            builder.header("authorization", format!("Bearer {}", api_key))
+            builder.header("Authorization", format!("Bearer {}", api_key))
         })
         .body(AsyncBody::default())?;
 

--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
-use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest, http};
+use http_client::{AsyncBody, HttpClient, HttpRequestExt, Method, Request as HttpRequest, http};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{convert::TryFrom, time::Duration};
@@ -448,16 +448,14 @@ pub async fn get_models(
     _: Option<Duration>,
 ) -> Result<Vec<ModelEntry>> {
     let uri = format!("{api_url}/models");
-    let mut request_builder = HttpRequest::builder()
+    let request = HttpRequest::builder()
         .method(Method::GET)
         .uri(uri)
-        .header("Accept", "application/json");
-
-    if let Some(api_key) = api_key {
-        request_builder = request_builder.header("Authorization", format!("Bearer {}", api_key));
-    }
-
-    let request = request_builder.body(AsyncBody::default())?;
+        .header("Accept", "application/json")
+        .when_some(api_key, |builder, api_key| {
+            builder.header("authorization", format!("Bearer {}", api_key))
+        })
+        .body(AsyncBody::default())?;
 
     let mut response = client.send(request).await?;
 

--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -3,7 +3,7 @@ use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::B
 use http_client::{AsyncBody, HttpClient, HttpRequestExt, Method, Request as HttpRequest, http};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{convert::TryFrom, time::Duration};
+use std::time::Duration;
 
 pub const LMSTUDIO_API_URL: &str = "http://localhost:1234/api/v0";
 
@@ -14,31 +14,6 @@ pub enum Role {
     Assistant,
     System,
     Tool,
-}
-
-impl TryFrom<String> for Role {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self> {
-        match value.as_str() {
-            "user" => Ok(Self::User),
-            "assistant" => Ok(Self::Assistant),
-            "system" => Ok(Self::System),
-            "tool" => Ok(Self::Tool),
-            _ => anyhow::bail!("invalid role '{value}'"),
-        }
-    }
-}
-
-impl From<Role> for String {
-    fn from(val: Role) -> Self {
-        match val {
-            Role::User => "user".to_owned(),
-            Role::Assistant => "assistant".to_owned(),
-            Role::System => "system".to_owned(),
-            Role::Tool => "tool".to_owned(),
-        }
-    }
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -358,17 +358,15 @@ pub async fn complete(
     request: ChatCompletionRequest,
 ) -> Result<ChatResponse> {
     let uri = format!("{api_url}/chat/completions");
-    let mut request_builder = HttpRequest::builder()
+    let serialized_request = serde_json::to_string(&request)?;
+    let request = HttpRequest::builder()
         .method(Method::POST)
         .uri(uri)
-        .header("Content-Type", "application/json");
-
-    if let Some(api_key) = api_key {
-        request_builder = request_builder.header("Authorization", format!("Bearer {}", api_key));
-    }
-
-    let serialized_request = serde_json::to_string(&request)?;
-    let request = request_builder.body(AsyncBody::from(serialized_request))?;
+        .header("Content-Type", "application/json")
+        .when_some(api_key, |builder, api_key| {
+            builder.header("Authorization", format!("Bearer {}", api_key))
+        })
+        .body(AsyncBody::from(serialized_request))?;
 
     let mut response = client.send(request).await?;
     if response.status().is_success() {
@@ -395,16 +393,15 @@ pub async fn stream_chat_completion(
     request: ChatCompletionRequest,
 ) -> Result<BoxStream<'static, Result<ResponseStreamEvent>>> {
     let uri = format!("{api_url}/chat/completions");
-    let mut request_builder = http::Request::builder()
+    let request = http::Request::builder()
         .method(Method::POST)
         .uri(uri)
-        .header("Content-Type", "application/json");
+        .header("Content-Type", "application/json")
+        .when_some(api_key, |builder, api_key| {
+            builder.header("Authorization", format!("Bearer {}", api_key))
+        })
+        .body(AsyncBody::from(serde_json::to_string(&request)?))?;
 
-    if let Some(api_key) = api_key {
-        request_builder = request_builder.header("Authorization", format!("Bearer {}", api_key));
-    }
-
-    let request = request_builder.body(AsyncBody::from(serde_json::to_string(&request)?))?;
     let mut response = client.send(request).await?;
     if response.status().is_success() {
         let reader = BufReader::new(response.into_body());

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
 use http_client::StatusCode;
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest, http};

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -8,7 +8,7 @@ pub use settings::DataCollection;
 pub use settings::ModelMode;
 pub use settings::OpenRouterAvailableModel as AvailableModel;
 pub use settings::OpenRouterProvider as Provider;
-use std::{convert::TryFrom, io, time::Duration};
+use std::{io, time::Duration};
 use strum::EnumString;
 use thiserror::Error;
 
@@ -39,31 +39,6 @@ pub enum Role {
     Assistant,
     System,
     Tool,
-}
-
-impl TryFrom<String> for Role {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self> {
-        match value.as_str() {
-            "user" => Ok(Self::User),
-            "assistant" => Ok(Self::Assistant),
-            "system" => Ok(Self::System),
-            "tool" => Ok(Self::Tool),
-            _ => Err(anyhow!("invalid role '{value}'")),
-        }
-    }
-}
-
-impl From<Role> for String {
-    fn from(val: Role) -> Self {
-        match val {
-            Role::User => "user".to_owned(),
-            Role::Assistant => "assistant".to_owned(),
-            Role::System => "system".to_owned(),
-            Role::Tool => "tool".to_owned(),
-        }
-    }
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -415,15 +415,13 @@ pub async fn stream_completion(
     request: Request,
 ) -> Result<BoxStream<'static, Result<ResponseStreamEvent, OpenRouterError>>, OpenRouterError> {
     let uri = format!("{api_url}/chat/completions");
-    let request_builder = HttpRequest::builder()
+    let request = HttpRequest::builder()
         .method(Method::POST)
         .uri(uri)
         .header("Content-Type", "application/json")
         .header("Authorization", format!("Bearer {}", api_key))
         .header("HTTP-Referer", "https://zed.dev")
-        .header("X-Title", "Zed Editor");
-
-    let request = request_builder
+        .header("X-Title", "Zed Editor")
         .body(AsyncBody::from(
             serde_json::to_string(&request).map_err(OpenRouterError::SerializeRequest)?,
         ))
@@ -508,15 +506,13 @@ pub async fn list_models(
     api_key: &str,
 ) -> Result<Vec<Model>, OpenRouterError> {
     let uri = format!("{api_url}/models/user");
-    let request_builder = HttpRequest::builder()
+    let request = HttpRequest::builder()
         .method(Method::GET)
         .uri(uri)
         .header("Accept", "application/json")
         .header("Authorization", format!("Bearer {}", api_key))
         .header("HTTP-Referer", "https://zed.dev")
-        .header("X-Title", "Zed Editor");
-
-    let request = request_builder
+        .header("X-Title", "Zed Editor")
         .body(AsyncBody::default())
         .map_err(OpenRouterError::BuildRequestBody)?;
     let mut response = client

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -14,20 +14,17 @@ use thiserror::Error;
 pub const OPEN_ROUTER_API_URL: &str = "https://openrouter.ai/api/v1";
 
 fn extract_retry_after(headers: &http::HeaderMap) -> Option<std::time::Duration> {
-    if let Some(reset) = headers.get("X-RateLimit-Reset") {
-        if let Ok(s) = reset.to_str() {
-            if let Ok(epoch_ms) = s.parse::<u64>() {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as u64;
-                if epoch_ms > now {
-                    return Some(std::time::Duration::from_millis(epoch_ms - now));
-                }
-            }
-        }
-    }
-    None
+    let epoch_ms = headers
+        .get("X-RateLimit-Reset")
+        .and_then(|header| header.to_str().ok())
+        .and_then(|reset| reset.parse::<u64>().ok())?;
+
+    let retry_at = Duration::from_millis(epoch_ms);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("SystemTime before Unix Epoch");
+
+    Some(retry_at.saturating_sub(now))
 }
 
 fn is_none_or_empty<T: AsRef<[U]>, U>(opt: &Option<T>) -> bool {
@@ -742,5 +739,25 @@ impl ApiErrorCode {
             503 => ApiErrorCode::OverloadedError,
             _ => ApiErrorCode::ApiError,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use http_client::http::{HeaderMap, HeaderValue};
+
+    use crate::extract_retry_after;
+
+    #[test]
+    fn extract_retry_reset_passed() {
+        let since_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let reset_header = HeaderValue::from_str(&format!("{}", since_epoch.as_millis())).unwrap();
+
+        let mut map = HeaderMap::default();
+        map.append("X-RateLimit-Reset", reset_header);
+
+        assert_eq!(extract_retry_after(&map), Some(Duration::ZERO));
     }
 }

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -684,17 +684,16 @@ pub enum ApiErrorCode {
 
 impl std::fmt::Display for ApiErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            ApiErrorCode::InvalidRequestError => "invalid_request_error",
-            ApiErrorCode::AuthenticationError => "authentication_error",
-            ApiErrorCode::PaymentRequiredError => "payment_required_error",
-            ApiErrorCode::PermissionError => "permission_error",
-            ApiErrorCode::RequestTimedOut => "request_timed_out",
-            ApiErrorCode::RateLimitError => "rate_limit_error",
-            ApiErrorCode::ApiError => "api_error",
-            ApiErrorCode::OverloadedError => "overloaded_error",
-        };
-        write!(f, "{s}")
+        f.write_str(match self {
+            Self::InvalidRequestError => "invalid_request_error",
+            Self::AuthenticationError => "authentication_error",
+            Self::PaymentRequiredError => "payment_required_error",
+            Self::PermissionError => "permission_error",
+            Self::RequestTimedOut => "request_timed_out",
+            Self::RateLimitError => "rate_limit_error",
+            Self::ApiError => "api_error",
+            Self::OverloadedError => "overloaded_error",
+        })
     }
 }
 

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -42,7 +42,7 @@ pub enum Role {
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Model {
     pub name: String,
     pub display_name: Option<String>,
@@ -54,8 +54,8 @@ pub struct Model {
     pub provider: Option<Provider>,
 }
 
-impl Model {
-    pub fn default() -> Self {
+impl Default for Model {
+    fn default() -> Self {
         Self::new(
             "openrouter/auto",
             Some("Auto Router"),
@@ -66,7 +66,9 @@ impl Model {
             None,
         )
     }
+}
 
+impl Model {
     pub fn new(
         name: &str,
         display_name: Option<&str>,

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
+use http_client::StatusCode;
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest, http};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -489,7 +490,7 @@ pub async fn stream_completion(
             })
             .boxed())
     } else {
-        let code = ApiErrorCode::from_status(response.status().as_u16());
+        let code = ApiErrorCode::from(response.status());
 
         let mut body = String::new();
         response
@@ -603,7 +604,7 @@ pub async fn list_models(
 
         Ok(models)
     } else {
-        let code = ApiErrorCode::from_status(response.status().as_u16());
+        let code = ApiErrorCode::from(response.status());
 
         let mut body = String::new();
         response
@@ -687,8 +688,8 @@ pub struct ApiError {
     pub message: String,
 }
 
-/// An OpenROuter API error code.
-/// <https://openrouter.ai/docs/api-reference/errors#error-codes>
+/// An OpenRouter API error code.
+/// <https://openrouter.ai/docs/api/reference/errors-and-debugging#error-codes>
 #[derive(Debug, PartialEq, Eq, Clone, Copy, EnumString, Serialize, Deserialize)]
 #[strum(serialize_all = "snake_case")]
 pub enum ApiErrorCode {
@@ -726,18 +727,18 @@ impl std::fmt::Display for ApiErrorCode {
     }
 }
 
-impl ApiErrorCode {
-    pub fn from_status(status: u16) -> Self {
-        match status {
-            400 => ApiErrorCode::InvalidRequestError,
-            401 => ApiErrorCode::AuthenticationError,
-            402 => ApiErrorCode::PaymentRequiredError,
-            403 => ApiErrorCode::PermissionError,
-            408 => ApiErrorCode::RequestTimedOut,
-            429 => ApiErrorCode::RateLimitError,
-            502 => ApiErrorCode::ApiError,
-            503 => ApiErrorCode::OverloadedError,
-            _ => ApiErrorCode::ApiError,
+impl From<StatusCode> for ApiErrorCode {
+    fn from(value: StatusCode) -> Self {
+        match value {
+            StatusCode::BAD_REQUEST => Self::InvalidRequestError,
+            StatusCode::UNAUTHORIZED => Self::AuthenticationError,
+            StatusCode::PAYMENT_REQUIRED => Self::PaymentRequiredError,
+            StatusCode::FORBIDDEN => Self::PermissionError,
+            StatusCode::REQUEST_TIMEOUT => Self::RequestTimedOut,
+            StatusCode::TOO_MANY_REQUESTS => Self::RateLimitError,
+            StatusCode::BAD_GATEWAY => Self::ApiError,
+            StatusCode::SERVICE_UNAVAILABLE => Self::OverloadedError,
+            _ => Self::ApiError,
         }
     }
 }


### PR DESCRIPTION
## Context

The `extract_retry_after` function in the `open_router` crate falsely returned `None` for its timeout when the reset had already passed before the function was called. This would make the caller assume the header was missing, and issue a default 60 second timeout.

The new behavior returns `Duration::ZERO` when the timeout has already passed.

## How to Review

The only logic change happens in the `extract_retry_after` function. I have included other nits such as updating documentation links, fixing typos, removing dead code and combining fragmented builder method calls. Going through the commits one by one keeps changes in logical groups.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fix rare incorrect rate limit handling when using OpenRouter
