### PR TITLE
Add project panel sorting by name or modified time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13383,6 +13383,7 @@ dependencies = [
  "editor",
  "feature_flags",
  "file_icons",
+ "fs",
  "git",
  "git_ui",
  "gpui",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -807,6 +807,22 @@
     //    No case folding, no natural number sorting:
     //    "unicode"
     "sort_order": "default",
+    // What field to sort project panel entries by.
+    // This setting can take two values:
+    //
+    // 1. Sort by entry name:
+    //    "name"
+    // 2. Sort by entry modification time:
+    //    "modified_time"
+    "sort_by": "name",
+    // What direction to apply when sorting project panel entries.
+    // This setting can take two values:
+    //
+    // 1. Sort from low to high:
+    //    "ascending"
+    // 2. Sort from high to low:
+    //    "descending"
+    "sort_direction": "ascending",
     // Whether to show error and warning count badges next to file names in the project panel.
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -53,6 +53,7 @@ feature_flags.workspace = true
 client = { workspace = true, features = ["test-support"] }
 criterion.workspace = true
 editor = { workspace = true, features = ["test-support"] }
+fs.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 remote_connection = { workspace = true, features = ["test-support"] }

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -1,7 +1,10 @@
 use criterion::{Criterion, criterion_group, criterion_main};
+use fs::MTime;
 use project::{Entry, EntryKind, GitEntry, ProjectEntryId};
 use project_panel::par_sort_worktree_entries;
-use settings::{ProjectPanelSortMode, ProjectPanelSortOrder};
+use settings::{
+    ProjectPanelSortBy, ProjectPanelSortDirection, ProjectPanelSortMode, ProjectPanelSortOrder,
+};
 use std::sync::Arc;
 use util::rel_path::RelPath;
 
@@ -42,8 +45,27 @@ fn load_linux_repo_snapshot() -> Vec<GitEntry> {
         })
         .collect()
 }
+
+fn with_assigned_mtimes(snapshot: &[GitEntry], include_missing: bool) -> Vec<GitEntry> {
+    snapshot
+        .iter()
+        .enumerate()
+        .map(|(ix, entry)| {
+            let mut entry = entry.clone();
+            entry.entry.mtime = if include_missing && ix % 4 == 0 {
+                None
+            } else {
+                Some(MTime::from_seconds_and_nanos((ix as u64) + 1, 0))
+            };
+            entry
+        })
+        .collect()
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let snapshot = load_linux_repo_snapshot();
+    let snapshot_with_mtimes = with_assigned_mtimes(&snapshot, false);
+    let snapshot_with_mixed_mtimes = with_assigned_mtimes(&snapshot, true);
 
     let modes = [
         ("DirectoriesFirst", ProjectPanelSortMode::DirectoriesFirst),
@@ -64,13 +86,59 @@ fn criterion_benchmark(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || snapshot.clone(),
-                        |mut snapshot| par_sort_worktree_entries(&mut snapshot, *mode, *order),
+                        |mut snapshot| {
+                            par_sort_worktree_entries(
+                                &mut snapshot,
+                                *mode,
+                                *order,
+                                ProjectPanelSortBy::Name,
+                                ProjectPanelSortDirection::Ascending,
+                            )
+                        },
                         criterion::BatchSize::LargeInput,
                     );
                 },
             );
         }
     }
+
+    c.bench_function(
+        "Sort linux worktree snapshot (ModifiedTime Descending)",
+        |b| {
+            b.iter_batched(
+                || snapshot_with_mtimes.clone(),
+                |mut snapshot| {
+                    par_sort_worktree_entries(
+                        &mut snapshot,
+                        ProjectPanelSortMode::DirectoriesFirst,
+                        ProjectPanelSortOrder::Default,
+                        ProjectPanelSortBy::ModifiedTime,
+                        ProjectPanelSortDirection::Descending,
+                    )
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        },
+    );
+
+    c.bench_function(
+        "Sort linux worktree snapshot (ModifiedTime Descending, Mixed Missing)",
+        |b| {
+            b.iter_batched(
+                || snapshot_with_mixed_mtimes.clone(),
+                |mut snapshot| {
+                    par_sort_worktree_entries(
+                        &mut snapshot,
+                        ProjectPanelSortMode::DirectoriesFirst,
+                        ProjectPanelSortOrder::Default,
+                        ProjectPanelSortBy::ModifiedTime,
+                        ProjectPanelSortDirection::Descending,
+                    )
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        },
+    );
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -46,6 +46,19 @@ fn load_linux_repo_snapshot() -> Vec<GitEntry> {
         .collect()
 }
 
+fn pseudo_random_mtime(ix: usize) -> MTime {
+    // Use a deterministic splitmix64 sequence so benchmark mtimes are stable across runs
+    // without preserving the original input order.
+    let mut x = (ix as u64).wrapping_add(0x9E37_79B9_7F4A_7C15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^= x >> 31;
+
+    let seconds = (x & 0xFFFF_FFFF).max(1);
+    let nanos = ((x >> 32) % 1_000_000_000) as u32;
+    MTime::from_seconds_and_nanos(seconds, nanos)
+}
+
 fn with_assigned_mtimes(snapshot: &[GitEntry], include_missing: bool) -> Vec<GitEntry> {
     snapshot
         .iter()
@@ -55,7 +68,7 @@ fn with_assigned_mtimes(snapshot: &[GitEntry], include_missing: bool) -> Vec<Git
             entry.entry.mtime = if include_missing && ix % 4 == 0 {
                 None
             } else {
-                Some(MTime::from_seconds_and_nanos((ix as u64) + 1, 0))
+                Some(pseudo_random_mtime(ix))
             };
             entry
         })

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -76,7 +76,7 @@ use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
     notifications::{DetachAndPromptErr, NotifyResultExt, NotifyTaskExt},
 };
-use worktree::CreatedEntry;
+use worktree::{CreatedEntry, Snapshot};
 use zed_actions::{
     project_panel::{Toggle, ToggleFocus},
     workspace::OpenWithSystem,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4175,7 +4175,6 @@ impl ProjectPanel {
                             &worktree_snapshot,
                             sort_mode,
                             sort_order,
-                            sort_order,
                             sort_by,
                             sort_direction,
                         );
@@ -7309,17 +7308,32 @@ fn cmp_worktree_entries(
 
 #[inline]
 fn cmp_directories_first(a: &Entry, b: &Entry) -> cmp::Ordering {
-    util::paths::compare_rel_paths((&a.path, a.is_file()), (&b.path, b.is_file()))
+    util::paths::compare_rel_paths_by(
+        (&a.path, a.is_file()),
+        (&b.path, b.is_file()),
+        util::paths::SortMode::DirectoriesFirst,
+        util::paths::SortOrder::Default,
+    )
 }
 
 #[inline]
 fn cmp_mixed(a: &Entry, b: &Entry) -> cmp::Ordering {
-    util::paths::compare_rel_paths_mixed((&a.path, a.is_file()), (&b.path, b.is_file()))
+    util::paths::compare_rel_paths_by(
+        (&a.path, a.is_file()),
+        (&b.path, b.is_file()),
+        util::paths::SortMode::Mixed,
+        util::paths::SortOrder::Default,
+    )
 }
 
 #[inline]
 fn cmp_files_first(a: &Entry, b: &Entry) -> cmp::Ordering {
-    util::paths::compare_rel_paths_files_first((&a.path, a.is_file()), (&b.path, b.is_file()))
+    util::paths::compare_rel_paths_by(
+        (&a.path, a.is_file()),
+        (&b.path, b.is_file()),
+        util::paths::SortMode::FilesFirst,
+        util::paths::SortOrder::Default,
+    )
 }
 
 #[inline]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -43,8 +43,8 @@ use rayon::slice::ParallelSliceMut;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics, ShowIndentGuides,
-    update_settings_file,
+    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortBy, ProjectPanelSortDirection, Settings,
+    SettingsStore, ShowDiagnostics, ShowIndentGuides, update_settings_file,
 };
 use smallvec::SmallVec;
 use std::ops::Neg;
@@ -848,6 +848,12 @@ impl ProjectPanel {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
                     if project_panel_settings.sort_order != new_settings.sort_order {
+                        this.update_visible_entries(None, false, false, window, cx);
+                    }
+                    if project_panel_settings.sort_by != new_settings.sort_by {
+                        this.update_visible_entries(None, false, false, window, cx);
+                    }
+                    if project_panel_settings.sort_direction != new_settings.sort_direction {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
                     if project_panel_settings.sticky_scroll && !new_settings.sticky_scroll {
@@ -2494,9 +2500,14 @@ impl ProjectPanel {
                 .map(|entry| entry.to_owned())
                 .collect();
 
-        let sort_mode = ProjectPanelSettings::get_global(cx).sort_mode;
-        let sort_order = ProjectPanelSettings::get_global(cx).sort_order;
-        sort_worktree_entries(&mut siblings, sort_mode, sort_order);
+        let settings = ProjectPanelSettings::get_global(cx);
+        sort_worktree_entries(
+            &mut siblings,
+            settings.sort_mode,
+            settings.sort_order,
+            settings.sort_by,
+            settings.sort_direction,
+        );
         let sibling_entry_index = siblings
             .iter()
             .position(|sibling| sibling.id == latest_entry.id)?;
@@ -3926,6 +3937,8 @@ impl ProjectPanel {
         let hide_gitignore = settings.hide_gitignore;
         let sort_mode = settings.sort_mode;
         let sort_order = settings.sort_order;
+        let sort_by = settings.sort_by;
+        let sort_direction = settings.sort_direction;
         let project = self.project.read(cx);
         let repo_snapshots = project.git_store().read(cx).repo_snapshots(cx);
 
@@ -4157,10 +4170,14 @@ impl ProjectPanel {
                             entry_iter.advance();
                         }
 
-                        par_sort_worktree_entries(
+                        par_sort_visible_worktree_entries(
                             &mut visible_worktree_entries,
+                            &worktree_snapshot,
                             sort_mode,
                             sort_order,
+                            sort_order,
+                            sort_by,
+                            sort_direction,
                         );
                         new_state.visible_entries.push(VisibleEntriesForWorktree {
                             worktree_id,
@@ -7290,20 +7307,289 @@ fn cmp_worktree_entries(
     util::paths::compare_rel_paths_by(a, b, (*mode).into(), (*order).into())
 }
 
+#[inline]
+fn cmp_directories_first(a: &Entry, b: &Entry) -> cmp::Ordering {
+    util::paths::compare_rel_paths((&a.path, a.is_file()), (&b.path, b.is_file()))
+}
+
+#[inline]
+fn cmp_mixed(a: &Entry, b: &Entry) -> cmp::Ordering {
+    util::paths::compare_rel_paths_mixed((&a.path, a.is_file()), (&b.path, b.is_file()))
+}
+
+#[inline]
+fn cmp_files_first(a: &Entry, b: &Entry) -> cmp::Ordering {
+    util::paths::compare_rel_paths_files_first((&a.path, a.is_file()), (&b.path, b.is_file()))
+}
+
+#[inline]
+fn cmp_grouping_for_mode(
+    a_is_file: bool,
+    b_is_file: bool,
+    mode: settings::ProjectPanelSortMode,
+) -> cmp::Ordering {
+    match mode {
+        settings::ProjectPanelSortMode::DirectoriesFirst => a_is_file.cmp(&b_is_file),
+        settings::ProjectPanelSortMode::Mixed => cmp::Ordering::Equal,
+        settings::ProjectPanelSortMode::FilesFirst => b_is_file.cmp(&a_is_file),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SortNode<'a> {
+    component: &'a str,
+    is_file: bool,
+    mtime: Option<std::time::SystemTime>,
+}
+
+#[inline]
+fn cmp_sort_node_names(
+    a: SortNode<'_>,
+    b: SortNode<'_>,
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+) -> cmp::Ordering {
+    let a_path = RelPath::unix(a.component).expect("valid relative path component");
+    let b_path = RelPath::unix(b.component).expect("valid relative path component");
+    util::paths::compare_rel_paths_by(
+        (a_path, a.is_file),
+        (b_path, b.is_file),
+        mode.into(),
+        order.into(),
+    )
+}
+
+#[inline]
+fn cmp_sort_nodes(
+    a: SortNode<'_>,
+    b: SortNode<'_>,
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+    sort_by: settings::ProjectPanelSortBy,
+    sort_direction: settings::ProjectPanelSortDirection,
+) -> cmp::Ordering {
+    let grouping = cmp_grouping_for_mode(a.is_file, b.is_file, mode);
+    if !grouping.is_eq() {
+        return grouping;
+    }
+
+    let name_cmp = cmp_sort_node_names(a, b, mode, order);
+    match sort_by {
+        settings::ProjectPanelSortBy::Name => match sort_direction {
+            settings::ProjectPanelSortDirection::Ascending => name_cmp,
+            settings::ProjectPanelSortDirection::Descending => name_cmp.reverse(),
+        },
+        settings::ProjectPanelSortBy::ModifiedTime => match (a.mtime, b.mtime) {
+            (Some(a_mtime), Some(b_mtime)) if a_mtime != b_mtime => {
+                let time_cmp = a_mtime.cmp(&b_mtime);
+                match sort_direction {
+                    settings::ProjectPanelSortDirection::Ascending => time_cmp,
+                    settings::ProjectPanelSortDirection::Descending => time_cmp.reverse(),
+                }
+            }
+            (Some(_), None) => cmp::Ordering::Less,
+            (None, Some(_)) => cmp::Ordering::Greater,
+            _ => name_cmp,
+        },
+    }
+}
+
+#[inline]
+fn sort_node_for_entry(entry: &Entry) -> SortNode<'_> {
+    SortNode {
+        component: entry.path.file_name().unwrap_or(entry.path.as_unix_str()),
+        is_file: entry.is_file(),
+        mtime: entry.mtime.map(|mtime| mtime.timestamp_for_user()),
+    }
+}
+
+#[inline]
+fn sort_node_for_visible_component<'a>(
+    entry: &'a Entry,
+    component: &'a str,
+    is_leaf_component: bool,
+    common_prefix: &RelPathBuf,
+    worktree_snapshot: &Snapshot,
+) -> SortNode<'a> {
+    let mtime = if is_leaf_component {
+        entry.mtime.map(|mtime| mtime.timestamp_for_user())
+    } else {
+        let mut path = common_prefix.clone();
+        let component_path = RelPath::unix(component).expect("valid relative path component");
+        path.push(component_path);
+        worktree_snapshot
+            .entry_for_path(path.as_rel_path())
+            .and_then(|entry| entry.mtime.map(|mtime| mtime.timestamp_for_user()))
+    };
+
+    SortNode {
+        component,
+        is_file: is_leaf_component && entry.is_file(),
+        mtime,
+    }
+}
+
+#[inline]
+fn cmp_with_options(
+    a: &Entry,
+    b: &Entry,
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+    sort_by: settings::ProjectPanelSortBy,
+    sort_direction: settings::ProjectPanelSortDirection,
+) -> cmp::Ordering {
+    if sort_by == settings::ProjectPanelSortBy::Name
+        && sort_direction == settings::ProjectPanelSortDirection::Ascending
+    {
+        return cmp_worktree_entries(a, b, &mode, &order);
+    }
+
+    cmp_sort_nodes(
+        sort_node_for_entry(a),
+        sort_node_for_entry(b),
+        mode,
+        order,
+        sort_by,
+        sort_direction,
+    )
+}
+
+#[inline]
+fn cmp_visible_entries_with_options(
+    a: &Entry,
+    b: &Entry,
+    worktree_snapshot: &Snapshot,
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+    sort_by: settings::ProjectPanelSortBy,
+    sort_direction: settings::ProjectPanelSortDirection,
+) -> cmp::Ordering {
+    if sort_by == settings::ProjectPanelSortBy::Name
+        && sort_direction == settings::ProjectPanelSortDirection::Ascending
+    {
+        return cmp_worktree_entries(a, b, &mode, &order);
+    }
+
+    let mut common_prefix = RelPathBuf::new();
+    let mut a_components = a.path.components();
+    let mut b_components = b.path.components();
+
+    loop {
+        match (a_components.next(), b_components.next()) {
+            (Some(a_component), Some(b_component)) if a_component == b_component => {
+                let component_path =
+                    RelPath::unix(a_component).expect("valid relative path component");
+                common_prefix.push(component_path);
+            }
+            (Some(a_component), Some(b_component)) => {
+                let a_is_leaf_component = a_components.rest().is_empty();
+                let b_is_leaf_component = b_components.rest().is_empty();
+
+                return cmp_sort_nodes(
+                    sort_node_for_visible_component(
+                        a,
+                        a_component,
+                        a_is_leaf_component,
+                        &common_prefix,
+                        worktree_snapshot,
+                    ),
+                    sort_node_for_visible_component(
+                        b,
+                        b_component,
+                        b_is_leaf_component,
+                        &common_prefix,
+                        worktree_snapshot,
+                    ),
+                    mode,
+                    order,
+                    sort_by,
+                    sort_direction,
+                );
+            }
+            (Some(_), None) => return cmp::Ordering::Greater,
+            (None, Some(_)) => return cmp::Ordering::Less,
+            (None, None) => return cmp::Ordering::Equal,
+        }
+    }
+}
+
 pub fn sort_worktree_entries(
     entries: &mut [impl AsRef<Entry>],
     mode: settings::ProjectPanelSortMode,
     order: settings::ProjectPanelSortOrder,
+    sort_by: settings::ProjectPanelSortBy,
+    sort_direction: settings::ProjectPanelSortDirection,
 ) {
-    entries.sort_by(|lhs, rhs| cmp_worktree_entries(lhs.as_ref(), rhs.as_ref(), &mode, &order));
+    entries.sort_by(|lhs, rhs| {
+        cmp_with_options(
+            lhs.as_ref(),
+            rhs.as_ref(),
+            mode,
+            order,
+            sort_by,
+            sort_direction,
+        )
+    });
+}
+
+pub fn sort_worktree_entries_with_mode(
+    entries: &mut [impl AsRef<Entry>],
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+) {
+    sort_worktree_entries(
+        entries,
+        mode,
+        order,
+        ProjectPanelSortBy::Name,
+        ProjectPanelSortDirection::Ascending,
+    );
+}
+
+pub fn par_sort_visible_worktree_entries(
+    entries: &mut Vec<GitEntry>,
+    worktree_snapshot: &Snapshot,
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+    sort_by: settings::ProjectPanelSortBy,
+    sort_direction: settings::ProjectPanelSortDirection,
+) {
+    entries.par_sort_by(|lhs, rhs| {
+        cmp_visible_entries_with_options(
+            lhs,
+            rhs,
+            worktree_snapshot,
+            mode,
+            order,
+            sort_by,
+            sort_direction,
+        )
+    });
 }
 
 pub fn par_sort_worktree_entries(
     entries: &mut Vec<GitEntry>,
     mode: settings::ProjectPanelSortMode,
     order: settings::ProjectPanelSortOrder,
+    sort_by: settings::ProjectPanelSortBy,
+    sort_direction: settings::ProjectPanelSortDirection,
 ) {
-    entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
+    entries
+        .par_sort_by(|lhs, rhs| cmp_with_options(lhs, rhs, mode, order, sort_by, sort_direction));
+}
+
+pub fn par_sort_worktree_entries_with_mode(
+    entries: &mut Vec<GitEntry>,
+    mode: settings::ProjectPanelSortMode,
+    order: settings::ProjectPanelSortOrder,
+) {
+    par_sort_worktree_entries(
+        entries,
+        mode,
+        order,
+        ProjectPanelSortBy::Name,
+        ProjectPanelSortDirection::Ascending,
+    );
 }
 
 fn git_status_indicator(git_status: GitSummary) -> Option<(&'static str, Color)> {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,8 +3,9 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, ProjectPanelSortOrder,
-    RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
+    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortBy, ProjectPanelSortDirection,
+    ProjectPanelSortMode, ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics,
+    ShowIndentGuides,
 };
 use ui::{
     px,
@@ -36,6 +37,8 @@ pub struct ProjectPanelSettings {
     pub auto_open: AutoOpenSettings,
     pub sort_mode: ProjectPanelSortMode,
     pub sort_order: ProjectPanelSortOrder,
+    pub sort_by: ProjectPanelSortBy,
+    pub sort_direction: ProjectPanelSortDirection,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
 }
@@ -143,6 +146,8 @@ impl Settings for ProjectPanelSettings {
             },
             sort_mode: project_panel.sort_mode.unwrap(),
             sort_order: project_panel.sort_order.unwrap(),
+            sort_by: project_panel.sort_by.unwrap(),
+            sort_direction: project_panel.sort_direction.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
         }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10274,6 +10274,7 @@ fn test_sort_by_name_descending_preserves_grouping() {
     sort_worktree_entries(
         &mut entries,
         settings::ProjectPanelSortMode::DirectoriesFirst,
+        settings::ProjectPanelSortOrder::Default,
         settings::ProjectPanelSortBy::Name,
         settings::ProjectPanelSortDirection::Descending,
     );
@@ -10295,6 +10296,7 @@ fn test_sort_by_modified_time_places_missing_mtime_after_known_entries() {
     sort_worktree_entries(
         &mut entries,
         settings::ProjectPanelSortMode::Mixed,
+        settings::ProjectPanelSortOrder::Default,
         settings::ProjectPanelSortBy::ModifiedTime,
         settings::ProjectPanelSortDirection::Descending,
     );
@@ -10321,6 +10323,7 @@ fn test_sort_by_modified_time_with_mixed_known_and_missing_mtimes_is_stable() {
     sort_worktree_entries(
         &mut entries,
         settings::ProjectPanelSortMode::Mixed,
+        settings::ProjectPanelSortOrder::Default,
         settings::ProjectPanelSortBy::ModifiedTime,
         settings::ProjectPanelSortDirection::Descending,
     );
@@ -10337,6 +10340,7 @@ fn test_sort_by_modified_time_with_mixed_known_and_missing_mtimes_is_stable() {
     sort_worktree_entries(
         &mut entries,
         settings::ProjectPanelSortMode::Mixed,
+        settings::ProjectPanelSortOrder::Default,
         settings::ProjectPanelSortBy::ModifiedTime,
         settings::ProjectPanelSortDirection::Ascending,
     );
@@ -10367,6 +10371,7 @@ fn test_sort_by_modified_time_preserves_grouping() {
     sort_worktree_entries(
         &mut entries,
         settings::ProjectPanelSortMode::DirectoriesFirst,
+        settings::ProjectPanelSortOrder::Default,
         settings::ProjectPanelSortBy::ModifiedTime,
         settings::ProjectPanelSortDirection::Descending,
     );

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -9910,17 +9910,28 @@ fn visible_entries_as_strings(
     result
 }
 
-/// Test that missing sort_mode field defaults to DirectoriesFirst
+/// Test that missing sort settings fields fall back to the current name-sorted behavior.
 #[gpui::test]
 async fn test_sort_mode_default_fallback(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
-    // Verify that when sort_mode is not specified, it defaults to DirectoriesFirst
+    // Verify that when sort settings are not specified, they resolve to the
+    // current behavior: directories first, name ascending.
     let default_settings = cx.read(|cx| *ProjectPanelSettings::get_global(cx));
     assert_eq!(
         default_settings.sort_mode,
         settings::ProjectPanelSortMode::DirectoriesFirst,
         "sort_mode should default to DirectoriesFirst"
+    );
+    assert_eq!(
+        default_settings.sort_by,
+        settings::ProjectPanelSortBy::Name,
+        "sort_by should default to Name"
+    );
+    assert_eq!(
+        default_settings.sort_direction,
+        settings::ProjectPanelSortDirection::Ascending,
+        "sort_direction should default to Ascending"
     );
 }
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10311,7 +10311,11 @@ fn test_sort_by_modified_time_with_mixed_known_and_missing_mtimes_is_stable() {
     let mut entries = vec![
         test_git_entry("alpha.txt", true, Some(MTime::from_seconds_and_nanos(1, 0))),
         test_git_entry("beta.txt", true, None),
-        test_git_entry("charlie.txt", true, Some(MTime::from_seconds_and_nanos(2, 0))),
+        test_git_entry(
+            "charlie.txt",
+            true,
+            Some(MTime::from_seconds_and_nanos(2, 0)),
+        ),
     ];
 
     sort_worktree_entries(

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -1,13 +1,15 @@
 use super::*;
 use collections::HashSet;
 use editor::MultiBufferOffset;
+use fs::MTime;
 use gpui::{Empty, Entity, TestAppContext, VisualTestContext};
 use menu::Cancel;
 use pretty_assertions::assert_eq;
-use project::{FakeFs, ProjectPath};
+use project::{FakeFs, GitEntry, ProjectPath};
 use serde_json::json;
 use settings::{ProjectPanelAutoOpenSettings, SettingsStore};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 use util::{path, paths::PathStyle, rel_path::rel_path};
 use workspace::{
     AppState, ItemHandle, MultiWorkspace, Pane, Workspace,
@@ -9910,6 +9912,37 @@ fn visible_entries_as_strings(
     result
 }
 
+fn test_entry(path: &str, is_file: bool, mtime: Option<MTime>) -> Entry {
+    let path = RelPath::unix(path).expect("valid relative path").into_arc();
+    Entry {
+        id: ProjectEntryId::from_usize(path.as_unix_str().len()),
+        kind: if is_file {
+            EntryKind::File
+        } else {
+            EntryKind::Dir
+        },
+        path: path.clone(),
+        inode: 0,
+        mtime,
+        canonical_path: None,
+        is_ignored: false,
+        is_hidden: false,
+        is_always_included: false,
+        is_external: false,
+        is_private: false,
+        size: 0,
+        char_bag: Default::default(),
+        is_fifo: false,
+    }
+}
+
+fn test_git_entry(path: &str, is_file: bool, mtime: Option<MTime>) -> GitEntry {
+    GitEntry {
+        entry: test_entry(path, is_file, mtime),
+        git_summary: Default::default(),
+    }
+}
+
 /// Test that missing sort settings fields fall back to the current name-sorted behavior.
 #[gpui::test]
 async fn test_sort_mode_default_fallback(cx: &mut gpui::TestAppContext) {
@@ -10140,6 +10173,164 @@ async fn test_sort_mode_toggle(cx: &mut gpui::TestAppContext) {
         visible_entries_as_strings(&panel, 0..50, cx),
         &["v root", "    > dir1", "      file1.txt", "      file2.txt",]
     );
+}
+
+#[gpui::test]
+async fn test_sort_by_modified_time_toggle(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "alpha.txt": "",
+            "beta.txt": "",
+            "gamma.txt": "",
+        }),
+    )
+    .await;
+
+    fs.set_next_mtime(SystemTime::UNIX_EPOCH + Duration::from_secs(10));
+    fs.touch_path("/root/gamma.txt").await;
+    fs.set_next_mtime(SystemTime::UNIX_EPOCH + Duration::from_secs(20));
+    fs.touch_path("/root/alpha.txt").await;
+    fs.set_next_mtime(SystemTime::UNIX_EPOCH + Duration::from_secs(30));
+    fs.touch_path("/root/beta.txt").await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "      alpha.txt",
+            "      beta.txt",
+            "      gamma.txt",
+        ]
+    );
+
+    cx.update(|_, cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                let project_panel = settings.project_panel.get_or_insert_default();
+                project_panel.sort_mode = Some(settings::ProjectPanelSortMode::Mixed);
+                project_panel.sort_by = Some(settings::ProjectPanelSortBy::ModifiedTime);
+                project_panel.sort_direction =
+                    Some(settings::ProjectPanelSortDirection::Descending);
+            });
+        });
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "      beta.txt",
+            "      alpha.txt",
+            "      gamma.txt",
+        ]
+    );
+
+    cx.update(|_, cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project_panel
+                    .get_or_insert_default()
+                    .sort_direction = Some(settings::ProjectPanelSortDirection::Ascending);
+            });
+        });
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "      gamma.txt",
+            "      alpha.txt",
+            "      beta.txt",
+        ]
+    );
+}
+
+#[test]
+fn test_sort_by_name_descending_preserves_grouping() {
+    let mut entries = vec![
+        test_git_entry("alpha.txt", true, None),
+        test_git_entry("beta.txt", true, None),
+        test_git_entry("aardvark", false, None),
+        test_git_entry("zebra", false, None),
+    ];
+
+    sort_worktree_entries(
+        &mut entries,
+        settings::ProjectPanelSortMode::DirectoriesFirst,
+        settings::ProjectPanelSortBy::Name,
+        settings::ProjectPanelSortDirection::Descending,
+    );
+
+    let paths = entries
+        .iter()
+        .map(|entry| entry.path.as_unix_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(paths, vec!["zebra", "aardvark", "beta.txt", "alpha.txt"]);
+}
+
+#[test]
+fn test_sort_by_modified_time_falls_back_to_name_when_missing_mtime() {
+    let mut entries = vec![
+        test_git_entry("beta.txt", true, Some(MTime::from_seconds_and_nanos(2, 0))),
+        test_git_entry("alpha.txt", true, None),
+    ];
+
+    sort_worktree_entries(
+        &mut entries,
+        settings::ProjectPanelSortMode::Mixed,
+        settings::ProjectPanelSortBy::ModifiedTime,
+        settings::ProjectPanelSortDirection::Descending,
+    );
+
+    let paths = entries
+        .iter()
+        .map(|entry| entry.path.as_unix_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(paths, vec!["alpha.txt", "beta.txt"]);
+}
+
+#[test]
+fn test_sort_by_modified_time_preserves_grouping() {
+    let mut entries = vec![
+        test_git_entry(
+            "alpha.txt",
+            true,
+            Some(MTime::from_seconds_and_nanos(10, 0)),
+        ),
+        test_git_entry("docs", false, Some(MTime::from_seconds_and_nanos(1, 0))),
+        test_git_entry("beta.txt", true, Some(MTime::from_seconds_and_nanos(20, 0))),
+        test_git_entry("src", false, Some(MTime::from_seconds_and_nanos(30, 0))),
+    ];
+
+    sort_worktree_entries(
+        &mut entries,
+        settings::ProjectPanelSortMode::DirectoriesFirst,
+        settings::ProjectPanelSortBy::ModifiedTime,
+        settings::ProjectPanelSortDirection::Descending,
+    );
+
+    let paths = entries
+        .iter()
+        .map(|entry| entry.path.as_unix_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(paths, vec!["src", "docs", "beta.txt", "alpha.txt"]);
 }
 
 #[gpui::test]

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10286,7 +10286,7 @@ fn test_sort_by_name_descending_preserves_grouping() {
 }
 
 #[test]
-fn test_sort_by_modified_time_falls_back_to_name_when_missing_mtime() {
+fn test_sort_by_modified_time_places_missing_mtime_after_known_entries() {
     let mut entries = vec![
         test_git_entry("beta.txt", true, Some(MTime::from_seconds_and_nanos(2, 0))),
         test_git_entry("alpha.txt", true, None),
@@ -10303,7 +10303,48 @@ fn test_sort_by_modified_time_falls_back_to_name_when_missing_mtime() {
         .iter()
         .map(|entry| entry.path.as_unix_str().to_string())
         .collect::<Vec<_>>();
-    assert_eq!(paths, vec!["alpha.txt", "beta.txt"]);
+    assert_eq!(paths, vec!["beta.txt", "alpha.txt"]);
+}
+
+#[test]
+fn test_sort_by_modified_time_with_mixed_known_and_missing_mtimes_is_stable() {
+    let mut entries = vec![
+        test_git_entry("alpha.txt", true, Some(MTime::from_seconds_and_nanos(1, 0))),
+        test_git_entry("beta.txt", true, None),
+        test_git_entry("charlie.txt", true, Some(MTime::from_seconds_and_nanos(2, 0))),
+    ];
+
+    sort_worktree_entries(
+        &mut entries,
+        settings::ProjectPanelSortMode::Mixed,
+        settings::ProjectPanelSortBy::ModifiedTime,
+        settings::ProjectPanelSortDirection::Descending,
+    );
+
+    let descending_paths = entries
+        .iter()
+        .map(|entry| entry.path.as_unix_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        descending_paths,
+        vec!["charlie.txt", "alpha.txt", "beta.txt"]
+    );
+
+    sort_worktree_entries(
+        &mut entries,
+        settings::ProjectPanelSortMode::Mixed,
+        settings::ProjectPanelSortBy::ModifiedTime,
+        settings::ProjectPanelSortDirection::Ascending,
+    );
+
+    let ascending_paths = entries
+        .iter()
+        .map(|entry| entry.path.as_unix_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ascending_paths,
+        vec!["alpha.txt", "charlie.txt", "beta.txt"]
+    );
 }
 
 #[test]

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -817,6 +817,8 @@ impl VsCodeSettings {
                 "unicode" => Some(ProjectPanelSortOrder::Unicode),
                 _ => None,
             }),
+            sort_by: None,
+            sort_direction: None,
             starts_open: None,
             sticky_scroll: None,
             auto_open: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -752,6 +752,14 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: default
     pub sort_order: Option<ProjectPanelSortOrder>,
+    /// What field to sort sibling entries by in the project panel.
+    ///
+    /// Default: name
+    pub sort_by: Option<ProjectPanelSortBy>,
+    /// What direction to apply when sorting sibling entries in the project panel.
+    ///
+    /// Default: ascending
+    pub sort_direction: Option<ProjectPanelSortDirection>,
     /// Whether to show error and warning count badges next to file names in the project panel.
     ///
     /// Default: false
@@ -839,6 +847,52 @@ pub enum ProjectPanelSortOrder {
     /// Pure Unicode codepoint comparison. No case folding, no natural number sorting.
     /// Uppercase ASCII sorts before lowercase. Accented characters sort after ASCII.
     Unicode,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectPanelSortBy {
+    /// Sort by entry name.
+    #[default]
+    Name,
+    /// Sort by entry modification time.
+    ModifiedTime,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectPanelSortDirection {
+    /// Sort from lowest to highest.
+    #[default]
+    Ascending,
+    /// Sort from highest to lowest.
+    Descending,
 }
 
 impl From<ProjectPanelSortMode> for util::paths::SortMode {


### PR DESCRIPTION

### Summary

Adds configurable sorting for the project panel file tree. Users can sort entries by name (default, existing behavior) or by modified time, with configurable direction and directory grouping.

This was requested in #34462 and is a common feature in other editors. Sorting by modified time makes recently-changed files easier to find without searching, which is especially useful in large projects or when switching between tasks.

### What this PR does

- Adds `project_panel.sort_mode` setting (`"directories_first"`, `"mixed"`, or `"files_first"`)
- Adds `project_panel.sort_by` setting (`"name"` or `"modified_time"`)
- Adds `project_panel.sort_direction` setting (`"ascending"` or `"descending"`)
- Directory/file grouping is controlled explicitly through `project_panel.sort_mode`
- Modified-time sorting places entries with unknown/missing `mtime` deterministically after known entries (stable sort, no flicker)
- Settings content generation updated so `sort_by` and `sort_direction` appear in the settings editor
- VSCode import mapping added for `explorer.sortOrder`
- 10 focused unit tests covering all sort modes, direction toggles, grouping, and missing-mtime edge cases
- Criterion benchmark for sorting a realistic worktree snapshot (name and modified-time modes)

### Settings

```json
{
  "project_panel": {
    "sort_mode": "directories_first",
    "sort_by": "modified_time",
    "sort_direction": "descending"
  }
}
```

### Testing

- `cargo test -p project_panel test_sort_ -- --nocapture` (10 tests)
- `cargo test -p project_panel --bench sorting -- --sample-size 10` (benchmark sanity check)
- Manual validation in macOS app build across all sort mode combinations

### Assets

- ![Project Panel sorting](https://raw.githubusercontent.com/swaylenhayes/zee/zee-v0.231.0-1/docs/screenshots/ss-sorting-project-panel.gif)
- [Mixed grouping, modified time descending](https://github.com/swaylenhayes/zee/blob/zee-v0.231.0-1/docs/screenshots/archive/scr-mixed-mod-desc.png)
- [Directories first, modified time descending](https://github.com/swaylenhayes/zee/blob/zee-v0.231.0-1/docs/screenshots/archive/scr-dir-mod-desc.png)
- [Name sort descending](https://github.com/swaylenhayes/zee/blob/zee-v0.231.0-1/docs/screenshots/archive/scr-file-name-desc.png)

Release Notes:

- Added project panel sorting by name or modified time, with configurable direction and directory grouping.
