### PR TITLE
Handle right and other mouse drag events on macOS

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -189,6 +189,14 @@ unsafe fn build_classes() {
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );
                 decl.add_method(
+                    sel!(rightMouseDragged:),
+                    handle_view_event as extern "C" fn(&Object, Sel, id),
+                );
+                decl.add_method(
+                    sel!(otherMouseDragged:),
+                    handle_view_event as extern "C" fn(&Object, Sel, id),
+                );
+                decl.add_method(
                     sel!(scrollWheel:),
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );


### PR DESCRIPTION
## Summary
- register `rightMouseDragged:` on `GPUIView`
- register `otherMouseDragged:` on `GPUIView`

## Why
`mouseDragged:` covers primary-button drags, but macOS secondary-button drags are delivered through `rightMouseDragged:` and `otherMouseDragged:`. Without those selectors, GPUI views miss right-drag gesture streams, which breaks secondary-button box-zoom style interactions in downstream apps.

## Testing
- not run (small selector registration fix)