### PR TITLE
agent_ui: Fix profile selector not repainting after cycling with Shift+Tab

### DIFF
--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -90,6 +90,7 @@ impl ProfileSelector {
 
         if let Some((next_profile_id, _)) = profiles.get_index(next_index) {
             self.provider.set_profile(next_profile_id.clone(), cx);
+            cx.notify();
         }
     }
 


### PR DESCRIPTION
Currently, when pressing Shift+Tab to change Zed Agent's profile, the UI isn't immediately updated. This PR fixes this issue so the `Change Profile` button updates immediately after pressing Shift+Tab.

The current behavior. Observe that the `Change Profile` button doesn't update right after Shift+Tab changes the active profile:

https://github.com/user-attachments/assets/fa1e6488-0dc3-4cc9-a4f3-7f62da48cc19

After this fix, the button text is update immediately on profile change:

https://github.com/user-attachments/assets/93261b11-037a-42c9-b1b8-0ca1e1adb851

---

Release Notes:

- Fixed Zed Agent profile selector button not visually updating when cycled with Shift+Tab.
