### PR TITLE
vim: Add vimrc keybinding support

### DIFF
--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -830,13 +830,13 @@ mod tests {
 
     #[test]
     fn test_source_precedence_sorting() {
-        // KeybindSource precedence: User (0) > Vim (1) > Base (2) > Default (3)
+        // KeybindSource precedence: User (0) > Vimrc (1) > Vim (2) > Base (3) > Default (4)
         // Test that user keymaps take precedence over default keymaps at the same context depth
         let mut keymap = Keymap::default();
 
         // Add a default keymap binding first
         let mut default_binding = KeyBinding::new("cmd-r", ActionAlpha {}, Some("Editor"));
-        default_binding.set_meta(KeyBindingMetaIndex(3)); // Default source
+        default_binding.set_meta(KeyBindingMetaIndex(4)); // Default source
         keymap.add_bindings([default_binding]);
 
         // Add a user keymap binding

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -240,7 +240,7 @@ impl SourceFilters {
     fn allows(&self, source: Option<KeybindSource>) -> bool {
         match source {
             Some(KeybindSource::User) => self.user,
-            Some(KeybindSource::Vim) => self.vim_defaults,
+            Some(KeybindSource::Vim | KeybindSource::Vimrc) => self.vim_defaults,
             Some(KeybindSource::Base | KeybindSource::Default | KeybindSource::Unknown) | None => {
                 self.zed_defaults
             }
@@ -2312,6 +2312,7 @@ impl Render for KeymapEditor {
                                                     match conflict.override_source {
                                                         KeybindSource::User  => Some("your keymap"),
                                                         KeybindSource::Vim => Some("the vim keymap"),
+                                                        KeybindSource::Vimrc => Some("your vimrc"),
                                                         KeybindSource::Base => Some("your base keymap"),
                                                         _ => {
                                                             log::error!("Unexpected override from the {} keymap", conflict.override_source.name());

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -254,6 +254,18 @@ pub fn keymap_file() -> &'static PathBuf {
     KEYMAP_FILE.get_or_init(|| config_dir().join("keymap.json"))
 }
 
+/// Returns the path to the Zed-specific vimrc file (`~/.config/zed/vimrc`).
+pub fn zed_vimrc_file() -> &'static PathBuf {
+    static VIMRC_FILE: OnceLock<PathBuf> = OnceLock::new();
+    VIMRC_FILE.get_or_init(|| config_dir().join("vimrc"))
+}
+
+/// Returns the path to the user's home `~/.vimrc` file.
+pub fn home_vimrc_file() -> &'static PathBuf {
+    static HOME_VIMRC_FILE: OnceLock<PathBuf> = OnceLock::new();
+    HOME_VIMRC_FILE.get_or_init(|| home_dir().join(".vimrc"))
+}
+
 /// Returns the path to the `keymap_backup.json` file.
 pub fn keymap_backup_file() -> &'static PathBuf {
     static KEYMAP_FILE: OnceLock<PathBuf> = OnceLock::new();

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -1318,6 +1318,7 @@ impl<'a> KeybindUpdateTarget<'a> {
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum KeybindSource {
     User,
+    Vimrc,
     Vim,
     Base,
     #[default]
@@ -1329,6 +1330,7 @@ impl KeybindSource {
     const BASE: KeyBindingMetaIndex = KeyBindingMetaIndex(KeybindSource::Base as u32);
     const DEFAULT: KeyBindingMetaIndex = KeyBindingMetaIndex(KeybindSource::Default as u32);
     const VIM: KeyBindingMetaIndex = KeyBindingMetaIndex(KeybindSource::Vim as u32);
+    const VIMRC: KeyBindingMetaIndex = KeyBindingMetaIndex(KeybindSource::Vimrc as u32);
     const USER: KeyBindingMetaIndex = KeyBindingMetaIndex(KeybindSource::User as u32);
 
     pub fn name(&self) -> &'static str {
@@ -1337,6 +1339,7 @@ impl KeybindSource {
             KeybindSource::Default => "Default",
             KeybindSource::Base => "Base",
             KeybindSource::Vim => "Vim",
+            KeybindSource::Vimrc => "Vimrc",
             KeybindSource::Unknown => "Unknown",
         }
     }
@@ -1347,6 +1350,7 @@ impl KeybindSource {
             KeybindSource::Default => Self::DEFAULT,
             KeybindSource::Base => Self::BASE,
             KeybindSource::Vim => Self::VIM,
+            KeybindSource::Vimrc => Self::VIMRC,
             KeybindSource::Unknown => KeyBindingMetaIndex(*self as u32),
         }
     }
@@ -1354,6 +1358,7 @@ impl KeybindSource {
     pub fn from_meta(index: KeyBindingMetaIndex) -> Self {
         match index {
             Self::USER => KeybindSource::User,
+            Self::VIMRC => KeybindSource::Vimrc,
             Self::BASE => KeybindSource::Base,
             Self::DEFAULT => KeybindSource::Default,
             Self::VIM => KeybindSource::Vim,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -17,6 +17,7 @@ mod replace;
 mod rewrap;
 mod state;
 mod surrounds;
+pub mod vimrc;
 mod visual;
 
 use crate::normal::paste::Paste as VimPaste;

--- a/crates/vim/src/vimrc.rs
+++ b/crates/vim/src/vimrc.rs
@@ -1,0 +1,795 @@
+use std::rc::Rc;
+
+use gpui::{App, DummyKeyboardMapper, KeyBinding, KeyBindingContextPredicate, NoAction};
+use log::warn;
+use settings::KeybindSource;
+use workspace::SendKeystrokes;
+
+pub struct VimrcError {
+    pub line_number: usize,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum VimrcMode {
+    Normal,
+    Insert,
+    Visual,
+    All,
+}
+
+struct VimrcMapping {
+    mode: VimrcMode,
+    lhs: String,
+    rhs: String,
+    line_number: usize,
+}
+
+struct VimrcUnmap {
+    mode: VimrcMode,
+    lhs: String,
+    line_number: usize,
+}
+
+struct VimrcFile {
+    mappings: Vec<VimrcMapping>,
+    unmaps: Vec<VimrcUnmap>,
+    leader: Option<String>,
+    errors: Vec<VimrcError>,
+}
+
+pub fn load_vimrc(content: &str, cx: &App) -> (Vec<KeyBinding>, Vec<VimrcError>) {
+    let parsed = parse(content);
+    to_key_bindings(parsed, cx)
+}
+
+fn parse(content: &str) -> VimrcFile {
+    let mut mappings = Vec::new();
+    let mut unmaps = Vec::new();
+    let mut leader: Option<String> = None;
+    let mut errors = Vec::new();
+
+    for (line_idx, raw_line) in content.lines().enumerate() {
+        let line_number = line_idx + 1;
+        let line = raw_line.trim();
+
+        if line.is_empty() || line.starts_with('"') {
+            continue;
+        }
+
+        let Some((command, rest)) = line.split_once(|c: char| c.is_whitespace()) else {
+            errors.push(VimrcError {
+                line_number,
+                message: format!("Unrecognized command: {line}"),
+            });
+            continue;
+        };
+
+        let rest = rest.trim_start();
+
+        match command {
+            "nmap" | "nnoremap" => {
+                if let Some(mapping) = parse_mapping(VimrcMode::Normal, rest, line_number) {
+                    mappings.push(mapping);
+                } else {
+                    errors.push(VimrcError {
+                        line_number,
+                        message: format!("Invalid mapping: {line}"),
+                    });
+                }
+            }
+            "imap" | "inoremap" => {
+                if let Some(mapping) = parse_mapping(VimrcMode::Insert, rest, line_number) {
+                    mappings.push(mapping);
+                } else {
+                    errors.push(VimrcError {
+                        line_number,
+                        message: format!("Invalid mapping: {line}"),
+                    });
+                }
+            }
+            "vmap" | "vnoremap" => {
+                if let Some(mapping) = parse_mapping(VimrcMode::Visual, rest, line_number) {
+                    mappings.push(mapping);
+                } else {
+                    errors.push(VimrcError {
+                        line_number,
+                        message: format!("Invalid mapping: {line}"),
+                    });
+                }
+            }
+            "map" | "noremap" => {
+                if let Some(mapping) = parse_mapping(VimrcMode::All, rest, line_number) {
+                    mappings.push(mapping);
+                } else {
+                    errors.push(VimrcError {
+                        line_number,
+                        message: format!("Invalid mapping: {line}"),
+                    });
+                }
+            }
+            "nunmap" => {
+                if let Some(unmap) = parse_unmap(VimrcMode::Normal, rest, line_number) {
+                    unmaps.push(unmap);
+                }
+            }
+            "iunmap" => {
+                if let Some(unmap) = parse_unmap(VimrcMode::Insert, rest, line_number) {
+                    unmaps.push(unmap);
+                }
+            }
+            "vunmap" => {
+                if let Some(unmap) = parse_unmap(VimrcMode::Visual, rest, line_number) {
+                    unmaps.push(unmap);
+                }
+            }
+            "unmap" => {
+                if let Some(unmap) = parse_unmap(VimrcMode::All, rest, line_number) {
+                    unmaps.push(unmap);
+                }
+            }
+            "let" => {
+                if let Some(new_leader) = parse_let_mapleader(rest) {
+                    leader = Some(new_leader);
+                } else {
+                    errors.push(VimrcError {
+                        line_number,
+                        message: format!("Unsupported let statement: {line}"),
+                    });
+                }
+            }
+            "set" => {
+                // set options are handled at a higher level; skip silently for now
+                // since we apply them through VimSettings rather than keybindings
+                errors.push(VimrcError {
+                    line_number,
+                    message: format!("'set' options are not yet supported in vimrc: {line}"),
+                });
+            }
+            _ => {
+                errors.push(VimrcError {
+                    line_number,
+                    message: format!("Unrecognized command: {command}"),
+                });
+            }
+        }
+    }
+
+    VimrcFile {
+        mappings,
+        unmaps,
+        leader,
+        errors,
+    }
+}
+
+fn parse_mapping(mode: VimrcMode, rest: &str, line_number: usize) -> Option<VimrcMapping> {
+    let (lhs, rhs) = split_lhs_rhs(rest)?;
+    Some(VimrcMapping {
+        mode,
+        lhs: lhs.to_string(),
+        rhs: rhs.to_string(),
+        line_number,
+    })
+}
+
+fn parse_unmap(mode: VimrcMode, rest: &str, line_number: usize) -> Option<VimrcUnmap> {
+    let lhs = rest.trim();
+    if lhs.is_empty() {
+        return None;
+    }
+    Some(VimrcUnmap {
+        mode,
+        lhs: lhs.to_string(),
+        line_number,
+    })
+}
+
+fn split_lhs_rhs(input: &str) -> Option<(&str, &str)> {
+    // The LHS is the first whitespace-delimited token (handling <...> as atomic),
+    // and the RHS is everything after the separating whitespace.
+    let input = input.trim();
+    let lhs_end = find_lhs_end(input)?;
+    let rhs = input[lhs_end..].trim_start();
+    if rhs.is_empty() {
+        return None;
+    }
+    Some((input[..lhs_end].trim_end(), rhs))
+}
+
+fn find_lhs_end(input: &str) -> Option<usize> {
+    let mut chars = input.char_indices().peekable();
+    let mut last_end = 0;
+
+    while let Some(&(idx, ch)) = chars.peek() {
+        if ch.is_whitespace() {
+            if last_end > 0 {
+                return Some(last_end);
+            }
+            return Some(idx);
+        }
+        if ch == '<' {
+            // Check if this looks like a <special> key (next char is not whitespace/end)
+            let saved_pos = idx;
+            chars.next();
+            if let Some(&(_, next_ch)) = chars.peek() {
+                if next_ch.is_whitespace() || next_ch == '<' {
+                    // Bare '<' character, not a special key
+                    last_end = saved_pos + 1;
+                    continue;
+                }
+            } else {
+                // '<' at end of string
+                last_end = saved_pos + 1;
+                continue;
+            }
+            // Scan forward to find matching '>'
+            let mut found_close = false;
+            while let Some(&(end_idx, c)) = chars.peek() {
+                chars.next();
+                if c == '>' {
+                    last_end = end_idx + 1;
+                    found_close = true;
+                    break;
+                }
+                if c.is_whitespace() {
+                    // No closing '>' before whitespace, treat '<' as plain char
+                    last_end = saved_pos + 1;
+                    return Some(last_end);
+                }
+            }
+            if !found_close {
+                last_end = saved_pos + 1;
+            }
+        } else {
+            chars.next();
+            last_end = idx + ch.len_utf8();
+        }
+    }
+
+    // If we consumed everything, there's no RHS
+    None
+}
+
+fn parse_let_mapleader(rest: &str) -> Option<String> {
+    // Parses: mapleader = "..." or mapleader="..."
+    let rest = rest.trim();
+    let rest = rest.strip_prefix("mapleader")?;
+    let rest = rest.trim();
+    let rest = rest.strip_prefix('=')?;
+    let rest = rest.trim();
+
+    // Accept single or double quoted value
+    if let Some(inner) = rest.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+        Some(unescape_vim_string(inner))
+    } else if let Some(inner) = rest.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+        Some(unescape_vim_string(inner))
+    } else {
+        None
+    }
+}
+
+fn unescape_vim_string(s: &str) -> String {
+    s.replace("\\<", "<")
+        .replace("\\\\", "\\")
+        .replace("\\\"", "\"")
+}
+
+fn context_for_mode(mode: VimrcMode) -> &'static str {
+    match mode {
+        VimrcMode::Normal => "vim_mode == normal",
+        VimrcMode::Insert => "vim_mode == insert",
+        VimrcMode::Visual => "vim_mode == visual",
+        VimrcMode::All => "VimControl && !menu",
+    }
+}
+
+fn translate_vim_keys(vim_keys: &str, leader: &Option<String>) -> Result<String, String> {
+    let mut result = Vec::new();
+    let mut chars = vim_keys.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '<' {
+            let mut special = String::new();
+            for c in chars.by_ref() {
+                if c == '>' {
+                    break;
+                }
+                special.push(c);
+            }
+            let translated = translate_special_key(&special, leader)?;
+            result.push(translated);
+        } else {
+            result.push(translate_plain_char(ch));
+        }
+    }
+
+    Ok(result.join(" "))
+}
+
+fn translate_special_key(key: &str, leader: &Option<String>) -> Result<String, String> {
+    let lower = key.to_lowercase();
+
+    if lower == "leader" {
+        let leader_val = leader.as_deref().unwrap_or("\\");
+        return translate_vim_keys(leader_val, &None);
+    }
+
+    // Modifier combos: C-x, S-x, A-x, M-x, D-x
+    if let Some(rest) = lower
+        .strip_prefix("c-")
+        .or_else(|| lower.strip_prefix("ctrl-"))
+    {
+        return Ok(format!("ctrl-{rest}"));
+    }
+    if let Some(rest) = lower
+        .strip_prefix("s-")
+        .or_else(|| lower.strip_prefix("shift-"))
+    {
+        return Ok(format!("shift-{rest}"));
+    }
+    if let Some(rest) = lower
+        .strip_prefix("a-")
+        .or_else(|| lower.strip_prefix("alt-"))
+        .or_else(|| lower.strip_prefix("m-"))
+    {
+        return Ok(format!("alt-{rest}"));
+    }
+    if let Some(rest) = lower
+        .strip_prefix("d-")
+        .or_else(|| lower.strip_prefix("cmd-"))
+    {
+        return Ok(format!("cmd-{rest}"));
+    }
+
+    match lower.as_str() {
+        "cr" | "enter" | "return" => Ok("enter".to_string()),
+        "esc" | "escape" => Ok("escape".to_string()),
+        "space" => Ok("space".to_string()),
+        "tab" => Ok("tab".to_string()),
+        "bs" | "backspace" => Ok("backspace".to_string()),
+        "del" | "delete" => Ok("delete".to_string()),
+        "up" => Ok("up".to_string()),
+        "down" => Ok("down".to_string()),
+        "left" => Ok("left".to_string()),
+        "right" => Ok("right".to_string()),
+        "home" => Ok("home".to_string()),
+        "end" => Ok("end".to_string()),
+        "pageup" => Ok("pageup".to_string()),
+        "pagedown" => Ok("pagedown".to_string()),
+        "nop" => Ok("".to_string()),
+        "bar" => Ok("|".to_string()),
+        "lt" => Ok("<".to_string()),
+        "gt" => Ok(">".to_string()),
+        "bslash" => Ok("\\".to_string()),
+        "f1" => Ok("f1".to_string()),
+        "f2" => Ok("f2".to_string()),
+        "f3" => Ok("f3".to_string()),
+        "f4" => Ok("f4".to_string()),
+        "f5" => Ok("f5".to_string()),
+        "f6" => Ok("f6".to_string()),
+        "f7" => Ok("f7".to_string()),
+        "f8" => Ok("f8".to_string()),
+        "f9" => Ok("f9".to_string()),
+        "f10" => Ok("f10".to_string()),
+        "f11" => Ok("f11".to_string()),
+        "f12" => Ok("f12".to_string()),
+        other => Err(format!("Unknown special key: <{other}>")),
+    }
+}
+
+fn translate_plain_char(ch: char) -> String {
+    match ch {
+        ' ' => "space".to_string(),
+        _ => ch.to_string(),
+    }
+}
+
+fn to_key_bindings(vimrc: VimrcFile, cx: &App) -> (Vec<KeyBinding>, Vec<VimrcError>) {
+    let mut bindings = Vec::new();
+    let mut errors = vimrc.errors;
+
+    for mapping in &vimrc.mappings {
+        let lhs = match translate_vim_keys(&mapping.lhs, &vimrc.leader) {
+            Ok(k) => k,
+            Err(err) => {
+                errors.push(VimrcError {
+                    line_number: mapping.line_number,
+                    message: err,
+                });
+                continue;
+            }
+        };
+
+        if lhs.is_empty() {
+            continue;
+        }
+
+        let action = resolve_rhs(&mapping.rhs, &vimrc.leader, cx);
+        let action = match action {
+            Ok(a) => a,
+            Err(err) => {
+                errors.push(VimrcError {
+                    line_number: mapping.line_number,
+                    message: err,
+                });
+                continue;
+            }
+        };
+
+        let modes = if mapping.mode == VimrcMode::All {
+            vec![VimrcMode::Normal, VimrcMode::Visual]
+        } else {
+            vec![mapping.mode]
+        };
+
+        for mode in modes {
+            let context_str = context_for_mode(mode);
+            let context_predicate = match KeyBindingContextPredicate::parse(context_str) {
+                Ok(pred) => Some(Rc::new(pred)),
+                Err(err) => {
+                    warn!("Failed to parse context predicate '{context_str}': {err}");
+                    continue;
+                }
+            };
+
+            match KeyBinding::load(
+                &lhs,
+                action.boxed_clone(),
+                context_predicate,
+                false,
+                None,
+                &DummyKeyboardMapper,
+            ) {
+                Ok(mut binding) => {
+                    binding.set_meta(KeybindSource::Vimrc.meta());
+                    bindings.push(binding);
+                }
+                Err(err) => {
+                    errors.push(VimrcError {
+                        line_number: mapping.line_number,
+                        message: format!("Invalid keystroke in LHS '{lhs}': {err}"),
+                    });
+                }
+            }
+        }
+    }
+
+    for unmap in &vimrc.unmaps {
+        let lhs = match translate_vim_keys(&unmap.lhs, &vimrc.leader) {
+            Ok(k) => k,
+            Err(err) => {
+                errors.push(VimrcError {
+                    line_number: unmap.line_number,
+                    message: err,
+                });
+                continue;
+            }
+        };
+
+        if lhs.is_empty() {
+            continue;
+        }
+
+        let modes = if unmap.mode == VimrcMode::All {
+            vec![VimrcMode::Normal, VimrcMode::Visual]
+        } else {
+            vec![unmap.mode]
+        };
+
+        for mode in modes {
+            let context_str = context_for_mode(mode);
+            let context_predicate = match KeyBindingContextPredicate::parse(context_str) {
+                Ok(pred) => Some(Rc::new(pred)),
+                Err(err) => {
+                    warn!("Failed to parse context predicate '{context_str}': {err}");
+                    continue;
+                }
+            };
+
+            match KeyBinding::load(
+                &lhs,
+                Box::new(NoAction {}),
+                context_predicate,
+                false,
+                None,
+                &DummyKeyboardMapper,
+            ) {
+                Ok(mut binding) => {
+                    binding.set_meta(KeybindSource::Vimrc.meta());
+                    bindings.push(binding);
+                }
+                Err(err) => {
+                    errors.push(VimrcError {
+                        line_number: unmap.line_number,
+                        message: format!("Invalid keystroke in unmap '{lhs}': {err}"),
+                    });
+                }
+            }
+        }
+    }
+
+    (bindings, errors)
+}
+
+fn resolve_rhs(
+    rhs: &str,
+    leader: &Option<String>,
+    cx: &App,
+) -> Result<Box<dyn gpui::Action>, String> {
+    // Case 1: Ex-command — starts with ':' and optionally ends with <CR>
+    if let Some(command) = rhs.strip_prefix(':') {
+        let command = command
+            .strip_suffix("<CR>")
+            .or_else(|| command.strip_suffix("<cr>"))
+            .or_else(|| command.strip_suffix("<Enter>"))
+            .or_else(|| command.strip_suffix("<enter>"))
+            .unwrap_or(command)
+            .trim();
+
+        // Try to resolve as a Zed action name directly (e.g., `:edit` -> known command)
+        if let Ok(action) = cx.build_action(command, None) {
+            return Ok(action);
+        }
+
+        // Fall back to SendKeystrokes with the : prefix and enter
+        let keystrokes = format!(": {command} enter");
+        return Ok(Box::new(SendKeystrokes(keystrokes)));
+    }
+
+    // Case 2: Zed action — contains "::" (e.g., "editor::GoToDefinition")
+    if rhs.contains("::") {
+        return cx
+            .build_action(rhs, None)
+            .map_err(|err| format!("Unknown action '{rhs}': {err}"));
+    }
+
+    // Case 3: <Nop> — no operation
+    let lower = rhs.to_lowercase();
+    if lower == "<nop>" {
+        return Ok(Box::new(NoAction {}));
+    }
+
+    // Case 4: Key sequence — translate and use SendKeystrokes
+    let translated = translate_vim_keys(rhs, leader)?;
+    if translated.is_empty() {
+        return Ok(Box::new(NoAction {}));
+    }
+    Ok(Box::new(SendKeystrokes(translated)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_empty() {
+        let vimrc = parse("");
+        assert!(vimrc.mappings.is_empty());
+        assert!(vimrc.errors.is_empty());
+        assert!(vimrc.leader.is_none());
+    }
+
+    #[test]
+    fn test_parse_comments_and_blank_lines() {
+        let content = r#"
+" This is a comment
+" Another comment
+
+"#;
+        let vimrc = parse(content);
+        assert!(vimrc.mappings.is_empty());
+        assert!(vimrc.errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_nnoremap() {
+        let content = "nnoremap <leader>f :Files<CR>";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.mappings.len(), 1);
+        assert_eq!(vimrc.mappings[0].mode, VimrcMode::Normal);
+        assert_eq!(vimrc.mappings[0].lhs, "<leader>f");
+        assert_eq!(vimrc.mappings[0].rhs, ":Files<CR>");
+    }
+
+    #[test]
+    fn test_parse_inoremap() {
+        let content = "inoremap jk <Esc>";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.mappings.len(), 1);
+        assert_eq!(vimrc.mappings[0].mode, VimrcMode::Insert);
+        assert_eq!(vimrc.mappings[0].lhs, "jk");
+        assert_eq!(vimrc.mappings[0].rhs, "<Esc>");
+    }
+
+    #[test]
+    fn test_parse_vnoremap() {
+        let content = "vnoremap < <gv";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.mappings.len(), 1);
+        assert_eq!(vimrc.mappings[0].mode, VimrcMode::Visual);
+        assert_eq!(vimrc.mappings[0].lhs, "<");
+        assert_eq!(vimrc.mappings[0].rhs, "<gv");
+    }
+
+    #[test]
+    fn test_parse_let_mapleader_space() {
+        let content = r#"let mapleader = " ""#;
+        let vimrc = parse(content);
+        assert_eq!(vimrc.leader.as_deref(), Some(" "));
+    }
+
+    #[test]
+    fn test_parse_let_mapleader_comma() {
+        let content = "let mapleader = ','";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.leader.as_deref(), Some(","));
+    }
+
+    #[test]
+    fn test_parse_unmap() {
+        let content = "nunmap <C-w>";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.unmaps.len(), 1);
+        assert_eq!(vimrc.unmaps[0].mode, VimrcMode::Normal);
+        assert_eq!(vimrc.unmaps[0].lhs, "<C-w>");
+    }
+
+    #[test]
+    fn test_parse_unrecognized_command() {
+        let content = "autocmd BufRead * echo 'hello'";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.errors.len(), 1);
+        assert!(vimrc.errors[0].message.contains("Unrecognized"));
+    }
+
+    #[test]
+    fn test_parse_multiple_mappings() {
+        let content = r#"
+let mapleader = " "
+nnoremap <leader>f :Files<CR>
+inoremap jk <Esc>
+vnoremap < <gv
+nunmap <C-a>
+"#;
+        let vimrc = parse(content);
+        assert_eq!(vimrc.mappings.len(), 3);
+        assert_eq!(vimrc.unmaps.len(), 1);
+        assert_eq!(vimrc.leader.as_deref(), Some(" "));
+        assert!(vimrc.errors.is_empty());
+    }
+
+    #[test]
+    fn test_translate_plain_chars() {
+        let result = translate_vim_keys("jk", &None).unwrap();
+        assert_eq!(result, "j k");
+    }
+
+    #[test]
+    fn test_translate_escape() {
+        let result = translate_vim_keys("<Esc>", &None).unwrap();
+        assert_eq!(result, "escape");
+    }
+
+    #[test]
+    fn test_translate_ctrl() {
+        let result = translate_vim_keys("<C-w>", &None).unwrap();
+        assert_eq!(result, "ctrl-w");
+    }
+
+    #[test]
+    fn test_translate_shift() {
+        let result = translate_vim_keys("<S-Tab>", &None).unwrap();
+        assert_eq!(result, "shift-tab");
+    }
+
+    #[test]
+    fn test_translate_alt() {
+        let result = translate_vim_keys("<A-x>", &None).unwrap();
+        assert_eq!(result, "alt-x");
+    }
+
+    #[test]
+    fn test_translate_cmd() {
+        let result = translate_vim_keys("<D-s>", &None).unwrap();
+        assert_eq!(result, "cmd-s");
+    }
+
+    #[test]
+    fn test_translate_cr() {
+        let result = translate_vim_keys("<CR>", &None).unwrap();
+        assert_eq!(result, "enter");
+    }
+
+    #[test]
+    fn test_translate_space() {
+        let result = translate_vim_keys("<Space>", &None).unwrap();
+        assert_eq!(result, "space");
+    }
+
+    #[test]
+    fn test_translate_leader_default() {
+        let result = translate_vim_keys("<leader>f", &None).unwrap();
+        assert_eq!(result, "\\ f");
+    }
+
+    #[test]
+    fn test_translate_leader_space() {
+        let leader = Some(" ".to_string());
+        let result = translate_vim_keys("<leader>ff", &leader).unwrap();
+        assert_eq!(result, "space f f");
+    }
+
+    #[test]
+    fn test_translate_leader_comma() {
+        let leader = Some(",".to_string());
+        let result = translate_vim_keys("<leader>w", &leader).unwrap();
+        assert_eq!(result, ", w");
+    }
+
+    #[test]
+    fn test_translate_complex_sequence() {
+        let leader = Some(" ".to_string());
+        let result = translate_vim_keys("<leader><C-w>h", &leader).unwrap();
+        assert_eq!(result, "space ctrl-w h");
+    }
+
+    #[test]
+    fn test_translate_nop() {
+        let result = translate_vim_keys("<Nop>", &None).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_translate_function_keys() {
+        let result = translate_vim_keys("<F5>", &None).unwrap();
+        assert_eq!(result, "f5");
+    }
+
+    #[test]
+    fn test_split_lhs_rhs_simple() {
+        let (lhs, rhs) = split_lhs_rhs("jk <Esc>").unwrap();
+        assert_eq!(lhs, "jk");
+        assert_eq!(rhs, "<Esc>");
+    }
+
+    #[test]
+    fn test_split_lhs_rhs_special_key_lhs() {
+        let (lhs, rhs) = split_lhs_rhs("<leader>f :Files<CR>").unwrap();
+        assert_eq!(lhs, "<leader>f");
+        assert_eq!(rhs, ":Files<CR>");
+    }
+
+    #[test]
+    fn test_split_lhs_rhs_angle_bracket_char() {
+        let (lhs, rhs) = split_lhs_rhs("< <gv").unwrap();
+        assert_eq!(lhs, "<");
+        assert_eq!(rhs, "<gv");
+    }
+
+    #[test]
+    fn test_split_lhs_rhs_ctrl_combo() {
+        let (lhs, rhs) = split_lhs_rhs("<C-w>h <C-w>l").unwrap();
+        assert_eq!(lhs, "<C-w>h");
+        assert_eq!(rhs, "<C-w>l");
+    }
+
+    #[test]
+    fn test_parse_map_command() {
+        let content = "map <C-n> :noh<CR>";
+        let vimrc = parse(content);
+        assert_eq!(vimrc.mappings.len(), 1);
+        assert_eq!(vimrc.mappings[0].mode, VimrcMode::All);
+    }
+
+    #[test]
+    fn test_context_for_mode() {
+        assert_eq!(context_for_mode(VimrcMode::Normal), "vim_mode == normal");
+        assert_eq!(context_for_mode(VimrcMode::Insert), "vim_mode == insert");
+        assert_eq!(context_for_mode(VimrcMode::Visual), "vim_mode == visual");
+        assert_eq!(
+            context_for_mode(VimrcMode::All),
+            "VimControl && !menu"
+        );
+    }
+}

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -416,6 +416,16 @@ fn main() {
         fs.clone(),
         paths::keymap_file().clone(),
     );
+    let (zed_vimrc_rx, zed_vimrc_watcher) = watch_config_file(
+        &app.background_executor(),
+        fs.clone(),
+        paths::zed_vimrc_file().clone(),
+    );
+    let (home_vimrc_rx, home_vimrc_watcher) = watch_config_file(
+        &app.background_executor(),
+        fs.clone(),
+        paths::home_vimrc_file().clone(),
+    );
 
     let (shell_env_loaded_tx, shell_env_loaded_rx) = oneshot::channel();
     if !stdout_is_a_pty() {
@@ -480,7 +490,15 @@ fn main() {
             global_settings_watcher,
             cx,
         );
-        handle_keymap_file_changes(user_keymap_file_rx, user_keymap_watcher, cx);
+        handle_keymap_file_changes(
+            user_keymap_file_rx,
+            user_keymap_watcher,
+            zed_vimrc_rx,
+            zed_vimrc_watcher,
+            home_vimrc_rx,
+            home_vimrc_watcher,
+            cx,
+        );
 
         let user_agent = format!(
             "Zed/{} ({}; {})",

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1661,6 +1661,10 @@ pub fn handle_settings_file_changes(
 pub fn handle_keymap_file_changes(
     mut user_keymap_file_rx: mpsc::UnboundedReceiver<String>,
     user_keymap_watcher: gpui::Task<()>,
+    mut zed_vimrc_rx: mpsc::UnboundedReceiver<String>,
+    zed_vimrc_watcher: gpui::Task<()>,
+    mut home_vimrc_rx: mpsc::UnboundedReceiver<String>,
+    home_vimrc_watcher: gpui::Task<()>,
     cx: &mut App,
 ) {
     let (base_keymap_tx, mut base_keymap_rx) = mpsc::unbounded();
@@ -1718,9 +1722,16 @@ pub fn handle_keymap_file_changes(
     struct KeymapParseErrorNotification;
     let notification_id = NotificationId::unique::<KeymapParseErrorNotification>();
 
+    struct VimrcParseErrorNotification;
+    let vimrc_notification_id = NotificationId::unique::<VimrcParseErrorNotification>();
+
     cx.spawn(async move |cx| {
         let _user_keymap_watcher = user_keymap_watcher;
+        let _zed_vimrc_watcher = zed_vimrc_watcher;
+        let _home_vimrc_watcher = home_vimrc_watcher;
         let mut user_keymap_content = String::new();
+        let mut zed_vimrc_content = String::new();
+        let mut home_vimrc_content = String::new();
         let mut migrating_in_memory = false;
         loop {
             select_biased! {
@@ -1737,6 +1748,16 @@ pub fn handle_keymap_file_changes(
                         }
                     }
                 }
+                content = zed_vimrc_rx.next() => {
+                    if let Some(content) = content {
+                        zed_vimrc_content = content;
+                    }
+                }
+                content = home_vimrc_rx.next() => {
+                    if let Some(content) = content {
+                        home_vimrc_content = content;
+                    }
+                }
             };
             cx.update(|cx| {
                 if let Some(notifier) = MigrationNotification::try_global(cx) {
@@ -1747,10 +1768,42 @@ pub fn handle_keymap_file_changes(
                         });
                     });
                 }
+
+                let effective_vimrc = if !zed_vimrc_content.is_empty() {
+                    &zed_vimrc_content
+                } else {
+                    &home_vimrc_content
+                };
+                let vimrc_bindings = if !effective_vimrc.is_empty() {
+                    let (bindings, errors) = vim::vimrc::load_vimrc(effective_vimrc, cx);
+                    if !errors.is_empty() {
+                        let error_lines: Vec<String> = errors
+                            .iter()
+                            .take(5)
+                            .map(|e| format!("Line {}: {}", e.line_number, e.message))
+                            .collect();
+                        let message = format!(
+                            "vimrc: {} error(s)\n{}",
+                            errors.len(),
+                            error_lines.join("\n")
+                        );
+                        show_vimrc_load_error(
+                            vimrc_notification_id.clone(),
+                            message.into(),
+                            cx,
+                        );
+                    } else {
+                        dismiss_app_notification(&vimrc_notification_id.clone(), cx);
+                    }
+                    bindings
+                } else {
+                    Vec::new()
+                };
+
                 let load_result = KeymapFile::load(&user_keymap_content, cx);
                 match load_result {
                     KeymapFileLoadResult::Success { key_bindings } => {
-                        reload_keymaps(cx, key_bindings);
+                        reload_keymaps(cx, vimrc_bindings, key_bindings);
                         dismiss_app_notification(&notification_id.clone(), cx);
                     }
                     KeymapFileLoadResult::SomeFailedToLoad {
@@ -1758,7 +1811,7 @@ pub fn handle_keymap_file_changes(
                         error_message,
                     } => {
                         if !key_bindings.is_empty() {
-                            reload_keymaps(cx, key_bindings);
+                            reload_keymaps(cx, vimrc_bindings, key_bindings);
                         }
                         show_keymap_file_load_error(notification_id.clone(), error_message, cx);
                     }
@@ -1809,6 +1862,16 @@ fn show_keymap_file_load_error(
     )
 }
 
+fn show_vimrc_load_error(
+    notification_id: NotificationId,
+    message: SharedString,
+    cx: &mut App,
+) {
+    show_app_notification(notification_id, cx, move |cx| {
+        cx.new(|cx| MessageNotification::new(message.clone(), cx))
+    });
+}
+
 fn show_markdown_app_notification<F>(
     notification_id: NotificationId,
     message: MarkdownString,
@@ -1842,9 +1905,17 @@ fn show_markdown_app_notification<F>(
     })
 }
 
-fn reload_keymaps(cx: &mut App, mut user_key_bindings: Vec<KeyBinding>) {
+fn reload_keymaps(
+    cx: &mut App,
+    vimrc_bindings: Vec<KeyBinding>,
+    mut user_key_bindings: Vec<KeyBinding>,
+) {
     cx.clear_key_bindings();
     load_default_keymap(cx);
+
+    if !vimrc_bindings.is_empty() {
+        cx.bind_keys(vimrc_bindings);
+    }
 
     for key_binding in &mut user_key_bindings {
         key_binding.set_meta(KeybindSource::User.meta());
@@ -4519,7 +4590,17 @@ mod tests {
                 global_settings_watcher,
                 cx,
             );
-            handle_keymap_file_changes(keymap_rx, keymap_watcher, cx);
+            let (zed_vimrc_rx, zed_vimrc_watcher) = watch_config_file(
+                &executor,
+                app_state.fs.clone(),
+                PathBuf::from("/zed_vimrc"),
+            );
+            let (home_vimrc_rx, home_vimrc_watcher) = watch_config_file(
+                &executor,
+                app_state.fs.clone(),
+                PathBuf::from("/home_vimrc"),
+            );
+            handle_keymap_file_changes(keymap_rx, keymap_watcher, zed_vimrc_rx, zed_vimrc_watcher, home_vimrc_rx, home_vimrc_watcher, cx);
         });
         window
             .update(cx, |_, _, cx| {
@@ -4651,7 +4732,17 @@ mod tests {
                 global_settings_watcher,
                 cx,
             );
-            handle_keymap_file_changes(keymap_rx, keymap_watcher, cx);
+            let (zed_vimrc_rx, zed_vimrc_watcher) = watch_config_file(
+                &executor,
+                app_state.fs.clone(),
+                PathBuf::from("/zed_vimrc"),
+            );
+            let (home_vimrc_rx, home_vimrc_watcher) = watch_config_file(
+                &executor,
+                app_state.fs.clone(),
+                PathBuf::from("/home_vimrc"),
+            );
+            handle_keymap_file_changes(keymap_rx, keymap_watcher, zed_vimrc_rx, zed_vimrc_watcher, home_vimrc_rx, home_vimrc_watcher, cx);
         });
 
         cx.background_executor.run_until_parked();


### PR DESCRIPTION
## Summary

- Parse `~/.vimrc` (or `~/.config/zed/vimrc`) and translate vim keybinding commands into Zed keybindings
- Supports `nmap`, `nnoremap`, `imap`, `inoremap`, `vmap`, `vnoremap`, `map`, `noremap`, `unmap`, `let mapleader`, and comments
- Hot-reloads on file changes, with best-effort parsing (invalid lines are skipped with warnings)

Release Notes:

- Added vimrc support: Zed now reads `~/.vimrc` and `~/.config/zed/vimrc` for vim-style key mappings with hot-reload