### PR TITLE
Don't auto-close in search

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -936,6 +936,7 @@ impl ProjectSearchView {
         let query_editor = cx.new(|cx| {
             let mut editor = Editor::auto_height(1, 4, window, cx);
             editor.set_placeholder_text("Search all files…", window, cx);
+            editor.set_use_autoclose(false);
             editor.set_text(query_text, window, cx);
             editor
         });


### PR DESCRIPTION
This was incidentally broken when we switched to the auto_height editor

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #52124

Release Notes:

- Disabled autoclose of brackets in the project search
