### PR TITLE
collab_panel: Fix favorite channels not surviving startup

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -683,11 +683,13 @@ impl CollabPanel {
 
         let mut request_entries = Vec::new();
 
-        let previous_len = self.favorite_channels.len();
-        self.favorite_channels
-            .retain(|id| self.channel_store.read(cx).channel_for_id(*id).is_some());
-        if self.favorite_channels.len() != previous_len {
-            self.serialize(cx);
+        if self.channel_store.read(cx).channel_count() > 0 {
+            let previous_len = self.favorite_channels.len();
+            self.favorite_channels
+                .retain(|id| self.channel_store.read(cx).channel_for_id(*id).is_some());
+            if self.favorite_channels.len() != previous_len {
+                self.serialize(cx);
+            }
         }
 
         let channel_store = self.channel_store.read(cx);


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/52378

This PR fixes a little race condition that was happening where we were running the favorite channel pruning function faster than the channels could load, leading to favorite channels not surviving the app restarting. The fix is to make the pruning happen only when the number of channels is bigger than 0, which means the list from the server has already been loaded.
Release Notes:

- N/A _(No release notes yet because this feature hasn't reached the wider public)_
