### PR TITLE
worktree: Avoid repository reloads for noisy `.git` events

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -57,7 +57,7 @@ use std::{
     future::Future,
     mem::{self},
     ops::{Deref, DerefMut, Range},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     pin::Pin,
     sync::{
         Arc,
@@ -77,6 +77,7 @@ pub use worktree_settings::WorktreeSettings;
 use crate::ignore::IgnoreKind;
 
 pub const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
+const INDEX_FILE: &str = "index";
 
 /// A set of local or remote files that are being opened as part of a project.
 /// Responsible for tracking related FS (for local)/collab (for remote) events and corresponding updates.
@@ -3180,6 +3181,58 @@ async fn is_git_dir(path: &Path, fs: &dyn Fs) -> bool {
     matches!(config_metadata, Ok(Some(_)))
 }
 
+fn should_trigger_git_repo_reload(path_in_git_dir: &Path) -> bool {
+    if path_in_git_dir.as_os_str().is_empty() {
+        return true;
+    }
+
+    let mut components = path_in_git_dir.components();
+    let Some(Component::Normal(first_component)) = components.next() else {
+        return false;
+    };
+
+    if first_component == OsStr::new("refs")
+        || first_component == OsStr::new("worktrees")
+        || first_component == OsStr::new("modules")
+        || first_component == OsStr::new("rebase-apply")
+        || first_component == OsStr::new("rebase-merge")
+        || first_component == OsStr::new("sequencer")
+    {
+        return true;
+    }
+
+    if first_component == OsStr::new("info") {
+        return components.next().is_some_and(|component| {
+            matches!(component, Component::Normal(name) if name == OsStr::new("exclude"))
+        });
+    }
+
+    if first_component == OsStr::new("objects")
+        || first_component == OsStr::new("logs")
+        || first_component == OsStr::new(FSMONITOR_DAEMON)
+        || first_component == OsStr::new(LFS_DIR)
+    {
+        return false;
+    }
+
+    if path_in_git_dir.extension() == Some(OsStr::new("lock")) {
+        return false;
+    }
+
+    path_in_git_dir == Path::new("HEAD")
+        || path_in_git_dir == Path::new("config")
+        || path_in_git_dir == Path::new("packed-refs")
+        || path_in_git_dir == Path::new("FETCH_HEAD")
+        || path_in_git_dir == Path::new("ORIG_HEAD")
+        || path_in_git_dir == Path::new("MERGE_HEAD")
+        || path_in_git_dir == Path::new("MERGE_MODE")
+        || path_in_git_dir == Path::new("MERGE_MSG")
+        || path_in_git_dir == Path::new("CHERRY_PICK_HEAD")
+        || path_in_git_dir == Path::new("REVERT_HEAD")
+        || path_in_git_dir == Path::new("BISECT_LOG")
+        || path_in_git_dir == Path::new(REPO_EXCLUDE)
+}
+
 async fn build_gitignore(abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
     let contents = fs
         .load(abs_path)
@@ -4101,7 +4154,7 @@ impl BackgroundScanner {
 
         // Certain directories may have FS changes, but do not lead to git data changes that Zed cares about.
         // Ignore these, to avoid Zed unnecessarily rescanning git metadata.
-        let skipped_files_in_dot_git = [COMMIT_MESSAGE, INDEX_LOCK];
+        let skipped_files_in_dot_git = [COMMIT_MESSAGE, INDEX_LOCK, INDEX_FILE];
         let skipped_dirs_in_dot_git = [FSMONITOR_DAEMON, LFS_DIR];
 
         let mut relative_paths = Vec::with_capacity(events.len());
@@ -4191,7 +4244,9 @@ impl BackgroundScanner {
                     }
 
                     is_git_related = true;
-                    if !dot_git_abs_paths.contains(&dot_git_abs_path) {
+                    if should_trigger_git_repo_reload(path_in_git_dir.as_path())
+                        && !dot_git_abs_paths.contains(&dot_git_abs_path)
+                    {
                         dot_git_abs_paths.push(dot_git_abs_path);
                     }
                 }

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use encoding_rs;
 use fs::{FakeFs, Fs, RealFs, RemoveOptions};
 use git::{DOT_GIT, GITIGNORE, REPO_EXCLUDE};
-use gpui::{AppContext as _, BackgroundExecutor, BorrowAppContext, Context, Task, TestAppContext};
+use gpui::{
+    AppContext as _, BackgroundExecutor, BorrowAppContext, Context, Entity, Task, TestAppContext,
+};
 use parking_lot::Mutex;
 use postage::stream::Stream;
 use pretty_assertions::assert_eq;
@@ -1512,6 +1514,112 @@ async fn test_fs_events_in_dot_git_worktree(cx: &mut TestAppContext) {
     tree.read_with(cx, |tree, _| {
         check_worktree_entries(tree, &[], &["HEAD", "foo", "new_file"], &[], &[])
     });
+}
+
+async fn setup_worktree_for_git_repo_reload_event_test(
+    cx: &mut TestAppContext,
+) -> (Arc<FakeFs>, Entity<Worktree>) {
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {
+                "HEAD": "ref: refs/heads/main\n",
+                "config": "[core]\n\trepositoryformatversion = 0\n",
+                "index": "index contents",
+                "refs": {
+                    "heads": {
+                        "main": "a1b2c3d4\n",
+                    },
+                },
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    tree.flush_fs_events(cx).await;
+
+    (fs, tree)
+}
+
+fn subscribe_git_repo_update_events(
+    tree: &Entity<Worktree>,
+    cx: &mut TestAppContext,
+) -> Arc<Mutex<usize>> {
+    let git_repo_update_count = Arc::new(Mutex::new(0usize));
+    tree.update(cx, |_, cx| {
+        let git_repo_update_count = git_repo_update_count.clone();
+        cx.subscribe(tree, move |_, _, event, _| {
+            if let Event::UpdatedGitRepositories(_) = event {
+                *git_repo_update_count.lock() += 1;
+            }
+        })
+        .detach();
+    });
+    git_repo_update_count
+}
+
+#[gpui::test]
+async fn test_fs_event_in_git_index_does_not_emit_repo_update(cx: &mut TestAppContext) {
+    init_test(cx);
+    let (fs, tree) = setup_worktree_for_git_repo_reload_event_test(cx).await;
+    let git_repo_update_count = subscribe_git_repo_update_events(&tree, cx);
+
+    fs.emit_fs_event("/root/.git/index", Some(fs::PathEventKind::Changed));
+    tree.flush_fs_events(cx).await;
+
+    assert_eq!(
+        *git_repo_update_count.lock(),
+        0,
+        "fs events for .git/index should not emit UpdatedGitRepositories"
+    );
+}
+
+#[gpui::test]
+async fn test_fs_event_in_git_config_emits_repo_update(cx: &mut TestAppContext) {
+    init_test(cx);
+    let (fs, tree) = setup_worktree_for_git_repo_reload_event_test(cx).await;
+    let git_repo_update_count = subscribe_git_repo_update_events(&tree, cx);
+
+    fs.emit_fs_event("/root/.git/config", Some(fs::PathEventKind::Changed));
+    tree.flush_fs_events(cx).await;
+
+    assert!(
+        *git_repo_update_count.lock() > 0,
+        "fs events for .git/config should emit UpdatedGitRepositories"
+    );
+}
+
+#[gpui::test]
+async fn test_fs_event_in_git_refs_emits_repo_update(cx: &mut TestAppContext) {
+    init_test(cx);
+    let (fs, tree) = setup_worktree_for_git_repo_reload_event_test(cx).await;
+    let git_repo_update_count = subscribe_git_repo_update_events(&tree, cx);
+
+    fs.emit_fs_event(
+        "/root/.git/refs/heads/main",
+        Some(fs::PathEventKind::Changed),
+    );
+    tree.flush_fs_events(cx).await;
+
+    assert!(
+        *git_repo_update_count.lock() > 0,
+        "fs events for .git/refs/** should emit UpdatedGitRepositories"
+    );
 }
 
 #[gpui::test(iterations = 30)]


### PR DESCRIPTION
Only trigger UpdatedGitRepositories for meaningful git metadata paths so index/lock churn does not cause repeated git rescans. Keep config and refs changes as reload triggers and lock behavior with integration tests.

Self-Review Checklist:

- [✓ ] I've reviewed my own diff for quality, security, and reliability
- [ ✓] Unsafe blocks (if any) have justifying comments
- [ ✓] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ✓] Tests cover the new/changed behavior
- [ ✓] Performance impact has been considered and is acceptable

Closes #52077 , #43861,  #13547 

Release Notes:

- Only trigger `UpdatedGitRepositories` for meaningful `.git` metadata paths.
- Ignore high-churn `.git` paths (including `index`) that can create repo-reload feedback loops.
- Add integration tests to verify:
  - `.git/index` does not emit repo update
  - `.git/config` emits repo update
  - `.git/refs/**` emits repo update

Why :
When `.git` watcher events from noisy paths trigger full repository reloads, Zed can repeatedly spawn `git.exe` and create a feedback loop on Windows. This narrows reload triggers to semantic git metadata changes while preserving expected updates for config and refs.
If you want, I can now create the PR command for your fork once you tell me your fork remote name.
