### PR TITLE
terminal: Bind Alt+F4 to Close Window in the terminal keymap

### DIFF
--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1197,6 +1197,7 @@
       "ctrl-delete": ["terminal::SendText", "\u001bd"],
       "ctrl-n": "workspace::NewTerminal",
       // Overrides for conflicting keybindings
+      "alt-f4": "workspace::CloseWindow",
       "ctrl-b": ["terminal::SendKeystroke", "ctrl-b"],
       "ctrl-c": ["terminal::SendKeystroke", "ctrl-c"],
       "ctrl-e": ["terminal::SendKeystroke", "ctrl-e"],

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -1492,10 +1492,9 @@ mod tests {
     use gpui::{Action, App, DummyKeyboardMapper, KeybindingKeystroke, Keystroke, Unbind};
     use serde_json::Value;
     use unindent::Unindent;
-    use util::asset_str;
 
     use crate::{
-        KeybindSource, KeymapFile, SettingsAssets,
+        KeybindSource, KeymapFile,
         keymap_file::{KeybindUpdateOperation, KeybindUpdateTarget},
     };
 
@@ -1659,26 +1658,6 @@ mod tests {
             }
             other => panic!("expected SomeFailedToLoad, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn windows_terminal_keymap_closes_window_on_alt_f4() {
-        let keymap =
-            KeymapFile::parse(asset_str::<SettingsAssets>("keymaps/default-windows.json").as_ref())
-                .unwrap();
-
-        let terminal_section = keymap
-            .0
-            .iter()
-            .find(|section| section.context == "Terminal")
-            .expect("default Windows keymap should include a Terminal section");
-        let alt_f4_binding = terminal_section
-            .bindings
-            .as_ref()
-            .and_then(|bindings| bindings.get("alt-f4"))
-            .expect("Terminal section should bind alt-f4");
-
-        assert_eq!(alt_f4_binding.to_string(), "workspace::CloseWindow");
     }
 
     #[test]

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -1492,9 +1492,10 @@ mod tests {
     use gpui::{Action, App, DummyKeyboardMapper, KeybindingKeystroke, Keystroke, Unbind};
     use serde_json::Value;
     use unindent::Unindent;
+    use util::asset_str;
 
     use crate::{
-        KeybindSource, KeymapFile,
+        KeybindSource, KeymapFile, SettingsAssets,
         keymap_file::{KeybindUpdateOperation, KeybindUpdateTarget},
     };
 
@@ -1658,6 +1659,26 @@ mod tests {
             }
             other => panic!("expected SomeFailedToLoad, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn windows_terminal_keymap_closes_window_on_alt_f4() {
+        let keymap =
+            KeymapFile::parse(asset_str::<SettingsAssets>("keymaps/default-windows.json").as_ref())
+                .unwrap();
+
+        let terminal_section = keymap
+            .0
+            .iter()
+            .find(|section| section.context == "Terminal")
+            .expect("default Windows keymap should include a Terminal section");
+        let alt_f4_binding = terminal_section
+            .bindings
+            .as_ref()
+            .and_then(|bindings| bindings.get("alt-f4"))
+            .expect("Terminal section should bind alt-f4");
+
+        assert_eq!(alt_f4_binding.to_string(), "workspace::CloseWindow");
     }
 
     #[test]


### PR DESCRIPTION
Closes #52774

## Summary
- Bind Windows `Alt+F4` to `workspace::CloseWindow` in the `Terminal` keymap context
- Add a regression test covering the built-in Windows terminal keymap entry

## Why
When the integrated terminal is focused, `Alt+F4` should close the window instead of falling through to terminal keystroke handling. Handling this in the Windows `Terminal` keymap keeps the fix aligned with the rest of the terminal shortcut overrides.

## Validation
- `cargo test -p settings windows_terminal_keymap_closes_window_on_alt_f4`

Release Notes:

- Fixed Alt+F4 on Windows so Zed closes even when the integrated terminal is focused.
