### PR TITLE
Scroll to bottom when reloading ACP agent threads

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -840,6 +840,8 @@ impl ConversationView {
 
         if let Some(scroll_position) = thread.read(cx).ui_scroll_position() {
             list_state.scroll_to(scroll_position);
+        } else {
+            list_state.set_follow_tail(true);
         }
 
         AgentDiff::set_active_thread(&self.workspace, thread.clone(), window, cx);


### PR DESCRIPTION
When reopening an ACP agent thread (e.g. after restarting Zed) that has no saved scroll position, the conversation now starts scrolled to the bottom so the user sees the latest messages instead of starting at the top.

Uses `set_follow_tail(true)` rather than a one-shot `scroll_to_end()` so the scroll position is re-anchored on every layout pass — ensuring it lands at the true bottom even when list items haven't been measured yet. The follow-tail mode automatically disengages as soon as the user scrolls up.

Release Notes:

- Fixed agent threads starting scrolled to the top when reopened after restarting Zed.