### PR TITLE
editor: Fix LSP extension commands failing at end of file

### DIFF
--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -33,11 +33,20 @@ where
     F: Fn(&Language) -> bool,
 {
     let project = editor.project.clone()?;
+    let singleton_buffer_id = editor
+        .buffer()
+        .read(cx)
+        .as_singleton()
+        .map(|buffer| buffer.read(cx).remote_id());
     editor
         .selections
         .disjoint_anchors_arc()
         .iter()
-        .filter_map(|selection| Some((selection.head(), selection.head().text_anchor.buffer_id?)))
+        .filter_map(|selection| {
+            let head = selection.head();
+            let buffer_id = head.text_anchor.buffer_id.or(singleton_buffer_id);
+            Some((head, buffer_id?))
+        })
         .unique_by(|(_, buffer_id)| *buffer_id)
         .find_map(|(trigger_anchor, buffer_id)| {
             let buffer = editor.buffer().read(cx).buffer(buffer_id)?;
@@ -172,4 +181,91 @@ pub fn lsp_tasks(
         })
         .await
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+    use gpui::{AppContext as _, TestAppContext};
+    use language::FakeLspAdapter;
+    use languages::rust_lang;
+    use lsp::LanguageServerName;
+    use multi_buffer::{MultiBuffer, MultiBufferOffset};
+    use project::{FakeFs, Project};
+    use util::path;
+
+    use crate::{SelectionEffects, editor_tests::init_test, test::build_editor_with_project};
+
+    use super::find_specific_language_server_in_selection;
+
+    #[gpui::test]
+    async fn test_find_language_server_at_end_of_file(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_file(path!("/file.rs"), "fn main() {}".into())
+            .await;
+
+        let project = Project::test(fs, [path!("/file.rs").as_ref()], cx).await;
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+        language_registry.add(rust_lang());
+        let mut fake_servers =
+            language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/file.rs"), cx)
+            })
+            .await
+            .unwrap();
+
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let (editor, cx) = cx.add_window_view(|window, cx| {
+            build_editor_with_project(project.clone(), buffer, window, cx)
+        });
+
+        let _fake_server = fake_servers.next().await.unwrap();
+        cx.executor().run_until_parked();
+
+        let language_server_name = LanguageServerName::new_static("the-fake-language-server");
+        let filter = |language: &language::Language| language.name().as_ref() == "Rust";
+
+        // Cursor at beginning of file (default position) — should find server.
+        editor.update(cx, |editor, cx| {
+            let result = find_specific_language_server_in_selection(
+                editor,
+                cx,
+                filter,
+                language_server_name.clone(),
+            );
+            assert!(
+                result.is_some(),
+                "should find language server at beginning of file"
+            );
+        });
+
+        // Move cursor to end of file.
+        editor.update_in(cx, |editor, window, cx| {
+            let text_len = editor.text(cx).len();
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_ranges([
+                    MultiBufferOffset(text_len)..MultiBufferOffset(text_len),
+                ])
+            });
+        });
+
+        // Cursor at end of file — should still find server.
+        editor.update(cx, |editor, cx| {
+            let result = find_specific_language_server_in_selection(
+                editor,
+                cx,
+                filter,
+                language_server_name.clone(),
+            );
+            assert!(
+                result.is_some(),
+                "should find language server at end of file"
+            );
+        });
+    }
 }

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -5,7 +5,6 @@ use crate::Editor;
 use collections::HashMap;
 use gpui::AsyncApp;
 use gpui::{App, Entity, Task};
-use itertools::Itertools;
 use language::Buffer;
 use language::Language;
 use lsp::LanguageServerId;
@@ -33,31 +32,38 @@ where
     F: Fn(&Language) -> bool,
 {
     let project = editor.project.clone()?;
-    let singleton_buffer_id = editor
-        .buffer()
-        .read(cx)
-        .as_singleton()
-        .map(|buffer| buffer.read(cx).remote_id());
+    let multi_buffer = editor.buffer();
+    let mut seen_buffer_ids = Vec::new();
     editor
         .selections
         .disjoint_anchors_arc()
         .iter()
-        .filter_map(|selection| {
+        .find_map(|selection| {
             let head = selection.head();
-            let buffer_id = head.text_anchor.buffer_id.or(singleton_buffer_id);
-            Some((head, buffer_id?))
-        })
-        .unique_by(|(_, buffer_id)| *buffer_id)
-        .find_map(|(trigger_anchor, buffer_id)| {
-            let buffer = editor.buffer().read(cx).buffer(buffer_id)?;
-            let language = buffer.read(cx).language_at(trigger_anchor.text_anchor)?;
+            let (buffer_id, buffer) = {
+                let multi_buffer_ref = multi_buffer.read(cx);
+                let snapshot = multi_buffer_ref.read(cx);
+                let buffer_id = snapshot
+                    .buffer_id_for_anchor(head)
+                    .or_else(|| snapshot.buffer_id_for_anchor(selection.tail()))?;
+                drop(snapshot);
+                let buffer = multi_buffer_ref.buffer(buffer_id)?;
+                (buffer_id, buffer)
+            };
+
+            if seen_buffer_ids.contains(&buffer_id) {
+                return None;
+            }
+            seen_buffer_ids.push(buffer_id);
+
+            let language = buffer.read(cx).language_at(head.text_anchor)?;
             if filter_language(&language) {
                 let server_id = buffer.update(cx, |buffer, cx| {
                     project
                         .read(cx)
                         .language_server_id_for_name(buffer, &language_server_name, cx)
                 })?;
-                Some((trigger_anchor, language, server_id, buffer))
+                Some((head, language, server_id, buffer))
             } else {
                 None
             }
@@ -185,12 +191,14 @@ pub fn lsp_tasks(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use futures::StreamExt as _;
-    use gpui::{AppContext as _, TestAppContext};
-    use language::FakeLspAdapter;
+    use gpui::{App, AppContext as _, Entity, TestAppContext};
+    use language::{FakeLspAdapter, Language};
     use languages::rust_lang;
-    use lsp::LanguageServerName;
-    use multi_buffer::{MultiBuffer, MultiBufferOffset};
+    use lsp::{LanguageServerId, LanguageServerName};
+    use multi_buffer::{Anchor, MultiBuffer, MultiBufferOffset};
     use project::{FakeFs, Project};
     use util::path;
 
@@ -212,35 +220,57 @@ mod tests {
         let mut fake_servers =
             language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
 
-        let buffer = project
+        let underlying_buffer = project
             .update(cx, |project, cx| {
                 project.open_local_buffer(path!("/file.rs"), cx)
             })
             .await
             .unwrap();
 
-        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(underlying_buffer.clone(), cx));
         let (editor, cx) = cx.add_window_view(|window, cx| {
             build_editor_with_project(project.clone(), buffer, window, cx)
         });
 
-        let _fake_server = fake_servers.next().await.unwrap();
+        let fake_server = fake_servers.next().await.unwrap();
         cx.executor().run_until_parked();
 
+        let expected_server_id = fake_server.server.server_id();
         let language_server_name = LanguageServerName::new_static("the-fake-language-server");
-        let filter = |language: &language::Language| language.name().as_ref() == "Rust";
+        let filter = |language: &Language| language.name().as_ref() == "Rust";
 
-        // Cursor at beginning of file (default position) — should find server.
-        editor.update(cx, |editor, cx| {
-            let result = find_specific_language_server_in_selection(
-                editor,
-                cx,
-                filter,
-                language_server_name.clone(),
+        let assert_result = |result: Option<(
+            Anchor,
+            Arc<Language>,
+            LanguageServerId,
+            Entity<language::Buffer>,
+        )>,
+                             cx: &App,
+                             message: &str| {
+            let (_, language, server_id, buffer) = result.expect(message);
+            assert_eq!(
+                language.name().as_ref(),
+                "Rust",
+                "{message}: wrong language"
             );
+            assert_eq!(server_id, expected_server_id, "{message}: wrong server ID");
+            assert_eq!(buffer, underlying_buffer, "{message}: wrong buffer");
             assert!(
-                result.is_some(),
-                "should find language server at beginning of file"
+                buffer.read(cx).file().is_some(),
+                "{message}: buffer should have a file"
+            );
+        };
+
+        editor.update(cx, |editor, cx| {
+            assert_result(
+                find_specific_language_server_in_selection(
+                    editor,
+                    cx,
+                    filter,
+                    language_server_name.clone(),
+                ),
+                cx,
+                "should find correct language server at beginning of file",
             );
         });
 
@@ -248,23 +278,20 @@ mod tests {
         editor.update_in(cx, |editor, window, cx| {
             let text_len = editor.text(cx).len();
             editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                s.select_ranges([
-                    MultiBufferOffset(text_len)..MultiBufferOffset(text_len),
-                ])
+                s.select_ranges([MultiBufferOffset(text_len)..MultiBufferOffset(text_len)])
             });
         });
 
-        // Cursor at end of file — should still find server.
         editor.update(cx, |editor, cx| {
-            let result = find_specific_language_server_in_selection(
-                editor,
+            assert_result(
+                find_specific_language_server_in_selection(
+                    editor,
+                    cx,
+                    filter,
+                    language_server_name.clone(),
+                ),
                 cx,
-                filter,
-                language_server_name.clone(),
-            );
-            assert!(
-                result.is_some(),
-                "should find language server at end of file"
+                "should find correct language server at end of file",
             );
         });
     }

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::Editor;
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use gpui::AsyncApp;
 use gpui::{App, Entity, Task};
 use language::Buffer;
@@ -33,37 +33,33 @@ where
 {
     let project = editor.project.clone()?;
     let multi_buffer = editor.buffer();
-    let mut seen_buffer_ids = Vec::new();
+    let mut seen_buffer_ids = HashSet::default();
     editor
         .selections
         .disjoint_anchors_arc()
         .iter()
         .find_map(|selection| {
-            let head = selection.head();
-            let (buffer_id, buffer) = {
-                let multi_buffer_ref = multi_buffer.read(cx);
-                let snapshot = multi_buffer_ref.read(cx);
-                let buffer_id = snapshot
-                    .buffer_id_for_anchor(head)
-                    .or_else(|| snapshot.buffer_id_for_anchor(selection.tail()))?;
-                drop(snapshot);
-                let buffer = multi_buffer_ref.buffer(buffer_id)?;
-                (buffer_id, buffer)
-            };
-
-            if seen_buffer_ids.contains(&buffer_id) {
+            let multi_buffer = multi_buffer.read(cx);
+            let (position, buffer) = multi_buffer
+                .buffer_for_anchor(selection.head(), cx)
+                .map(|buffer| (selection.head(), buffer))
+                .or_else(|| {
+                    multi_buffer
+                        .buffer_for_anchor(selection.tail(), cx)
+                        .map(|buffer| (selection.tail(), buffer))
+                })?;
+            if !seen_buffer_ids.insert(buffer.read(cx).remote_id()) {
                 return None;
             }
-            seen_buffer_ids.push(buffer_id);
 
-            let language = buffer.read(cx).language_at(head.text_anchor)?;
+            let language = buffer.read(cx).language_at(position.text_anchor)?;
             if filter_language(&language) {
                 let server_id = buffer.update(cx, |buffer, cx| {
                     project
                         .read(cx)
                         .language_server_id_for_name(buffer, &language_server_name, cx)
                 })?;
-                Some((head, language, server_id, buffer))
+                Some((position, language, server_id, buffer))
             } else {
                 None
             }
@@ -194,15 +190,15 @@ mod tests {
     use std::sync::Arc;
 
     use futures::StreamExt as _;
-    use gpui::{App, AppContext as _, Entity, TestAppContext};
+    use gpui::{AppContext as _, Entity, TestAppContext};
     use language::{FakeLspAdapter, Language};
     use languages::rust_lang;
     use lsp::{LanguageServerId, LanguageServerName};
-    use multi_buffer::{Anchor, MultiBuffer, MultiBufferOffset};
+    use multi_buffer::{Anchor, MultiBuffer};
     use project::{FakeFs, Project};
     use util::path;
 
-    use crate::{SelectionEffects, editor_tests::init_test, test::build_editor_with_project};
+    use crate::{MoveToEnd, editor_tests::init_test, test::build_editor_with_project};
 
     use super::find_specific_language_server_in_selection;
 
@@ -245,7 +241,6 @@ mod tests {
             LanguageServerId,
             Entity<language::Buffer>,
         )>,
-                             cx: &App,
                              message: &str| {
             let (_, language, server_id, buffer) = result.expect(message);
             assert_eq!(
@@ -255,10 +250,6 @@ mod tests {
             );
             assert_eq!(server_id, expected_server_id, "{message}: wrong server ID");
             assert_eq!(buffer, underlying_buffer, "{message}: wrong buffer");
-            assert!(
-                buffer.read(cx).file().is_some(),
-                "{message}: buffer should have a file"
-            );
         };
 
         editor.update(cx, |editor, cx| {
@@ -269,17 +260,12 @@ mod tests {
                     filter,
                     language_server_name.clone(),
                 ),
-                cx,
                 "should find correct language server at beginning of file",
             );
         });
 
-        // Move cursor to end of file.
         editor.update_in(cx, |editor, window, cx| {
-            let text_len = editor.text(cx).len();
-            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                s.select_ranges([MultiBufferOffset(text_len)..MultiBufferOffset(text_len)])
-            });
+            editor.move_to_end(&MoveToEnd, window, cx);
         });
 
         editor.update(cx, |editor, cx| {
@@ -290,7 +276,6 @@ mod tests {
                     filter,
                     language_server_name.clone(),
                 ),
-                cx,
                 "should find correct language server at end of file",
             );
         });


### PR DESCRIPTION
## Context

Closes #51330

When the cursor is at the very end of a file, `find_specific_language_server_in_selection` in `crates/editor/src/lsp_ext.rs` silently skips the selection because the anchor's `buffer_id` is `None`. This causes `editor: switch source header` (clangd) and rust-analyzer extension commands (`expand macro`, `open docs`, `open playground`) to do nothing.

The fix falls back to the singleton buffer's ID when the anchor has no `buffer_id`.

## How to Review

Single file change in `crates/editor/src/lsp_ext.rs`. The diff is small — pre-compute the singleton buffer ID, then use it as fallback in the `filter_map` closure. An integration test verifies the fix.

## Self-Review Checklist

- [x] Reviewed own diff for quality, security, and reliability
- [x] No unsafe blocks
- [x] Tests pass (639 editor tests, 0 failures)
- [x] Manual testing: switch source header works at beginning, middle, and end of C++ file

## Test Plan

- [x] New integration test: `test_find_language_server_at_end_of_file` — verifies `find_specific_language_server_in_selection` returns `Some` at both beginning and end of file
- [x] Confirmed the test fails without the fix (assertion on "should find language server at end of file")
- [x] Manual: open a C++ file with clangd, place cursor at very end, run `switch source header` — now correctly opens the header
- [x] Manual: verify it still works at beginning and middle of file (non-regression)
- [x] `cargo test -p editor` — 639 passed, 0 failed

Release Notes:

- Fixed `editor: switch source header` and other LSP extension commands not working when the cursor is at the very end of a file.