### PR TITLE
Fix diagnostics in editor control enabling by itself

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1178,6 +1178,7 @@ pub struct Editor {
     select_syntax_node_history: SelectSyntaxNodeHistory,
     ime_transaction: Option<TransactionId>,
     pub diagnostics_max_severity: DiagnosticSeverity,
+    diagnostics_manually_toggled: bool,
     active_diagnostics: ActiveDiagnostic,
     show_inline_diagnostics: bool,
     inline_diagnostics_update: Task<()>,
@@ -2462,6 +2463,7 @@ impl Editor {
             inline_diagnostics: Vec::new(),
             soft_wrap_mode_override,
             diagnostics_max_severity,
+            diagnostics_manually_toggled: false,
             hard_wrap: None,
             completion_provider: project.clone().map(|project| Rc::new(project) as _),
             semantics_provider: project
@@ -20585,11 +20587,13 @@ impl Editor {
         }
 
         let new_severity = if self.diagnostics_max_severity == DiagnosticSeverity::Off {
+            self.diagnostics_manually_toggled = false;
             EditorSettings::get_global(cx)
                 .diagnostics_max_severity
                 .filter(|severity| severity != &DiagnosticSeverity::Off)
                 .unwrap_or(DiagnosticSeverity::Hint)
         } else {
+            self.diagnostics_manually_toggled = true;
             DiagnosticSeverity::Off
         };
         self.set_max_diagnostics_severity(new_severity, cx);
@@ -25332,7 +25336,7 @@ impl Editor {
         let accents_changed = new_accents != self.accent_data;
         self.accent_data = new_accents;
 
-        if self.diagnostics_enabled() {
+        if self.diagnostics_enabled() && !self.diagnostics_manually_toggled {
             let new_severity = EditorSettings::get_global(cx)
                 .diagnostics_max_severity
                 .unwrap_or(DiagnosticSeverity::Hint);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1178,7 +1178,6 @@ pub struct Editor {
     select_syntax_node_history: SelectSyntaxNodeHistory,
     ime_transaction: Option<TransactionId>,
     pub diagnostics_max_severity: DiagnosticSeverity,
-    diagnostics_manually_toggled: bool,
     active_diagnostics: ActiveDiagnostic,
     show_inline_diagnostics: bool,
     inline_diagnostics_update: Task<()>,
@@ -2463,7 +2462,6 @@ impl Editor {
             inline_diagnostics: Vec::new(),
             soft_wrap_mode_override,
             diagnostics_max_severity,
-            diagnostics_manually_toggled: false,
             hard_wrap: None,
             completion_provider: project.clone().map(|project| Rc::new(project) as _),
             semantics_provider: project
@@ -20582,22 +20580,20 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) {
-        if !self.diagnostics_enabled() {
-            return;
-        }
+        let diagnostics_enabled =
+            self.diagnostics_enabled() && self.diagnostics_max_severity != DiagnosticSeverity::Off;
+        self.diagnostics_enabled = !diagnostics_enabled;
 
-        let new_severity = if self.diagnostics_max_severity == DiagnosticSeverity::Off {
-            self.diagnostics_manually_toggled = false;
+        let new_severity = if self.diagnostics_enabled {
             EditorSettings::get_global(cx)
                 .diagnostics_max_severity
                 .filter(|severity| severity != &DiagnosticSeverity::Off)
                 .unwrap_or(DiagnosticSeverity::Hint)
         } else {
-            self.diagnostics_manually_toggled = true;
             DiagnosticSeverity::Off
         };
         self.set_max_diagnostics_severity(new_severity, cx);
-        if self.diagnostics_max_severity == DiagnosticSeverity::Off {
+        if self.diagnostics_enabled {
             self.active_diagnostics = ActiveDiagnostic::None;
             self.inline_diagnostics_update = Task::ready(());
             self.inline_diagnostics.clear();
@@ -25336,7 +25332,7 @@ impl Editor {
         let accents_changed = new_accents != self.accent_data;
         self.accent_data = new_accents;
 
-        if self.diagnostics_enabled() && !self.diagnostics_manually_toggled {
+        if self.diagnostics_enabled() {
             let new_severity = EditorSettings::get_global(cx)
                 .diagnostics_max_severity
                 .unwrap_or(DiagnosticSeverity::Hint);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -37367,3 +37367,44 @@ fn setup_syntax_highlighting_with_theme(
         );
     });
 }
+
+#[gpui::test]
+async fn test_toggle_diagnostics_persists_across_settings_change(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor.diagnostics_enabled(),
+            "diagnostics should start enabled by default"
+        );
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.toggle_diagnostics(&actions::ToggleDiagnostics, window, cx);
+        assert!(
+            !editor.diagnostics_enabled(),
+            "diagnostics should be disabled after toggle"
+        );
+    });
+
+    update_test_editor_settings(&mut cx, &|settings| {
+        settings.cursor_blink = Some(false);
+    });
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            !editor.diagnostics_enabled(),
+            "diagnostics should remain disabled after settings change"
+        );
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.toggle_diagnostics(&actions::ToggleDiagnostics, window, cx);
+        assert!(
+            editor.diagnostics_enabled(),
+            "diagnostics should be re-enabled after second toggle"
+        );
+    });
+}

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -120,7 +120,8 @@ impl Render for QuickActionBar {
         let semantic_highlights_enabled = editor_value.semantic_highlights_enabled();
         let code_lens_enabled = editor_value.code_lens_enabled();
         let is_full = editor_value.mode().is_full();
-        let diagnostics_enabled = editor_value.diagnostics_max_severity != DiagnosticSeverity::Off;
+        let diagnostics_enabled = editor_value.diagnostics_enabled()
+            && editor_value.diagnostics_max_severity != DiagnosticSeverity::Off;
         let supports_inline_diagnostics = editor_value.inline_diagnostics_enabled();
         let inline_diagnostics_enabled = editor_value.show_inline_diagnostics();
         let git_blame_inline_enabled = editor_value.git_blame_inline_enabled();


### PR DESCRIPTION
### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments  ← N/A, no unsafe blocks
- [x] The content is consistent with the UI/UX checklist
- [ ] Tests cover the new/changed behavior  ← no existing tests; none added
- [x] Performance impact has been considered and is acceptable

#### Closes #52881

### Fix

Add a `diagnostics_manually_toggled: bool` field to `Editor`. It is set to `true` when the user toggles diagnostics off, and back to `false` when they toggle them on again. `settings_changed` now skips the severity override while this flag is set, preserving the user's intent across settings reloads.


Video 

[Screencast from 2026-04-01 20-42-16.webm](https://github.com/user-attachments/assets/0e52868c-85bb-4270-b487-30bf50da97c2)


Release Notes:

- Fixed "Diagnostics" in Editor Controls re-enabling itself after being manually disabled
