### PR TITLE
Document generate-action-metadata step for local docs preview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,14 @@ Welcome to Zed's documentation.
 
 This is built on push to `main` and published automatically to [https://zed.dev/docs](https://zed.dev/docs).
 
-To preview the docs locally you will need to install [mdBook](https://rust-lang.github.io/mdBook/) (`cargo install mdbook@0.4.40`) and then run:
+To preview the docs locally you will need to install [mdBook](https://rust-lang.github.io/mdBook/) (`cargo install mdbook@0.4.40`), generate the action metadata, and then serve:
 
 ```sh
+script/generate-action-metadata
 mdbook serve docs
 ```
+
+The first command dumps an action manifest to `crates/docs_preprocessor/actions.json`. Without it, the preprocessor cannot validate keybinding and action references in the docs and will report errors. You only need to re-run it when actions change.
 
 It's important to note the version number above. For an unknown reason, as of 2025-04-23, running 0.4.48 will cause odd URL behavior that breaks things.
 


### PR DESCRIPTION
I needed to run the docs locally and ran into this error when following the [docs README.md](https://github.com/zed-industries/zed/blob/main/docs/README.md).

```
Error: Found 27 errors in docs
2026-04-01 10:15:39 [ERROR] (mdbook::utils): Error: The "zed_docs_preprocessor" preprocessor exited unsuccessfully with exit status: 1 status
```

It turns out I needed to run `script/generate-action-metadata` first. This PR adds that step to the doc.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A
