### PR TITLE
Don't save buffers by default when running tasks

### DIFF
--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -50,7 +50,7 @@
     "show_command": true,
     // Which edited buffers to save before running the task:
     // * `all` — save all edited buffers
-    // * `current` — save current buffer only
+    // * `current` — save currently active buffer only
     // * `none` — don't save any buffers
     "save": "none",
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.

--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -52,7 +52,7 @@
     // * `all` — save all edited buffers
     // * `current` — save current buffer only
     // * `none` — don't save any buffers
-    "save": "all",
+    "save": "none",
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     // "tags": []
   },

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -127,11 +127,11 @@ pub enum HideStrategy {
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SaveStrategy {
-    #[default]
     /// Save all edited buffers.
     All,
     /// Save the current buffer.
     Current,
+    #[default]
     /// Don't save any buffers.
     None,
 }

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -53,7 +53,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated [terminal](
     "show_command": true,
     // Which edited buffers to save before running the task:
     // * `all` — save all edited buffers
-    // * `current` — save current buffer only
+    // * `current` — save currently active buffer only
     // * `none` — don't save any buffers
     "save": "none"
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -55,7 +55,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated [terminal](
     // * `all` — save all edited buffers
     // * `current` — save current buffer only
     // * `none` — don't save any buffers
-    "save": "all"
+    "save": "none"
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     // "tags": []
   }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #52926
Follow-up to #48861
cc @SomeoneToIgnore

Release Notes:

- Edited buffers are no longer saved by default before running a task, but you can still configure this using the "save" field in `tasks.json`.