### PR TITLE
Set agent-first workspace layout as the default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -712,7 +712,7 @@
     // Default width of the project panel.
     "default_width": 240,
     // Where to dock the project panel. Can be 'left' or 'right'.
-    "dock": "left",
+    "dock": "right",
     // Spacing between worktree entries in the project panel. Can be 'comfortable' or 'standard'.
     "entry_spacing": "comfortable",
     // Whether to show file icons in the project panel.
@@ -814,7 +814,7 @@
     // Default width of the outline panel.
     "default_width": 300,
     // Where to dock the outline panel. Can be 'left' or 'right'.
-    "dock": "left",
+    "dock": "right",
     // Whether to show file icons in the outline panel.
     "file_icons": true,
     // Whether to show folder icons or chevrons for directories in the outline panel.
@@ -866,7 +866,7 @@
     // Whether to show the collaboration panel button in the status bar.
     "button": true,
     // Where to dock the collaboration panel. Can be 'left' or 'right'.
-    "dock": "left",
+    "dock": "right",
     // Default width of the collaboration panel.
     "default_width": 240,
   },
@@ -874,7 +874,7 @@
     // Whether to show the git panel button in the status bar.
     "button": true,
     // Where to dock the git panel. Can be 'left' or 'right'.
-    "dock": "left",
+    "dock": "right",
     // Default width of the git panel.
     "default_width": 360,
     // Style of the git status indicator in the panel.
@@ -933,7 +933,7 @@
   },
   "notification_panel": {
     // Whether to show the notification panel button in the status bar.
-    "button": true,
+    "button": false,
     // Where to dock the notification panel. Can be 'left' or 'right'.
     "dock": "right",
     // Default width of the notification panel.
@@ -949,7 +949,7 @@
     // Whether to show the agent panel button in the status bar.
     "button": true,
     // Where to dock the agent panel. Can be 'left', 'right' or 'bottom'.
-    "dock": "right",
+    "dock": "left",
     // Whether the agent panel should use flexible (proportional) sizing.
     //
     // Default: true

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -35,7 +35,7 @@ pub struct PanelLayout {
 }
 
 impl PanelLayout {
-    const AGENT: Self = Self {
+    pub const AGENT: Self = Self {
         agent_dock: Some(DockPosition::Left),
         project_panel_dock: Some(DockSide::Right),
         outline_panel_dock: Some(DockSide::Right),
@@ -44,7 +44,7 @@ impl PanelLayout {
         notification_panel_button: Some(false),
     };
 
-    const EDITOR: Self = Self {
+    pub const EDITOR: Self = Self {
         agent_dock: Some(DockPosition::Right),
         project_panel_dock: Some(DockSide::Left),
         outline_panel_dock: Some(DockSide::Left),
@@ -72,7 +72,7 @@ impl PanelLayout {
         }
     }
 
-    fn write_to(&self, settings: &mut SettingsContent) {
+    pub fn write_to(&self, settings: &mut SettingsContent) {
         settings.agent.get_or_insert_default().dock = self.agent_dock;
         settings.project_panel.get_or_insert_default().dock = self.project_panel_dock;
         settings.outline_panel.get_or_insert_default().dock = self.outline_panel_dock;

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 
 use ::ui::IconName;
 use agent_client_protocol as acp;
-use agent_settings::{AgentProfileId, AgentSettings};
+use agent_settings::{AgentProfileId, AgentSettings, PanelLayout};
 use command_palette_hooks::CommandPaletteFilter;
 use feature_flags::{AgentV2FeatureFlag, FeatureFlagAppExt as _};
 use fs::Fs;
@@ -56,7 +56,7 @@ use project::{AgentId, DisableAiSettings};
 use prompt_store::PromptBuilder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{DockPosition, DockSide, LanguageModelSelection, Settings as _, SettingsStore};
+use settings::{LanguageModelSelection, Settings as _, SettingsStore};
 use std::any::TypeId;
 use workspace::Workspace;
 
@@ -485,30 +485,11 @@ pub fn init(
     // TODO: remove this field when we're ready remove the feature flag
     maybe_backfill_editor_layout(fs, is_new_install, false, cx);
 
-    cx.observe_flag::<AgentV2FeatureFlag, _>(|is_enabled, cx| {
-        SettingsStore::update_global(cx, |store, cx| {
-            store.update_default_settings(cx, |defaults| {
-                if is_enabled {
-                    defaults.agent.get_or_insert_default().dock = Some(DockPosition::Left);
-                    defaults.project_panel.get_or_insert_default().dock = Some(DockSide::Right);
-                    defaults.outline_panel.get_or_insert_default().dock = Some(DockSide::Right);
-                    defaults.collaboration_panel.get_or_insert_default().dock =
-                        Some(DockPosition::Right);
-                    defaults.git_panel.get_or_insert_default().dock = Some(DockPosition::Right);
-                    defaults.notification_panel.get_or_insert_default().button = Some(false);
-                } else {
-                    defaults.agent.get_or_insert_default().dock = Some(DockPosition::Right);
-                    defaults.project_panel.get_or_insert_default().dock = Some(DockSide::Left);
-                    defaults.outline_panel.get_or_insert_default().dock = Some(DockSide::Left);
-                    defaults.collaboration_panel.get_or_insert_default().dock =
-                        Some(DockPosition::Left);
-                    defaults.git_panel.get_or_insert_default().dock = Some(DockPosition::Left);
-                    defaults.notification_panel.get_or_insert_default().button = Some(true);
-                }
-            });
+    SettingsStore::update_global(cx, |store, cx| {
+        store.update_default_settings(cx, |defaults| {
+            PanelLayout::AGENT.write_to(defaults);
         });
-    })
-    .detach();
+    });
 }
 
 fn maybe_backfill_editor_layout(


### PR DESCRIPTION
## Summary

- Apply the agent-first panel layout unconditionally at startup instead of toggling it behind `AgentV2FeatureFlag`
- Expose `PanelLayout::AGENT`/`EDITOR` presets and `write_to` as `pub` so `agent_ui` can reuse them as the single source of truth
- Replace flag-driven dock defaulting in `agent_ui::init` with a direct `PanelLayout::AGENT.write_to` call
- Align shipped defaults in `default.json` with the agent-first preset (agent panel left, file panels right, notification button hidden)

## Test plan

- [ ] Launch with a clean settings file — agent panel should dock on the left, project/outline/git/collaboration panels on the right
- [ ] Move a panel (e.g. project panel to the left) — verify it persists via existing per-panel dock settings, not a new layout key
- [ ] Existing users with explicit dock overrides in `settings.json` should see no change

Release Notes:

- Improved default workspace layout to place the AI chat panel on the left and file-oriented panels on the right