### PR TITLE
Return image content from MCP tool response

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -26,10 +26,10 @@ use gpui::{
 use indoc::indoc;
 use language_model::{
     CompletionIntent, LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent,
-    LanguageModelId, LanguageModelProviderName, LanguageModelRegistry, LanguageModelRequest,
-    LanguageModelRequestMessage, LanguageModelToolResult, LanguageModelToolSchemaFormat,
-    LanguageModelToolUse, MessageContent, Role, StopReason, TokenUsage,
-    fake_provider::FakeLanguageModel,
+    LanguageModelId, LanguageModelImage, LanguageModelProviderName, LanguageModelRegistry,
+    LanguageModelRequest, LanguageModelRequestMessage, LanguageModelToolResult,
+    LanguageModelToolResultContent, LanguageModelToolSchemaFormat, LanguageModelToolUse,
+    MessageContent, Role, StopReason, TokenUsage, fake_provider::FakeLanguageModel,
 };
 use pretty_assertions::assert_eq;
 use project::{
@@ -1573,6 +1573,119 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
                 output: Some("mcp".into()),
             },),
         ]
+    );
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
+async fn test_mcp_tool_image_result(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+    fake_model.set_supports_images(true);
+
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "tool_permissions": { "default": "allow" },
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {
+                            ImageTool::NAME: true,
+                        }
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    let mut mcp_tool_calls = setup_context_server(
+        "test_server",
+        vec![context_server::types::Tool {
+            name: "screen_capture".into(),
+            description: None,
+            input_schema: json!({"type": "object", "properties": {}}),
+            output_schema: None,
+            annotations: None,
+        }],
+        &context_server_store,
+        cx,
+    );
+
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["Take a screenshot"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    assert_eq!(
+        tool_names_for_completion(&completion),
+        vec!["screen_capture"]
+    );
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: "screen_capture".into(),
+            raw_input: json!({}).to_string(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let image_base64 = "Base64EncodedImage";
+
+    let (tool_call_params, tool_call_response) = mcp_tool_calls.next().await.unwrap();
+    assert_eq!(tool_call_params.name, "screen_capture");
+    tool_call_response
+        .send(context_server::types::CallToolResponse {
+            content: vec![context_server::types::ToolResponseContent::Image {
+                data: image_base64.into(),
+                mime_type: "image/png".into(),
+            }],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    assert_eq!(
+        completion.messages.last().unwrap().content,
+        vec![MessageContent::ToolResult(LanguageModelToolResult {
+            tool_use_id: "tool_1".into(),
+            tool_name: "screen_capture".into(),
+            is_error: false,
+            content: LanguageModelToolResultContent::Image(LanguageModelImage {
+                source: image_base64.into(),
+                size: None,
+            }),
+            output: Some(json!({
+                "type": "image",
+                "mime_type": "image/png",
+            })),
+        })]
     );
     fake_model.end_last_completion_stream();
     events.collect::<Vec<_>>().await;

--- a/crates/agent/src/tests/test_tools.rs
+++ b/crates/agent/src/tests/test_tools.rs
@@ -1,6 +1,7 @@
 use super::*;
 use agent_settings::AgentSettings;
 use gpui::{App, SharedString, Task};
+use language_model::LanguageModelImage;
 use std::future;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -217,6 +218,45 @@ impl AgentTool for DelayTool {
                 .map_err(|e| format!("Failed to receive tool input: {e}"))?;
             executor.timer(Duration::from_millis(input.ms)).await;
             Ok("Ding".to_string())
+        })
+    }
+}
+
+/// A tool that returns an image
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub struct ImageToolInput {}
+
+pub struct ImageTool;
+
+impl AgentTool for ImageTool {
+    type Input = ImageToolInput;
+    type Output = LanguageModelImage;
+
+    const NAME: &'static str = "image";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        _input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        "Image".into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        _input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<LanguageModelImage, LanguageModelImage>> {
+        cx.spawn(async move |_cx| {
+            Ok(LanguageModelImage {
+                source: "Encoded Image".into(),
+                size: None,
+            })
         })
     }
 }

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -5,6 +5,7 @@ use collections::{BTreeMap, HashMap};
 use context_server::{ContextServerId, client::NotificationSubscription};
 use futures::FutureExt as _;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task};
+use language_model::LanguageModelImage;
 use project::context_server_store::{ContextServerStatus, ContextServerStore};
 use std::sync::Arc;
 use util::ResultExt;
@@ -395,8 +396,17 @@ impl AnyAgentTool for ContextServerTool {
                     context_server::types::ToolResponseContent::Text { text } => {
                         result.push_str(&text);
                     }
-                    context_server::types::ToolResponseContent::Image { .. } => {
-                        log::warn!("Ignoring image content from tool response");
+                    context_server::types::ToolResponseContent::Image { data, mime_type } => {
+                        return Ok(AgentToolOutput {
+                            raw_output: serde_json::json!({
+                                "type": "image",
+                                "mime_type": mime_type,
+                            }),
+                            llm_output: LanguageModelImage {
+                                source: data.into(),
+                                size: None,
+                            }.into(),
+                        });
                     }
                     context_server::types::ToolResponseContent::Audio { .. } => {
                         log::warn!("Ignoring audio content from tool response");

--- a/crates/language_model/src/fake_provider.rs
+++ b/crates/language_model/src/fake_provider.rs
@@ -125,6 +125,7 @@ pub struct FakeLanguageModel {
     >,
     forbid_requests: AtomicBool,
     supports_thinking: AtomicBool,
+    supports_images: AtomicBool,
 }
 
 impl Default for FakeLanguageModel {
@@ -137,6 +138,7 @@ impl Default for FakeLanguageModel {
             current_completion_txs: Mutex::new(Vec::new()),
             forbid_requests: AtomicBool::new(false),
             supports_thinking: AtomicBool::new(false),
+            supports_images: AtomicBool::new(false),
         }
     }
 }
@@ -167,6 +169,10 @@ impl FakeLanguageModel {
 
     pub fn set_supports_thinking(&self, supports: bool) {
         self.supports_thinking.store(supports, SeqCst);
+    }
+
+    pub fn set_supports_images(&self, supports: bool) {
+        self.supports_images.store(supports, SeqCst);
     }
 
     pub fn pending_completions(&self) -> Vec<LanguageModelRequest> {
@@ -275,7 +281,7 @@ impl LanguageModel for FakeLanguageModel {
     }
 
     fn supports_images(&self) -> bool {
-        false
+        self.supports_images.load(SeqCst)
     }
 
     fn supports_thinking(&self) -> bool {


### PR DESCRIPTION
Currently Zed Agent MCP tool calls only support text responses, this PR adds support for images as well. When using Zed Agent with a locally ran llm like Qwen3.5 that supports images, this makes tools like grabbing screenshots possible. 

Main change is simply doing an early return in `crates/agent/src/tools/context_server_registry.rs` when parsing content in case an image is encountered. I recon this solution isn't perfect, in case the tool call returns both a string and an image, or multiple images for that matter, but it does feel like a step up from the current behavior of just ignoring it.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Parse image in MCP Tool Response