### PR TITLE
agent_ui: Fix parsing directory mention on paste

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -507,6 +507,15 @@ mod tests {
     }
 
     #[test]
+    fn test_directory_uri_inserts_trailing_slash() {
+        let uri = MentionUri::Directory {
+            abs_path: PathBuf::from(path!("/path/to/dir")),
+        };
+        let expected = uri!("file:///path/to/dir/");
+        assert_eq!(uri.to_uri().to_string(), expected);
+    }
+
+    #[test]
     fn test_to_directory_uri_without_slash() {
         let uri = MentionUri::Directory {
             abs_path: PathBuf::from(path!("/path/to/dir/")),

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -337,7 +337,11 @@ impl MentionUri {
             MentionUri::PastedImage => Url::parse("zed:///agent/pasted-image").unwrap(),
             MentionUri::Directory { abs_path } => {
                 let mut url = Url::parse("file:///").unwrap();
-                url.set_path(&abs_path.to_string_lossy());
+                let mut path_str = abs_path.to_string_lossy().into_owned();
+                if !path_str.ends_with('/') {
+                    path_str.push('/');
+                }
+                url.set_path(&path_str);
                 url
             }
             MentionUri::Symbol {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #48564

Release Notes:

- agent: Fixed directory mentions being incorrectly parsed as files when pasting into prompt editor
