### PR TITLE
diagnostics: Hide Inline Assist toolbar button when agent is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,6 +4868,7 @@ dependencies = [
 name = "diagnostics"
 version = "0.1.0"
 dependencies = [
+ "agent_settings",
  "anyhow",
  "collections",
  "component",

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/diagnostics.rs"
 doctest = false
 
 [dependencies]
+agent_settings.workspace = true
 anyhow.workspace = true
 collections.workspace = true
 component.workspace = true

--- a/crates/diagnostics/src/toolbar_controls.rs
+++ b/crates/diagnostics/src/toolbar_controls.rs
@@ -1,6 +1,8 @@
 use crate::{BufferDiagnosticsEditor, ProjectDiagnosticsEditor, ToggleDiagnosticsRefresh};
+use agent_settings::AgentSettings;
 use gpui::{Context, EventEmitter, ParentElement, Render, Window};
 use language::DiagnosticEntry;
+use settings::Settings;
 use text::{Anchor, BufferId};
 use ui::{Tooltip, prelude::*};
 use workspace::{ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, item::ItemHandle};
@@ -46,6 +48,8 @@ impl Render for ToolbarControls {
             None => {}
         }
 
+        let is_agent_enabled = AgentSettings::get_global(cx).enabled(cx);
+
         let (warning_tooltip, warning_color) = if include_warnings {
             ("Exclude Warnings", Color::Warning)
         } else {
@@ -65,16 +69,18 @@ impl Render for ToolbarControls {
                         window.dispatch_action(Box::new(buffer_search::Deploy::find()), cx);
                     })
             })
-            .child({
-                IconButton::new("inline_assist", IconName::ZedAssistant)
-                    .icon_size(IconSize::Small)
-                    .tooltip(Tooltip::for_action_title(
-                        "Inline Assist",
-                        &InlineAssist::default(),
-                    ))
-                    .on_click(|_, window, cx| {
-                        window.dispatch_action(Box::new(InlineAssist::default()), cx);
-                    })
+            .when(is_agent_enabled, |this| {
+                this.child(
+                    IconButton::new("inline_assist", IconName::ZedAssistant)
+                        .icon_size(IconSize::Small)
+                        .tooltip(Tooltip::for_action_title(
+                            "Inline Assist",
+                            &InlineAssist::default(),
+                        ))
+                        .on_click(|_, window, cx| {
+                            window.dispatch_action(Box::new(InlineAssist::default()), cx);
+                        }),
+                )
             })
             .map(|div| {
                 if is_updating {


### PR DESCRIPTION
### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

#### Closes #52702

### Video 

[Screencast from 2026-03-30 13-17-08.webm](https://github.com/user-attachments/assets/8b0f6927-04d2-406b-b7fd-064a730b2f86)

Release Notes:

- Fixed the Inline Assist button showing in the Project Diagnostics toolbar when the agent is disabled.