### PR TITLE
project: Prevent Python venv activation in restricted mode

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -133,24 +133,28 @@ impl Project {
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
 
-            let activation_script = maybe!(async {
-                for toolchain in toolchains {
-                    let Some(toolchain) = toolchain.await else {
-                        continue;
-                    };
-                    let language = lang_registry
-                        .language_for_name(&toolchain.language_name.0)
-                        .await
-                        .ok();
-                    let lister = language?.toolchain_lister()?;
-                    let future =
-                        cx.update(|cx| lister.activation_script(&toolchain, shell_kind, cx));
-                    return Some(future.await);
-                }
-                None
-            })
-            .await
-            .unwrap_or_default();
+            let activation_script = if self.is_restricted_project(cx) {
+                Vec::new() // Do not activate environments if project is restricted
+            } else {
+                maybe!(async {
+                    for toolchain in toolchains {
+                        let Some(toolchain) = toolchain.await else {
+                            continue;
+                        };
+                        let language = lang_registry
+                            .language_for_name(&toolchain.language_name.0)
+                            .await
+                            .ok();
+                        let lister = language?.toolchain_lister()?;
+                        let future =
+                            cx.update(|cx| lister.activation_script(&toolchain, shell_kind, cx));
+                        return Some(future.await);
+                    }
+                    None
+                })
+                .await
+                .unwrap_or_default()
+            };
 
             let builder = project
                 .update(cx, move |_, cx| {
@@ -283,6 +287,15 @@ impl Project {
                 terminal_handle
             })
         })
+    }
+
+    pub fn is_restricted_project(&self, cx: &App) -> bool {
+        // Access Zed's global settings
+        let session_settings = settings::SessionSettings::current(cx);
+        let trust_all_worktrees = session_settings.trust_all_worktrees.unwrap_or(false);
+
+        // If not trusted all worktrees → restricted mode
+        !trust_all_worktrees
     }
 
     pub fn create_terminal_shell(

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -135,6 +135,7 @@ impl Project {
 
             let activation_script = if self.is_restricted_project(cx) {
                 Vec::new() // Do not activate environments if project is restricted
+                
             } else {
                 maybe!(async {
                     for toolchain in toolchains {


### PR DESCRIPTION
Closes #48300

## Context

Currently, Zed automatically activates Python virtual environments (venv) when opening a terminal inside a project. This behavior can be a **security risk** for **untrusted projects** or when in **Restricted Mode**, as it executes scripts automatically without explicit user approval.

This Pull Request adds a check for **Restricted Mode** before running any venv activation scripts, using the workspace trust configuration (`trust_all_worktrees`).

---

## Changes made

* Added the method `is_restricted_project(&self, cx: &App) -> bool` in `Project` to determine if the project is in **Restricted Mode**.
* Updated `terminal.rs` so that the `activation_script`:

  * **Does not activate any venv** if the project is restricted.
  * Keeps the original behavior for trusted projects.
* Ensures that automatic Python venv activation respects workspace security, fixing issue [[#48300](https://github.com/zed-industries/zed/issues/48300)](https://github.com/zed-industries/zed/issues/48300).

---

## How to test

1. Open a project in Zed in **Restricted Mode**.
2. Open a terminal within the project.
3. Verify that **no venv activation occurs** automatically.
4. Open a trusted project and verify that automatic venv activation **still works as before**.

---

## Release Notes

- Fixed: Prevent Python virtual environment activation in Restricted Mode