### PR TITLE
Fix tooltip reference cycles

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3588,60 +3588,13 @@ impl ScrollHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AppContext as _, Context, Modifiers, TestAppContext, size};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering::SeqCst},
-    };
+    use crate::{AppContext as _, Context, TestAppContext};
 
-    struct TooltipLifecycleCounts {
-        created: AtomicUsize,
-        dropped: AtomicUsize,
-    }
+    struct TestTooltipView;
 
-    struct DropTrackingTooltip {
-        tooltip_lifecycle_counts: Arc<TooltipLifecycleCounts>,
-    }
-
-    impl Drop for DropTrackingTooltip {
-        fn drop(&mut self) {
-            self.tooltip_lifecycle_counts.dropped.fetch_add(1, SeqCst);
-        }
-    }
-
-    impl Render for DropTrackingTooltip {
+    impl Render for TestTooltipView {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
             div().w(px(20.)).h(px(20.)).child("tooltip")
-        }
-    }
-
-    struct TooltipOwner {
-        show_target: bool,
-        tooltip_lifecycle_counts: Arc<TooltipLifecycleCounts>,
-    }
-
-    impl Render for TooltipOwner {
-        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-            let root = div().size_full();
-            if self.show_target {
-                let tooltip_lifecycle_counts = self.tooltip_lifecycle_counts.clone();
-                root.child(
-                    div()
-                        .id("target")
-                        .w(px(50.))
-                        .h(px(50.))
-                        .tooltip(move |_window, cx| {
-                            tooltip_lifecycle_counts.created.fetch_add(1, SeqCst);
-                            let tooltip_lifecycle_counts = tooltip_lifecycle_counts.clone();
-                            cx.new(|_| DropTrackingTooltip {
-                                tooltip_lifecycle_counts,
-                            })
-                            .into()
-                        }),
-                )
-            } else {
-                root
-            }
         }
     }
 
@@ -3686,45 +3639,25 @@ mod tests {
     #[test]
     fn tooltip_is_released_when_its_owner_disappears() {
         let mut test_app = TestAppContext::single();
-        let tooltip_lifecycle_counts = Arc::new(TooltipLifecycleCounts {
-            created: AtomicUsize::new(0),
-            dropped: AtomicUsize::new(0),
+
+        let active_tooltip: Rc<RefCell<Option<ActiveTooltip>>> = Rc::new(RefCell::new(None));
+        let weak_active_tooltip = Rc::downgrade(&active_tooltip);
+        let tooltip_view = test_app.update(|cx| cx.new(|_| TestTooltipView).into());
+
+        *active_tooltip.borrow_mut() = Some(ActiveTooltip::Visible {
+            tooltip: AnyTooltip {
+                view: tooltip_view,
+                mouse_position: point(px(0.), px(0.)),
+                check_visible_and_update: Rc::new(move |_, _, _| {
+                    weak_active_tooltip.upgrade().is_some()
+                }),
+            },
+            is_hoverable: false,
         });
 
-        let (view, cx) = test_app.add_window_view({
-            let tooltip_lifecycle_counts = tooltip_lifecycle_counts.clone();
-            move |_window, _cx| TooltipOwner {
-                show_target: true,
-                tooltip_lifecycle_counts,
-            }
-        });
+        let weak_active_tooltip = Rc::downgrade(&active_tooltip);
+        drop(active_tooltip);
 
-        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
-            view.clone().into_any_element()
-        });
-        cx.simulate_mouse_move(point(px(10.), px(10.)), None, Modifiers::default());
-        cx.run_until_parked();
-        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
-            view.clone().into_any_element()
-        });
-
-        assert_eq!(tooltip_lifecycle_counts.created.load(SeqCst), 1);
-        assert_eq!(tooltip_lifecycle_counts.dropped.load(SeqCst), 0);
-
-        cx.update(|_window, app| {
-            view.update(app, |tooltip_owner, cx| {
-                tooltip_owner.show_target = false;
-                cx.notify();
-            });
-        });
-        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
-            view.clone().into_any_element()
-        });
-        cx.run_until_parked();
-        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
-            view.clone().into_any_element()
-        });
-
-        assert_eq!(tooltip_lifecycle_counts.dropped.load(SeqCst), 1);
+        assert!(weak_active_tooltip.upgrade().is_none());
     }
 }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3644,8 +3644,15 @@ mod tests {
 
         let active_tooltip: Rc<RefCell<Option<ActiveTooltip>>> = Rc::new(RefCell::new(None));
         let weak_active_tooltip = Rc::downgrade(&active_tooltip);
+
+        let mut interactivity = Interactivity::default();
+        interactivity.tooltip(|_, cx| cx.new(|_| TestTooltipView).into());
+        let tooltip_builder = interactivity.tooltip_builder.take().unwrap();
+        let tooltip_is_hoverable = tooltip_builder.hoverable;
         let build_tooltip: Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>> =
-            Rc::new(|_, cx| Some((cx.new(|_| TestTooltipView).into(), false)));
+            Rc::new(move |window: &mut Window, cx: &mut App| {
+                Some(((tooltip_builder.build)(window, cx), tooltip_is_hoverable))
+            });
         let check_is_hovered: Rc<dyn Fn(&Window) -> bool> = Rc::new(|_: &Window| true);
         let check_is_hovered_during_prepaint: Rc<dyn Fn(&Window) -> bool> =
             Rc::new(|_: &Window| true);

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -38,7 +38,7 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     mem,
-    rc::Rc,
+    rc::{Rc, Weak},
     sync::Arc,
     time::Duration,
 };
@@ -2878,7 +2878,7 @@ pub struct InteractiveElementState {
     pub(crate) hover_listener_state: Option<Rc<RefCell<bool>>>,
     pub(crate) pending_mouse_down: Option<Rc<RefCell<Option<MouseDownEvent>>>>,
     pub(crate) scroll_offset: Option<Rc<RefCell<Point<Pixels>>>>,
-    pub(crate) active_tooltip: Option<Rc<RefCell<Option<ActiveTooltip>>>>,
+    pub(crate) active_tooltip: Option<ActiveTooltipState>,
 }
 
 /// Whether or not the element or a group that contains it is clicked by the mouse.
@@ -2907,6 +2907,9 @@ pub struct ElementHoverState {
     pub element: bool,
 }
 
+type ActiveTooltipState = Rc<RefCell<Option<ActiveTooltip>>>;
+type WeakActiveTooltipState = Weak<RefCell<Option<ActiveTooltip>>>;
+
 pub(crate) enum ActiveTooltip {
     /// Currently delaying before showing the tooltip.
     WaitingForShow { _task: Task<()> },
@@ -2923,10 +2926,7 @@ pub(crate) enum ActiveTooltip {
     },
 }
 
-pub(crate) fn clear_active_tooltip(
-    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
-    window: &mut Window,
-) {
+pub(crate) fn clear_active_tooltip(active_tooltip: &ActiveTooltipState, window: &mut Window) {
     match active_tooltip.borrow_mut().take() {
         None => {}
         Some(ActiveTooltip::WaitingForShow { .. }) => {}
@@ -2936,7 +2936,7 @@ pub(crate) fn clear_active_tooltip(
 }
 
 pub(crate) fn clear_active_tooltip_if_not_hoverable(
-    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
+    active_tooltip: &ActiveTooltipState,
     window: &mut Window,
 ) {
     let should_clear = match active_tooltip.borrow().as_ref() {
@@ -2952,7 +2952,7 @@ pub(crate) fn clear_active_tooltip_if_not_hoverable(
 }
 
 pub(crate) fn set_tooltip_on_window(
-    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
+    active_tooltip: &ActiveTooltipState,
     window: &mut Window,
 ) -> Option<TooltipId> {
     let tooltip = match active_tooltip.borrow().as_ref() {
@@ -2965,7 +2965,7 @@ pub(crate) fn set_tooltip_on_window(
 }
 
 pub(crate) fn register_tooltip_mouse_handlers(
-    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
+    active_tooltip: &ActiveTooltipState,
     tooltip_id: Option<TooltipId>,
     build_tooltip: Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>>,
     check_is_hovered: Rc<dyn Fn(&Window) -> bool>,
@@ -3020,7 +3020,7 @@ pub(crate) fn register_tooltip_mouse_handlers(
 /// does not know if the hitbox is occluded. In the case where a tooltip gets displayed and then
 /// gets occluded after display, it will stick around until the mouse exits the hover bounds.
 fn handle_tooltip_mouse_move(
-    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
+    active_tooltip: &ActiveTooltipState,
     build_tooltip: &Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>>,
     check_is_hovered: &Rc<dyn Fn(&Window) -> bool>,
     check_is_hovered_during_prepaint: &Rc<dyn Fn(&Window) -> bool>,
@@ -3067,21 +3067,29 @@ fn handle_tooltip_mouse_move(
         }
         Action::ScheduleShow => {
             let delayed_show_task = window.spawn(cx, {
-                let active_tooltip = active_tooltip.clone();
+                let weak_active_tooltip = Rc::downgrade(active_tooltip);
                 let build_tooltip = build_tooltip.clone();
                 let check_is_hovered_during_prepaint = check_is_hovered_during_prepaint.clone();
                 async move |cx| {
                     cx.background_executor().timer(TOOLTIP_SHOW_DELAY).await;
+                    let Some(active_tooltip) = weak_active_tooltip.upgrade() else {
+                        return;
+                    };
                     cx.update(|window, cx| {
                         let new_tooltip =
                             build_tooltip(window, cx).map(|(view, tooltip_is_hoverable)| {
-                                let active_tooltip = active_tooltip.clone();
+                                let weak_active_tooltip = Rc::downgrade(&active_tooltip);
                                 ActiveTooltip::Visible {
                                     tooltip: AnyTooltip {
                                         view,
                                         mouse_position: window.mouse_position(),
                                         check_visible_and_update: Rc::new(
                                             move |tooltip_bounds, window, cx| {
+                                                let Some(active_tooltip) =
+                                                    weak_active_tooltip.upgrade()
+                                                else {
+                                                    return false;
+                                                };
                                                 handle_tooltip_check_visible_and_update(
                                                     &active_tooltip,
                                                     tooltip_is_hoverable,
@@ -3115,7 +3123,7 @@ fn handle_tooltip_mouse_move(
 /// purpose of doing this logic here instead of the mouse move handler is that the mouse move
 /// handler won't get called when the element is not painted (e.g. via use of `visible_on_hover`).
 fn handle_tooltip_check_visible_and_update(
-    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
+    active_tooltip: &ActiveTooltipState,
     tooltip_is_hoverable: bool,
     check_is_hovered: &Rc<dyn Fn(&Window) -> bool>,
     tooltip_bounds: Bounds<Pixels>,
@@ -3160,11 +3168,14 @@ fn handle_tooltip_check_visible_and_update(
         Action::Hide => clear_active_tooltip(active_tooltip, window),
         Action::ScheduleHide(tooltip) => {
             let delayed_hide_task = window.spawn(cx, {
-                let active_tooltip = active_tooltip.clone();
+                let weak_active_tooltip: WeakActiveTooltipState = Rc::downgrade(active_tooltip);
                 async move |cx| {
                     cx.background_executor()
                         .timer(HOVERABLE_TOOLTIP_HIDE_DELAY)
                         .await;
+                    let Some(active_tooltip) = weak_active_tooltip.upgrade() else {
+                        return;
+                    };
                     if active_tooltip.borrow_mut().take().is_some() {
                         cx.update(|window, _cx| window.refresh()).ok();
                     }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -38,7 +38,7 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     mem,
-    rc::{Rc, Weak},
+    rc::Rc,
     sync::Arc,
     time::Duration,
 };
@@ -2878,7 +2878,7 @@ pub struct InteractiveElementState {
     pub(crate) hover_listener_state: Option<Rc<RefCell<bool>>>,
     pub(crate) pending_mouse_down: Option<Rc<RefCell<Option<MouseDownEvent>>>>,
     pub(crate) scroll_offset: Option<Rc<RefCell<Point<Pixels>>>>,
-    pub(crate) active_tooltip: Option<ActiveTooltipState>,
+    pub(crate) active_tooltip: Option<Rc<RefCell<Option<ActiveTooltip>>>>,
 }
 
 /// Whether or not the element or a group that contains it is clicked by the mouse.
@@ -2907,9 +2907,6 @@ pub struct ElementHoverState {
     pub element: bool,
 }
 
-type ActiveTooltipState = Rc<RefCell<Option<ActiveTooltip>>>;
-type WeakActiveTooltipState = Weak<RefCell<Option<ActiveTooltip>>>;
-
 pub(crate) enum ActiveTooltip {
     /// Currently delaying before showing the tooltip.
     WaitingForShow { _task: Task<()> },
@@ -2926,7 +2923,10 @@ pub(crate) enum ActiveTooltip {
     },
 }
 
-pub(crate) fn clear_active_tooltip(active_tooltip: &ActiveTooltipState, window: &mut Window) {
+pub(crate) fn clear_active_tooltip(
+    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
+    window: &mut Window,
+) {
     match active_tooltip.borrow_mut().take() {
         None => {}
         Some(ActiveTooltip::WaitingForShow { .. }) => {}
@@ -2936,7 +2936,7 @@ pub(crate) fn clear_active_tooltip(active_tooltip: &ActiveTooltipState, window: 
 }
 
 pub(crate) fn clear_active_tooltip_if_not_hoverable(
-    active_tooltip: &ActiveTooltipState,
+    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
     window: &mut Window,
 ) {
     let should_clear = match active_tooltip.borrow().as_ref() {
@@ -2952,7 +2952,7 @@ pub(crate) fn clear_active_tooltip_if_not_hoverable(
 }
 
 pub(crate) fn set_tooltip_on_window(
-    active_tooltip: &ActiveTooltipState,
+    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
     window: &mut Window,
 ) -> Option<TooltipId> {
     let tooltip = match active_tooltip.borrow().as_ref() {
@@ -2965,7 +2965,7 @@ pub(crate) fn set_tooltip_on_window(
 }
 
 pub(crate) fn register_tooltip_mouse_handlers(
-    active_tooltip: &ActiveTooltipState,
+    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
     tooltip_id: Option<TooltipId>,
     build_tooltip: Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>>,
     check_is_hovered: Rc<dyn Fn(&Window) -> bool>,
@@ -3020,7 +3020,7 @@ pub(crate) fn register_tooltip_mouse_handlers(
 /// does not know if the hitbox is occluded. In the case where a tooltip gets displayed and then
 /// gets occluded after display, it will stick around until the mouse exits the hover bounds.
 fn handle_tooltip_mouse_move(
-    active_tooltip: &ActiveTooltipState,
+    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
     build_tooltip: &Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>>,
     check_is_hovered: &Rc<dyn Fn(&Window) -> bool>,
     check_is_hovered_during_prepaint: &Rc<dyn Fn(&Window) -> bool>,
@@ -3123,7 +3123,7 @@ fn handle_tooltip_mouse_move(
 /// purpose of doing this logic here instead of the mouse move handler is that the mouse move
 /// handler won't get called when the element is not painted (e.g. via use of `visible_on_hover`).
 fn handle_tooltip_check_visible_and_update(
-    active_tooltip: &ActiveTooltipState,
+    active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
     tooltip_is_hoverable: bool,
     check_is_hovered: &Rc<dyn Fn(&Window) -> bool>,
     tooltip_bounds: Bounds<Pixels>,
@@ -3168,7 +3168,7 @@ fn handle_tooltip_check_visible_and_update(
         Action::Hide => clear_active_tooltip(active_tooltip, window),
         Action::ScheduleHide(tooltip) => {
             let delayed_hide_task = window.spawn(cx, {
-                let weak_active_tooltip: WeakActiveTooltipState = Rc::downgrade(active_tooltip);
+                let weak_active_tooltip = Rc::downgrade(active_tooltip);
                 async move |cx| {
                     cx.background_executor()
                         .timer(HOVERABLE_TOOLTIP_HIDE_DELAY)
@@ -3588,6 +3588,62 @@ impl ScrollHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{AppContext as _, Context, Modifiers, TestAppContext, size};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering::SeqCst},
+    };
+
+    struct TooltipLifecycleCounts {
+        created: AtomicUsize,
+        dropped: AtomicUsize,
+    }
+
+    struct DropTrackingTooltip {
+        tooltip_lifecycle_counts: Arc<TooltipLifecycleCounts>,
+    }
+
+    impl Drop for DropTrackingTooltip {
+        fn drop(&mut self) {
+            self.tooltip_lifecycle_counts.dropped.fetch_add(1, SeqCst);
+        }
+    }
+
+    impl Render for DropTrackingTooltip {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().w(px(20.)).h(px(20.)).child("tooltip")
+        }
+    }
+
+    struct TooltipOwner {
+        show_target: bool,
+        tooltip_lifecycle_counts: Arc<TooltipLifecycleCounts>,
+    }
+
+    impl Render for TooltipOwner {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let root = div().size_full();
+            if self.show_target {
+                let tooltip_lifecycle_counts = self.tooltip_lifecycle_counts.clone();
+                root.child(
+                    div()
+                        .id("target")
+                        .w(px(50.))
+                        .h(px(50.))
+                        .tooltip(move |_window, cx| {
+                            tooltip_lifecycle_counts.created.fetch_add(1, SeqCst);
+                            let tooltip_lifecycle_counts = tooltip_lifecycle_counts.clone();
+                            cx.new(|_| DropTrackingTooltip {
+                                tooltip_lifecycle_counts,
+                            })
+                            .into()
+                        }),
+                )
+            } else {
+                root
+            }
+        }
+    }
 
     #[test]
     fn scroll_handle_aligns_wide_children_to_left_edge() {
@@ -3625,5 +3681,50 @@ mod tests {
         handle.scroll_to_active_item();
 
         assert_eq!(handle.offset().y, px(-25.));
+    }
+
+    #[test]
+    fn tooltip_is_released_when_its_owner_disappears() {
+        let mut test_app = TestAppContext::single();
+        let tooltip_lifecycle_counts = Arc::new(TooltipLifecycleCounts {
+            created: AtomicUsize::new(0),
+            dropped: AtomicUsize::new(0),
+        });
+
+        let (view, cx) = test_app.add_window_view({
+            let tooltip_lifecycle_counts = tooltip_lifecycle_counts.clone();
+            move |_window, _cx| TooltipOwner {
+                show_target: true,
+                tooltip_lifecycle_counts,
+            }
+        });
+
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            view.clone().into_any_element()
+        });
+        cx.simulate_mouse_move(point(px(10.), px(10.)), None, Modifiers::default());
+        cx.run_until_parked();
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            view.clone().into_any_element()
+        });
+
+        assert_eq!(tooltip_lifecycle_counts.created.load(SeqCst), 1);
+        assert_eq!(tooltip_lifecycle_counts.dropped.load(SeqCst), 0);
+
+        cx.update(|_window, app| {
+            view.update(app, |tooltip_owner, cx| {
+                tooltip_owner.show_target = false;
+                cx.notify();
+            });
+        });
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            view.clone().into_any_element()
+        });
+        cx.run_until_parked();
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            view.clone().into_any_element()
+        });
+
+        assert_eq!(tooltip_lifecycle_counts.dropped.load(SeqCst), 1);
     }
 }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3639,23 +3639,46 @@ mod tests {
     #[test]
     fn tooltip_is_released_when_its_owner_disappears() {
         let mut test_app = TestAppContext::single();
+        let window = test_app.add_window(|_, _| crate::Empty);
+        let any_window = window.into();
 
         let active_tooltip: Rc<RefCell<Option<ActiveTooltip>>> = Rc::new(RefCell::new(None));
         let weak_active_tooltip = Rc::downgrade(&active_tooltip);
-        let tooltip_view = test_app.update(|cx| cx.new(|_| TestTooltipView).into());
+        let build_tooltip: Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>> =
+            Rc::new(|_, cx| Some((cx.new(|_| TestTooltipView).into(), false)));
+        let check_is_hovered: Rc<dyn Fn(&Window) -> bool> = Rc::new(|_: &Window| true);
+        let check_is_hovered_during_prepaint: Rc<dyn Fn(&Window) -> bool> =
+            Rc::new(|_: &Window| true);
 
-        *active_tooltip.borrow_mut() = Some(ActiveTooltip::Visible {
-            tooltip: AnyTooltip {
-                view: tooltip_view,
-                mouse_position: point(px(0.), px(0.)),
-                check_visible_and_update: Rc::new(move |_, _, _| {
-                    weak_active_tooltip.upgrade().is_some()
-                }),
-            },
-            is_hoverable: false,
-        });
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                handle_tooltip_mouse_move(
+                    &active_tooltip,
+                    &build_tooltip,
+                    &check_is_hovered,
+                    &check_is_hovered_during_prepaint,
+                    DispatchPhase::Bubble,
+                    window,
+                    cx,
+                );
+            })
+            .unwrap();
 
-        let weak_active_tooltip = Rc::downgrade(&active_tooltip);
+        assert!(matches!(
+            active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::WaitingForShow { .. })
+        ));
+        assert_eq!(Rc::strong_count(&active_tooltip), 1);
+
+        test_app.dispatcher.advance_clock(TOOLTIP_SHOW_DELAY);
+        test_app.run_until_parked();
+
+        assert!(matches!(
+            active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::Visible { .. })
+        ));
+        assert_eq!(Rc::strong_count(&active_tooltip), 1);
+
         drop(active_tooltip);
 
         assert!(weak_active_tooltip.upgrade().is_none());

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3588,13 +3588,110 @@ impl ScrollHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AppContext as _, Context, TestAppContext};
+    use crate::{AppContext as _, Context, InputEvent, MouseMoveEvent, TestAppContext};
+    use std::rc::Weak;
 
     struct TestTooltipView;
 
     impl Render for TestTooltipView {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
             div().w(px(20.)).h(px(20.)).child("tooltip")
+        }
+    }
+
+    type CapturedActiveTooltip = Rc<RefCell<Option<Weak<RefCell<Option<ActiveTooltip>>>>>>;
+
+    struct TooltipCaptureElement {
+        child: AnyElement,
+        captured_active_tooltip: CapturedActiveTooltip,
+    }
+
+    impl IntoElement for TooltipCaptureElement {
+        type Element = Self;
+
+        fn into_element(self) -> Self::Element {
+            self
+        }
+    }
+
+    impl Element for TooltipCaptureElement {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            None
+        }
+
+        fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> (LayoutId, Self::RequestLayoutState) {
+            (self.child.request_layout(window, cx), ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            _bounds: Bounds<Pixels>,
+            _request_layout: &mut Self::RequestLayoutState,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> Self::PrepaintState {
+            self.child.prepaint(window, cx);
+        }
+
+        fn paint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            _bounds: Bounds<Pixels>,
+            _request_layout: &mut Self::RequestLayoutState,
+            _prepaint: &mut Self::PrepaintState,
+            window: &mut Window,
+            cx: &mut App,
+        ) {
+            self.child.paint(window, cx);
+            window.with_global_id("target".into(), |global_id, window| {
+                window.with_element_state::<InteractiveElementState, _>(
+                    global_id,
+                    |state, _window| {
+                        let state = state.unwrap();
+                        *self.captured_active_tooltip.borrow_mut() =
+                            state.active_tooltip.as_ref().map(Rc::downgrade);
+                        ((), state)
+                    },
+                )
+            });
+        }
+    }
+
+    struct TooltipOwner {
+        captured_active_tooltip: CapturedActiveTooltip,
+    }
+
+    impl Render for TooltipOwner {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            TooltipCaptureElement {
+                child: div()
+                    .size_full()
+                    .child(
+                        div()
+                            .id("target")
+                            .w(px(50.))
+                            .h(px(50.))
+                            .tooltip(|_, cx| cx.new(|_| TestTooltipView).into()),
+                    )
+                    .into_any_element(),
+                captured_active_tooltip: self.captured_active_tooltip.clone(),
+            }
         }
     }
 
@@ -3636,46 +3733,78 @@ mod tests {
         assert_eq!(handle.offset().y, px(-25.));
     }
 
-    #[test]
-    fn tooltip_is_released_when_its_owner_disappears() {
+    fn setup_tooltip_owner_test() -> (
+        TestAppContext,
+        crate::AnyWindowHandle,
+        CapturedActiveTooltip,
+    ) {
         let mut test_app = TestAppContext::single();
-        let window = test_app.add_window(|_, _| crate::Empty);
+        let captured_active_tooltip: CapturedActiveTooltip = Rc::new(RefCell::new(None));
+        let window = test_app.add_window({
+            let captured_active_tooltip = captured_active_tooltip.clone();
+            move |_, _| TooltipOwner {
+                captured_active_tooltip,
+            }
+        });
         let any_window = window.into();
-
-        let active_tooltip: Rc<RefCell<Option<ActiveTooltip>>> = Rc::new(RefCell::new(None));
-        let weak_active_tooltip = Rc::downgrade(&active_tooltip);
-
-        let mut interactivity = Interactivity::default();
-        interactivity.tooltip(|_, cx| cx.new(|_| TestTooltipView).into());
-        let tooltip_builder = interactivity.tooltip_builder.take().unwrap();
-        let tooltip_is_hoverable = tooltip_builder.hoverable;
-        let build_tooltip: Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>> =
-            Rc::new(move |window: &mut Window, cx: &mut App| {
-                Some(((tooltip_builder.build)(window, cx), tooltip_is_hoverable))
-            });
-        let check_is_hovered: Rc<dyn Fn(&Window) -> bool> = Rc::new(|_: &Window| true);
-        let check_is_hovered_during_prepaint: Rc<dyn Fn(&Window) -> bool> =
-            Rc::new(|_: &Window| true);
 
         test_app
             .update_window(any_window, |_, window, cx| {
-                handle_tooltip_mouse_move(
-                    &active_tooltip,
-                    &build_tooltip,
-                    &check_is_hovered,
-                    &check_is_hovered_during_prepaint,
-                    DispatchPhase::Bubble,
-                    window,
+                window.draw(cx).clear();
+            })
+            .unwrap();
+
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.dispatch_event(
+                    MouseMoveEvent {
+                        position: point(px(10.), px(10.)),
+                        modifiers: Default::default(),
+                        pressed_button: None,
+                    }
+                    .to_platform_input(),
                     cx,
                 );
             })
             .unwrap();
 
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.draw(cx).clear();
+            })
+            .unwrap();
+
+        (test_app, any_window, captured_active_tooltip)
+    }
+
+    #[test]
+    fn tooltip_waiting_for_show_is_released_when_its_owner_disappears() {
+        let (mut test_app, any_window, captured_active_tooltip) = setup_tooltip_owner_test();
+
+        let weak_active_tooltip = captured_active_tooltip.borrow().clone().unwrap();
+        let active_tooltip = weak_active_tooltip.upgrade().unwrap();
         assert!(matches!(
             active_tooltip.borrow().as_ref(),
             Some(ActiveTooltip::WaitingForShow { .. })
         ));
-        assert_eq!(Rc::strong_count(&active_tooltip), 1);
+
+        test_app
+            .update_window(any_window, |_, window, _| {
+                window.remove_window();
+            })
+            .unwrap();
+        test_app.run_until_parked();
+        drop(active_tooltip);
+
+        assert!(weak_active_tooltip.upgrade().is_none());
+    }
+
+    #[test]
+    fn tooltip_is_released_when_its_owner_disappears() {
+        let (mut test_app, any_window, captured_active_tooltip) = setup_tooltip_owner_test();
+
+        let weak_active_tooltip = captured_active_tooltip.borrow().clone().unwrap();
+        let active_tooltip = weak_active_tooltip.upgrade().unwrap();
 
         test_app.dispatcher.advance_clock(TOOLTIP_SHOW_DELAY);
         test_app.run_until_parked();
@@ -3684,8 +3813,13 @@ mod tests {
             active_tooltip.borrow().as_ref(),
             Some(ActiveTooltip::Visible { .. })
         ));
-        assert_eq!(Rc::strong_count(&active_tooltip), 1);
 
+        test_app
+            .update_window(any_window, |_, window, _| {
+                window.remove_window();
+            })
+            .unwrap();
+        test_app.run_until_parked();
         drop(active_tooltip);
 
         assert!(weak_active_tooltip.upgrade().is_none());


### PR DESCRIPTION
## Summary
- break tooltip back-references from stored callbacks and tasks with weak handles
- keep the tooltip controller as the sole strong owner of tooltip lifecycle state
- add a regression test that exercises the visible-tooltip ownership graph directly

## Testing
- cargo test -p gpui tooltip_is_released_when_its_owner_disappears --lib

Closes AI-120

Release Notes:

- Fixed a tooltip memory leak.