### PR TITLE
git_graph: Improve active chip visibility and add `leading_icon` in chip component

### DIFF
--- a/assets/icons/git_tag.svg
+++ b/assets/icons/git_tag.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+     d="M 2,2 H 7 L 14,9 9,14 2,7 V 2" stroke="#c6cad0" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle fill="#c6cad0" cx="5" cy="5" r="1" />
+</svg>

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1198,7 +1198,14 @@ impl GitGraph {
         accent_color: gpui::Hsla,
         is_head: bool,
     ) -> impl IntoElement {
-        Chip::new(name.clone())
+        let is_tag = name.clone().contains("tag: ");
+
+        let display_name = match is_tag {
+            true => name.replace("tag: ", "").into(),
+            false => name.clone(),
+        };
+
+        Chip::new(display_name)
             .label_size(LabelSize::Small)
             .truncate()
             .map(|chip| {
@@ -1207,8 +1214,13 @@ impl GitGraph {
                         .bg_color(accent_color.opacity(0.25))
                         .border_color(accent_color.opacity(0.5))
                 } else {
-                    chip.bg_color(accent_color.opacity(0.08))
-                        .border_color(accent_color.opacity(0.25))
+                    chip.icon(if is_tag {
+                        IconName::GitTag
+                    } else {
+                        IconName::GitBranch
+                    })
+                    .bg_color(accent_color.opacity(0.08))
+                    .border_color(accent_color.opacity(0.25))
                 }
             })
     }

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -150,6 +150,7 @@ pub enum IconName {
     GitBranchPlus,
     GitCommit,
     GitGraph,
+    GitTag,
     GitMergeConflict,
     GitWorktree,
     Github,

--- a/crates/ui/src/components/chip.rs
+++ b/crates/ui/src/components/chip.rs
@@ -115,9 +115,7 @@ impl RenderOnce for Chip {
             .bg(bg_color)
             .overflow_hidden()
             .when_some(self.icon, |this, icon| {
-                this
-                    .pl_0()
-                    .child(
+                this.pl_0().child(
                     h_flex()
                         .flex_grow()
                         .h_full()
@@ -129,10 +127,10 @@ impl RenderOnce for Chip {
                         .items_center()
                         .justify_center()
                         .child(
-                    Icon::new(icon)
-                        .size(IconSize::XSmall)
-                        .color(self.icon_color),
-                        )
+                            Icon::new(icon)
+                                .size(IconSize::XSmall)
+                                .color(self.icon_color),
+                        ),
                 )
             })
             .child(

--- a/crates/ui/src/components/chip.rs
+++ b/crates/ui/src/components/chip.rs
@@ -115,10 +115,24 @@ impl RenderOnce for Chip {
             .bg(bg_color)
             .overflow_hidden()
             .when_some(self.icon, |this, icon| {
-                this.child(
+                this
+                    .pl_0()
+                    .child(
+                    h_flex()
+                        .flex_grow()
+                        .h_full()
+                        .border_r_1()
+                        .px_1()
+                        .bg(bg_color) // this will overlay the background color on the icon container which eventually make icon section looks like it has a different background color than the rest of the chip when bg_color is set to some color with opacity less than 1.0
+                        .border_color(border_color)
+                        .rounded_l_sm()
+                        .items_center()
+                        .justify_center()
+                        .child(
                     Icon::new(icon)
                         .size(IconSize::XSmall)
                         .color(self.icon_color),
+                        )
                 )
             })
             .child(


### PR DESCRIPTION
## This PR enhances the chip component and its implementation in the git graph

- ~~Add optional `leading_icon` in the `Chip` component~~ (updated in the PR #53803)
- Separate branches and tags with `icon` attribute
- add new icon `git_tag.svg` with `IconName::GitTag` enum
- display active branch / HEAD with bolder chips
  - ~~Added a numerical multiplier to multiply the chip's properties when the chip contains `HEAD`~~.

### Before:

<img width="1292" height="552" alt="image" src="https://github.com/user-attachments/assets/d840dc5d-a7f1-47e6-8344-201f89af8d91" />

### After:
<img width="1359" height="550" alt="image" src="https://github.com/user-attachments/assets/d7a5de0a-c5b1-4517-ae4f-1f3242b498fe" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Git Graph: show chip with leading icons for branches and tags
