### PR TITLE
project: Avoid corrupting overlapping LSP formatting edits

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3235,7 +3235,18 @@ impl LocalLspStore {
                 //
                 // In order for the diffing logic below to work properly, any edits that
                 // cancel each other out must be combined into one.
+                //
+                // Do not merge overlapping edits by concatenating replacement text.
+                // Some language servers (e.g. oxc for nested sort-keys fixes) return
+                // nested replacements whose ranges overlap. The outermost edit already
+                // contains the correct final text for its entire range, so we discard
+                // any edit whose start falls inside the current range.
                 while let Some((next_range, next_text)) = lsp_edits.peek() {
+                    if next_range.start.0 < range.end {
+                        lsp_edits.next();
+                        continue;
+                    }
+
                     if next_range.start.0 > range.end {
                         if next_range.start.0.row > range.end.row + 1
                             || next_range.start.0.column > 0
@@ -3246,6 +3257,7 @@ impl LocalLspStore {
                         {
                             break;
                         }
+
                         new_text.push('\n');
                     }
                     range.end = snapshot.clip_point_utf16(next_range.end, Bias::Left);

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -4271,6 +4271,99 @@ async fn test_edits_from_lsp_with_replacement_followed_by_adjacent_insertion(
 }
 
 #[gpui::test]
+async fn test_edits_from_lsp_with_overlapping_multiline_replacements(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let text = "
+        export const obj = {
+          b: 1,
+          a: {
+            d: 1,
+            c: {
+              f: 1,
+              e: 1,
+            },
+          },
+        };
+    "
+    .unindent();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "a.js": text.clone(),
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let lsp_store = project.read_with(cx, |project, _| project.lsp_store());
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/dir/a.js"), cx)
+        })
+        .await
+        .unwrap();
+
+    let edits = lsp_store
+        .update(cx, |lsp_store, cx| {
+            lsp_store.as_local_mut().unwrap().edits_from_lsp(
+                &buffer,
+                [
+                    // Outermost edit: sorts top-level keys and already contains the
+                    // fully-sorted nested result.  Overlaps with E2 and E3.
+                    lsp::TextEdit {
+                        range: lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(9, 0)),
+                        new_text: "  a: {\n    c: {\n      e: 1,\n      f: 1,\n    },\n    d: 1,\n  },\n  b: 1,\n".into(),
+                    },
+                    // Middle edit: sorts second-level keys inside `a`.
+                    // Range is entirely inside E1 and should be discarded.
+                    lsp::TextEdit {
+                        range: lsp::Range::new(lsp::Position::new(3, 0), lsp::Position::new(8, 0)),
+                        new_text: "    c: {\n      e: 1,\n      f: 1,\n    },\n    d: 1,\n".into(),
+                    },
+                    // Innermost edit: sorts third-level keys inside `c`.
+                    // Range is entirely inside E2 (and E1) and should be discarded.
+                    lsp::TextEdit {
+                        range: lsp::Range::new(lsp::Position::new(5, 0), lsp::Position::new(7, 0)),
+                        new_text: "      e: 1,\n      f: 1,\n".into(),
+                    },
+                ],
+                LanguageServerId(0),
+                None,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    buffer.update(cx, |buffer, cx| {
+        for (range, new_text) in edits {
+            buffer.edit([(range, new_text)], None, cx);
+        }
+        assert_eq!(
+            buffer.text(),
+            "
+                export const obj = {
+                  a: {
+                    c: {
+                      e: 1,
+                      f: 1,
+                    },
+                    d: 1,
+                  },
+                  b: 1,
+                };
+            "
+            .unindent()
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_invalid_edits_from_lsp2(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #52823

## Summary

Fix corruption when formatting via LSP code actions that produce overlapping edits, such as `source.fixAll.oxc` with nested `sort-keys` fixes from oxlint.

## What changed

- In `edits_from_lsp`, stop merging truly overlapping edits by concatenating their replacement text.
- Keep the existing merge behavior for adjacent edits and same-position insertions used by existing LSP flows.
- When applying formatting code-action edits, apply the resolved edits sequentially instead of in one batched `buffer.edit(...)` call.

_Disclaimer: I'm not a Rust developer. This fix was developed with AI assistance. Happy to take feedback on anything I've missed._

## Validation

Added a regression test for overlapping multiline replacements and kept the nearby edit-normalization regressions passing:

- `test_edits_from_lsp_with_overlapping_multiline_replacements`
- `test_edits_from_lsp2_with_edits_on_adjacent_lines`
- `test_edits_from_lsp_with_replacement_followed_by_adjacent_insertion`
- `test_invalid_edits_from_lsp2`

Also verified manually with a local Zed build against a repro project using `source.fixAll.oxc` and nested `sort-keys`, where the file previously corrupted on save and now formats correctly.

<details>
<summary>One test fails, but seems like this is inherited from `main`</summary>

```
failures:

---- tests::test_backfill_sets_kvp_flag stdout ----

thread 'tests::test_backfill_sets_kvp_flag' (29959776) panicked at crates/agent_ui/src/agent_ui.rs:836:13:
assertion failed: kvp.read_kvp(PARALLEL_AGENT_LAYOUT_BACKFILL_KEY).unwrap().is_none()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_backfill_sets_kvp_flag

test result: FAILED. 198 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.74s

error: test failed, to rerun pass `-p agent_ui --lib`
```

</details>


Release Notes:

- Fixed a bug where formatting via LSP code actions could corrupt files when the language server returned overlapping edits.