### PR TITLE
language_models: Support any tool choice in inline Copilot Chat

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -296,9 +296,10 @@ impl LanguageModel for CopilotChatLanguageModel {
 
     fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
         match choice {
-            LanguageModelToolChoice::Auto
-            | LanguageModelToolChoice::Any
-            | LanguageModelToolChoice::None => self.supports_tools(),
+            LanguageModelToolChoice::Auto | LanguageModelToolChoice::None => {
+                self.supports_tools()
+            }
+            LanguageModelToolChoice::Any => false,
         }
     }
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #52711 #52668 

Release Notes:

Fixed the bug where the inline agent raise an error if using copilot as a provider. 
Error

```js
Failed to connect to API: 400 Bad Request { "error":{"message":"The requested tool_choice of any is not supported for gpt-4o-2024-11-20. ToolChoice must be one of auto, none, required, or validated","code": "tool_choice_not_supported","param": "tool_choice","type":"invalid_request_error"} }
```


After the Fix


https://github.com/user-attachments/assets/45801729-21e3-4553-9661-63f3486a0ba6

