### PR TITLE
markdown: Show copy button on hover to prevent overlapping code block…

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -826,8 +826,8 @@ impl MarkdownElement {
             markdown,
             style,
             code_block_renderer: CodeBlockRenderer::Default {
-                copy_button: true,
-                copy_button_on_hover: false,
+                copy_button: false,
+                copy_button_on_hover: true,
                 border: false,
             },
             on_url_click: None,


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #52064

Release Notes:

- Fixed copy button overlapping code block content in the Agent panel (#52064)

## Demo

Before:
<img width="496" height="139" alt="image" src="https://github.com/user-attachments/assets/6c49ad7f-ae36-4a6b-be72-783ff6e98537" />
<img width="411" height="182" alt="image" src="https://github.com/user-attachments/assets/a4b89407-2ae0-4629-875b-706592e81b34" />

After:

https://github.com/user-attachments/assets/a139db06-3909-4a22-881a-836262ed3c36


