### PR TITLE
agent_ui: Fix collapsing bug with thinking blocks in auto-mode

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -5207,9 +5207,12 @@ impl ThreadView {
 
         match thinking_display {
             ThinkingBlockDisplay::Auto => {
-                if self.expanded_thinking_blocks.contains(&key) {
+                let is_open = self.expanded_thinking_blocks.contains(&key)
+                    || self.user_toggled_thinking_blocks.contains(&key);
+
+                if is_open {
                     self.expanded_thinking_blocks.remove(&key);
-                    self.user_toggled_thinking_blocks.insert(key);
+                    self.user_toggled_thinking_blocks.remove(&key);
                 } else {
                     self.expanded_thinking_blocks.insert(key);
                     self.user_toggled_thinking_blocks.insert(key);


### PR DESCRIPTION
Quick follow up to https://github.com/zed-industries/zed/pull/52874 where expanded thinking blocks, when in auto-mode, wouldn't collapse again.

Release Notes:

- N/A
