### PR TITLE
languages: Update vscode-eslint to 3.0.24 and fix ESLint 8-10 breaking cases

### DIFF
--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -322,7 +322,10 @@ impl LspAdapter for EsLintLspAdapter {
     }
 }
 
-fn ancestor_directories(worktree_root: &Path, requested_file: Option<&Path>) -> Vec<PathBuf> {
+fn ancestor_directories<'a>(
+    worktree_root: &'a Path,
+    requested_file: Option<&'a Path>,
+) -> impl Iterator<Item = &'a Path> + 'a {
     let start = requested_file
         .filter(|file| file.starts_with(worktree_root))
         .and_then(Path::parent)
@@ -330,9 +333,7 @@ fn ancestor_directories(worktree_root: &Path, requested_file: Option<&Path>) -> 
 
     start
         .ancestors()
-        .take_while(|dir| dir.starts_with(worktree_root))
-        .map(Path::to_path_buf)
-        .collect()
+        .take_while(move |dir| dir.starts_with(worktree_root))
 }
 
 fn flat_config_file_names(version: Option<&Version>) -> &'static [&'static str] {
@@ -787,15 +788,16 @@ mod tests {
                 "/workspace/packages/web/src/index.js",
             ));
 
-            let directories = ancestor_directories(&worktree_root, Some(&requested_file));
+            let directories: Vec<&Path> =
+                ancestor_directories(&worktree_root, Some(&requested_file)).collect();
 
             assert_eq!(
                 directories,
                 vec![
-                    PathBuf::from(unix_path_to_platform("/workspace/packages/web/src")),
-                    PathBuf::from(unix_path_to_platform("/workspace/packages/web")),
-                    PathBuf::from(unix_path_to_platform("/workspace/packages")),
-                    PathBuf::from(unix_path_to_platform("/workspace")),
+                    Path::new(&unix_path_to_platform("/workspace/packages/web/src")),
+                    Path::new(&unix_path_to_platform("/workspace/packages/web")),
+                    Path::new(&unix_path_to_platform("/workspace/packages")),
+                    Path::new(&unix_path_to_platform("/workspace")),
                 ]
             );
         }

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -7,8 +7,9 @@ use http_client::{
 };
 use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
-use node_runtime::NodeRuntime;
+use node_runtime::{NodeRuntime, read_package_installed_version};
 use project::lsp_store::language_server_settings_for;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use settings::SettingsLocation;
@@ -34,8 +35,8 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
-    const CURRENT_VERSION: &'static str = "2.4.4";
-    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
+    const CURRENT_VERSION: &'static str = "3.0.24";
+    const CURRENT_VERSION_TAG_NAME: &'static str = "release/3.0.24";
 
     #[cfg(not(windows))]
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
@@ -45,13 +46,24 @@ impl EsLintLspAdapter {
     const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
     const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("eslint");
 
-    const FLAT_CONFIG_FILE_NAMES: &'static [&'static str] = &[
+    const FLAT_CONFIG_FILE_NAMES_V8_21: &'static [&'static str] = &["eslint.config.js"];
+    const FLAT_CONFIG_FILE_NAMES_V8_57: &'static [&'static str] =
+        &["eslint.config.js", "eslint.config.mjs", "eslint.config.cjs"];
+    const FLAT_CONFIG_FILE_NAMES_V10: &'static [&'static str] = &[
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
         "eslint.config.cts",
         "eslint.config.mts",
+    ];
+    const LEGACY_CONFIG_FILE_NAMES: &'static [&'static str] = &[
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
+        ".eslintrc.json",
     ];
 
     pub fn new(node: NodeRuntime) -> Self {
@@ -73,7 +85,7 @@ impl LspInstaller for EsLintLspAdapter {
         _: &mut AsyncApp,
     ) -> Result<GitHubLspBinaryVersion> {
         let url = build_asset_url(
-            "zed-industries/vscode-eslint",
+            "microsoft/vscode-eslint",
             Self::CURRENT_VERSION_TAG_NAME,
             Self::GITHUB_ASSET_KIND,
         )?;
@@ -156,6 +168,39 @@ impl LspInstaller for EsLintLspAdapter {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EslintConfigKind {
+    Flat,
+    Legacy,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct EslintSettingsOverrides {
+    use_flat_config: Option<bool>,
+    experimental_use_flat_config: Option<bool>,
+}
+
+impl EslintSettingsOverrides {
+    fn apply_to(self, workspace_configuration: &mut Value) {
+        if let Some(use_flat_config) = self.use_flat_config
+            && let Some(workspace_configuration) = workspace_configuration.as_object_mut()
+        {
+            workspace_configuration.insert("useFlatConfig".to_string(), json!(use_flat_config));
+        }
+
+        if let Some(experimental_use_flat_config) = self.experimental_use_flat_config
+            && let Some(experimental) = workspace_configuration
+                .get_mut("experimental")
+                .and_then(Value::as_object_mut)
+        {
+            experimental.insert(
+                "useFlatConfig".to_string(),
+                json!(experimental_use_flat_config),
+            );
+        }
+    }
+}
+
 #[async_trait(?Send)]
 impl LspAdapter for EsLintLspAdapter {
     fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
@@ -173,9 +218,21 @@ impl LspAdapter for EsLintLspAdapter {
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let worktree_root = delegate.worktree_root_path();
-        let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
-            .iter()
-            .any(|file| worktree_root.join(file).is_file());
+        let requested_file_path = requested_file_path(requested_uri.as_ref(), worktree_root);
+        let eslint_version = find_eslint_version(
+            delegate.as_ref(),
+            worktree_root,
+            requested_file_path.as_deref(),
+        )
+        .await?;
+        let config_kind = find_eslint_config_kind(
+            worktree_root,
+            requested_file_path.as_deref(),
+            eslint_version.as_ref(),
+            |path| path.is_file(),
+        );
+        let eslint_settings_overrides =
+            eslint_settings_overrides_for(eslint_version.as_ref(), config_kind);
 
         let mut default_workspace_configuration = json!({
             "validate": "on",
@@ -206,25 +263,13 @@ impl LspAdapter for EsLintLspAdapter {
                     "enable": true
                 }
             },
-            "experimental": {
-                "useFlatConfig": use_flat_config,
-            }
+            "experimental": {}
         });
+        eslint_settings_overrides.apply_to(&mut default_workspace_configuration);
 
-        let file_path = requested_uri
+        let file_path = requested_file_path
             .as_ref()
-            .and_then(|uri| {
-                (uri.scheme() == "file")
-                    .then(|| uri.to_file_path().ok())
-                    .flatten()
-            })
-            .and_then(|abs_path| {
-                abs_path
-                    .strip_prefix(&worktree_root)
-                    .ok()
-                    .map(ToOwned::to_owned)
-            });
-        let file_path = file_path
+            .and_then(|abs_path| abs_path.strip_prefix(worktree_root).ok())
             .and_then(|p| RelPath::unix(&p).ok().map(ToOwned::to_owned))
             .unwrap_or_else(|| RelPath::empty().to_owned());
         let override_options = cx.update(|cx| {
@@ -269,6 +314,136 @@ impl LspAdapter for EsLintLspAdapter {
     fn name(&self) -> LanguageServerName {
         Self::SERVER_NAME
     }
+}
+
+fn requested_file_path(requested_uri: Option<&Uri>, worktree_root: &Path) -> Option<PathBuf> {
+    requested_uri
+        .filter(|uri| uri.scheme() == "file")
+        .and_then(|uri| uri.to_file_path().ok())
+        .filter(|path| path.starts_with(worktree_root))
+}
+
+// vscode-eslint 3.x already walks upward from the active file to choose its
+// working directory and config roots. We do a smaller upward walk here only to
+// answer the two compatibility questions that still belong to Zed:
+//
+// - Is this file using a flat config that needs experimental opt-in on ESLint 8.21-8.56?
+// - Is this file using a legacy config that needs useFlatConfig = false on ESLint 9?
+fn ancestor_directories(worktree_root: &Path, requested_file: Option<&Path>) -> Vec<PathBuf> {
+    let mut directory = requested_file
+        .filter(|file| file.starts_with(worktree_root))
+        .and_then(Path::parent)
+        .unwrap_or(worktree_root)
+        .to_path_buf();
+    let mut directories = Vec::new();
+
+    loop {
+        if !directory.starts_with(worktree_root) {
+            break;
+        }
+
+        directories.push(directory.clone());
+
+        if directory == worktree_root {
+            break;
+        }
+
+        let Some(parent) = directory.parent() else {
+            break;
+        };
+        directory = parent.to_path_buf();
+    }
+
+    directories
+}
+
+fn flat_config_file_names(version: Option<&Version>) -> &'static [&'static str] {
+    match version {
+        Some(version) if version.major >= 10 => EsLintLspAdapter::FLAT_CONFIG_FILE_NAMES_V10,
+        Some(version) if version.major == 9 => EsLintLspAdapter::FLAT_CONFIG_FILE_NAMES_V8_57,
+        Some(version) if version.major == 8 && version.minor >= 57 => {
+            EsLintLspAdapter::FLAT_CONFIG_FILE_NAMES_V8_57
+        }
+        Some(version) if version.major == 8 && version.minor >= 21 => {
+            EsLintLspAdapter::FLAT_CONFIG_FILE_NAMES_V8_21
+        }
+        _ => &[],
+    }
+}
+
+fn find_eslint_config_kind(
+    worktree_root: &Path,
+    requested_file: Option<&Path>,
+    version: Option<&Version>,
+    path_exists: impl Fn(&Path) -> bool,
+) -> Option<EslintConfigKind> {
+    let flat_config_file_names = flat_config_file_names(version);
+
+    for directory in ancestor_directories(worktree_root, requested_file) {
+        for file_name in flat_config_file_names {
+            if path_exists(&directory.join(file_name)) {
+                return Some(EslintConfigKind::Flat);
+            }
+        }
+
+        for file_name in EsLintLspAdapter::LEGACY_CONFIG_FILE_NAMES {
+            if path_exists(&directory.join(file_name)) {
+                return Some(EslintConfigKind::Legacy);
+            }
+        }
+    }
+
+    None
+}
+
+fn eslint_settings_overrides_for(
+    version: Option<&Version>,
+    config_kind: Option<EslintConfigKind>,
+) -> EslintSettingsOverrides {
+    // vscode-eslint 3.x already discovers config files and chooses a working
+    // directory from the active file on its own. Zed only overrides settings
+    // for the two cases where leaving everything unset is known to be wrong:
+    //
+    // - ESLint 8.21-8.56 flat config still needs experimental.useFlatConfig.
+    // - ESLint 9.x legacy config needs useFlatConfig = false.
+    //
+    // All other cases should defer to the server's own defaults and discovery.
+    let Some(version) = version else {
+        return EslintSettingsOverrides::default();
+    };
+
+    match config_kind {
+        Some(EslintConfigKind::Flat) if version.major == 8 && (21..57).contains(&version.minor) => {
+            EslintSettingsOverrides {
+                use_flat_config: None,
+                experimental_use_flat_config: Some(true),
+            }
+        }
+        Some(EslintConfigKind::Legacy) if version.major == 9 => EslintSettingsOverrides {
+            use_flat_config: Some(false),
+            experimental_use_flat_config: None,
+        },
+        _ => EslintSettingsOverrides::default(),
+    }
+}
+
+async fn find_eslint_version(
+    delegate: &dyn LspAdapterDelegate,
+    worktree_root: &Path,
+    requested_file: Option<&Path>,
+) -> Result<Option<Version>> {
+    for directory in ancestor_directories(worktree_root, requested_file) {
+        if let Some(version) =
+            read_package_installed_version(directory.join("node_modules"), "eslint").await?
+        {
+            return Ok(Some(version));
+        }
+    }
+
+    Ok(delegate
+        .npm_package_installed_version("eslint")
+        .await?
+        .map(|(_, version)| version))
 }
 
 /// On Windows, converts Unix-style separators (/) to Windows-style (\).
@@ -480,6 +655,7 @@ enum ResultWorkingDirectory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     mod glob_patterns {
         use super::*;
@@ -620,6 +796,177 @@ mod tests {
                 &unix_path_to_platform("/workspace/apps/web/"),
                 false,
             );
+        }
+    }
+
+    mod eslint_settings {
+        use super::*;
+
+        #[test]
+        fn test_ancestor_directories_for_package_local_file() {
+            let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
+            let requested_file = PathBuf::from(unix_path_to_platform(
+                "/workspace/packages/web/src/index.js",
+            ));
+
+            let directories = ancestor_directories(&worktree_root, Some(&requested_file));
+
+            assert_eq!(
+                directories,
+                vec![
+                    PathBuf::from(unix_path_to_platform("/workspace/packages/web/src")),
+                    PathBuf::from(unix_path_to_platform("/workspace/packages/web")),
+                    PathBuf::from(unix_path_to_platform("/workspace/packages")),
+                    PathBuf::from(unix_path_to_platform("/workspace")),
+                ]
+            );
+        }
+
+        #[test]
+        fn test_eslint_8_flat_root_repo_uses_experimental_flag() {
+            let version = Version::parse("8.56.0").expect("valid ESLint version");
+            let settings =
+                eslint_settings_overrides_for(Some(&version), Some(EslintConfigKind::Flat));
+
+            assert_eq!(
+                settings,
+                EslintSettingsOverrides {
+                    use_flat_config: None,
+                    experimental_use_flat_config: Some(true),
+                }
+            );
+        }
+
+        #[test]
+        fn test_eslint_8_57_flat_repo_uses_no_override() {
+            let version = Version::parse("8.57.0").expect("valid ESLint version");
+            let settings =
+                eslint_settings_overrides_for(Some(&version), Some(EslintConfigKind::Flat));
+
+            assert_eq!(settings, EslintSettingsOverrides::default());
+        }
+
+        #[test]
+        fn test_eslint_9_legacy_repo_uses_use_flat_config_false() {
+            let version = Version::parse("9.0.0").expect("valid ESLint version");
+            let settings =
+                eslint_settings_overrides_for(Some(&version), Some(EslintConfigKind::Legacy));
+
+            assert_eq!(
+                settings,
+                EslintSettingsOverrides {
+                    use_flat_config: Some(false),
+                    experimental_use_flat_config: None,
+                }
+            );
+        }
+
+        #[test]
+        fn test_eslint_10_repo_uses_no_override() {
+            let version = Version::parse("10.0.0").expect("valid ESLint version");
+            let settings =
+                eslint_settings_overrides_for(Some(&version), Some(EslintConfigKind::Flat));
+
+            assert_eq!(settings, EslintSettingsOverrides::default());
+        }
+
+        #[test]
+        fn test_eslint_8_56_does_not_treat_cjs_as_flat_config() {
+            let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
+            let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
+            let version = Version::parse("8.56.0").expect("valid ESLint version");
+            let paths = path_set(&["/workspace/eslint.config.cjs"]);
+
+            let config_kind = find_eslint_config_kind(
+                &worktree_root,
+                Some(&requested_file),
+                Some(&version),
+                |path| paths.contains(path),
+            );
+
+            assert_eq!(config_kind, None);
+        }
+
+        #[test]
+        fn test_eslint_8_57_treats_cjs_as_flat_config() {
+            let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
+            let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
+            let version = Version::parse("8.57.0").expect("valid ESLint version");
+            let paths = path_set(&["/workspace/eslint.config.cjs"]);
+
+            let config_kind = find_eslint_config_kind(
+                &worktree_root,
+                Some(&requested_file),
+                Some(&version),
+                |path| paths.contains(path),
+            );
+
+            assert_eq!(config_kind, Some(EslintConfigKind::Flat));
+        }
+
+        #[test]
+        fn test_eslint_10_treats_typescript_config_as_flat_config() {
+            let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
+            let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
+            let version = Version::parse("10.0.0").expect("valid ESLint version");
+            let paths = path_set(&["/workspace/eslint.config.ts"]);
+
+            let config_kind = find_eslint_config_kind(
+                &worktree_root,
+                Some(&requested_file),
+                Some(&version),
+                |path| paths.contains(path),
+            );
+
+            assert_eq!(config_kind, Some(EslintConfigKind::Flat));
+        }
+
+        #[test]
+        fn test_package_local_flat_config_is_preferred_for_monorepo_file() {
+            let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
+            let requested_file = PathBuf::from(unix_path_to_platform(
+                "/workspace/packages/web/src/index.js",
+            ));
+            let version = Version::parse("8.56.0").expect("valid ESLint version");
+            let paths = path_set(&[
+                "/workspace/eslint.config.js",
+                "/workspace/packages/web/eslint.config.js",
+            ]);
+
+            let config_kind = find_eslint_config_kind(
+                &worktree_root,
+                Some(&requested_file),
+                Some(&version),
+                |path| paths.contains(path),
+            );
+
+            assert_eq!(config_kind, Some(EslintConfigKind::Flat));
+        }
+
+        #[test]
+        fn test_package_local_legacy_config_is_detected_for_eslint_9() {
+            let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
+            let requested_file = PathBuf::from(unix_path_to_platform(
+                "/workspace/packages/web/src/index.js",
+            ));
+            let version = Version::parse("9.0.0").expect("valid ESLint version");
+            let paths = path_set(&["/workspace/packages/web/.eslintrc.cjs"]);
+
+            let config_kind = find_eslint_config_kind(
+                &worktree_root,
+                Some(&requested_file),
+                Some(&version),
+                |path| paths.contains(path),
+            );
+
+            assert_eq!(config_kind, Some(EslintConfigKind::Legacy));
+        }
+
+        fn path_set(paths: &[&str]) -> HashSet<PathBuf> {
+            paths
+                .iter()
+                .map(|path| PathBuf::from(unix_path_to_platform(path)))
+                .collect()
         }
     }
 

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -8,6 +8,7 @@ use http_client::{
 use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, read_package_installed_version};
+use project::Fs;
 use project::lsp_store::language_server_settings_for;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -32,6 +33,7 @@ fn eslint_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
 
 pub struct EsLintLspAdapter {
     node: NodeRuntime,
+    fs: Arc<dyn Fs>,
 }
 
 impl EsLintLspAdapter {
@@ -66,8 +68,8 @@ impl EsLintLspAdapter {
         ".eslintrc.json",
     ];
 
-    pub fn new(node: NodeRuntime) -> Self {
-        EsLintLspAdapter { node }
+    pub fn new(node: NodeRuntime, fs: Arc<dyn Fs>) -> Self {
+        EsLintLspAdapter { node, fs }
     }
 
     fn build_destination_path(container_dir: &Path) -> PathBuf {
@@ -236,8 +238,9 @@ impl LspAdapter for EsLintLspAdapter {
             worktree_root,
             requested_file_path.as_deref(),
             eslint_version.as_ref(),
-            |path| path.is_file(),
-        );
+            self.fs.as_ref(),
+        )
+        .await;
         let eslint_settings_overrides =
             eslint_settings_overrides_for(eslint_version.as_ref(), config_kind);
 
@@ -350,23 +353,23 @@ fn flat_config_file_names(version: Option<&Version>) -> &'static [&'static str] 
     }
 }
 
-fn find_eslint_config_kind(
+async fn find_eslint_config_kind(
     worktree_root: &Path,
     requested_file: Option<&Path>,
     version: Option<&Version>,
-    path_exists: impl Fn(&Path) -> bool,
+    fs: &dyn Fs,
 ) -> Option<EslintConfigKind> {
     let flat_config_file_names = flat_config_file_names(version);
 
     for directory in ancestor_directories(worktree_root, requested_file) {
         for file_name in flat_config_file_names {
-            if path_exists(&directory.join(file_name)) {
+            if fs.is_file(&directory.join(file_name)).await {
                 return Some(EslintConfigKind::Flat);
             }
         }
 
         for file_name in EsLintLspAdapter::LEGACY_CONFIG_FILE_NAMES {
-            if path_exists(&directory.join(file_name)) {
+            if fs.is_file(&directory.join(file_name)).await {
                 return Some(EslintConfigKind::Legacy);
             }
         }
@@ -634,7 +637,6 @@ enum ResultWorkingDirectory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
 
     mod glob_patterns {
         use super::*;
@@ -780,6 +782,8 @@ mod tests {
 
     mod eslint_settings {
         use super::*;
+        use ::fs::FakeFs;
+        use gpui::TestAppContext;
 
         #[test]
         fn test_ancestor_directories_for_package_local_file() {
@@ -850,103 +854,126 @@ mod tests {
             assert_eq!(settings, EslintSettingsOverrides::default());
         }
 
-        #[test]
-        fn test_eslint_8_56_does_not_treat_cjs_as_flat_config() {
+        #[gpui::test]
+        async fn test_eslint_8_56_does_not_treat_cjs_as_flat_config(cx: &mut TestAppContext) {
+            let fs = FakeFs::new(cx.executor());
+            fs.insert_file(
+                unix_path_to_platform("/workspace/eslint.config.cjs"),
+                vec![],
+            )
+            .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
             let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
             let version = Version::parse("8.56.0").expect("valid ESLint version");
-            let paths = path_set(&["/workspace/eslint.config.cjs"]);
 
             let config_kind = find_eslint_config_kind(
                 &worktree_root,
                 Some(&requested_file),
                 Some(&version),
-                |path| paths.contains(path),
-            );
+                fs.as_ref(),
+            )
+            .await;
 
             assert_eq!(config_kind, None);
         }
 
-        #[test]
-        fn test_eslint_8_57_treats_cjs_as_flat_config() {
+        #[gpui::test]
+        async fn test_eslint_8_57_treats_cjs_as_flat_config(cx: &mut TestAppContext) {
+            let fs = FakeFs::new(cx.executor());
+            fs.insert_file(
+                unix_path_to_platform("/workspace/eslint.config.cjs"),
+                vec![],
+            )
+            .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
             let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
             let version = Version::parse("8.57.0").expect("valid ESLint version");
-            let paths = path_set(&["/workspace/eslint.config.cjs"]);
 
             let config_kind = find_eslint_config_kind(
                 &worktree_root,
                 Some(&requested_file),
                 Some(&version),
-                |path| paths.contains(path),
-            );
+                fs.as_ref(),
+            )
+            .await;
 
             assert_eq!(config_kind, Some(EslintConfigKind::Flat));
         }
 
-        #[test]
-        fn test_eslint_10_treats_typescript_config_as_flat_config() {
+        #[gpui::test]
+        async fn test_eslint_10_treats_typescript_config_as_flat_config(cx: &mut TestAppContext) {
+            let fs = FakeFs::new(cx.executor());
+            fs.insert_file(unix_path_to_platform("/workspace/eslint.config.ts"), vec![])
+                .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
             let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
             let version = Version::parse("10.0.0").expect("valid ESLint version");
-            let paths = path_set(&["/workspace/eslint.config.ts"]);
 
             let config_kind = find_eslint_config_kind(
                 &worktree_root,
                 Some(&requested_file),
                 Some(&version),
-                |path| paths.contains(path),
-            );
+                fs.as_ref(),
+            )
+            .await;
 
             assert_eq!(config_kind, Some(EslintConfigKind::Flat));
         }
 
-        #[test]
-        fn test_package_local_flat_config_is_preferred_for_monorepo_file() {
+        #[gpui::test]
+        async fn test_package_local_flat_config_is_preferred_for_monorepo_file(
+            cx: &mut TestAppContext,
+        ) {
+            let fs = FakeFs::new(cx.executor());
+            fs.insert_file(unix_path_to_platform("/workspace/eslint.config.js"), vec![])
+                .await;
+            fs.insert_file(
+                unix_path_to_platform("/workspace/packages/web/eslint.config.js"),
+                vec![],
+            )
+            .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
             let requested_file = PathBuf::from(unix_path_to_platform(
                 "/workspace/packages/web/src/index.js",
             ));
             let version = Version::parse("8.56.0").expect("valid ESLint version");
-            let paths = path_set(&[
-                "/workspace/eslint.config.js",
-                "/workspace/packages/web/eslint.config.js",
-            ]);
 
             let config_kind = find_eslint_config_kind(
                 &worktree_root,
                 Some(&requested_file),
                 Some(&version),
-                |path| paths.contains(path),
-            );
+                fs.as_ref(),
+            )
+            .await;
 
             assert_eq!(config_kind, Some(EslintConfigKind::Flat));
         }
 
-        #[test]
-        fn test_package_local_legacy_config_is_detected_for_eslint_9() {
+        #[gpui::test]
+        async fn test_package_local_legacy_config_is_detected_for_eslint_9(
+            cx: &mut TestAppContext,
+        ) {
+            let fs = FakeFs::new(cx.executor());
+            fs.insert_file(
+                unix_path_to_platform("/workspace/packages/web/.eslintrc.cjs"),
+                vec![],
+            )
+            .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
             let requested_file = PathBuf::from(unix_path_to_platform(
                 "/workspace/packages/web/src/index.js",
             ));
             let version = Version::parse("9.0.0").expect("valid ESLint version");
-            let paths = path_set(&["/workspace/packages/web/.eslintrc.cjs"]);
 
             let config_kind = find_eslint_config_kind(
                 &worktree_root,
                 Some(&requested_file),
                 Some(&version),
-                |path| paths.contains(path),
-            );
+                fs.as_ref(),
+            )
+            .await;
 
             assert_eq!(config_kind, Some(EslintConfigKind::Legacy));
-        }
-
-        fn path_set(paths: &[&str]) -> HashSet<PathBuf> {
-            paths
-                .iter()
-                .map(|path| PathBuf::from(unix_path_to_platform(path)))
-                .collect()
         }
     }
 

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -857,9 +857,9 @@ mod tests {
         #[gpui::test]
         async fn test_eslint_8_56_does_not_treat_cjs_as_flat_config(cx: &mut TestAppContext) {
             let fs = FakeFs::new(cx.executor());
-            fs.insert_file(
-                unix_path_to_platform("/workspace/eslint.config.cjs"),
-                vec![],
+            fs.insert_tree(
+                unix_path_to_platform("/workspace"),
+                json!({ "eslint.config.cjs": "" }),
             )
             .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
@@ -880,9 +880,9 @@ mod tests {
         #[gpui::test]
         async fn test_eslint_8_57_treats_cjs_as_flat_config(cx: &mut TestAppContext) {
             let fs = FakeFs::new(cx.executor());
-            fs.insert_file(
-                unix_path_to_platform("/workspace/eslint.config.cjs"),
-                vec![],
+            fs.insert_tree(
+                unix_path_to_platform("/workspace"),
+                json!({ "eslint.config.cjs": "" }),
             )
             .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
@@ -903,8 +903,11 @@ mod tests {
         #[gpui::test]
         async fn test_eslint_10_treats_typescript_config_as_flat_config(cx: &mut TestAppContext) {
             let fs = FakeFs::new(cx.executor());
-            fs.insert_file(unix_path_to_platform("/workspace/eslint.config.ts"), vec![])
-                .await;
+            fs.insert_tree(
+                unix_path_to_platform("/workspace"),
+                json!({ "eslint.config.ts": "" }),
+            )
+            .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
             let requested_file = PathBuf::from(unix_path_to_platform("/workspace/src/index.js"));
             let version = Version::parse("10.0.0").expect("valid ESLint version");
@@ -925,11 +928,16 @@ mod tests {
             cx: &mut TestAppContext,
         ) {
             let fs = FakeFs::new(cx.executor());
-            fs.insert_file(unix_path_to_platform("/workspace/eslint.config.js"), vec![])
-                .await;
-            fs.insert_file(
-                unix_path_to_platform("/workspace/packages/web/eslint.config.js"),
-                vec![],
+            fs.insert_tree(
+                unix_path_to_platform("/workspace"),
+                json!({
+                    "eslint.config.js": "",
+                    "packages": {
+                        "web": {
+                            "eslint.config.js": ""
+                        }
+                    }
+                }),
             )
             .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));
@@ -954,9 +962,15 @@ mod tests {
             cx: &mut TestAppContext,
         ) {
             let fs = FakeFs::new(cx.executor());
-            fs.insert_file(
-                unix_path_to_platform("/workspace/packages/web/.eslintrc.cjs"),
-                vec![],
+            fs.insert_tree(
+                unix_path_to_platform("/workspace"),
+                json!({
+                    "packages": {
+                        "web": {
+                            ".eslintrc.cjs": ""
+                        }
+                    }
+                }),
             )
             .await;
             let worktree_root = PathBuf::from(unix_path_to_platform("/workspace"));

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -218,7 +218,11 @@ impl LspAdapter for EsLintLspAdapter {
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let worktree_root = delegate.worktree_root_path();
-        let requested_file_path = requested_file_path(requested_uri.as_ref(), worktree_root);
+        let requested_file_path = requested_uri
+            .as_ref()
+            .filter(|uri| uri.scheme() == "file")
+            .and_then(|uri| uri.to_file_path().ok())
+            .filter(|path| path.starts_with(worktree_root));
         let eslint_version = find_eslint_version(
             delegate.as_ref(),
             worktree_root,
@@ -316,45 +320,17 @@ impl LspAdapter for EsLintLspAdapter {
     }
 }
 
-fn requested_file_path(requested_uri: Option<&Uri>, worktree_root: &Path) -> Option<PathBuf> {
-    requested_uri
-        .filter(|uri| uri.scheme() == "file")
-        .and_then(|uri| uri.to_file_path().ok())
-        .filter(|path| path.starts_with(worktree_root))
-}
-
-// vscode-eslint 3.x already walks upward from the active file to choose its
-// working directory and config roots. We do a smaller upward walk here only to
-// answer the two compatibility questions that still belong to Zed:
-//
-// - Is this file using a flat config that needs experimental opt-in on ESLint 8.21-8.56?
-// - Is this file using a legacy config that needs useFlatConfig = false on ESLint 9?
 fn ancestor_directories(worktree_root: &Path, requested_file: Option<&Path>) -> Vec<PathBuf> {
-    let mut directory = requested_file
+    let start = requested_file
         .filter(|file| file.starts_with(worktree_root))
         .and_then(Path::parent)
-        .unwrap_or(worktree_root)
-        .to_path_buf();
-    let mut directories = Vec::new();
+        .unwrap_or(worktree_root);
 
-    loop {
-        if !directory.starts_with(worktree_root) {
-            break;
-        }
-
-        directories.push(directory.clone());
-
-        if directory == worktree_root {
-            break;
-        }
-
-        let Some(parent) = directory.parent() else {
-            break;
-        };
-        directory = parent.to_path_buf();
-    }
-
-    directories
+    start
+        .ancestors()
+        .take_while(|dir| dir.starts_with(worktree_root))
+        .map(Path::to_path_buf)
+        .collect()
 }
 
 fn flat_config_file_names(version: Option<&Version>) -> &'static [&'static str] {

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -189,14 +189,17 @@ impl EslintSettingsOverrides {
         }
 
         if let Some(experimental_use_flat_config) = self.experimental_use_flat_config
-            && let Some(experimental) = workspace_configuration
-                .get_mut("experimental")
-                .and_then(Value::as_object_mut)
+            && let Some(workspace_configuration) = workspace_configuration.as_object_mut()
         {
-            experimental.insert(
-                "useFlatConfig".to_string(),
-                json!(experimental_use_flat_config),
-            );
+            let experimental = workspace_configuration
+                .entry("experimental")
+                .or_insert_with(|| json!({}));
+            if let Some(experimental) = experimental.as_object_mut() {
+                experimental.insert(
+                    "useFlatConfig".to_string(),
+                    json!(experimental_use_flat_config),
+                );
+            }
         }
     }
 }
@@ -266,8 +269,7 @@ impl LspAdapter for EsLintLspAdapter {
                 "showDocumentation": {
                     "enable": true
                 }
-            },
-            "experimental": {}
+            }
         });
         eslint_settings_overrides.apply_to(&mut default_workspace_configuration);
 

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -59,7 +59,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
 
     let c_lsp_adapter = Arc::new(c::CLspAdapter);
     let css_lsp_adapter = Arc::new(css::CssLspAdapter::new(node.clone()));
-    let eslint_adapter = Arc::new(eslint::EsLintLspAdapter::new(node.clone()));
+    let eslint_adapter = Arc::new(eslint::EsLintLspAdapter::new(node.clone(), fs.clone()));
     let go_context_provider = Arc::new(go::GoContextProvider);
     let go_lsp_adapter = Arc::new(go::GoLspAdapter);
     let json_context_provider = Arc::new(JsonTaskProvider);


### PR DESCRIPTION
Closes #29757
Closes #49387

This PR upgrades ESLint language server from `vscode-eslint 2.4.4` to upstream `microsoft/vscode-eslint 3.0.24`, and make the workspace configuration version-aware so ESLint 8, 9, and 10 take the correct config-mode path.

The key part is that the 3.x bump alone is not enough. This PR keeps Zed out of that path except where it is still actually needed. Rest heavy-lifting is done by eslint server itself.

Zed now only overrides ESLint settings in the two known broken cases:
  - ESLint 8.21-8.56 flat config: send `experimental.useFlatConfig = true`
  - ESLint 9 legacy config: send `useFlatConfig = false`
  
All other cases defer to `vscode-eslint 3.x`'s own config and working-directory discovery.

For testing, I created https://github.com/smitbarmase/eslint-repros, which contains a versioned ESLint repros covering root flat config, legacy config, and package-local monorepo cases across ESLint 8, 9, and 10. Here is compare between `zed/main`, a pure `vscode-eslint 3.x` upgrade and this branch with the config-mode fixes:

  ## zed main

  ```text
  eslint-v8_21-flat-root-single
  eslint-v8_56-flat-package-local-monorepo  -> breaks on main
  eslint-v8_56-flat-root-single
  eslint-v8_56-legacy-root-single
  eslint-v8_57-flat-package-local-monorepo  -> breaks on main
  eslint-v8_57-flat-root-single
  eslint-v8_57-legacy-root-single
  eslint-v9_0-flat-package-local-monorepo
  eslint-v9_0-flat-root-single
  eslint-v9_0-legacy-root-single            -> breaks on main
  eslint-v10_0-flat-package-local-monorepo
  eslint-v10_0-flat-root-single             -> breaks on main
  ```
  
  ## vscode-eslint 3.x upgrade

  ```text
  eslint-v8_21-flat-root-single
  eslint-v8_56-flat-package-local-monorepo  -> breaks on 3.x upgrade
  eslint-v8_56-flat-root-single
  eslint-v8_56-legacy-root-single
  eslint-v8_57-flat-package-local-monorepo
  eslint-v8_57-flat-root-single
  eslint-v8_57-legacy-root-single
  eslint-v9_0-flat-package-local-monorepo
  eslint-v9_0-flat-root-single
  eslint-v9_0-legacy-root-single            -> breaks on 3.x upgrade
  eslint-v10_0-flat-package-local-monorepo
  eslint-v10_0-flat-root-single             -> breaks on 3.x upgrade
  ```
  
  ## vscode-eslint 3.x upgrade + use flat config fixes

  ```text
  eslint-v8_21-flat-root-single
  eslint-v8_56-flat-package-local-monorepo
  eslint-v8_56-flat-root-single
  eslint-v8_56-legacy-root-single
  eslint-v8_57-flat-package-local-monorepo
  eslint-v8_57-flat-root-single
  eslint-v8_57-legacy-root-single
  eslint-v9_0-flat-package-local-monorepo
  eslint-v9_0-flat-root-single
  eslint-v9_0-legacy-root-single
  eslint-v10_0-flat-package-local-monorepo
  eslint-v10_0-flat-root-single
  ```
  
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed ESLint not reporting diagnostics in some cases for projects that use flat-config, legacy-config, and monorepo projects across ESLint 8, 9, and 10.