### PR TITLE
Dismiss search bar on Escape in Helix normal mode

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -1446,4 +1446,41 @@ mod test {
         // The cursor should be at the match location on line 3 (row 2).
         cx.assert_state("hello world\nfoo bar\nhello ˇagain\n", Mode::Normal);
     }
+
+
+    #[gpui::test]
+    async fn test_helix_search_dismiss_on_escape(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.set_state("ˇhello world
+foo bar
+hello again
+", Mode::HelixNormal);
+
+        // Open search
+        cx.simulate_keystrokes("/");
+        cx.run_until_parked();
+
+        // Type query and submit
+        cx.simulate_keystrokes("h e l l o");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+
+        // Search bar should be dismissed (like Vim mode), verify escape works
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        // Verify search bar is dismissed
+        cx.workspace(|workspace, _window, cx| {
+            let pane = workspace.active_pane().read(cx);
+            let search_bar = pane
+                .toolbar()
+                .read(cx)
+                .item_of_type::<search::BufferSearchBar>();
+            assert!(
+                search_bar.is_none_or(|bar| bar.read(cx).is_dismissed()),
+                "Search bar should be dismissed after pressing Escape in Helix normal mode"
+            );
+        });
+    }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -698,7 +698,26 @@ impl Vim {
                 editor,
                 cx,
                 |vim, _: &SwitchToHelixNormalMode, window, cx| {
-                    vim.switch_mode(Mode::HelixNormal, true, window, cx)
+                    vim.switch_mode(Mode::HelixNormal, true, window, cx);
+                    // Dismiss the search bar on Escape, matching Vim's behavior
+                    // where editor::Cancel propagates to dismiss the search bar.
+                    if let Some(pane) = vim.pane(window, cx) {
+                        pane.update(cx, |pane, cx| {
+                            if let Some(search_bar) =
+                                pane.toolbar().read(cx).item_of_type::<BufferSearchBar>()
+                            {
+                                search_bar.update(cx, |bar, cx| {
+                                    if !bar.is_dismissed() {
+                                        bar.dismiss(
+                                            &search::buffer_search::Dismiss,
+                                            window,
+                                            cx,
+                                        );
+                                    }
+                                });
+                            }
+                        });
+                    }
                 },
             );
             Vim::action(editor, cx, |_, _: &PushForcedMotion, _, cx| {


### PR DESCRIPTION
## Summary
- Fixes the search bar not closing on Escape when using Helix keymap (#47797)
- In Helix mode, the `SwitchToHelixNormalMode` action (bound to Escape) overrides `editor::Cancel`, which normally propagates to dismiss the search bar
- The fix adds search bar dismissal logic to the `SwitchToHelixNormalMode` handler, matching Vim mode behavior

## Root Cause
The Helix-specific escape binding (`VimControl && vim_mode == helix_normal && !menu` -> `vim::SwitchToHelixNormalMode`) is more specific than the shared binding (`(vim_mode == normal || vim_mode == helix_normal) && !menu` -> `editor::Cancel`), so it takes precedence. Since `editor::Cancel` never fires, the `BufferSearchBar` never receives the dismiss signal.

## Test Plan
- [x] Added `test_helix_search_dismiss_on_escape` test - verifies the search bar is dismissed after pressing Escape in Helix normal mode
- [x] All 28 existing search tests pass
- [x] Manual reproduction steps from #47797 verified

## Release Notes
- Fixed search bar not closing on Escape when using Helix keymap (#47797)
