### PR TITLE
Add CodeLens UI

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -320,6 +320,13 @@
     // The delay in milliseconds that must elapse before drag and drop is allowed. Otherwise, a new text selection is created.
     "delay": 300,
   },
+  // Code lens settings for showing reference counts and other metadata above code elements.
+  "code_lens": {
+    // Whether code lens is enabled.
+    "enabled": false,
+    // The debounce delay in milliseconds before querying code lens from the language server.
+    "debounce": 300
+  },
   // What to do when go to definition yields no results.
   //
   // 1. Do nothing: `none`

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -835,6 +835,8 @@ actions!(
         ToggleInlayHints,
         /// Toggles semantic highlights display.
         ToggleSemanticHighlights,
+        /// Toggles code lens display.
+        ToggleCodeLens,
         /// Toggles inline values display.
         ToggleInlineValues,
         /// Toggles inline diagnostics display.

--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -1,0 +1,591 @@
+use collections::HashMap;
+use gpui::{SharedString, Task, WeakEntity};
+use language::BufferId;
+use multi_buffer::{Anchor, MultiBufferRow, MultiBufferSnapshot, ToPoint as _};
+use project::CodeAction;
+use settings::Settings as _;
+use ui::{Context, Window, div, prelude::*};
+use workspace::{Toast, notifications::NotificationId};
+
+use crate::{
+    Editor, FindAllReferences, GoToImplementation, SelectionEffects,
+    display_map::{BlockPlacement, BlockProperties, BlockStyle, CustomBlockId},
+};
+
+struct CodeLensToast;
+
+#[derive(Clone, Debug)]
+pub struct CodeLensItem {
+    pub text: SharedString,
+    pub action: Option<CodeAction>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CodeLensData {
+    pub position: Anchor,
+    pub symbol_position: Anchor,
+    pub items: Vec<CodeLensItem>,
+}
+
+#[derive(Default)]
+pub struct CodeLensCache {
+    enabled: bool,
+    lenses: HashMap<BufferId, Vec<CodeLensData>>,
+    pending_refresh: HashMap<BufferId, Task<()>>,
+    block_ids: HashMap<BufferId, Vec<CustomBlockId>>,
+}
+
+impl CodeLensCache {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            lenses: HashMap::default(),
+            pending_refresh: HashMap::default(),
+            block_ids: HashMap::default(),
+        }
+    }
+
+    pub fn toggle(&mut self, enabled: bool) -> bool {
+        if self.enabled == enabled {
+            return false;
+        }
+        self.enabled = enabled;
+        if !enabled {
+            self.clear();
+        }
+        true
+    }
+
+    pub fn clear(&mut self) {
+        self.lenses.clear();
+        self.pending_refresh.clear();
+        self.block_ids.clear();
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn set_lenses_for_buffer(&mut self, buffer_id: BufferId, lenses: Vec<CodeLensData>) {
+        self.lenses.insert(buffer_id, lenses);
+    }
+
+    pub fn set_block_ids(&mut self, buffer_id: BufferId, block_ids: Vec<CustomBlockId>) {
+        self.block_ids.insert(buffer_id, block_ids);
+    }
+
+    pub fn get_block_ids(&self, buffer_id: &BufferId) -> Option<&Vec<CustomBlockId>> {
+        self.block_ids.get(buffer_id)
+    }
+
+    pub fn all_block_ids(&self) -> Vec<CustomBlockId> {
+        self.block_ids
+            .values()
+            .flat_map(|ids| ids.iter().copied())
+            .collect()
+    }
+
+    pub fn set_refresh_task(&mut self, buffer_id: BufferId, task: Task<()>) {
+        self.pending_refresh.insert(buffer_id, task);
+    }
+
+    pub fn remove_refresh_task(&mut self, buffer_id: &BufferId) {
+        self.pending_refresh.remove(buffer_id);
+    }
+}
+
+fn group_lenses_by_row(
+    lenses: Vec<(Anchor, CodeLensItem)>,
+    snapshot: &MultiBufferSnapshot,
+) -> Vec<CodeLensData> {
+    let mut grouped: HashMap<u32, (Anchor, Vec<CodeLensItem>)> = HashMap::default();
+
+    for (position, item) in lenses {
+        let row = position.to_point(snapshot).row;
+        grouped
+            .entry(row)
+            .or_insert_with(|| (position, Vec::new()))
+            .1
+            .push(item);
+    }
+
+    let mut result: Vec<CodeLensData> = grouped
+        .into_iter()
+        .map(|(row, (symbol_position, items))| {
+            let indent = snapshot.indent_size_for_line(MultiBufferRow(row));
+            let position = snapshot.anchor_at(text::Point::new(row, indent.len), text::Bias::Left);
+            CodeLensData {
+                position,
+                symbol_position,
+                items,
+            }
+        })
+        .collect();
+
+    result.sort_by_key(|lens| lens.position.to_point(snapshot).row);
+    result
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CodeLensKind {
+    References,
+    Implementations,
+    Other,
+}
+
+fn detect_lens_kind(title: &str) -> CodeLensKind {
+    let title_lower = title.to_lowercase();
+    if title_lower.contains("reference") {
+        CodeLensKind::References
+    } else if title_lower.contains("implementation") {
+        CodeLensKind::Implementations
+    } else {
+        CodeLensKind::Other
+    }
+}
+
+fn should_hide_lens(title: &str) -> bool {
+    title.starts_with("0 ") // 0 reference or 0 implementation
+}
+
+fn render_code_lens_line(
+    lens: CodeLensData,
+    editor: WeakEntity<Editor>,
+) -> impl Fn(&mut crate::display_map::BlockContext) -> gpui::AnyElement {
+    move |cx| {
+        let mut children: Vec<gpui::AnyElement> = Vec::new();
+
+        for (i, item) in lens.items.iter().enumerate() {
+            if i > 0 {
+                children.push(
+                    div()
+                        .text_ui_xs(cx.app)
+                        .text_color(cx.app.theme().colors().text_muted)
+                        .child(" | ")
+                        .into_any_element(),
+                );
+            }
+
+            let text = item.text.clone();
+            let action = item.action.clone();
+            let editor_clone = editor.clone();
+            let position = lens.symbol_position;
+
+            children.push(
+                div()
+                    .id(SharedString::from(format!("code-lens-{}-{}", i, text)))
+                    .text_ui_xs(cx.app)
+                    .text_color(cx.app.theme().colors().text_muted)
+                    .cursor_pointer()
+                    .hover(|style| style.text_color(cx.app.theme().colors().text))
+                    .child(text.clone())
+                    .on_click({
+                        let text = text.clone();
+                        move |_event, window, cx| {
+                            let kind = detect_lens_kind(&text);
+                            if let Some(editor) = editor_clone.upgrade() {
+                                editor.update(cx, |editor, cx| {
+                                    editor.change_selections(
+                                        SelectionEffects::default(),
+                                        window,
+                                        cx,
+                                        |s| {
+                                            s.select_anchor_ranges([position..position]);
+                                        },
+                                    );
+
+                                    match kind {
+                                        CodeLensKind::References => {
+                                            if let Some(task) = editor.find_all_references(
+                                                &FindAllReferences::default(),
+                                                window,
+                                                cx,
+                                            ) {
+                                                task.detach_and_log_err(cx);
+                                            }
+                                        }
+                                        CodeLensKind::Implementations => {
+                                            editor
+                                                .go_to_implementation(
+                                                    &GoToImplementation,
+                                                    window,
+                                                    cx,
+                                                )
+                                                .detach_and_log_err(cx);
+                                        }
+                                        CodeLensKind::Other => {
+                                            if let Some(action) = &action {
+                                                if let Some(workspace) = editor.workspace() {
+                                                    let project =
+                                                        workspace.read(cx).project().clone();
+                                                    let action = action.clone();
+                                                    let buffer = editor.buffer().clone();
+                                                    if let Some(excerpt_buffer) =
+                                                        buffer.read(cx).as_singleton()
+                                                    {
+                                                        project
+                                                            .update(cx, |project, cx| {
+                                                                project.apply_code_action(
+                                                                    excerpt_buffer.clone(),
+                                                                    action,
+                                                                    true,
+                                                                    cx,
+                                                                )
+                                                            })
+                                                            .detach_and_log_err(cx);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                    })
+                    .into_any_element(),
+            );
+        }
+
+        div()
+            .size_full()
+            .pl(cx.anchor_x)
+            .flex()
+            .flex_row()
+            .items_end()
+            .children(children)
+            .into_any_element()
+    }
+}
+
+impl Editor {
+    pub fn code_lens_enabled(&self) -> bool {
+        self.code_lens_cache.enabled()
+    }
+
+    pub fn refresh_code_lenses(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.code_lens_enabled() {
+            return;
+        }
+
+        let buffer = self.buffer().read(cx);
+        let excerpt_buffer = match buffer.as_singleton() {
+            Some(b) => b,
+            None => return,
+        };
+        let buffer_id = excerpt_buffer.read(cx).remote_id();
+        let excerpt_buffer = excerpt_buffer.clone();
+
+        let Some(project) = self.project.clone() else {
+            return;
+        };
+
+        let debounce = crate::EditorSettings::get_global(cx).code_lens.debounce.0;
+        let text_range = text::Anchor::min_max_range_for_buffer(buffer_id);
+        let multibuffer = self.buffer().clone();
+
+        let task = cx.spawn_in(window, async move |editor, cx| {
+            cx.background_executor()
+                .timer(std::time::Duration::from_millis(debounce))
+                .await;
+
+            let actions_task = project.update(cx, |project, cx| {
+                project.code_lens_actions::<text::Anchor>(&excerpt_buffer, text_range.clone(), cx)
+            });
+
+            let actions: anyhow::Result<Option<Vec<CodeAction>>> = actions_task.await;
+
+            if let Err(e) = &actions {
+                log::error!("Failed to fetch code lens actions: {e:#}");
+            }
+
+            if let Ok(Some(actions)) = actions {
+                let lenses = multibuffer.update(cx, |multibuffer, cx| {
+                    let snapshot = multibuffer.snapshot(cx);
+
+                    let individual_lenses: Vec<(Anchor, CodeLensItem)> = actions
+                        .into_iter()
+                        .filter_map(|action| {
+                            let position = snapshot.anchor_in_excerpt(action.range.start)?;
+
+                            let text = match &action.lsp_action {
+                                project::LspAction::CodeLens(lens) => {
+                                    lens.command.as_ref().map(|cmd| cmd.title.clone())
+                                }
+                                _ => None,
+                            };
+
+                            text.and_then(|text| {
+                                if should_hide_lens(&text) {
+                                    None
+                                } else {
+                                    Some((
+                                        position,
+                                        CodeLensItem {
+                                            text: text.into(),
+                                            action: Some(action),
+                                        },
+                                    ))
+                                }
+                            })
+                        })
+                        .collect();
+
+                    group_lenses_by_row(individual_lenses, &snapshot)
+                });
+
+                if let Err(e) = editor.update(cx, |editor, cx| {
+                    if !editor.code_lens_cache.enabled() {
+                        return;
+                    }
+
+                    if let Some(old_block_ids) = editor.code_lens_cache.get_block_ids(&buffer_id) {
+                        editor.remove_blocks(old_block_ids.iter().copied().collect(), None, cx);
+                    }
+
+                    editor
+                        .code_lens_cache
+                        .set_lenses_for_buffer(buffer_id, lenses.clone());
+
+                    let editor_handle = cx.entity().downgrade();
+
+                    let blocks = lenses
+                        .into_iter()
+                        .map(|lens| {
+                            let position = lens.position;
+                            let render_fn = render_code_lens_line(lens, editor_handle.clone());
+                            BlockProperties {
+                                placement: BlockPlacement::Above(position),
+                                height: Some(1),
+                                style: BlockStyle::Sticky,
+                                render: std::sync::Arc::new(render_fn),
+                                priority: 0,
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    let block_ids = editor.insert_blocks(blocks, None, cx);
+                    editor.code_lens_cache.set_block_ids(buffer_id, block_ids);
+                    if let Some(workspace) = editor.workspace() {
+                        workspace.update(cx, |workspace, cx| {
+                            workspace.dismiss_notification(
+                                &NotificationId::unique::<CodeLensToast>(),
+                                cx,
+                            );
+                        });
+                    }
+                    cx.notify();
+                }) {
+                    editor
+                        .update(cx, |editor, _cx| {
+                            editor.code_lens_cache.remove_refresh_task(&buffer_id);
+                        })
+                        .ok();
+                    log::error!("Failed to update code lens blocks: {e:#}");
+                    return;
+                }
+            }
+
+            editor
+                .update(cx, |editor, cx| {
+                    editor.code_lens_cache.remove_refresh_task(&buffer_id);
+                    if let Some(workspace) = editor.workspace() {
+                        workspace.update(cx, |workspace, cx| {
+                            workspace.dismiss_notification(
+                                &NotificationId::unique::<CodeLensToast>(),
+                                cx,
+                            );
+                        });
+                    }
+                })
+                .ok();
+        });
+
+        self.code_lens_cache.set_refresh_task(buffer_id, task);
+    }
+
+    pub fn toggle_code_lenses(
+        &mut self,
+        _: &crate::actions::ToggleCodeLens,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let enabled = !self.code_lens_cache.enabled();
+        if enabled {
+            self.code_lens_cache.toggle(enabled);
+            self.refresh_code_lenses(window, cx);
+            if let Some(workspace) = self.workspace() {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.show_toast(
+                        Toast::new(
+                            NotificationId::unique::<CodeLensToast>(),
+                            "Code lens enabled, loading...",
+                        ),
+                        cx,
+                    );
+                });
+            }
+        } else {
+            let all_block_ids = self.code_lens_cache.all_block_ids();
+            self.code_lens_cache.toggle(enabled);
+            if !all_block_ids.is_empty() {
+                self.remove_blocks(all_block_ids.into_iter().collect(), None, cx);
+            }
+            if let Some(workspace) = self.workspace() {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.dismiss_notification(&NotificationId::unique::<CodeLensToast>(), cx);
+                });
+            }
+        }
+        cx.notify();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor_tests::init_test;
+    use crate::test::editor_lsp_test_context::EditorLspTestContext;
+    use gpui::TestAppContext;
+    use indoc::indoc;
+
+    #[test]
+    fn test_detect_lens_kind() {
+        assert_eq!(detect_lens_kind("3 references"), CodeLensKind::References);
+        assert_eq!(detect_lens_kind("1 reference"), CodeLensKind::References);
+        assert_eq!(
+            detect_lens_kind("2 implementations"),
+            CodeLensKind::Implementations
+        );
+        assert_eq!(
+            detect_lens_kind("1 implementation"),
+            CodeLensKind::Implementations
+        );
+        assert_eq!(detect_lens_kind("Run test"), CodeLensKind::Other);
+        assert_eq!(detect_lens_kind("Debug"), CodeLensKind::Other);
+    }
+
+    #[test]
+    fn test_should_hide_lens() {
+        assert!(should_hide_lens("0 references"));
+        assert!(should_hide_lens("0 implementations"));
+        assert!(!should_hide_lens("1 reference"));
+        assert!(!should_hide_lens("3 references"));
+        assert!(!should_hide_lens("Run test"));
+    }
+
+    #[test]
+    fn test_cache_toggle() {
+        let mut cache = CodeLensCache::new(false);
+        assert!(!cache.enabled());
+
+        cache.toggle(true);
+        assert!(cache.enabled());
+
+        cache.toggle(false);
+        assert!(!cache.enabled());
+        assert!(cache.all_block_ids().is_empty());
+    }
+
+    #[test]
+    fn test_cache_toggle_clears_state() {
+        let mut cache = CodeLensCache::new(true);
+        cache.set_lenses_for_buffer(BufferId::new(1).unwrap(), vec![]);
+        cache.set_block_ids(
+            BufferId::new(1).unwrap(),
+            vec![CustomBlockId(1)],
+        );
+
+        assert_eq!(cache.all_block_ids(), vec![CustomBlockId(1)]);
+
+        cache.toggle(false);
+        assert!(cache.all_block_ids().is_empty());
+        assert!(cache.get_block_ids(&BufferId::new(1).unwrap()).is_none());
+    }
+
+    #[test]
+    fn test_cache_all_block_ids_across_buffers() {
+        let mut cache = CodeLensCache::new(true);
+        cache.set_block_ids(
+            BufferId::new(1).unwrap(),
+            vec![CustomBlockId(1), CustomBlockId(2)],
+        );
+        cache.set_block_ids(
+            BufferId::new(2).unwrap(),
+            vec![CustomBlockId(3)],
+        );
+
+        let mut all = cache.all_block_ids();
+        all.sort_by_key(|id| id.0);
+        assert_eq!(
+            all,
+            vec![CustomBlockId(1), CustomBlockId(2), CustomBlockId(3)]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_code_lens_toggle(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let mut cx = EditorLspTestContext::new_rust(
+            lsp::ServerCapabilities {
+                code_lens_provider: Some(lsp::CodeLensOptions {
+                    resolve_provider: Some(false),
+                }),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+
+        cx.set_state(indoc! {"
+            struct Fooˇ;
+        "});
+
+        // Initially disabled
+        cx.editor(|editor, _, _cx| {
+            assert!(!editor.code_lens_enabled());
+        });
+
+        // Toggle on
+        cx.update_editor(|editor, window, cx| {
+            editor.toggle_code_lenses(&crate::actions::ToggleCodeLens, window, cx);
+            assert!(editor.code_lens_enabled());
+        });
+
+        // Toggle off
+        cx.update_editor(|editor, window, cx| {
+            editor.toggle_code_lenses(&crate::actions::ToggleCodeLens, window, cx);
+            assert!(!editor.code_lens_enabled());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_code_lens_toggle_on_off_clears_blocks(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let mut cx = EditorLspTestContext::new_rust(
+            lsp::ServerCapabilities {
+                code_lens_provider: Some(lsp::CodeLensOptions {
+                    resolve_provider: Some(false),
+                }),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+
+        cx.set_state(indoc! {"
+            fn helloˇ() {}
+        "});
+
+        // Toggle on then off - should not leave stale blocks
+        cx.update_editor(|editor, window, cx| {
+            editor.toggle_code_lenses(&crate::actions::ToggleCodeLens, window, cx);
+        });
+        cx.update_editor(|editor, window, cx| {
+            editor.toggle_code_lenses(&crate::actions::ToggleCodeLens, window, cx);
+            assert!(!editor.code_lens_enabled());
+            assert!(editor.code_lens_cache.all_block_ids().is_empty());
+        });
+    }
+}

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16,6 +16,7 @@ pub mod blink_manager;
 mod bracket_colorization;
 mod clangd_ext;
 pub mod code_context_menus;
+mod code_lens;
 pub mod display_map;
 mod document_colors;
 mod document_symbols;
@@ -1335,6 +1336,7 @@ pub struct Editor {
     use_document_folding_ranges: bool,
     refresh_folding_ranges_task: Task<()>,
     inlay_hints: Option<LspInlayHintData>,
+    code_lens_cache: code_lens::CodeLensCache,
     folding_newlines: Task<()>,
     select_next_is_case_sensitive: Option<bool>,
     pub lookup_key: Option<Box<dyn Any + Send + Sync>>,
@@ -2140,7 +2142,7 @@ impl Editor {
                 window,
                 |editor, _, event, window, cx| match event {
                     project::Event::RefreshCodeLens => {
-                        // we always query lens with actions, without storing them, always refreshing them
+                        editor.refresh_code_lenses(window, cx);
                     }
                     project::Event::RefreshInlayHints {
                         server_id,
@@ -2207,6 +2209,7 @@ impl Editor {
                             refresh_linked_ranges(editor, window, cx);
                             editor.refresh_code_actions(window, cx);
                             editor.refresh_document_highlights(cx);
+                            editor.refresh_code_lenses(window, cx);
                         }
                     }
 
@@ -2562,6 +2565,9 @@ impl Editor {
             use_document_folding_ranges: false,
             refresh_folding_ranges_task: Task::ready(()),
             inlay_hints: None,
+            code_lens_cache: code_lens::CodeLensCache::new(
+                EditorSettings::get_global(cx).code_lens.enabled,
+            ),
             next_color_inlay_id: 0,
             post_scroll_update: Task::ready(()),
             linked_edit_ranges: Default::default(),
@@ -2649,7 +2655,8 @@ impl Editor {
                                 .await;
                             editor
                                 .update_in(cx, |editor, window, cx| {
-                                    editor.update_data_on_scroll(window, cx)
+                                    editor.update_data_on_scroll(window, cx);
+                                    editor.refresh_code_lenses(window, cx);
                                 })
                                 .ok();
                         });

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -61,6 +61,7 @@ pub struct EditorSettings {
     pub completion_detail_alignment: CompletionDetailAlignment,
     pub diff_view_style: DiffViewStyle,
     pub minimum_split_diff_width: f32,
+    pub code_lens: CodeLens,
 }
 #[derive(Debug, Clone)]
 pub struct Jupyter {
@@ -73,6 +74,12 @@ pub struct Jupyter {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StickyScroll {
     pub enabled: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CodeLens {
+    pub enabled: bool,
+    pub debounce: DelayMs,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -195,6 +202,7 @@ impl Settings for EditorSettings {
         let search = editor.search.unwrap();
         let drag_and_drop_selection = editor.drag_and_drop_selection.unwrap();
         let sticky_scroll = editor.sticky_scroll.unwrap();
+        let code_lens = editor.code_lens.unwrap();
         Self {
             cursor_blink: editor.cursor_blink.unwrap(),
             cursor_shape: editor.cursor_shape.map(Into::into),
@@ -296,6 +304,10 @@ impl Settings for EditorSettings {
             completion_detail_alignment: editor.completion_detail_alignment.unwrap(),
             diff_view_style: editor.diff_view_style.unwrap(),
             minimum_split_diff_width: editor.minimum_split_diff_width.unwrap(),
+            code_lens: CodeLens {
+                enabled: code_lens.enabled.unwrap(),
+                debounce: code_lens.debounce.unwrap(),
+            },
         }
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -499,6 +499,7 @@ impl EditorElement {
         register_action(editor, window, Editor::toggle_indent_guides);
         register_action(editor, window, Editor::toggle_inlay_hints);
         register_action(editor, window, Editor::toggle_semantic_highlights);
+        register_action(editor, window, Editor::toggle_code_lenses);
         register_action(editor, window, Editor::toggle_edit_predictions);
         if editor.read(cx).diagnostics_enabled() {
             register_action(editor, window, Editor::toggle_diagnostics);

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -687,6 +687,7 @@ impl Editor {
                         editor.colorize_brackets(false, cx);
                         editor.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
                         editor.update_lsp_data(None, window, cx);
+                        editor.refresh_code_lenses(window, cx);
                     })
                     .ok();
             });

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -31,7 +31,8 @@ use util::merge_json_value_into;
 use util::rel_path::RelPath;
 use util::{ResultExt, maybe};
 
-use crate::language_settings::LanguageSettings;
+use language::language_settings::LanguageSettings;
+use project::lsp_store::language_server_settings;
 
 pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
     let content = grammars::get_file("rust/semantic_token_rules.json")
@@ -245,6 +246,55 @@ impl ManifestProvider for CargoManifestProvider {
         }
 
         outermost_cargo_toml
+    }
+}
+
+fn set_experimental_capabilities(params: &mut InitializeParams, enable_lsp_tasks: bool) {
+    let mut experimental = json!({
+        "commands": {
+            "commands": [
+                "rust-analyzer.showReferences",
+            ]
+        }
+    });
+
+    if enable_lsp_tasks {
+        merge_json_value_into(
+            json!({
+                "runnables": {
+                    "kinds": [ "cargo", "shell" ],
+                },
+            }),
+            &mut experimental,
+        );
+    }
+
+    if let Some(original_experimental) = &mut params.capabilities.experimental {
+        merge_json_value_into(experimental, original_experimental);
+    } else {
+        params.capabilities.experimental = Some(experimental);
+    }
+}
+
+fn set_initialization_options(params: &mut InitializeParams) {
+    let lens_config = json!({
+        "lens": {
+            "enable": true,
+            "implementations": { "enable": true },
+            "references": {
+                "adt": { "enable": true },
+                "adt.field": { "enable": true },
+                "enumVariant": { "enable": true },
+                "method": { "enable": true },
+                "trait": { "enable": true }
+            }
+        }
+    });
+
+    if let Some(init_options) = &mut params.initialization_options {
+        merge_json_value_into(lens_config, init_options);
+    } else {
+        params.initialization_options = Some(lens_config);
     }
 }
 
@@ -608,20 +658,50 @@ impl LspAdapter for RustLspAdapter {
             .lsp
             .get(&SERVER_NAME)
             .is_some_and(|s| s.enable_lsp_tasks);
-        if enable_lsp_tasks {
-            let experimental = json!({
-                "runnables": {
-                    "kinds": [ "cargo", "shell" ],
-                },
-            });
-            if let Some(original_experimental) = &mut original.capabilities.experimental {
-                merge_json_value_into(experimental, original_experimental);
-            } else {
-                original.capabilities.experimental = Some(experimental);
-            }
-        }
+
+        set_experimental_capabilities(&mut original, enable_lsp_tasks);
+        set_initialization_options(&mut original);
 
         Ok(original)
+    }
+
+    async fn workspace_configuration(
+        self: Arc<Self>,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        _: Option<Toolchain>,
+        _: Option<lsp::Uri>,
+        cx: &mut AsyncApp,
+    ) -> Result<serde_json::Value> {
+        let user_settings = cx.update(|cx| {
+            language_server_settings(delegate.as_ref(), &SERVER_NAME, cx)
+                .and_then(|s| s.settings.clone())
+        });
+
+        let mut default_config = serde_json::json!({
+            "lens": {
+                "enable": true,
+                "forceCustomCommands": false,
+                "run": { "enable": true },
+                "debug": { "enable": true },
+                "implementations": { "enable": true },
+                "references": {
+                    "adt": { "enable": true },
+                    "adt.field": { "enable": true },
+                    "enumVariant": { "enable": true },
+                    "method": { "enable": true },
+                    "trait": { "enable": true }
+                }
+            }
+        });
+
+        if let Some(override_settings) = user_settings {
+            merge_json_value_into(override_settings, &mut default_config);
+        }
+
+        let config = serde_json::json!({
+            "rust-analyzer": default_config
+        });
+        Ok(config)
     }
 }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1085,6 +1085,7 @@ impl LocalLspStore {
                     let mut cx = cx.clone();
                     async move {
                         this.update(&mut cx, |this, cx| {
+                            this.invalidate_code_lens_cache_for_server(server_id);
                             cx.emit(LspStoreEvent::RefreshCodeLens);
                             this.downstream_client.as_ref().map(|(client, project_id)| {
                                 client.send(proto::RefreshCodeLens {
@@ -10242,13 +10243,15 @@ impl LspStore {
         cx: &mut Context<Self>,
     ) {
         if let Some(status) = self.language_server_statuses.get_mut(&language_server_id) {
-            if let Some(work) = status.pending_work.remove(&token)
-                && !work.is_disk_based_diagnostics_progress
-            {
-                cx.emit(LspStoreEvent::RefreshInlayHints {
-                    server_id: language_server_id,
-                    request_id: None,
-                });
+            if let Some(work) = status.pending_work.remove(&token) {
+                if !work.is_disk_based_diagnostics_progress {
+                    self.invalidate_code_lens_cache_for_server(language_server_id);
+                    cx.emit(LspStoreEvent::RefreshInlayHints {
+                        server_id: language_server_id,
+                        request_id: None,
+                    });
+                    cx.emit(LspStoreEvent::RefreshCodeLens);
+                }
             }
             cx.notify();
         }
@@ -13270,6 +13273,18 @@ impl LspStore {
             lsp_data.semantic_tokens = semantic_tokens;
         }
         lsp_data
+    }
+
+    fn invalidate_code_lens_cache_for_server(&mut self, server_id: LanguageServerId) {
+        for lsp_data in self.lsp_data.values_mut() {
+            if let Some(code_lens) = &mut lsp_data.code_lens {
+                if code_lens.lens.remove(&server_id).is_some() {
+                    if code_lens.lens.is_empty() {
+                        lsp_data.code_lens = None;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/crates/project/src/lsp_store/code_lens.rs
+++ b/crates/project/src/lsp_store/code_lens.rs
@@ -7,7 +7,7 @@ use futures::{
     FutureExt as _,
     future::{Shared, join_all},
 };
-use gpui::{AppContext as _, AsyncApp, Context, Entity, Task};
+use gpui::{AsyncApp, Context, Entity, Task};
 use language::Buffer;
 use lsp::LanguageServerId;
 use rpc::{TypedEnvelope, proto};
@@ -194,10 +194,42 @@ impl LspStore {
                 Ok(Some(code_lens_actions))
             })
         } else {
+            let request_timeout = ProjectSettings::get_global(cx)
+                .global_lsp_settings
+                .get_request_timeout();
             let code_lens_actions_task =
                 self.request_multiple_lsp_locally(buffer, None::<usize>, GetCodeLens, cx);
-            cx.background_spawn(async move {
-                Ok(Some(code_lens_actions_task.await.into_iter().collect()))
+            cx.spawn(async move |lsp_store, cx| {
+                let result = code_lens_actions_task.await;
+                if result.is_empty() {
+                    return Ok(None);
+                }
+
+                let mut resolved_result: HashMap<LanguageServerId, Vec<CodeAction>> =
+                    HashMap::default();
+                for (server_id, mut actions) in result {
+                    let language_server = lsp_store.update(cx, |lsp_store, _| {
+                        lsp_store
+                            .as_local()
+                            .and_then(|local| local.language_server_for_id(server_id))
+                    })?;
+
+                    if let Some(language_server) = language_server {
+                        for action in &mut actions {
+                            if let Err(e) = super::LocalLspStore::try_resolve_code_action(
+                                &language_server,
+                                action,
+                                request_timeout,
+                            )
+                            .await
+                            {
+                                log::warn!("Failed to resolve code lens: {e:#}");
+                            }
+                        }
+                    }
+                    resolved_result.insert(server_id, actions);
+                }
+                Ok(Some(resolved_result))
             })
         }
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4294,11 +4294,11 @@ impl Project {
                     range
                         .start
                         .cmp(&code_lens_action.range.start, &snapshot)
-                        .is_ge()
+                        .is_le()
                         && range
                             .end
                             .cmp(&code_lens_action.range.end, &snapshot)
-                            .is_le()
+                            .is_ge()
                 });
             }
             Ok(code_lens_actions)

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -309,6 +309,7 @@ impl VsCodeSettings {
             completion_detail_alignment: None,
             diff_view_style: None,
             minimum_split_diff_width: None,
+            code_lens: None,
         }
     }
 

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -234,6 +234,9 @@ pub struct EditorSettingsContent {
     ///
     /// Default: 100
     pub minimum_split_diff_width: Option<f32>,
+
+    /// Code lens settings for showing reference counts and other metadata above code elements.
+    pub code_lens: Option<CodeLensContent>,
 }
 
 #[derive(
@@ -866,6 +869,21 @@ pub struct DragAndDropSelectionContent {
     ///
     /// Default: 300
     pub delay: Option<DelayMs>,
+}
+
+/// Code lens settings
+#[with_fallible_options]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+pub struct CodeLensContent {
+    /// Whether code lens is enabled.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+
+    /// The debounce delay before querying code lens from the language server.
+    ///
+    /// Default: 300
+    pub debounce: Option<DelayMs>,
 }
 
 /// When to show the minimap in the editor.


### PR DESCRIPTION
<img width="870" height="550" alt="image" src="https://github.com/user-attachments/assets/58230299-37e9-4fbd-a7f6-798e38e07bb7" />

Adds code lens support that shows reference and implementation counts. Clicking a code lens item triggers the corresponding action (Find All References Or Implementation). Currently tested with Rust-analyzer only.

- Code lens aligns to the line's indentation level
- Disabled by default - opt in via `"code_lens": { "enabled": true }` in settings or the "Toggle Code Lens" command
  - This let me test with other languages and fix any bugs
- Shows a loading toast when enabled via toggle
- Debounce configurable via `"code_lens": { "debounce": 300 }`

Closes: https://github.com/zed-industries/zed/issues/11565


Release Notes:

- Added code lens support showing reference counts, implementations, and other LSP metadata above code symbols. Disabled by default - enable via `"code_lens":
 { "enabled": true }` in settings or the "Toggle Code Lens" command.