### PR TITLE
Use `pane_focused_border` for active pane border instead of `border_selected`

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1465,7 +1465,7 @@ mod element {
                             0.,
                             gpui::transparent_black(),
                             border,
-                            cx.theme().colors().border_selected,
+                            cx.theme().colors().pane_focused_border,
                             BorderStyle::Solid,
                         ));
                     }


### PR DESCRIPTION
## Summary

- The active pane border in `pane_group.rs` uses `border_selected` instead of the dedicated `pane_focused_border` theme colour
- This means setting `pane.focused_border` in `theme_overrides` or custom themes has no effect
- One-line fix: swap `border_selected` → `pane_focused_border` in the quad paint call

## Context

`pane_focused_border` is defined in `ThemeStyleContent` (with serde rename `pane.focused_border`), stored in `ThemeColors`, and has defaults in `default_colors.rs` — but the pane group renderer never reads it. All bundled themes set it to `null`.

## Test plan

- Set `"pane.focused_border": "#ff0000ff"` in `theme_overrides` → active pane border turns red
- Without the override, default `pane_focused_border` colour from `default_colors.rs` applies (blue)
- `border_selected` continues to work for its other consumers (list selections, etc.)
- `cargo test -p workspace` passes (152 tests)

Release Notes:

- Fixed `pane.focused_border` theme override having no effect on the active pane border