### PR TITLE
ci: Add pull request write permissions for cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -37,6 +37,7 @@ jobs:
         private-key: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
         permission-contents: write
         permission-workflows: write
+        permission-pull-requests: write
     - name: cherry_pick::run_cherry_pick::cherry_pick
       run: ./script/cherry-pick "$BRANCH" "$COMMIT" "$CHANNEL"
       env:

--- a/tooling/xtask/src/tasks/workflows/cherry_pick.rs
+++ b/tooling/xtask/src/tasks/workflows/cherry_pick.rs
@@ -49,6 +49,7 @@ fn run_cherry_pick(
         .with_permissions([
             (TokenPermissions::Contents, Level::Write),
             (TokenPermissions::Workflows, Level::Write),
+            (TokenPermissions::PullRequests, Level::Write),
         ])
         .into();
 


### PR DESCRIPTION
This was missing from the previous permissions changes.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
