### PR TITLE
docs: Add Grok context windows to models docs

### DIFF
--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -93,6 +93,10 @@ A context window is the maximum span of text and code an LLM can consider at onc
 | GPT-5 nano        | OpenAI    | 400k                      |
 | Gemini 3.1 Pro    | Google    | 200k                      |
 | Gemini 3 Flash    | Google    | 200k                      |
+| Grok 4            | X.ai      | 256k                      |
+| Grok 4 Fast       | X.ai      | 2M                        |
+| Grok 4 (Non-Reasoning) | X.ai | 2M                        |
+| Grok Code Fast 1  | X.ai      | 256k                      |
 
 > Context window limits for hosted Gemini 3.1 Pro/3 Pro/Flash may increase in future releases.
 


### PR DESCRIPTION
Closes #52684

## Summary

- add the missing Grok context window rows to the hosted models documentation
- align the docs table with the current xAI model definitions used by Zed

Release Notes:

- N/A