### PR TITLE
git_panel: Fix space key being swallowed in branch picker

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -960,7 +960,7 @@
     },
   },
   {
-    "context": "GitPanel && ChangesList",
+    "context": "GitPanel && ChangesList && !GitBranchSelector",
     "bindings": {
       "left": "git_panel::CollapseSelectedEntry",
       "right": "git_panel::ExpandSelectedEntry",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1031,7 +1031,7 @@
     },
   },
   {
-    "context": "GitPanel && ChangesList",
+    "context": "GitPanel && ChangesList && !GitBranchSelector",
     "use_key_equivalents": true,
     "bindings": {
       "up": "git_panel::PreviousEntry",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -955,7 +955,7 @@
     },
   },
   {
-    "context": "GitPanel && ChangesList",
+    "context": "GitPanel && ChangesList && !GitBranchSelector",
     "use_key_equivalents": true,
     "bindings": {
       "up": "git_panel::PreviousEntry",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1017,7 +1017,7 @@
     },
   },
   {
-    "context": "GitPanel && ChangesList",
+    "context": "GitPanel && ChangesList && !GitBranchSelector",
     "use_key_equivalents": true,
     "bindings": {
       "k": "menu::SelectPrevious",


### PR DESCRIPTION
## Context

Fixes a regression where typing a space in the Git Panel's "Switch Branch" picker would make no response at all instead of inserting the character. The same picker in the title-bar Git Switcher was unaffected.

Root cause: `PopoverMenu` links the opened menu's focus handle into the parent element's dispatch tree so that `contains_focused` returns `true` on the parent while the popover is open. `GitPanel::dispatch_context` uses
`contains_focused` to decide whether to add the `ChangesList` key context, so that context is active while the branch picker is open. Because `Picker` and `Editor` have no binding for a bare `space`, dispatch fell through to
the `"GitPanel && ChangesList"` binding, which maps `space` to `git::ToggleStaged`, consuming the keystroke before it could reach the text input.

The fix narrows the context guard to `"GitPanel && ChangesList && !GitBranchSelector"`,
so those bindings are skipped whenever the branch picker (or any other `GitBranchSelector` context) is focused inside the panel. 

The same change is applied to the vim keymap, which would have similarly intercepted `k`,
`j`, `x`, and other letter keys typed in the picker, this behavior was observed in https://github.com/zed-industries/zed/issues/52617 and I made the same fix in https://github.com/zed-industries/zed/pull/52687

Closes #52771 and potentially https://github.com/zed-industries/zed/issues/52617

Video of the manual test of the fix below :

[Screencast from 2026-03-31 00-01-54.webm](https://github.com/user-attachments/assets/76f64507-4f5a-4a8e-8582-4cdb9bec584c)

## How to Review

- `assets/keymaps/default-linux.json`, `default-windows.json`,
  `default-macos.json`, `vim.json` : identical one-line change in each: I added   `&& !GitBranchSelector` to
  the `"GitPanel && ChangesList"` 
. No Rust changes needed.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed space and other keys being swallowed when typing in the Git Panel branch picker
