### PR TITLE
docs: Add instructions for custom Expert builds

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -80,6 +80,19 @@ The following example sets the minimum number of characters required for a proje
 
 See the [Expert configuration](https://expert-lsp.org/docs/configuration/) page for all available options.
 
+To use a custom Expert build, add the following to your setttings file:
+
+```json [settings]
+  "lsp": {
+    "expert": {
+      "binary": {
+        "path": "/path/to/expert",
+        "arguments": ["--stdio"]
+      }
+    }
+  }
+```
+
 ### Using Next LS
 
 Enable Next LS by adding the following to your settings file:

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -80,7 +80,7 @@ The following example sets the minimum number of characters required for a proje
 
 See the [Expert configuration](https://expert-lsp.org/docs/configuration/) page for all available options.
 
-To use a custom Expert build, add the following to your setttings file:
+To use a custom Expert build, add the following to your settings file:
 
 ```json [settings]
   "lsp": {


### PR DESCRIPTION
Adds a section on how to configure Zed to use a custom Expert build.

There's already [*some* docs](https://zed.dev/docs/configuring-languages#possible-configuration-options) on how to do this, but I think it's important to make it clear that the `--stdio` flag is also required for expert.

Release Notes:

- N/A