### PR TITLE
Skip PR assignee selection for org-member PRs

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -83,6 +83,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           TARGET_REPO: ${{ github.repository }}
+          ASSIGN_INTERNAL: ${{ vars.ASSIGN_INTERNAL || 'false' }}
+          ASSIGN_EXTERNAL: ${{ vars.ASSIGN_EXTERNAL || 'true' }}
         run: |
           cd codeowner-coordinator
           python .github/scripts/assign-reviewers.py \


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes N/A — deploying [codeowner-coordinator#90](https://github.com/zed-industries/codeowner-coordinator/pull/90) to zed repo.

## Summary

Pass `ASSIGN_INTERNAL` and `ASSIGN_EXTERNAL` repository variables to the assign-reviewers workflow. The coordinator script now uses these to control whether an individual PR assignee is set based on the author's org membership.

**Defaults:** org members skip assignee (teams self-organize accountability), external contributors get an assignee (identifies who should shepherd the PR). Both are togglable from repo Settings → Variables without code changes.

Side benefit: skips the 30-55 second `poll_for_reviewers` polling loop for org-member PRs.

## Post-merge manual step

Set repository variables (Settings → Secrets and variables → Actions → Variables):
- `ASSIGN_INTERNAL` = `false`
- `ASSIGN_EXTERNAL` = `true`

Release Notes:

- N/A