### PR TITLE
docs: Update guide to remove user data on macOS when uninstalling Zed

### DIFF
--- a/docs/src/uninstall.md
+++ b/docs/src/uninstall.md
@@ -40,9 +40,10 @@ To completely remove all Zed configuration files and data:
 2. Press `Cmd + Shift + G` to open "Go to Folder"
 3. Delete the following directories if they exist:
    - `~/Library/Application Support/Zed`
-   - `~/Library/Saved Application State/dev.zed.Zed.savedState`
    - `~/Library/Logs/Zed`
-   - `~/Library/Caches/dev.zed.Zed`
+   - `~/Library/Caches/Zed`
+   - `~/.config/zed`
+   - `~/.local/state/Zed`
 
 ## Linux
 

--- a/docs/src/uninstall.md
+++ b/docs/src/uninstall.md
@@ -40,7 +40,9 @@ To completely remove all Zed configuration files and data:
 2. Press `Cmd + Shift + G` to open "Go to Folder"
 3. Delete the following directories if they exist:
    - `~/Library/Application Support/Zed`
+   - `~/Library/Saved Application State/dev.zed.Zed.savedState`
    - `~/Library/Logs/Zed`
+   - `~/Library/Caches/dev.zed.Zed`
    - `~/Library/Caches/Zed`
    - `~/.config/zed`
    - `~/.local/state/Zed`


### PR DESCRIPTION
I recently encountered some issue on my mac and I tried to uninstall Zed completely. However the current guide to remove user data does not cover some configs that Zed uses. There are also some directories that should be removed according to the doc but never exist. So I have this pull request to make the user data directories more accurate, according to my own experience.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A: doc update
