### PR TITLE
remote: Use SSH nicknames in display names

### DIFF
--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -1285,7 +1285,10 @@ pub enum RemoteConnectionOptions {
 impl RemoteConnectionOptions {
     pub fn display_name(&self) -> String {
         match self {
-            RemoteConnectionOptions::Ssh(opts) => opts.host.to_string(),
+            RemoteConnectionOptions::Ssh(opts) => opts
+                .nickname
+                .clone()
+                .unwrap_or_else(|| opts.host.to_string()),
             RemoteConnectionOptions::Wsl(opts) => opts.distro_name.clone(),
             RemoteConnectionOptions::Docker(opts) => {
                 if opts.use_podman {
@@ -1297,6 +1300,32 @@ impl RemoteConnectionOptions {
             #[cfg(any(test, feature = "test-support"))]
             RemoteConnectionOptions::Mock(opts) => format!("mock-{}", opts.id),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ssh_display_name_prefers_nickname() {
+        let options = RemoteConnectionOptions::Ssh(SshConnectionOptions {
+            host: "1.2.3.4".into(),
+            nickname: Some("My Cool Project".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(options.display_name(), "My Cool Project");
+    }
+
+    #[test]
+    fn test_ssh_display_name_falls_back_to_host() {
+        let options = RemoteConnectionOptions::Ssh(SshConnectionOptions {
+            host: "1.2.3.4".into(),
+            ..Default::default()
+        });
+
+        assert_eq!(options.display_name(), "1.2.3.4");
     }
 }
 


### PR DESCRIPTION
Closes #52943

## Summary
- Prefer SSH nicknames over raw hosts in remote connection display names
- Add regression tests for nickname and host fallback behavior

## Why
The `nickname` field is documented as the user-facing label for SSH connections, but `RemoteConnectionOptions::display_name()` always returned the raw host. That meant recent-projects UI surfaces kept ignoring nicknames even when they were configured.

## Validation
- `cargo test -p remote ssh_display_name`
- `cargo test -p remote`

Release Notes:

- Fixed SSH recent-project labels to show configured nicknames instead of raw hosts when available.
