### PR TITLE
Update links to troubleshooting images

### DIFF
--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -45,13 +45,13 @@ Xcode Instruments (which comes bundled with your [Xcode](https://apps.apple.com/
 
 1. With Zed running, open Instruments
 1. Select `Time Profiler` as the profiling template
-   ![Instruments template picker with Time Profiler selected](https://images.zed.dev/troubleshooting/instruments-template-picker.webp)
+   ![Instruments template picker with Time Profiler selected](https://images.zed.dev/docs/troubleshooting/instruments-template-picker.webp)
 1. In the `Time Profiler` configuration, set the target to the running Zed process
 1. Start recording
-   ![Time Profiler configuration showing the target dropdown and record button](https://images.zed.dev/troubleshooting/instruments-target-and-record.webp)
+   ![Time Profiler configuration showing the target dropdown and record button](https://images.zed.dev/docs/troubleshooting/instruments-target-and-record.webp)
 1. Perform the action in Zed that causes performance issues
 1. Stop recording
-   ![A completed Time Profiler recording in Instruments](https://images.zed.dev/troubleshooting/instruments-recording.webp)
+   ![A completed Time Profiler recording in Instruments](https://images.zed.dev/docs/troubleshooting/instruments-recording.webp)
 1. Save the trace file
 1. Compress the trace file into a zip archive
 1. File a [GitHub issue](https://github.com/zed-industries/zed/issues/new/choose) with the trace zip attached


### PR DESCRIPTION
Now that I've started migrating blog content into the `zeddotdev-images` bucket, I've added a bit of structure.

`/blog`
`/docs`

This PR just updates the links so we can stay organized going forward. Shouldn't be seeing much thrash like this after this PR.

Release Notes:

- N/A
