### PR TITLE
markdown_preview: Add footnotes support

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1831,6 +1831,24 @@ impl Element for MarkdownElement {
                                 );
                                 builder.pop_div();
                             }
+                            builder.push_div(
+                                div()
+                                    .pt_1()
+                                    .mb_1()
+                                    .line_height(rems(1.3))
+                                    .text_size(rems(0.85))
+                                    .h_flex()
+                                    .items_start()
+                                    .gap_2()
+                                    .child(
+                                        div()
+                                            .text_size(rems(0.85))
+                                            .child(format!("{}.", label)),
+                                    ),
+                                range,
+                                markdown_end,
+                            );
+                            builder.push_div(div().flex_1().w_0(), range, markdown_end);
                         }
                         MarkdownTag::MetadataBlock(_) => {}
                         MarkdownTag::Table(alignments) => {
@@ -1986,6 +2004,10 @@ impl Element for MarkdownElement {
                         builder.replace_pending_checkbox(range);
                         builder.pop_div();
                         builder.table.end_cell();
+                    }
+                    MarkdownTagEnd::FootnoteDefinition => {
+                        builder.pop_div();
+                        builder.pop_div();
                     }
                     _ => log::debug!("unsupported markdown tag end: {:?}", tag),
                 },

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -536,15 +536,18 @@ impl Markdown {
 
     fn footnote_definition_content_start(&self, label: &SharedString) -> Option<usize> {
         let mut inside_target_def = false;
-        self.parsed_markdown.events.iter().find_map(|(range, event)| {
-            if inside_target_def && matches!(event, MarkdownEvent::Text) {
-                return Some(range.start);
-            }
-            if let MarkdownEvent::Start(MarkdownTag::FootnoteDefinition(def_label)) = event {
-                inside_target_def = *def_label == *label;
-            }
-            None
-        })
+        self.parsed_markdown
+            .events
+            .iter()
+            .find_map(|(range, event)| {
+                if inside_target_def && matches!(event, MarkdownEvent::Text) {
+                    return Some(range.start);
+                }
+                if let MarkdownEvent::Start(MarkdownTag::FootnoteDefinition(def_label)) = event {
+                    inside_target_def = *def_label == *label;
+                }
+                None
+            })
     }
 
     pub fn set_active_root_for_source_index(
@@ -1355,7 +1358,9 @@ impl MarkdownElement {
             move |markdown, event: &MouseDownEvent, phase, window, cx| {
                 if hitbox.is_hovered(window) {
                     if phase.bubble() {
-                        if let Some(footnote_ref) = rendered_text.footnote_ref_for_position(event.position) {
+                        if let Some(footnote_ref) =
+                            rendered_text.footnote_ref_for_position(event.position)
+                        {
                             markdown.pressed_footnote_ref = Some(footnote_ref.clone());
                         } else if let Some(link) = rendered_text.link_for_position(event.position) {
                             markdown.pressed_link = Some(link.clone());
@@ -1435,10 +1440,13 @@ impl MarkdownElement {
                     markdown.autoscroll_request = Some(source_index);
                     cx.notify();
                 } else {
-                    let is_hovering_link = rendered_text.link_for_position(event.position).is_some();
-                    let is_hovering_footnote_ref = rendered_text.footnote_ref_for_position(event.position).is_some();
-                    let is_hovering_clickable = hitbox.is_hovered(window)
-                        && (is_hovering_link || is_hovering_footnote_ref);
+                    let is_hovering_link =
+                        rendered_text.link_for_position(event.position).is_some();
+                    let is_hovering_footnote_ref = rendered_text
+                        .footnote_ref_for_position(event.position)
+                        .is_some();
+                    let is_hovering_clickable =
+                        hitbox.is_hovered(window) && (is_hovering_link || is_hovering_footnote_ref);
                     if is_hovering_clickable != was_hovering_clickable {
                         cx.notify();
                     }
@@ -1453,8 +1461,8 @@ impl MarkdownElement {
                         && Some(&pressed_footnote_ref)
                             == rendered_text.footnote_ref_for_position(event.position)
                     {
-                        if let Some(source_index) = markdown
-                            .footnote_definition_content_start(&pressed_footnote_ref.label)
+                        if let Some(source_index) =
+                            markdown.footnote_definition_content_start(&pressed_footnote_ref.label)
                         {
                             markdown.autoscroll_request = Some(source_index);
                             cx.notify();
@@ -1874,9 +1882,7 @@ impl Element for MarkdownElement {
                                     .items_start()
                                     .gap_2()
                                     .child(
-                                        div()
-                                            .text_size(rems(0.85))
-                                            .child(format!("{}.", label)),
+                                        div().text_size(rems(0.85)).child(format!("{}.", label)),
                                     ),
                                 range,
                                 markdown_end,
@@ -2944,10 +2950,7 @@ impl RenderedText {
             .find(|link| link.source_range.contains(&source_index))
     }
 
-    fn footnote_ref_for_position(
-        &self,
-        position: Point<Pixels>,
-    ) -> Option<&RenderedFootnoteRef> {
+    fn footnote_ref_for_position(&self, position: Point<Pixels>) -> Option<&RenderedFootnoteRef> {
         let source_index = self.source_index_for_position(position).ok()?;
         self.footnote_refs
             .iter()

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1302,14 +1302,18 @@ impl MarkdownElement {
             return;
         }
 
-        let is_hovering_link = hitbox.is_hovered(window)
+        let is_hovering_link = rendered_text
+            .link_for_position(window.mouse_position())
+            .is_some();
+        let is_hovering_footnote_ref = rendered_text
+            .footnote_ref_for_position(window.mouse_position())
+            .is_some();
+        let is_hovering_clickable = hitbox.is_hovered(window)
             && !self.markdown.read(cx).selection.pending
-            && rendered_text
-                .link_for_position(window.mouse_position())
-                .is_some();
+            && (is_hovering_link || is_hovering_footnote_ref);
 
         if !self.style.prevent_mouse_interaction {
-            if is_hovering_link {
+            if is_hovering_clickable {
                 window.set_cursor_style(CursorStyle::PointingHand, hitbox);
             } else {
                 window.set_cursor_style(CursorStyle::IBeam, hitbox);
@@ -1400,7 +1404,7 @@ impl MarkdownElement {
         self.on_mouse_event(window, cx, {
             let rendered_text = rendered_text.clone();
             let hitbox = hitbox.clone();
-            let was_hovering_link = is_hovering_link;
+            let was_hovering_clickable = is_hovering_clickable;
             move |markdown, event: &MouseMoveEvent, phase, window, cx| {
                 if phase.capture() {
                     return;
@@ -1416,9 +1420,11 @@ impl MarkdownElement {
                     markdown.autoscroll_request = Some(source_index);
                     cx.notify();
                 } else {
-                    let is_hovering_link = hitbox.is_hovered(window)
-                        && rendered_text.link_for_position(event.position).is_some();
-                    if is_hovering_link != was_hovering_link {
+                    let is_hovering_link = rendered_text.link_for_position(event.position).is_some();
+                    let is_hovering_footnote_ref = rendered_text.footnote_ref_for_position(event.position).is_some();
+                    let is_hovering_clickable = hitbox.is_hovered(window)
+                        && (is_hovering_link || is_hovering_footnote_ref);
+                    if is_hovering_clickable != was_hovering_clickable {
                         cx.notify();
                     }
                 }
@@ -2313,6 +2319,7 @@ struct MarkdownElementBuilder {
     rendered_lines: Vec<RenderedLine>,
     pending_line: PendingLine,
     rendered_links: Vec<RenderedLink>,
+    rendered_footnote_refs: Vec<RenderedFootnoteRef>,
     current_source_index: usize,
     html_comment: bool,
     rendered_footnote_separator: bool,
@@ -2350,6 +2357,7 @@ impl MarkdownElementBuilder {
             rendered_lines: Vec::new(),
             pending_line: PendingLine::default(),
             rendered_links: Vec::new(),
+            rendered_footnote_refs: Vec::new(),
             current_source_index: 0,
             html_comment: false,
             rendered_footnote_separator: false,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1353,19 +1353,27 @@ impl MarkdownElement {
             move |markdown, event: &MouseDownEvent, phase, window, cx| {
                 if hitbox.is_hovered(window) {
                     if phase.bubble() {
-                        let source_index =
-                            match rendered_text.source_index_for_position(event.position) {
+                        let position_result =
+                            rendered_text.source_index_for_position(event.position);
+
+                        if let Ok(source_index) = position_result {
+                            if let Some(footnote_ref) =
+                                rendered_text.footnote_ref_for_source_index(source_index)
+                            {
+                                markdown.pressed_footnote_ref = Some(footnote_ref.clone());
+                            } else if let Some(link) =
+                                rendered_text.link_for_source_index(source_index)
+                            {
+                                markdown.pressed_link = Some(link.clone());
+                            }
+                        }
+
+                        if markdown.pressed_footnote_ref.is_none()
+                            && markdown.pressed_link.is_none()
+                        {
+                            let source_index = match position_result {
                                 Ok(ix) | Err(ix) => ix,
                             };
-                        if let Some(footnote_ref) =
-                            rendered_text.footnote_ref_for_source_index(source_index)
-                        {
-                            markdown.pressed_footnote_ref = Some(footnote_ref.clone());
-                        } else if let Some(link) =
-                            rendered_text.link_for_source_index(source_index)
-                        {
-                            markdown.pressed_link = Some(link.clone());
-                        } else {
                             if let Some(handler) = on_source_click.as_ref() {
                                 let blocked = handler(source_index, event.click_count, window, cx);
                                 if blocked {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1353,17 +1353,19 @@ impl MarkdownElement {
             move |markdown, event: &MouseDownEvent, phase, window, cx| {
                 if hitbox.is_hovered(window) {
                     if phase.bubble() {
+                        let source_index =
+                            match rendered_text.source_index_for_position(event.position) {
+                                Ok(ix) | Err(ix) => ix,
+                            };
                         if let Some(footnote_ref) =
-                            rendered_text.footnote_ref_for_position(event.position)
+                            rendered_text.footnote_ref_for_source_index(source_index)
                         {
                             markdown.pressed_footnote_ref = Some(footnote_ref.clone());
-                        } else if let Some(link) = rendered_text.link_for_position(event.position) {
+                        } else if let Some(link) =
+                            rendered_text.link_for_source_index(source_index)
+                        {
                             markdown.pressed_link = Some(link.clone());
                         } else {
-                            let source_index =
-                                match rendered_text.source_index_for_position(event.position) {
-                                    Ok(ix) | Err(ix) => ix,
-                                };
                             if let Some(handler) = on_source_click.as_ref() {
                                 let blocked = handler(source_index, event.click_count, window, cx);
                                 if blocked {
@@ -1455,9 +1457,13 @@ impl MarkdownElement {
             let rendered_text = rendered_text.clone();
             move |markdown, event: &MouseUpEvent, phase, window, cx| {
                 if phase.bubble() {
+                    let source_index = rendered_text
+                        .source_index_for_position(event.position)
+                        .ok();
                     if let Some(pressed_footnote_ref) = markdown.pressed_footnote_ref.take()
-                        && Some(&pressed_footnote_ref)
-                            == rendered_text.footnote_ref_for_position(event.position)
+                        && source_index
+                            .and_then(|ix| rendered_text.footnote_ref_for_source_index(ix))
+                            == Some(&pressed_footnote_ref)
                     {
                         if let Some(source_index) =
                             markdown.footnote_definition_content_start(&pressed_footnote_ref.label)
@@ -1466,7 +1472,9 @@ impl MarkdownElement {
                             cx.notify();
                         }
                     } else if let Some(pressed_link) = markdown.pressed_link.take()
-                        && Some(&pressed_link) == rendered_text.link_for_position(event.position)
+                        && source_index
+                            .and_then(|ix| rendered_text.link_for_source_index(ix))
+                            == Some(&pressed_link)
                     {
                         if let Some(open_url) = on_open_url.as_ref() {
                             open_url(pressed_link.destination_url, window, cx);
@@ -2953,15 +2961,6 @@ impl RenderedText {
             .find(|fref| fref.source_range.contains(&source_index))
     }
 
-    fn link_for_position(&self, position: Point<Pixels>) -> Option<&RenderedLink> {
-        let source_index = self.source_index_for_position(position).ok()?;
-        self.link_for_source_index(source_index)
-    }
-
-    fn footnote_ref_for_position(&self, position: Point<Pixels>) -> Option<&RenderedFootnoteRef> {
-        let source_index = self.source_index_for_position(position).ok()?;
-        self.footnote_ref_for_source_index(source_index)
-    }
 }
 
 #[cfg(test)]

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1325,12 +1325,10 @@ impl MarkdownElement {
                             .is_some()
                 });
 
-        if !self.style.prevent_mouse_interaction {
-            if is_hovering_clickable {
-                window.set_cursor_style(CursorStyle::PointingHand, hitbox);
-            } else {
-                window.set_cursor_style(CursorStyle::IBeam, hitbox);
-            }
+        if is_hovering_clickable {
+            window.set_cursor_style(CursorStyle::PointingHand, hitbox);
+        } else {
+            window.set_cursor_style(CursorStyle::IBeam, hitbox);
         }
 
         let on_open_url = self.on_url_click.take();

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1313,15 +1313,17 @@ impl MarkdownElement {
             return;
         }
 
-        let is_hovering_link = rendered_text
-            .link_for_position(window.mouse_position())
-            .is_some();
-        let is_hovering_footnote_ref = rendered_text
-            .footnote_ref_for_position(window.mouse_position())
-            .is_some();
         let is_hovering_clickable = hitbox.is_hovered(window)
             && !self.markdown.read(cx).selection.pending
-            && (is_hovering_link || is_hovering_footnote_ref);
+            && rendered_text
+                .source_index_for_position(window.mouse_position())
+                .ok()
+                .is_some_and(|source_index| {
+                    rendered_text.link_for_source_index(source_index).is_some()
+                        || rendered_text
+                            .footnote_ref_for_source_index(source_index)
+                            .is_some()
+                });
 
         if !self.style.prevent_mouse_interaction {
             if is_hovering_clickable {
@@ -1435,13 +1437,16 @@ impl MarkdownElement {
                     markdown.autoscroll_request = Some(source_index);
                     cx.notify();
                 } else {
-                    let is_hovering_link =
-                        rendered_text.link_for_position(event.position).is_some();
-                    let is_hovering_footnote_ref = rendered_text
-                        .footnote_ref_for_position(event.position)
-                        .is_some();
-                    let is_hovering_clickable =
-                        hitbox.is_hovered(window) && (is_hovering_link || is_hovering_footnote_ref);
+                    let is_hovering_clickable = hitbox.is_hovered(window)
+                        && rendered_text
+                            .source_index_for_position(event.position)
+                            .ok()
+                            .is_some_and(|source_index| {
+                                rendered_text.link_for_source_index(source_index).is_some()
+                                    || rendered_text
+                                        .footnote_ref_for_source_index(source_index)
+                                        .is_some()
+                            });
                     if is_hovering_clickable != was_hovering_clickable {
                         cx.notify();
                     }
@@ -2938,18 +2943,26 @@ impl RenderedText {
         accumulator
     }
 
-    fn link_for_position(&self, position: Point<Pixels>) -> Option<&RenderedLink> {
-        let source_index = self.source_index_for_position(position).ok()?;
+    fn link_for_source_index(&self, source_index: usize) -> Option<&RenderedLink> {
         self.links
             .iter()
             .find(|link| link.source_range.contains(&source_index))
     }
 
-    fn footnote_ref_for_position(&self, position: Point<Pixels>) -> Option<&RenderedFootnoteRef> {
-        let source_index = self.source_index_for_position(position).ok()?;
+    fn footnote_ref_for_source_index(&self, source_index: usize) -> Option<&RenderedFootnoteRef> {
         self.footnote_refs
             .iter()
             .find(|fref| fref.source_range.contains(&source_index))
+    }
+
+    fn link_for_position(&self, position: Point<Pixels>) -> Option<&RenderedLink> {
+        let source_index = self.source_index_for_position(position).ok()?;
+        self.link_for_source_index(source_index)
+    }
+
+    fn footnote_ref_for_position(&self, position: Point<Pixels>) -> Option<&RenderedFootnoteRef> {
+        let source_index = self.source_index_for_position(position).ok()?;
+        self.footnote_ref_for_source_index(source_index)
     }
 }
 

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1818,6 +1818,20 @@ impl Element for MarkdownElement {
                                 builder.push_text_style(style)
                             }
                         }
+                        MarkdownTag::FootnoteDefinition(label) => {
+                            if !builder.rendered_footnote_separator {
+                                builder.rendered_footnote_separator = true;
+                                builder.push_div(
+                                    div()
+                                        .border_t_1()
+                                        .mt_2()
+                                        .border_color(self.style.rule_color),
+                                    range,
+                                    markdown_end,
+                                );
+                                builder.pop_div();
+                            }
+                        }
                         MarkdownTag::MetadataBlock(_) => {}
                         MarkdownTag::Table(alignments) => {
                             builder.table.start(alignments.clone());
@@ -2272,6 +2286,7 @@ struct MarkdownElementBuilder {
     rendered_links: Vec<RenderedLink>,
     current_source_index: usize,
     html_comment: bool,
+    rendered_footnote_separator: bool,
     base_text_style: TextStyle,
     text_style_stack: Vec<TextStyleRefinement>,
     code_block_stack: Vec<Option<Arc<Language>>>,
@@ -2308,6 +2323,7 @@ impl MarkdownElementBuilder {
             rendered_links: Vec::new(),
             current_source_index: 0,
             html_comment: false,
+            rendered_footnote_separator: false,
             base_text_style,
             text_style_stack: Vec::new(),
             code_block_stack: Vec::new(),

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -249,6 +249,7 @@ pub struct Markdown {
     source: SharedString,
     selection: Selection,
     pressed_link: Option<RenderedLink>,
+    pressed_footnote_ref: Option<RenderedFootnoteRef>,
     autoscroll_request: Option<usize>,
     active_root_block: Option<usize>,
     parsed_markdown: ParsedMarkdown,
@@ -419,6 +420,7 @@ impl Markdown {
             source,
             selection: Selection::default(),
             pressed_link: None,
+            pressed_footnote_ref: None,
             autoscroll_request: None,
             active_root_block: None,
             should_reparse: false,
@@ -2065,6 +2067,7 @@ impl Element for MarkdownElement {
                     // handled inside the `MarkdownTag::Item` case
                 }
                 MarkdownEvent::FootnoteReference(label) => {
+                    builder.push_footnote_ref(label.clone(), range.clone());
                     builder.push_text_style(self.style.link.clone());
                     builder.push_text(&format!("[{label}]"), range.clone());
                     builder.pop_text_style();
@@ -2501,6 +2504,13 @@ impl MarkdownElementBuilder {
         });
     }
 
+    fn push_footnote_ref(&mut self, label: SharedString, source_range: Range<usize>) {
+        self.rendered_footnote_refs.push(RenderedFootnoteRef {
+            source_range,
+            label,
+        });
+    }
+
     fn push_text(&mut self, text: &str, source_range: Range<usize>) {
         self.pending_line.source_mappings.push(SourceMapping {
             rendered_index: self.pending_line.text.len(),
@@ -2618,6 +2628,7 @@ impl MarkdownElementBuilder {
             text: RenderedText {
                 lines: self.rendered_lines.into(),
                 links: self.rendered_links.into(),
+                footnote_refs: self.rendered_footnote_refs.into(),
             },
         }
     }
@@ -2732,12 +2743,19 @@ pub struct RenderedMarkdown {
 struct RenderedText {
     lines: Rc<[RenderedLine]>,
     links: Rc<[RenderedLink]>,
+    footnote_refs: Rc<[RenderedFootnoteRef]>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct RenderedLink {
     source_range: Range<usize>,
     destination_url: SharedString,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct RenderedFootnoteRef {
+    source_range: Range<usize>,
+    label: SharedString,
 }
 
 impl RenderedText {
@@ -2891,6 +2909,16 @@ impl RenderedText {
         self.links
             .iter()
             .find(|link| link.source_range.contains(&source_index))
+    }
+
+    fn footnote_ref_for_position(
+        &self,
+        position: Point<Pixels>,
+    ) -> Option<&RenderedFootnoteRef> {
+        let source_index = self.source_index_for_position(position).ok()?;
+        self.footnote_refs
+            .iter()
+            .find(|fref| fref.source_range.contains(&source_index))
     }
 }
 

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2064,7 +2064,11 @@ impl Element for MarkdownElement {
                 MarkdownEvent::TaskListMarker(_) => {
                     // handled inside the `MarkdownTag::Item` case
                 }
-                _ => log::debug!("unsupported markdown event {:?}", event),
+                MarkdownEvent::FootnoteReference(label) => {
+                    builder.push_text_style(self.style.link.clone());
+                    builder.push_text(&format!("[{label}]"), range.clone());
+                    builder.pop_text_style();
+                }
             }
         }
         if self.style.code_block_overflow_x_scroll {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -535,19 +535,10 @@ impl Markdown {
     }
 
     fn footnote_definition_content_start(&self, label: &SharedString) -> Option<usize> {
-        let mut inside_target_def = false;
         self.parsed_markdown
-            .events
-            .iter()
-            .find_map(|(range, event)| {
-                if inside_target_def && matches!(event, MarkdownEvent::Text) {
-                    return Some(range.start);
-                }
-                if let MarkdownEvent::Start(MarkdownTag::FootnoteDefinition(def_label)) = event {
-                    inside_target_def = *def_label == *label;
-                }
-                None
-            })
+            .footnote_definitions
+            .get(label)
+            .copied()
     }
 
     pub fn set_active_root_for_source_index(
@@ -714,6 +705,7 @@ impl Markdown {
                         html_blocks: BTreeMap::default(),
                         mermaid_diagrams: BTreeMap::default(),
                         heading_slugs: HashMap::default(),
+                        footnote_definitions: HashMap::default(),
                     },
                     Default::default(),
                 );
@@ -727,6 +719,7 @@ impl Markdown {
             let root_block_starts = parsed.root_block_starts;
             let html_blocks = parsed.html_blocks;
             let heading_slugs = parsed.heading_slugs;
+            let footnote_definitions = parsed.footnote_definitions;
             let mermaid_diagrams = if should_render_mermaid_diagrams {
                 extract_mermaid_diagrams(&source, &events)
             } else {
@@ -794,6 +787,7 @@ impl Markdown {
                     html_blocks,
                     mermaid_diagrams,
                     heading_slugs,
+                    footnote_definitions,
                 },
                 images_by_source_offset,
             )
@@ -918,6 +912,7 @@ pub struct ParsedMarkdown {
     pub(crate) html_blocks: BTreeMap<usize, html::html_parser::ParsedHtmlBlock>,
     pub(crate) mermaid_diagrams: BTreeMap<usize, ParsedMarkdownMermaidDiagram>,
     pub heading_slugs: HashMap<SharedString, usize>,
+    pub footnote_definitions: HashMap<SharedString, usize>,
 }
 
 impl ParsedMarkdown {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1465,9 +1465,7 @@ impl MarkdownElement {
             let rendered_text = rendered_text.clone();
             move |markdown, event: &MouseUpEvent, phase, window, cx| {
                 if phase.bubble() {
-                    let source_index = rendered_text
-                        .source_index_for_position(event.position)
-                        .ok();
+                    let source_index = rendered_text.source_index_for_position(event.position).ok();
                     if let Some(pressed_footnote_ref) = markdown.pressed_footnote_ref.take()
                         && source_index
                             .and_then(|ix| rendered_text.footnote_ref_for_source_index(ix))
@@ -1480,8 +1478,7 @@ impl MarkdownElement {
                             cx.notify();
                         }
                     } else if let Some(pressed_link) = markdown.pressed_link.take()
-                        && source_index
-                            .and_then(|ix| rendered_text.link_for_source_index(ix))
+                        && source_index.and_then(|ix| rendered_text.link_for_source_index(ix))
                             == Some(&pressed_link)
                     {
                         if let Some(open_url) = on_open_url.as_ref() {
@@ -2968,7 +2965,6 @@ impl RenderedText {
             .iter()
             .find(|fref| fref.source_range.contains(&source_index))
     }
-
 }
 
 #[cfg(test)]

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -534,6 +534,19 @@ impl Markdown {
         cx.refresh_windows();
     }
 
+    fn footnote_definition_content_start(&self, label: &SharedString) -> Option<usize> {
+        let mut inside_target_def = false;
+        self.parsed_markdown.events.iter().find_map(|(range, event)| {
+            if inside_target_def && matches!(event, MarkdownEvent::Text) {
+                return Some(range.start);
+            }
+            if let MarkdownEvent::Start(MarkdownTag::FootnoteDefinition(def_label)) = event {
+                inside_target_def = *def_label == *label;
+            }
+            None
+        })
+    }
+
     pub fn set_active_root_for_source_index(
         &mut self,
         source_index: Option<usize>,
@@ -1342,7 +1355,9 @@ impl MarkdownElement {
             move |markdown, event: &MouseDownEvent, phase, window, cx| {
                 if hitbox.is_hovered(window) {
                     if phase.bubble() {
-                        if let Some(link) = rendered_text.link_for_position(event.position) {
+                        if let Some(footnote_ref) = rendered_text.footnote_ref_for_position(event.position) {
+                            markdown.pressed_footnote_ref = Some(footnote_ref.clone());
+                        } else if let Some(link) = rendered_text.link_for_position(event.position) {
                             markdown.pressed_link = Some(link.clone());
                         } else {
                             let source_index =
@@ -1434,7 +1449,17 @@ impl MarkdownElement {
             let rendered_text = rendered_text.clone();
             move |markdown, event: &MouseUpEvent, phase, window, cx| {
                 if phase.bubble() {
-                    if let Some(pressed_link) = markdown.pressed_link.take()
+                    if let Some(pressed_footnote_ref) = markdown.pressed_footnote_ref.take()
+                        && Some(&pressed_footnote_ref)
+                            == rendered_text.footnote_ref_for_position(event.position)
+                    {
+                        if let Some(source_index) = markdown
+                            .footnote_definition_content_start(&pressed_footnote_ref.label)
+                        {
+                            markdown.autoscroll_request = Some(source_index);
+                            cx.notify();
+                        }
+                    } else if let Some(pressed_link) = markdown.pressed_link.take()
                         && Some(&pressed_link) == rendered_text.link_for_position(event.position)
                     {
                         if let Some(open_url) = on_open_url.as_ref() {

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -38,6 +38,7 @@ pub(crate) struct ParsedMarkdownData {
     pub root_block_starts: Vec<usize>,
     pub html_blocks: BTreeMap<usize, html::html_parser::ParsedHtmlBlock>,
     pub heading_slugs: HashMap<SharedString, usize>,
+    pub footnote_definitions: HashMap<SharedString, usize>,
 }
 
 impl ParseState {
@@ -518,6 +519,7 @@ pub(crate) fn parse_markdown_with_options(
     } else {
         HashMap::default()
     };
+    let footnote_definitions = build_footnote_definitions(&state.events);
 
     ParsedMarkdownData {
         events: state.events,
@@ -526,7 +528,34 @@ pub(crate) fn parse_markdown_with_options(
         root_block_starts: state.root_block_starts,
         html_blocks,
         heading_slugs,
+        footnote_definitions,
     }
+}
+
+fn build_footnote_definitions(
+    events: &[(Range<usize>, MarkdownEvent)],
+) -> HashMap<SharedString, usize> {
+    let mut definitions = HashMap::default();
+    let mut current_label: Option<SharedString> = None;
+
+    for (range, event) in events {
+        match event {
+            MarkdownEvent::Start(MarkdownTag::FootnoteDefinition(label)) => {
+                current_label = Some(label.clone());
+            }
+            MarkdownEvent::End(MarkdownTagEnd::FootnoteDefinition) => {
+                current_label = None;
+            }
+            MarkdownEvent::Text if current_label.is_some() => {
+                if let Some(label) = current_label.take() {
+                    definitions.entry(label).or_insert(range.start);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    definitions
 }
 
 pub fn parse_links_only(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
@@ -1117,6 +1146,7 @@ mod tests {
         assert_eq!(
             parse_markdown_with_options(
                 "Text with a footnote[^1] and some more text.\n\n[^1]: This is the footnote content.",
+                false,
                 false
             )
             .events,

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -499,8 +499,11 @@ pub(crate) fn parse_markdown_with_options(
             pulldown_cmark::Event::InlineHtml(_) => {
                 state.push_event(range, MarkdownEvent::InlineHtml)
             }
-            pulldown_cmark::Event::FootnoteReference(_) => {
-                state.push_event(range, MarkdownEvent::FootnoteReference)
+            pulldown_cmark::Event::FootnoteReference(label) => {
+                state.push_event(
+                    range,
+                    MarkdownEvent::FootnoteReference(SharedString::from(label.to_string())),
+                )
             }
             pulldown_cmark::Event::SoftBreak => state.push_event(range, MarkdownEvent::SoftBreak),
             pulldown_cmark::Event::HardBreak => state.push_event(range, MarkdownEvent::HardBreak),

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -1143,13 +1143,13 @@ mod tests {
 
     #[test]
     fn test_footnotes() {
+        let parsed = parse_markdown_with_options(
+            "Text with a footnote[^1] and some more text.\n\n[^1]: This is the footnote content.",
+            false,
+            false,
+        );
         assert_eq!(
-            parse_markdown_with_options(
-                "Text with a footnote[^1] and some more text.\n\n[^1]: This is the footnote content.",
-                false,
-                false
-            )
-            .events,
+            parsed.events,
             vec![
                 (0..45, RootStart),
                 (0..45, Start(Paragraph)),
@@ -1167,6 +1167,20 @@ mod tests {
                 (46..81, RootEnd(1)),
             ]
         );
+        assert_eq!(parsed.footnote_definitions.len(), 1);
+        assert_eq!(parsed.footnote_definitions.get("1").copied(), Some(52));
+    }
+
+    #[test]
+    fn test_footnote_definitions_multiple() {
+        let parsed = parse_markdown_with_options(
+            "Text[^a] and[^b].\n\n[^a]: First.\n\n[^b]: Second.",
+            false,
+            false,
+        );
+        assert_eq!(parsed.footnote_definitions.len(), 2);
+        assert!(parsed.footnote_definitions.contains_key("a"));
+        assert!(parsed.footnote_definitions.contains_key("b"));
     }
 
     #[test]

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -592,7 +592,7 @@ pub enum MarkdownEvent {
     /// A reference to a footnote with given label, which may or may not be defined
     /// by an event with a `Tag::FootnoteDefinition` tag. Definitions and references to them may
     /// occur in any order.
-    FootnoteReference,
+    FootnoteReference(SharedString),
     /// A soft line break.
     SoftBreak,
     /// A hard line break.

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -1115,6 +1115,33 @@ mod tests {
     }
 
     #[test]
+    fn test_footnotes() {
+        assert_eq!(
+            parse_markdown_with_options(
+                "Text with a footnote[^1] and some more text.\n\n[^1]: This is the footnote content.",
+                false
+            )
+            .events,
+            vec![
+                (0..45, RootStart),
+                (0..45, Start(Paragraph)),
+                (0..20, Text),
+                (20..24, FootnoteReference("1".into())),
+                (24..44, Text),
+                (0..45, End(MarkdownTagEnd::Paragraph)),
+                (0..45, RootEnd(0)),
+                (46..81, RootStart),
+                (46..81, Start(FootnoteDefinition("1".into()))),
+                (52..81, Start(Paragraph)),
+                (52..81, Text),
+                (52..81, End(MarkdownTagEnd::Paragraph)),
+                (46..81, End(MarkdownTagEnd::FootnoteDefinition)),
+                (46..81, RootEnd(1)),
+            ]
+        );
+    }
+
+    #[test]
     fn test_links_split_across_fragments() {
         // This test verifies that links split across multiple text fragments due to escaping or other issues
         // are correctly detected and processed

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -499,12 +499,10 @@ pub(crate) fn parse_markdown_with_options(
             pulldown_cmark::Event::InlineHtml(_) => {
                 state.push_event(range, MarkdownEvent::InlineHtml)
             }
-            pulldown_cmark::Event::FootnoteReference(label) => {
-                state.push_event(
-                    range,
-                    MarkdownEvent::FootnoteReference(SharedString::from(label.to_string())),
-                )
-            }
+            pulldown_cmark::Event::FootnoteReference(label) => state.push_event(
+                range,
+                MarkdownEvent::FootnoteReference(SharedString::from(label.to_string())),
+            ),
             pulldown_cmark::Event::SoftBreak => state.push_event(range, MarkdownEvent::SoftBreak),
             pulldown_cmark::Event::HardBreak => state.push_event(range, MarkdownEvent::HardBreak),
             pulldown_cmark::Event::Rule => state.push_event(range, MarkdownEvent::Rule),


### PR DESCRIPTION
## What does this PR changed

Adds footnote rendering and navigation to Zed's markdown preview.

- **Footnote references**: (`[^1]`) render inline as `[1]` with link styling (color + underline)
- **Footnote definitions**: (`[^1]: ...`) render at the bottom with a horizontal separator, smaller text (85% size), and a label prefix
- **Click-to-navigate**: clicking a footnote reference scrolls to its definition

https://github.com/user-attachments/assets/a79a0136-f22d-40ac-8b53-cfefa8573d21

## OOS/ Need discussion

- **Display style**: Since currently the gpui crate does not provide a superscript style, in this PR we publish the feature with using [`[1]`]() instead of aligning to the GFM styled[^1]
- **Footnote definition placement**: GFM renders the footnote at the bottom of the content no matter where the user place the footnote definition, but the `pulldown_cmark` renders the footnote just at where user place it, for this PR I'll keep the footnote where `pulldown_cmark` renders it, and we may have some more discuss on if we need to move them to the bottom of the markdown preview

[^1]: GitHub-flavoured markdown

## What to test

- [ ] Open a markdown file with footnotes (e.g. `Text[^1]\n\n[^1]: Definition`)
- [ ] Verify reference renders as `[1]` with link color
- [ ] Verify definition renders below a separator with smaller text
- [ ] Verify pointer cursor appears on hover over `[1]`
- [ ] Verify clicking `[1]` scrolls to the definition
- [ ] Verify normal links still work as before
- [ ] `cargo test -p markdown` passes (46 tests)

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #13603

Release Notes:

- Added support for footnotes in Markdown Preview.