### PR TITLE
docs: Suggest using nextest not `cargo test`

### DIFF
--- a/.factory/prompts/crash/fix.md
+++ b/.factory/prompts/crash/fix.md
@@ -18,7 +18,7 @@ If either is missing, ask the user to provide them or run the investigation phas
 Run the reproduction test and verify it fails with the expected crash:
 
 ```
-cargo test -p <crate> <test_name>
+cargo nextest run -p <crate> <test_name>
 ```
 
 Read the failure output. Confirm the panic message and stack trace match what ANALYSIS.md describes. If the test doesn't fail, or fails differently than expected, stop and reassess before proceeding.
@@ -45,13 +45,13 @@ Apply the minimal change needed to resolve the root cause. Guidelines:
 Run the reproduction test and confirm it passes:
 
 ```
-cargo test -p <crate> <test_name>
+cargo nextest run -p <crate> <test_name>
 ```
 
 Then run the full test suite for the affected crate to check for regressions:
 
 ```
-cargo test -p <crate>
+cargo nextest run -p <crate>
 ```
 
 If any tests fail, determine whether the fix introduced a regression. Fix regressions before proceeding.

--- a/.factory/prompts/crash/investigate.md
+++ b/.factory/prompts/crash/investigate.md
@@ -75,7 +75,7 @@ Create an `ANALYSIS.md` file (in the working directory root, or wherever instruc
 ## Reproduction
 <Describe what the test does and how it triggers the same crash.
 Include the exact command to run the test, e.g.:
-`cargo test -p <crate> <test_name>`>
+`cargo nextest run -p <crate> <test_name>`>
 
 ## Suggested Fix
 <Describe the fix approach. Be specific: which function, what check to add,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,11 @@ When your changes affect UI, consult this checklist:
 - Are power features discoverable but not intrusive?
 - Is there a path from beginner → expert usage (progressive disclosure)?
 
+## Building and testing Zed
+
+Some tests in this tree will only pass under Nextest, not under `cargo test`. To run tests, use
+
+    cargo nextest run -p <PACKAGE>
 
 ## Things we will (probably) not merge
 

--- a/docs/src/development/freebsd.md
+++ b/docs/src/development/freebsd.md
@@ -34,7 +34,7 @@ cargo run
 And to run the tests:
 
 ```sh
-cargo test --workspace
+cargo nextest run --workspace
 ```
 
 In release mode, the primary user interface is the `cli` crate. You can run it in development with:

--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -61,7 +61,7 @@ cargo run
 And to run the tests:
 
 ```sh
-cargo test --workspace
+cargo nextest run --workspace
 ```
 
 In release mode, the primary user interface is the `cli` crate. You can run it in development with:

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -55,7 +55,7 @@ cargo run --release
 And to run the tests:
 
 ```sh
-cargo test --workspace
+cargo nextest run --workspace
 ```
 
 ## Visual Regression Tests

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -110,7 +110,7 @@ cargo run --release
 And to run the tests:
 
 ```sh
-cargo test --workspace
+cargo nextest run --workspace
 ```
 
 > **Note:** Visual regression tests are currently macOS-only and require Screen Recording permission. See [Building Zed for macOS](./macos.md#visual-regression-tests) for details.


### PR DESCRIPTION
When trying to get started on Zed development I found that some tests consistently fail under `cargo test`, and they seem to need nextest.

Fixes #37713

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- n/a: Tests cover the new/changed behavior
- n/a: Performance impact has been considered and is acceptable

Closes #37713

Release Notes:

- N/A or Added/Fixed/Improved ...
