### PR TITLE
editor: Add basic editor cursor slide animation

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -120,8 +120,8 @@ use gpui::{
     KeyContext, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad, ParentElement,
     Pixels, PressureStage, Render, ScrollHandle, SharedString, SharedUri, Size, Stateful, Styled,
     Subscription, Task, TextRun, TextStyle, TextStyleRefinement, UTF16Selection, UnderlineStyle,
-    UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, div, point, prelude::*,
-    pulsating_between, px, relative, size,
+    UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, div, ease_in_out, point,
+    prelude::*, pulsating_between, px, relative, size,
 };
 use hover_links::{HoverLink, HoveredLinkState, find_file};
 use hover_popover::{HoverState, hide_hover};
@@ -243,6 +243,7 @@ pub const FILE_HEADER_HEIGHT: u32 = 2;
 pub const BUFFER_HEADER_PADDING: Rems = rems(0.25);
 pub const MULTI_BUFFER_EXCERPT_HEADER_HEIGHT: u32 = 1;
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
+const CURSOR_ANIMATION_DURATION: Duration = Duration::from_millis(120);
 const MAX_LINE_LEN: usize = 1024;
 const MIN_NAVIGATION_HISTORY_ROW_DELTA: i64 = 10;
 const MAX_SELECTION_HISTORY_LEN: usize = 1024;
@@ -1253,6 +1254,7 @@ pub struct Editor {
     next_color_inlay_id: usize,
     _subscriptions: Vec<Subscription>,
     pixel_position_of_newest_cursor: Option<gpui::Point<Pixels>>,
+    cursor_animation: Option<CursorAnimationState>,
     gutter_dimensions: GutterDimensions,
     style: Option<EditorStyle>,
     text_style_refinement: Option<TextStyleRefinement>,
@@ -1544,6 +1546,20 @@ struct DeferredSelectionEffectsState {
     effects: SelectionEffects,
     old_cursor_position: Anchor,
     history_entry: SelectionHistoryEntry,
+}
+
+#[derive(Clone, Copy)]
+struct CursorAnimationState {
+    from: Anchor,
+    to: Anchor,
+    started_at: Instant,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct CursorAnimationFrame {
+    pub from: DisplayPoint,
+    pub to: DisplayPoint,
+    pub progress: f32,
 }
 
 #[derive(Default)]
@@ -2482,6 +2498,7 @@ impl Editor {
             inline_value_cache: InlineValueCache::new(inlay_hint_settings.show_value_hints),
             gutter_hovered: false,
             pixel_position_of_newest_cursor: None,
+            cursor_animation: None,
             last_bounds: None,
             last_position_map: None,
             expect_bounds_change: None,
@@ -3683,6 +3700,12 @@ impl Editor {
         let newest_selection = self.selections.newest_anchor();
         let new_cursor_position = newest_selection.head();
         let selection_start = newest_selection.start;
+        self.update_cursor_animation(
+            local,
+            old_cursor_position,
+            new_cursor_position,
+            &display_map,
+        );
 
         if effects.nav_history.is_none() || effects.nav_history == Some(true) {
             self.push_to_nav_history(
@@ -3825,6 +3848,51 @@ impl Editor {
         }
 
         cx.notify();
+    }
+
+    fn update_cursor_animation(
+        &mut self,
+        local: bool,
+        old_cursor_position: &Anchor,
+        new_cursor_position: Anchor,
+        display_map: &DisplaySnapshot,
+    ) {
+        let old_cursor_position = *old_cursor_position;
+        let should_animate = local
+            && self.selections.count() == 1
+            && old_cursor_position != new_cursor_position
+            && old_cursor_position.to_display_point(display_map)
+                != new_cursor_position.to_display_point(display_map);
+
+        self.cursor_animation = should_animate.then_some(CursorAnimationState {
+            from: old_cursor_position,
+            to: new_cursor_position,
+            started_at: Instant::now(),
+        });
+    }
+
+    pub(crate) fn cursor_animation_frame(
+        &self,
+        display_map: &DisplaySnapshot,
+    ) -> Option<CursorAnimationFrame> {
+        let animation = self.cursor_animation?;
+        let progress =
+            animation.started_at.elapsed().as_secs_f32() / CURSOR_ANIMATION_DURATION.as_secs_f32();
+        if progress >= 1.0 {
+            return None;
+        }
+
+        let from = animation.from.to_display_point(display_map);
+        let to = animation.to.to_display_point(display_map);
+        if from == to {
+            return None;
+        }
+
+        Some(CursorAnimationFrame {
+            from,
+            to,
+            progress: ease_in_out(progress.clamp(0.0, 1.0)),
+        })
     }
 
     fn folds_did_change(&mut self, cx: &mut Context<Self>) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1,13 +1,13 @@
 use crate::{
     ActiveDiagnostic, BUFFER_HEADER_PADDING, BlockId, CURSORS_VISIBLE_FOR, ChunkRendererContext,
     ChunkReplacement, CodeActionSource, ColumnarMode, ConflictsOurs, ConflictsOursMarker,
-    ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker, ContextMenuPlacement, CursorShape,
-    CustomBlockId, DisplayDiffHunk, DisplayPoint, DisplayRow, EditDisplayMode, EditPrediction,
-    Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle, FILE_HEADER_HEIGHT,
-    FocusedBlock, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput, HoveredCursor,
-    InlayHintRefreshReason, JumpData, LineDown, LineHighlight, LineUp, MAX_LINE_LEN,
-    MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown, PageUp,
-    PhantomBreakpointIndicator, PhantomDiffReviewIndicator, Point, RowExt, RowRangeExt,
+    ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker, ContextMenuPlacement,
+    CursorAnimationFrame, CursorShape, CustomBlockId, DisplayDiffHunk, DisplayPoint, DisplayRow,
+    EditDisplayMode, EditPrediction, Editor, EditorMode, EditorSettings, EditorSnapshot,
+    EditorStyle, FILE_HEADER_HEIGHT, FocusedBlock, GutterDimensions, HalfPageDown, HalfPageUp,
+    HandleInput, HoveredCursor, InlayHintRefreshReason, JumpData, LineDown, LineHighlight, LineUp,
+    MAX_LINE_LEN, MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown,
+    PageUp, PhantomBreakpointIndicator, PhantomDiffReviewIndicator, Point, RowExt, RowRangeExt,
     SelectPhase, Selection, SelectionDragState, SelectionEffects, SizingBehavior, SoftWrap,
     StickyHeaderExcerpt, ToPoint, ToggleFold, ToggleFoldAll,
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
@@ -1804,6 +1804,25 @@ impl EditorElement {
             let mut cursors = Vec::new();
 
             let show_local_cursors = editor.show_local_cursors(window, cx);
+            let cursor_animation = editor.cursor_animation_frame(&snapshot.display_snapshot);
+            let cursor_origin = |cursor_position: DisplayPoint| -> Option<gpui::Point<Pixels>> {
+                if !visible_display_row_range.contains(&cursor_position.row()) {
+                    return None;
+                }
+
+                let cursor_row_layout = &line_layouts
+                    [cursor_position.row().minus(visible_display_row_range.start) as usize];
+                let cursor_column = cursor_position.column() as usize;
+                let cursor_x = cursor_row_layout.x_for_index(cursor_column)
+                    + cursor_row_layout
+                        .alignment_offset(self.style.text.text_align, text_hitbox.size.width)
+                    - scroll_pixel_position.x.into();
+                let cursor_y = ((cursor_position.row().as_f64() - scroll_position.y)
+                    * ScrollPixelOffset::from(line_height))
+                .into();
+
+                Some(point(cursor_x, cursor_y))
+            };
 
             for (player_color, selections) in selections {
                 for selection in selections {
@@ -1900,6 +1919,21 @@ impl EditorElement {
                     let y = ((cursor_position.row().as_f64() - scroll_position.y)
                         * ScrollPixelOffset::from(line_height))
                     .into();
+                    let mut origin = point(x, y);
+
+                    if selection.is_local
+                        && selection.is_newest
+                        && let Some(CursorAnimationFrame { from, to, progress }) = cursor_animation
+                        && to == cursor_position
+                        && let Some(from_origin) = cursor_origin(from)
+                    {
+                        origin = point(
+                            from_origin.x + (origin.x - from_origin.x) * progress,
+                            from_origin.y + (origin.y - from_origin.y) * progress,
+                        );
+                        window.request_animation_frame();
+                    }
+
                     if selection.is_newest {
                         editor.pixel_position_of_newest_cursor = Some(point(
                             text_hitbox.origin.x + x + block_width / 2.,
@@ -1938,7 +1972,7 @@ impl EditorElement {
                     let mut cursor = CursorLayout {
                         color: player_color.cursor,
                         block_width,
-                        origin: point(x, y),
+                        origin,
                         line_height,
                         shape: selection.cursor_shape,
                         block_text,


### PR DESCRIPTION
## Summary
Add a basic slide animation for the primary local editor cursor.

## What changed
- track a short-lived cursor movement animation when the newest local selection changes
- interpolate the newest local cursor origin during painting
- keep the scope limited to the single-cursor local path

## Notes
- this is a first pass and does not animate multicursor, remote cursors, or cursor shape transitions
- `cargo check -p editor --lib` was not completed in this environment because dependency fetching stalled; `rustfmt` and `git diff --check` were run

## Release Notes
- Improved editor cursor movement with a basic slide animation for the primary local cursor.
