### PR TITLE
Fix license check triggering on worktree root entry changes

### DIFF
--- a/crates/edit_prediction/src/license_detection.rs
+++ b/crates/edit_prediction/src/license_detection.rs
@@ -21,14 +21,23 @@ use worktree::ChildEntriesOptions;
 static LICENSE_FILE_NAME_REGEX: LazyLock<regex::bytes::Regex> = LazyLock::new(|| {
     regex::bytes::RegexBuilder::new(
         "^ \
-        (?: license | licence)? \
-        (?: [\\-._]? \
+        (?: \
+            (?: license | licence) \
+            (?: [\\-._]? \
+                (?: apache (?: [\\-._] (?: 2.0 | 2 ))? | \
+                    0? bsd (?: [\\-._] [0123])? (?: [\\-._] clause)? | \
+                    isc | \
+                    mit | \
+                    upl | \
+                    zlib))? \
+          | \
             (?: apache (?: [\\-._] (?: 2.0 | 2 ))? | \
                 0? bsd (?: [\\-._] [0123])? (?: [\\-._] clause)? | \
                 isc | \
                 mit | \
                 upl | \
-                zlib))? \
+                zlib) \
+        ) \
         (?: [\\-._]? (?: license | licence))? \
         (?: \\.txt | \\.md)? \
         $",
@@ -350,6 +359,9 @@ impl LicenseDetectionWatcher {
             return None;
         };
         let metadata = fs.metadata(&abs_path).await.log_err()??;
+        if metadata.is_dir {
+            return None;
+        }
         if metadata.len > LICENSE_PATTERNS.approximate_max_length as u64 {
             log::debug!(
                 "`{abs_path:?}` license file was skipped \
@@ -697,6 +709,7 @@ mod tests {
         assert!(LICENSE_FILE_NAME_REGEX.is_match(b"licence-upl.txt"));
 
         // Test non-matching patterns
+        assert!(!LICENSE_FILE_NAME_REGEX.is_match(b""));
         assert!(!LICENSE_FILE_NAME_REGEX.is_match(b"COPYING"));
         assert!(!LICENSE_FILE_NAME_REGEX.is_match(b"LICENSE.html"));
         assert!(!LICENSE_FILE_NAME_REGEX.is_match(b"MYLICENSE"));


### PR DESCRIPTION
Had been seeing this for some time

<img width="1683" height="167" alt="bad" src="https://github.com/user-attachments/assets/bd7370c9-617a-45c2-8785-ef268444f00a" />

and the culprit turned out to be the fact that the regex matched empty strings.

The fix changes the regex to ensure it stops matching empty strings, and patches the `log_err` callsite logic to avoid reading directories.

Release Notes:

- N/A
