### PR TITLE
Improve the application menu visibility on Windows and Linux

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -466,7 +466,7 @@
     // Whether to show the sign in button in the titlebar.
     "show_sign_in": true,
     // Whether to show the menus in the titlebar.
-    "show_menus": false,
+    "show_menus": true,
     // The layout of window control buttons in the title bar (Linux only).
     "button_layout": "platform_default",
   },

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -264,21 +264,23 @@ impl ApplicationMenu {
         cx.defer_in(window, move |_, window, cx| next_handle.show(window, cx));
     }
 
-    pub fn all_menus_shown(&self, cx: &mut Context<Self>) -> bool {
-        show_menus(cx)
+    pub fn all_menus_shown(&self, window: &Window, cx: &App) -> bool {
+        show_menus(window, cx)
             || self.entries.iter().any(|entry| entry.handle.is_deployed())
             || self.pending_menu_open.is_some()
     }
 }
 
-pub(crate) fn show_menus(cx: &mut App) -> bool {
-    TitleBarSettings::get_global(cx).show_menus
+pub(crate) fn show_menus(window: &Window, cx: &App) -> bool {
+    let title_bar_settings = TitleBarSettings::get_global(cx);
+    title_bar_settings.show_menus
         && (cfg!(not(target_os = "macos")) || option_env!("ZED_USE_CROSS_PLATFORM_MENU").is_some())
+        && window.window_bounds().get_bounds().size.width > px(600.0)
 }
 
 impl Render for ApplicationMenu {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let all_menus_shown = self.all_menus_shown(cx);
+        let all_menus_shown = self.all_menus_shown(window, cx);
 
         if let Some(pending_menu_open) = self.pending_menu_open.take()
             && let Some(entry) = self

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -179,7 +179,7 @@ impl Render for TitleBar {
         let title_bar_settings = *TitleBarSettings::get_global(cx);
         let button_layout = title_bar_settings.button_layout;
 
-        let show_menus = show_menus(cx);
+        let show_menus = show_menus(window, cx);
 
         let mut children = Vec::new();
 
@@ -215,7 +215,7 @@ impl Render for TitleBar {
                             self.application_menu.clone().filter(|_| !show_menus),
                             |title_bar, menu| {
                                 render_project_items &=
-                                    !menu.update(cx, |menu, cx| menu.all_menus_shown(cx));
+                                    !menu.update(cx, |menu, cx| menu.all_menus_shown(window, cx));
                                 title_bar.child(menu)
                             },
                         )

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4636,7 +4636,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     "show_user_picture": true,
     "show_user_menu": true,
     "show_sign_in": true,
-    "show_menus": false,
+    "show_menus": true,
     "button_layout": "platform_default"
   }
 }

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -125,7 +125,7 @@ To disable this behavior use:
     "show_user_picture": true,      // Show/hide user avatar
     "show_user_menu": true,         // Show/hide app user button
     "show_sign_in": true,           // Show/hide sign-in button
-    "show_menus": false             // Show/hide menus
+    "show_menus": true              // Show/hide menus
   },
 ```
 


### PR DESCRIPTION
Improved the application menu visibility on Windows and Linux by making it visible by default and adding responsive collapsing for narrow windows.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #44037 

Release Notes:

- Improved the application menu visibility on Windows and Linux by making it visible by default 
