### PR TITLE
Add dock panel overlay mode for non-reflowing panel display

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -18,7 +18,7 @@
       "ctrl-enter": "menu::SecondaryConfirm",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
       "alt-shift-enter": "menu::Restart",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "ctrl-alt-enter": ["picker::ConfirmInput", { "secondary": true }],

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -18,7 +18,7 @@
       "ctrl-enter": "menu::SecondaryConfirm",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "escape": "project_panel::Dismiss",
+      "escape": "menu::Cancel",
       "alt-shift-enter": "menu::Restart",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "ctrl-alt-enter": ["picker::ConfirmInput", { "secondary": true }],
@@ -948,7 +948,7 @@
       "ctrl-alt-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -30,7 +30,7 @@
       "cmd-escape": "menu::Cancel",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "escape": "project_panel::Dismiss",
+      "escape": "menu::Cancel",
       "alt-shift-enter": "menu::Restart",
       "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
@@ -306,7 +306,7 @@
     "context": "AgentFeedbackMessageEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
       "enter": "menu::Confirm",
       "alt-enter": "editor::Newline",
     },
@@ -1002,7 +1002,7 @@
       "cmd-alt-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -30,7 +30,7 @@
       "cmd-escape": "menu::Cancel",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
       "alt-shift-enter": "menu::Restart",
       "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -688,7 +688,7 @@
       "cmd-7": ["workspace::ActivatePane", 6],
       "cmd-8": ["workspace::ActivatePane", 7],
       "cmd-9": ["workspace::ActivatePane", 8],
-      "cmd-b": "workspace::ToggleLeftDock",
+      "cmd-b": "project_panel::Toggle",
       "cmd-alt-b": "workspace::ToggleRightDock",
       "cmd-r": "workspace::ToggleRightDock",
       "cmd-j": "workspace::ToggleBottomDock",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -18,7 +18,7 @@
       "enter": "menu::Confirm",
       "ctrl-enter": "menu::SecondaryConfirm",
       "ctrl-c": "menu::Cancel",
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
       "shift-alt-enter": "menu::Restart",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "ctrl-alt-enter": ["picker::ConfirmInput", { "secondary": true }],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -18,7 +18,7 @@
       "enter": "menu::Confirm",
       "ctrl-enter": "menu::SecondaryConfirm",
       "ctrl-c": "menu::Cancel",
-      "escape": "project_panel::Dismiss",
+      "escape": "menu::Cancel",
       "shift-alt-enter": "menu::Restart",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "ctrl-alt-enter": ["picker::ConfirmInput", { "secondary": true }],
@@ -940,7 +940,7 @@
       "ctrl-k ctrl-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
-      "escape": "menu::Cancel",
+      "escape": "project_panel::Dismiss",
     },
   },
   {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -91,6 +91,13 @@
   // 1. "push" keeps the current Zed behavior where docks participate in layout.
   // 2. "overlay" renders dock panels above the workspace instead of reflowing it.
   "dock_panel_mode": "push",
+  // Optional per-panel dock mode overrides keyed by each panel's internal panel key.
+  // Example:
+  // "dock_panel_modes": {
+  //   "ProjectPanel": "overlay",
+  //   "OutlinePanel": "push",
+  //   "TerminalPanel": "overlay"
+  // },
   // The direction that you want to split panes horizontally. Defaults to "down"
   "pane_split_direction_horizontal": "down",
   // The direction that you want to split panes vertically. Defaults to "right"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -87,6 +87,10 @@
   // Layout mode of the bottom dock. Defaults to "contained"
   //   choices: contained, full, left_aligned, right_aligned
   "bottom_dock_layout": "contained",
+  // How dock-backed panels are rendered.
+  // 1. "push" keeps the current Zed behavior where docks participate in layout.
+  // 2. "overlay" renders dock panels above the workspace instead of reflowing it.
+  "dock_panel_mode": "push",
   // The direction that you want to split panes horizontally. Defaults to "down"
   "pane_split_direction_horizontal": "down",
   // The direction that you want to split panes vertically. Defaults to "right"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -92,6 +92,8 @@
   // 2. "overlay" renders dock panels above the workspace instead of reflowing it.
   "dock_panel_mode": "push",
   // Optional per-panel dock mode overrides keyed by each panel's internal panel key.
+  // Panels not listed here fall back to `dock_panel_mode`.
+  // Valid override values are "push" and "overlay".
   // Example:
   // "dock_panel_modes": {
   //   "ProjectPanel": "overlay",

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2011,10 +2011,10 @@ impl ProjectPanel {
         }
 
         if let Some(workspace) = self.workspace.upgrade()
-            && workspace.read(cx).project_panel_overlay_visible(cx)
+            && workspace.read(cx).panel_is_overlay_visible::<ProjectPanel>(cx)
         {
             workspace.update(cx, |workspace, cx| {
-                workspace.dismiss_project_panel_overlay(window, cx);
+                workspace.dismiss_panel_overlay::<ProjectPanel>(window, cx);
             });
             return;
         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -399,6 +399,8 @@ actions!(
         SelectPrevDirectory,
         /// Opens a diff view to compare two marked files.
         CompareMarkedFiles,
+        /// Dismisses the project panel when it is active.
+        Dismiss,
         /// Undoes the last file operation.
         Undo,
     ]
@@ -1999,6 +2001,8 @@ impl ProjectPanel {
         if cx.stop_active_drag(window) {
             self.drag_target_entry.take();
             self.hover_expand_task.take();
+            window.prevent_default();
+            cx.stop_propagation();
             return;
         }
 
@@ -2007,15 +2011,21 @@ impl ProjectPanel {
             cx.notify();
             self.discard_edit_state(window, cx);
             window.focus(&self.focus_handle, cx);
+            window.prevent_default();
+            cx.stop_propagation();
             return;
         }
 
         if let Some(workspace) = self.workspace.upgrade()
             && workspace.read(cx).panel_is_overlay_visible::<ProjectPanel>(cx)
         {
-            workspace.update(cx, |workspace, cx| {
-                workspace.dismiss_panel_overlay::<ProjectPanel>(window, cx);
+            window.defer(cx, move |window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.dismiss_panel_overlay::<ProjectPanel>(window, cx);
+                });
             });
+            window.prevent_default();
+            cx.stop_propagation();
             return;
         }
 
@@ -2023,6 +2033,12 @@ impl ProjectPanel {
         cx.notify();
         self.discard_edit_state(window, cx);
         window.focus(&self.focus_handle, cx);
+        window.prevent_default();
+        cx.stop_propagation();
+    }
+
+    fn dismiss(&mut self, _: &Dismiss, window: &mut Window, cx: &mut Context<Self>) {
+        self.cancel(&menu::Cancel, window, cx);
     }
 
     fn open_entry(
@@ -6646,6 +6662,7 @@ impl Render for ProjectPanel {
                 .on_action(cx.listener(Self::open_split_vertical))
                 .on_action(cx.listener(Self::open_split_horizontal))
                 .on_action(cx.listener(Self::confirm))
+                .on_action(cx.listener(Self::dismiss))
                 .on_action(cx.listener(Self::cancel))
                 .on_action(cx.listener(Self::copy_path))
                 .on_action(cx.listener(Self::copy_relative_path))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -456,9 +456,7 @@ pub fn init(cx: &mut App) {
             workspace.toggle_panel_focus::<ProjectPanel>(window, cx);
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if !workspace.toggle_panel_focus::<ProjectPanel>(window, cx) {
-                workspace.close_panel::<ProjectPanel>(window, cx);
-            }
+            workspace.toggle_panel_visibility::<ProjectPanel>(window, cx);
         });
 
         workspace.register_action(|workspace, _: &ToggleHideGitIgnore, _, cx| {
@@ -2003,6 +2001,24 @@ impl ProjectPanel {
             self.hover_expand_task.take();
             return;
         }
+
+        if self.state.edit_state.is_some() {
+            self.marked_entries.clear();
+            cx.notify();
+            self.discard_edit_state(window, cx);
+            window.focus(&self.focus_handle, cx);
+            return;
+        }
+
+        if let Some(workspace) = self.workspace.upgrade()
+            && workspace.read(cx).project_panel_overlay_visible(cx)
+        {
+            workspace.update(cx, |workspace, cx| {
+                workspace.dismiss_project_panel_overlay(window, cx);
+            });
+            return;
+        }
+
         self.marked_entries.clear();
         cx.notify();
         self.discard_edit_state(window, cx);
@@ -7224,7 +7240,7 @@ impl Panel for ProjectPanel {
     }
 
     fn toggle_action(&self) -> Box<dyn Action> {
-        Box::new(ToggleFocus)
+        Box::new(Toggle)
     }
 
     fn persistent_name() -> &'static str {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10568,6 +10568,61 @@ async fn run_create_file_in_folded_path_case(
     }
 }
 
+#[gpui::test]
+async fn test_dismiss_closes_project_panel_overlay(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+    enable_overlay_dock_panel_mode(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project_root",
+        json!({
+            "dir": {
+                "file.txt": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/project_root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = ProjectPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.open_panel::<ProjectPanel>(window, cx);
+        workspace.focus_panel::<ProjectPanel>(window, cx);
+    });
+    cx.run_until_parked();
+
+    select_path(&panel, "project_root/dir", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        window.focus(&panel.focus_handle(cx), cx);
+    });
+    cx.run_until_parked();
+
+    workspace.update_in(cx, |workspace, _window, cx| {
+        assert!(workspace.is_panel_visible::<ProjectPanel>(cx));
+    });
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.dismiss(&Dismiss, window, cx);
+    });
+    cx.run_until_parked();
+
+    workspace.update_in(cx, |workspace, _window, cx| {
+        assert!(!workspace.is_panel_visible::<ProjectPanel>(cx));
+    });
+}
+
 pub(crate) fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);
@@ -10603,6 +10658,14 @@ fn init_test_with_editor(cx: &mut TestAppContext) {
                     .auto_fold_dirs = Some(false);
                 settings.project.worktree.file_scan_exclusions = Some(Vec::new())
             });
+        });
+    });
+}
+
+fn enable_overlay_dock_panel_mode(cx: &mut TestAppContext) {
+    cx.update_global::<SettingsStore, _>(|store, cx| {
+        store.update_user_settings(cx, |settings| {
+            settings.workspace.dock_panel_mode = Some(settings::DockPanelMode::Overlay);
         });
     });
 }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10623,6 +10623,40 @@ async fn test_dismiss_closes_project_panel_overlay(cx: &mut gpui::TestAppContext
     });
 }
 
+#[gpui::test]
+async fn test_escape_binding_routes_to_project_panel_dismiss(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+    enable_overlay_dock_panel_mode(cx);
+    load_default_keymap(cx);
+    cx.update(|cx| {
+        let input = [gpui::Keystroke::parse("escape").unwrap()];
+
+        let mut project_panel_context = gpui::KeyContext::new_with_defaults();
+        project_panel_context.add("ProjectPanel");
+        project_panel_context.add("menu");
+        project_panel_context.add("not_editing");
+
+        let mut default_context = gpui::KeyContext::new_with_defaults();
+        default_context.add("menu");
+
+        let keymap = cx.key_bindings();
+        let keymap = keymap.borrow();
+
+        let (project_panel_bindings, _) =
+            keymap.bindings_for_input(&input, &[project_panel_context]);
+        assert_eq!(
+            project_panel_bindings.first().map(|binding| binding.action().name()),
+            Some("project_panel::Dismiss"),
+        );
+
+        let (default_bindings, _) = keymap.bindings_for_input(&input, &[default_context]);
+        assert_eq!(
+            default_bindings.first().map(|binding| binding.action().name()),
+            Some("menu::Cancel"),
+        );
+    });
+}
+
 pub(crate) fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);
@@ -10667,6 +10701,18 @@ fn enable_overlay_dock_panel_mode(cx: &mut TestAppContext) {
         store.update_user_settings(cx, |settings| {
             settings.workspace.dock_panel_mode = Some(settings::DockPanelMode::Overlay);
         });
+    });
+}
+
+fn load_default_keymap(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        cx.bind_keys(
+            settings::KeymapFile::load_asset_allow_partial_failure(
+                settings::DEFAULT_KEYMAP_PATH,
+                cx,
+            )
+            .expect("failed to load default keymap"),
+        );
     });
 }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -974,6 +974,7 @@ impl VsCodeSettings {
             }),
             bottom_dock_layout: None,
             dock_panel_mode: None,
+            dock_panel_modes: None,
             centered_layout: None,
             close_on_file_delete: None,
             close_panel_on_toggle: None,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -973,6 +973,7 @@ impl VsCodeSettings {
                 _ => None,
             }),
             bottom_dock_layout: None,
+            dock_panel_mode: None,
             centered_layout: None,
             close_on_file_delete: None,
             close_panel_on_toggle: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -23,6 +23,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: contained
     pub bottom_dock_layout: Option<BottomDockLayout>,
+    /// How dock-backed panels are rendered.
+    ///
+    /// Default: push
+    pub dock_panel_mode: Option<DockPanelMode>,
     /// Direction to split horizontally.
     ///
     /// Default: "up"
@@ -321,6 +325,29 @@ pub enum BottomDockLayout {
     LeftAligned,
     /// Extends under the right dock while snapping to the left dock
     RightAligned,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum DockPanelMode {
+    /// Docks participate in workspace layout and reflow the center panes.
+    #[default]
+    Push,
+    /// Docks render above the workspace instead of participating in layout.
+    Overlay,
 }
 
 #[derive(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -27,6 +27,12 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: push
     pub dock_panel_mode: Option<DockPanelMode>,
+    /// Optional per-panel overrides for dock-backed panel rendering, keyed by `Panel::panel_key()`.
+    ///
+    /// Example keys include `ProjectPanel`, `OutlinePanel`, and `TerminalPanel`.
+    ///
+    /// Default: none
+    pub dock_panel_modes: Option<HashMap<String, DockPanelMode>>,
     /// Direction to split horizontally.
     ///
     /// Default: "up"

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1179,20 +1179,24 @@ impl Render for PanelButtons {
                 let workspace_for_menu = workspace.clone();
 
                 let is_active_button = Some(i) == active_index && is_open;
+                let is_project_panel_button = entry.panel.panel_key() == super::PROJECT_PANEL_KEY;
                 let (action, tooltip) = if is_active_button {
-                    let action = dock.toggle_action();
+                    if is_project_panel_button {
+                        let action = entry.panel.toggle_action(window, cx);
+                        (action, icon_tooltip.into())
+                    } else {
+                        let action = dock.toggle_action();
 
-                    let tooltip: SharedString =
-                        format!("Close {} Dock", dock.position.label()).into();
+                        let tooltip: SharedString =
+                            format!("Close {} Dock", dock.position.label()).into();
 
-                    (action, tooltip)
+                        (action, tooltip)
+                    }
                 } else {
                     let action = entry.panel.toggle_action(window, cx);
 
                     (action, icon_tooltip.into())
                 };
-
-                let focus_handle = dock.focus_handle(cx);
                 let icon_label = entry.panel.icon_label(window, cx);
 
                 Some(
@@ -1289,7 +1293,9 @@ impl Render for PanelButtons {
                                 .on_click({
                                     let action = action.boxed_clone();
                                     move |_, window, cx| {
-                                        window.focus(&focus_handle, cx);
+                                        // The project panel overlay keeps the underlying dock out of
+                                        // the rendered tree, so dispatch from the current focus
+                                        // instead of forcing focus onto the dock first.
                                         window.dispatch_action(action.boxed_clone(), cx)
                                     }
                                 })

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1293,8 +1293,8 @@ impl Render for PanelButtons {
                                 .on_click({
                                     let action = action.boxed_clone();
                                     move |_, window, cx| {
-                                        // The project panel overlay keeps the underlying dock out of
-                                        // the rendered tree, so dispatch from the current focus
+                                        // Overlay-mode docks keep the underlying dock out of the
+                                        // normal layout tree, so dispatch from the current focus
                                         // instead of forcing focus onto the dock first.
                                         window.dispatch_action(action.boxed_clone(), cx)
                                     }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1179,19 +1179,13 @@ impl Render for PanelButtons {
                 let workspace_for_menu = workspace.clone();
 
                 let is_active_button = Some(i) == active_index && is_open;
-                let is_project_panel_button = entry.panel.panel_key() == super::PROJECT_PANEL_KEY;
                 let (action, tooltip) = if is_active_button {
-                    if is_project_panel_button {
-                        let action = entry.panel.toggle_action(window, cx);
-                        (action, icon_tooltip.into())
-                    } else {
-                        let action = dock.toggle_action();
+                    let action = dock.toggle_action();
 
-                        let tooltip: SharedString =
-                            format!("Close {} Dock", dock.position.label()).into();
+                    let tooltip: SharedString =
+                        format!("Close {} Dock", dock.position.label()).into();
 
-                        (action, tooltip)
-                    }
+                    (action, tooltip)
                 } else {
                     let action = entry.panel.toggle_action(window, cx);
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4328,6 +4328,14 @@ impl Workspace {
             .any(|(position, dock)| self.dock_renders_as_overlay(position, &dock, cx))
     }
 
+    pub fn panel_is_overlay_visible<T: Panel>(&self, cx: &App) -> bool {
+        self.visible_overlay_docks(cx).into_iter().any(|(_, dock)| {
+            dock.read(cx)
+                .visible_panel()
+                .is_some_and(|panel| panel.panel_key() == T::panel_key())
+        })
+    }
+
     pub fn dismiss_overlay_docks(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let overlay_docks = self.visible_overlay_docks(cx);
         if overlay_docks.is_empty() {
@@ -4338,6 +4346,19 @@ impl Workspace {
             dock.update(cx, |dock, cx| dock.set_open(false, window, cx));
         }
         self.restore_overlay_focus(window, cx);
+        self.serialize_workspace(window, cx);
+        cx.notify();
+    }
+
+    pub fn dismiss_panel_overlay<T: Panel>(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.panel_is_overlay_visible::<T>(cx) {
+            return;
+        }
+
+        self.close_panel::<T>(window, cx);
+        if !self.overlay_docks_visible(cx) {
+            self.restore_overlay_focus(window, cx);
+        }
         self.serialize_workspace(window, cx);
         cx.notify();
     }
@@ -12569,6 +12590,53 @@ mod tests {
 
             let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
             assert!(pane_focus.contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn dismiss_panel_overlay_closes_only_target_overlay(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(TestItem::new);
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let bottom_panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 50, cx));
+            workspace.add_panel(bottom_panel, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+            workspace.toggle_dock(DockPosition::Bottom, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.panel_is_overlay_visible::<TestProjectPanel>(cx));
+            assert!(workspace.bottom_dock().read(cx).is_open());
+
+            workspace.dismiss_panel_overlay::<TestProjectPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, _window, cx| {
+            assert!(!workspace.panel_is_overlay_visible::<TestProjectPanel>(cx));
+            assert!(!workspace.left_dock().read(cx).is_open());
+            assert!(workspace.bottom_dock().read(cx).is_open());
+            assert!(workspace.overlay_docks_visible(cx));
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4378,7 +4378,7 @@ impl Workspace {
     }
 
     fn dock_panel_mode(&self, cx: &App) -> DockPanelMode {
-        WorkspaceSettings::get_global(cx).dock_panel_mode
+        WorkspaceSettings::get_global(cx).fallback_dock_panel_mode()
     }
 
     fn dock_renders_as_overlay(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -12331,6 +12331,70 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn switching_panels_while_project_panel_overlay_open_works(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |multi_workspace, _| {
+            multi_workspace.workspace().clone()
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.register_action(|workspace, _: &dock::test::ToggleTestPanel, window, cx| {
+                workspace.toggle_panel_focus::<TestPanel>(window, cx);
+            });
+
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let other_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 50, cx));
+            workspace.add_panel(other_panel, window, cx);
+
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.project_panel_overlay_visible(cx));
+            window.dispatch_action(Box::new(dock::test::ToggleTestPanel), cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let visible_panel_key = workspace
+                .left_dock()
+                .read(cx)
+                .visible_panel()
+                .map(|panel| panel.panel_key().to_string());
+            let active_panel_key = workspace
+                .left_dock()
+                .read(cx)
+                .active_panel()
+                .map(|panel| panel.panel_key().to_string());
+            assert!(
+                !workspace.project_panel_overlay_visible(cx),
+                "Project overlay should close when another left-dock panel is activated. visible={visible_panel_key:?} active={active_panel_key:?}"
+            );
+
+            let visible_panel = workspace
+                .left_dock()
+                .read(cx)
+                .visible_panel()
+                .expect("left dock should have a visible panel");
+            assert_eq!(visible_panel.panel_key(), TestPanel::panel_key());
+            assert!(workspace.left_dock().read(cx).is_open());
+
+            let other_panel = workspace.panel::<TestPanel>(cx).expect("test panel exists");
+            assert!(other_panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
     async fn test_close_panel_on_toggle(cx: &mut gpui::TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -150,7 +150,8 @@ use util::{
 };
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, FocusFollowsMouse, RestoreOnStartupBehavior,
+    AutosaveSetting, BottomDockLayout, DockPanelMode, FocusFollowsMouse,
+    RestoreOnStartupBehavior,
     StatusBarSettings, TabBarSettings, WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
@@ -7584,6 +7585,10 @@ impl Workspace {
         }
 
         Some(container)
+    }
+
+    fn dock_panel_mode(&self, cx: &App) -> DockPanelMode {
+        WorkspaceSettings::get_global(cx).dock_panel_mode
     }
 
     fn render_project_panel_overlay(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -60,8 +60,7 @@ use gpui::{
     Context, CursorStyle, Decorations, DragMoveEvent, Entity, EntityId, EventEmitter, FocusHandle,
     Focusable, Global, HitboxBehavior, Hsla, KeyContext, Keystroke, ManagedView, MouseButton,
     PathPromptOptions, Point, PromptLevel, Render, ResizeEdge, Size, Stateful, Subscription,
-    StyleRefinement, SystemWindowTabController, Task, Tiling, WeakEntity, WindowBounds,
-    WindowHandle, WindowId,
+    SystemWindowTabController, Task, Tiling, WeakEntity, WindowBounds, WindowHandle, WindowId,
     WindowOptions, actions, canvas, point, relative, size, transparent_black,
 };
 pub use history_manager::*;
@@ -1373,7 +1372,7 @@ pub struct Workspace {
     open_in_dev_container: bool,
     _dev_container_task: Option<Task<Result<()>>>,
     _panels_task: Option<Task<Result<()>>>,
-    project_panel_previous_focus: Option<FocusHandle>,
+    overlay_dock_previous_focus: Option<FocusHandle>,
     sidebar_focus_handle: Option<FocusHandle>,
     multi_workspace: Option<WeakEntity<MultiWorkspace>>,
 }
@@ -1803,7 +1802,7 @@ impl Workspace {
             scheduled_tasks: Vec::new(),
             last_open_dock_positions: Vec::new(),
             removing: false,
-            project_panel_previous_focus: None,
+            overlay_dock_previous_focus: None,
             sidebar_focus_handle: None,
             multi_workspace,
             open_in_dev_container: false,
@@ -3966,6 +3965,9 @@ impl Workspace {
         }
         if was_visible {
             self.save_open_dock_positions(cx);
+        } else if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
+        {
+            self.overlay_dock_previous_focus = window.focused(cx);
         }
 
         let dock = self.dock_at_position(dock_side);
@@ -4002,7 +4004,12 @@ impl Workspace {
             self.dismiss_zoomed_items_to_reveal(Some(dock_side), window, cx);
         }
 
-        if focus_center {
+        if self.dock_panel_mode(cx) == DockPanelMode::Overlay
+            && was_visible
+            && !self.overlay_docks_visible(cx)
+        {
+            self.restore_overlay_focus(window, cx);
+        } else if focus_center {
             self.active_pane
                 .update(cx, |pane, cx| window.focus(&pane.focus_handle(cx), cx))
         }
@@ -4023,6 +4030,10 @@ impl Workspace {
             dock.update(cx, |dock, cx| {
                 dock.set_open(false, window, cx);
             });
+            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
+            {
+                self.restore_overlay_focus(window, cx);
+            }
             return true;
         }
         false
@@ -4030,13 +4041,19 @@ impl Workspace {
 
     pub fn close_all_docks(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.save_open_dock_positions(cx);
+        let had_overlay_docks =
+            self.dock_panel_mode(cx) == DockPanelMode::Overlay && self.overlay_docks_visible(cx);
         for dock in self.all_docks() {
             dock.update(cx, |dock, cx| {
                 dock.set_open(false, window, cx);
             });
         }
 
-        cx.focus_self(window);
+        if had_overlay_docks {
+            self.restore_overlay_focus(window, cx);
+        } else {
+            cx.focus_self(window);
+        }
         cx.notify();
         self.serialize_workspace(window, cx);
     }
@@ -4108,6 +4125,13 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Entity<T>> {
+        if self.dock_panel_mode(cx) == DockPanelMode::Overlay
+            && !self.is_panel_visible::<T>(cx)
+            && !self.overlay_docks_visible(cx)
+        {
+            self.overlay_dock_previous_focus = window.focused(cx);
+        }
+
         let panel = self.focus_or_unfocus_panel::<T>(window, cx, &mut |_, _, _| true)?;
         panel.to_any().downcast().ok()
     }
@@ -4121,6 +4145,13 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
+        if self.dock_panel_mode(cx) == DockPanelMode::Overlay
+            && !self.is_panel_visible::<T>(cx)
+            && !self.overlay_docks_visible(cx)
+        {
+            self.overlay_dock_previous_focus = window.focused(cx);
+        }
+
         let mut did_focus_panel = false;
         self.focus_or_unfocus_panel::<T>(window, cx, &mut |panel, window, cx| {
             did_focus_panel = !panel.panel_focus_handle(cx).contains_focused(window, cx);
@@ -4129,6 +4160,10 @@ impl Workspace {
 
         if !did_focus_panel && WorkspaceSettings::get_global(cx).close_panel_on_toggle {
             self.close_panel::<T>(window, cx);
+            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
+            {
+                self.restore_overlay_focus(window, cx);
+            }
         }
 
         telemetry::event!(
@@ -4157,13 +4192,15 @@ impl Workspace {
     ) -> bool {
         if self.is_panel_visible::<T>(cx) {
             self.close_panel::<T>(window, cx);
-            if T::panel_key() == PROJECT_PANEL_KEY {
-                self.restore_project_panel_focus(window, cx);
+            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
+            {
+                self.restore_overlay_focus(window, cx);
             }
             false
         } else {
-            if T::panel_key() == PROJECT_PANEL_KEY {
-                self.project_panel_previous_focus = window.focused(cx);
+            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
+            {
+                self.overlay_dock_previous_focus = window.focused(cx);
             }
             self.open_panel::<T>(window, cx);
             self.focus_panel::<T>(window, cx);
@@ -4284,17 +4321,22 @@ impl Workspace {
         }
     }
 
-    pub fn project_panel_overlay_visible(&self, cx: &App) -> bool {
-        self.project_panel_overlay_dock(cx).is_some()
+    pub fn overlay_docks_visible(&self, cx: &App) -> bool {
+        self.positioned_docks()
+            .into_iter()
+            .any(|(position, dock)| self.dock_renders_as_overlay(position, &dock, cx))
     }
 
-    pub fn dismiss_project_panel_overlay(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some((_, dock)) = self.project_panel_overlay_dock(cx) else {
+    pub fn dismiss_overlay_docks(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let overlay_docks = self.visible_overlay_docks(cx);
+        if overlay_docks.is_empty() {
             return;
-        };
+        }
 
-        dock.update(cx, |dock, cx| dock.set_open(false, window, cx));
-        self.restore_project_panel_focus(window, cx);
+        for (_, dock) in overlay_docks {
+            dock.update(cx, |dock, cx| dock.set_open(false, window, cx));
+        }
+        self.restore_overlay_focus(window, cx);
         self.serialize_workspace(window, cx);
         cx.notify();
     }
@@ -4305,23 +4347,39 @@ impl Workspace {
             .find_map(|dock| dock.read(cx).panel::<T>())
     }
 
-    fn project_panel_overlay_dock(&self, cx: &App) -> Option<(DockPosition, Entity<Dock>)> {
+    fn positioned_docks(&self) -> [(DockPosition, Entity<Dock>); 3] {
         [
             (DockPosition::Left, self.left_dock.clone()),
+            (DockPosition::Bottom, self.bottom_dock.clone()),
             (DockPosition::Right, self.right_dock.clone()),
         ]
-        .into_iter()
-        .find(|(_, dock)| {
-            let dock = dock.read(cx);
-            dock.is_open()
-                && dock
-                    .visible_panel()
-                    .is_some_and(|panel| panel.panel_key() == PROJECT_PANEL_KEY)
-        })
     }
 
-    fn restore_project_panel_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(previous_focus) = self.project_panel_previous_focus.take() {
+    fn dock_panel_mode(&self, cx: &App) -> DockPanelMode {
+        WorkspaceSettings::get_global(cx).dock_panel_mode
+    }
+
+    fn dock_renders_as_overlay(
+        &self,
+        position: DockPosition,
+        dock: &Entity<Dock>,
+        cx: &App,
+    ) -> bool {
+        self.dock_panel_mode(cx) == DockPanelMode::Overlay
+            && self.zoomed_position != Some(position)
+            && dock.read(cx).is_open()
+            && dock.read(cx).visible_panel().is_some()
+    }
+
+    fn visible_overlay_docks(&self, cx: &App) -> Vec<(DockPosition, Entity<Dock>)> {
+        self.positioned_docks()
+            .into_iter()
+            .filter(|(position, dock)| self.dock_renders_as_overlay(*position, dock, cx))
+            .collect()
+    }
+
+    fn restore_overlay_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(previous_focus) = self.overlay_dock_previous_focus.take() {
             previous_focus.focus(window, cx);
             if previous_focus.contains_focused(window, cx) {
                 return;
@@ -7527,12 +7585,7 @@ impl Workspace {
             return None;
         }
 
-        if dock.read(cx).is_open()
-            && dock
-                .read(cx)
-                .visible_panel()
-                .is_some_and(|panel| panel.panel_key() == PROJECT_PANEL_KEY)
-        {
+        if self.dock_renders_as_overlay(position, dock, cx) {
             return None;
         }
 
@@ -7587,39 +7640,31 @@ impl Workspace {
         Some(container)
     }
 
-    fn render_project_panel_overlay(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Option<Div> {
-        let (position, dock) = self.project_panel_overlay_dock(cx)?;
-        let (panel, size) = {
-            let dock = dock.read(cx);
-            (dock.visible_panel()?.clone(), dock.active_panel_size(window, cx)?)
-        };
+    fn render_overlay_docks(&self, _window: &mut Window, cx: &mut Context<Self>) -> Option<Div> {
+        let overlay_docks = self.visible_overlay_docks(cx);
+        if overlay_docks.is_empty() {
+            return None;
+        }
 
-        let panel = div()
-            .id("project-panel-overlay")
-            .absolute()
-            .top_0()
-            .bottom_0()
-            .w(size)
-            .overflow_hidden()
-            .bg(cx.theme().colors().panel_background)
-            .border_color(cx.theme().colors().border)
-            .child(
-                panel
-                    .to_any()
-                    .cached(StyleRefinement::default().v_flex().size_full()),
-            )
-            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                cx.stop_propagation();
-            })
-            .map(|this| match position {
-                DockPosition::Left => this.left_0().border_r_1(),
-                DockPosition::Right => this.right_0().border_l_1(),
-                DockPosition::Bottom => this,
-            });
+        let overlays = overlay_docks.into_iter().map(|(position, dock)| {
+            div()
+                .id(match position {
+                    DockPosition::Left => "left-dock-overlay",
+                    DockPosition::Bottom => "bottom-dock-overlay",
+                    DockPosition::Right => "right-dock-overlay",
+                })
+                .absolute()
+                .overflow_hidden()
+                .child(dock)
+                .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                    cx.stop_propagation();
+                })
+                .map(|this| match position {
+                    DockPosition::Left => this.top_0().bottom_0().left_0(),
+                    DockPosition::Right => this.top_0().bottom_0().right_0(),
+                    DockPosition::Bottom => this.left_0().right_0().bottom_0(),
+                })
+        });
 
         Some(
             div()
@@ -7636,11 +7681,11 @@ impl Workspace {
                         .on_mouse_down(
                             MouseButton::Left,
                             cx.listener(|workspace, _, window, cx| {
-                                workspace.dismiss_project_panel_overlay(window, cx);
+                                workspace.dismiss_overlay_docks(window, cx);
                             }),
                         ),
                 )
-                .child(panel),
+                .children(overlays),
         )
     }
 
@@ -8662,7 +8707,7 @@ impl Render for Workspace {
                                         }
                                     })
                                 }))
-                                .children(self.render_project_panel_overlay(window, cx))
+                                .children(self.render_overlay_docks(window, cx))
                                 .children(self.render_notifications(window, cx)),
                         )
                         .when(self.status_bar_visible(cx), |parent| {
@@ -12195,6 +12240,7 @@ mod tests {
         cx: &mut gpui::TestAppContext,
     ) {
         init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
 
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, [], cx).await;
@@ -12241,10 +12287,62 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn toggle_bottom_dock_overlay_does_not_reflow_workspace(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let window = cx.windows().into_iter().next().unwrap();
+        let cx = &mut VisualTestContext::from_window(window, cx);
+
+        let item = cx.new(TestItem::new);
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 50, cx));
+            workspace.add_panel(panel, window, cx);
+        });
+        cx.run_until_parked();
+
+        let center_bounds_before = cx.debug_bounds("workspace-center").unwrap();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_dock(DockPosition::Bottom, window, cx);
+        });
+        cx.run_until_parked();
+
+        let center_bounds_after_open = cx.debug_bounds("workspace-center").unwrap();
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.bottom_dock().read(cx).is_open());
+            assert!(
+                workspace
+                    .render_dock(DockPosition::Bottom, workspace.bottom_dock(), window, cx)
+                    .is_none()
+            );
+        });
+        assert_eq!(center_bounds_before.size, center_bounds_after_open.size);
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_dock(DockPosition::Bottom, window, cx);
+        });
+        cx.run_until_parked();
+
+        let center_bounds_after_close = cx.debug_bounds("workspace-center").unwrap();
+        assert_eq!(center_bounds_before.size, center_bounds_after_close.size);
+    }
+
+    #[gpui::test]
     async fn toggle_project_panel_overlay_moves_and_restores_focus(
         cx: &mut gpui::TestAppContext,
     ) {
         init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
 
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, [], cx).await;
@@ -12287,10 +12385,58 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn toggle_left_dock_overlay_moves_and_restores_focus(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(TestItem::new);
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 50, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+
+            workspace.toggle_panel_focus::<TestPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.left_dock().read(cx).is_open());
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_dock(DockPosition::Left, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(!workspace.left_dock().read(cx).is_open());
+
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            assert!(pane_focus.contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
     async fn dismiss_project_panel_overlay_closes_and_restores_focus(
         cx: &mut gpui::TestAppContext,
     ) {
         init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
 
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, [], cx).await;
@@ -12316,14 +12462,14 @@ mod tests {
         });
 
         workspace.update_in(cx, |workspace, window, cx| {
-            assert!(workspace.project_panel_overlay_visible(cx));
+            assert!(workspace.overlay_docks_visible(cx));
             assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
 
-            workspace.dismiss_project_panel_overlay(window, cx);
+            workspace.dismiss_overlay_docks(window, cx);
         });
 
         workspace.update_in(cx, |workspace, window, cx| {
-            assert!(!workspace.project_panel_overlay_visible(cx));
+            assert!(!workspace.overlay_docks_visible(cx));
             assert!(!workspace.left_dock().read(cx).is_open());
 
             let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
@@ -12336,6 +12482,7 @@ mod tests {
         cx: &mut gpui::TestAppContext,
     ) {
         init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
 
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, [], cx).await;
@@ -12361,7 +12508,7 @@ mod tests {
         cx.run_until_parked();
 
         workspace.update_in(cx, |workspace, window, cx| {
-            assert!(workspace.project_panel_overlay_visible(cx));
+            assert!(workspace.overlay_docks_visible(cx));
             window.dispatch_action(Box::new(dock::test::ToggleTestPanel), cx);
         });
         cx.run_until_parked();
@@ -12378,8 +12525,8 @@ mod tests {
                 .active_panel()
                 .map(|panel| panel.panel_key().to_string());
             assert!(
-                !workspace.project_panel_overlay_visible(cx),
-                "Project overlay should close when another left-dock panel is activated. visible={visible_panel_key:?} active={active_panel_key:?}"
+                workspace.overlay_docks_visible(cx),
+                "The left dock should stay rendered as an overlay when another left-dock panel is activated. visible={visible_panel_key:?} active={active_panel_key:?}"
             );
 
             let visible_panel = workspace
@@ -15296,6 +15443,14 @@ mod tests {
             cx.set_global(settings_store);
             cx.set_global(db::AppDatabase::test_new());
             theme_settings::init(theme::LoadThemes::JustBase, cx);
+        });
+    }
+
+    fn enable_overlay_dock_panel_mode(cx: &mut TestAppContext) {
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.dock_panel_mode = Some(DockPanelMode::Overlay);
+            });
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3956,6 +3956,11 @@ impl Workspace {
 
         let other_is_zoomed = self.zoomed.is_some() && self.zoomed_position != Some(dock_side);
         let was_visible = self.is_dock_at_position_open(dock_side, cx) && !other_is_zoomed;
+        let closing_overlay = was_visible
+            && self.dock_renders_as_overlay(dock_side, &self.dock_at_position(dock_side), cx);
+        let had_overlay_docks = self.overlay_docks_visible(cx);
+        let previous_focus = (!had_overlay_docks).then(|| window.focused(cx)).flatten();
+        let mut opening_overlay = false;
 
         if let Some(panel) = self.dock_at_position(dock_side).read(cx).active_panel() {
             telemetry::event!(
@@ -3966,9 +3971,6 @@ impl Workspace {
         }
         if was_visible {
             self.save_open_dock_positions(cx);
-        } else if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
-        {
-            self.overlay_dock_previous_focus = window.focused(cx);
         }
 
         let dock = self.dock_at_position(dock_side);
@@ -3983,6 +3985,12 @@ impl Workspace {
                     return;
                 };
                 dock.activate_panel(panel_ix, window, cx);
+            }
+
+            if !was_visible {
+                opening_overlay =
+                    WorkspaceSettings::get_global(cx).resolved_dock_mode_for_dock(dock)
+                        == DockPanelMode::Overlay;
             }
 
             if let Some(active_panel) = dock.active_panel() {
@@ -4001,14 +4009,15 @@ impl Workspace {
             }
         });
 
+        if opening_overlay && !had_overlay_docks {
+            self.overlay_dock_previous_focus = previous_focus;
+        }
+
         if reveal_dock {
             self.dismiss_zoomed_items_to_reveal(Some(dock_side), window, cx);
         }
 
-        if self.dock_panel_mode(cx) == DockPanelMode::Overlay
-            && was_visible
-            && !self.overlay_docks_visible(cx)
-        {
+        if closing_overlay && !self.overlay_docks_visible(cx) {
             self.restore_overlay_focus(window, cx);
         } else if focus_center {
             self.active_pane
@@ -4027,12 +4036,13 @@ impl Workspace {
 
     fn close_active_dock(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         if let Some(dock) = self.active_dock(window, cx).cloned() {
+            let position = dock.read(cx).position();
+            let had_overlay = self.dock_renders_as_overlay(position, &dock, cx);
             self.save_open_dock_positions(cx);
             dock.update(cx, |dock, cx| {
                 dock.set_open(false, window, cx);
             });
-            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
-            {
+            if had_overlay && !self.overlay_docks_visible(cx) {
                 self.restore_overlay_focus(window, cx);
             }
             return true;
@@ -4042,8 +4052,7 @@ impl Workspace {
 
     pub fn close_all_docks(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.save_open_dock_positions(cx);
-        let had_overlay_docks =
-            self.dock_panel_mode(cx) == DockPanelMode::Overlay && self.overlay_docks_visible(cx);
+        let had_overlay_docks = self.overlay_docks_visible(cx);
         for dock in self.all_docks() {
             dock.update(cx, |dock, cx| {
                 dock.set_open(false, window, cx);
@@ -4126,7 +4135,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Entity<T>> {
-        if self.dock_panel_mode(cx) == DockPanelMode::Overlay
+        if self.resolved_dock_mode_for_panel::<T>(cx) == DockPanelMode::Overlay
             && !self.is_panel_visible::<T>(cx)
             && !self.overlay_docks_visible(cx)
         {
@@ -4146,7 +4155,8 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        if self.dock_panel_mode(cx) == DockPanelMode::Overlay
+        let panel_mode = self.resolved_dock_mode_for_panel::<T>(cx);
+        if panel_mode == DockPanelMode::Overlay
             && !self.is_panel_visible::<T>(cx)
             && !self.overlay_docks_visible(cx)
         {
@@ -4161,8 +4171,7 @@ impl Workspace {
 
         if !did_focus_panel && WorkspaceSettings::get_global(cx).close_panel_on_toggle {
             self.close_panel::<T>(window, cx);
-            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
-            {
+            if panel_mode == DockPanelMode::Overlay && !self.overlay_docks_visible(cx) {
                 self.restore_overlay_focus(window, cx);
             }
         }
@@ -4191,16 +4200,15 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
+        let panel_mode = self.resolved_dock_mode_for_panel::<T>(cx);
         if self.is_panel_visible::<T>(cx) {
             self.close_panel::<T>(window, cx);
-            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
-            {
+            if panel_mode == DockPanelMode::Overlay && !self.overlay_docks_visible(cx) {
                 self.restore_overlay_focus(window, cx);
             }
             false
         } else {
-            if self.dock_panel_mode(cx) == DockPanelMode::Overlay && !self.overlay_docks_visible(cx)
-            {
+            if panel_mode == DockPanelMode::Overlay && !self.overlay_docks_visible(cx) {
                 self.overlay_dock_previous_focus = window.focused(cx);
             }
             self.open_panel::<T>(window, cx);
@@ -4377,8 +4385,12 @@ impl Workspace {
         ]
     }
 
-    fn dock_panel_mode(&self, cx: &App) -> DockPanelMode {
-        WorkspaceSettings::get_global(cx).fallback_dock_panel_mode()
+    fn resolved_dock_mode_for_panel<T: Panel>(&self, cx: &App) -> DockPanelMode {
+        WorkspaceSettings::get_global(cx).resolved_dock_mode_for_panel::<T>()
+    }
+
+    fn resolved_dock_mode_for_dock(&self, dock: &Dock, cx: &App) -> DockPanelMode {
+        WorkspaceSettings::get_global(cx).resolved_dock_mode_for_dock(dock)
     }
 
     fn dock_renders_as_overlay(
@@ -4387,7 +4399,7 @@ impl Workspace {
         dock: &Entity<Dock>,
         cx: &App,
     ) -> bool {
-        self.dock_panel_mode(cx) == DockPanelMode::Overlay
+        self.resolved_dock_mode_for_dock(&dock.read(cx), cx) == DockPanelMode::Overlay
             && self.zoomed_position != Some(position)
             && dock.read(cx).is_open()
             && dock.read(cx).visible_panel().is_some()
@@ -12706,6 +12718,159 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn switching_from_overlay_panel_to_push_panel_reflows_same_dock(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        set_dock_panel_modes(cx, DockPanelMode::Push, [(PROJECT_PANEL_KEY, DockPanelMode::Overlay)]);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |multi_workspace, _| {
+            multi_workspace.workspace().clone()
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.register_action(|workspace, _: &dock::test::ToggleTestPanel, window, cx| {
+                workspace.toggle_panel_focus::<TestPanel>(window, cx);
+            });
+
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let other_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 50, cx));
+            workspace.add_panel(other_panel, window, cx);
+
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.overlay_docks_visible(cx));
+            window.dispatch_action(Box::new(dock::test::ToggleTestPanel), cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                !workspace.overlay_docks_visible(cx),
+                "switching to a push-mode panel should remove the left dock from the overlay layer"
+            );
+            assert!(
+                !workspace.dock_renders_as_overlay(DockPosition::Left, workspace.left_dock(), cx),
+                "left dock should rejoin layout for the push-mode panel"
+            );
+
+            let visible_panel = workspace
+                .left_dock()
+                .read(cx)
+                .visible_panel()
+                .expect("left dock should have a visible panel");
+            assert_eq!(visible_panel.panel_key(), TestPanel::panel_key());
+
+            let other_panel = workspace.panel::<TestPanel>(cx).expect("test panel exists");
+            assert!(other_panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn switching_from_push_panel_to_overlay_panel_promotes_same_dock_to_overlay(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        set_dock_panel_modes(cx, DockPanelMode::Push, [(PROJECT_PANEL_KEY, DockPanelMode::Overlay)]);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let other_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 50, cx));
+            workspace.add_panel(other_panel, window, cx);
+
+            workspace.toggle_panel_focus::<TestPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(!workspace.overlay_docks_visible(cx));
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                workspace.overlay_docks_visible(cx),
+                "switching to an overlay-mode panel should move the left dock into the overlay layer"
+            );
+            assert!(
+                workspace.dock_renders_as_overlay(DockPosition::Left, workspace.left_dock(), cx),
+                "left dock should render as an overlay for the project panel"
+            );
+
+            let visible_panel = workspace
+                .left_dock()
+                .read(cx)
+                .visible_panel()
+                .expect("left dock should have a visible panel");
+            assert_eq!(visible_panel.panel_key(), PROJECT_PANEL_KEY);
+
+            let project_panel = workspace
+                .panel::<TestProjectPanel>(cx)
+                .expect("project panel exists");
+            assert!(project_panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn dismiss_overlay_docks_leaves_push_mode_docks_open(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        set_dock_panel_modes(cx, DockPanelMode::Push, [(PROJECT_PANEL_KEY, DockPanelMode::Overlay)]);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let right_panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 50, cx));
+            workspace.add_panel(right_panel, window, cx);
+
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+            workspace.toggle_panel_focus::<TestPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.overlay_docks_visible(cx));
+            assert!(workspace.right_dock().read(cx).is_open());
+
+            workspace.dismiss_overlay_docks(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, _window, cx| {
+            assert!(!workspace.left_dock().read(cx).is_open());
+            assert!(
+                workspace.right_dock().read(cx).is_open(),
+                "dismiss_overlay_docks should leave push-mode docks untouched"
+            );
+            assert!(!workspace.overlay_docks_visible(cx));
+        });
+    }
+
+    #[gpui::test]
     async fn test_close_panel_on_toggle(cx: &mut gpui::TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());
@@ -15610,10 +15775,55 @@ mod tests {
     }
 
     fn enable_overlay_dock_panel_mode(cx: &mut TestAppContext) {
+        set_dock_panel_modes(cx, DockPanelMode::Overlay, []);
+    }
+
+    fn set_dock_panel_modes(
+        cx: &mut TestAppContext,
+        fallback: DockPanelMode,
+        overrides: impl IntoIterator<Item = (&'static str, DockPanelMode)>,
+    ) {
         cx.update_global(|store: &mut SettingsStore, cx| {
             store.update_user_settings(cx, |settings| {
-                settings.workspace.dock_panel_mode = Some(DockPanelMode::Overlay);
+                settings.workspace.dock_panel_mode = Some(fallback);
+                settings.workspace.dock_panel_modes = Some(
+                    overrides
+                        .into_iter()
+                        .map(|(key, mode)| (key.to_string(), mode))
+                        .collect(),
+                );
             });
+        });
+    }
+
+    #[gpui::test]
+    async fn resolved_dock_panel_mode_for_key_prefers_override_and_falls_back(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        set_dock_panel_modes(
+            cx,
+            DockPanelMode::Push,
+            [
+                (PROJECT_PANEL_KEY, DockPanelMode::Overlay),
+                (TestPanel::panel_key(), DockPanelMode::Push),
+            ],
+        );
+
+        cx.update(|cx| {
+            let settings = WorkspaceSettings::get_global(cx);
+            assert_eq!(
+                settings.resolved_dock_panel_mode_for_key(PROJECT_PANEL_KEY),
+                DockPanelMode::Overlay
+            );
+            assert_eq!(
+                settings.resolved_dock_panel_mode_for_key(TestPanel::panel_key()),
+                DockPanelMode::Push
+            );
+            assert_eq!(
+                settings.resolved_dock_panel_mode_for_key("UnknownPanel"),
+                DockPanelMode::Push
+            );
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7587,10 +7587,6 @@ impl Workspace {
         Some(container)
     }
 
-    fn dock_panel_mode(&self, cx: &App) -> DockPanelMode {
-        WorkspaceSettings::get_global(cx).dock_panel_mode
-    }
-
     fn render_project_panel_overlay(
         &self,
         window: &mut Window,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -10976,12 +10976,8 @@ mod tests {
             self.position = position;
         }
 
-        fn size(&self, _window: &Window, _: &App) -> Pixels {
+        fn default_size(&self, _window: &Window, _: &App) -> Pixels {
             self.size
-        }
-
-        fn set_size(&mut self, size: Option<Pixels>, _: &mut Window, _: &mut Context<Self>) {
-            self.size = size.unwrap_or(px(300.));
         }
 
         fn icon(&self, _: &Window, _: &App) -> Option<ui::IconName> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -60,7 +60,8 @@ use gpui::{
     Context, CursorStyle, Decorations, DragMoveEvent, Entity, EntityId, EventEmitter, FocusHandle,
     Focusable, Global, HitboxBehavior, Hsla, KeyContext, Keystroke, ManagedView, MouseButton,
     PathPromptOptions, Point, PromptLevel, Render, ResizeEdge, Size, Stateful, Subscription,
-    SystemWindowTabController, Task, Tiling, WeakEntity, WindowBounds, WindowHandle, WindowId,
+    StyleRefinement, SystemWindowTabController, Task, Tiling, WeakEntity, WindowBounds,
+    WindowHandle, WindowId,
     WindowOptions, actions, canvas, point, relative, size, transparent_black,
 };
 pub use history_manager::*;
@@ -164,6 +165,7 @@ use crate::{
 };
 
 pub const SERIALIZATION_THROTTLE_TIME: Duration = Duration::from_millis(200);
+const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 
 static ZED_WINDOW_SIZE: LazyLock<Option<Size<Pixels>>> = LazyLock::new(|| {
     env::var("ZED_WINDOW_SIZE")
@@ -1370,6 +1372,7 @@ pub struct Workspace {
     open_in_dev_container: bool,
     _dev_container_task: Option<Task<Result<()>>>,
     _panels_task: Option<Task<Result<()>>>,
+    project_panel_previous_focus: Option<FocusHandle>,
     sidebar_focus_handle: Option<FocusHandle>,
     multi_workspace: Option<WeakEntity<MultiWorkspace>>,
 }
@@ -1799,6 +1802,7 @@ impl Workspace {
             scheduled_tasks: Vec::new(),
             last_open_dock_positions: Vec::new(),
             removing: false,
+            project_panel_previous_focus: None,
             sidebar_focus_handle: None,
             multi_workspace,
             open_in_dev_container: false,
@@ -4135,6 +4139,37 @@ impl Workspace {
         did_focus_panel
     }
 
+    pub fn is_panel_visible<T: Panel>(&self, cx: &App) -> bool {
+        self.all_docks().iter().any(|dock| {
+            let dock = dock.read(cx);
+            dock.is_open()
+                && dock
+                    .visible_panel()
+                    .is_some_and(|panel| panel.panel_key() == T::panel_key())
+        })
+    }
+
+    pub fn toggle_panel_visibility<T: Panel>(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.is_panel_visible::<T>(cx) {
+            self.close_panel::<T>(window, cx);
+            if T::panel_key() == PROJECT_PANEL_KEY {
+                self.restore_project_panel_focus(window, cx);
+            }
+            false
+        } else {
+            if T::panel_key() == PROJECT_PANEL_KEY {
+                self.project_panel_previous_focus = window.focused(cx);
+            }
+            self.open_panel::<T>(window, cx);
+            self.focus_panel::<T>(window, cx);
+            true
+        }
+    }
+
     pub fn focus_center_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(item) = self.active_item(cx) {
             item.item_focus_handle(cx).focus(window, cx);
@@ -4248,10 +4283,52 @@ impl Workspace {
         }
     }
 
+    pub fn project_panel_overlay_visible(&self, cx: &App) -> bool {
+        self.project_panel_overlay_dock(cx).is_some()
+    }
+
+    pub fn dismiss_project_panel_overlay(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some((_, dock)) = self.project_panel_overlay_dock(cx) else {
+            return;
+        };
+
+        dock.update(cx, |dock, cx| dock.set_open(false, window, cx));
+        self.restore_project_panel_focus(window, cx);
+        self.serialize_workspace(window, cx);
+        cx.notify();
+    }
+
     pub fn panel<T: Panel>(&self, cx: &App) -> Option<Entity<T>> {
         self.all_docks()
             .iter()
             .find_map(|dock| dock.read(cx).panel::<T>())
+    }
+
+    fn project_panel_overlay_dock(&self, cx: &App) -> Option<(DockPosition, Entity<Dock>)> {
+        [
+            (DockPosition::Left, self.left_dock.clone()),
+            (DockPosition::Right, self.right_dock.clone()),
+        ]
+        .into_iter()
+        .find(|(_, dock)| {
+            let dock = dock.read(cx);
+            dock.is_open()
+                && dock
+                    .visible_panel()
+                    .is_some_and(|panel| panel.panel_key() == PROJECT_PANEL_KEY)
+        })
+    }
+
+    fn restore_project_panel_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(previous_focus) = self.project_panel_previous_focus.take() {
+            previous_focus.focus(window, cx);
+            if previous_focus.contains_focused(window, cx) {
+                return;
+            }
+        }
+
+        self.active_pane
+            .update(cx, |pane, cx| window.focus(&pane.focus_handle(cx), cx));
     }
 
     fn dismiss_zoomed_items_to_reveal(
@@ -7449,6 +7526,15 @@ impl Workspace {
             return None;
         }
 
+        if dock.read(cx).is_open()
+            && dock
+                .read(cx)
+                .visible_panel()
+                .is_some_and(|panel| panel.panel_key() == PROJECT_PANEL_KEY)
+        {
+            return None;
+        }
+
         let leader_border = dock.read(cx).active_panel().and_then(|panel| {
             let pane = panel.pane(cx)?;
             let follower_states = &self.follower_states;
@@ -7498,6 +7584,63 @@ impl Workspace {
         }
 
         Some(container)
+    }
+
+    fn render_project_panel_overlay(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Div> {
+        let (position, dock) = self.project_panel_overlay_dock(cx)?;
+        let (panel, size) = {
+            let dock = dock.read(cx);
+            (dock.visible_panel()?.clone(), dock.active_panel_size(window, cx)?)
+        };
+
+        let panel = div()
+            .id("project-panel-overlay")
+            .absolute()
+            .top_0()
+            .bottom_0()
+            .w(size)
+            .overflow_hidden()
+            .bg(cx.theme().colors().panel_background)
+            .border_color(cx.theme().colors().border)
+            .child(
+                panel
+                    .to_any()
+                    .cached(StyleRefinement::default().v_flex().size_full()),
+            )
+            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                cx.stop_propagation();
+            })
+            .map(|this| match position {
+                DockPosition::Left => this.left_0().border_r_1(),
+                DockPosition::Right => this.right_0().border_l_1(),
+                DockPosition::Bottom => this,
+            });
+
+        Some(
+            div()
+                .absolute()
+                .size_full()
+                .inset_0()
+                .child(
+                    div()
+                        .absolute()
+                        .size_full()
+                        .inset_0()
+                        .occlude()
+                        .bg(transparent_black())
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|workspace, _, window, cx| {
+                                workspace.dismiss_project_panel_overlay(window, cx);
+                            }),
+                        ),
+                )
+                .child(panel),
+        )
     }
 
     pub fn for_window(window: &Window, cx: &App) -> Option<Entity<Workspace>> {
@@ -8260,6 +8403,9 @@ impl Render for Workspace {
                                                             .overflow_hidden()
                                                             .child(
                                                                 h_flex()
+                                                                    .debug_selector(|| {
+                                                                        "workspace-center".into()
+                                                                    })
                                                                     .flex_1()
                                                                     .when_some(
                                                                         paddings.0,
@@ -8333,6 +8479,9 @@ impl Render for Workspace {
                                                                     .overflow_hidden()
                                                                     .child(
                                                                         h_flex()
+                                                                            .debug_selector(|| {
+                                                                                "workspace-center".into()
+                                                                            })
                                                                             .flex_1()
                                                                             .when_some(paddings.0, |this, p| this.child(p.border_r_1()))
                                                                             .child(self.center.render(
@@ -8396,6 +8545,9 @@ impl Render for Workspace {
                                                                     .overflow_hidden()
                                                                     .child(
                                                                         h_flex()
+                                                                            .debug_selector(|| {
+                                                                                "workspace-center".into()
+                                                                            })
                                                                             .flex_1()
                                                                             .when_some(paddings.0, |this, p| this.child(p.border_r_1()))
                                                                             .child(self.center.render(
@@ -8443,6 +8595,9 @@ impl Render for Workspace {
                                                     .overflow_hidden()
                                                     .child(
                                                         h_flex()
+                                                            .debug_selector(|| {
+                                                                "workspace-center".into()
+                                                            })
                                                             .flex_1()
                                                             .when_some(paddings.0, |this, p| {
                                                                 this.child(p.border_r_1())
@@ -8506,6 +8661,7 @@ impl Render for Workspace {
                                         }
                                     })
                                 }))
+                                .children(self.render_project_panel_overlay(window, cx))
                                 .children(self.render_notifications(window, cx)),
                         )
                         .when(self.status_bar_visible(cx), |parent| {
@@ -10655,7 +10811,7 @@ mod tests {
     };
     use fs::FakeFs;
     use gpui::{
-        DismissEvent, Empty, EventEmitter, FocusHandle, Focusable, Render, TestAppContext,
+        DismissEvent, Empty, EventEmitter, FocusHandle, Focusable, Render, TestAppContext, div,
         UpdateGlobal, VisualTestContext, px,
     };
     use project::{Project, ProjectEntryId};
@@ -10663,6 +10819,84 @@ mod tests {
     use settings::SettingsStore;
     use util::path;
     use util::rel_path::rel_path;
+
+    struct TestProjectPanel {
+        position: DockPosition,
+        focus_handle: FocusHandle,
+        size: Pixels,
+    }
+
+    impl TestProjectPanel {
+        fn new(position: DockPosition, cx: &mut App) -> Self {
+            Self {
+                position,
+                focus_handle: cx.focus_handle(),
+                size: px(300.),
+            }
+        }
+    }
+
+    impl EventEmitter<PanelEvent> for TestProjectPanel {}
+
+    impl Focusable for TestProjectPanel {
+        fn focus_handle(&self, _: &App) -> FocusHandle {
+            self.focus_handle.clone()
+        }
+    }
+
+    impl Render for TestProjectPanel {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .id("test-project-panel")
+                .track_focus(&self.focus_handle(cx))
+        }
+    }
+
+    impl Panel for TestProjectPanel {
+        fn persistent_name() -> &'static str {
+            "Project Panel"
+        }
+
+        fn panel_key() -> &'static str {
+            PROJECT_PANEL_KEY
+        }
+
+        fn position(&self, _window: &Window, _: &App) -> DockPosition {
+            self.position
+        }
+
+        fn position_is_valid(&self, position: DockPosition) -> bool {
+            matches!(position, DockPosition::Left | DockPosition::Right)
+        }
+
+        fn set_position(&mut self, position: DockPosition, _: &mut Window, _: &mut Context<Self>) {
+            self.position = position;
+        }
+
+        fn size(&self, _window: &Window, _: &App) -> Pixels {
+            self.size
+        }
+
+        fn set_size(&mut self, size: Option<Pixels>, _: &mut Window, _: &mut Context<Self>) {
+            self.size = size.unwrap_or(px(300.));
+        }
+
+        fn icon(&self, _: &Window, _: &App) -> Option<ui::IconName> {
+            None
+        }
+
+        fn icon_tooltip(&self, _: &Window, _: &App) -> Option<&'static str> {
+            Some("Project Panel")
+        }
+
+        fn toggle_action(&self) -> Box<dyn Action> {
+            Box::new(crate::ToggleLeftDock)
+        }
+
+        fn activation_priority(&self) -> u32 {
+            100
+        }
+    }
 
     #[gpui::test]
     async fn test_tab_disambiguation(cx: &mut TestAppContext) {
@@ -11952,6 +12186,147 @@ mod tests {
             assert!(!pane.focus_handle(cx).is_focused(window));
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(workspace.zoomed.is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn toggle_project_panel_overlay_does_not_reflow_workspace(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let window = cx.windows().into_iter().next().unwrap();
+        let cx = &mut VisualTestContext::from_window(window, cx);
+
+        let item = cx.new(TestItem::new);
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(panel, window, cx);
+        });
+        cx.run_until_parked();
+
+        let center_bounds_before = cx.debug_bounds("workspace-center").unwrap();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        let center_bounds_after_open = cx.debug_bounds("workspace-center").unwrap();
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.left_dock().read(cx).is_open());
+            assert!(
+                workspace
+                    .render_dock(DockPosition::Left, workspace.left_dock(), window, cx)
+                    .is_none()
+            );
+        });
+        assert_eq!(center_bounds_before.size, center_bounds_after_open.size);
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        let center_bounds_after_close = cx.debug_bounds("workspace-center").unwrap();
+        assert_eq!(center_bounds_before.size, center_bounds_after_close.size);
+    }
+
+    #[gpui::test]
+    async fn toggle_project_panel_overlay_moves_and_restores_focus(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(TestItem::new);
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.left_dock().read(cx).is_open());
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(!workspace.left_dock().read(cx).is_open());
+
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            assert!(pane_focus.contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn dismiss_project_panel_overlay_closes_and_restores_focus(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(TestItem::new);
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.project_panel_overlay_visible(cx));
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+
+            workspace.dismiss_project_panel_overlay(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(!workspace.project_panel_overlay_visible(cx));
+            assert!(!workspace.left_dock().read(cx).is_open());
+
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            assert!(pane_focus.contains_focused(window, cx));
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -165,6 +165,7 @@ use crate::{
 };
 
 pub const SERIALIZATION_THROTTLE_TIME: Duration = Duration::from_millis(200);
+#[cfg(any(test, feature = "test-support"))]
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 
 static ZED_WINDOW_SIZE: LazyLock<Option<Size<Pixels>>> = LazyLock::new(|| {
@@ -12432,6 +12433,50 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn toggle_left_dock_closes_project_panel_overlay_and_restores_focus(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(TestItem::new);
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.overlay_docks_visible(cx));
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            workspace.toggle_dock(DockPosition::Left, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(!workspace.overlay_docks_visible(cx));
+            assert!(!workspace.left_dock().read(cx).is_open());
+
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            assert!(pane_focus.contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
     async fn dismiss_project_panel_overlay_closes_and_restores_focus(
         cx: &mut gpui::TestAppContext,
     ) {
@@ -12471,6 +12516,56 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert!(!workspace.overlay_docks_visible(cx));
             assert!(!workspace.left_dock().read(cx).is_open());
+
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            assert!(pane_focus.contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn dismiss_overlay_docks_closes_multiple_open_overlays(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        enable_overlay_dock_panel_mode(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(TestItem::new);
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let bottom_panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 50, cx));
+            workspace.add_panel(bottom_panel, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+            workspace.toggle_dock(DockPosition::Bottom, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.overlay_docks_visible(cx));
+            assert!(workspace.left_dock().read(cx).is_open());
+            assert!(workspace.bottom_dock().read(cx).is_open());
+
+            workspace.dismiss_overlay_docks(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(!workspace.overlay_docks_visible(cx));
+            assert!(!workspace.left_dock().read(cx).is_open());
+            assert!(!workspace.bottom_dock().read(cx).is_open());
 
             let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
             assert!(pane_focus.contains_focused(window, cx));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4024,6 +4024,10 @@ impl Workspace {
                 .update(cx, |pane, cx| window.focus(&pane.focus_handle(cx), cx))
         }
 
+        if !closing_overlay {
+            self.clear_stale_overlay_focus_if_no_overlays(cx);
+        }
+
         cx.notify();
         self.serialize_workspace(window, cx);
     }
@@ -4044,6 +4048,8 @@ impl Workspace {
             });
             if had_overlay && !self.overlay_docks_visible(cx) {
                 self.restore_overlay_focus(window, cx);
+            } else {
+                self.clear_stale_overlay_focus_if_no_overlays(cx);
             }
             return true;
         }
@@ -4062,6 +4068,7 @@ impl Workspace {
         if had_overlay_docks {
             self.restore_overlay_focus(window, cx);
         } else {
+            self.clear_stale_overlay_focus_if_no_overlays(cx);
             cx.focus_self(window);
         }
         cx.notify();
@@ -4143,6 +4150,9 @@ impl Workspace {
         }
 
         let panel = self.focus_or_unfocus_panel::<T>(window, cx, &mut |_, _, _| true)?;
+        if self.resolved_dock_mode_for_panel::<T>(cx) == DockPanelMode::Push {
+            self.clear_stale_overlay_focus_if_no_overlays(cx);
+        }
         panel.to_any().downcast().ok()
     }
 
@@ -4174,6 +4184,10 @@ impl Workspace {
             if panel_mode == DockPanelMode::Overlay && !self.overlay_docks_visible(cx) {
                 self.restore_overlay_focus(window, cx);
             }
+        }
+
+        if panel_mode == DockPanelMode::Push {
+            self.clear_stale_overlay_focus_if_no_overlays(cx);
         }
 
         telemetry::event!(
@@ -4213,6 +4227,9 @@ impl Workspace {
             }
             self.open_panel::<T>(window, cx);
             self.focus_panel::<T>(window, cx);
+            if panel_mode == DockPanelMode::Push {
+                self.clear_stale_overlay_focus_if_no_overlays(cx);
+            }
             true
         }
     }
@@ -4422,6 +4439,12 @@ impl Workspace {
 
         self.active_pane
             .update(cx, |pane, cx| window.focus(&pane.focus_handle(cx), cx));
+    }
+
+    fn clear_stale_overlay_focus_if_no_overlays(&mut self, cx: &App) {
+        if !self.overlay_docks_visible(cx) {
+            self.overlay_dock_previous_focus = None;
+        }
     }
 
     fn dismiss_zoomed_items_to_reveal(
@@ -12718,6 +12741,71 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn switching_between_overlay_panels_keeps_same_dock_as_overlay_in_mixed_mode(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        set_dock_panel_modes(
+            cx,
+            DockPanelMode::Push,
+            [
+                (PROJECT_PANEL_KEY, DockPanelMode::Overlay),
+                (TestPanel::panel_key(), DockPanelMode::Overlay),
+            ],
+        );
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |multi_workspace, _| {
+            multi_workspace.workspace().clone()
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.register_action(|workspace, _: &dock::test::ToggleTestPanel, window, cx| {
+                workspace.toggle_panel_focus::<TestPanel>(window, cx);
+            });
+
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let other_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 50, cx));
+            workspace.add_panel(other_panel, window, cx);
+
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.overlay_docks_visible(cx));
+            window.dispatch_action(Box::new(dock::test::ToggleTestPanel), cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                workspace.overlay_docks_visible(cx),
+                "switching between overlay panels should keep the dock in the overlay layer"
+            );
+            assert!(
+                workspace.dock_renders_as_overlay(DockPosition::Left, workspace.left_dock(), cx),
+                "left dock should remain an overlay when the replacement panel also resolves to overlay"
+            );
+
+            let visible_panel = workspace
+                .left_dock()
+                .read(cx)
+                .visible_panel()
+                .expect("left dock should have a visible panel");
+            assert_eq!(visible_panel.panel_key(), TestPanel::panel_key());
+
+            let other_panel = workspace.panel::<TestPanel>(cx).expect("test panel exists");
+            assert!(other_panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
     async fn switching_from_overlay_panel_to_push_panel_reflows_same_dock(
         cx: &mut gpui::TestAppContext,
     ) {
@@ -12769,6 +12857,62 @@ mod tests {
                 .visible_panel()
                 .expect("left dock should have a visible panel");
             assert_eq!(visible_panel.panel_key(), TestPanel::panel_key());
+
+            let other_panel = workspace.panel::<TestPanel>(cx).expect("test panel exists");
+            assert!(other_panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn switching_from_overlay_panel_to_push_panel_clears_saved_overlay_focus(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        set_dock_panel_modes(cx, DockPanelMode::Push, [(PROJECT_PANEL_KEY, DockPanelMode::Overlay)]);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |multi_workspace, _| {
+            multi_workspace.workspace().clone()
+        });
+
+        let item = cx.new(TestItem::new);
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.register_action(|workspace, _: &dock::test::ToggleTestPanel, window, cx| {
+                workspace.toggle_panel_focus::<TestPanel>(window, cx);
+            });
+
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+
+            let project_panel = cx.new(|cx| TestProjectPanel::new(DockPosition::Left, cx));
+            workspace.add_panel(project_panel, window, cx);
+
+            let other_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 50, cx));
+            workspace.add_panel(other_panel, window, cx);
+
+            let pane_focus = workspace.active_pane().read(cx).focus_handle(cx);
+            window.focus(&pane_focus, cx);
+            workspace.toggle_panel_visibility::<TestProjectPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.overlay_dock_previous_focus.is_some());
+            window.dispatch_action(Box::new(dock::test::ToggleTestPanel), cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                !workspace.overlay_docks_visible(cx),
+                "push takeover should remove the dock from the overlay layer"
+            );
+            assert!(
+                workspace.overlay_dock_previous_focus.is_none(),
+                "saved overlay focus should be cleared when a push panel takes over the last visible overlay"
+            );
 
             let other_panel = workspace.panel::<TestPanel>(cx).expect("test panel exists");
             assert!(other_panel.read(cx).focus_handle(cx).contains_focused(window, cx));

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -1,6 +1,9 @@
 use std::{num::NonZeroUsize, time::Duration};
 
-use crate::DockPosition;
+use crate::{
+    DockPosition,
+    dock::{Dock, Panel},
+};
 use collections::HashMap;
 use serde::Deserialize;
 pub use settings::{
@@ -152,6 +155,16 @@ impl WorkspaceSettings {
             .get(panel_key)
             .copied()
             .unwrap_or(self.dock_panel_mode)
+    }
+
+    pub fn resolved_dock_mode_for_panel<T: Panel>(&self) -> DockPanelMode {
+        self.resolved_dock_panel_mode_for_key(T::panel_key())
+    }
+
+    pub fn resolved_dock_mode_for_dock(&self, dock: &Dock) -> DockPanelMode {
+        dock.active_panel()
+            .map(|panel| self.resolved_dock_panel_mode_for_key(panel.panel_key()))
+            .unwrap_or_else(|| self.fallback_dock_panel_mode())
     }
 }
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -14,6 +14,7 @@ pub struct WorkspaceSettings {
     pub active_pane_modifiers: ActivePanelModifiers,
     pub bottom_dock_layout: settings::BottomDockLayout,
     pub dock_panel_mode: settings::DockPanelMode,
+    pub dock_panel_modes: HashMap<String, settings::DockPanelMode>,
     pub pane_split_direction_horizontal: settings::PaneSplitDirectionHorizontal,
     pub pane_split_direction_vertical: settings::PaneSplitDirectionVertical,
     pub centered_layout: settings::CenteredLayoutSettings,
@@ -94,6 +95,7 @@ impl Settings for WorkspaceSettings {
             },
             bottom_dock_layout: workspace.bottom_dock_layout.unwrap(),
             dock_panel_mode: workspace.dock_panel_mode.unwrap(),
+            dock_panel_modes: workspace.dock_panel_modes.clone().unwrap_or_default(),
             pane_split_direction_horizontal: workspace.pane_split_direction_horizontal.unwrap(),
             pane_split_direction_vertical: workspace.pane_split_direction_vertical.unwrap(),
             centered_layout: workspace.centered_layout.unwrap(),
@@ -137,6 +139,19 @@ impl Settings for WorkspaceSettings {
                 ),
             },
         }
+    }
+}
+
+impl WorkspaceSettings {
+    pub fn fallback_dock_panel_mode(&self) -> DockPanelMode {
+        self.dock_panel_mode
+    }
+
+    pub fn resolved_dock_panel_mode_for_key(&self, panel_key: &str) -> DockPanelMode {
+        self.dock_panel_modes
+            .get(panel_key)
+            .copied()
+            .unwrap_or(self.dock_panel_mode)
     }
 }
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -4,7 +4,7 @@ use crate::DockPosition;
 use collections::HashMap;
 use serde::Deserialize;
 pub use settings::{
-    AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, InactiveOpacity,
+    AutosaveSetting, BottomDockLayout, DockPanelMode, EncodingDisplayOptions, InactiveOpacity,
     PaneSplitDirectionHorizontal, PaneSplitDirectionVertical, RegisterSetting,
     RestoreOnStartupBehavior, Settings,
 };
@@ -13,6 +13,7 @@ pub use settings::{
 pub struct WorkspaceSettings {
     pub active_pane_modifiers: ActivePanelModifiers,
     pub bottom_dock_layout: settings::BottomDockLayout,
+    pub dock_panel_mode: settings::DockPanelMode,
     pub pane_split_direction_horizontal: settings::PaneSplitDirectionHorizontal,
     pub pane_split_direction_vertical: settings::PaneSplitDirectionVertical,
     pub centered_layout: settings::CenteredLayoutSettings,
@@ -92,6 +93,7 @@ impl Settings for WorkspaceSettings {
                 ),
             },
             bottom_dock_layout: workspace.bottom_dock_layout.unwrap(),
+            dock_panel_mode: workspace.dock_panel_mode.unwrap(),
             pane_split_direction_horizontal: workspace.pane_split_direction_horizontal.unwrap(),
             pane_split_direction_vertical: workspace.pane_split_direction_vertical.unwrap(),
             centered_layout: workspace.centered_layout.unwrap(),

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -30,10 +30,14 @@
 //! Update baseline images (when UI intentionally changes):
 //!   UPDATE_BASELINE=1 cargo run -p zed --bin zed_visual_test_runner --features visual-tests
 //!
+//! Run only the project panel overlay test:
+//!   VISUAL_TEST_PROJECT_PANEL_ONLY=1 cargo run -p zed --bin zed_visual_test_runner --features visual-tests
+//!
 //! ## Environment Variables
 //!
 //!   UPDATE_BASELINE - Set to update baseline images instead of comparing
 //!   VISUAL_TEST_OUTPUT_DIR - Directory to save test output (default: target/visual_tests)
+//!   VISUAL_TEST_PROJECT_PANEL_ONLY - Run only the project panel visual test
 
 // Stub main for non-macOS platforms
 #[cfg(not(target_os = "macos"))]
@@ -147,6 +151,8 @@ use constants::*;
 
 #[cfg(target_os = "macos")]
 fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> {
+    let project_panel_only = std::env::var("VISUAL_TEST_PROJECT_PANEL_ONLY").is_ok();
+
     // Create the visual test context with deterministic task scheduling
     // Use real Assets so that SVG icons render properly
     let mut cx = VisualTestAppContext::with_asset_source(
@@ -386,6 +392,24 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
     .log_err();
 
     cx.run_until_parked();
+
+    if project_panel_only {
+        println!("\n--- Test 1: project_panel ---");
+        let result = run_visual_test(
+            "project_panel",
+            workspace_window.into(),
+            &mut cx,
+            update_baseline,
+        )
+        .map(|_| ())
+        .context("project_panel visual test failed");
+
+        // This targeted mode is used as a one-shot verifier during development.
+        // Avoid leak-detector teardown noise from the full app graph after the
+        // screenshot has already been captured and written.
+        std::mem::forget(cx);
+        return result;
+    }
 
     // Track test results
     let mut passed = 0;

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -40,7 +40,7 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
             ],
         }),
         MenuItem::separator(),
-        MenuItem::action("Project Panel", zed_actions::project_panel::ToggleFocus),
+        MenuItem::action("Project Panel", zed_actions::project_panel::Toggle),
         MenuItem::action("Outline Panel", outline_panel::ToggleFocus),
         MenuItem::action("Collab Panel", collab_panel::ToggleFocus),
         MenuItem::action("Terminal Panel", terminal_panel::ToggleFocus),


### PR DESCRIPTION

### Summary

Adds a `dock_panel_mode` setting that controls whether dock panels display in `push` mode (default, current behavior — resizes the workspace) or `overlay` mode (renders the panel as a floating layer without reflowing the workspace layout).

This addresses a common workflow friction: toggling a panel like the Project Panel currently forces the editor and terminal to resize, which is disruptive when working with dense multi-pane layouts.

### What this PR does

- Introduces `dock_panel_mode` workspace setting (`"push"` or `"overlay"`)
- Adds `dock_panel_modes` for per-panel overrides (e.g., Project Panel as overlay while Terminal stays push)
- Generalizes dock overlay rendering so any dock panel can use overlay mode
- Implements overlay-specific focus management: open captures focus, close restores it to the previous target
- Adds generic overlay dismissal via Escape (scoped so Escape during rename/create stays within the panel)
- Click-outside dismissal for overlay panels
- Unifies dock toggle behavior so panel buttons work consistently across modes
- 14 focused tests covering toggle, dismiss, focus restore, mixed-mode switching, and multi-overlay scenarios

### Settings

```json
{
  "dock_panel_mode": "overlay",
  "dock_panel_modes": {
    "ProjectPanel": "overlay",
    "TerminalPanel": "push"
  }
}
```

### Testing

- `cargo test -p workspace overlay -- --nocapture` (14 tests)
- Manual validation in macOS app build: toggle, Escape dismiss, click-outside dismiss, rapid toggle, mixed mode switching

### Before/After

- ![Push vs overlay comparison](https://raw.githubusercontent.com/swaylenhayes/zee/zee-v0.231.0-1/docs/screenshots/scr-anno-push-vs-overlay-hero.png)
- [Right-docked push](https://github.com/swaylenhayes/zee/blob/zee-v0.231.0-1/docs/screenshots/archive/scr-pp-push-right.png)
- [Right-docked overlay](https://github.com/swaylenhayes/zee/blob/zee-v0.231.0-1/docs/screenshots/archive/scr-pp-over-right.png)
- [Panel mode screen recording (.mov)](https://github.com/swaylenhayes/zee/blob/zee-v0.231.0-1/docs/screenshots/archive/screen-record-panel-modes.mov)

Release Notes:

- Added a dock panel overlay mode so dock-backed panels can open without reflowing the workspace layout.
