### PR TITLE
gpui: Fix `scroll_to_reveal_item` scrolling for visible items

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -442,31 +442,39 @@ impl ListState {
     /// Scroll the list to the given item, such that the item is fully visible.
     pub fn scroll_to_reveal_item(&self, ix: usize) {
         let state = &mut *self.0.borrow_mut();
-
         let mut scroll_top = state.logical_scroll_top();
-        let height = state
+        let viewport_height = state
             .last_layout_bounds
             .map_or(px(0.), |bounds| bounds.size.height);
         let padding = state.last_padding.unwrap_or_default();
 
-        if ix <= scroll_top.item_ix {
+        // calculate top coordinate
+        let mut cursor = state.items.cursor::<ListItemSummary>(());
+        cursor.seek(&Count(scroll_top.item_ix), Bias::Right);
+        let current_scroll_px = cursor.start().height + scroll_top.offset_in_item;
+
+        // calculate the item top boundary
+        cursor.seek(&Count(ix), Bias::Right);
+        let item_top = cursor.start().height + padding.top;
+
+        // calculate the item bottom boundary (item + 1 top boundary)
+        cursor.seek(&Count(ix + 1), Bias::Right);
+        let item_bottom = cursor.start().height + padding.top;
+
+        if item_top < current_scroll_px {
+            // CASE: Item is partially or fully ABOVE the viewport
             scroll_top.item_ix = ix;
             scroll_top.offset_in_item = px(0.);
-        } else {
-            let mut cursor = state.items.cursor::<ListItemSummary>(());
-            cursor.seek(&Count(ix + 1), Bias::Right);
-            let bottom = cursor.start().height + padding.top;
-            let goal_top = px(0.).max(bottom - height + padding.bottom);
+        } else if item_bottom > current_scroll_px + viewport_height {
+            // CASE: Item is partially or fully BELOW the viewport
+            let goal_top = item_bottom - viewport_height + padding.bottom;
 
             cursor.seek(&Height(goal_top), Bias::Left);
-            let start_ix = cursor.start().count;
-            let start_item_top = cursor.start().height;
-
-            if start_ix >= scroll_top.item_ix {
-                scroll_top.item_ix = start_ix;
-                scroll_top.offset_in_item = goal_top - start_item_top;
-            }
+            scroll_top.item_ix = cursor.start().count;
+            scroll_top.offset_in_item = goal_top - cursor.start().height;
         }
+
+        // ELSE: Item is already within the viewport! Do nothing.
 
         state.logical_scroll_top = Some(scroll_top);
     }


### PR DESCRIPTION
## Improved List Navigation: Nearest Scroll Strategy

### Description

This PR refactors `scroll_to_reveal_item` in `gpui` to prevent unnecessary "jumping" when navigating through a list. 

Previously, moving "Up" would aggressively snap the selected item to the top of the viewport even if it was already fully visible.

 #### Previous behavior:

https://github.com/user-attachments/assets/bb3e646c-f2b4-4c4a-b384-77d5b9a3ac58

#### New behavior:


https://github.com/user-attachments/assets/4b144e43-ad3c-4982-8964-de2a09c7ab90

#### How:

The new implementation uses pixel-coordinate math (via `SumTree` cursors) to implement a **Nearest** scroll strategy:
- **If the item is already fully visible:** The scroll position remains unchanged.
- **If the item is above the viewport:** The list scrolls just enough to align the item's top with the viewport's top.
- **If the item is below the viewport:** The list scrolls just enough to align the item's bottom with the viewport's bottom.

This creates a much smoother experience in the Launcher and other list-heavy interfaces where users frequently toggle between adjacent items.

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tested locally on a project
- [x] Performance impact has been considered and is acceptable


### Release Notes:

- Fixed "jumpy" list scrolling by ensuring items only trigger a scroll when they are actually outside the visible area.