### PR TITLE
terminal: Send SIGTERM synchronously on terminal drop

### DIFF
--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -165,7 +165,7 @@ impl PtyProcessInfo {
 
     #[cfg(not(unix))]
     pub(crate) fn terminate_child_process(&self) -> bool {
-        self.get_child().is_some_and(|process| process.kill())
+        false
     }
 
     fn load(&self) -> Option<ProcessInfo> {

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -157,6 +157,17 @@ impl PtyProcessInfo {
         self.get_child().is_some_and(|process| process.kill())
     }
 
+    #[cfg(unix)]
+    pub(crate) fn terminate_child_process(&self) -> bool {
+        let pid = self.pid_getter.fallback_pid();
+        unsafe { libc::killpg(pid.as_u32() as i32, libc::SIGTERM) == 0 }
+    }
+
+    #[cfg(not(unix))]
+    pub(crate) fn terminate_child_process(&self) -> bool {
+        self.get_child().is_some_and(|process| process.kill())
+    }
+
     fn load(&self) -> Option<ProcessInfo> {
         let process = self.refresh()?;
         let cwd = process.cwd().map_or(PathBuf::new(), |p| p.to_owned());

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2424,6 +2424,7 @@ impl Drop for Terminal {
             std::mem::replace(&mut self.terminal_type, TerminalType::DisplayOnly)
         {
             pty_tx.0.send(Msg::Shutdown).ok();
+            info.terminate_child_process();
 
             let timer = self.background_executor.timer(Duration::from_millis(100));
             self.background_executor


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Partially addresses #51455

Release Notes:

- Fixed terminal child processes surviving after closing Zed by sending SIGTERM synchronously on terminal drop