### PR TITLE
workspace: Skip preview tab paths when choosing default save location

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1470,9 +1470,18 @@ pub mod test {
 
     impl TestProjectItem {
         pub fn new(id: u64, path: &str, cx: &mut App) -> Entity<Self> {
+            Self::new_in_worktree(id, path, WorktreeId::from_usize(0), cx)
+        }
+
+        pub fn new_in_worktree(
+            id: u64,
+            path: &str,
+            worktree_id: WorktreeId,
+            cx: &mut App,
+        ) -> Entity<Self> {
             let entry_id = Some(ProjectEntryId::from_proto(id));
             let project_path = Some(ProjectPath {
-                worktree_id: WorktreeId::from_usize(0),
+                worktree_id,
                 path: rel_path(path).into(),
             });
             cx.new(|_| Self {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3731,8 +3731,17 @@ impl Workspace {
     }
 
     pub fn most_recent_active_path(&self, cx: &App) -> Option<PathBuf> {
+        let preview_paths: HashSet<ProjectPath> = self
+            .panes
+            .iter()
+            .filter_map(|pane| pane.read(cx).preview_item()?.project_path(cx))
+            .collect();
+
         self.recent_navigation_history_iter(cx)
             .filter_map(|(path, abs_path)| {
+                if preview_paths.contains(&path) {
+                    return None;
+                }
                 let worktree = self
                     .project
                     .read(cx)
@@ -14829,5 +14838,74 @@ mod tests {
                 "Both panels should still be in the right dock"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_most_recent_active_path_skips_preview_items(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                "src": { "main.rs": "" },
+                ".venv": { "lib": { "dep.py": "" } },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        let worktree_id = project.update(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+
+        let item_main = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new_in_worktree(
+                1001,
+                "src/main.rs",
+                worktree_id,
+                cx,
+            )])
+        });
+        let item_dep = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new_in_worktree(
+                1002,
+                ".venv/lib/dep.py",
+                worktree_id,
+                cx,
+            )])
+        });
+
+        // Only item_main → it's the active item → most_recent_active_path returns its path
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item_main.clone()), None, true, window, cx);
+        });
+        let path = workspace.read_with(cx, |workspace, cx| workspace.most_recent_active_path(cx));
+        assert_eq!(path, Some(PathBuf::from(path!("/project/src/main.rs"))));
+
+        // dep.py is now the active item and is a preview tab → should be skipped.
+        // Since main.rs is no longer active and has no abs_path in navigation history
+        // (TestItems don't register real project entries), we fall through to None.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item_dep.clone()), None, true, window, cx);
+        });
+        pane.update(cx, |pane, cx| {
+            pane.set_preview_item_id(Some(item_dep.item_id()), cx);
+        });
+        let path = workspace.read_with(cx, |workspace, cx| workspace.most_recent_active_path(cx));
+        assert_eq!(path, None);
+
+        // Unpreview dep.py (user double-clicked to keep the tab) → now it should be used
+        pane.update(cx, |pane, cx| {
+            pane.set_preview_item_id(None, cx);
+        });
+        let path = workspace.read_with(cx, |workspace, cx| workspace.most_recent_active_path(cx));
+        assert_eq!(
+            path,
+            Some(PathBuf::from(path!("/project/.venv/lib/dep.py")))
+        );
     }
 }


### PR DESCRIPTION
Fixes #42787

## Summary

When "Go to Definition" navigates into a dependency (e.g., a file inside `.venv/` or `node_modules/`), the file opens as a preview tab. If the user then creates a new buffer and saves it, the save dialog defaulted to the dependency directory — almost never the intended location.

This PR makes `most_recent_active_path` skip paths belonging to current preview tabs, causing the save dialog to fall back to the next non-preview path, the worktree root, or the home directory.

## Design tradeoffs

We considered three approaches:

1. **Filter by `is_ignored`/`is_hidden`/`is_external` on worktree entries** — check if the path or any ancestor directory is gitignored, hidden (dotfile), or external (symlinked outside worktree). This catches `.venv` when it's in `.gitignore` (via `is_ignored`) or when it starts with `.` (via `is_hidden` matching the default `"**/.*"` pattern). However, it also false-positives on `.github/workflows/` — a directory users intentionally edit but that matches `is_hidden`. It would also miss `node_modules` when there's no `.gitignore`.

2. **Hardcode directory names** like `.venv`, `node_modules`, `site-packages` — fragile, opinionated, and would be a whack-a-mole game as ecosystems evolve.

3. **Use preview tab status** (this PR) — "Go to Definition" opens files as preview tabs by default. Skipping preview tab paths directly targets the user intent: the file was navigated to transitively, not opened deliberately. If the user double-clicks the tab (unpreviewing it), the path becomes eligible again — correctly reflecting a deliberate choice to work there.

The one gap in approach 3: if the user has disabled preview tabs entirely, "Go to Definition" opens files as regular tabs and they won't be filtered. We consider this acceptable since disabling preview tabs is an explicit opt-in to treating every opened file as permanent.

## Test plan

- [x] Manual test: open project with `.venv`, Go to Definition into a dependency, create new file, verify save dialog defaults to project root instead of `.venv/...` path
- [x] Added `test_most_recent_active_path_skips_preview_items` covering: normal active path returned, preview path skipped, unpreviewed path returned
- [x] All existing workspace tests pass (141/143 pass; 2 pre-existing flaky persistence tests)

Release Notes:

- Fixed save dialog defaulting to dependency directories (e.g. `.venv/`, `node_modules/`) after using Go to Definition.