### PR TITLE
git_graph: Fix empty search case

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1317,6 +1317,7 @@ impl GitGraph {
 
         if query.as_str().is_empty() {
             self.search_state.state = QueryState::Empty;
+            cx.notify();
             return;
         }
 

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1317,6 +1317,7 @@ impl GitGraph {
 
         if query.as_str().is_empty() {
             self.search_state.state = QueryState::Empty;
+            return;
         }
 
         let (request_tx, request_rx) = smol::channel::unbounded::<Oid>();

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1315,6 +1315,10 @@ impl GitGraph {
             editor.set_text_style_refinement(Default::default());
         });
 
+        if query.as_str().is_empty() {
+            self.search_state.state = QueryState::Empty;
+        }
+
         let (request_tx, request_rx) = smol::channel::unbounded::<Oid>();
 
         repo.update(cx, |repo, cx| {


### PR DESCRIPTION
This fixes a bug where search would match all commits if there was an empty query instead of setting the query to None

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
