### PR TITLE
workspace: Fix edge case when saving workspace with no paths

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1417,6 +1417,21 @@ impl WorkspaceDb {
                     .context("clearing out old locations")?;
                 }
 
+                // If there are no paths in the workspace, make sure to save
+                // paths as NULL in the database, not as an empty string.
+                // Otherwise, the workspace may fail to restore, potentially
+                // losing any unsaved buffers.
+                let maybe_paths = if !paths.paths.is_empty() {
+                    Some(paths.paths.clone())
+                } else {
+                    None
+                };
+                let maybe_order = if !paths.order.is_empty() {
+                    Some(paths.order.clone())
+                } else {
+                    None
+                };
+
                 // Upsert
                 let query = sql!(
                     INSERT INTO workspaces(
@@ -1459,8 +1474,8 @@ impl WorkspaceDb {
                 let mut prepared_query = conn.exec_bound(query)?;
                 let args = (
                     workspace.id,
-                    paths.paths.clone(),
-                    paths.order.clone(),
+                    maybe_paths,
+                    maybe_order,
                     remote_connection_id,
                     workspace.docks,
                     workspace.session_id,


### PR DESCRIPTION
Closes #48468
Supersedes #52713

Avoid issues with restoring workspaces by making sure to save `paths` and `paths_order` as `NULL` in the `workspaces` table when there are no paths. This also helps to avoid losing unsaved buffers in the workspace.

Details:

There was an issue where sporadically, a workspace with no project paths (and especially with unsaved buffers that could be lost) would not be restored after restarting Zed. (Refer to #48468 and #15098)

A consistent symptom seemed to be that in the `workspaces` table, the `paths` and `paths_order` columns might have an empty string instead of `NULL`. Explicitly saving the workspace with `NULL`s in that case seems to solve the problem.

Special thanks to @dhnm as his suggested bash script here https://github.com/zed-industries/zed/issues/48468#issuecomment-3973941351 helped me to realize that the discrepancy with `paths` being an empty string when it should have been `NULL` was the least common denominator.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fix edge case when saving workspace with no paths

No additional tests were added but perhaps someone can suggest one. (The existing tests seem to be passing for me locally now, unlike the superseded PR.) The issue seems sporadic based on GitHub issue discussion, which might make it harder to unit test, although it was reproducible with a clean install of Zed 0.228.0 on macOS (including a fresh db).