### PR TITLE
dev_container: Make volumes key and source key in volume mounts optional

### DIFF
--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -424,8 +424,8 @@ fn deserialize_mount_definition<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    use serde::de::Error;
     use serde::Deserialize;
+    use serde::de::Error;
 
     #[derive(Deserialize)]
     #[serde(untagged)]
@@ -475,8 +475,8 @@ fn deserialize_mount_definitions<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    use serde::de::Error;
     use serde::Deserialize;
+    use serde::de::Error;
 
     #[derive(Deserialize)]
     #[serde(untagged)]

--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -69,24 +69,23 @@ pub(crate) struct MountDefinition {
 
 impl Display for MountDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let source = self.source.clone().unwrap_or_default();
-        write!(
-            f,
-            "type={},source={},target={},consistency=cached",
-            self.mount_type.clone().unwrap_or_else(|| {
+        let mount_type = self.mount_type.clone().unwrap_or_else(|| {
+            if let Some(source) = &self.source {
                 if source.starts_with('/')
                     || source.starts_with("\\\\")
                     || source.get(1..3) == Some(":\\")
                     || source.get(1..3) == Some(":/")
                 {
-                    "bind".to_string()
-                } else {
-                    "volume".to_string()
+                    return "bind".to_string();
                 }
-            }),
-            source,
-            self.target
-        )
+            }
+            "volume".to_string()
+        });
+        write!(f, "type={}", mount_type)?;
+        if let Some(source) = &self.source {
+            write!(f, ",source={}", source)?;
+        }
+        write!(f, ",target={},consistency=cached", self.target)
     }
 }
 
@@ -1403,5 +1402,18 @@ mod test {
             rendered.starts_with("type=bind,"),
             "Expected mount type 'bind' for Windows absolute path, but got: {rendered}"
         );
+    }
+
+    #[test]
+    fn mount_definition_should_omit_source_when_none() {
+        let mount = MountDefinition {
+            source: None,
+            target: "/tmp".to_string(),
+            mount_type: Some("tmpfs".to_string()),
+        };
+
+        let rendered = mount.to_string();
+
+        assert_eq!(rendered, "type=tmpfs,target=/tmp,consistency=cached");
     }
 }

--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -62,8 +62,7 @@ pub(crate) enum ShutdownAction {
 pub(crate) struct MountDefinition {
     #[serde(default)]
     pub(crate) source: Option<String>,
-    #[serde(default)]
-    pub(crate) target: Option<String>,
+    pub(crate) target: String,
     #[serde(rename = "type")]
     pub(crate) mount_type: Option<String>,
 }
@@ -71,7 +70,6 @@ pub(crate) struct MountDefinition {
 impl Display for MountDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let source = self.source.clone().unwrap_or_default();
-        let target = self.target.clone().unwrap_or_default();
         write!(
             f,
             "type={},source={},target={},consistency=cached",
@@ -87,7 +85,7 @@ impl Display for MountDefinition {
                 }
             }),
             source,
-            target
+            self.target
         )
     }
 }
@@ -427,6 +425,7 @@ fn deserialize_mount_definition<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
+    use serde::de::Error;
     use serde::Deserialize;
 
     #[derive(Deserialize)]
@@ -457,6 +456,9 @@ where
                 }
             }
 
+            let target = target
+                .ok_or_else(|| D::Error::custom(format!("mount string missing 'target': {}", s)))?;
+
             MountDefinition {
                 source,
                 target,
@@ -474,6 +476,7 @@ fn deserialize_mount_definitions<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
+    use serde::de::Error;
     use serde::Deserialize;
 
     #[derive(Deserialize)]
@@ -505,6 +508,10 @@ where
                         }
                     }
                 }
+
+                let target = target.ok_or_else(|| {
+                    D::Error::custom(format!("mount string missing 'target': {}", s))
+                })?;
 
                 mounts.push(MountDefinition {
                     source,
@@ -871,7 +878,7 @@ mod test {
                 container_user: Some("myUser".to_string()),
                 mounts: Some(vec![MountDefinition {
                     source: Some("/localfolder/app".to_string()),
-                    target: Some("/workspaces/app".to_string()),
+                    target: "/workspaces/app".to_string(),
                     mount_type: Some("volume".to_string()),
                 }]),
                 run_args: Some(vec!["-c".to_string(), "some_command".to_string()]),
@@ -880,7 +887,7 @@ mod test {
                 workspace_folder: Some("/workspaces".to_string()),
                 workspace_mount: Some(MountDefinition {
                     source: Some("/app".to_string()),
-                    target: Some("/workspaces/app".to_string()),
+                    target: "/workspaces/app".to_string(),
                     mount_type: Some("bind".to_string())
                 }),
                 customizations: Some(ZedCustomizationsWrapper {
@@ -1314,12 +1321,12 @@ mod test {
                 mounts: Some(vec![
                     MountDefinition {
                         source: Some("/localfolder/app".to_string()),
-                        target: Some("/workspaces/app".to_string()),
+                        target: "/workspaces/app".to_string(),
                         mount_type: Some("volume".to_string()),
                     },
                     MountDefinition {
                         source: Some("dev-containers-cli-bashhistory".to_string()),
-                        target: Some("/home/node/commandhistory".to_string()),
+                        target: "/home/node/commandhistory".to_string(),
                         mount_type: None,
                     }
                 ]),
@@ -1329,7 +1336,7 @@ mod test {
                 workspace_folder: Some("/workspaces".to_string()),
                 workspace_mount: Some(MountDefinition {
                     source: Some("/folder".to_string()),
-                    target: Some("/workspace".to_string()),
+                    target: "/workspace".to_string(),
                     mount_type: Some("bind".to_string())
                 }),
                 build: Some(ContainerBuild {
@@ -1354,7 +1361,7 @@ mod test {
     fn mount_definition_should_use_bind_type_for_unix_absolute_paths() {
         let mount = MountDefinition {
             source: Some("/home/user/project".to_string()),
-            target: Some("/workspaces/project".to_string()),
+            target: "/workspaces/project".to_string(),
             mount_type: None,
         };
 
@@ -1370,7 +1377,7 @@ mod test {
     fn mount_definition_should_use_bind_type_for_windows_unc_paths() {
         let mount = MountDefinition {
             source: Some("\\\\server\\share\\project".to_string()),
-            target: Some("/workspaces/project".to_string()),
+            target: "/workspaces/project".to_string(),
             mount_type: None,
         };
 
@@ -1386,7 +1393,7 @@ mod test {
     fn mount_definition_should_use_bind_type_for_windows_absolute_paths() {
         let mount = MountDefinition {
             source: Some("C:\\Users\\mrg\\cli".to_string()),
-            target: Some("/workspaces/cli".to_string()),
+            target: "/workspaces/cli".to_string(),
             mount_type: None,
         };
 

--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -60,30 +60,34 @@ pub(crate) enum ShutdownAction {
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct MountDefinition {
-    pub(crate) source: String,
-    pub(crate) target: String,
+    #[serde(default)]
+    pub(crate) source: Option<String>,
+    #[serde(default)]
+    pub(crate) target: Option<String>,
     #[serde(rename = "type")]
     pub(crate) mount_type: Option<String>,
 }
 
 impl Display for MountDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let source = self.source.clone().unwrap_or_default();
+        let target = self.target.clone().unwrap_or_default();
         write!(
             f,
             "type={},source={},target={},consistency=cached",
             self.mount_type.clone().unwrap_or_else(|| {
-                if self.source.starts_with('/')
-                    || self.source.starts_with("\\\\")
-                    || self.source.get(1..3) == Some(":\\")
-                    || self.source.get(1..3) == Some(":/")
+                if source.starts_with('/')
+                    || source.starts_with("\\\\")
+                    || source.get(1..3) == Some(":\\")
+                    || source.get(1..3) == Some(":/")
                 {
                     "bind".to_string()
                 } else {
                     "volume".to_string()
                 }
             }),
-            self.source,
-            self.target
+            source,
+            target
         )
     }
 }
@@ -424,7 +428,6 @@ where
     D: serde::Deserializer<'de>,
 {
     use serde::Deserialize;
-    use serde::de::Error;
 
     #[derive(Deserialize)]
     #[serde(untagged)]
@@ -454,11 +457,6 @@ where
                 }
             }
 
-            let source = source
-                .ok_or_else(|| D::Error::custom(format!("mount string missing 'source': {}", s)))?;
-            let target = target
-                .ok_or_else(|| D::Error::custom(format!("mount string missing 'target': {}", s)))?;
-
             MountDefinition {
                 source,
                 target,
@@ -477,7 +475,6 @@ where
     D: serde::Deserializer<'de>,
 {
     use serde::Deserialize;
-    use serde::de::Error;
 
     #[derive(Deserialize)]
     #[serde(untagged)]
@@ -508,13 +505,6 @@ where
                         }
                     }
                 }
-
-                let source = source.ok_or_else(|| {
-                    D::Error::custom(format!("mount string missing 'source': {}", s))
-                })?;
-                let target = target.ok_or_else(|| {
-                    D::Error::custom(format!("mount string missing 'target': {}", s))
-                })?;
 
                 mounts.push(MountDefinition {
                     source,
@@ -880,8 +870,8 @@ mod test {
                 ])),
                 container_user: Some("myUser".to_string()),
                 mounts: Some(vec![MountDefinition {
-                    source: "/localfolder/app".to_string(),
-                    target: "/workspaces/app".to_string(),
+                    source: Some("/localfolder/app".to_string()),
+                    target: Some("/workspaces/app".to_string()),
                     mount_type: Some("volume".to_string()),
                 }]),
                 run_args: Some(vec!["-c".to_string(), "some_command".to_string()]),
@@ -889,8 +879,8 @@ mod test {
                 override_command: Some(true),
                 workspace_folder: Some("/workspaces".to_string()),
                 workspace_mount: Some(MountDefinition {
-                    source: "/app".to_string(),
-                    target: "/workspaces/app".to_string(),
+                    source: Some("/app".to_string()),
+                    target: Some("/workspaces/app".to_string()),
                     mount_type: Some("bind".to_string())
                 }),
                 customizations: Some(ZedCustomizationsWrapper {
@@ -1323,13 +1313,13 @@ mod test {
                 container_user: Some("myUser".to_string()),
                 mounts: Some(vec![
                     MountDefinition {
-                        source: "/localfolder/app".to_string(),
-                        target: "/workspaces/app".to_string(),
+                        source: Some("/localfolder/app".to_string()),
+                        target: Some("/workspaces/app".to_string()),
                         mount_type: Some("volume".to_string()),
                     },
                     MountDefinition {
-                        source: "dev-containers-cli-bashhistory".to_string(),
-                        target: "/home/node/commandhistory".to_string(),
+                        source: Some("dev-containers-cli-bashhistory".to_string()),
+                        target: Some("/home/node/commandhistory".to_string()),
                         mount_type: None,
                     }
                 ]),
@@ -1338,8 +1328,8 @@ mod test {
                 override_command: Some(true),
                 workspace_folder: Some("/workspaces".to_string()),
                 workspace_mount: Some(MountDefinition {
-                    source: "/folder".to_string(),
-                    target: "/workspace".to_string(),
+                    source: Some("/folder".to_string()),
+                    target: Some("/workspace".to_string()),
                     mount_type: Some("bind".to_string())
                 }),
                 build: Some(ContainerBuild {
@@ -1363,8 +1353,8 @@ mod test {
     #[test]
     fn mount_definition_should_use_bind_type_for_unix_absolute_paths() {
         let mount = MountDefinition {
-            source: "/home/user/project".to_string(),
-            target: "/workspaces/project".to_string(),
+            source: Some("/home/user/project".to_string()),
+            target: Some("/workspaces/project".to_string()),
             mount_type: None,
         };
 
@@ -1379,8 +1369,8 @@ mod test {
     #[test]
     fn mount_definition_should_use_bind_type_for_windows_unc_paths() {
         let mount = MountDefinition {
-            source: "\\\\server\\share\\project".to_string(),
-            target: "/workspaces/project".to_string(),
+            source: Some("\\\\server\\share\\project".to_string()),
+            target: Some("/workspaces/project".to_string()),
             mount_type: None,
         };
 
@@ -1395,8 +1385,8 @@ mod test {
     #[test]
     fn mount_definition_should_use_bind_type_for_windows_absolute_paths() {
         let mount = MountDefinition {
-            source: "C:\\Users\\mrg\\cli".to_string(),
-            target: "/workspaces/cli".to_string(),
+            source: Some("C:\\Users\\mrg\\cli".to_string()),
+            target: Some("/workspaces/cli".to_string()),
             mount_type: None,
         };
 

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -1733,7 +1733,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         Ok(MountDefinition {
             source: Some(self.local_workspace_folder()),
-            target: Some(format!("/workspaces/{}", project_directory_name.display())),
+            target: format!("/workspaces/{}", project_directory_name.display()),
             mount_type: None,
         })
     }
@@ -3565,7 +3565,7 @@ ENV DOCKER_BUILDKIT=1
                         volumes: vec![
                             MountDefinition {
                                 source: Some("dind-var-lib-docker-42dad4b4ca7b8ced".to_string()),
-                                target: Some("/var/lib/docker".to_string()),
+                                target: "/var/lib/docker".to_string(),
                                 mount_type: Some("volume".to_string())
                             }
                         ],
@@ -4446,7 +4446,7 @@ chmod +x ./install.sh
                                 }),
                                 volumes: vec![MountDefinition {
                                     source: Some("../..".to_string()),
-                                    target: Some("/workspaces".to_string()),
+                                    target: "/workspaces".to_string(),
                                     mount_type: Some("bind".to_string()),
                                 }],
                                 network_mode: Some("service:db".to_string()),
@@ -4459,7 +4459,7 @@ chmod +x ./install.sh
                                 image: Some("postgres:14.1".to_string()),
                                 volumes: vec![MountDefinition {
                                     source: Some("postgres-data".to_string()),
-                                    target: Some("/var/lib/postgresql/data".to_string()),
+                                    target: "/var/lib/postgresql/data".to_string(),
                                     mount_type: Some("volume".to_string()),
                                 }],
                                 env_file: Some(vec![".env".to_string()]),

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -1074,11 +1074,12 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             .filter_map(|mount| {
                 if let Some(mount_type) = &mount.mount_type
                     && mount_type.to_lowercase() == "volume"
+                    && let Some(source) = &mount.source
                 {
                     Some((
-                        mount.source.clone(),
+                        source.clone(),
                         DockerComposeVolume {
-                            name: mount.source.clone(),
+                            name: source.clone(),
                         },
                     ))
                 } else {
@@ -1731,8 +1732,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
         };
 
         Ok(MountDefinition {
-            source: self.local_workspace_folder(),
-            target: format!("/workspaces/{}", project_directory_name.display()),
+            source: Some(self.local_workspace_folder()),
+            target: Some(format!("/workspaces/{}", project_directory_name.display())),
             mount_type: None,
         })
     }
@@ -3563,8 +3564,8 @@ ENV DOCKER_BUILDKIT=1
                         ])),
                         volumes: vec![
                             MountDefinition {
-                                source: "dind-var-lib-docker-42dad4b4ca7b8ced".to_string(),
-                                target: "/var/lib/docker".to_string(),
+                                source: Some("dind-var-lib-docker-42dad4b4ca7b8ced".to_string()),
+                                target: Some("/var/lib/docker".to_string()),
                                 mount_type: Some("volume".to_string())
                             }
                         ],
@@ -4444,8 +4445,8 @@ chmod +x ./install.sh
                                     additional_contexts: None,
                                 }),
                                 volumes: vec![MountDefinition {
-                                    source: "../..".to_string(),
-                                    target: "/workspaces".to_string(),
+                                    source: Some("../..".to_string()),
+                                    target: Some("/workspaces".to_string()),
                                     mount_type: Some("bind".to_string()),
                                 }],
                                 network_mode: Some("service:db".to_string()),
@@ -4457,8 +4458,8 @@ chmod +x ./install.sh
                             DockerComposeService {
                                 image: Some("postgres:14.1".to_string()),
                                 volumes: vec![MountDefinition {
-                                    source: "postgres-data".to_string(),
-                                    target: "/var/lib/postgresql/data".to_string(),
+                                    source: Some("postgres-data".to_string()),
+                                    target: Some("/var/lib/postgresql/data".to_string()),
                                     mount_type: Some("volume".to_string()),
                                 }],
                                 env_file: Some(vec![".env".to_string()]),

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -994,7 +994,7 @@ mod test {
                         volumes: vec![MountDefinition {
                             mount_type: Some("bind".to_string()),
                             source: Some("/path/to".to_string()),
-                            target: Some("/workspaces".to_string()),
+                            target: "/workspaces".to_string(),
                         }],
                         network_mode: Some("service:db".to_string()),
 
@@ -1024,7 +1024,7 @@ mod test {
                         volumes: vec![MountDefinition {
                             mount_type: Some("volume".to_string()),
                             source: Some("postgres-data".to_string()),
-                            target: Some("/var/lib/postgresql/data".to_string()),
+                            target: "/var/lib/postgresql/data".to_string(),
                         }],
                         ..Default::default()
                     },
@@ -1156,7 +1156,7 @@ mod test {
         let service = config.services.get("app").unwrap();
         assert_eq!(service.volumes.len(), 1);
         assert_eq!(service.volumes[0].source, None);
-        assert_eq!(service.volumes[0].target, Some("/tmp".to_string()));
+        assert_eq!(service.volumes[0].target, "/tmp");
         assert_eq!(service.volumes[0].mount_type, Some("tmpfs".to_string()));
     }
 

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -993,8 +993,8 @@ mod test {
                         ),
                         volumes: vec![MountDefinition {
                             mount_type: Some("bind".to_string()),
-                            source: "/path/to".to_string(),
-                            target: "/workspaces".to_string(),
+                            source: Some("/path/to".to_string()),
+                            target: Some("/workspaces".to_string()),
                         }],
                         network_mode: Some("service:db".to_string()),
 
@@ -1023,8 +1023,8 @@ mod test {
                         image: Some("postgres:14.1".to_string()),
                         volumes: vec![MountDefinition {
                             mount_type: Some("volume".to_string()),
-                            source: "postgres-data".to_string(),
-                            target: "/var/lib/postgresql/data".to_string(),
+                            source: Some("postgres-data".to_string()),
+                            target: Some("/var/lib/postgresql/data".to_string()),
                         }],
                         ..Default::default()
                     },

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -142,6 +142,7 @@ pub(crate) struct DockerComposeService {
     pub(crate) build: Option<DockerComposeServiceBuild>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) privileged: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) volumes: Vec<MountDefinition>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) env_file: Option<Vec<String>>,

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -1116,6 +1116,51 @@ mod test {
     }
 
     #[test]
+    fn should_deserialize_compose_with_missing_volumes_field() {
+        let given_config = r#"
+        {
+            "name": "devcontainer",
+            "services": {
+                "sidecar": {
+                    "image": "ubuntu:24.04"
+                }
+            }
+        }
+        "#;
+
+        let config: DockerComposeConfig = serde_json_lenient::from_str(given_config).unwrap();
+        let service = config.services.get("sidecar").unwrap();
+        assert!(service.volumes.is_empty());
+    }
+
+    #[test]
+    fn should_deserialize_compose_volume_without_source() {
+        let given_config = r#"
+        {
+            "name": "devcontainer",
+            "services": {
+                "app": {
+                    "image": "ubuntu:24.04",
+                    "volumes": [
+                        {
+                            "type": "tmpfs",
+                            "target": "/tmp"
+                        }
+                    ]
+                }
+            }
+        }
+        "#;
+
+        let config: DockerComposeConfig = serde_json_lenient::from_str(given_config).unwrap();
+        let service = config.services.get("app").unwrap();
+        assert_eq!(service.volumes.len(), 1);
+        assert_eq!(service.volumes[0].source, None);
+        assert_eq!(service.volumes[0].target, Some("/tmp".to_string()));
+        assert_eq!(service.volumes[0].mount_type, Some("tmpfs".to_string()));
+    }
+
+    #[test]
     fn should_deserialize_inspect_without_labels() {
         let given_config = r#"
         {


### PR DESCRIPTION
Fixes some issues concerning volume mounts in the `dev_container` integration:
1. Docker Compose services that don't define a volumes key cause deserialization to fail because the field was required. This field is not strictly necessary, i.e. for other services in a docker compose devcontainer configuration which the editor is not attached to.
1. Volume mounts where source or target is absent (e.g. `tmpfs` mounts that only need a target) also fail to parse because both fields were required. This makes the source key optional, matching the Docker Compose spec.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed devcontainer initialization erroneously requiring each service to have a volumes key.
- Fixed devcontainer initialization erroneously requiring source keys for all volume mounts.