### PR TITLE
git_graph: Fix checkout curve rendering

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1854,13 +1854,45 @@ impl GitGraph {
                                         -COMMIT_CIRCLE_RADIUS - COMMIT_CIRCLE_STROKE_WIDTH
                                     };
 
-                                    let control = match curve_kind {
+                                    match curve_kind {
                                         CurveKind::Checkout => {
                                             if is_last {
                                                 to_column -= column_shift;
                                             }
                                             builder.move_to(point(current_column, current_row));
-                                            point(current_column, to_row)
+
+                                            if (to_column - current_column).abs() > LANE_WIDTH {
+                                                // Multi-lane checkout: straight down, small
+                                                // curve turn, then straight horizontal.
+                                                if (to_row - current_row).abs() > row_height {
+                                                    let vertical_end =
+                                                        point(current_column, to_row - row_height);
+                                                    builder.line_to(vertical_end);
+                                                    builder.move_to(vertical_end);
+                                                }
+
+                                                let lane_shift = if going_right {
+                                                    LANE_WIDTH
+                                                } else {
+                                                    -LANE_WIDTH
+                                                };
+                                                let curve_end =
+                                                    point(current_column + lane_shift, to_row);
+                                                let curve_control = point(current_column, to_row);
+                                                builder.curve_to(curve_end, curve_control);
+                                                builder.move_to(curve_end);
+
+                                                builder.line_to(point(to_column, to_row));
+                                            } else {
+                                                if (to_row - current_row).abs() > row_height {
+                                                    let start_curve =
+                                                        point(current_column, to_row - row_height);
+                                                    builder.line_to(start_curve);
+                                                    builder.move_to(start_curve);
+                                                }
+                                                let control = point(current_column, to_row);
+                                                builder.curve_to(point(to_column, to_row), control);
+                                            }
                                         }
                                         CurveKind::Merge => {
                                             if is_last {
@@ -1870,37 +1902,25 @@ impl GitGraph {
                                                 current_column + column_shift,
                                                 current_row - COMMIT_CIRCLE_RADIUS,
                                             ));
-                                            point(to_column, current_row)
+
+                                            if (to_column - current_column).abs() > LANE_WIDTH {
+                                                let column_shift = if going_right {
+                                                    LANE_WIDTH
+                                                } else {
+                                                    -LANE_WIDTH
+                                                };
+                                                let start_curve = point(
+                                                    current_column + column_shift,
+                                                    current_row - COMMIT_CIRCLE_RADIUS,
+                                                );
+                                                builder.line_to(start_curve);
+                                                builder.move_to(start_curve);
+                                            }
+
+                                            let control = point(to_column, current_row);
+                                            builder.curve_to(point(to_column, to_row), control);
                                         }
-                                    };
-
-                                    match curve_kind {
-                                        CurveKind::Checkout
-                                            if (to_row - current_row).abs() > row_height =>
-                                        {
-                                            let start_curve =
-                                                point(current_column, current_row + row_height);
-                                            builder.line_to(start_curve);
-                                            builder.move_to(start_curve);
-                                        }
-                                        CurveKind::Merge
-                                            if (to_column - current_column).abs() > LANE_WIDTH =>
-                                        {
-                                            let column_shift =
-                                                if going_right { LANE_WIDTH } else { -LANE_WIDTH };
-
-                                            let start_curve = point(
-                                                current_column + column_shift,
-                                                current_row - COMMIT_CIRCLE_RADIUS,
-                                            );
-
-                                            builder.line_to(start_curve);
-                                            builder.move_to(start_curve);
-                                        }
-                                        _ => {}
-                                    };
-
-                                    builder.curve_to(point(to_column, to_row), control);
+                                    }
                                     current_row = to_row;
                                     current_column = to_column;
                                     builder.move_to(point(current_column, current_row));


### PR DESCRIPTION
This makes the curves start later in the graph which is one of the last things for the graph to be ready for release

### Before
<img width="266" height="182" alt="image" src="https://github.com/user-attachments/assets/830a8586-c0a4-4ce8-8e64-82082b8afb25" />

### After
<img width="266" height="224" alt="image" src="https://github.com/user-attachments/assets/06dbe2a3-763f-41c2-a74b-30dda0c9e0bd" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A or Added/Fixed/Improved ...
