### PR TITLE
agent: Remove duplicated description from tool schema

### DIFF
--- a/crates/language_model/src/tool_schema.rs
+++ b/crates/language_model/src/tool_schema.rs
@@ -67,6 +67,7 @@ pub fn adapt_schema_to_format(
     if let Value::Object(obj) = json {
         obj.remove("$schema");
         obj.remove("title");
+        obj.remove("description");
     }
 
     match format {


### PR DESCRIPTION
Turns out we were including the description of a tool inside the schema again, which I don't think is needed.
Before:
```
LanguageModelRequestTool {
    name: "web_search",
    description: "Search the web for information using your query.\nUse this when you need real-time information, facts, or data that might not be in your training.\nResults will include snippets and links from relevant web pages.",
    input_schema: Object {
        "required": Array [
            String("query"),
        ],
        "description": String("Search the web for information using your query.\nUse this when you need real-time information, facts, or data that might not be in your training.\nResults will include snippets and links from relevant web pages."),
        "type": String("object"),
        "properties": Object {
            "query": Object {
                "description": String("The search term or question to query on the web."),
                "type": String("string"),
            },
        },
        "additionalProperties": Bool(false),
    },
    use_input_streaming: false,
},
```



After:
```
LanguageModelRequestTool {
    name: "web_search",
    description: "Search the web for information using your query.\nUse this when you need real-time information, facts, or data that might not be in your training.\nResults will include snippets and links from relevant web pages.",
    input_schema: Object {
        "required": Array [
            String("query"),
        ],
        "type": String("object"),
        "properties": Object {
            "query": Object {
                "description": String("The search term or question to query on the web."),
                "type": String("string"),
            },
        },
        "additionalProperties": Bool(false),
    },
    use_input_streaming: false,
},
```


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #45315

Release Notes:

- agent: Reduced amount of tokens consumed by tool descriptions
