### PR TITLE
go: Fix "not all subtests are localized"

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3434,7 +3434,7 @@ impl BufferSnapshot {
             &self.text,
             TreeSitterOptions {
                 max_bytes_to_query: Some(MAX_BYTES_TO_QUERY),
-                max_start_depth: None,
+                ..Default::default()
             },
             |grammar| Some(&grammar.indents_config.as_ref()?.query),
         );
@@ -4590,7 +4590,7 @@ impl BufferSnapshot {
                 &self.text,
                 TreeSitterOptions {
                     max_bytes_to_query: Some(MAX_BYTES_TO_QUERY),
-                    max_start_depth: None,
+                    ..Default::default()
                 },
                 |grammar| grammar.brackets_config.as_ref().map(|c| &c.query),
             );
@@ -5120,9 +5120,15 @@ impl BufferSnapshot {
         &self,
         offset_range: Range<usize>,
     ) -> impl Iterator<Item = RunnableRange> + '_ {
-        let mut syntax_matches = self.syntax.matches(offset_range, self, |grammar| {
-            grammar.runnable_config.as_ref().map(|config| &config.query)
-        });
+        let mut syntax_matches = self.syntax.matches_with_options(
+            offset_range,
+            self,
+            TreeSitterOptions {
+                match_limit: Some(1024),
+                ..Default::default()
+            },
+            |grammar| grammar.runnable_config.as_ref().map(|config| &config.query),
+        );
 
         let test_configs = syntax_matches
             .grammars()

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1212,6 +1212,7 @@ impl<'a> SyntaxMapCaptures<'a> {
 pub struct TreeSitterOptions {
     pub max_start_depth: Option<u32>,
     pub max_bytes_to_query: Option<usize>,
+    pub match_limit: Option<u32>,
 }
 
 impl TreeSitterOptions {
@@ -1219,6 +1220,7 @@ impl TreeSitterOptions {
         Self {
             max_start_depth: Some(max_start_depth),
             max_bytes_to_query: None,
+            match_limit: None,
         }
     }
 }
@@ -1251,6 +1253,9 @@ impl<'a> SyntaxMapMatches<'a> {
                 )
             };
             cursor.set_max_start_depth(options.max_start_depth);
+            if let Some(match_limit) = options.match_limit {
+                cursor.set_match_limit(match_limit);
+            }
 
             if let Some(max_bytes_to_query) = options.max_bytes_to_query {
                 let midpoint = (range.start + range.end) / 2;

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -1183,22 +1183,21 @@ mod tests {
         );
 
         let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
-        // This is currently broken; see #39148
-        // let go_table_test_count = tag_strings
-        //     .iter()
-        //     .filter(|&tag| tag == "go-table-test-case")
-        //     .count();
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case")
+            .count();
 
         assert!(
             go_test_count == 1,
             "Should find exactly 1 go-test, found: {}",
             go_test_count
         );
-        // assert!(
-        //     go_table_test_count == 3,
-        //     "Should find exactly 3 go-table-test-case, found: {}",
-        //     go_table_test_count
-        // );
+        assert!(
+            go_table_test_count == 3,
+            "Should find exactly 3 go-table-test-case, found: {}",
+            go_table_test_count
+        );
     }
 
     #[gpui::test]
@@ -1530,6 +1529,61 @@ mod tests {
             !tag_strings.contains(&"go-table-test-case".to_string()),
             "Should find go-table-test-case tag, found: {:?}",
             tag_strings
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_map_many_entries(cx: &mut TestAppContext) {
+        let language = language("go", tree_sitter_go::LANGUAGE.into());
+
+        let mut entries = String::new();
+        for i in 1..=40 {
+            entries.push_str(&format!(
+                "          \"test case {i}\": {{\n             someStr: \"val{i}\",\n          }},\n"
+            ));
+        }
+
+        let table_test = format!(
+            r#"
+        package main
+
+        import "testing"
+
+        func TestManyEntries(t *testing.T) {{
+           testCases := map[string]struct {{
+              someStr string
+           }}{{
+{entries}
+           }}
+
+            for name, _ := range testCases {{
+                t.Run(name, func(t *testing.T) {{
+                    // test code here
+                }})
+            }}
+        }}
+        "#
+        );
+
+        let buffer =
+            cx.new(|cx| crate::Buffer::local(&table_test, cx).with_language(language.clone(), cx));
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(0..table_test.len()).collect()
+        });
+
+        let go_table_test_count = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .filter(|tag| tag.0.as_ref() == "go-table-test-case")
+            .count();
+
+        assert_eq!(
+            go_table_test_count, 40,
+            "Should find all 40 go-table-test-case entries, found: {}",
+            go_table_test_count
         );
     }
 


### PR DESCRIPTION
Performance impact: increases the memory+cpu occupation for up to 16 times but only for `fn runnable_ranges`, which runs only on scroll/edit. And 16 is the upper limit, usually go table tests have up to 10-15 cases which should be just 2-3x from current state.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #46881

Screenshots:

Before:
<img width="1136" height="1239" alt="image" src="https://github.com/user-attachments/assets/7a678334-c1e6-4f04-a5da-0def119fa3f9" />

After (locally):
<img width="1136" height="1239" alt="image" src="https://github.com/user-attachments/assets/16ddc157-babe-434f-b9ef-54aeb96e1f3e" />

Catches:

The proposed limit of 1024 is still finite, thus files with more then ~80 subtests will still fail to show all of the run buttons. But this is a small change that will help in the majority of situations.

Release Notes:

- go: fix a bug with not all of the subtests being runnable
