### PR TITLE
Improve wording in collab channels filter tooltip

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2747,7 +2747,7 @@ impl CollabPanel {
                                 .tooltip(Tooltip::text(if self.filter_active_channels {
                                     "Show All Channels"
                                 } else {
-                                    "Show Active Channels"
+                                    "Show Occupied Channels"
                                 })),
                         )
                         .child(


### PR DESCRIPTION
I heard a comment that `active` didn't really explain what this filter was for, and I've had the same feeling. I think `occupied` makes it more clear.

## Self-Review Checklist

<!-- Check before requesting review: -->
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A
