### PR TITLE
agent: Add `ask_user` tool

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -562,6 +562,10 @@ pub enum ToolCallStatus {
         options: PermissionOptions,
         respond_tx: oneshot::Sender<SelectedPermissionOutcome>,
     },
+    /// The tool call is waiting for (text) input from the user.
+    WaitingForInput {
+        respond_tx: oneshot::Sender<String>,
+    },
     /// The tool call is currently running.
     InProgress,
     /// The tool call completed successfully.
@@ -599,6 +603,7 @@ impl Display for ToolCallStatus {
                 ToolCallStatus::Failed => "Failed",
                 ToolCallStatus::Rejected => "Rejected",
                 ToolCallStatus::Canceled => "Canceled",
+                ToolCallStatus::WaitingForInput { .. } => "Waiting for input",
             }
         )
     }
@@ -1311,7 +1316,7 @@ impl AcpThread {
             match entry {
                 AgentThreadEntry::UserMessage(_) => return false,
                 AgentThreadEntry::ToolCall(ToolCall {
-                    status: ToolCallStatus::WaitingForConfirmation { .. },
+                    status: ToolCallStatus::WaitingForConfirmation { .. } | ToolCallStatus::WaitingForInput { .. },
                     ..
                 }) => return true,
                 AgentThreadEntry::ToolCall(_)
@@ -1996,6 +2001,40 @@ impl AcpThread {
         })
         .detach();
     }
+    pub fn request_tool_call_input(
+        &mut self,
+        tool_call: acp::ToolCallUpdate,
+        cx: &mut Context<Self>,
+    ) -> Result<Task<Option<String>>> {
+        let (tx, rx) = oneshot::channel();
+        let status = ToolCallStatus::WaitingForInput { respond_tx: tx };
+        self.upsert_tool_call_inner(tool_call, status, cx)?;
+        Ok(cx.spawn(async move |_this, _cx| rx.await.ok()))
+    }
+
+    pub fn submit_tool_call_input(
+        &mut self,
+        id: acp::ToolCallId,
+        input: String,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((ix, call)) = self.tool_call_mut(&id) else { return; };
+        let ToolCallStatus::WaitingForInput { respond_tx } = std::mem::replace(&mut call.status, ToolCallStatus::InProgress) else { return; };
+        let _ = respond_tx.send(input);
+        cx.emit(AcpThreadEvent::EntryUpdated(ix));
+    }
+
+    pub fn cancel_tool_call_input(
+        &mut self,
+        id: acp::ToolCallId,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((ix, call)) = self.tool_call_mut(&id) else { return; };
+        let ToolCallStatus::WaitingForInput { respond_tx: _ } = std::mem::replace(&mut call.status, ToolCallStatus::Canceled) else { return; };
+        cx.emit(AcpThreadEvent::EntryUpdated(ix));
+    }
+
+
 
     pub fn request_tool_call_authorization(
         &mut self,
@@ -5182,4 +5221,93 @@ mod tests {
             "session info title update should not propagate back to the connection"
         );
     }
+
+    #[gpui::test]
+    async fn test_tool_call_input(cx: &mut TestAppContext) {
+        use std::rc::Rc;
+        init_test(cx);
+        let project = project::Project::test(FakeFs::new(cx.executor()), [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let session_id = acp::SessionId::new("1");
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+
+        let thread = cx.new(|cx| {
+            let (_, prompt_capabilities_rx) = watch::channel(acp::PromptCapabilities::default());
+            AcpThread::new(None, Some("Test".into()), None, connection, project, action_log, session_id, prompt_capabilities_rx, cx)
+        });
+
+        let tool_call_id = acp::ToolCallId::new("test_tool_call");
+        let tool_call = acp::ToolCallUpdate::new(
+            tool_call_id.to_string(),
+            acp::ToolCallUpdateFields::new().title("test_title"),
+        );
+
+        let task = thread.update(cx, |thread, cx| {
+            thread.request_tool_call_input(tool_call, cx).unwrap()
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _| {
+            assert!(thread.is_waiting_for_confirmation());
+            let (_, call) = thread.tool_call(&tool_call_id).unwrap();
+            assert!(matches!(call.status, ToolCallStatus::WaitingForInput { .. }));
+        });
+
+        thread.update(cx, |thread, cx| {
+            thread.submit_tool_call_input(tool_call_id.clone(), "test input".into(), cx);
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _| {
+            assert!(!thread.is_waiting_for_confirmation());
+            let (_, call) = thread.tool_call(&tool_call_id).unwrap();
+            assert!(matches!(call.status, ToolCallStatus::InProgress));
+        });
+
+        assert_eq!(task.await.unwrap(), "test input");
+    }
+
+    #[gpui::test]
+    async fn test_cancel_tool_call_input(cx: &mut TestAppContext) {
+        use std::rc::Rc;
+        init_test(cx);
+        let project = project::Project::test(FakeFs::new(cx.executor()), [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let session_id = acp::SessionId::new("1");
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+
+        let thread = cx.new(|cx| {
+            let (_, prompt_capabilities_rx) = watch::channel(acp::PromptCapabilities::default());
+            AcpThread::new(None, Some("Test".into()), None, connection, project, action_log, session_id, prompt_capabilities_rx, cx)
+        });
+
+        let tool_call_id = acp::ToolCallId::new("test_tool_call");
+        let tool_call = acp::ToolCallUpdate::new(
+            tool_call_id.to_string(),
+            acp::ToolCallUpdateFields::new().title("test_title"),
+        );
+
+        let task = thread.update(cx, |thread, cx| {
+            thread.request_tool_call_input(tool_call, cx).unwrap()
+        });
+
+        cx.run_until_parked();
+
+        thread.update(cx, |thread, cx| {
+            thread.cancel_tool_call_input(tool_call_id.clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _| {
+            assert!(!thread.is_waiting_for_confirmation());
+            let (_, call) = thread.tool_call(&tool_call_id).unwrap();
+            assert!(matches!(call.status, ToolCallStatus::Canceled));
+        });
+
+        assert_eq!(task.await, None);
+    }
+
 }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1224,6 +1224,25 @@ impl NativeAgentConnection {
                                 })
                                 .detach();
                             }
+                            ThreadEvent::ToolCallInputRequest(
+                                crate::thread::ToolCallInputRequest {
+                                    tool_call,
+                                    response,
+                                },
+                            ) => {
+                                let input_task = acp_thread.update(cx, |thread, cx| {
+                                    thread.request_tool_call_input(tool_call, cx)
+                                })??;
+                                cx.background_spawn(async move {
+                                    if let Some(input) = input_task.await {
+                                        response
+                                            .send(input)
+                                            .map(|_| anyhow!("input receiver was dropped"))
+                                            .log_err();
+                                    }
+                                })
+                                .detach();
+                            }
                             ThreadEvent::ToolCall(tool_call) => {
                                 acp_thread.update(cx, |thread, cx| {
                                     thread.upsert_tool_call(tool_call, cx)

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
+    AskUserTool, ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
     DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
     ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot, ReadFileTool,
     RestoreFileFromDiskTool, SaveFileTool, SpawnAgentTool, StreamingEditFileTool,
@@ -661,6 +661,7 @@ pub enum ThreadEvent {
     ToolCallUpdate(acp_thread::ToolCallUpdate),
     Plan(acp::Plan),
     ToolCallAuthorization(ToolCallAuthorization),
+    ToolCallInputRequest(ToolCallInputRequest),
     SubagentSpawned(acp::SessionId),
     Retry(acp_thread::RetryStatus),
     Stop(acp::StopReason),
@@ -910,6 +911,12 @@ pub struct ToolCallAuthorization {
     pub options: acp_thread::PermissionOptions,
     pub response: oneshot::Sender<acp_thread::SelectedPermissionOutcome>,
     pub context: Option<ToolPermissionContext>,
+}
+
+#[derive(Debug)]
+pub struct ToolCallInputRequest {
+    pub tool_call: acp::ToolCallUpdate,
+    pub response: oneshot::Sender<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1540,6 +1547,7 @@ impl Thread {
         self.add_tool(RestoreFileFromDiskTool::new(self.project.clone()));
         self.add_tool(TerminalTool::new(self.project.clone(), environment.clone()));
         self.add_tool(WebSearchTool);
+        self.add_tool(AskUserTool);
 
         if self.depth() < MAX_SUBAGENT_DEPTH {
             self.add_tool(SpawnAgentTool::new(environment));
@@ -3596,6 +3604,23 @@ impl ToolCallEventStream {
             .update_tool_call_fields(&self.tool_use_id, fields, meta);
     }
 
+    pub fn request_input(&self) -> oneshot::Receiver<String> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.stream
+            .0
+            .unbounded_send(Ok(ThreadEvent::ToolCallInputRequest(
+                ToolCallInputRequest {
+                    tool_call: acp::ToolCallUpdate::new(
+                        self.tool_use_id.to_string(),
+                        acp::ToolCallUpdateFields::new(),
+                    ),
+                    response: response_tx,
+                },
+            )))
+            .ok();
+        response_rx
+    }
+
     pub fn update_diff(&self, diff: Entity<acp_thread::Diff>) {
         self.stream
             .0
@@ -3915,6 +3940,15 @@ impl ToolCallEventStreamReceiver {
             plan
         } else {
             panic!("Expected plan but got: {:?}", event);
+        }
+    }
+
+    pub async fn expect_input_request(&mut self) -> ToolCallInputRequest {
+        let event = self.0.next().await;
+        if let Some(Ok(ThreadEvent::ToolCallInputRequest(req))) = event {
+            req
+        } else {
+            panic!("Expected ToolCallInputRequest but got: {:?}", event);
         }
     }
 }

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -1,3 +1,4 @@
+mod ask_user_tool;
 mod context_server_registry;
 mod copy_path_tool;
 mod create_directory_tool;
@@ -27,6 +28,7 @@ mod web_search_tool;
 use crate::AgentTool;
 use language_model::{LanguageModelRequestTool, LanguageModelToolSchemaFormat};
 
+pub use ask_user_tool::*;
 pub use context_server_registry::*;
 pub use copy_path_tool::*;
 pub use create_directory_tool::*;
@@ -119,6 +121,7 @@ macro_rules! tools {
 }
 
 tools! {
+    AskUserTool,
     CopyPathTool,
     CreateDirectoryTool,
     DeletePathTool,

--- a/crates/agent/src/tools/ask_user_tool.rs
+++ b/crates/agent/src/tools/ask_user_tool.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use gpui::{App, SharedString, Task};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{AgentTool, ToolCallEventStream, thread::ToolInput};
+use agent_client_protocol as acp;
+use std::sync::Arc;
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AskUserArgs {
+    /// The prompt to display to the user.
+    pub prompt: String,
+}
+
+pub struct AskUserTool;
+
+impl AgentTool for AskUserTool {
+    type Input = AskUserArgs;
+    type Output = String;
+
+    const NAME: &'static str = "ask_user";
+
+    fn description() -> SharedString {
+        "Ask the user a question and wait for their free-text input.".into()
+    }
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Fetch
+    }
+
+    fn initial_title(
+        &self,
+        input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        input
+            .map(|x| x.prompt)
+            .unwrap_or_else(|_| "Asking a question...".to_string())
+            .into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        _input: ToolInput<Self::Input>,
+        event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, String>> {
+        cx.spawn(async move |_cx| {
+            // Wait for the UI to submit the response
+            let user_response = event_stream
+                .request_input()
+                .await
+                .map_err(|e| format!("Input request cancelled: {}", e))?;
+
+            Ok(user_response)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    async fn test_ask_user_tool(cx: &mut TestAppContext) {
+        let tool = Arc::new(AskUserTool);
+        let (event_stream, mut event_rx) = ToolCallEventStream::test();
+
+        let input = AskUserArgs {
+            prompt: "How are you?".to_string(),
+        };
+
+        let task = cx.update(|cx| tool.run(ToolInput::resolved(input), event_stream, cx));
+
+        // Expect the fields update (content)
+        let update_fields = event_rx.expect_update_fields().await;
+        assert_eq!(update_fields.content.unwrap().len(), 1);
+
+        // Expect the input request
+        let req = event_rx.expect_input_request().await;
+
+        // Respond to the input request
+        req.response.send("I am doing great!".to_string()).unwrap();
+
+        // Wait for the tool to finish
+        let result = task.await.unwrap();
+        assert_eq!(result, "I am doing great!");
+    }
+
+    #[gpui::test]
+    async fn test_ask_user_tool_cancellation(cx: &mut TestAppContext) {
+        let tool = Arc::new(AskUserTool);
+        let (event_stream, mut event_rx) = ToolCallEventStream::test();
+
+        let input = AskUserArgs {
+            prompt: "How are you?".to_string(),
+        };
+
+        let task = cx.update(|cx| tool.run(ToolInput::resolved(input), event_stream, cx));
+
+        // Expect the fields update (content)
+        let _ = event_rx.expect_update_fields().await;
+
+        // Expect the input request
+        let req = event_rx.expect_input_request().await;
+
+        // Cancel by dropping the response channel
+        drop(req.response);
+
+        // Wait for the tool to finish
+        let err = task.await.unwrap_err();
+        assert!(err.contains("Input request cancelled"));
+    }
+}

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1688,6 +1688,7 @@ impl ThreadView {
             matches!(
                 tool_call.status,
                 ToolCallStatus::WaitingForConfirmation { .. }
+                    | ToolCallStatus::WaitingForInput { .. }
             )
         } else {
             false
@@ -5993,7 +5994,7 @@ impl ThreadView {
 
         let needs_confirmation = matches!(
             tool_call.status,
-            ToolCallStatus::WaitingForConfirmation { .. }
+            ToolCallStatus::WaitingForConfirmation { .. } | ToolCallStatus::WaitingForInput { .. }
         );
         let is_terminal_tool = matches!(tool_call.kind, acp::ToolKind::Execute);
 
@@ -6036,6 +6037,59 @@ impl ThreadView {
 
         let tool_output_display = if is_open {
             match &tool_call.status {
+                ToolCallStatus::WaitingForInput { .. } => {
+                    let editor = self
+                        .entry_view_state
+                        .read(cx)
+                        .entry(entry_ix)
+                        .and_then(|entry| entry.ask_user_input_editor())
+                        .unwrap();
+
+                    v_flex()
+                        .p_2()
+                        .gap_2()
+                        .child(
+                            div()
+                                .w_full()
+                                .p_1()
+                                .rounded_md()
+                                .bg(cx.theme().colors().editor_background)
+                                .border_1()
+                                .border_color(cx.theme().colors().border)
+                                .child(editor.clone()),
+                        )
+                        .child(
+                            h_flex()
+                                .justify_end()
+                                .gap_2()
+                                .child(Button::new("cancel_input", "Cancel").on_click({
+                                    let tool_call_id = tool_call.id.clone();
+                                    cx.listener(move |this, _, _window, cx| {
+                                        this.thread.update(cx, |thread, cx| {
+                                            thread.cancel_tool_call_input(tool_call_id.clone(), cx);
+                                        });
+                                    })
+                                }))
+                                .child(
+                                    Button::new("submit_input", "Submit")
+                                        .style(ButtonStyle::Filled)
+                                        .on_click({
+                                            let tool_call_id = tool_call.id.clone();
+                                            cx.listener(move |this, _, _window, cx| {
+                                                let text = editor.read(cx).text(cx);
+                                                this.thread.update(cx, |thread, cx| {
+                                                    thread.submit_tool_call_input(
+                                                        tool_call_id.clone(),
+                                                        text,
+                                                        cx,
+                                                    );
+                                                });
+                                            })
+                                        }),
+                                ),
+                        )
+                        .into_any_element()
+                }
                 ToolCallStatus::WaitingForConfirmation { options, .. } => v_flex()
                     .w_full()
                     .children(

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -122,8 +122,15 @@ impl EntryViewState {
                 let terminals = tool_call.terminals().cloned().collect::<Vec<_>>();
                 let diffs = tool_call.diffs().cloned().collect::<Vec<_>>();
 
-                let views = if let Some(Entry::ToolCall(tool_call)) = self.entries.get_mut(index) {
-                    &mut tool_call.content
+                let is_waiting_for_input = matches!(
+                    tool_call.status,
+                    acp_thread::ToolCallStatus::WaitingForInput { .. }
+                );
+                let is_tool_call_completed =
+                    matches!(tool_call.status, acp_thread::ToolCallStatus::Completed);
+
+                let tool_call_entry = if let Some(Entry::ToolCall(tool_call_entry)) = self.entries.get_mut(index) {
+                    tool_call_entry
                 } else {
                     self.set_entry(
                         index,
@@ -131,14 +138,33 @@ impl EntryViewState {
                             content: HashMap::default(),
                         }),
                     );
-                    let Some(Entry::ToolCall(tool_call)) = self.entries.get_mut(index) else {
+                    let Some(Entry::ToolCall(tool_call_entry)) = self.entries.get_mut(index) else {
                         unreachable!()
                     };
-                    &mut tool_call.content
+                    tool_call_entry
                 };
 
-                let is_tool_call_completed =
-                    matches!(tool_call.status, acp_thread::ToolCallStatus::Completed);
+                if is_waiting_for_input {
+                    tool_call_entry
+                        .content
+                        .entry(ToolCallEntry::ask_user_editor_key())
+                        .or_insert_with(|| {
+                            cx.new(|cx| {
+                                let mut editor = editor::Editor::auto_height(1, 10, window, cx);
+                                editor.set_placeholder_text(
+                                    "Type your response here...",
+                                    window,
+                                    cx,
+                                );
+                                editor
+                            })
+                            .into_any()
+                        });
+                } else {
+                    tool_call_entry.remove_ask_user_input_editor();
+                }
+
+                let views = &mut tool_call_entry.content;
 
                 for terminal in terminals {
                     match views.entry(terminal.entity_id()) {
@@ -322,6 +348,25 @@ pub struct ToolCallEntry {
     content: HashMap<EntityId, AnyEntity>,
 }
 
+impl ToolCallEntry {
+    fn ask_user_editor_key() -> EntityId {
+        EntityId::from(u64::MAX)
+    }
+
+    pub fn ask_user_input_editor(&self) -> Option<Entity<editor::Editor>> {
+        self.content
+            .get(&Self::ask_user_editor_key())
+            .cloned()
+            .map(|entity| entity.downcast::<Editor>().unwrap())
+    }
+
+
+
+    fn remove_ask_user_input_editor(&mut self) {
+        self.content.remove(&Self::ask_user_editor_key());
+    }
+}
+
 #[derive(Debug)]
 pub enum Entry {
     UserMessage(Entity<MessageEditor>),
@@ -363,6 +408,13 @@ impl Entry {
             .map(|entity| entity.downcast::<TerminalView>().unwrap())
     }
 
+    pub fn ask_user_input_editor(&self) -> Option<Entity<Editor>> {
+        match self {
+            Self::ToolCall(tool_call_entry) => tool_call_entry.ask_user_input_editor(),
+            Self::UserMessage(_) | Self::AssistantMessage(_) | Self::CompletedPlan => None,
+        }
+    }
+
     pub fn scroll_handle_for_assistant_message_chunk(
         &self,
         chunk_ix: usize,
@@ -375,7 +427,7 @@ impl Entry {
 
     fn content_map(&self) -> Option<&HashMap<EntityId, AnyEntity>> {
         match self {
-            Self::ToolCall(ToolCallEntry { content }) => Some(content),
+            Self::ToolCall(ToolCallEntry { content, .. }) => Some(content),
             _ => None,
         }
     }
@@ -383,7 +435,7 @@ impl Entry {
     #[cfg(test)]
     pub fn has_content(&self) -> bool {
         match self {
-            Self::ToolCall(ToolCallEntry { content }) => !content.is_empty(),
+            Self::ToolCall(ToolCallEntry { content, .. }) => !content.is_empty(),
             Self::UserMessage(_) | Self::AssistantMessage(_) | Self::CompletedPlan => false,
         }
     }


### PR DESCRIPTION
This is a first draft of a tool that asks the user a question.

Currently, the agent's question is displayed in the title of the tool call, which gets cut off if it's too long. I'm not sure what I should do about that UX-wise, so I'm creating this as a draft PR in the hopes that someone will chime in.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments N/A
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added `ask_user` tool
