### PR TITLE
eslint: Fix ESLint server startup failure on stale cached server install

### DIFF
--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -148,6 +148,7 @@ impl LspInstaller for EsLintLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let server_path =
             Self::build_destination_path(&container_dir).join(EsLintLspAdapter::SERVER_PATH);
+        fs::metadata(&server_path).await.ok()?;
         Some(LanguageServerBinary {
             path: self.node.binary_path().await.ok()?,
             env: None,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/19709#issuecomment-3494789304
Closes https://github.com/zed-industries/zed/issues/24194#issuecomment-2835787560

This PR fixes case where if eslint cached install is partial or stale, Zed can try to launch a missing `eslintServer.js` and the server crashes with `MODULE_NOT_FOUND`.

```
Error: Cannot find module '/Users/.../languages/eslint/vscode-eslint-2.4.4/vscode-eslint/server/out/eslintServer.js'
```

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed ESLint server startup failures caused by reusing an incomplete or stale cached server install.
