### PR TITLE
editor: Prevent blame popover from appearing when cursor is on different pane

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1289,7 +1289,9 @@ impl EditorElement {
             cx.notify();
         }
 
-        if let Some((bounds, buffer_id, blame_entry)) = &position_map.inline_blame_bounds {
+        if text_hovered
+            && let Some((bounds, buffer_id, blame_entry)) = &position_map.inline_blame_bounds
+        {
             let mouse_over_inline_blame = bounds.contains(&event.position);
             let mouse_over_popover = editor
                 .inline_blame_popover


### PR DESCRIPTION
The blame popover shouldn't appear when the cursor hovers over the annotation but on a different pane.

Before:

https://github.com/user-attachments/assets/dbf6f7b5-e27f-495b-8d6f-fa75a4feee18

After:

https://github.com/user-attachments/assets/d5e186df-4ebf-4b4c-bb5f-4d9e7b0f62c7

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a bug that caused git blame annotations to be hoverable from a different pane.
