### PR TITLE
agent: Add tool-use hooks for the built-in agent

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1251,6 +1251,20 @@ impl NativeAgentConnection {
                                 log::debug!("Assistant message complete: {:?}", stop_reason);
                                 return Ok(acp::PromptResponse::new(stop_reason));
                             }
+                            ThreadEvent::ToolUseStarted(event) => {
+                                log::debug!(
+                                    "Tool use started: {} ({})",
+                                    event.tool_name,
+                                    event.tool_use_id
+                                );
+                            }
+                            ThreadEvent::ToolUseFinished(event) => {
+                                log::debug!(
+                                    "Tool use finished: {} ({:?})",
+                                    event.tool_name,
+                                    event.status
+                                );
+                            }
                         }
                     }
                     Err(e) => {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -667,6 +667,28 @@ pub enum ThreadEvent {
     SubagentSpawned(acp::SessionId),
     Retry(acp_thread::RetryStatus),
     Stop(acp::StopReason),
+    ToolUseStarted(ToolUseHookEvent),
+    ToolUseFinished(ToolUseHookEvent),
+}
+
+/// Event data passed to tool-use hooks.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolUseHookEvent {
+    pub event: &'static str,
+    pub tool_name: String,
+    pub tool_use_id: String,
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<ToolUseHookStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolUseHookStatus {
+    Completed,
+    Failed,
 }
 
 #[derive(Debug)]
@@ -2333,6 +2355,7 @@ impl Thread {
                     tool_input,
                     tool_use.id,
                     tool_use.name,
+                    None,
                     event_stream,
                     cancellation_rx,
                     cx,
@@ -2353,12 +2376,14 @@ impl Thread {
         }
 
         log::debug!("Running tool {}", tool_use.name);
+        let hook_input = Some(tool_use.input.clone());
         let tool_input = ToolInput::ready(tool_use.input);
         Some(self.run_tool(
             tool,
             tool_input,
             tool_use.id,
             tool_use.name,
+            hook_input,
             event_stream,
             cancellation_rx,
             cx,
@@ -2371,6 +2396,7 @@ impl Thread {
         tool_input: ToolInput<serde_json::Value>,
         tool_use_id: LanguageModelToolUseId,
         tool_name: Arc<str>,
+        hook_input: Option<serde_json::Value>,
         event_stream: &ThreadEventStream,
         cancellation_rx: watch::Receiver<bool>,
         cx: &mut Context<Self>,
@@ -2385,6 +2411,25 @@ impl Thread {
         tool_event_stream.update_fields(
             acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::InProgress),
         );
+
+        let session_id = self.id.to_string();
+        let started_event = ToolUseHookEvent {
+            event: "tool_use_started",
+            tool_name: tool_name.to_string(),
+            tool_use_id: tool_use_id.to_string(),
+            session_id: session_id.clone(),
+            input: hook_input,
+            status: None,
+        };
+
+        event_stream.send_tool_use_started(started_event.clone());
+
+        let hooks = AgentSettings::get_global(cx).hooks.clone();
+        if let Some(ref command) = hooks.pre_tool_use {
+            run_hook_command(command, &started_event, cx);
+        }
+
+        let event_stream_clone = event_stream.clone();
         let supports_images = self.model().is_some_and(|model| model.supports_images());
         let tool_result = tool.run(tool_input, tool_event_stream, cx);
         cx.foreground_executor().spawn(async move {
@@ -2403,6 +2448,27 @@ impl Thread {
                 }
                 Err(output) => (true, output),
             };
+
+            let status = if is_error {
+                ToolUseHookStatus::Failed
+            } else {
+                ToolUseHookStatus::Completed
+            };
+
+            let finished_event = ToolUseHookEvent {
+                event: "tool_use_finished",
+                tool_name: tool_name.to_string(),
+                tool_use_id: tool_use_id.to_string(),
+                session_id,
+                input: None,
+                status: Some(status),
+            };
+
+            event_stream_clone.send_tool_use_finished(finished_event.clone());
+
+            if let Some(ref command) = hooks.post_tool_use {
+                run_hook_command_sync(command, &finished_event);
+            }
 
             LanguageModelToolResult {
                 tool_use_id,
@@ -3506,6 +3572,18 @@ impl ThreadEventStream {
             .ok();
     }
 
+    fn send_tool_use_started(&self, event: ToolUseHookEvent) {
+        self.0
+            .unbounded_send(Ok(ThreadEvent::ToolUseStarted(event)))
+            .ok();
+    }
+
+    fn send_tool_use_finished(&self, event: ToolUseHookEvent) {
+        self.0
+            .unbounded_send(Ok(ThreadEvent::ToolUseFinished(event)))
+            .ok();
+    }
+
     fn send_error(&self, error: impl Into<anyhow::Error>) {
         self.0.unbounded_send(Err(error.into())).ok();
     }
@@ -4035,6 +4113,82 @@ fn convert_image(image_content: acp::ImageContent) -> LanguageModelImage {
     LanguageModelImage {
         source: image_content.data.into(),
         size: None,
+    }
+}
+
+fn run_hook_command(command: &str, event: &ToolUseHookEvent, cx: &mut App) {
+    let command = command.to_string();
+    let json = match serde_json::to_string(event) {
+        Ok(json) => json,
+        Err(err) => {
+            log::error!("Failed to serialize hook event: {}", err);
+            return;
+        }
+    };
+    cx.background_spawn(async move {
+        run_hook_command_inner(&command, &json);
+    })
+    .detach();
+}
+
+fn run_hook_command_sync(command: &str, event: &ToolUseHookEvent) {
+    let command = command.to_string();
+    let json = match serde_json::to_string(event) {
+        Ok(json) => json,
+        Err(err) => {
+            log::error!("Failed to serialize hook event: {}", err);
+            return;
+        }
+    };
+    std::thread::spawn(move || {
+        run_hook_command_inner(&command, &json);
+    });
+}
+
+fn run_hook_command_inner(command: &str, json: &str) {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let shell = if cfg!(target_os = "windows") {
+        "cmd"
+    } else {
+        "sh"
+    };
+    let shell_arg = if cfg!(target_os = "windows") {
+        "/C"
+    } else {
+        "-c"
+    };
+
+    let child = Command::new(shell)
+        .arg(shell_arg)
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn();
+
+    match child {
+        Ok(mut child) => {
+            if let Some(mut stdin) = child.stdin.take() {
+                if let Err(err) = stdin.write_all(json.as_bytes()) {
+                    log::warn!("Failed to write to hook stdin: {}", err);
+                }
+            }
+            match child.wait() {
+                Ok(status) => {
+                    if !status.success() {
+                        log::warn!("Hook command exited with status: {}", status);
+                    }
+                }
+                Err(err) => {
+                    log::warn!("Failed to wait for hook command: {}", err);
+                }
+            }
+        }
+        Err(err) => {
+            log::error!("Failed to spawn hook command '{}': {}", command, err);
+        }
     }
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2467,7 +2467,7 @@ impl Thread {
             event_stream_clone.send_tool_use_finished(finished_event.clone());
 
             if let Some(ref command) = hooks.post_tool_use {
-                run_hook_command_sync(command, &finished_event);
+                run_hook_command_async(command, &finished_event).await;
             }
 
             LanguageModelToolResult {
@@ -4126,13 +4126,12 @@ fn run_hook_command(command: &str, event: &ToolUseHookEvent, cx: &mut App) {
         }
     };
     cx.background_spawn(async move {
-        run_hook_command_inner(&command, &json);
+        run_hook_command_inner(&command, &json).await;
     })
     .detach();
 }
 
-fn run_hook_command_sync(command: &str, event: &ToolUseHookEvent) {
-    let command = command.to_string();
+async fn run_hook_command_async(command: &str, event: &ToolUseHookEvent) {
     let json = match serde_json::to_string(event) {
         Ok(json) => json,
         Err(err) => {
@@ -4140,14 +4139,12 @@ fn run_hook_command_sync(command: &str, event: &ToolUseHookEvent) {
             return;
         }
     };
-    std::thread::spawn(move || {
-        run_hook_command_inner(&command, &json);
-    });
+    run_hook_command_inner(command, &json).await;
 }
 
-fn run_hook_command_inner(command: &str, json: &str) {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
+async fn run_hook_command_inner(command: &str, json: &str) {
+    use futures::AsyncWriteExt;
+    use util::command::Stdio;
 
     let shell = if cfg!(target_os = "windows") {
         "cmd"
@@ -4160,7 +4157,7 @@ fn run_hook_command_inner(command: &str, json: &str) {
         "-c"
     };
 
-    let child = Command::new(shell)
+    let child = util::command::new_command(shell)
         .arg(shell_arg)
         .arg(command)
         .stdin(Stdio::piped())
@@ -4171,11 +4168,11 @@ fn run_hook_command_inner(command: &str, json: &str) {
     match child {
         Ok(mut child) => {
             if let Some(mut stdin) = child.stdin.take() {
-                if let Err(err) = stdin.write_all(json.as_bytes()) {
+                if let Err(err) = stdin.write_all(json.as_bytes()).await {
                     log::warn!("Failed to write to hook stdin: {}", err);
                 }
             }
-            match child.wait() {
+            match child.status().await {
                 Ok(status) => {
                     if !status.success() {
                         log::warn!("Hook command exited with status: {}", status);

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -54,6 +54,22 @@ pub struct AgentSettings {
     pub show_turn_stats: bool,
     pub tool_permissions: ToolPermissions,
     pub new_thread_location: NewThreadLocation,
+    pub hooks: AgentHooks,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AgentHooks {
+    pub pre_tool_use: Option<String>,
+    pub post_tool_use: Option<String>,
+}
+
+impl From<settings::AgentHooksContent> for AgentHooks {
+    fn from(content: settings::AgentHooksContent) -> Self {
+        Self {
+            pre_tool_use: content.pre_tool_use,
+            post_tool_use: content.post_tool_use,
+        }
+    }
 }
 
 impl AgentSettings {
@@ -454,6 +470,7 @@ impl Settings for AgentSettings {
             show_turn_stats: agent.show_turn_stats.unwrap(),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
             new_thread_location: agent.new_thread_location.unwrap_or_default(),
+            hooks: agent.hooks.map(Into::into).unwrap_or_default(),
         }
     }
 }

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -187,6 +187,19 @@ pub struct AgentSettingsContent {
     /// `always_confirm`) match against the tool's text input (command, path,
     /// URL, etc.).
     pub tool_permissions: Option<ToolPermissionsContent>,
+    /// Shell commands to run before and after agent tool invocations.
+    /// These hooks receive tool information as JSON via stdin.
+    ///
+    /// Example:
+    /// ```json
+    /// {
+    ///   "hooks": {
+    ///     "pre_tool_use": "my-hook-script --pre",
+    ///     "post_tool_use": "my-hook-script --post"
+    ///   }
+    /// }
+    /// ```
+    pub hooks: Option<AgentHooksContent>,
 }
 
 impl AgentSettingsContent {
@@ -622,6 +635,16 @@ impl std::fmt::Display for ToolPermissionMode {
             ToolPermissionMode::Confirm => write!(f, "Confirm"),
         }
     }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct AgentHooksContent {
+    /// Shell command to run before each tool invocation.
+    /// Receives JSON on stdin with fields: event, tool_name, tool_use_id, input, session_id.
+    pub pre_tool_use: Option<String>,
+    /// Shell command to run after each tool invocation.
+    /// Receives JSON on stdin with fields: event, tool_name, tool_use_id, status, session_id.
+    pub post_tool_use: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `ToolUseStarted` and `ToolUseFinished` events to the internal `ThreadEvent` pipeline, emitted before and after each tool invocation by the built-in agent
- Adds `agent.hooks` settings (`pre_tool_use` and `post_tool_use`) for configuring shell commands that run on these events
- Hook commands receive tool information (name, ID, input, status, session ID) as JSON via stdin

This enables external processes to observe agent tool invocations — the primary use case is [git-ai](https://github.com/git-ai-project/git-ai), which tracks AI-generated edits for attribution purposes.

### Configuration

```json
{
  "agent": {
    "hooks": {
      "pre_tool_use": "my-hook-script --event pre",
      "post_tool_use": "my-hook-script --event post"
    }
  }
}
```

### Hook JSON format

**Pre-tool-use stdin:**
```json
{
  "event": "tool_use_started",
  "tool_name": "edit_file",
  "tool_use_id": "toolu_abc123",
  "input": { "path": "/src/main.rs", "..." },
  "session_id": "session-uuid"
}
```

**Post-tool-use stdin:**
```json
{
  "event": "tool_use_finished",
  "tool_name": "edit_file",
  "tool_use_id": "toolu_abc123",
  "status": "completed",
  "session_id": "session-uuid"
}
```

## Test plan

- [x] `cargo check -p agent` passes
- [x] `cargo test -p agent_settings` — all 21 tests pass
- [x] `cargo test -p settings_content` — all 20 tests pass
- [ ] Manual: configure hooks in settings and verify they fire during agent tool use

Closes #52688

Release Notes:

- Added tool-use hooks that notify external processes before and after agent tool invocations (configure via `agent.hooks` settings)