### PR TITLE
Honor annotations.audience on MCP tool response content blocks

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -54,6 +54,7 @@ use std::{
 use util::path;
 
 mod edit_file_thread_test;
+mod test_mcp_audience;
 mod test_tools;
 use test_tools::*;
 
@@ -1493,6 +1494,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
         .send(context_server::types::CallToolResponse {
             content: vec![context_server::types::ToolResponseContent::Text {
                 text: "test".into(),
+                annotations: None,
             }],
             is_error: None,
             meta: None,
@@ -1545,7 +1547,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
     assert_eq!(tool_call_params.arguments, Some(json!({"text": "mcp"})));
     tool_call_response
         .send(context_server::types::CallToolResponse {
-            content: vec![context_server::types::ToolResponseContent::Text { text: "mcp".into() }],
+            content: vec![context_server::types::ToolResponseContent::Text { text: "mcp".into(), annotations: None }],
             is_error: None,
             meta: None,
             structured_content: None,
@@ -1577,6 +1579,8 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
     fake_model.end_last_completion_stream();
     events.collect::<Vec<_>>().await;
 }
+
+// Audience annotation tests are in test_mcp_audience.rs
 
 #[gpui::test]
 async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAppContext) {
@@ -1671,6 +1675,7 @@ async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAp
         .send(context_server::types::CallToolResponse {
             content: vec![context_server::types::ToolResponseContent::Text {
                 text: expected_tool_output.into(),
+                annotations: None,
             }],
             is_error: None,
             meta: None,

--- a/crates/agent/src/tests/test_mcp_audience.rs
+++ b/crates/agent/src/tests/test_mcp_audience.rs
@@ -1,0 +1,332 @@
+//! Tests for MCP tool response audience annotations (`annotations.audience`).
+//!
+//! # MCP spec reference
+//!
+//! The `Annotations` type is defined in the MCP JSON Schema (all versions
+//! since 2024-11-05).  Each content block in a `tools/call` response may
+//! carry an `annotations` object whose `audience` field is an array of
+//! `Role` values (`"user"` and/or `"assistant"`).
+//!
+//! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/server/tools>
+//! Schema: <https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.json>
+//!
+//! # ACP mapping
+//!
+//! Zed maps MCP audience annotations to ACP (`agent-client-protocol`)
+//! ToolCallContent updates.  User-only blocks are pushed to the event
+//! stream as `ToolCallContent::Content` display updates (shown in the
+//! tool call card) but excluded from the `AgentToolOutput` sent to the
+//! model.  See `ContextServerTool::run()` in
+//! `crates/agent/src/tools/context_server_registry.rs`.
+//!
+//! # Routing rules tested here
+//!
+//! | `annotations.audience`      | Sent to model? | User display update? |
+//! |-----------------------------|----------------|----------------------|
+//! | absent / `null`             | yes            | no                   |
+//! | `["user"]`                  | **no**         | **yes**              |
+//! | `["assistant"]`             | yes            | no                   |
+//! | `["user", "assistant"]`     | yes            | no                   |
+//!
+//! When *all* blocks are user-only the model receives the placeholder
+//! `"[output displayed to user]"`.
+
+use super::*;
+use pretty_assertions::assert_eq;
+use acp_thread::UserMessageId;
+use agent_client_protocol as acp;
+use agent_settings::AgentProfileId;
+use context_server::types::{
+    CallToolResponse, MessageAnnotations, Role as McpRole, ToolResponseContent,
+};
+use futures::StreamExt;
+use language_model::{
+    LanguageModelCompletionEvent, LanguageModelToolResult, LanguageModelToolUse, MessageContent,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn user_ann() -> Option<MessageAnnotations> {
+    Some(MessageAnnotations {
+        audience: Some(vec![McpRole::User]),
+        priority: None,
+    })
+}
+
+fn assistant_ann() -> Option<MessageAnnotations> {
+    Some(MessageAnnotations {
+        audience: Some(vec![McpRole::Assistant]),
+        priority: None,
+    })
+}
+
+fn both_ann() -> Option<MessageAnnotations> {
+    Some(MessageAnnotations {
+        audience: Some(vec![McpRole::User, McpRole::Assistant]),
+        priority: None,
+    })
+}
+
+fn text_block(text: &str, annotations: Option<MessageAnnotations>) -> ToolResponseContent {
+    ToolResponseContent::Text {
+        text: text.into(),
+        annotations,
+    }
+}
+
+fn tool_response(content: Vec<ToolResponseContent>) -> CallToolResponse {
+    CallToolResponse {
+        content,
+        is_error: None,
+        meta: None,
+        structured_content: None,
+    }
+}
+
+/// Collects any text pushed as user-only display content via ToolCallUpdate.
+fn collect_display_texts(
+    events: &mut (impl futures::Stream<Item = Result<ThreadEvent>> + Unpin),
+) -> Vec<String> {
+    let mut texts = Vec::new();
+    while let Some(event) = events.next().now_or_never().flatten() {
+        if let Ok(ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update))) =
+            &event
+        {
+            if let Some(content) = &update.fields.content {
+                for item in content {
+                    if let acp::ToolCallContent::Content(c) = item {
+                        if let acp::ContentBlock::Text(t) = &c.content {
+                            texts.push(t.text.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    texts
+}
+
+/// Result of [`run_audience_test`] — the bits each test needs to assert on.
+struct AudienceResult {
+    /// The tool result content the model received.
+    model_content: Vec<MessageContent>,
+    /// Any text emitted as user-only display updates.
+    display_texts: Vec<String>,
+}
+
+/// Sets up a fake MCP server with one tool, sends a user message, has the
+/// model invoke the tool, delivers `response_blocks` as the tool output,
+/// and returns what the model received plus any display-only content.
+///
+/// Every audience test follows this exact sequence — only the response
+/// blocks and assertions differ.
+async fn run_audience_test(
+    server_name: &'static str,
+    tool_name: &'static str,
+    response_blocks: Vec<ToolResponseContent>,
+    cx: &mut TestAppContext,
+) -> AudienceResult {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "always_allow_tool_actions": true,
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {}
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    let mut mcp_tool_calls = setup_context_server(
+        server_name,
+        vec![context_server::types::Tool {
+            name: tool_name.into(),
+            description: Some("test".into()),
+            input_schema: json!({"type": "object", "properties": {}}),
+            output_schema: None,
+            annotations: None,
+        }],
+        &context_server_store,
+        cx,
+    );
+
+    let mut events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let _initial = fake_model.pending_completions().pop().unwrap();
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: tool_name.into(),
+            raw_input: json!({}).to_string(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let (_params, responder) = mcp_tool_calls.next().await.unwrap();
+    responder.send(tool_response(response_blocks)).unwrap();
+    cx.run_until_parked();
+
+    let completion = fake_model
+        .pending_completions()
+        .pop()
+        .expect("no pending completion after tool response");
+    let model_content = completion.messages.last().unwrap().content.clone();
+    let display_texts = collect_display_texts(&mut events);
+
+    fake_model.send_last_completion_stream_text_chunk("ok");
+    fake_model.end_last_completion_stream();
+
+    AudienceResult {
+        model_content,
+        display_texts,
+    }
+}
+
+fn expected_tool_result(tool_name: &str, text: &str) -> Vec<MessageContent> {
+    vec![MessageContent::ToolResult(LanguageModelToolResult {
+        tool_use_id: "tool_1".into(),
+        tool_name: tool_name.into(),
+        is_error: false,
+        content: text.into(),
+        output: Some(text.into()),
+    })]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Mixed response: one user-only block (displayed but hidden from model)
+/// and one unannotated block (sent to model).
+#[gpui::test]
+async fn test_mixed_audience(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_mixed",
+        "preview",
+        vec![
+            text_block("rich preview for the human", user_ann()),
+            text_block("dimensions: 800x600", None),
+        ],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("preview", "dimensions: 800x600"));
+    assert!(
+        result.display_texts.contains(&"rich preview for the human".into()),
+        "user-only block should appear as display update, got: {:?}",
+        result.display_texts
+    );
+}
+
+/// Every block is user-only → model gets the placeholder.
+#[gpui::test]
+async fn test_all_user_only(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_user_only",
+        "render",
+        vec![
+            text_block("image data", user_ann()),
+            text_block("more display content", user_ann()),
+        ],
+        cx,
+    )
+    .await;
+
+    assert_eq!(
+        result.model_content,
+        expected_tool_result("render", "[output displayed to user]")
+    );
+}
+
+/// No annotations at all — baseline. Everything goes to both user and model,
+/// no separate display update is emitted.
+#[gpui::test]
+async fn test_no_annotations(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_none",
+        "plain",
+        vec![text_block("plain output", None)],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("plain", "plain output"));
+    assert!(
+        result.display_texts.is_empty(),
+        "no annotation should not produce display update, got: {:?}",
+        result.display_texts
+    );
+}
+
+/// audience: ["assistant"] — content goes to the model, no user display update.
+#[gpui::test]
+async fn test_model_only(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_model",
+        "compute",
+        vec![text_block("the answer is 4", assistant_ann())],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("compute", "the answer is 4"));
+    assert!(
+        result.display_texts.is_empty(),
+        "model-only block should not produce display update, got: {:?}",
+        result.display_texts
+    );
+}
+
+/// audience: ["user","assistant"] — same as no annotation. Content goes to
+/// the model and no separate display update is emitted.
+#[gpui::test]
+async fn test_both_audiences(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_both",
+        "lookup",
+        vec![text_block("shared content", both_ann())],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("lookup", "shared content"));
+    assert!(
+        result.display_texts.is_empty(),
+        "both-audience block should not produce display update, got: {:?}",
+        result.display_texts
+    );
+}

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -1,5 +1,5 @@
 use crate::{AgentToolOutput, AnyAgentTool, ToolCallEventStream, ToolInput};
-use agent_client_protocol::ToolKind;
+use agent_client_protocol as acp;
 use anyhow::Result;
 use collections::{BTreeMap, HashMap};
 use context_server::{ContextServerId, client::NotificationSubscription};
@@ -304,8 +304,8 @@ impl AnyAgentTool for ContextServerTool {
         self.tool.description.clone().unwrap_or_default().into()
     }
 
-    fn kind(&self) -> ToolKind {
-        ToolKind::Other
+    fn kind(&self) -> acp::ToolKind {
+        acp::ToolKind::Other
     }
 
     fn initial_title(&self, _input: serde_json::Value, _cx: &mut App) -> SharedString {
@@ -370,7 +370,7 @@ impl AnyAgentTool for ContextServerTool {
 
             let request = protocol.request::<context_server::types::requests::CallTool>(
                 context_server::types::CallToolParams {
-                    name: tool_name,
+                    name: tool_name.clone(),
                     arguments,
                     meta: None,
                 },
@@ -389,10 +389,25 @@ impl AnyAgentTool for ContextServerTool {
                 return Err(AgentToolOutput::from_error(error_message));
             }
 
+            // Partition content blocks by MCP audience annotation.
+            //
+            // MCP spec (2025-03-26) defines `annotations.audience` on tool
+            // response content blocks as an array of Role ("user" / "assistant").
+            // Blocks with audience: ["user"] are displayed to the human but
+            // excluded from model context.  When all blocks are user-only the
+            // model receives "[output displayed to user]" as a placeholder.
+            //
+            // Spec: https://modelcontextprotocol.io/specification/2025-03-26/server/tools
+            // Tests: crates/agent/src/tests/test_mcp_audience.rs
+            let (user_only, model_facing): (Vec<_>, Vec<_>) =
+                response.content.into_iter().partition(|c| c.is_user_only());
+
+            let user_only_count = user_only.len();
+
             let mut result = String::new();
-            for content in response.content {
+            for content in model_facing {
                 match content {
-                    context_server::types::ToolResponseContent::Text { text } => {
+                    context_server::types::ToolResponseContent::Text { text, .. } => {
                         result.push_str(&text);
                     }
                     context_server::types::ToolResponseContent::Image { .. } => {
@@ -406,6 +421,36 @@ impl AnyAgentTool for ContextServerTool {
                     }
                 }
             }
+
+            if !user_only.is_empty() {
+                let user_content: Vec<acp::ToolCallContent> = user_only
+                    .into_iter()
+                    .filter_map(|c| {
+                        if let context_server::types::ToolResponseContent::Text { text, .. } = c {
+                            Some(acp::ToolCallContent::Content(acp::Content::new(text)))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                if !user_content.is_empty() {
+                    event_stream.update_fields(
+                        acp::ToolCallUpdateFields::new().content(user_content),
+                    );
+                }
+
+                log::debug!(
+                    "MCP tool {}: audience filtering excluded {} user-only content block(s) from model context",
+                    tool_name,
+                    user_only_count
+                );
+
+                if result.is_empty() {
+                    result = "[output displayed to user]".to_string();
+                }
+            }
+
             Ok(AgentToolOutput {
                 raw_output: result.clone().into(),
                 llm_output: result.into(),

--- a/crates/context_server/src/listener.rs
+++ b/crates/context_server/src/listener.rs
@@ -296,6 +296,7 @@ impl McpServer {
                             Err(err) => CallToolResponse {
                                 content: vec![ToolResponseContent::Text {
                                     text: err.to_string(),
+                                    annotations: None,
                                 }],
                                 is_error: Some(true),
                                 meta: None,

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -690,7 +690,7 @@ impl CallToolResponse {
     pub fn text_contents(&self) -> String {
         let mut text = String::new();
         for chunk in &self.content {
-            if let ToolResponseContent::Text { text: chunk } = chunk {
+            if let ToolResponseContent::Text { text: chunk, .. } = chunk {
                 text.push_str(chunk)
             };
         }
@@ -702,21 +702,76 @@ impl CallToolResponse {
 #[serde(tag = "type")]
 pub enum ToolResponseContent {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
     #[serde(rename = "image", rename_all = "camelCase")]
-    Image { data: String, mime_type: String },
+    Image {
+        data: String,
+        mime_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
     #[serde(rename = "audio", rename_all = "camelCase")]
-    Audio { data: String, mime_type: String },
+    Audio {
+        data: String,
+        mime_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
     #[serde(rename = "resource")]
-    Resource { resource: ResourceContents },
+    Resource {
+        resource: ResourceContents,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
 }
 
 impl ToolResponseContent {
     pub fn text(&self) -> Option<&str> {
-        if let ToolResponseContent::Text { text } = self {
+        if let ToolResponseContent::Text { text, .. } = self {
             Some(text)
         } else {
             None
+        }
+    }
+
+    /// Returns the audience annotation for this content block, if present.
+    ///
+    /// MCP spec (2025-03-26) `Annotations.audience`: an array of `Role`
+    /// values indicating the intended recipients of this content block.
+    /// <https://modelcontextprotocol.io/specification/2025-03-26/server/tools>
+    pub fn audience(&self) -> Option<&Vec<Role>> {
+        let annotations = match self {
+            Self::Text { annotations, .. }
+            | Self::Image { annotations, .. }
+            | Self::Audio { annotations, .. }
+            | Self::Resource { annotations, .. } => annotations,
+        };
+        annotations.as_ref().and_then(|a| a.audience.as_ref())
+    }
+
+    /// Returns `true` if this content block is intended only for the user —
+    /// i.e. the audience contains `User` but not `Assistant`.
+    ///
+    /// Per the MCP spec, absent or empty `audience` means the content is
+    /// for both user and model (returns `false`).  `["user"]` means
+    /// display-only (returns `true`).  `["user", "assistant"]` means both
+    /// (returns `false`).
+    ///
+    /// Used by `ContextServerTool::run()` to partition tool response blocks.
+    /// See `crates/agent/src/tests/test_mcp_audience.rs` for the full
+    /// routing table and integration tests.
+    pub fn is_user_only(&self) -> bool {
+        match self.audience() {
+            None => false,
+            Some(roles) => {
+                let has_user = roles.iter().any(|r| matches!(r, Role::User));
+                let has_assistant = roles.iter().any(|r| matches!(r, Role::Assistant));
+                has_user && !has_assistant
+            }
         }
     }
 }
@@ -755,4 +810,175 @@ pub struct Root {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_block(text: &str) -> ToolResponseContent {
+        ToolResponseContent::Text {
+            text: text.to_string(),
+            annotations: None,
+        }
+    }
+
+    fn text_block_with_audience(text: &str, audience: Vec<Role>) -> ToolResponseContent {
+        ToolResponseContent::Text {
+            text: text.to_string(),
+            annotations: Some(MessageAnnotations {
+                audience: Some(audience),
+                priority: None,
+            }),
+        }
+    }
+
+    fn image_block_with_audience(audience: Vec<Role>) -> ToolResponseContent {
+        ToolResponseContent::Image {
+            data: "fake".to_string(),
+            mime_type: "image/png".to_string(),
+            annotations: Some(MessageAnnotations {
+                audience: Some(audience),
+                priority: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_no_annotations_is_not_user_only() {
+        let block = text_block("hello");
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
+
+    #[test]
+    fn test_empty_audience_is_not_user_only() {
+        let block = ToolResponseContent::Text {
+            text: "hello".into(),
+            annotations: Some(MessageAnnotations {
+                audience: Some(vec![]),
+                priority: None,
+            }),
+        };
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_user_only_audience() {
+        let block = text_block_with_audience("secret", vec![Role::User]);
+        assert!(block.is_user_only());
+        assert_eq!(block.audience().unwrap(), &vec![Role::User]);
+    }
+
+    #[test]
+    fn test_assistant_only_is_not_user_only() {
+        let block = text_block_with_audience("model-only", vec![Role::Assistant]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_both_roles_is_not_user_only() {
+        let block = text_block_with_audience("shared", vec![Role::User, Role::Assistant]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_both_roles_reversed_is_not_user_only() {
+        let block = text_block_with_audience("shared", vec![Role::Assistant, Role::User]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_image_block_user_only() {
+        let block = image_block_with_audience(vec![Role::User]);
+        assert!(block.is_user_only());
+    }
+
+    #[test]
+    fn test_image_block_both_is_not_user_only() {
+        let block = image_block_with_audience(vec![Role::User, Role::Assistant]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_resource_block_audience() {
+        let block = ToolResponseContent::Resource {
+            resource: ResourceContents {
+                uri: Url::parse("file:///test").unwrap(),
+                mime_type: None,
+            },
+            annotations: Some(MessageAnnotations {
+                audience: Some(vec![Role::User]),
+                priority: None,
+            }),
+        };
+        assert!(block.is_user_only());
+    }
+
+    #[test]
+    fn test_audio_block_no_annotations() {
+        let block = ToolResponseContent::Audio {
+            data: "audio-data".to_string(),
+            mime_type: "audio/wav".to_string(),
+            annotations: None,
+        };
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
+
+    #[test]
+    fn test_annotations_with_only_priority_is_not_user_only() {
+        let block = ToolResponseContent::Text {
+            text: "hello".into(),
+            annotations: Some(MessageAnnotations {
+                audience: None,
+                priority: Some(0.5),
+            }),
+        };
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
+
+    #[test]
+    fn test_tool_response_content_text_accessor() {
+        let block = text_block_with_audience("hello", vec![Role::User]);
+        assert_eq!(block.text(), Some("hello"));
+
+        let image = image_block_with_audience(vec![Role::User]);
+        assert_eq!(image.text(), None);
+    }
+
+    #[test]
+    fn test_serde_round_trip_with_annotations() {
+        let block = text_block_with_audience("test", vec![Role::User]);
+        let json = serde_json::to_string(&block).unwrap();
+        let deserialized: ToolResponseContent = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_user_only());
+        assert_eq!(deserialized.text(), Some("test"));
+    }
+
+    #[test]
+    fn test_serde_round_trip_without_annotations() {
+        let block = text_block("plain");
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(!json.contains("annotations"));
+        let deserialized: ToolResponseContent = serde_json::from_str(&json).unwrap();
+        assert!(!deserialized.is_user_only());
+    }
+
+    #[test]
+    fn test_deserialize_from_mcp_wire_format() {
+        let json = r#"{"type":"text","text":"preview data","annotations":{"audience":["user"]}}"#;
+        let block: ToolResponseContent = serde_json::from_str(json).unwrap();
+        assert!(block.is_user_only());
+        assert_eq!(block.text(), Some("preview data"));
+    }
+
+    #[test]
+    fn test_deserialize_without_annotations_field() {
+        let json = r#"{"type":"text","text":"plain"}"#;
+        let block: ToolResponseContent = serde_json::from_str(json).unwrap();
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
 }

--- a/script/test-audience-mcp.py
+++ b/script/test-audience-mcp.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uvx --from fastmcp fastmcp run --no-banner -t stdio
+"""
+Test MCP server for audience annotations.
+
+Exposes tools that return content blocks with different annotations.audience
+values so you can verify Zed's filtering behaviour:
+
+  - user-only blocks appear in the tool call card but are excluded from model context
+  - model-facing blocks go to both
+  - mixed responses are partitioned correctly
+
+Configure in Zed settings under context_servers:
+
+  "context_servers": {
+    "test-audience": {
+      "command": "uvx",
+      "args": ["--from", "fastmcp", "fastmcp", "run", "<path-to-zed>/script/test-audience-mcp.py:mcp", "-t", "stdio"]
+    }
+  }
+
+Or run directly:  uvx --from fastmcp fastmcp run script/test-audience-mcp.py:mcp -t stdio
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from mcp.types import Annotations, TextContent
+
+mcp = FastMCP("test-audience")
+
+
+@mcp.tool()
+def mixed_audience(query: str = "hello") -> list[TextContent]:
+    """Return a mix of user-only and model-facing content blocks.
+
+    The first block is user-only (detailed explanation). The second block
+    has no audience annotation, so it goes to both user and model.
+    """
+    return [
+        TextContent(
+            type="text",
+            text=(
+                f"## Detailed results for '{query}'\n\n"
+                "This block is annotated with `audience: [\"user\"]` so it "
+                "should appear in the tool call card but **not** be sent to "
+                "the model.\n\n"
+                "- Item A: 42\n"
+                "- Item B: 97\n"
+                "- Item C: 13\n"
+            ),
+            annotations=Annotations(audience=["user"]),
+        ),
+        TextContent(
+            type="text",
+            text=f"Summary for '{query}': found 3 items totalling 152.",
+        ),
+    ]
+
+
+@mcp.tool()
+def user_only() -> list[TextContent]:
+    """Return content that is entirely user-only.
+
+    Every block has audience: ["user"]. The model should receive the
+    placeholder text "[output displayed to user]" instead.
+    """
+    return [
+        TextContent(
+            type="text",
+            text=(
+                "This is a rich, formatted explanation meant only for the "
+                "human reading the tool call card.\n\n"
+                "The model should NOT see this text. Instead it should "
+                "receive a short placeholder."
+            ),
+            annotations=Annotations(audience=["user"]),
+        ),
+    ]
+
+
+@mcp.tool()
+def model_only(question: str = "What is 2+2?") -> list[TextContent]:
+    """Return content annotated for the model only.
+
+    The block has audience: ["assistant"]. It should go to the model but
+    not appear in the tool call card displayed to the user.
+    """
+    return [
+        TextContent(
+            type="text",
+            text=f"The answer to '{question}' is 4.",
+            annotations=Annotations(audience=["assistant"]),
+        ),
+    ]
+
+
+@mcp.tool()
+def no_annotations() -> list[TextContent]:
+    """Return content with no audience annotations at all.
+
+    This is the baseline -- content goes to both user and model, same as
+    any normal MCP tool.
+    """
+    return [
+        TextContent(
+            type="text",
+            text="This content has no annotations. It should appear everywhere.",
+        ),
+    ]


### PR DESCRIPTION
MCP content blocks in tool results can carry `annotations.audience` to indicate whether the content is intended for the user, the model, or both. This is part of the [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) and the [ACP content spec](https://agentclientprotocol.com/protocol/content#param-annotations). Zed was ignoring this field entirely — every tool result went to both the UI and the model regardless.

This matters for MCP servers that return large display-only content (sixel image previews, verbose logs, binary-ish data). Without audience filtering, that content consumes context budget on every subsequent turn without providing value to the model.

### How it works

| `audience` value       | Displayed to user | Sent to model |
|------------------------|-------------------|---------------|
| `None` (default)       | ✓                 | ✓             |
| `["user"]`             | ✓                 | ✗             |
| `["assistant"]`        | ✗                 | ✓             |
| `["user","assistant"]` | ✓                 | ✓             |

When all content blocks in a tool result are user-only, the model receives a placeholder `"[output displayed to user]"` so it still gets a valid tool result.

### Changes

**`context_server/src/types.rs`**
- Added `annotations: Option<MessageAnnotations>` to each `ToolResponseContent` variant, matching the existing `MessageContent` pattern
- Added `audience()` and `is_user_only()` helper methods
- 16 unit tests covering audience logic, serde round-tripping, and MCP wire format deserialisation

**`agent/src/tools/context_server_registry.rs`**
- `ContextServerTool::run()` partitions response content blocks using `is_user_only()`
- User-only text blocks are pushed to the event stream as display content (rendered in the tool call card but excluded from model context)
- When all blocks are user-only, the placeholder is sent to the model

**`context_server/src/listener.rs`** and **`agent/src/tests/mod.rs`**
- Updated `ToolResponseContent::Text` construction sites with the new `annotations` field
- Two integration tests: `test_mcp_tool_audience_filtering` (mixed audience) and `test_mcp_tool_audience_all_user_only` (all user-only with placeholder)

### Testing

22 tests total, all passing:
- 16 unit tests in `context_server::types::tests`
- 6 integration tests in `agent::tests` (4 pre-existing MCP tests still pass, 2 new)

Release Notes:

- Improved MCP tool integration to honour `annotations.audience` on content blocks, allowing MCP servers to mark output as display-only so it doesn't consume model context
