### PR TITLE
keymaps: Add Ctrl+R open recent binding for macOS and Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -574,6 +574,7 @@
       // Change the default action on `menu::Confirm` by setting the parameter
       // "alt-ctrl-o": ["projects::OpenRecent", { "create_new_window": true }],
       "alt-ctrl-o": ["projects::OpenRecent", { "create_new_window": false }],
+      "ctrl-r": ["projects::OpenRecent", { "create_new_window": false }],
       "alt-shift-open": ["projects::OpenRemote", { "from_existing_connection": false, "create_new_window": false }],
       // Change to open path modal for existing remote connection by setting the parameter
       // "alt-ctrl-shift-o": "["projects::OpenRemote", { "from_existing_connection": true }]",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -644,6 +644,7 @@
       // Change the default action on `menu::Confirm` by setting the parameter
       // "alt-cmd-o": ["projects::OpenRecent", {"create_new_window": true }],
       "alt-cmd-o": ["projects::OpenRecent", { "create_new_window": false }],
+      "ctrl-r": ["projects::OpenRecent", { "create_new_window": false }],
       "ctrl-cmd-o": ["projects::OpenRemote", { "from_existing_connection": false, "create_new_window": false }],
       "ctrl-cmd-shift-o": ["projects::OpenRemote", { "from_existing_connection": true, "create_new_window": false }],
       "cmd-ctrl-b": "branches::OpenRecent",


### PR DESCRIPTION
Closes #52879

## Summary

VS Code binds `Ctrl+R` to open recent workspaces/folders on all platforms (Windows, macOS, and Linux). Zed already had this binding in `default-windows.json`, but it was missing from `default-macos.json` and `default-linux.json`.

Since `BaseKeymap::VSCode` returns no supplemental keymap file and relies entirely on the platform default keymaps, users who selected VS Code keybindings on macOS or Linux would not get the expected `Ctrl+R` behavior — instead getting nothing, or having to use the non-VSCode binding (`Alt+Cmd+O` / `Alt+Ctrl+O`).

This adds the missing binding to both platform defaults, consistent with what Windows already had.

## Screenshot
The default keybinding in VS Code:
<img width="1512" height="319" alt="Screenshot 2026-04-01 at 07 38 09" src="https://github.com/user-attachments/assets/12d483a3-3c52-4649-a00f-ee2b8e40bc8c" />


Release Notes:

- Added `Ctrl+R` keybinding for opening recent projects on macOS and Linux, matching VS Code's default behavior on all platforms.