### PR TITLE
editor: Fix auto indent adding trailing whitespace on repeated enter

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5232,7 +5232,7 @@ impl Editor {
                             buffer.indent_size_for_line(MultiBufferRow(start_point.row));
                         let full_indent_len = existing_indent.len;
                         existing_indent.len = cmp::min(existing_indent.len, start_point.column);
-                        let start = selection.start;
+                        let mut start = selection.start;
                         let end = selection.end;
                         let selection_is_empty = start == end;
                         let language_scope = buffer.language_scope_at(start);
@@ -5382,25 +5382,21 @@ impl Editor {
                                     }
                                     new_text.extend(extra_indent.chars());
                                 }
-                                // Extend the edit to the beginning of the line when the
-                                // line is blank so that auto-indent whitespace is replaced
-                                // rather than left as trailing whitespace.
-                                let edit_start = if selection_is_empty && preserve_indent {
-                                    let line_len =
-                                        buffer.line_len(MultiBufferRow(start_point.row));
-                                    if line_len > 0
-                                        && line_len == full_indent_len
-                                        && start_point.column == line_len
-                                    {
-                                        buffer.point_to_offset(Point::new(start_point.row, 0))
-                                    } else {
-                                        start
-                                    }
-                                } else {
-                                    start
-                                };
+                                // Extend the edit to the beginning of the line
+                                // to clear auto-indent whitespace that would
+                                // otherwise remain as trailing whitespace. This
+                                // applies to blank lines and lines where only
+                                // indentation remains before the cursor.
+                                if selection_is_empty
+                                    && preserve_indent
+                                    && full_indent_len > 0
+                                    && start_point.column == full_indent_len
+                                {
+                                    start = buffer.point_to_offset(Point::new(start_point.row, 0));
+                                }
+
                                 (
-                                    edit_start,
+                                    start,
                                     new_text,
                                     *prevent_auto_indent || !apply_syntax_indent,
                                 )

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5230,6 +5230,7 @@ impl Editor {
                         let start_point = selection.start.to_point(&buffer);
                         let mut existing_indent =
                             buffer.indent_size_for_line(MultiBufferRow(start_point.row));
+                        let full_indent_len = existing_indent.len;
                         existing_indent.len = cmp::min(existing_indent.len, start_point.column);
                         let start = selection.start;
                         let end = selection.end;
@@ -5381,8 +5382,25 @@ impl Editor {
                                     }
                                     new_text.extend(extra_indent.chars());
                                 }
+                                // Extend the edit to the beginning of the line when the
+                                // line is blank so that auto-indent whitespace is replaced
+                                // rather than left as trailing whitespace.
+                                let edit_start = if selection_is_empty && preserve_indent {
+                                    let line_len =
+                                        buffer.line_len(MultiBufferRow(start_point.row));
+                                    if line_len > 0
+                                        && line_len == full_indent_len
+                                        && start_point.column == line_len
+                                    {
+                                        buffer.point_to_offset(Point::new(start_point.row, 0))
+                                    } else {
+                                        start
+                                    }
+                                } else {
+                                    start
+                                };
                                 (
-                                    start,
+                                    edit_start,
                                     new_text,
                                     *prevent_auto_indent || !apply_syntax_indent,
                                 )

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3353,80 +3353,78 @@ fn test_newline(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-fn test_newline_clears_trailing_whitespace_on_blank_line(cx: &mut TestAppContext) {
+fn test_newline_trailing_whitespace(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
     });
 
-    let editor = cx.add_window(|window, cx| {
-        let buffer = MultiBuffer::build_simple("    hello\n    world\n", cx);
-        build_editor(buffer, window, cx)
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("    hello\n    world\n", cx));
+    let editor = cx.add_window(|window, cx| build_editor(buffer.clone(), window, cx));
+
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_display_ranges([
+                    DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9)
+                ])
+            });
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hello\n    \n    world\n");
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hello\n\n    \n    world\n");
+        })
+        .unwrap();
+
+    buffer.update(cx, |buffer, cx| {
+        let start = MultiBufferOffset(0);
+        let end = buffer.len(cx);
+        buffer.edit([(start..end, "    hello\n    world\n")], None, cx);
     });
 
-    _ = editor.update(cx, |editor, window, cx| {
-        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_display_ranges([
-                DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9),
-            ])
-        });
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_display_ranges([
+                    DisplayPoint::new(DisplayRow(0), 7)..DisplayPoint::new(DisplayRow(0), 7)
+                ])
+            });
 
-        editor.newline(&Newline, window, cx);
-        assert_eq!(editor.text(cx), "    hello\n    \n    world\n");
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hel\n    lo\n    world\n");
 
-        editor.newline(&Newline, window, cx);
-        assert_eq!(editor.text(cx), "    hello\n\n    \n    world\n");
-    });
-}
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hel\n\n    lo\n    world\n");
+        })
+        .unwrap();
 
-#[gpui::test]
-fn test_newline_preserves_whitespace_on_non_blank_line(cx: &mut TestAppContext) {
-    init_test(cx, |settings| {
-        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
-    });
-
-    let editor = cx.add_window(|window, cx| {
-        let buffer = MultiBuffer::build_simple("    hello\n    world\n", cx);
-        build_editor(buffer, window, cx)
-    });
-
-    _ = editor.update(cx, |editor, window, cx| {
-        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_display_ranges([
-                DisplayPoint::new(DisplayRow(0), 7)..DisplayPoint::new(DisplayRow(0), 7),
-            ])
-        });
-
-        editor.newline(&Newline, window, cx);
-        assert_eq!(editor.text(cx), "    hel\n    lo\n    world\n");
-    });
-}
-
-#[gpui::test]
-fn test_newline_clears_trailing_whitespace_with_tabs(cx: &mut TestAppContext) {
-    init_test(cx, |settings| {
-        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
+    update_test_language_settings(cx, &|settings| {
         settings.defaults.tab_size = NonZeroU32::new(4);
         settings.defaults.hard_tabs = Some(true);
     });
 
-    let editor = cx.add_window(|window, cx| {
-        let buffer = MultiBuffer::build_simple("\thello\n\tworld\n", cx);
-        build_editor(buffer, window, cx)
+    buffer.update(cx, |buffer, cx| {
+        let start = MultiBufferOffset(0);
+        let end = buffer.len(cx);
+        buffer.edit([(start..end, "\thello\n\tworld\n")], None, cx);
     });
 
-    _ = editor.update(cx, |editor, window, cx| {
-        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_display_ranges([
-                DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9),
-            ])
-        });
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_display_ranges([
+                    DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9)
+                ])
+            });
 
-        editor.newline(&Newline, window, cx);
-        assert_eq!(editor.text(cx), "\thello\n\t\n\tworld\n");
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "\thello\n\t\n\tworld\n");
 
-        editor.newline(&Newline, window, cx);
-        assert_eq!(editor.text(cx), "\thello\n\n\t\n\tworld\n");
-    });
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "\thello\n\n\t\n\tworld\n");
+        })
+        .unwrap();
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3353,6 +3353,83 @@ fn test_newline(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_newline_clears_trailing_whitespace_on_blank_line(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
+    });
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple("    hello\n    world\n", cx);
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9),
+            ])
+        });
+
+        editor.newline(&Newline, window, cx);
+        assert_eq!(editor.text(cx), "    hello\n    \n    world\n");
+
+        editor.newline(&Newline, window, cx);
+        assert_eq!(editor.text(cx), "    hello\n\n    \n    world\n");
+    });
+}
+
+#[gpui::test]
+fn test_newline_preserves_whitespace_on_non_blank_line(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
+    });
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple("    hello\n    world\n", cx);
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 7)..DisplayPoint::new(DisplayRow(0), 7),
+            ])
+        });
+
+        editor.newline(&Newline, window, cx);
+        assert_eq!(editor.text(cx), "    hel\n    lo\n    world\n");
+    });
+}
+
+#[gpui::test]
+fn test_newline_clears_trailing_whitespace_with_tabs(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple("\thello\n\tworld\n", cx);
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9),
+            ])
+        });
+
+        editor.newline(&Newline, window, cx);
+        assert_eq!(editor.text(cx), "\thello\n\t\n\tworld\n");
+
+        editor.newline(&Newline, window, cx);
+        assert_eq!(editor.text(cx), "\thello\n\n\t\n\tworld\n");
+    });
+}
+
+#[gpui::test]
 async fn test_newline_yaml(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Fixes #34316

## Problem

Pressing Enter repeatedly on an auto-indented blank line leaves trailing
whitespace on every line left behind.

Reproduction steps:
1. Open a Python file with `if __name__ == "__main__":` followed by an indented line
2. Place the cursor at the end of the `if` line
3. Press Enter — a new indented line is created correctly
4. Press Enter again — the previous blank line now has trailing whitespace (`    `)

The root cause is in `newline()` in `editor.rs`. The edit that inserts
the new line starts at the cursor position. When the cursor is at the
end of a whitespace-only line (e.g. `    |`), the edit inserts `\n    `
*after* the existing whitespace, leaving the original `    ` behind as
trailing whitespace.

## Fix

`editor.rs` — when the cursor is at the end of a whitespace-only line,
the edit range is extended to the beginning of that line so the
whitespace is replaced rather than kept.

## Test Plan

3 unit tests added to `editor_tests.rs`:
- `test_newline_clears_trailing_whitespace_on_blank_line` — reproduces the reported bug and verifies the fix
- `test_newline_preserves_whitespace_on_non_blank_line` — verifies that pressing Enter mid-line is unaffected by the change
- `test_newline_clears_trailing_whitespace_with_tabs` — verifies the fix works with tab-based indentation

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #34316 

Release Notes:

- Fixed auto indent leaving trailing whitespace on blank indented lines when creating new lines.⁠