### PR TITLE
project_panel: Wrap filenames in code spans in confirmation dialogs

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -640,6 +640,10 @@ fn get_item_color(is_sticky: bool, cx: &App) -> ItemColors {
     }
 }
 
+fn code_span(name: &str) -> String {
+    format!("`{}`", name)
+}
+
 impl ProjectPanel {
     fn new(
         workspace: &mut Workspace,
@@ -2350,7 +2354,7 @@ impl ProjectPanel {
             let file_name = entry.path.file_name()?.to_string();
 
             let answer = if !action.skip_prompt {
-                let prompt = format!("Discard changes to {}?", file_name);
+                let prompt = format!("Discard changes to {}?", code_span(&file_name));
                 Some(window.prompt(PromptLevel::Info, &prompt, None, &["Restore", "Cancel"], cx))
             } else {
                 None
@@ -4541,7 +4545,7 @@ impl ProjectPanel {
                             "already exists in the destination folder. ",
                             "Do you want to replace it?"
                         ),
-                        filename
+                        code_span(filename)
                     );
                     let answer = cx
                         .update(|window, cx| {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -640,10 +640,6 @@ fn get_item_color(is_sticky: bool, cx: &App) -> ItemColors {
     }
 }
 
-fn code_span(name: &str) -> String {
-    format!("`{}`", name)
-}
-
 impl ProjectPanel {
     fn new(
         workspace: &mut Workspace,
@@ -2354,7 +2350,7 @@ impl ProjectPanel {
             let file_name = entry.path.file_name()?.to_string();
 
             let answer = if !action.skip_prompt {
-                let prompt = format!("Discard changes to {}?", code_span(&file_name));
+                let prompt = format!("Discard changes to {}?", MarkdownInlineCode(&file_name));
                 Some(window.prompt(PromptLevel::Info, &prompt, None, &["Restore", "Cancel"], cx))
             } else {
                 None
@@ -2574,7 +2570,7 @@ impl ProjectPanel {
                                 .iter()
                                 .map(|(_, _, path)| MarkdownInlineCode(path).to_string())
                                 .take(CUTOFF_POINT)
-                                .collect::<Vec<_>>();
+                                .collect::<Vec<String>>();
                             paths.truncate(CUTOFF_POINT);
                             if truncated_path_counts == 1 {
                                 paths.push(".. 1 file not shown".into());
@@ -4545,7 +4541,7 @@ impl ProjectPanel {
                             "already exists in the destination folder. ",
                             "Do you want to replace it?"
                         ),
-                        code_span(filename)
+                        MarkdownInlineCode(filename)
                     );
                     let answer = cx
                         .update(|window, cx| {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -11060,3 +11060,41 @@ async fn test_delete_prompt_escapes_markdown_in_file_name(cx: &mut gpui::TestApp
         "Are you sure you want to permanently delete `__somefile__`?"
     );
 }
+
+#[gpui::test]
+async fn test_restore_file_prompt_escapes_markdown_in_file_name(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "__init__.py": "modified contents",
+        }),
+    )
+    .await;
+    fs.set_head_and_index_for_repo(
+        path!("/root/.git").as_ref(),
+        &[("__init__.py", "original contents".into())],
+    );
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/__init__.py", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.restore_file(&git::RestoreFile { skip_prompt: false }, window, cx)
+    });
+    let (message, _detail) = cx
+        .pending_prompt()
+        .expect("restore should show a confirmation prompt");
+
+    assert_eq!(message, "Discard changes to `__init__.py`?");
+}

--- a/crates/util/src/markdown.rs
+++ b/crates/util/src/markdown.rs
@@ -310,6 +310,34 @@ mod tests {
     }
 
     #[test]
+    fn test_markdown_inline_code_filenames() {
+        assert_eq!(
+            MarkdownInlineCode("__init__.py").to_string(),
+            "`__init__.py`"
+        );
+        assert_eq!(
+            MarkdownInlineCode("__main__.py").to_string(),
+            "`__main__.py`"
+        );
+        assert_eq!(
+            MarkdownInlineCode("test__file.py").to_string(),
+            "`test__file.py`"
+        );
+        assert_eq!(
+            MarkdownInlineCode("_private_module.rs").to_string(),
+            "`_private_module.rs`"
+        );
+        assert_eq!(
+            MarkdownInlineCode("*glob*pattern*").to_string(),
+            "`*glob*pattern*`"
+        );
+        assert_eq!(
+            MarkdownInlineCode("file`with`backticks.py").to_string(),
+            "``file`with`backticks.py``"
+        );
+    }
+
+    #[test]
     fn test_count_max_consecutive_chars() {
         assert_eq!(
             count_max_consecutive_chars("``a```b``", '`'),

--- a/crates/util/src/markdown.rs
+++ b/crates/util/src/markdown.rs
@@ -310,34 +310,6 @@ mod tests {
     }
 
     #[test]
-    fn test_markdown_inline_code_filenames() {
-        assert_eq!(
-            MarkdownInlineCode("__init__.py").to_string(),
-            "`__init__.py`"
-        );
-        assert_eq!(
-            MarkdownInlineCode("__main__.py").to_string(),
-            "`__main__.py`"
-        );
-        assert_eq!(
-            MarkdownInlineCode("test__file.py").to_string(),
-            "`test__file.py`"
-        );
-        assert_eq!(
-            MarkdownInlineCode("_private_module.rs").to_string(),
-            "`_private_module.rs`"
-        );
-        assert_eq!(
-            MarkdownInlineCode("*glob*pattern*").to_string(),
-            "`*glob*pattern*`"
-        );
-        assert_eq!(
-            MarkdownInlineCode("file`with`backticks.py").to_string(),
-            "``file`with`backticks.py``"
-        );
-    }
-
-    #[test]
     fn test_count_max_consecutive_chars() {
         assert_eq!(
             count_max_consecutive_chars("``a```b``", '`'),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -50,7 +50,8 @@ use ui::{
     Tooltip, prelude::*, right_click_menu,
 };
 use util::{
-    ResultExt, debug_panic, maybe, paths::PathStyle, serde::default_true, truncate_and_remove_front,
+    ResultExt, debug_panic, markdown::MarkdownInlineCode, maybe, paths::PathStyle,
+    serde::default_true, truncate_and_remove_front,
 };
 
 /// A selected entry in e.g. project panel.
@@ -4890,10 +4891,6 @@ impl NavHistoryState {
     }
 }
 
-fn code_span(name: impl AsRef<str>) -> String {
-    format!("`{}`", name.as_ref())
-}
-
 fn dirty_message_for(buffer_path: Option<ProjectPath>, path_style: PathStyle) -> String {
     let path = buffer_path
         .as_ref()
@@ -4905,7 +4902,7 @@ fn dirty_message_for(buffer_path: Option<ProjectPath>, path_style: PathStyle) ->
     let path = truncate_and_remove_front(&path, 80);
     format!(
         "{} contains unsaved edits. Do you want to save it?",
-        code_span(path)
+        MarkdownInlineCode(path.as_str())
     )
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4892,18 +4892,20 @@ impl NavHistoryState {
 }
 
 fn dirty_message_for(buffer_path: Option<ProjectPath>, path_style: PathStyle) -> String {
-    let path = buffer_path
-        .as_ref()
-        .and_then(|p| {
-            let path = p.path.display(path_style);
-            if path.is_empty() { None } else { Some(path) }
-        })
-        .unwrap_or("This buffer".into());
-    let path = truncate_and_remove_front(&path, 80);
-    format!(
-        "{} contains unsaved edits. Do you want to save it?",
-        MarkdownInlineCode(path.as_str())
-    )
+    let path = buffer_path.as_ref().and_then(|p| {
+        let path = p.path.display(path_style);
+        if path.is_empty() { None } else { Some(path) }
+    });
+    match path {
+        Some(path) => {
+            let path = truncate_and_remove_front(&path, 80);
+            format!(
+                "{} contains unsaved edits. Do you want to save it?",
+                MarkdownInlineCode(path.as_str())
+            )
+        }
+        None => "This buffer contains unsaved edits. Do you want to save it?".to_string(),
+    }
 }
 
 pub fn tab_details(items: &[Box<dyn ItemHandle>], _window: &Window, cx: &App) -> Vec<usize> {
@@ -9095,6 +9097,22 @@ mod tests {
                 assert_pane_ids_on_axis(&workspace, expected_ids, expected_axis, cx);
             }
         }
+    }
+
+    #[test]
+    fn test_dirty_message_for_escapes_markdown_in_path() {
+        let project_path = ProjectPath {
+            worktree_id: WorktreeId::from_usize(0),
+            path: util::rel_path::rel_path("dir/__init__.py").into(),
+        };
+        assert_eq!(
+            dirty_message_for(Some(project_path), PathStyle::Posix),
+            "`dir/__init__.py` contains unsaved edits. Do you want to save it?"
+        );
+        assert_eq!(
+            dirty_message_for(None, PathStyle::Posix),
+            "This buffer contains unsaved edits. Do you want to save it?"
+        );
     }
 
     mod property_test {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4890,6 +4890,10 @@ impl NavHistoryState {
     }
 }
 
+fn code_span(name: impl AsRef<str>) -> String {
+    format!("`{}`", name.as_ref())
+}
+
 fn dirty_message_for(buffer_path: Option<ProjectPath>, path_style: PathStyle) -> String {
     let path = buffer_path
         .as_ref()
@@ -4899,7 +4903,10 @@ fn dirty_message_for(buffer_path: Option<ProjectPath>, path_style: PathStyle) ->
         })
         .unwrap_or("This buffer".into());
     let path = truncate_and_remove_front(&path, 80);
-    format!("{path} contains unsaved edits. Do you want to save it?")
+    format!(
+        "{} contains unsaved edits. Do you want to save it?",
+        code_span(path)
+    )
 }
 
 pub fn tab_details(items: &[Box<dyn ItemHandle>], _window: &Window, cx: &App) -> Vec<usize> {


### PR DESCRIPTION
Closes #53060 

Filenames with double underscores (e.g. __init__.py) were rendered as Markdown bold in confirmation dialogs because the prompt renderer interprets the message as Markdown. Wrap filenames in backticks so they render as inline code instead.

Release Notes:
 - Fixed filenames with double underscores rendering as bold in project panel confirmation dialogs
 
 

<img width="327" height="186" alt="image" src="https://github.com/user-attachments/assets/ea178055-e7e9-4a4c-80de-587fda53d894" />
<img width="328" height="129" alt="image" src="https://github.com/user-attachments/assets/de93eb43-da71-41b1-9bb2-c02b86205051" />
<img width="329" height="175" alt="image" src="https://github.com/user-attachments/assets/eed19f8a-1a99-4485-abf6-57c506e01e00" />
