### PR TITLE
project_panel: Fix new file/folder doing nothing in empty project with hide_root enabled

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2067,34 +2067,34 @@ impl ProjectPanel {
 
         let directory_id;
         let new_entry_id = self.resolve_entry(entry_id);
-        if let Some((worktree, expanded_dir_ids)) = self
-            .project
-            .read(cx)
-            .worktree_for_id(worktree_id, cx)
-            .zip(self.state.expanded_dir_ids.get_mut(&worktree_id))
-        {
-            let worktree = worktree.read(cx);
-            if let Some(mut entry) = worktree.entry_for_id(new_entry_id) {
-                loop {
-                    if entry.is_dir() {
-                        if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
-                            expanded_dir_ids.insert(ix, entry.id);
-                        }
-                        directory_id = entry.id;
-                        break;
-                    } else {
-                        if let Some(parent_path) = entry.path.parent()
-                            && let Some(parent_entry) = worktree.entry_for_path(parent_path)
-                        {
-                            entry = parent_entry;
-                            continue;
-                        }
-                        return;
+        let Some(worktree) = self.project.read(cx).worktree_for_id(worktree_id, cx) else {
+            return;
+        };
+
+        let expanded_dir_ids = self
+            .state
+            .expanded_dir_ids
+            .entry(worktree_id)
+            .or_default();
+        let worktree = worktree.read(cx);
+        if let Some(mut entry) = worktree.entry_for_id(new_entry_id) {
+            loop {
+                if entry.is_dir() {
+                    if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
+                        expanded_dir_ids.insert(ix, entry.id);
                     }
+                    directory_id = entry.id;
+                    break;
+                } else {
+                    if let Some(parent_path) = entry.path.parent()
+                        && let Some(parent_entry) = worktree.entry_for_path(parent_path)
+                    {
+                        entry = parent_entry;
+                        continue;
+                    }
+                    return;
                 }
-            } else {
-                return;
-            };
+            }
         } else {
             return;
         };

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10287,6 +10287,140 @@ async fn test_preserve_temporary_unfolded_active_index_on_blur_from_context_menu
     );
 }
 
+#[gpui::test]
+async fn test_new_file_in_empty_dir_with_hide_root(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", json!({})).await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+
+    cx.update(|_, cx| {
+        let settings = *ProjectPanelSettings::get_global(cx);
+        ProjectPanelSettings::override_global(
+            ProjectPanelSettings {
+                hide_root: true,
+                ..settings
+            },
+            cx,
+        );
+    });
+
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    // With hide_root enabled the root folder row is not rendered.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[] as &[&str],
+        "panel should show no entries for an empty directory with hide_root enabled"
+    );
+
+    panel.update_in(cx, |panel, window, cx| panel.new_file(&NewFile, window, cx));
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["  [EDITOR: '']  <== selected"],
+        "inline editor should appear inside the hidden root without a root folder row"
+    );
+
+    panel
+        .update_in(cx, |panel, window, cx| {
+            panel.filename_editor.update(cx, |editor, cx| {
+                editor.set_text("new_file.txt", window, cx);
+            });
+            panel.confirm_edit(true, window, cx).unwrap()
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    assert!(
+        fs.is_file(Path::new("/root/new_file.txt")).await,
+        "file should be created directly inside the project root"
+    );
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["  new_file.txt  <== selected  <== marked"],
+        "created file should be visible without a root folder row"
+    );
+}
+
+#[gpui::test]
+async fn test_new_directory_in_empty_dir_with_hide_root(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", json!({})).await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+
+    cx.update(|_, cx| {
+        let settings = *ProjectPanelSettings::get_global(cx);
+        ProjectPanelSettings::override_global(
+            ProjectPanelSettings {
+                hide_root: true,
+                ..settings
+            },
+            cx,
+        );
+    });
+
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    // With hide_root enabled the root folder row is not rendered.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[] as &[&str],
+        "panel should show no entries for an empty directory with hide_root enabled"
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.new_directory(&NewDirectory, window, cx)
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["> [EDITOR: '']  <== selected"],
+        "inline editor should appear inside the hidden root without a root folder row"
+    );
+
+    panel
+        .update_in(cx, |panel, window, cx| {
+            panel.filename_editor.update(cx, |editor, cx| {
+                editor.set_text("new_dir", window, cx);
+            });
+            panel.confirm_edit(true, window, cx).unwrap()
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    assert!(
+        fs.is_dir(Path::new("/root/new_dir")).await,
+        "directory should be created directly inside the project root"
+    );
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v new_dir  <== selected"],
+        "created directory should be visible without a root folder row"
+    );
+}
+
 async fn run_create_file_in_folded_path_case(
     case_name: &str,
     active_ancestor_path: &str,


### PR DESCRIPTION
## Summary

Closes #52652

When `project_panel.hide_root` is `true` and the opened project is an empty directory, invoking "New File" or "New Folder" — via the right-click context menu or keybind — does nothing. The context menu appears correctly, but the inline file-creation field never shows.

**Root cause:** `expanded_dir_ids` tracks which directories are expanded per worktree. It is initialized inside the `update_visible_entries` render loop. With `hide_root: true`, the root entry is skipped via `continue`, and an empty directory has no children, so the loop body never executes. The map is never populated for this worktree.

`add_entry` used `.get_mut(&worktree_id)` to retrieve the expanded dirs, which returned `None` in this case. The subsequent `.zip()` failed and the function returned silently without setting `edit_state` or showing the inline editor.

**Fix:** Replace `.get_mut()` with `.entry().or_default()` so the map entry is created on demand when missing. This matches the existing pattern used elsewhere in the same file (e.g. `expand_to_selection`).

## Demo

https://github.com/user-attachments/assets/aff3fde9-06c8-4c43-8ae6-117aa50eb121

