### PR TITLE
Show failed servers in language server menu

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -775,7 +775,7 @@ where
                         delegate.update_status(
                             self.name(),
                             BinaryStatus::Failed {
-                                error: format!("{error:?}"),
+                                error: format!("{error:#}"),
                             },
                         );
                     }

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -851,9 +851,6 @@ impl LspButton {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.lsp_menu.is_none() {
-            return;
-        };
         let mut updated = false;
 
         // TODO `LspStore` is global and reports status from all language servers, even from the other windows.
@@ -950,7 +947,7 @@ impl LspButton {
             _ => {}
         };
 
-        if updated {
+        if updated && self.lsp_menu.is_some() {
             self.refresh_lsp_menu(false, window, cx);
         }
     }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #46876

Release Notes:

- Fixed language server menu not showing servers that failed to install, and showing a raw debug string in the tooltip instead of a readable error message.

