### PR TITLE
git_ui: Fix branch picker stealing vim keys in Git panel

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1017,7 +1017,7 @@
     },
   },
   {
-    "context": "GitPanel && ChangesList",
+    "context": "GitPanel && ChangesList && !GitBranchSelector",
     "use_key_equivalents": true,
     "bindings": {
       "k": "menu::SelectPrevious",


### PR DESCRIPTION
## Context

When `vim_mode` is enabled, opening the branch selector popover in the Git panel and pressing `i`, `j`, `k`, or `x` triggered Git panel actions (`FocusEditor`, `SelectNext`, `ToggleStaged`, etc.) instead of reaching the picker's search field.

The `"GitPanel && ChangesList"` keybinding block in `vim.json` matched whenever _any_ child of the git panel's focus handle was focused — including the branch picker popover — because `GitPanel::dispatch_context()` adds `ChangesList` based on `focus_handle.contains_focused()`, which is true for all children, not just the changes list itself.

The branch picker's root element already sets `.key_context("GitBranchSelector")` (branch_picker.rs). GPUI's `Not` predicate evaluates against the entire context path, so adding `&& !GitBranchSelector` to the block's context suppresses all those bindings whenever the picker is open, and restores them exactly as before once it's closed.

Closes #52617

Video of the manual test of the fix below :

[Screencast from 2026-03-29 22-01-11.webm](https://github.com/user-attachments/assets/217e8e31-9bee-4e77-a7aa-0c094874ed9a)

## How to Review

- `assets/keymaps/vim.json` : changed the `"GitPanel && ChangesList"` context string ,I added`&& !GitBranchSelector`. 

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed branch picker in the Git panel stealing vim keystrokes (`i`, `j`, `k`, `x`) when vim mode is enabled
