### PR TITLE
Add quick selector for agent tool permissions

### DIFF
--- a/assets/icons/shield.svg
+++ b/assets/icons/shield.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield-icon lucide-shield">
+  <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/>
+</svg>

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -157,6 +157,8 @@ actions!(
         ResetTrialEndUpsell,
         /// Opens the "Add Context" menu in the message editor.
         OpenAddContextMenu,
+        /// Opens the tool permissions menu in the message editor.
+        OpenToolPermissionsMenu,
         /// Continues the current thread.
         ContinueThread,
         /// Interrupts the current generation and sends the message immediately.

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -3432,6 +3432,34 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_open_tool_permissions_menu(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let thread_view = active_thread(&conversation_view, cx);
+
+        thread_view.update_in(cx, |view, window, cx| {
+            assert!(!view.tool_permissions_menu_handle.is_deployed());
+            view.focus_handle(cx).focus(window, cx);
+        });
+
+        cx.run_until_parked();
+
+        thread_view.update_in(cx, |_, window, cx| {
+            window.dispatch_action(Box::new(crate::OpenToolPermissionsMenu), cx);
+        });
+
+        cx.run_until_parked();
+
+        thread_view.update_in(cx, |view, _window, _cx| {
+            assert!(view.tool_permissions_menu_handle.is_deployed());
+        });
+    }
+
+    #[gpui::test]
     async fn test_notification_closed_when_thread_view_dropped(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4115,14 +4115,14 @@ impl ThreadView {
 
         match current_mode {
             settings::ToolPermissionMode::Confirm => menu.trigger_with_tooltip(
-                IconButton::new("tool-permissions", IconName::Settings)
+                IconButton::new("tool-permissions", IconName::Shield)
                     .icon_size(IconSize::Small)
                     .icon_color(Color::Muted),
                 {
                     let focus_handle = focus_handle.clone();
                     move |_window, cx| {
                         Tooltip::for_action_in(
-                            "Tool Permissions",
+                            "Tool permissions Selector",
                             &crate::OpenToolPermissionsMenu,
                             &focus_handle,
                             cx,
@@ -4143,22 +4143,26 @@ impl ThreadView {
                             h_flex()
                                 .gap_1()
                                 .child(
-                                    Icon::new(IconName::Settings)
+                                    Icon::new(IconName::Shield)
                                         .size(IconSize::Small)
-                                        .color(Color::Muted),
+                                        .color(Color::Warning),
                                 )
-                                .child(Label::new(label).size(LabelSize::Small).color(Color::Muted))
+                                .child(
+                                    Label::new(label)
+                                        .size(LabelSize::Small)
+                                        .color(Color::Warning),
+                                )
                                 .child(
                                     Icon::new(IconName::ChevronDown)
                                         .size(IconSize::XSmall)
-                                        .color(Color::Muted),
+                                        .color(Color::Warning),
                                 ),
                         ),
                     {
                         let focus_handle = focus_handle.clone();
                         move |_window, cx| {
                             Tooltip::for_action_in(
-                                "Tool Permissions",
+                                "Tool permissions Selector",
                                 &crate::OpenToolPermissionsMenu,
                                 &focus_handle,
                                 cx,
@@ -4186,7 +4190,7 @@ impl ThreadView {
             let deny_selected = matches!(current_mode, settings::ToolPermissionMode::Deny);
 
             menu.key_context("ToolPermissionsMenu")
-                .header("Tool Permissions")
+                .header("Tool permissions Selector")
                 .item(
                     ContextMenuEntry::new("Allow")
                         .toggleable(IconPosition::End, allow_selected)

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -283,6 +283,7 @@ pub struct ThreadView {
     pub _subscriptions: Vec<Subscription>,
     pub message_editor: Entity<MessageEditor>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
+    pub tool_permissions_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub thinking_effort_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub project: WeakEntity<Project>,
     pub recent_history_entries: Vec<AgentSessionInfo>,
@@ -522,6 +523,7 @@ impl ThreadView {
             in_flight_prompt: None,
             message_editor,
             add_context_menu_handle: PopoverMenuHandle::default(),
+            tool_permissions_menu_handle: PopoverMenuHandle::default(),
             thinking_effort_menu_handle: PopoverMenuHandle::default(),
             project,
             recent_history_entries,
@@ -3193,6 +3195,7 @@ impl ThreadView {
                         h_flex()
                             .gap_0p5()
                             .child(self.render_add_context_button(cx))
+                            .child(self.render_tool_permissions_button(cx))
                             .child(self.render_follow_toggle(cx))
                             .children(self.render_fast_mode_control(cx))
                             .children(self.render_thinking_control(cx)),
@@ -4083,6 +4086,158 @@ impl ThreadView {
                                 message_editor.update(cx, |editor, cx| {
                                     editor.insert_branch_diff_crease(window, cx);
                                 });
+                            }
+                        }),
+                )
+        })
+    }
+
+    fn render_tool_permissions_button(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        let focus_handle = self.message_editor.focus_handle(cx);
+        let weak_self = cx.weak_entity();
+
+        let current_mode = agent_settings::AgentSettings::get_global(cx)
+            .tool_permissions
+            .default;
+
+        let menu = PopoverMenu::new("tool-permissions-menu")
+            .anchor(Corner::BottomLeft)
+            .with_handle(self.tool_permissions_menu_handle.clone())
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-2.0),
+            })
+            .menu(move |window, cx| {
+                weak_self
+                    .update(cx, |this, cx| this.build_tool_permissions_menu(window, cx))
+                    .ok()
+            });
+
+        match current_mode {
+            settings::ToolPermissionMode::Confirm => menu.trigger_with_tooltip(
+                IconButton::new("tool-permissions", IconName::Settings)
+                    .icon_size(IconSize::Small)
+                    .icon_color(Color::Muted),
+                {
+                    let focus_handle = focus_handle.clone();
+                    move |_window, cx| {
+                        Tooltip::for_action_in(
+                            "Tool Permissions",
+                            &crate::OpenToolPermissionsMenu,
+                            &focus_handle,
+                            cx,
+                        )
+                    }
+                },
+            ),
+            settings::ToolPermissionMode::Allow | settings::ToolPermissionMode::Deny => {
+                let label = if matches!(current_mode, settings::ToolPermissionMode::Allow) {
+                    "Allow"
+                } else {
+                    "Deny"
+                };
+                menu.trigger_with_tooltip(
+                    ButtonLike::new("tool-permissions")
+                        .style(ButtonStyle::Subtle)
+                        .child(
+                            h_flex()
+                                .gap_1()
+                                .child(
+                                    Icon::new(IconName::Settings)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(Label::new(label).size(LabelSize::Small).color(Color::Muted))
+                                .child(
+                                    Icon::new(IconName::ChevronDown)
+                                        .size(IconSize::XSmall)
+                                        .color(Color::Muted),
+                                ),
+                        ),
+                    {
+                        let focus_handle = focus_handle.clone();
+                        move |_window, cx| {
+                            Tooltip::for_action_in(
+                                "Tool Permissions",
+                                &crate::OpenToolPermissionsMenu,
+                                &focus_handle,
+                                cx,
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    fn build_tool_permissions_menu(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<ContextMenu> {
+        let workspace = self.workspace.clone();
+        let current_mode = agent_settings::AgentSettings::get_global(cx)
+            .tool_permissions
+            .default;
+
+        ContextMenu::build(window, cx, move |menu, _window, _cx| {
+            let allow_selected = matches!(current_mode, settings::ToolPermissionMode::Allow);
+            let confirm_selected = matches!(current_mode, settings::ToolPermissionMode::Confirm);
+            let deny_selected = matches!(current_mode, settings::ToolPermissionMode::Deny);
+
+            menu.key_context("ToolPermissionsMenu")
+                .header("Tool Permissions")
+                .item(
+                    ContextMenuEntry::new("Allow")
+                        .toggleable(IconPosition::End, allow_selected)
+                        .disabled(allow_selected)
+                        .handler({
+                            let workspace = workspace.clone();
+                            move |_window, cx| {
+                                if let Some(workspace) = workspace.upgrade() {
+                                    let fs = workspace.read(cx).app_state().fs.clone();
+                                    settings::update_settings_file(fs, cx, move |settings, _cx| {
+                                        let agent = settings.agent.get_or_insert_default();
+                                        agent.tool_permissions.get_or_insert_default().default =
+                                            Some(settings::ToolPermissionMode::Allow);
+                                    });
+                                }
+                            }
+                        }),
+                )
+                .item(
+                    ContextMenuEntry::new("Needs Confirmation")
+                        .toggleable(IconPosition::End, confirm_selected)
+                        .disabled(confirm_selected)
+                        .handler({
+                            let workspace = workspace.clone();
+                            move |_window, cx| {
+                                if let Some(workspace) = workspace.upgrade() {
+                                    let fs = workspace.read(cx).app_state().fs.clone();
+                                    settings::update_settings_file(fs, cx, move |settings, _cx| {
+                                        let agent = settings.agent.get_or_insert_default();
+                                        agent.tool_permissions.get_or_insert_default().default =
+                                            Some(settings::ToolPermissionMode::Confirm);
+                                    });
+                                }
+                            }
+                        }),
+                )
+                .item(
+                    ContextMenuEntry::new("Deny")
+                        .toggleable(IconPosition::End, deny_selected)
+                        .disabled(deny_selected)
+                        .handler({
+                            let workspace = workspace.clone();
+                            move |_window, cx| {
+                                if let Some(workspace) = workspace.upgrade() {
+                                    let fs = workspace.read(cx).app_state().fs.clone();
+                                    settings::update_settings_file(fs, cx, move |settings, _cx| {
+                                        let agent = settings.agent.get_or_insert_default();
+                                        agent.tool_permissions.get_or_insert_default().default =
+                                            Some(settings::ToolPermissionMode::Deny);
+                                    });
+                                }
                             }
                         }),
                 )
@@ -8325,6 +8480,18 @@ impl ThreadView {
         });
     }
 
+    fn open_tool_permissions_menu(
+        &mut self,
+        _action: &crate::OpenToolPermissionsMenu,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let menu_handle = self.tool_permissions_menu_handle.clone();
+        window.defer(cx, move |window, cx| {
+            menu_handle.toggle(window, cx);
+        });
+    }
+
     fn toggle_fast_mode(&mut self, cx: &mut Context<Self>) {
         if !self.fast_mode_available(cx) {
             return;
@@ -8453,6 +8620,7 @@ impl Render for ThreadView {
             .on_action(cx.listener(Self::handle_toggle_command_pattern))
             .on_action(cx.listener(Self::open_permission_dropdown))
             .on_action(cx.listener(Self::open_add_context_menu))
+            .on_action(cx.listener(Self::open_tool_permissions_menu))
             .on_action(cx.listener(|this, _: &ToggleFastMode, _window, cx| {
                 this.toggle_fast_mode(cx);
             }))

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3195,8 +3195,8 @@ impl ThreadView {
                         h_flex()
                             .gap_0p5()
                             .child(self.render_add_context_button(cx))
-                            .child(self.render_tool_permissions_button(cx))
                             .child(self.render_follow_toggle(cx))
+                            .child(self.render_tool_permissions_button(cx))
                             .children(self.render_fast_mode_control(cx))
                             .children(self.render_thinking_control(cx)),
                     )

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -217,6 +217,7 @@ pub enum IconName {
     Send,
     Server,
     Settings,
+    Shield,
     Shift,
     SignalHigh,
     SignalLow,


### PR DESCRIPTION
## Description
This PR introduces a new UI component in the `ThreadView` message editor that allows users to configure tool permissions for the AI Agent without leaving the conversation view.

A quick-access menu is added next to the "Add Context" and "Follow" buttons, letting developers toggle between trust levels in real-time and reducing confirmation friction during agent-heavy workflows. The selected policy applies globally to the agent's behavior.

### Key Changes
- **Quick Selection Menu**: New button that opens a "Tool permissions Selector" menu with "Allow", "Needs Confirmation" (default), and "Deny" options.
- **Dynamic UI**:
  - Shows a muted shield icon when the default policy ("Needs Confirmation") is active.
  - Transitions to a pill button (Shield Icon + Label + Chevron) highlighted in yellow (Warning color) for non-default policies (`Allow` or `Deny`). This gives immediate, clear visual feedback that the default security state has been altered.
- **New Action**: `OpenToolPermissionsMenu` for keyboard accessibility.

## Demo

https://github.com/user-attachments/assets/eacf834a-9766-4987-bcaa-5429f83c4712


## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
- Added a quick selector for Agent tool permissions in the message editor, allowing users to quickly toggle between auto-allow, manual confirmation, and auto-deny modes.
