### PR TITLE
Add browser settings for configuring which browser opens URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21463,6 +21463,7 @@ dependencies = [
  "markdown",
  "menu",
  "node_runtime",
+ "open",
  "parking_lot",
  "postage",
  "pretty_assertions",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -194,6 +194,15 @@
   //
   // Default: "client"
   "window_decorations": "client",
+  // The browser to use when opening URLs.
+  // Can be:
+  //   - "system" to use the system default browser
+  //   - A path to a browser executable (e.g., "/usr/bin/firefox")
+  //   - An object with "program" and optional "args" fields:
+  //     { "program": "firefox", "args": ["--private-window"] }
+  //
+  // Default: "system"
+  "browser": "system",
   // Whether to use the system provided dialogs for Open and Save As.
   // When set to false, Zed will use the built-in keyboard-first pickers.
   "use_system_path_prompts": true,

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -28,7 +28,7 @@ use ui::{
     WithScrollbar, prelude::*,
 };
 use util::ResultExt as _;
-use workspace::{ModalView, Workspace};
+use workspace::{ModalView, Workspace, open_url_with_browser_settings};
 
 use crate::AddContextServer;
 
@@ -841,7 +841,9 @@ impl ConfigureContextServerModal {
                             })
                             .on_click({
                                 let repository_url = repository_url.clone();
-                                move |_, _, cx| cx.open_url(&repository_url)
+                                move |_, _, cx| {
+                                    open_url_with_browser_settings(&repository_url, cx).log_err();
+                                }
                             }),
                     )
                 } else {

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -17,9 +17,11 @@ use ui::{
     ButtonStyle, ScrollableHandle, ToggleButtonGroup, ToggleButtonGroupSize,
     ToggleButtonGroupStyle, ToggleButtonSimple, Tooltip, WithScrollbar, prelude::*,
 };
+use util::ResultExt as _;
 use workspace::{
     Workspace,
     item::{Item, ItemEvent},
+    open_url_with_browser_settings,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -399,7 +401,7 @@ impl AgentRegistryPage {
                 )
             })
             .on_click(move |_, _, cx| {
-                cx.open_url(&repository_for_click);
+                open_url_with_browser_settings(&repository_for_click, cx).log_err();
             })
         });
 
@@ -415,7 +417,7 @@ impl AgentRegistryPage {
                 Tooltip::with_meta("Visit Agent Website", None, website.clone(), cx)
             })
             .on_click(move |_, _, cx| {
-                cx.open_url(&website_for_click);
+                open_url_with_browser_settings(&website_for_click, cx).log_err();
             })
         });
 
@@ -565,7 +567,7 @@ impl Render for AgentRegistryPage {
                                             .color(Color::Muted),
                                     )
                                     .on_click(move |_, _, cx| {
-                                        cx.open_url(&zed_urls::acp_registry_blog(cx))
+                                        open_url_with_browser_settings(&zed_urls::acp_registry_blog(cx), cx).log_err();
                                     }),
                             ),
                     )

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -15,7 +15,7 @@ use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
 use settings::update_settings_file;
 use ui::{ButtonLike, SplitButton, SplitButtonStyle, Tab};
-use workspace::SERIALIZATION_THROTTLE_TIME;
+use workspace::{SERIALIZATION_THROTTLE_TIME, open_url_with_browser_settings};
 
 use super::*;
 
@@ -8106,7 +8106,8 @@ impl ThreadView {
             .on_click(cx.listener({
                 move |this, _, _, cx| {
                     this.clear_thread_error(cx);
-                    cx.open_url(&zed_urls::upgrade_to_zed_pro_url(cx));
+                    open_url_with_browser_settings(&zed_urls::upgrade_to_zed_pro_url(cx), cx)
+                        .log_err();
                 }
             }))
     }
@@ -8823,7 +8824,7 @@ pub(crate) fn open_link(
     cx: &mut App,
 ) {
     let Some(workspace) = workspace.upgrade() else {
-        cx.open_url(&url);
+        open_url_with_browser_settings(&url, cx).log_err();
         return;
     };
 
@@ -8913,7 +8914,7 @@ pub(crate) fn open_link(
                 )
             }
             MentionUri::Fetch { url } => {
-                cx.open_url(url.as_str());
+                open_url_with_browser_settings(url.as_str(), cx).log_err();
             }
             MentionUri::Diagnostics { .. } => {}
             MentionUri::TerminalSelection { .. } => {}
@@ -8921,6 +8922,6 @@ pub(crate) fn open_link(
             MentionUri::MergeConflict { .. } => {}
         })
     } else {
-        cx.open_url(&url);
+        open_url_with_browser_settings(&url, cx).log_err();
     }
 }

--- a/crates/agent_ui/src/ui/end_trial_upsell.rs
+++ b/crates/agent_ui/src/ui/end_trial_upsell.rs
@@ -4,6 +4,8 @@ use ai_onboarding::{AgentPanelOnboardingCard, PlanDefinitions};
 use client::zed_urls;
 use gpui::{AnyElement, App, IntoElement, RenderOnce, Window};
 use ui::{Divider, Tooltip, prelude::*};
+use util::ResultExt as _;
+use workspace::open_url_with_browser_settings;
 
 #[derive(IntoElement, RegisterComponent)]
 pub struct EndTrialUpsell {
@@ -38,7 +40,8 @@ impl RenderOnce for EndTrialUpsell {
                     .style(ButtonStyle::Tinted(ui::TintColor::Accent))
                     .on_click(move |_, _window, cx| {
                         telemetry::event!("Upgrade To Pro Clicked", state = "end-of-trial");
-                        cx.open_url(&zed_urls::upgrade_to_zed_pro_url(cx))
+                        open_url_with_browser_settings(&zed_urls::upgrade_to_zed_pro_url(cx), cx)
+                            .log_err();
                     }),
             );
 

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -11,7 +11,8 @@ use rope::Point;
 use settings::Settings;
 use theme_settings::ThemeSettings;
 use ui::{ButtonLike, TintColor, Tooltip, prelude::*};
-use workspace::{OpenOptions, Workspace};
+use util::ResultExt as _;
+use workspace::{OpenOptions, Workspace, open_url_with_browser_settings};
 
 use crate::Agent;
 
@@ -182,7 +183,7 @@ fn open_mention_uri(
             open_rule(workspace, id, window, cx);
         }
         MentionUri::Fetch { url } => {
-            cx.open_url(url.as_str());
+            open_url_with_browser_settings(url.as_str(), cx).log_err();
         }
         MentionUri::PastedImage
         | MentionUri::Selection { abs_path: None, .. }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -999,6 +999,7 @@ impl VsCodeSettings {
                 }
             }),
             zoomed_padding: None,
+            browser: None,
         }
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -122,6 +122,10 @@ pub struct WorkspaceSettingsContent {
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,
+    /// The browser to use when opening URLs.
+    ///
+    /// Default: system (uses the system's default browser)
+    pub browser: Option<BrowserSettings>,
 }
 
 #[with_fallible_options]
@@ -824,6 +828,46 @@ pub struct ProjectPanelScrollbarSettingsContent {
 )]
 pub struct ProjectPanelIndentGuidesSettings {
     pub show: Option<ShowIndentGuides>,
+}
+
+/// Configuration for the browser to use when opening URLs.
+///
+/// Can be:
+/// - "system" to use the system default browser
+/// - A path to a browser executable (e.g., "/usr/bin/firefox")
+/// - An object with "program" and optional "args" fields
+///
+/// Examples:
+/// ```json
+/// { "browser": "system" }
+/// { "browser": "/Applications/Firefox.app/Contents/MacOS/firefox" }
+/// { "browser": { "program": "firefox", "args": ["--private-window"] } }
+/// ```
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserSettings {
+    /// Use the system's default browser
+    #[default]
+    System,
+    /// Use a specific browser program with no arguments
+    Program(String),
+    /// Use a specific browser program with arguments
+    WithArguments {
+        /// The browser program to run
+        program: String,
+        /// The arguments to pass to the browser (the URL will be appended)
+        args: Vec<String>,
+    },
 }
 
 /// Controls how semantic tokens from language servers are used for syntax highlighting.

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -48,6 +48,7 @@ log.workspace = true
 menu.workspace = true
 markdown.workspace = true
 node_runtime.workspace = true
+open.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 project.workspace = true

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -147,8 +147,8 @@ use util::{
 };
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings,
-    WorkspaceSettings,
+    AutosaveSetting, BottomDockLayout, BrowserSettings, RestoreOnStartupBehavior,
+    StatusBarSettings, TabBarSettings, WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
 
@@ -10523,6 +10523,38 @@ fn load_legacy_panel_size(
         .detach_and_log_err(cx);
 
     Some(size)
+}
+
+/// Opens a URL respecting the user's browser settings.
+///
+/// Uses the `browser` setting from workspace settings to determine
+/// how to open URLs:
+/// - `"system"` — the OS default browser via `cx.open_url()`
+/// - A program name/path — via the `open` crate's `open::with()`
+/// - `{ "program": "…", "args": ["…"] }` — via `std::process::Command`
+pub fn open_url_with_browser_settings(url: &str, cx: &App) -> anyhow::Result<()> {
+    use settings::BrowserSettings;
+
+    let browser_settings = WorkspaceSettings::get_global(cx).browser.clone();
+
+    match browser_settings {
+        BrowserSettings::System => {
+            cx.open_url(url);
+            Ok(())
+        }
+        BrowserSettings::Program(program) => open::with(url, &program)
+            .map_err(|e| anyhow::anyhow!("Failed to open URL with '{}': {}", program, e)),
+        BrowserSettings::WithArguments { program, args } => {
+            std::process::Command::new(&program)
+                .args(&args)
+                .arg(url)
+                .spawn()
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to open URL with '{}': {}", program, e)
+                })?;
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -4,7 +4,7 @@ use crate::DockPosition;
 use collections::HashMap;
 use serde::Deserialize;
 pub use settings::{
-    AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, InactiveOpacity,
+    AutosaveSetting, BottomDockLayout, BrowserSettings, EncodingDisplayOptions, InactiveOpacity,
     PaneSplitDirectionHorizontal, PaneSplitDirectionVertical, RegisterSetting,
     RestoreOnStartupBehavior, Settings,
 };
@@ -35,6 +35,7 @@ pub struct WorkspaceSettings {
     pub use_system_window_tabs: bool,
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
+    pub browser: BrowserSettings,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
@@ -113,6 +114,7 @@ impl Settings for WorkspaceSettings {
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),
+            browser: workspace.browser.clone().unwrap_or_default(),
         }
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -791,8 +791,9 @@ fn register_actions(
             // Parse and validate the URL to ensure it's properly formatted
             match url::Url::parse(&action.url) {
                 Ok(parsed_url) => {
-                    // Use the parsed URL's string representation which is properly escaped
-                    cx.open_url(parsed_url.as_str());
+                    if let Err(e) = workspace::open_url_with_browser_settings(parsed_url.as_str(), cx) {
+                        workspace.show_error(&e, cx);
+                    }
                 }
                 Err(e) => {
                     workspace.show_error(


### PR DESCRIPTION
Add `browser` setting for configuring which browser opens URLs

Zed currently always opens URLs with the system default browser via `cx.open_url()`. This adds a `browser` workspace setting that lets users choose which browser to use, supporting three forms:

```json
// Use the system default (current behaviour, and the new default)
"browser": "system"

// Use a specific program
"browser": "Safari"

// Use a program with arguments
"browser": { "program": "firefox", "args": ["--private-window"] }
```

### Changes

**Core:**
- `crates/settings_content/src/workspace.rs` — defines `BrowserSettings` enum with `System`, `Program(String)`, and `WithArguments { program, args }` variants
- `crates/workspace/src/workspace.rs` — adds `open_url_with_browser_settings()` which reads the setting and dispatches via `cx.open_url()`, `open::with()`, or `std::process::Command` respectively
- `crates/workspace/src/workspace_settings.rs` — adds `browser: BrowserSettings` field
- `crates/workspace/Cargo.toml` — adds `open` crate dependency
- `assets/settings/default.json` — adds default `"browser": "system"` entry
- `crates/settings/src/vscode_import.rs` — adds `browser: None` to VS Code import

**Wiring:**
- `crates/agent_ui/` — replaces all `cx.open_url()` calls with `open_url_with_browser_settings()` across `thread_view.rs`, `configure_context_server_modal.rs`, `agent_registry_ui.rs`, `end_trial_upsell.rs`, and `mention_crease.rs`
- `crates/zed/src/zed.rs` — replaces `cx.open_url()` in the `OpenUrl` action handler

### Not yet wired

There are remaining `cx.open_url()` calls in `zed.rs` that were intentionally left alone:
- `OpenDocs` action and account URL — could be wired up in a follow-up
- Error-then-quit paths (inotify warning, Windows warning, software emulation) — the app exits immediately after, so the browser setting is less relevant
- Other crates (`editor`, `collab`, `extensions`, etc.) may also have `cx.open_url()` calls worth converting

### Testing

The `workspace` crate compiles cleanly. Full build verification of downstream crates (`agent_ui`, `zed`) is pending.

Release Notes:

- Added a `browser` setting to control which browser Zed uses to open URLs, with support for specifying a program name and custom arguments.
