### PR TITLE
Skip stale workspace file restores

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -52,7 +52,7 @@ use workspace::{
     },
 };
 use workspace::{
-    Pane, WorkspaceSettings,
+    Pane, SkipItemDeserialization, WorkspaceSettings,
     item::{FollowEvent, ProjectItemKind},
     searchable::SearchOptions,
 };
@@ -1240,17 +1240,22 @@ impl SerializableItem for Editor {
                 mtime,
                 ..
             } => {
-                let opened_buffer = project.update(cx, |project, cx| {
+                let fs = project.read(cx).fs().clone();
+                let project_path = project.update(cx, |project, cx| {
                     let (worktree, path) = project.find_worktree(&abs_path, cx)?;
-                    let project_path = ProjectPath {
+                    if worktree.read(cx).entry_for_path(&path).is_none() {
+                        return None;
+                    }
+                    Some(ProjectPath {
                         worktree_id: worktree.read(cx).id(),
                         path: path,
-                    };
-                    Some(project.open_path(project_path, cx))
+                    })
                 });
 
-                match opened_buffer {
-                    Some(opened_buffer) => window.spawn(cx, async move |cx| {
+                match project_path {
+                    Some(project_path) => window.spawn(cx, async move |cx| {
+                        let opened_buffer =
+                            project.update(cx, |project, cx| project.open_path(project_path, cx));
                         let (_, buffer) = opened_buffer
                             .await
                             .context("Failed to open path in project")?;
@@ -1272,12 +1277,23 @@ impl SerializableItem for Editor {
                         })
                     }),
                     None => {
-                        // File is not in any worktree (e.g., opened as a standalone file).
-                        // Open the buffer directly via the project rather than through
-                        // workspace.open_abs_path(), which has the side effect of adding
-                        // the item to a pane. The caller (deserialize_to) will add the
-                        // returned item to the correct pane.
                         window.spawn(cx, async move |cx| {
+                            let file_exists = fs
+                                .metadata(&abs_path)
+                                .await
+                                .log_err()
+                                .flatten()
+                                .is_some_and(|metadata| !metadata.is_dir);
+                            if !file_exists {
+                                return Err(anyhow::Error::new(SkipItemDeserialization));
+                            }
+
+                            // File is not currently in the worktree snapshot (e.g., restored
+                            // from stale workspace state or opened as a standalone file). Open
+                            // the buffer directly via the project rather than through
+                            // workspace.open_abs_path(), which has the side effect of adding
+                            // the item to a pane. The caller (deserialize_to) will add the
+                            // returned item to the correct pane.
                             let buffer = project
                                 .update(cx, |project, cx| project.open_local_buffer(&abs_path, cx))
                                 .await
@@ -2429,6 +2445,60 @@ mod tests {
         assert_eq!(
             pane_items_before, pane_items_after,
             "Editor::deserialize should not add items to panes as a side effect"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_deserialize_missing_worktree_file_returns_skip_error(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx, |_| {});
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({})).await;
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let db = cx.update(|_, cx| workspace::WorkspaceDb::global(cx));
+        let editor_db = cx.update(|_, cx| EditorDb::global(cx));
+
+        let workspace_id = db.next_id().await.unwrap();
+        let item_id = 123456 as ItemId;
+
+        let serialized_editor = SerializedEditor {
+            abs_path: Some(PathBuf::from(path!("/project/missing.rs"))),
+            contents: None,
+            language: None,
+            mtime: None,
+        };
+
+        editor_db
+            .save_serialized_editor(item_id, workspace_id, serialized_editor)
+            .await
+            .unwrap();
+
+        let result = workspace.update_in(cx, |workspace, window, cx| {
+            let pane = workspace.active_pane();
+            pane.update(cx, |_, cx| {
+                Editor::deserialize(
+                    project.clone(),
+                    workspace.weak_handle(),
+                    workspace_id,
+                    item_id,
+                    window,
+                    cx,
+                )
+            })
+        });
+
+        let error = result
+            .await
+            .expect_err("missing project file should be skipped");
+        assert!(
+            error.downcast_ref::<SkipItemDeserialization>().is_some(),
+            "missing project files should raise SkipItemDeserialization"
         );
     }
 }

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -327,13 +327,23 @@ impl SerializedPane {
 
         let mut items = Vec::new();
         for item_handle in futures::future::join_all(item_tasks).await {
-            let item_handle = item_handle.log_err();
-            items.push(item_handle.clone());
-
-            if let Some(item_handle) = item_handle {
-                pane.update_in(cx, |pane, window, cx| {
-                    pane.add_item(item_handle.clone(), true, true, None, window, cx);
-                })?;
+            match item_handle {
+                Ok(item_handle) => {
+                    items.push(Some(item_handle.clone()));
+                    pane.update_in(cx, |pane, window, cx| {
+                        pane.add_item(item_handle.clone(), true, true, None, window, cx);
+                    })?;
+                }
+                Err(error) => {
+                    if error
+                        .downcast_ref::<crate::SkipItemDeserialization>()
+                        .is_some()
+                    {
+                        items.push(None);
+                    } else {
+                        items.push(Err(error).log_err());
+                    }
+                }
             }
         }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -59,6 +59,17 @@ use gpui::{
     SystemWindowTabController, Task, Tiling, WeakEntity, WindowBounds, WindowHandle, WindowId,
     WindowOptions, actions, canvas, point, relative, size, transparent_black,
 };
+
+#[derive(Debug)]
+pub struct SkipItemDeserialization;
+
+impl std::fmt::Display for SkipItemDeserialization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "skip item deserialization")
+    }
+}
+
+impl std::error::Error for SkipItemDeserialization {}
 pub use history_manager::*;
 pub use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,


### PR DESCRIPTION
## Summary
Treat restored project file paths as stale when they are no longer present in the worktree snapshot.
Reopen the file as a local buffer if it still exists on disk, and otherwise skip deserializing the editor without logging a startup error.
Add a regression test for missing worktree files and keep the existing non-worktree restore behavior covered.

Release Notes:

- Improved workspace restore to quietly skip stale saved file tabs that no longer exist.
