### PR TITLE
vim: Fix insert above auto-indentation

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3275,7 +3275,7 @@ impl Editor {
         });
     }
 
-    pub fn edit_bottom_up_with_autoindent<I, S, T>(&mut self, edits: I, cx: &mut Context<Self>)
+    pub fn edit_before_with_autoindent<I, S, T>(&mut self, edits: I, cx: &mut Context<Self>)
     where
         I: IntoIterator<Item = (Range<S>, T)>,
         S: ToOffset,
@@ -3286,7 +3286,7 @@ impl Editor {
         }
 
         self.buffer.update(cx, |buffer, cx| {
-            buffer.edit_bottom_up(edits, self.autoindent_mode.clone(), cx)
+            buffer.edit_before(edits, self.autoindent_mode.clone(), cx)
         });
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3275,6 +3275,21 @@ impl Editor {
         });
     }
 
+    pub fn edit_bottom_up_with_autoindent<I, S, T>(&mut self, edits: I, cx: &mut Context<Self>)
+    where
+        I: IntoIterator<Item = (Range<S>, T)>,
+        S: ToOffset,
+        T: Into<Arc<str>>,
+    {
+        if self.read_only(cx) {
+            return;
+        }
+
+        self.buffer.update(cx, |buffer, cx| {
+            buffer.edit_bottom_up(edits, self.autoindent_mode.clone(), cx)
+        });
+    }
+
     pub fn edit_with_block_indent<I, S, T>(
         &mut self,
         edits: I,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -950,6 +950,12 @@ impl EditPreview {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EditDirection {
+    TopDown,
+    BottomUp,
+}
+
 impl Buffer {
     /// Create a new buffer with the given base text.
     pub fn local<T: Into<String>>(base_text: T, cx: &Context<Self>) -> Self {
@@ -2732,7 +2738,35 @@ impl Buffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits_iter, autoindent_mode, true, cx)
+        self.edit_internal(
+            edits_iter,
+            autoindent_mode,
+            true,
+            EditDirection::TopDown,
+            cx,
+        )
+    }
+
+    /// Like [`edit`](Self::edit), but for edits made before the cursor. Used for Vim actions like
+    /// `InsertLineAbove`
+    pub fn edit_bottom_up<I, S, T>(
+        &mut self,
+        edits_iter: I,
+        autoindent_mode: Option<AutoindentMode>,
+        cx: &mut Context<Self>,
+    ) -> Option<clock::Lamport>
+    where
+        I: IntoIterator<Item = (Range<S>, T)>,
+        S: ToOffset,
+        T: Into<Arc<str>>,
+    {
+        self.edit_internal(
+            edits_iter,
+            autoindent_mode,
+            true,
+            EditDirection::BottomUp,
+            cx,
+        )
     }
 
     /// Like [`edit`](Self::edit), but does not coalesce adjacent edits.
@@ -2747,7 +2781,13 @@ impl Buffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits_iter, autoindent_mode, false, cx)
+        self.edit_internal(
+            edits_iter,
+            autoindent_mode,
+            false,
+            EditDirection::TopDown,
+            cx,
+        )
     }
 
     fn edit_internal<I, S, T>(
@@ -2755,6 +2795,7 @@ impl Buffer {
         edits_iter: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
+        edit_direction: EditDirection,
         cx: &mut Context<Self>,
     ) -> Option<clock::Lamport>
     where
@@ -2861,8 +2902,12 @@ impl Buffer {
 
                     // When inserting text starting with a newline, avoid auto-indenting the
                     // previous line.
-                    if new_text.starts_with('\n') {
+                    if edit_direction == EditDirection::TopDown && new_text.starts_with('\n') {
                         range_of_insertion_to_indent.start += 1;
+                        first_line_is_new = true;
+                    } else if edit_direction == EditDirection::BottomUp && new_text.ends_with('\n')
+                    {
+                        range_of_insertion_to_indent.end -= 1;
                         first_line_is_new = true;
                     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -950,10 +950,13 @@ impl EditPreview {
     }
 }
 
+/// Which newline boundary of an insertion is excluded from auto-indentation.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum EditDirection {
-    TopDown,
-    BottomUp,
+pub enum AutoIndentBoundary {
+    /// When the inserted text starts with a newline, the previous line is not auto-indented.
+    LeadingNewLine,
+    /// When the inserted text ends with a newline, the following line is not auto-indented.
+    TrailingNewLine,
 }
 
 impl Buffer {
@@ -2742,14 +2745,14 @@ impl Buffer {
             edits_iter,
             autoindent_mode,
             true,
-            EditDirection::TopDown,
+            AutoIndentBoundary::LeadingNewLine,
             cx,
         )
     }
 
     /// Like [`edit`](Self::edit), but for edits made before the cursor. Used for Vim actions like
     /// `InsertLineAbove`
-    pub fn edit_bottom_up<I, S, T>(
+    pub fn edit_before<I, S, T>(
         &mut self,
         edits_iter: I,
         autoindent_mode: Option<AutoindentMode>,
@@ -2764,7 +2767,7 @@ impl Buffer {
             edits_iter,
             autoindent_mode,
             true,
-            EditDirection::BottomUp,
+            AutoIndentBoundary::TrailingNewLine,
             cx,
         )
     }
@@ -2785,7 +2788,7 @@ impl Buffer {
             edits_iter,
             autoindent_mode,
             false,
-            EditDirection::TopDown,
+            AutoIndentBoundary::LeadingNewLine,
             cx,
         )
     }
@@ -2795,7 +2798,7 @@ impl Buffer {
         edits_iter: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
-        edit_direction: EditDirection,
+        autoindent_boundary: AutoIndentBoundary,
         cx: &mut Context<Self>,
     ) -> Option<clock::Lamport>
     where
@@ -2902,10 +2905,13 @@ impl Buffer {
 
                     // When inserting text starting with a newline, avoid auto-indenting the
                     // previous line.
-                    if edit_direction == EditDirection::TopDown && new_text.starts_with('\n') {
+                    if autoindent_boundary == AutoIndentBoundary::LeadingNewLine
+                        && new_text.starts_with('\n')
+                    {
                         range_of_insertion_to_indent.start += 1;
                         first_line_is_new = true;
-                    } else if edit_direction == EditDirection::BottomUp && new_text.ends_with('\n')
+                    } else if autoindent_boundary == AutoIndentBoundary::TrailingNewLine
+                        && new_text.ends_with('\n')
                     {
                         range_of_insertion_to_indent.end -= 1;
                         first_line_is_new = true;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -950,13 +950,14 @@ impl EditPreview {
     }
 }
 
-/// Which newline boundary of an insertion is excluded from auto-indentation.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum AutoIndentBoundary {
-    /// When the inserted text starts with a newline, the previous line is not auto-indented.
-    LeadingNewLine,
-    /// When the inserted text ends with a newline, the following line is not auto-indented.
-    TrailingNewLine,
+/// Which pre-existing line to exclude from auto-indentation when inserting
+/// text.
+#[derive(Clone, Copy, Debug)]
+pub enum AutoIndentExclusion {
+    /// Exclude the preceding line when the inserted text starts with a newline.
+    PrecedingLine,
+    /// Exclude the following line when the inserted text ends with a newline.
+    FollowingLine,
 }
 
 impl Buffer {
@@ -2745,13 +2746,13 @@ impl Buffer {
             edits_iter,
             autoindent_mode,
             true,
-            AutoIndentBoundary::LeadingNewLine,
+            AutoIndentExclusion::PrecedingLine,
             cx,
         )
     }
 
-    /// Like [`edit`](Self::edit), but for edits made before the cursor. Used for Vim actions like
-    /// `InsertLineAbove`
+    /// Like [`edit`](Self::edit), but preserves the following line's
+    /// indentation when the inserted text ends with a newline.
     pub fn edit_before<I, S, T>(
         &mut self,
         edits_iter: I,
@@ -2767,7 +2768,7 @@ impl Buffer {
             edits_iter,
             autoindent_mode,
             true,
-            AutoIndentBoundary::TrailingNewLine,
+            AutoIndentExclusion::FollowingLine,
             cx,
         )
     }
@@ -2788,7 +2789,7 @@ impl Buffer {
             edits_iter,
             autoindent_mode,
             false,
-            AutoIndentBoundary::LeadingNewLine,
+            AutoIndentExclusion::PrecedingLine,
             cx,
         )
     }
@@ -2798,7 +2799,7 @@ impl Buffer {
         edits_iter: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
-        autoindent_boundary: AutoIndentBoundary,
+        autoindent_exclusion: AutoIndentExclusion,
         cx: &mut Context<Self>,
     ) -> Option<clock::Lamport>
     where
@@ -2903,18 +2904,21 @@ impl Buffer {
                         first_line_is_new = false;
                     }
 
-                    // When inserting text starting with a newline, avoid auto-indenting the
-                    // previous line.
-                    if autoindent_boundary == AutoIndentBoundary::LeadingNewLine
-                        && new_text.starts_with('\n')
-                    {
-                        range_of_insertion_to_indent.start += 1;
-                        first_line_is_new = true;
-                    } else if autoindent_boundary == AutoIndentBoundary::TrailingNewLine
-                        && new_text.ends_with('\n')
-                    {
-                        range_of_insertion_to_indent.end -= 1;
-                        first_line_is_new = true;
+                    // When the insertion introduces a line boundary, exclude
+                    // the adjacent pre-existing line from auto-indentation.
+                    match autoindent_exclusion {
+                        AutoIndentExclusion::PrecedingLine => {
+                            if new_text.starts_with('\n') {
+                                range_of_insertion_to_indent.start += 1;
+                                first_line_is_new = true;
+                            }
+                        }
+                        AutoIndentExclusion::FollowingLine => {
+                            if new_text.ends_with('\n') {
+                                range_of_insertion_to_indent.end -= 1;
+                                first_line_is_new = true;
+                            }
+                        }
                     }
 
                     let mut original_indent_column = None;

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2335,6 +2335,42 @@ fn test_autoindent_multi_line_insertion(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_autoindent_bottom_up_insertion(cx: &mut App) {
+    init_settings(cx, |_| {});
+
+    cx.new(|cx| {
+        let text = "
+            fn a() {
+                    b();
+            }
+        "
+        .unindent();
+
+        // Insert a new line above a line that is over-indented. Only the newly added line should
+        // be auto-formatted. The rest of the text should remain the same as before the operation.
+        let mut buffer = Buffer::local(text, cx).with_language(rust_lang(), cx);
+        buffer.edit_bottom_up(
+            [(Point::new(1, 0)..Point::new(1, 0), "        \n")],
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
+        assert_eq!(
+            buffer.text(),
+            "
+                fn a() {
+                    |
+                        b();
+                }
+            "
+            .unindent()
+            .replace('|', "")
+        );
+
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_autoindent_block_mode(cx: &mut App) {
     init_settings(cx, |_| {});
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2335,7 +2335,7 @@ fn test_autoindent_multi_line_insertion(cx: &mut App) {
 }
 
 #[gpui::test]
-fn test_autoindent_bottom_up_insertion(cx: &mut App) {
+fn test_autoindent_edit_before_insertion(cx: &mut App) {
     init_settings(cx, |_| {});
 
     cx.new(|cx| {
@@ -2349,7 +2349,7 @@ fn test_autoindent_bottom_up_insertion(cx: &mut App) {
         // Insert a new line above a line that is over-indented. Only the newly added line should
         // be auto-formatted. The rest of the text should remain the same as before the operation.
         let mut buffer = Buffer::local(text, cx).with_language(rust_lang(), cx);
-        buffer.edit_bottom_up(
+        buffer.edit_before(
             [(Point::new(1, 0)..Point::new(1, 0), "        \n")],
             Some(AutoindentMode::EachLine),
             cx,

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2350,7 +2350,7 @@ fn test_autoindent_edit_before_insertion(cx: &mut App) {
         // be auto-formatted. The rest of the text should remain the same as before the operation.
         let mut buffer = Buffer::local(text, cx).with_language(rust_lang(), cx);
         buffer.edit_before(
-            [(Point::new(1, 0)..Point::new(1, 0), "        \n")],
+            [(Point::new(1, 0)..Point::new(1, 0), "        c();\n")],
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -2358,12 +2358,11 @@ fn test_autoindent_edit_before_insertion(cx: &mut App) {
             buffer.text(),
             "
                 fn a() {
-                    |
+                    c();
                         b();
                 }
             "
             .unindent()
-            .replace('|', "")
         );
 
         buffer

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -21,8 +21,9 @@ use gpui::{App, Context, Entity, EventEmitter};
 use itertools::Itertools;
 use language::{
     AutoindentMode, Buffer, BufferChunks, BufferEditSource, BufferRow, BufferSnapshot, Capability,
-    CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape, DiagnosticEntryRef, File,
-    IndentGuideSettings, IndentSize, Language, LanguageAwareStyling, LanguageScope, OffsetRangeExt,
+    CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape, DiagnosticEntryRef,
+    EditDirection, File, IndentGuideSettings, IndentSize, Language, LanguageAwareStyling,
+    LanguageScope, OffsetRangeExt,
     OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection, TextDimension, TextObject,
     ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions, Unclipped,
     language_settings::{AllLanguageSettings, LanguageSettings},
@@ -1377,7 +1378,20 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, true, cx);
+        self.edit_internal(edits, autoindent_mode, true, EditDirection::TopDown, cx);
+    }
+
+    pub fn edit_bottom_up<I, S, T>(
+        &mut self,
+        edits: I,
+        autoindent_mode: Option<AutoindentMode>,
+        cx: &mut Context<Self>,
+    ) where
+        I: IntoIterator<Item = (Range<S>, T)>,
+        S: ToOffset,
+        T: Into<Arc<str>>,
+    {
+        self.edit_internal(edits, autoindent_mode, true, EditDirection::BottomUp, cx);
     }
 
     pub fn edit_non_coalesce<I, S, T>(
@@ -1390,7 +1404,7 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, false, cx);
+        self.edit_internal(edits, autoindent_mode, false, EditDirection::TopDown, cx);
     }
 
     fn edit_internal<I, S, T>(
@@ -1398,6 +1412,7 @@ impl MultiBuffer {
         edits: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
+        edit_direction: EditDirection,
         cx: &mut Context<Self>,
     ) where
         I: IntoIterator<Item = (Range<S>, T)>,
@@ -1420,7 +1435,14 @@ impl MultiBuffer {
             })
             .collect::<Vec<_>>();
 
-        return edit_internal(self, edits, autoindent_mode, coalesce_adjacent, cx);
+        return edit_internal(
+            self,
+            edits,
+            autoindent_mode,
+            coalesce_adjacent,
+            edit_direction,
+            cx,
+        );
 
         // Non-generic part of edit, hoisted out to avoid blowing up LLVM IR.
         fn edit_internal(
@@ -1428,6 +1450,7 @@ impl MultiBuffer {
             edits: Vec<(Range<MultiBufferOffset>, Arc<str>)>,
             mut autoindent_mode: Option<AutoindentMode>,
             coalesce_adjacent: bool,
+            edit_direction: EditDirection,
             cx: &mut Context<MultiBuffer>,
         ) {
             let original_indent_columns = match &mut autoindent_mode {
@@ -1515,8 +1538,13 @@ impl MultiBuffer {
                         };
 
                     if coalesce_adjacent {
-                        buffer.edit(deletions, deletion_autoindent_mode, cx);
-                        buffer.edit(insertions, insertion_autoindent_mode, cx);
+                        if edit_direction == EditDirection::TopDown {
+                            buffer.edit(deletions, deletion_autoindent_mode, cx);
+                            buffer.edit(insertions, insertion_autoindent_mode, cx);
+                        } else {
+                            buffer.edit_bottom_up(deletions, deletion_autoindent_mode, cx);
+                            buffer.edit_bottom_up(insertions, insertion_autoindent_mode, cx);
+                        }
                     } else {
                         buffer.edit_non_coalesce(deletions, deletion_autoindent_mode, cx);
                         buffer.edit_non_coalesce(insertions, insertion_autoindent_mode, cx);

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -20,7 +20,7 @@ use futures_lite::future::yield_now;
 use gpui::{App, Context, Entity, EventEmitter};
 use itertools::Itertools;
 use language::{
-    AutoIndentBoundary, AutoindentMode, Buffer, BufferChunks, BufferEditSource, BufferRow,
+    AutoIndentExclusion, AutoindentMode, Buffer, BufferChunks, BufferEditSource, BufferRow,
     BufferSnapshot, Capability, CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape,
     DiagnosticEntryRef, File, IndentGuideSettings, IndentSize, Language, LanguageAwareStyling,
     LanguageScope, OffsetRangeExt, OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection,
@@ -1382,7 +1382,7 @@ impl MultiBuffer {
             edits,
             autoindent_mode,
             true,
-            AutoIndentBoundary::LeadingNewLine,
+            AutoIndentExclusion::PrecedingLine,
             cx,
         );
     }
@@ -1401,7 +1401,7 @@ impl MultiBuffer {
             edits,
             autoindent_mode,
             true,
-            AutoIndentBoundary::TrailingNewLine,
+            AutoIndentExclusion::FollowingLine,
             cx,
         );
     }
@@ -1420,7 +1420,7 @@ impl MultiBuffer {
             edits,
             autoindent_mode,
             false,
-            AutoIndentBoundary::LeadingNewLine,
+            AutoIndentExclusion::PrecedingLine,
             cx,
         );
     }
@@ -1430,7 +1430,7 @@ impl MultiBuffer {
         edits: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
-        autoindent_boundary: AutoIndentBoundary,
+        autoindent_exclusion: AutoIndentExclusion,
         cx: &mut Context<Self>,
     ) where
         I: IntoIterator<Item = (Range<S>, T)>,
@@ -1458,7 +1458,7 @@ impl MultiBuffer {
             edits,
             autoindent_mode,
             coalesce_adjacent,
-            autoindent_boundary,
+            autoindent_exclusion,
             cx,
         );
 
@@ -1468,7 +1468,7 @@ impl MultiBuffer {
             edits: Vec<(Range<MultiBufferOffset>, Arc<str>)>,
             mut autoindent_mode: Option<AutoindentMode>,
             coalesce_adjacent: bool,
-            autoindent_boundary: AutoIndentBoundary,
+            autoindent_exclusion: AutoIndentExclusion,
             cx: &mut Context<MultiBuffer>,
         ) {
             let original_indent_columns = match &mut autoindent_mode {
@@ -1556,12 +1556,15 @@ impl MultiBuffer {
                         };
 
                     if coalesce_adjacent {
-                        if autoindent_boundary == AutoIndentBoundary::LeadingNewLine {
-                            buffer.edit(deletions, deletion_autoindent_mode, cx);
-                            buffer.edit(insertions, insertion_autoindent_mode, cx);
-                        } else {
-                            buffer.edit_before(deletions, deletion_autoindent_mode, cx);
-                            buffer.edit_before(insertions, insertion_autoindent_mode, cx);
+                        match autoindent_exclusion {
+                            AutoIndentExclusion::PrecedingLine => {
+                                buffer.edit(deletions, deletion_autoindent_mode, cx);
+                                buffer.edit(insertions, insertion_autoindent_mode, cx);
+                            }
+                            AutoIndentExclusion::FollowingLine => {
+                                buffer.edit_before(deletions, deletion_autoindent_mode, cx);
+                                buffer.edit_before(insertions, insertion_autoindent_mode, cx);
+                            }
                         }
                     } else {
                         buffer.edit_non_coalesce(deletions, deletion_autoindent_mode, cx);

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -20,12 +20,12 @@ use futures_lite::future::yield_now;
 use gpui::{App, Context, Entity, EventEmitter};
 use itertools::Itertools;
 use language::{
-    AutoindentMode, Buffer, BufferChunks, BufferEditSource, BufferRow, BufferSnapshot, Capability,
-    CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape, DiagnosticEntryRef,
-    EditDirection, File, IndentGuideSettings, IndentSize, Language, LanguageAwareStyling,
-    LanguageScope, OffsetRangeExt,
-    OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection, TextDimension, TextObject,
-    ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions, Unclipped,
+    AutoIndentBoundary, AutoindentMode, Buffer, BufferChunks, BufferEditSource, BufferRow,
+    BufferSnapshot, Capability, CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape,
+    DiagnosticEntryRef, File, IndentGuideSettings, IndentSize, Language, LanguageAwareStyling,
+    LanguageScope, OffsetRangeExt, OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection,
+    TextDimension, TextObject, ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions,
+    Unclipped,
     language_settings::{AllLanguageSettings, LanguageSettings},
 };
 
@@ -1378,10 +1378,16 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, true, EditDirection::TopDown, cx);
+        self.edit_internal(
+            edits,
+            autoindent_mode,
+            true,
+            AutoIndentBoundary::LeadingNewLine,
+            cx,
+        );
     }
 
-    pub fn edit_bottom_up<I, S, T>(
+    pub fn edit_before<I, S, T>(
         &mut self,
         edits: I,
         autoindent_mode: Option<AutoindentMode>,
@@ -1391,7 +1397,13 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, true, EditDirection::BottomUp, cx);
+        self.edit_internal(
+            edits,
+            autoindent_mode,
+            true,
+            AutoIndentBoundary::TrailingNewLine,
+            cx,
+        );
     }
 
     pub fn edit_non_coalesce<I, S, T>(
@@ -1404,7 +1416,13 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, false, EditDirection::TopDown, cx);
+        self.edit_internal(
+            edits,
+            autoindent_mode,
+            false,
+            AutoIndentBoundary::LeadingNewLine,
+            cx,
+        );
     }
 
     fn edit_internal<I, S, T>(
@@ -1412,7 +1430,7 @@ impl MultiBuffer {
         edits: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
-        edit_direction: EditDirection,
+        autoindent_boundary: AutoIndentBoundary,
         cx: &mut Context<Self>,
     ) where
         I: IntoIterator<Item = (Range<S>, T)>,
@@ -1440,7 +1458,7 @@ impl MultiBuffer {
             edits,
             autoindent_mode,
             coalesce_adjacent,
-            edit_direction,
+            autoindent_boundary,
             cx,
         );
 
@@ -1450,7 +1468,7 @@ impl MultiBuffer {
             edits: Vec<(Range<MultiBufferOffset>, Arc<str>)>,
             mut autoindent_mode: Option<AutoindentMode>,
             coalesce_adjacent: bool,
-            edit_direction: EditDirection,
+            autoindent_boundary: AutoIndentBoundary,
             cx: &mut Context<MultiBuffer>,
         ) {
             let original_indent_columns = match &mut autoindent_mode {
@@ -1538,12 +1556,12 @@ impl MultiBuffer {
                         };
 
                     if coalesce_adjacent {
-                        if edit_direction == EditDirection::TopDown {
+                        if autoindent_boundary == AutoIndentBoundary::LeadingNewLine {
                             buffer.edit(deletions, deletion_autoindent_mode, cx);
                             buffer.edit(insertions, insertion_autoindent_mode, cx);
                         } else {
-                            buffer.edit_bottom_up(deletions, deletion_autoindent_mode, cx);
-                            buffer.edit_bottom_up(insertions, insertion_autoindent_mode, cx);
+                            buffer.edit_before(deletions, deletion_autoindent_mode, cx);
+                            buffer.edit_before(insertions, insertion_autoindent_mode, cx);
                         }
                     } else {
                         buffer.edit_non_coalesce(deletions, deletion_autoindent_mode, cx);

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1746,6 +1746,23 @@ mod test {
                 }"},
             Mode::Insert,
         );
+
+        // Inserting a line above should auto-indent the newly added line and leave the previous
+        // line unchanged
+        cx.assert_binding(
+            "shift-o",
+            indoc! {"
+                fn test() {
+                        println!(ˇ);
+                }"},
+            Mode::Normal,
+            indoc! {"
+                fn test() {
+                    ˇ
+                        println!();
+                }"},
+            Mode::Insert,
+        );
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -778,7 +778,7 @@ impl Vim {
                     editor.edit(plain_edits, cx);
                 }
                 if !auto_indent_edits.is_empty() {
-                    editor.edit_with_autoindent(auto_indent_edits, cx);
+                    editor.edit_bottom_up_with_autoindent(auto_indent_edits, cx);
                 }
 
                 editor.change_selections(Default::default(), window, cx, |s| {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -778,7 +778,7 @@ impl Vim {
                     editor.edit(plain_edits, cx);
                 }
                 if !auto_indent_edits.is_empty() {
-                    editor.edit_bottom_up_with_autoindent(auto_indent_edits, cx);
+                    editor.edit_before_with_autoindent(auto_indent_edits, cx);
                 }
 
                 editor.change_selections(Default::default(), window, cx, |s| {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -2230,6 +2230,11 @@ mod test {
         cx.set_state("    let xˇ = 1;", Mode::Normal);
         cx.simulate_keystrokes("shift-o");
         cx.assert_state("    ˇ\n    let x = 1;", Mode::Insert);
+
+        // O on an unindented line: the new line gets no indentation
+        cx.set_state("fn test() {\n    println!(\"\");\nˇ}", Mode::Normal);
+        cx.simulate_keystrokes("shift-o");
+        cx.assert_state("fn test() {\n    println!(\"\");\nˇ\n}", Mode::Insert);
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -753,17 +753,7 @@ impl Vim {
                     let indent = if auto_indent_mode == AutoIndentMode::None {
                         String::new()
                     } else {
-                        let indent_size = snapshot.indent_size_for_line(MultiBufferRow(row)).len;
-                        let first_char = snapshot.chars_at(Point::new(row, indent_size)).next();
-                        let indent_row = if matches!(first_char, Some('}') | Some(')')) {
-                            snapshot
-                                .prev_non_blank_row(MultiBufferRow(row))
-                                .map(|r| r.0)
-                                .unwrap_or(row)
-                        } else {
-                            row
-                        };
-                        snapshot.indent_and_comment_for_line(MultiBufferRow(indent_row), cx)
+                        snapshot.indent_and_comment_for_line(MultiBufferRow(row), cx)
                     };
                     let start_of_line = Point::new(row, 0);
                     let edit = (start_of_line..start_of_line, indent + "\n");


### PR DESCRIPTION
Fixes InsertLineAbove (Shift + O) auto-indent handling by deciding whether to trim the first character or the last character based on direction. Previously, inserting a line above would auto format the line the cursor was originally on and not the new line (instead of the correct behavior which is to do the opposite).

No tests because I couldn't find any Vim-specific auto-indent tests and this only affects Vim mode. If I'm missing something there LMK and I'll take a closer look.

Closes #52588.

Release Notes:

- Vim: Fixed auto-indentation for insert above action.
