### PR TITLE
elixir: Disable Emmet by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2042,7 +2042,7 @@
       "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
     },
     "Elixir": {
-      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "!emmet-language-server", "..."],
     },
     "Elm": {
       "tab_size": 4,


### PR DESCRIPTION
The Emmet extension is enabled for Elixir files (`.ex`) because of the `~H` sigil, but this is a bit unexpected if you work exclusively with HEEx files (`.heex`) or you don't actually use Phoenix in any capacity

With this change, the user must explicitly opt into Emmet for Elixir files, just like Tailwind

Release Notes:

- N/A
