### PR TITLE
git_graph: Fix loading graph hang

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4705,12 +4705,11 @@ impl Repository {
                                 .commit_oid_to_index
                                 .insert(commit_data.sha, graph_data.commit_data.len());
                             graph_data.commit_data.push(commit_data);
-
-                            cx.emit(RepositoryEvent::GraphEvent(
-                                graph_data_key.clone(),
-                                GitGraphEvent::CountUpdated(graph_data.commit_data.len()),
-                            ));
                         }
+                        cx.emit(RepositoryEvent::GraphEvent(
+                            graph_data_key.clone(),
+                            GitGraphEvent::CountUpdated(graph_data.commit_data.len()),
+                        ));
                     });
 
                 match &graph_data {


### PR DESCRIPTION
This hang was caused by emitting the Git Graph Count Updated event for every commit being added to the graph instead of every batch of commits. This would cause gpui to have a massive amount of events to handle on the foreground thread, even if most of them had very little work involved. 

For example, Zed graph has over 80k commits, that means we were emitting 80k plus events instead of 80.

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
