### PR TITLE
gpui: Add scroll_to_max/is_at_bottom utilities, is_scrollbar_dragging, and width-change scroll preservation to `list`

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1225,6 +1225,28 @@ impl Element for List {
             .last_layout_bounds
             .is_none_or(|last_bounds| last_bounds.size.width != bounds.size.width)
         {
+            // Save proportional scroll position before reset so layout_items()
+            // can restore it after items are re-measured at the new width.
+            // Mirrors the same logic in remeasure().
+            if let Some(scroll_top) = state.logical_scroll_top {
+                let mut cursor = state.items.cursor::<Count>(());
+                cursor.seek(&Count(scroll_top.item_ix), Bias::Right);
+
+                if let Some(item) = cursor.item() {
+                    if let Some(size) = item.size() {
+                        let fraction = if size.height.0 > 0.0 {
+                            (scroll_top.offset_in_item.0 / size.height.0).clamp(0.0, 1.0)
+                        } else {
+                            0.0
+                        };
+                        state.pending_scroll = Some(PendingScrollFraction {
+                            item_ix: scroll_top.item_ix,
+                            fraction,
+                        });
+                    }
+                }
+            }
+
             let new_items = SumTree::from_iter(
                 state.items.iter().map(|item| ListItem::Unmeasured {
                     focus_handle: item.focus_handle(),

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -555,6 +555,81 @@ impl ListState {
     pub fn viewport_bounds(&self) -> Bounds<Pixels> {
         self.0.borrow().last_layout_bounds.unwrap_or_default()
     }
+
+    /// Scroll to the maximum offset (bottom of content).
+    /// Unlike setting `logical_scroll_top = None` (which is a sentinel for
+    /// `ListAlignment::Bottom`), this computes the actual scroll position
+    /// and works with any `ListAlignment`.
+    pub fn scroll_to_max(&self) {
+        let state = &mut *self.0.borrow_mut();
+        let bounds = state.last_layout_bounds.unwrap_or_default();
+        let padding = state.last_padding.unwrap_or_default();
+        let total_height = state.items.summary().height;
+        let scroll_max =
+            (total_height + padding.top + padding.bottom - bounds.size.height).max(px(0.));
+
+        let (start, ..) =
+            state
+                .items
+                .find::<ListItemSummary, _>((), &Height(scroll_max), Bias::Right);
+        state.logical_scroll_top = Some(ListOffset {
+            item_ix: start.count,
+            offset_in_item: scroll_max - start.height,
+        });
+    }
+
+    /// Returns true if the list is scrolled to (or very near) the bottom.
+    /// Works with any alignment by comparing current scroll position to max.
+    pub fn is_at_bottom(&self) -> bool {
+        let state = self.0.borrow();
+        let bounds = state.last_layout_bounds.unwrap_or_default();
+        let padding = state.last_padding.unwrap_or_default();
+        let total_height = state.items.summary().height;
+        let scroll_max =
+            (total_height + padding.top + padding.bottom - bounds.size.height).max(px(0.));
+
+        if scroll_max == px(0.) {
+            return true; // Content fits in viewport
+        }
+
+        let scroll_top = state.logical_scroll_top();
+        let mut cursor = state.items.cursor::<ListItemSummary>(());
+        let summary: ListItemSummary =
+            cursor.summary(&Count(scroll_top.item_ix), Bias::Right);
+        let current_pos = summary.height + scroll_top.offset_in_item;
+
+        (scroll_max - current_pos) < px(1.0)
+    }
+
+    /// Returns true if the list is within `tolerance` pixels of the bottom.
+    /// Useful when height estimation makes the strict 1px `is_at_bottom()`
+    /// threshold unreliable (e.g., variable-height items being measured lazily).
+    pub fn is_near_bottom(&self, tolerance: Pixels) -> bool {
+        let state = self.0.borrow();
+        let bounds = state.last_layout_bounds.unwrap_or_default();
+        let padding = state.last_padding.unwrap_or_default();
+        let total_height = state.items.summary().height;
+        let scroll_max =
+            (total_height + padding.top + padding.bottom - bounds.size.height).max(px(0.));
+
+        if scroll_max == px(0.) {
+            return true;
+        }
+
+        let scroll_top = state.logical_scroll_top();
+        let mut cursor = state.items.cursor::<ListItemSummary>(());
+        let summary: ListItemSummary =
+            cursor.summary(&Count(scroll_top.item_ix), Bias::Right);
+        let current_pos = summary.height + scroll_top.offset_in_item;
+
+        (scroll_max - current_pos) < tolerance
+    }
+
+    /// Returns true if the scrollbar is currently being dragged.
+    /// Set by [`scrollbar_drag_started`] / [`scrollbar_drag_ended`].
+    pub fn is_scrollbar_dragging(&self) -> bool {
+        self.0.borrow().scrollbar_drag_start_height.is_some()
+    }
 }
 
 impl StateInner {


### PR DESCRIPTION
## Summary

Adds public methods and a bug fix to the `List` element for better scroll control in variable-height list usage:

### New methods on `ListState`

- **`scroll_to_max()`** — Scrolls to the maximum offset by computing the actual scroll position. Works with any `ListAlignment`, unlike setting `logical_scroll_top = None` which is a `ListAlignment::Bottom` sentinel. Useful for chat/conversation views using `ListAlignment::Top` that need to programmatically scroll to the bottom.

- **`is_at_bottom()`** — Returns true when the list is within 1px of the bottom. Works with any alignment by comparing current position to computed max. Enables auto-scroll reconnection (re-engage "follow tail" after user scrolls back to bottom).

- **`is_near_bottom(tolerance)`** — Like `is_at_bottom()` but with a configurable tolerance in pixels. Useful when lazy height estimation makes the strict 1px threshold unreliable (variable-height items measured on demand can cause ±25px oscillation in total height).

- **`is_scrollbar_dragging()`** — Exposes whether the scrollbar is currently being dragged. The state is already tracked internally via `scrollbar_drag_start_height`; this just makes it queryable. Useful for suppressing auto-scroll during active drag.

### Bug fix: Preserve scroll position across width changes

When the list width changes (window resize, panel width change), all items are reset to `Unmeasured` and re-laid-out. Previously this discarded the scroll position, causing the list to jump to the top. This fix saves the current position as a `PendingScrollFraction` before the reset — the same mechanism `remeasure()` already uses — so `layout_items()` can restore the proportional position after re-measurement.

## Test plan

- [x] Verified in a real application with variable-height list items (conversation view with markdown content)
- [ ] `scroll_to_max()` scrolls to bottom correctly with `ListAlignment::Top` and `ListAlignment::Bottom`
- [ ] `is_at_bottom()` returns true when at bottom, false when scrolled up
- [ ] `is_near_bottom(px(25.))` returns true within tolerance zone
- [ ] `is_scrollbar_dragging()` returns true during drag, false after release
- [ ] Resizing window width preserves scroll position instead of jumping to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)