### PR TITLE
Add the ability to reorder favorited collab channels

### DIFF
--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -166,17 +166,18 @@ impl ChannelStore {
     }
 
     pub fn is_channel_favorited(&self, channel_id: ChannelId) -> bool {
-        self.favorite_channel_ids.binary_search(&channel_id).is_ok()
+        self.favorite_channel_ids.contains(&channel_id)
     }
 
     pub fn toggle_favorite_channel(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
-        match self.favorite_channel_ids.binary_search(&channel_id) {
-            Ok(ix) => {
-                self.favorite_channel_ids.remove(ix);
-            }
-            Err(ix) => {
-                self.favorite_channel_ids.insert(ix, channel_id);
-            }
+        if let Some(ix) = self
+            .favorite_channel_ids
+            .iter()
+            .position(|id| *id == channel_id)
+        {
+            self.favorite_channel_ids.remove(ix);
+        } else {
+            self.favorite_channel_ids.push(channel_id);
         }
         cx.notify();
     }

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -199,6 +199,43 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "[Contacts]",
         ]
     );
+
+    // Navigate to favorite channel-c and unfavorite it.
+    // Favorites section should disappear entirely.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-c  <== selected",
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c  <== selected",
+            "[Contacts]",
+        ]
+    );
 }
 
 #[gpui::test]

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -182,6 +182,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
     );
 
     // Unfavorite channel-b via action.
+    // Selection should move to channel-b in the Channels section.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
@@ -193,7 +194,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "[Channels]",
             "  v root",
             "    #️⃣ channel-a",
-            "    #️⃣ channel-b",
+            "    #️⃣ channel-b  <== selected",
             "    #️⃣ channel-c",
             "[Contacts]",
         ]

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -5,7 +5,7 @@ use gpui::TestAppContext;
 use rpc::proto;
 
 #[gpui::test]
-async fn test_favorite_channels(cx: &mut TestAppContext) {
+async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestAppContext) {
     let (server, client) = TestServer::start1(cx).await;
     let _channel_a = server
         .make_channel("channel-a", None, (&client, cx), &mut [])
@@ -146,7 +146,7 @@ async fn test_favorite_channels(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_reorder_channels_does_not_affect_favorites(cx: &mut TestAppContext) {
+async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContext) {
     let (server, client) = TestServer::start1(cx).await;
     let root = server
         .make_channel("root", None, (&client, cx), &mut [])
@@ -190,7 +190,6 @@ async fn test_reorder_channels_does_not_affect_favorites(cx: &mut TestAppContext
     );
 
     // Reorder the real channels: move channel-a down (swaps with channel-b).
-    // The Favorites section should remain unchanged.
     cx.read(ChannelStore::global)
         .update(cx, |store, cx| {
             store.reorder_channel(channel_a, proto::reorder_channel::Direction::Down, cx)

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -1,0 +1,217 @@
+use crate::TestServer;
+use channel::ChannelStore;
+use collab_ui::CollabPanel;
+use gpui::TestAppContext;
+use rpc::proto;
+
+#[gpui::test]
+async fn test_favorite_channels(cx: &mut TestAppContext) {
+    let (server, client) = TestServer::start1(cx).await;
+    let _channel_a = server
+        .make_channel("channel-a", None, (&client, cx), &mut [])
+        .await;
+    let channel_b = server
+        .make_channel("channel-b", None, (&client, cx), &mut [])
+        .await;
+    let channel_c = server
+        .make_channel("channel-c", None, (&client, cx), &mut [])
+        .await;
+
+    let (workspace, cx) = client.build_test_workspace(cx).await;
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = CollabPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    // Verify initial state: just channels, no favorites.
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Favorite channel-b and channel-c.
+    panel.update(cx, |panel, cx| {
+        panel.toggle_favorite_channel(channel_b, cx);
+        panel.toggle_favorite_channel(channel_c, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Reorder favorites: move channel-b down (should swap with channel-c).
+    // The Channels section should remain unchanged.
+    panel.update(cx, |panel, cx| {
+        panel.reorder_favorite(channel_b, proto::reorder_channel::Direction::Down, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-c",
+            "  #️⃣ channel-b",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Reorder favorites: move channel-b up (should swap back with channel-c).
+    // The Channels section should remain unchanged.
+    panel.update(cx, |panel, cx| {
+        panel.reorder_favorite(channel_b, proto::reorder_channel::Direction::Up, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Reorder favorites: move channel-b up when it's already first (should be no-op).
+    panel.update(cx, |panel, cx| {
+        panel.reorder_favorite(channel_b, proto::reorder_channel::Direction::Up, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Unfavorite channel-b.
+    panel.update(cx, |panel, cx| {
+        panel.toggle_favorite_channel(channel_b, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-c",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Unfavorite channel-c: favorites section should disappear.
+    panel.update(cx, |panel, cx| {
+        panel.toggle_favorite_channel(channel_c, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_reorder_channels_does_not_affect_favorites(cx: &mut TestAppContext) {
+    let (server, client) = TestServer::start1(cx).await;
+    let root = server
+        .make_channel("root", None, (&client, cx), &mut [])
+        .await;
+    let channel_a = server
+        .make_channel("channel-a", Some(root), (&client, cx), &mut [])
+        .await;
+    let channel_b = server
+        .make_channel("channel-b", Some(root), (&client, cx), &mut [])
+        .await;
+    let _channel_c = server
+        .make_channel("channel-c", Some(root), (&client, cx), &mut [])
+        .await;
+
+    let (workspace, cx) = client.build_test_workspace(cx).await;
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = CollabPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    // Favorite channel-a and channel-b (in that order).
+    panel.update(cx, |panel, cx| {
+        panel.toggle_favorite_channel(channel_a, cx);
+        panel.toggle_favorite_channel(channel_b, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Reorder the real channels: move channel-a down (swaps with channel-b).
+    // The Favorites section should remain unchanged.
+    cx.read(ChannelStore::global)
+        .update(cx, |store, cx| {
+            store.reorder_channel(channel_a, proto::reorder_channel::Direction::Down, cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    // Channels section should reflect the reorder, but favorites stay the same.
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+}

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -1,19 +1,19 @@
 use crate::TestServer;
-use channel::ChannelStore;
 use collab_ui::CollabPanel;
+use collab_ui::collab_panel::{MoveChannelDown, MoveChannelUp, ToggleSelectedChannelFavorite};
 use gpui::TestAppContext;
-use rpc::proto;
+use menu::{SelectNext, SelectPrevious};
 
 #[gpui::test]
 async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestAppContext) {
     let (server, client) = TestServer::start1(cx).await;
-    let _channel_a = server
+    let _ = server
         .make_channel("channel-a", None, (&client, cx), &mut [])
         .await;
-    let channel_b = server
+    let _ = server
         .make_channel("channel-b", None, (&client, cx), &mut [])
         .await;
-    let channel_c = server
+    let _ = server
         .make_channel("channel-c", None, (&client, cx), &mut [])
         .await;
 
@@ -37,10 +37,45 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Favorite channel-b and channel-c.
-    panel.update(cx, |panel, cx| {
-        panel.toggle_favorite_channel(channel_b, cx);
-        panel.toggle_favorite_channel(channel_c, cx);
+    // Select channel-b and favorite it.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_next(&SelectNext, window, cx);
+        panel.select_next(&SelectNext, window, cx);
+        panel.select_next(&SelectNext, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b  <== selected",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-b",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b  <== selected",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Select channel-c and favorite it.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_next(&SelectNext, window, cx);
+    });
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
@@ -51,22 +86,26 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "[Channels]",
             "  #️⃣ channel-a",
             "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  #️⃣ channel-c  <== selected",
             "[Contacts]",
         ]
     );
 
-    // Reorder favorites: move channel-b down (should swap with channel-c).
+    // Navigate up to favorite channel-b and move it down.
     // The Channels section should remain unchanged.
-    panel.update(cx, |panel, cx| {
-        panel.reorder_favorite(channel_b, proto::reorder_channel::Direction::Down, cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
+        panel.select_previous(&SelectPrevious, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Favorites]",
+            "  #️⃣ channel-b  <== selected",
             "  #️⃣ channel-c",
-            "  #️⃣ channel-b",
             "[Channels]",
             "  #️⃣ channel-a",
             "  #️⃣ channel-b",
@@ -75,16 +114,33 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Reorder favorites: move channel-b up (should swap back with channel-c).
+    panel.update_in(cx, |panel, window, cx| {
+        panel.move_channel_down(&MoveChannelDown, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-c",
+            "  #️⃣ channel-b  <== selected",
+            "[Channels]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "  #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Move favorite channel-b back up.
     // The Channels section should remain unchanged.
-    panel.update(cx, |panel, cx| {
-        panel.reorder_favorite(channel_b, proto::reorder_channel::Direction::Up, cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.move_channel_up(&MoveChannelUp, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Favorites]",
-            "  #️⃣ channel-b",
+            "  #️⃣ channel-b  <== selected",
             "  #️⃣ channel-c",
             "[Channels]",
             "  #️⃣ channel-a",
@@ -94,15 +150,15 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Reorder favorites: move channel-b up when it's already first (should be no-op).
-    panel.update(cx, |panel, cx| {
-        panel.reorder_favorite(channel_b, proto::reorder_channel::Direction::Up, cx);
+    // Move favorite channel-b up when it's already first (should be no-op).
+    panel.update_in(cx, |panel, window, cx| {
+        panel.move_channel_up(&MoveChannelUp, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Favorites]",
-            "  #️⃣ channel-b",
+            "  #️⃣ channel-b  <== selected",
             "  #️⃣ channel-c",
             "[Channels]",
             "  #️⃣ channel-a",
@@ -112,30 +168,15 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Unfavorite channel-b.
-    panel.update(cx, |panel, cx| {
-        panel.toggle_favorite_channel(channel_b, cx);
+    // Unfavorite channel-b via action.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Favorites]",
             "  #️⃣ channel-c",
-            "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
-            "[Contacts]",
-        ]
-    );
-
-    // Unfavorite channel-c: favorites section should disappear.
-    panel.update(cx, |panel, cx| {
-        panel.toggle_favorite_channel(channel_c, cx);
-    });
-    assert_eq!(
-        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
-        &[
             "[Channels]",
             "  #️⃣ channel-a",
             "  #️⃣ channel-b",
@@ -151,13 +192,13 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
     let root = server
         .make_channel("root", None, (&client, cx), &mut [])
         .await;
-    let channel_a = server
+    let _ = server
         .make_channel("channel-a", Some(root), (&client, cx), &mut [])
         .await;
-    let channel_b = server
+    let _ = server
         .make_channel("channel-b", Some(root), (&client, cx), &mut [])
         .await;
-    let _channel_c = server
+    let _ = server
         .make_channel("channel-c", Some(root), (&client, cx), &mut [])
         .await;
 
@@ -169,10 +210,52 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
     });
     cx.run_until_parked();
 
-    // Favorite channel-a and channel-b (in that order).
-    panel.update(cx, |panel, cx| {
-        panel.toggle_favorite_channel(channel_a, cx);
-        panel.toggle_favorite_channel(channel_b, cx);
+    // Select channel-a and channel-b, favorite them via action.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_next(&SelectNext, window, cx);
+        panel.select_next(&SelectNext, window, cx);
+        panel.select_next(&SelectNext, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-a  <== selected",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
+    });
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_next(&SelectNext, window, cx);
+        panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-a",
+            "  #️⃣ channel-b",
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b  <== selected",
+            "    #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
+    // Select channel-a in the Channels section and move it down.
+    // The Favorites section should remain unchanged.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_previous(&SelectPrevious, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
@@ -182,23 +265,21 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
             "  #️⃣ channel-b",
             "[Channels]",
             "  v root",
-            "    #️⃣ channel-a",
+            "    #️⃣ channel-a  <== selected",
             "    #️⃣ channel-b",
             "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
 
-    // Reorder the real channels: move channel-a down (swaps with channel-b).
-    cx.read(ChannelStore::global)
-        .update(cx, |store, cx| {
-            store.reorder_channel(channel_a, proto::reorder_channel::Direction::Down, cx)
-        })
-        .await
-        .unwrap();
+    panel.update_in(cx, |panel, window, cx| {
+        panel.move_channel_down(&MoveChannelDown, window, cx);
+    });
     cx.run_until_parked();
 
-    // Channels section should reflect the reorder, but favorites stay the same.
+    // Channels section reflects the reorder; favorites stay the same.
+    // Selection should remain on channel-a in the Channels section,
+    // not jump to channel-a in Favorites.
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
@@ -208,7 +289,7 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
             "[Channels]",
             "  v root",
             "    #️⃣ channel-b",
-            "    #️⃣ channel-a",
+            "    #️⃣ channel-a  <== selected",
             "    #️⃣ channel-c",
             "[Contacts]",
         ]

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -41,7 +41,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Select channel-b and favorite it.
+    // Select channel-b.
     panel.update_in(cx, |panel, window, cx| {
         panel.select_next(&SelectNext, window, cx);
         panel.select_next(&SelectNext, window, cx);
@@ -60,6 +60,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
+    // Favorite channel-b.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
@@ -77,10 +78,11 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Select channel-c and favorite it.
+    // Select channel-c.
     panel.update_in(cx, |panel, window, cx| {
         panel.select_next(&SelectNext, window, cx);
     });
+    // Favorite channel-c.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
@@ -99,8 +101,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Navigate up to favorite channel-b and move it down.
-    // The Channels section should remain unchanged.
+    // Navigate up to favorite channel-b .
     panel.update_in(cx, |panel, window, cx| {
         panel.select_previous(&SelectPrevious, window, cx);
         panel.select_previous(&SelectPrevious, window, cx);
@@ -124,6 +125,8 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
+    // Move favorite channel-b down.
+    // The Channels section should remain unchanged
     panel.update_in(cx, |panel, window, cx| {
         panel.move_channel_down(&MoveChannelDown, window, cx);
     });
@@ -162,7 +165,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Move favorite channel-b up when it's already first (should be no-op).
+    // Move favorite channel-b up again when it's already first (should be no-op).
     panel.update_in(cx, |panel, window, cx| {
         panel.move_channel_up(&MoveChannelUp, window, cx);
     });
@@ -181,7 +184,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Unfavorite channel-b via action.
+    // Unfavorite channel-b.
     // Selection should move to channel-b in the Channels section.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
@@ -200,8 +203,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
-    // Navigate to favorite channel-c and unfavorite it.
-    // Favorites section should disappear entirely.
+    // Navigate to favorite channel-c.
     panel.update_in(cx, |panel, window, cx| {
         panel.select_previous(&SelectPrevious, window, cx);
         panel.select_previous(&SelectPrevious, window, cx);
@@ -222,6 +224,8 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
+    // Unfavorite channel-c.
+    // Favorites section should disappear entirely.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
@@ -262,7 +266,7 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
     });
     cx.run_until_parked();
 
-    // Select channel-a and channel-b, favorite them via action.
+    // Select channel-a.
     panel.update_in(cx, |panel, window, cx| {
         panel.select_next(&SelectNext, window, cx);
         panel.select_next(&SelectNext, window, cx);
@@ -280,9 +284,13 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
         ]
     );
 
+    // Favorite channel-a.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
+
+    // Select channel-b.
+    // Favorite channel-b.
     panel.update_in(cx, |panel, window, cx| {
         panel.select_next(&SelectNext, window, cx);
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
@@ -304,8 +312,7 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
         ]
     );
 
-    // Select channel-a in the Channels section and move it down.
-    // The Favorites section should remain unchanged.
+    // Select channel-a in the Channels section.
     panel.update_in(cx, |panel, window, cx| {
         panel.select_previous(&SelectPrevious, window, cx);
     });
@@ -324,14 +331,15 @@ async fn test_reorder_channels_independently_of_favorites(cx: &mut TestAppContex
         ]
     );
 
+    // Move channel-a down.
+    // The Favorites section should remain unchanged.
+    // Selection should remain on channel-a in the Channels section,
+    // not jump to channel-a in Favorites.
     panel.update_in(cx, |panel, window, cx| {
         panel.move_channel_down(&MoveChannelDown, window, cx);
     });
     cx.run_until_parked();
 
-    // Channels section reflects the reorder; favorites stay the same.
-    // Selection should remain on channel-a in the Channels section,
-    // not jump to channel-a in Favorites.
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -7,14 +7,17 @@ use menu::{SelectNext, SelectPrevious};
 #[gpui::test]
 async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestAppContext) {
     let (server, client) = TestServer::start1(cx).await;
-    let _ = server
-        .make_channel("channel-a", None, (&client, cx), &mut [])
+    let root = server
+        .make_channel("root", None, (&client, cx), &mut [])
         .await;
     let _ = server
-        .make_channel("channel-b", None, (&client, cx), &mut [])
+        .make_channel("channel-a", Some(root), (&client, cx), &mut [])
         .await;
     let _ = server
-        .make_channel("channel-c", None, (&client, cx), &mut [])
+        .make_channel("channel-b", Some(root), (&client, cx), &mut [])
+        .await;
+    let _ = server
+        .make_channel("channel-c", Some(root), (&client, cx), &mut [])
         .await;
 
     let (workspace, cx) = client.build_test_workspace(cx).await;
@@ -25,14 +28,15 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
     });
     cx.run_until_parked();
 
-    // Verify initial state: just channels, no favorites.
+    // Verify initial state.
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -42,14 +46,16 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         panel.select_next(&SelectNext, window, cx);
         panel.select_next(&SelectNext, window, cx);
         panel.select_next(&SelectNext, window, cx);
+        panel.select_next(&SelectNext, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b  <== selected",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b  <== selected",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -63,9 +69,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "[Favorites]",
             "  #️⃣ channel-b",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b  <== selected",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b  <== selected",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -84,9 +91,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "  #️⃣ channel-b",
             "  #️⃣ channel-c",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c  <== selected",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c  <== selected",
             "[Contacts]",
         ]
     );
@@ -94,6 +102,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
     // Navigate up to favorite channel-b and move it down.
     // The Channels section should remain unchanged.
     panel.update_in(cx, |panel, window, cx| {
+        panel.select_previous(&SelectPrevious, window, cx);
         panel.select_previous(&SelectPrevious, window, cx);
         panel.select_previous(&SelectPrevious, window, cx);
         panel.select_previous(&SelectPrevious, window, cx);
@@ -107,9 +116,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "  #️⃣ channel-b  <== selected",
             "  #️⃣ channel-c",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -124,9 +134,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "  #️⃣ channel-c",
             "  #️⃣ channel-b  <== selected",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -143,9 +154,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "  #️⃣ channel-b  <== selected",
             "  #️⃣ channel-c",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -161,9 +173,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "  #️⃣ channel-b  <== selected",
             "  #️⃣ channel-c",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );
@@ -178,9 +191,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
             "[Favorites]",
             "  #️⃣ channel-c",
             "[Channels]",
-            "  #️⃣ channel-a",
-            "  #️⃣ channel-b",
-            "  #️⃣ channel-c",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -204,30 +204,9 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
     );
 
     // Unfavorite channel-b.
-    // Selection should move to channel-b in the Channels section.
+    // Selection should move to the next favorite (channel-c).
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
-    });
-    assert_eq!(
-        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
-        &[
-            "[Favorites]",
-            "  #️⃣ channel-c",
-            "[Channels]",
-            "  v root",
-            "    #️⃣ channel-a",
-            "    #️⃣ channel-b  <== selected",
-            "    #️⃣ channel-c",
-            "[Contacts]",
-        ]
-    );
-
-    // Navigate to favorite channel-c.
-    panel.update_in(cx, |panel, window, cx| {
-        panel.select_previous(&SelectPrevious, window, cx);
-        panel.select_previous(&SelectPrevious, window, cx);
-        panel.select_previous(&SelectPrevious, window, cx);
-        panel.select_previous(&SelectPrevious, window, cx);
     });
     assert_eq!(
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
@@ -245,6 +224,7 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
 
     // Unfavorite channel-c.
     // Favorites section should disappear entirely.
+    // Selection should move to the next available item.
     panel.update_in(cx, |panel, window, cx| {
         panel.toggle_selected_channel_favorite(&ToggleSelectedChannelFavorite, window, cx);
     });
@@ -252,10 +232,10 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         panel.read_with(cx, |panel, _| panel.entries_as_strings()),
         &[
             "[Channels]",
-            "  v root",
+            "  v root  <== selected",
             "    #️⃣ channel-a",
             "    #️⃣ channel-b",
-            "    #️⃣ channel-c  <== selected",
+            "    #️⃣ channel-c",
             "[Contacts]",
         ]
     );

--- a/crates/collab/tests/integration/collab_panel_tests.rs
+++ b/crates/collab/tests/integration/collab_panel_tests.rs
@@ -145,6 +145,25 @@ async fn test_reorder_favorite_channels_independently_of_channels(cx: &mut TestA
         ]
     );
 
+    // Move favorite channel-b down again when it's already last (should be no-op).
+    panel.update_in(cx, |panel, window, cx| {
+        panel.move_channel_down(&MoveChannelDown, window, cx);
+    });
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.entries_as_strings()),
+        &[
+            "[Favorites]",
+            "  #️⃣ channel-c",
+            "  #️⃣ channel-b  <== selected",
+            "[Channels]",
+            "  v root",
+            "    #️⃣ channel-a",
+            "    #️⃣ channel-b",
+            "    #️⃣ channel-c",
+            "[Contacts]",
+        ]
+    );
+
     // Move favorite channel-b back up.
     // The Channels section should remain unchanged.
     panel.update_in(cx, |panel, window, cx| {

--- a/crates/collab/tests/integration/collab_tests.rs
+++ b/crates/collab/tests/integration/collab_tests.rs
@@ -6,6 +6,7 @@ mod agent_sharing_tests;
 mod channel_buffer_tests;
 mod channel_guest_tests;
 mod channel_tests;
+mod collab_panel_tests;
 mod db_tests;
 mod editor_tests;
 mod following_tests;

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1926,7 +1926,7 @@ impl CollabPanel {
         self.collapsed_channels.binary_search(&channel_id).is_ok()
     }
 
-    fn toggle_favorite_channel(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+    pub fn toggle_favorite_channel(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
         let was_selected_favorite = self.selected_entry_is_favorite()
             && self
                 .selected_channel()
@@ -2222,7 +2222,7 @@ impl CollabPanel {
         }
     }
 
-    fn reorder_favorite(
+    pub fn reorder_favorite(
         &mut self,
         channel_id: ChannelId,
         direction: proto::reorder_channel::Direction,
@@ -3636,5 +3636,83 @@ impl Render for JoinChannelTooltip {
                         .child(render_participant_name_and_handle(participant))
                 }))
         })
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl CollabPanel {
+    pub fn entries_as_strings(&self) -> Vec<String> {
+        let mut result = Vec::new();
+        for (ix, entry) in self.entries.iter().enumerate() {
+            let selected = if self.selection == Some(ix) {
+                "  <== selected"
+            } else {
+                ""
+            };
+            match entry {
+                ListEntry::Header(section) => {
+                    let name = match section {
+                        Section::ActiveCall => "Active Call",
+                        Section::FavoriteChannels => "Favorites",
+                        Section::Channels => "Channels",
+                        Section::ChannelInvites => "Channel Invites",
+                        Section::ContactRequests => "Contact Requests",
+                        Section::Contacts => "Contacts",
+                        Section::Online => "Online",
+                        Section::Offline => "Offline",
+                    };
+                    result.push(format!("[{name}]"));
+                }
+                ListEntry::Channel {
+                    channel,
+                    depth,
+                    has_children,
+                    ..
+                } => {
+                    let indent = "  ".repeat(*depth + 1);
+                    let icon = if *has_children {
+                        "v "
+                    } else if channel.visibility == proto::ChannelVisibility::Public {
+                        "🛜 "
+                    } else {
+                        "#️⃣ "
+                    };
+                    result.push(format!("{indent}{icon}{}{selected}", channel.name));
+                }
+                ListEntry::ChannelNotes { .. } => {
+                    result.push(format!("  (notes){selected}"));
+                }
+                ListEntry::ChannelEditor { depth } => {
+                    let indent = "  ".repeat(*depth + 1);
+                    result.push(format!("{indent}[editor]{selected}"));
+                }
+                ListEntry::ChannelInvite(channel) => {
+                    result.push(format!("  (invite) #{}{selected}", channel.name));
+                }
+                ListEntry::CallParticipant { user, .. } => {
+                    result.push(format!("  {}{selected}", user.github_login));
+                }
+                ListEntry::ParticipantProject {
+                    worktree_root_names,
+                    ..
+                } => {
+                    result.push(format!("    {}{selected}", worktree_root_names.join(", ")));
+                }
+                ListEntry::ParticipantScreen { .. } => {
+                    result.push(format!("    (screen){selected}"));
+                }
+                ListEntry::IncomingRequest(user) => {
+                    result.push(format!("  (incoming) {}{selected}", user.github_login));
+                }
+                ListEntry::OutgoingRequest(user) => {
+                    result.push(format!("  (outgoing) {}{selected}", user.github_login));
+                }
+                ListEntry::Contact { contact, .. } => {
+                    result.push(format!("  {}{selected}", contact.user.github_login));
+                }
+                ListEntry::ContactPlaceholder => {}
+            }
+        }
+        result
     }
 }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1954,6 +1954,12 @@ impl CollabPanel {
     }
 
     fn persist_favorites(&mut self, cx: &mut Context<Self>) {
+        // GlobalKeyValueStore uses a sqlez worker thread that the test
+        // scheduler can't control, causing non-determinism failures.
+        if cfg!(any(test, feature = "test-support")) {
+            return;
+        }
+
         let favorite_ids: Vec<u64> = self
             .channel_store
             .read(cx)

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -306,6 +306,7 @@ enum ListEntry {
         channel: Arc<Channel>,
         depth: usize,
         has_children: bool,
+        is_favorite: bool,
         // `None` when the channel is a parent of a matched channel.
         string_match: Option<StringMatch>,
     },
@@ -727,6 +728,7 @@ impl CollabPanel {
                         channel: (*channel).clone(),
                         depth: 0,
                         has_children: false,
+                        is_favorite: true,
                         string_match: matches_by_candidate.get(&ix).cloned().cloned(),
                     });
                 }
@@ -827,6 +829,7 @@ impl CollabPanel {
                             channel: channel.clone(),
                             depth,
                             has_children: false,
+                            is_favorite: false,
                             string_match: matches_by_id.get(&channel.id).map(|mat| (*mat).clone()),
                         });
                         self.entries
@@ -843,6 +846,7 @@ impl CollabPanel {
                             channel: channel.clone(),
                             depth,
                             has_children,
+                            is_favorite: false,
                             string_match: matches_by_id.get(&channel.id).map(|mat| (*mat).clone()),
                         });
                     }
@@ -1923,10 +1927,25 @@ impl CollabPanel {
     }
 
     fn toggle_favorite_channel(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+        let was_selected_favorite = self.selected_entry_is_favorite()
+            && self
+                .selected_channel()
+                .is_some_and(|channel| channel.id == channel_id);
+
         self.channel_store.update(cx, |store, cx| {
             store.toggle_favorite_channel(channel_id, cx);
         });
         self.persist_favorites(cx);
+
+        if was_selected_favorite && self.selection.is_none() {
+            self.selection = self.entries.iter().position(|entry| {
+                matches!(
+                    entry,
+                    ListEntry::Channel { channel, is_favorite: false, .. }
+                    if channel.id == channel_id
+                )
+            });
+        }
     }
 
     fn is_channel_favorited(&self, channel_id: ChannelId, cx: &App) -> bool {
@@ -2161,12 +2180,21 @@ impl CollabPanel {
     }
 
     fn move_channel_up(&mut self, _: &MoveChannelUp, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(channel) = self.selected_channel() {
-            self.channel_store.update(cx, |store, cx| {
-                store
-                    .reorder_channel(channel.id, proto::reorder_channel::Direction::Up, cx)
-                    .detach_and_prompt_err("Failed to move channel up", window, cx, |_, _, _| None)
-            });
+        if let Some(channel) = self.selected_channel().cloned() {
+            if self.selected_entry_is_favorite() {
+                self.reorder_favorite(channel.id, proto::reorder_channel::Direction::Up, cx);
+            } else {
+                self.channel_store.update(cx, |store, cx| {
+                    store
+                        .reorder_channel(channel.id, proto::reorder_channel::Direction::Up, cx)
+                        .detach_and_prompt_err(
+                            "Failed to move channel up",
+                            window,
+                            cx,
+                            |_, _, _| None,
+                        )
+                });
+            }
         }
     }
 
@@ -2176,15 +2204,49 @@ impl CollabPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(channel) = self.selected_channel() {
-            self.channel_store.update(cx, |store, cx| {
-                store
-                    .reorder_channel(channel.id, proto::reorder_channel::Direction::Down, cx)
-                    .detach_and_prompt_err("Failed to move channel down", window, cx, |_, _, _| {
-                        None
-                    })
-            });
+        if let Some(channel) = self.selected_channel().cloned() {
+            if self.selected_entry_is_favorite() {
+                self.reorder_favorite(channel.id, proto::reorder_channel::Direction::Down, cx);
+            } else {
+                self.channel_store.update(cx, |store, cx| {
+                    store
+                        .reorder_channel(channel.id, proto::reorder_channel::Direction::Down, cx)
+                        .detach_and_prompt_err(
+                            "Failed to move channel down",
+                            window,
+                            cx,
+                            |_, _, _| None,
+                        )
+                });
+            }
         }
+    }
+
+    fn reorder_favorite(
+        &mut self,
+        channel_id: ChannelId,
+        direction: proto::reorder_channel::Direction,
+        cx: &mut Context<Self>,
+    ) {
+        self.channel_store.update(cx, |store, cx| {
+            let favorite_ids = store.favorite_channel_ids();
+            let Some(channel_index) = favorite_ids.iter().position(|id| *id == channel_id) else {
+                return;
+            };
+            let target_channel_index = match direction {
+                proto::reorder_channel::Direction::Up => channel_index.checked_sub(1),
+                proto::reorder_channel::Direction::Down => {
+                    let next = channel_index + 1;
+                    (next < favorite_ids.len()).then_some(next)
+                }
+            };
+            if let Some(target_channel_index) = target_channel_index {
+                let mut new_ids = favorite_ids.to_vec();
+                new_ids.swap(channel_index, target_channel_index);
+                store.set_favorite_channel_ids(new_ids, cx);
+            }
+        });
+        self.persist_favorites(cx);
     }
 
     fn open_channel_notes(
@@ -2252,6 +2314,20 @@ impl CollabPanel {
             .and_then(|entry| match entry {
                 ListEntry::Channel { channel, .. } => Some(channel),
                 _ => None,
+            })
+    }
+
+    fn selected_entry_is_favorite(&self) -> bool {
+        self.selection
+            .and_then(|ix| self.entries.get(ix))
+            .is_some_and(|entry| {
+                matches!(
+                    entry,
+                    ListEntry::Channel {
+                        is_favorite: true,
+                        ..
+                    }
+                )
             })
     }
 
@@ -2552,6 +2628,7 @@ impl CollabPanel {
                 depth,
                 has_children,
                 string_match,
+                ..
             } => self
                 .render_channel(
                     channel,
@@ -3445,13 +3522,17 @@ impl PartialEq for ListEntry {
                 }
             }
             ListEntry::Channel {
-                channel: channel_1, ..
+                channel: channel_1,
+                is_favorite: is_favorite_1,
+                ..
             } => {
                 if let ListEntry::Channel {
-                    channel: channel_2, ..
+                    channel: channel_2,
+                    is_favorite: is_favorite_2,
+                    ..
                 } = other
                 {
-                    return channel_1.id == channel_2.id;
+                    return channel_1.id == channel_2.id && is_favorite_1 == is_favorite_2;
                 }
             }
             ListEntry::ChannelNotes { channel_id } => {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -23,7 +23,7 @@ use menu::{Cancel, Confirm, SecondaryConfirm, SelectNext, SelectPrevious};
 use project::{Fs, Project};
 use rpc::{
     ErrorCode, ErrorExt,
-    proto::{self, ChannelVisibility, PeerId},
+    proto::{self, ChannelVisibility, PeerId, reorder_channel::Direction},
 };
 use serde::{Deserialize, Serialize};
 use settings::Settings;
@@ -2185,22 +2185,7 @@ impl CollabPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(channel) = self.selected_channel().cloned() {
-            if self.selected_entry_is_favorite() {
-                self.reorder_favorite(channel.id, proto::reorder_channel::Direction::Up, cx);
-            } else {
-                self.channel_store.update(cx, |store, cx| {
-                    store
-                        .reorder_channel(channel.id, proto::reorder_channel::Direction::Up, cx)
-                        .detach_and_prompt_err(
-                            "Failed to move channel up",
-                            window,
-                            cx,
-                            |_, _, _| None,
-                        )
-                });
-            }
-        }
+        self.reorder_selected_channel(Direction::Up, window, cx);
     }
 
     pub fn move_channel_down(
@@ -2209,28 +2194,41 @@ impl CollabPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.reorder_selected_channel(Direction::Down, window, cx);
+    }
+
+    fn reorder_selected_channel(
+        &mut self,
+        direction: Direction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(channel) = self.selected_channel().cloned() {
             if self.selected_entry_is_favorite() {
-                self.reorder_favorite(channel.id, proto::reorder_channel::Direction::Down, cx);
-            } else {
-                self.channel_store.update(cx, |store, cx| {
-                    store
-                        .reorder_channel(channel.id, proto::reorder_channel::Direction::Down, cx)
-                        .detach_and_prompt_err(
-                            "Failed to move channel down",
-                            window,
-                            cx,
-                            |_, _, _| None,
-                        )
-                });
+                self.reorder_favorite(channel.id, direction, cx);
+                return;
             }
+
+            self.channel_store.update(cx, |store, cx| {
+                store
+                    .reorder_channel(channel.id, direction, cx)
+                    .detach_and_prompt_err(
+                        match direction {
+                            Direction::Up => "Failed to move channel up",
+                            Direction::Down => "Failed to move channel down",
+                        },
+                        window,
+                        cx,
+                        |_, _, _| None,
+                    )
+            });
         }
     }
 
     pub fn reorder_favorite(
         &mut self,
         channel_id: ChannelId,
-        direction: proto::reorder_channel::Direction,
+        direction: Direction,
         cx: &mut Context<Self>,
     ) {
         self.channel_store.update(cx, |store, cx| {
@@ -2239,8 +2237,8 @@ impl CollabPanel {
                 return;
             };
             let target_channel_index = match direction {
-                proto::reorder_channel::Direction::Up => channel_index.checked_sub(1),
-                proto::reorder_channel::Direction::Down => {
+                Direction::Up => channel_index.checked_sub(1),
+                Direction::Down => {
                     let next = channel_index + 1;
                     (next < favorite_ids.len()).then_some(next)
                 }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -998,12 +998,21 @@ impl CollabPanel {
 
         if select_same_item {
             if let Some(prev_selected_entry) = prev_selected_entry {
-                self.selection.take();
+                let prev_selection = self.selection.take();
                 for (ix, entry) in self.entries.iter().enumerate() {
                     if *entry == prev_selected_entry {
                         self.selection = Some(ix);
                         break;
                     }
+                }
+                if self.selection.is_none() {
+                    self.selection = prev_selection.and_then(|prev_ix| {
+                        if self.entries.is_empty() {
+                            None
+                        } else {
+                            Some(prev_ix.min(self.entries.len() - 1))
+                        }
+                    });
                 }
             }
         } else {
@@ -1927,31 +1936,10 @@ impl CollabPanel {
     }
 
     pub fn toggle_favorite_channel(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
-        let old_selection = if self.selected_entry_is_favorite()
-            && self
-                .selected_channel()
-                .is_some_and(|channel| channel.id == channel_id)
-        {
-            self.selection
-        } else {
-            None
-        };
-
         self.channel_store.update(cx, |store, cx| {
             store.toggle_favorite_channel(channel_id, cx);
         });
         self.persist_favorites(cx);
-        self.update_entries(true, cx);
-
-        if let Some(old_ix) = old_selection {
-            if self.selection.is_none() {
-                self.selection = if self.entries.is_empty() {
-                    None
-                } else {
-                    Some(old_ix.min(self.entries.len() - 1))
-                };
-            }
-        }
     }
 
     fn is_channel_favorited(&self, channel_id: ChannelId, cx: &App) -> bool {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1927,10 +1927,15 @@ impl CollabPanel {
     }
 
     pub fn toggle_favorite_channel(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
-        let was_selected_favorite = self.selected_entry_is_favorite()
+        let old_selection = if self.selected_entry_is_favorite()
             && self
                 .selected_channel()
-                .is_some_and(|channel| channel.id == channel_id);
+                .is_some_and(|channel| channel.id == channel_id)
+        {
+            self.selection
+        } else {
+            None
+        };
 
         self.channel_store.update(cx, |store, cx| {
             store.toggle_favorite_channel(channel_id, cx);
@@ -1938,14 +1943,14 @@ impl CollabPanel {
         self.persist_favorites(cx);
         self.update_entries(true, cx);
 
-        if was_selected_favorite && self.selection.is_none() {
-            self.selection = self.entries.iter().position(|entry| {
-                matches!(
-                    entry,
-                    ListEntry::Channel { channel, is_favorite: false, .. }
-                    if channel.id == channel_id
-                )
-            });
+        if let Some(old_ix) = old_selection {
+            if self.selection.is_none() {
+                self.selection = if self.entries.is_empty() {
+                    None
+                } else {
+                    Some(old_ix.min(self.entries.len() - 1))
+                };
+            }
         }
     }
 

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -3645,9 +3645,9 @@ impl Render for JoinChannelTooltip {
 #[cfg(any(test, feature = "test-support"))]
 impl CollabPanel {
     pub fn entries_as_strings(&self) -> Vec<String> {
-        let mut result = Vec::new();
-        for (ix, entry) in self.entries.iter().enumerate() {
-            let selected = if self.selection == Some(ix) {
+        let mut string_entries = Vec::new();
+        for (index, entry) in self.entries.iter().enumerate() {
+            let selected_marker = if self.selection == Some(index) {
                 "  <== selected"
             } else {
                 ""
@@ -3664,7 +3664,7 @@ impl CollabPanel {
                         Section::Online => "Online",
                         Section::Offline => "Offline",
                     };
-                    result.push(format!("[{name}]"));
+                    string_entries.push(format!("[{name}]"));
                 }
                 ListEntry::Channel {
                     channel,
@@ -3680,42 +3680,52 @@ impl CollabPanel {
                     } else {
                         "#️⃣ "
                     };
-                    result.push(format!("{indent}{icon}{}{selected}", channel.name));
+                    string_entries.push(format!("{indent}{icon}{}{selected_marker}", channel.name));
                 }
                 ListEntry::ChannelNotes { .. } => {
-                    result.push(format!("  (notes){selected}"));
+                    string_entries.push(format!("  (notes){selected_marker}"));
                 }
                 ListEntry::ChannelEditor { depth } => {
                     let indent = "  ".repeat(*depth + 1);
-                    result.push(format!("{indent}[editor]{selected}"));
+                    string_entries.push(format!("{indent}[editor]{selected_marker}"));
                 }
                 ListEntry::ChannelInvite(channel) => {
-                    result.push(format!("  (invite) #{}{selected}", channel.name));
+                    string_entries.push(format!("  (invite) #{}{selected_marker}", channel.name));
                 }
                 ListEntry::CallParticipant { user, .. } => {
-                    result.push(format!("  {}{selected}", user.github_login));
+                    string_entries.push(format!("  {}{selected_marker}", user.github_login));
                 }
                 ListEntry::ParticipantProject {
                     worktree_root_names,
                     ..
                 } => {
-                    result.push(format!("    {}{selected}", worktree_root_names.join(", ")));
+                    string_entries.push(format!(
+                        "    {}{selected_marker}",
+                        worktree_root_names.join(", ")
+                    ));
                 }
                 ListEntry::ParticipantScreen { .. } => {
-                    result.push(format!("    (screen){selected}"));
+                    string_entries.push(format!("    (screen){selected_marker}"));
                 }
                 ListEntry::IncomingRequest(user) => {
-                    result.push(format!("  (incoming) {}{selected}", user.github_login));
+                    string_entries.push(format!(
+                        "  (incoming) {}{selected_marker}",
+                        user.github_login
+                    ));
                 }
                 ListEntry::OutgoingRequest(user) => {
-                    result.push(format!("  (outgoing) {}{selected}", user.github_login));
+                    string_entries.push(format!(
+                        "  (outgoing) {}{selected_marker}",
+                        user.github_login
+                    ));
                 }
                 ListEntry::Contact { contact, .. } => {
-                    result.push(format!("  {}{selected}", contact.user.github_login));
+                    string_entries
+                        .push(format!("  {}{selected_marker}", contact.user.github_login));
                 }
                 ListEntry::ContactPlaceholder => {}
             }
         }
-        result
+        string_entries
     }
 }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1936,6 +1936,7 @@ impl CollabPanel {
             store.toggle_favorite_channel(channel_id, cx);
         });
         self.persist_favorites(cx);
+        self.update_entries(true, cx);
 
         if was_selected_favorite && self.selection.is_none() {
             self.selection = self.entries.iter().position(|entry| {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1658,7 +1658,7 @@ impl CollabPanel {
         self.update_entries(false, cx);
     }
 
-    fn select_next(&mut self, _: &SelectNext, _: &mut Window, cx: &mut Context<Self>) {
+    pub fn select_next(&mut self, _: &SelectNext, _: &mut Window, cx: &mut Context<Self>) {
         let ix = self.selection.map_or(0, |ix| ix + 1);
         if ix < self.entries.len() {
             self.selection = Some(ix);
@@ -1670,7 +1670,7 @@ impl CollabPanel {
         cx.notify();
     }
 
-    fn select_previous(&mut self, _: &SelectPrevious, _: &mut Window, cx: &mut Context<Self>) {
+    pub fn select_previous(&mut self, _: &SelectPrevious, _: &mut Window, cx: &mut Context<Self>) {
         let ix = self.selection.take().unwrap_or(0);
         if ix > 0 {
             self.selection = Some(ix - 1);
@@ -2088,7 +2088,7 @@ impl CollabPanel {
         }
     }
 
-    fn toggle_selected_channel_favorite(
+    pub fn toggle_selected_channel_favorite(
         &mut self,
         _: &ToggleSelectedChannelFavorite,
         _window: &mut Window,
@@ -2179,7 +2179,12 @@ impl CollabPanel {
             })
     }
 
-    fn move_channel_up(&mut self, _: &MoveChannelUp, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn move_channel_up(
+        &mut self,
+        _: &MoveChannelUp,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(channel) = self.selected_channel().cloned() {
             if self.selected_entry_is_favorite() {
                 self.reorder_favorite(channel.id, proto::reorder_channel::Direction::Up, cx);
@@ -2198,7 +2203,7 @@ impl CollabPanel {
         }
     }
 
-    fn move_channel_down(
+    pub fn move_channel_down(
         &mut self,
         _: &MoveChannelDown,
         window: &mut Window,


### PR DESCRIPTION
Currently, if you try to re-order a favorite, the favorite will not reorder, but the actual channels will.

https://github.com/user-attachments/assets/1fbab9ea-4ff4-473f-8de3-d3b60696c5a1

Additionally, a new bug seems to be that if you reorder channels, focus jumps to a favorite:

https://github.com/user-attachments/assets/fa776ad2-8648-4e68-a253-a98f57bd4951

This PR allows for re-ordering of favorites independent of the actual channels, and fixes the focusing bug

https://github.com/user-attachments/assets/977e575a-055c-4f26-8183-2744ff7f8f56

I didn't feel comfortable adding just the functionality/fixes alone, so I added a function to represent the state of the collab panel as a list of strings, like how testing around the project panel is, and wrote a few tests to ensure the behavior was pinned down.

The tests cover testing:

- Favoriting/unfavoriting
- Reordering favorites without impacting order of channels in the channels list
- Reordering channels in the channels list without impacting order of favorites

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Added the ability to reorder favorited collab channels.
