### PR TITLE
tasks_ui: Fix previously used task tooltip

### DIFF
--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -567,7 +567,7 @@ impl PickerDelegate for TasksModalDelegate {
                                     picker.refresh(window, cx);
                                 }))
                                 .tooltip(|_, cx| {
-                                    Tooltip::simple("Delete Previously Scheduled Task", cx)
+                                    Tooltip::simple("Delete from Recent Tasks", cx)
                                 }),
                         );
                         item.end_slot_on_hover(delete_button)

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -566,9 +566,7 @@ impl PickerDelegate for TasksModalDelegate {
                                         .checked_sub(1);
                                     picker.refresh(window, cx);
                                 }))
-                                .tooltip(|_, cx| {
-                                    Tooltip::simple("Delete from Recent Tasks", cx)
-                                }),
+                                .tooltip(|_, cx| Tooltip::simple("Delete from Recent Tasks", cx)),
                         );
                         item.end_slot_on_hover(delete_button)
                     } else {


### PR DESCRIPTION
Closes #52941

## Summary

- update the task picker delete button tooltip to describe the recently used task entry it removes
- keep the change scoped to the inaccurate user-facing copy in the tasks modal

## Testing

- cargo test -p tasks_ui

Release Notes:

- N/A