### PR TITLE
workspace: Fix edge case when saving workspace with unsaved buffers

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1479,21 +1479,23 @@ impl WorkspaceDb {
                 // the pane group is a pane variant, and the buffer is an
                 // unsaved file. However, it might mask an underlying issue
                 // in the workspace or editor deserialization.
-                conn.exec_bound(sql!(
-                    UPDATE workspaces SET paths=NULL WHERE workspace_id=?1 AND paths="";
-                    INSERT INTO pane_groups (workspace_id,parent_group_id,position,axis,flexes)
-                    SELECT ?1,NULL,0,"Horizontal",NULL
-                    WHERE NOT EXISTS (SELECT * FROM pane_groups WHERE workspace_id=?1 LIMIT 1);
-                    UPDATE center_panes
-                    SET parent_group_id=(
-                        SELECT group_id FROM pane_groups
-                        WHERE workspace_id=?1
-                        ORDER BY group_id DESC
-                        LIMIT 1
-                    )
-                    WHERE pane_id IN (SELECT pane_id FROM panes WHERE workspace_id=?1)
-                        AND parent_group_id IS NULL;
-                ))?(workspace.id).context("make sure to save a pane group for the center pane in save workspace")?;
+                if matches!(workspace.center_group, SerializedPaneGroup::Pane(_)) {
+                    conn.exec_bound(sql!(
+                        UPDATE workspaces SET paths=NULL WHERE workspace_id=?1 AND paths="";
+                        INSERT INTO pane_groups (workspace_id,parent_group_id,position,axis,flexes)
+                        SELECT ?1,NULL,0,"Horizontal",NULL
+                        WHERE NOT EXISTS (SELECT * FROM pane_groups WHERE workspace_id=?1 LIMIT 1);
+                        UPDATE center_panes
+                        SET parent_group_id=(
+                            SELECT group_id FROM pane_groups
+                            WHERE workspace_id=?1
+                            ORDER BY group_id DESC
+                            LIMIT 1
+                        )
+                        WHERE pane_id IN (SELECT pane_id FROM panes WHERE workspace_id=?1)
+                            AND parent_group_id IS NULL;
+                    ))?(workspace.id).context("make sure to save a pane group for the center pane in save workspace")?;
+                }
 
                 Ok(())
             })

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1473,6 +1473,28 @@ impl WorkspaceDb {
                 Self::save_pane_group(conn, workspace.id, &workspace.center_group, None)
                     .context("save pane group in save workspace")?;
 
+                // Make sure to save a row in the pane_groups table associating
+                // the pane group and the workspace. This avoids a loading
+                // failure in some cases where the workspace has no worktree,
+                // the pane group is a pane variant, and the buffer is an
+                // unsaved file. However, it might mask an underlying issue
+                // in the workspace or editor deserialization.
+                conn.exec_bound(sql!(
+                    UPDATE workspaces SET paths=NULL WHERE workspace_id=?1 AND paths="";
+                    INSERT INTO pane_groups (workspace_id,parent_group_id,position,axis,flexes)
+                    SELECT ?1,NULL,0,"Horizontal",NULL
+                    WHERE NOT EXISTS (SELECT * FROM pane_groups WHERE workspace_id=?1 LIMIT 1);
+                    UPDATE center_panes
+                    SET parent_group_id=(
+                        SELECT group_id FROM pane_groups
+                        WHERE workspace_id=?1
+                        ORDER BY group_id DESC
+                        LIMIT 1
+                    )
+                    WHERE pane_id IN (SELECT pane_id FROM panes WHERE workspace_id=?1)
+                        AND parent_group_id IS NULL;
+                ))?(workspace.id).context("make sure to save a pane group for the center pane in save workspace")?;
+
                 Ok(())
             })
             .log_err();


### PR DESCRIPTION
Closes #48468

There was an issue where sporadically, a workspace with no worktree and with unsaved buffers would not be restored after restarting Zed. (Refer to https://github.com/zed-industries/zed/issues/48468 and https://github.com/zed-industries/zed/issues/15098)

This PR does an extra step after trying to save the workspace to make sure to save a row in the pane_groups table associating the pane group and the workspace. This avoids a loading failure in some cases where the workspace has no worktree, the pane group is a pane variant, and the buffer is an unsaved file.

Primarily based on a suggested database query by @dhnm who also narrowed down the symptoms. (Refer to https://github.com/zed-industries/zed/issues/48468#issuecomment-3973941351)

However, this fix might mask another underlying issue in the workspace or editor deserialization.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fix an edge case where a serialized pane group did not always get an associated row in pane_groups, which caused an error when loading the workspace

No additional tests were added but perhaps someone can suggest one. The issue seems sporadic based on GitHub issue discussion, although it seems reproducible with a clean install of Zed 0.228.0 on macOS (including a fresh db).

I think @dhnm also needs to approve the pull request as a co-author.