### PR TITLE
Restore language query watcher in dev builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14868,9 +14868,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.7.2"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -14879,9 +14879,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.7.2"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14892,9 +14892,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.7.2"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -680,7 +680,7 @@ rsa = "0.9.6"
 runtimelib = { version = "1.4.0", default-features = false, features = [
     "async-dispatcher-runtime", "aws-lc-rs"
 ] }
-rust-embed = { version = "8.4", features = ["include-exclude"] }
+rust-embed = { version = "8.11", features = ["include-exclude"] }
 rustc-hash = "2.1.0"
 rustls = { version = "0.23.26" }
 rustls-platform-verifier = "0.5.0"

--- a/crates/edit_prediction_cli/Cargo.toml
+++ b/crates/edit_prediction_cli/Cargo.toml
@@ -65,7 +65,7 @@ rand.workspace = true
 similar = "2.7.0"
 flate2 = "1.1.8"
 toml.workspace = true
-rust-embed = { workspace = true, features = ["debug-embed"] }
+rust-embed.workspace = true
 gaoya = "0.2.0"
 
 # Wasmtime is included as a dependency in order to enable the same

--- a/crates/language_core/src/grammar.rs
+++ b/crates/language_core/src/grammar.rs
@@ -315,7 +315,7 @@ impl Grammar {
         let name = &config.name;
         if let Some(query) = queries.highlights {
             self = self
-                .with_highlights_query(dbg!(query.as_ref()))
+                .with_highlights_query(query.as_ref())
                 .context("Error loading highlights query")?;
         }
         if let Some(query) = queries.brackets {

--- a/crates/language_core/src/grammar.rs
+++ b/crates/language_core/src/grammar.rs
@@ -315,7 +315,7 @@ impl Grammar {
         let name = &config.name;
         if let Some(query) = queries.highlights {
             self = self
-                .with_highlights_query(query.as_ref())
+                .with_highlights_query(dbg!(query.as_ref()))
                 .context("Error loading highlights query")?;
         }
         if let Some(query) = queries.brackets {

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -362,7 +362,7 @@ fn register_language(
         Arc::new(move || {
             Ok(LoadedLanguage {
                 config: config.clone(),
-                queries: load_queries(name),
+                queries: grammars::load_queries(name),
                 context_provider: context.clone(),
                 toolchain_provider: toolchain.clone(),
                 manifest_name: manifest_name.clone(),
@@ -383,8 +383,4 @@ pub fn language(name: &str, grammar: tree_sitter::Language) -> Arc<Language> {
 fn load_config(name: &str) -> LanguageConfig {
     let grammars_loaded = cfg!(any(feature = "load-grammars", test));
     grammars::load_config_for_feature(name, grammars_loaded)
-}
-
-fn load_queries(name: &str) -> LanguageQueries {
-    grammars::load_queries(name)
 }

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -27,7 +27,7 @@ log.workspace = true
 migrator.workspace = true
 paths.workspace = true
 release_channel.workspace = true
-rust-embed = { workspace = true, features = ["debug-embed"] }
+rust-embed.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -811,6 +811,7 @@ fn main() {
         let fs = app_state.fs.clone();
         load_user_themes_in_background(fs.clone(), cx);
         watch_themes(fs.clone(), cx);
+        #[cfg(debug_assertions)]
         watch_languages(fs.clone(), app_state.languages.clone(), cx);
 
         let menus = app_menus(cx);
@@ -1821,7 +1822,7 @@ fn watch_languages(fs: Arc<dyn fs::Fs>, languages: Arc<LanguageRegistry>, cx: &m
     use std::time::Duration;
 
     cx.background_spawn(async move {
-        let languages_src = Path::new("crates/languages/src");
+        let languages_src = Path::new("crates/grammars/src");
         let Some(languages_src) = fs.canonicalize(languages_src).await.log_err() else {
             return;
         };
@@ -1850,9 +1851,6 @@ fn watch_languages(fs: Arc<dyn fs::Fs>, languages: Arc<LanguageRegistry>, cx: &m
     })
     .detach();
 }
-
-#[cfg(not(debug_assertions))]
-fn watch_languages(_fs: Arc<dyn fs::Fs>, _languages: Arc<LanguageRegistry>, _cx: &mut App) {}
 
 fn dump_all_gpui_actions() {
     #[derive(Debug, serde::Serialize)]


### PR DESCRIPTION
The watcher had been broken for some time, but became even more broken after the recent move of the queries. 

This PR restores the reloading behavior for debug builds so that languages are reloaded once a scheme file is changed. 

Release Notes:

- N/A
