### PR TITLE
Save Settings text inputs on blur

### DIFF
--- a/crates/settings_ui/src/components/input_field.rs
+++ b/crates/settings_ui/src/components/input_field.rs
@@ -124,7 +124,11 @@ impl RenderOnce for SettingsInputField {
                         editor.set_text(text, window, cx);
                     }
 
-                    if let Some(confirm) = confirm.take() {
+                    if let Some(confirm) = confirm.take()
+                        && !self.display_confirm_button
+                        && !self.display_clear_button
+                        && !self.clear_on_confirm
+                    {
                         cx.on_focus_out(
                             &editor_focus_handle,
                             window,
@@ -156,7 +160,11 @@ impl RenderOnce for SettingsInputField {
                         editor.set_text(text, window, cx);
                     }
 
-                    if let Some(confirm) = confirm.take() {
+                    if let Some(confirm) = confirm.take()
+                        && !self.display_confirm_button
+                        && !self.display_clear_button
+                        && !self.clear_on_confirm
+                    {
                         cx.on_focus_out(
                             &editor_focus_handle,
                             window,

--- a/crates/settings_ui/src/components/input_field.rs
+++ b/crates/settings_ui/src/components/input_field.rs
@@ -1,11 +1,10 @@
 use std::rc::Rc;
 
-use editor::{Editor, EditorEvent};
-use gpui::{AnyElement, ElementId, Entity, Focusable, ReadGlobal as _, TextStyleRefinement};
-use settings::{Settings as _, SettingsStore};
+use editor::Editor;
+use gpui::{AnyElement, ElementId, Focusable, TextStyleRefinement};
+use settings::Settings as _;
 use theme::ThemeSettings;
 use ui::{Tooltip, prelude::*, rems};
-use workspace::ItemHandle;
 
 #[derive(IntoElement)]
 pub struct SettingsInputField {
@@ -20,7 +19,6 @@ pub struct SettingsInputField {
     clear_on_confirm: bool,
     action_slot: Option<AnyElement>,
     color: Option<Color>,
-    // settings_file_has_updated: bool,
 }
 
 impl SettingsInputField {
@@ -111,7 +109,7 @@ impl RenderOnce for SettingsInputField {
             ..Default::default()
         };
 
-        // let cached_data: Entity<Option<gpui::Task>> = window.use_state(cx, |window, cx| None);
+        let first_render_initial_text = window.use_state(cx, |_, _| self.initial_text.clone());
 
         let editor = if let Some(id) = self.id {
             window.use_keyed_state(id, cx, {
@@ -120,10 +118,8 @@ impl RenderOnce for SettingsInputField {
                 let mut confirm = self.confirm.clone();
 
                 move |window, cx| {
-                    dbg!("id editor: {}", &initial_text);
                     let mut editor = Editor::single_line(window, cx);
                     let editor_focus_handle = editor.focus_handle(cx);
-                    dbg!(&initial_text);
                     if let Some(text) = initial_text {
                         editor.set_text(text, window, cx);
                     }
@@ -133,7 +129,7 @@ impl RenderOnce for SettingsInputField {
                             &editor_focus_handle,
                             window,
                             move |editor, _, window, cx| {
-                                let text = Some(dbg!(editor.text(cx)));
+                                let text = Some(editor.text(cx));
                                 confirm(text, window, cx);
                             },
                         )
@@ -152,44 +148,19 @@ impl RenderOnce for SettingsInputField {
                 let initial_text = self.initial_text.clone();
                 let placeholder = self.placeholder;
                 let mut confirm = self.confirm.clone();
-                let mut confirm2 = self.confirm.clone();
 
                 move |window, cx| {
-                    log::info!("none id editor: {:?}", &initial_text);
                     let mut editor = Editor::single_line(window, cx);
                     let editor_focus_handle = editor.focus_handle(cx);
                     if let Some(text) = initial_text {
-                        log::info!("setting text");
                         editor.set_text(text, window, cx);
                     }
 
-                    cx.subscribe_in(
-                        &cx.entity(),
-                        window,
-                        move |editor, test, event: &EditorEvent, window, cx| match event {
-                            EditorEvent::Edited { .. } => {
-                                log::info!("EditorEvent::Edited: {} {:?}", editor.text(cx), test);
-                            }
-                            // EditorEvent::Blurred => {
-                            //     if let Some(confirm) = confirm.take() {
-                            //         log::info!("EditorEvent::Blurred {:?}", editor.text(cx));
-                            //         let text = Some(editor.text(cx));
-                            //         confirm(text, window, cx);
-                            //     }
-                            // }
-                            event2 => {
-                                log::info!("{:?}", event2);
-                            }
-                        },
-                    )
-                    .detach();
-
-                    if let Some(confirm) = confirm2.take() {
+                    if let Some(confirm) = confirm.take() {
                         cx.on_focus_out(
                             &editor_focus_handle,
                             window,
                             move |editor, _, window, cx| {
-                                log::info!("on_focus_out handler {:?}", editor.text(cx));
                                 let text = Some(editor.text(cx));
                                 confirm(text, window, cx);
                             },
@@ -198,7 +169,6 @@ impl RenderOnce for SettingsInputField {
                     }
 
                     if let Some(placeholder) = placeholder {
-                        log::info!("placeholder {}", placeholder);
                         editor.set_placeholder_text(placeholder, window, cx);
                     }
                     editor.set_text_style_refinement(styles);
@@ -211,11 +181,11 @@ impl RenderOnce for SettingsInputField {
         // re-renders but use_keyed_state returns the cached editor with stale text.
         // Reconcile with the expected initial_text when the editor is not focused,
         // so we don't clobber what the user is actively typing.
-        if let Some(initial_text) = &self.initial_text {
-            log::warn!("Setting initial_text {}", initial_text);
-            let current_text = editor.read(cx).text(cx);
-            log::warn!("{} -- {}", current_text, initial_text);
-            if current_text != *initial_text && !editor.read(cx).is_focused(window) {
+        if let Some(initial_text) = &self.initial_text
+            && let Some(first_initial) = first_render_initial_text.read(cx)
+        {
+            if initial_text != first_initial && !editor.read(cx).is_focused(window) {
+                *first_render_initial_text.as_mut(cx) = self.initial_text.clone();
                 let weak_editor = editor.downgrade();
                 let initial_text = initial_text.clone();
 

--- a/crates/settings_ui/src/components/input_field.rs
+++ b/crates/settings_ui/src/components/input_field.rs
@@ -1,10 +1,11 @@
 use std::rc::Rc;
 
-use editor::Editor;
-use gpui::{AnyElement, ElementId, Focusable, TextStyleRefinement};
-use settings::Settings as _;
+use editor::{Editor, EditorEvent};
+use gpui::{AnyElement, ElementId, Entity, Focusable, ReadGlobal as _, TextStyleRefinement};
+use settings::{Settings as _, SettingsStore};
 use theme::ThemeSettings;
 use ui::{Tooltip, prelude::*, rems};
+use workspace::ItemHandle;
 
 #[derive(IntoElement)]
 pub struct SettingsInputField {
@@ -19,6 +20,7 @@ pub struct SettingsInputField {
     clear_on_confirm: bool,
     action_slot: Option<AnyElement>,
     color: Option<Color>,
+    // settings_file_has_updated: bool,
 }
 
 impl SettingsInputField {
@@ -109,14 +111,33 @@ impl RenderOnce for SettingsInputField {
             ..Default::default()
         };
 
+        // let cached_data: Entity<Option<gpui::Task>> = window.use_state(cx, |window, cx| None);
+
         let editor = if let Some(id) = self.id {
             window.use_keyed_state(id, cx, {
                 let initial_text = self.initial_text.clone();
                 let placeholder = self.placeholder;
+                let mut confirm = self.confirm.clone();
+
                 move |window, cx| {
+                    dbg!("id editor: {}", &initial_text);
                     let mut editor = Editor::single_line(window, cx);
+                    let editor_focus_handle = editor.focus_handle(cx);
+                    dbg!(&initial_text);
                     if let Some(text) = initial_text {
                         editor.set_text(text, window, cx);
+                    }
+
+                    if let Some(confirm) = confirm.take() {
+                        cx.on_focus_out(
+                            &editor_focus_handle,
+                            window,
+                            move |editor, _, window, cx| {
+                                let text = Some(dbg!(editor.text(cx)));
+                                confirm(text, window, cx);
+                            },
+                        )
+                        .detach();
                     }
 
                     if let Some(placeholder) = placeholder {
@@ -130,13 +151,54 @@ impl RenderOnce for SettingsInputField {
             window.use_state(cx, {
                 let initial_text = self.initial_text.clone();
                 let placeholder = self.placeholder;
+                let mut confirm = self.confirm.clone();
+                let mut confirm2 = self.confirm.clone();
+
                 move |window, cx| {
+                    log::info!("none id editor: {:?}", &initial_text);
                     let mut editor = Editor::single_line(window, cx);
+                    let editor_focus_handle = editor.focus_handle(cx);
                     if let Some(text) = initial_text {
+                        log::info!("setting text");
                         editor.set_text(text, window, cx);
                     }
 
+                    cx.subscribe_in(
+                        &cx.entity(),
+                        window,
+                        move |editor, test, event: &EditorEvent, window, cx| match event {
+                            EditorEvent::Edited { .. } => {
+                                log::info!("EditorEvent::Edited: {} {:?}", editor.text(cx), test);
+                            }
+                            // EditorEvent::Blurred => {
+                            //     if let Some(confirm) = confirm.take() {
+                            //         log::info!("EditorEvent::Blurred {:?}", editor.text(cx));
+                            //         let text = Some(editor.text(cx));
+                            //         confirm(text, window, cx);
+                            //     }
+                            // }
+                            event2 => {
+                                log::info!("{:?}", event2);
+                            }
+                        },
+                    )
+                    .detach();
+
+                    if let Some(confirm) = confirm2.take() {
+                        cx.on_focus_out(
+                            &editor_focus_handle,
+                            window,
+                            move |editor, _, window, cx| {
+                                log::info!("on_focus_out handler {:?}", editor.text(cx));
+                                let text = Some(editor.text(cx));
+                                confirm(text, window, cx);
+                            },
+                        )
+                        .detach();
+                    }
+
                     if let Some(placeholder) = placeholder {
+                        log::info!("placeholder {}", placeholder);
                         editor.set_placeholder_text(placeholder, window, cx);
                     }
                     editor.set_text_style_refinement(styles);
@@ -150,10 +212,19 @@ impl RenderOnce for SettingsInputField {
         // Reconcile with the expected initial_text when the editor is not focused,
         // so we don't clobber what the user is actively typing.
         if let Some(initial_text) = &self.initial_text {
+            log::warn!("Setting initial_text {}", initial_text);
             let current_text = editor.read(cx).text(cx);
+            log::warn!("{} -- {}", current_text, initial_text);
             if current_text != *initial_text && !editor.read(cx).is_focused(window) {
-                editor.update(cx, |editor, cx| {
-                    editor.set_text(initial_text.clone(), window, cx);
+                let weak_editor = editor.downgrade();
+                let initial_text = initial_text.clone();
+
+                window.defer(cx, move |window, cx| {
+                    weak_editor
+                        .update(cx, |editor, cx| {
+                            editor.set_text(initial_text, window, cx);
+                        })
+                        .ok();
                 });
             }
         }

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -4011,12 +4011,14 @@ fn render_text_field<T: From<String> + Into<String> + AsRef<str> + Clone>(
         )
         .on_confirm({
             move |new_text, window, cx| {
+                log::info!("on_confirm {:?}", new_text);
                 update_settings_file(
                     file.clone(),
                     field.json_path,
                     window,
                     cx,
                     move |settings, _cx| {
+                        log::info!("This saves the relevant setting");
                         (field.write)(settings, new_text.map(Into::into));
                     },
                 )

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -4011,14 +4011,12 @@ fn render_text_field<T: From<String> + Into<String> + AsRef<str> + Clone>(
         )
         .on_confirm({
             move |new_text, window, cx| {
-                log::info!("on_confirm {:?}", new_text);
                 update_settings_file(
                     file.clone(),
                     field.json_path,
                     window,
                     cx,
                     move |settings, _cx| {
-                        log::info!("This saves the relevant setting");
                         (field.write)(settings, new_text.map(Into::into));
                     },
                 )


### PR DESCRIPTION
Previously, when writing in a Settings input field and tabbing between text inputs, the value the user wrote would be lost. This was particularly an issue when searching for settings meant that a text value was at the *end* of the settings page, and a tab out of the input would result in cycling to the top and losing a view of the input.

Settings inputs that don't have confirm buttons should confirm when blurring focus, since a user has written something into the text box.

This is complicated by the fact that there is another piece of code here that fires events during render, which is an anti-pattern since it means that events relating to inputs will fire out-of-order (such as: on_blur:confirm -> render:set_state back to original value -> render value from Settings file). However this code's behavior is meant to prevent the override of a user's active field if the settings file is changed by another process. It is unclear to me that this is a good behavior, since a user can lose that data without realizing it, but it was intentionally implemented.

The test for this render logic currently uses the user's written data in the input field for comparison, which isn't actually indicating whether the initial value has changed. So in this PR we store the *original* initial value, and compare future initial values against it, updating the initial value if necessary.

## Previous Behavior

https://github.com/user-attachments/assets/26f69809-787b-497c-ace5-c959c57a68bd

## This PR

https://github.com/user-attachments/assets/cb55d4c9-3553-4337-9f02-a8fb4c81aea7

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Settings text inputs no longer lose user data when blurring focus
