### PR TITLE
Add Avian LLM provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/auto_update",
     "crates/auto_update_helper",
     "crates/auto_update_ui",
+    "crates/avian",
     "crates/aws_http_client",
     "crates/bedrock",
     "crates/breadcrumbs",
@@ -272,6 +273,7 @@ assets = { path = "crates/assets" }
 audio = { path = "crates/audio" }
 auto_update = { path = "crates/auto_update" }
 auto_update_ui = { path = "crates/auto_update_ui" }
+avian = { path = "crates/avian" }
 aws_http_client = { path = "crates/aws_http_client" }
 bedrock = { path = "crates/bedrock" }
 breadcrumbs = { path = "crates/breadcrumbs" }

--- a/assets/icons/ai_avian.svg
+++ b/assets/icons/ai_avian.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.5 3.5C13.5 3.5 12 2 9.5 2C7 2 5 3.5 4 5.5C3 7.5 2 8 1 8.5C2 9 3.5 9 4.5 8.5C4 10 3.5 11.5 2.5 13C4 12.5 5.5 11.5 6.5 10C7.5 10.5 8.5 10.5 9.5 10C10.5 9.5 11.5 8.5 12 7C12.5 5.5 13.5 3.5 13.5 3.5Z" fill="black" stroke="black" stroke-width="0.5" stroke-linejoin="round"/>
+<circle cx="10" cy="5" r="0.75" fill="white"/>
+</svg>

--- a/crates/avian/Cargo.toml
+++ b/crates/avian/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "avian"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/avian.rs"
+
+[features]
+default = []
+schemars = ["dep:schemars"]
+
+[dependencies]
+anyhow.workspace = true
+schemars = { workspace = true, optional = true }
+serde.workspace = true
+strum.workspace = true

--- a/crates/avian/src/avian.rs
+++ b/crates/avian/src/avian.rs
@@ -1,0 +1,120 @@
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+
+pub const AVIAN_API_URL: &str = "https://api.avian.io/v1";
+
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
+pub enum Model {
+    #[default]
+    #[serde(rename = "deepseek-v3-0324")]
+    DeepSeekV3,
+    #[serde(rename = "kimi-k2.5")]
+    KimiK2_5,
+    #[serde(rename = "glm-5")]
+    Glm5,
+    #[serde(rename = "minimax-m2.5")]
+    MiniMaxM2_5,
+    #[serde(rename = "custom")]
+    Custom {
+        name: String,
+        /// The name displayed in the UI, such as in the assistant panel model dropdown menu.
+        display_name: Option<String>,
+        max_tokens: u64,
+        max_output_tokens: Option<u64>,
+        max_completion_tokens: Option<u64>,
+        supports_images: Option<bool>,
+        supports_tools: Option<bool>,
+        parallel_tool_calls: Option<bool>,
+    },
+}
+
+impl Model {
+    pub fn default_fast() -> Self {
+        Self::DeepSeekV3
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            Self::DeepSeekV3 => "deepseek-v3-0324",
+            Self::KimiK2_5 => "kimi-k2.5",
+            Self::Glm5 => "glm-5",
+            Self::MiniMaxM2_5 => "minimax-m2.5",
+            Self::Custom { name, .. } => name,
+        }
+    }
+
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::DeepSeekV3 => "DeepSeek V3.2",
+            Self::KimiK2_5 => "Kimi K2.5",
+            Self::Glm5 => "GLM-5",
+            Self::MiniMaxM2_5 => "MiniMax M2.5",
+            Self::Custom {
+                name, display_name, ..
+            } => display_name.as_ref().unwrap_or(name),
+        }
+    }
+
+    pub fn max_token_count(&self) -> u64 {
+        match self {
+            Self::DeepSeekV3 => 164_000,
+            Self::KimiK2_5 => 128_000,
+            Self::Glm5 => 128_000,
+            Self::MiniMaxM2_5 => 1_000_000,
+            Self::Custom { max_tokens, .. } => *max_tokens,
+        }
+    }
+
+    pub fn max_output_tokens(&self) -> Option<u64> {
+        match self {
+            Self::DeepSeekV3 => Some(8_192),
+            Self::KimiK2_5 => Some(8_192),
+            Self::Glm5 => Some(8_192),
+            Self::MiniMaxM2_5 => Some(8_192),
+            Self::Custom {
+                max_output_tokens, ..
+            } => *max_output_tokens,
+        }
+    }
+
+    pub fn supports_parallel_tool_calls(&self) -> bool {
+        match self {
+            Self::DeepSeekV3 | Self::KimiK2_5 | Self::Glm5 | Self::MiniMaxM2_5 => false,
+            Self::Custom {
+                parallel_tool_calls: Some(support),
+                ..
+            } => *support,
+            Self::Custom { .. } => false,
+        }
+    }
+
+    pub fn requires_json_schema_subset(&self) -> bool {
+        false
+    }
+
+    pub fn supports_prompt_cache_key(&self) -> bool {
+        false
+    }
+
+    pub fn supports_tool(&self) -> bool {
+        match self {
+            Self::DeepSeekV3 | Self::KimiK2_5 | Self::Glm5 | Self::MiniMaxM2_5 => true,
+            Self::Custom {
+                supports_tools: Some(support),
+                ..
+            } => *support,
+            Self::Custom { .. } => false,
+        }
+    }
+
+    pub fn supports_images(&self) -> bool {
+        match self {
+            Self::Custom {
+                supports_images: Some(support),
+                ..
+            } => *support,
+            _ => false,
+        }
+    }
+}

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -10,6 +10,7 @@ use strum::{EnumIter, EnumString, IntoStaticStr};
 pub enum IconName {
     AcpRegistry,
     AiAnthropic,
+    AiAvian,
     AiBedrock,
     AiClaude,
     AiDeepSeek,

--- a/crates/language_model/src/provider.rs
+++ b/crates/language_model/src/provider.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod avian;
 pub mod google;
 pub mod open_ai;
 pub mod open_router;
@@ -6,6 +7,7 @@ pub mod x_ai;
 pub mod zed;
 
 pub use anthropic::*;
+pub use avian::*;
 pub use google::*;
 pub use open_ai::*;
 pub use x_ai::*;

--- a/crates/language_model/src/provider/avian.rs
+++ b/crates/language_model/src/provider/avian.rs
@@ -1,0 +1,4 @@
+use crate::{LanguageModelProviderId, LanguageModelProviderName};
+
+pub const AVIAN_PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("avian");
+pub const AVIAN_PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Avian");

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/language_models.rs"
 ai_onboarding.workspace = true
 anthropic = { workspace = true, features = ["schemars"] }
 anyhow.workspace = true
+avian = { workspace = true, features = ["schemars"] }
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-credential-types = { workspace = true, features = ["hardcoded-credentials"] }
 aws_http_client.workspace = true

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -15,6 +15,7 @@ mod settings;
 pub use crate::extension::init_proxy as init_extension_proxy;
 
 use crate::provider::anthropic::AnthropicLanguageModelProvider;
+use crate::provider::avian::AvianLanguageModelProvider;
 use crate::provider::bedrock::BedrockLanguageModelProvider;
 use crate::provider::cloud::CloudLanguageModelProvider;
 use crate::provider::copilot_chat::CopilotChatLanguageModelProvider;
@@ -197,6 +198,14 @@ fn register_language_model_providers(
     );
     registry.register_provider(
         Arc::new(OpenAiLanguageModelProvider::new(
+            client.http_client(),
+            credentials_provider.clone(),
+            cx,
+        )),
+        cx,
+    );
+    registry.register_provider(
+        Arc::new(AvianLanguageModelProvider::new(
             client.http_client(),
             credentials_provider.clone(),
             cx,

--- a/crates/language_models/src/provider.rs
+++ b/crates/language_models/src/provider.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod avian;
 pub mod bedrock;
 pub mod cloud;
 pub mod copilot_chat;

--- a/crates/language_models/src/provider/avian.rs
+++ b/crates/language_models/src/provider/avian.rs
@@ -1,0 +1,523 @@
+use anyhow::Result;
+use collections::BTreeMap;
+use credentials_provider::CredentialsProvider;
+use futures::{FutureExt, StreamExt, future::BoxFuture};
+use gpui::{AnyView, App, AsyncApp, Context, Entity, Task, Window};
+use http_client::HttpClient;
+use language_model::{
+    ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel, LanguageModelCompletionError,
+    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
+    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
+    LanguageModelRequest, LanguageModelToolChoice, LanguageModelToolSchemaFormat, RateLimiter,
+    Role, env_var,
+};
+use open_ai::ResponseStreamEvent;
+pub use settings::AvianAvailableModel as AvailableModel;
+use settings::{Settings, SettingsStore};
+use std::sync::{Arc, LazyLock};
+use strum::IntoEnumIterator;
+use ui::{ButtonLink, ConfiguredApiCard, List, ListBulletItem, prelude::*};
+use ui_input::InputField;
+use util::ResultExt;
+use avian::{Model, AVIAN_API_URL};
+
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("avian");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Avian");
+
+const API_KEY_ENV_VAR_NAME: &str = "AVIAN_API_KEY";
+static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct AvianSettings {
+    pub api_url: String,
+    pub available_models: Vec<AvailableModel>,
+}
+
+pub struct AvianLanguageModelProvider {
+    http_client: Arc<dyn HttpClient>,
+    state: Entity<State>,
+}
+
+pub struct State {
+    api_key_state: ApiKeyState,
+    credentials_provider: Arc<dyn CredentialsProvider>,
+}
+
+impl State {
+    fn is_authenticated(&self) -> bool {
+        self.api_key_state.has_key()
+    }
+
+    fn set_api_key(&mut self, api_key: Option<String>, cx: &mut Context<Self>) -> Task<Result<()>> {
+        let credentials_provider = self.credentials_provider.clone();
+        let api_url = AvianLanguageModelProvider::api_url(cx);
+        self.api_key_state.store(
+            api_url,
+            api_key,
+            |this| &mut this.api_key_state,
+            credentials_provider,
+            cx,
+        )
+    }
+
+    fn authenticate(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
+        let credentials_provider = self.credentials_provider.clone();
+        let api_url = AvianLanguageModelProvider::api_url(cx);
+        self.api_key_state.load_if_needed(
+            api_url,
+            |this| &mut this.api_key_state,
+            credentials_provider,
+            cx,
+        )
+    }
+}
+
+impl AvianLanguageModelProvider {
+    pub fn new(
+        http_client: Arc<dyn HttpClient>,
+        credentials_provider: Arc<dyn CredentialsProvider>,
+        cx: &mut App,
+    ) -> Self {
+        let state = cx.new(|cx| {
+            cx.observe_global::<SettingsStore>(|this: &mut State, cx| {
+                let credentials_provider = this.credentials_provider.clone();
+                let api_url = Self::api_url(cx);
+                this.api_key_state.handle_url_change(
+                    api_url,
+                    |this| &mut this.api_key_state,
+                    credentials_provider,
+                    cx,
+                );
+                cx.notify();
+            })
+            .detach();
+            State {
+                api_key_state: ApiKeyState::new(Self::api_url(cx), (*API_KEY_ENV_VAR).clone()),
+                credentials_provider,
+            }
+        });
+
+        Self { http_client, state }
+    }
+
+    fn create_language_model(&self, model: avian::Model) -> Arc<dyn LanguageModel> {
+        Arc::new(AvianLanguageModel {
+            id: LanguageModelId::from(model.id().to_string()),
+            model,
+            state: self.state.clone(),
+            http_client: self.http_client.clone(),
+            request_limiter: RateLimiter::new(4),
+        })
+    }
+
+    fn settings(cx: &App) -> &AvianSettings {
+        &crate::AllLanguageModelSettings::get_global(cx).avian
+    }
+
+    fn api_url(cx: &App) -> SharedString {
+        let api_url = &Self::settings(cx).api_url;
+        if api_url.is_empty() {
+            AVIAN_API_URL.into()
+        } else {
+            SharedString::new(api_url.as_str())
+        }
+    }
+}
+
+impl LanguageModelProviderState for AvianLanguageModelProvider {
+    type ObservableEntity = State;
+
+    fn observable_entity(&self) -> Option<Entity<Self::ObservableEntity>> {
+        Some(self.state.clone())
+    }
+}
+
+impl LanguageModelProvider for AvianLanguageModelProvider {
+    fn id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn icon(&self) -> IconOrSvg {
+        IconOrSvg::Icon(IconName::AiAvian)
+    }
+
+    fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(avian::Model::default()))
+    }
+
+    fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(avian::Model::default_fast()))
+    }
+
+    fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
+        let mut models = BTreeMap::default();
+
+        for model in avian::Model::iter() {
+            if !matches!(model, avian::Model::Custom { .. }) {
+                models.insert(model.id().to_string(), model);
+            }
+        }
+
+        for model in &Self::settings(cx).available_models {
+            models.insert(
+                model.name.clone(),
+                avian::Model::Custom {
+                    name: model.name.clone(),
+                    display_name: model.display_name.clone(),
+                    max_tokens: model.max_tokens,
+                    max_output_tokens: model.max_output_tokens,
+                    max_completion_tokens: model.max_completion_tokens,
+                    supports_images: model.supports_images,
+                    supports_tools: model.supports_tools,
+                    parallel_tool_calls: model.parallel_tool_calls,
+                },
+            );
+        }
+
+        models
+            .into_values()
+            .map(|model| self.create_language_model(model))
+            .collect()
+    }
+
+    fn is_authenticated(&self, cx: &App) -> bool {
+        self.state.read(cx).is_authenticated()
+    }
+
+    fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {
+        self.state.update(cx, |state, cx| state.authenticate(cx))
+    }
+
+    fn configuration_view(
+        &self,
+        _target_agent: language_model::ConfigurationViewTargetAgent,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> AnyView {
+        cx.new(|cx| ConfigurationView::new(self.state.clone(), window, cx))
+            .into()
+    }
+
+    fn reset_credentials(&self, cx: &mut App) -> Task<Result<()>> {
+        self.state
+            .update(cx, |state, cx| state.set_api_key(None, cx))
+    }
+}
+
+pub struct AvianLanguageModel {
+    id: LanguageModelId,
+    model: avian::Model,
+    state: Entity<State>,
+    http_client: Arc<dyn HttpClient>,
+    request_limiter: RateLimiter,
+}
+
+impl AvianLanguageModel {
+    fn stream_completion(
+        &self,
+        request: open_ai::Request,
+        cx: &AsyncApp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            futures::stream::BoxStream<'static, Result<ResponseStreamEvent>>,
+            LanguageModelCompletionError,
+        >,
+    > {
+        let http_client = self.http_client.clone();
+
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
+            let api_url = AvianLanguageModelProvider::api_url(cx);
+            (state.api_key_state.key(&api_url), api_url)
+        });
+
+        let future = self.request_limiter.stream(async move {
+            let provider = PROVIDER_NAME;
+            let Some(api_key) = api_key else {
+                return Err(LanguageModelCompletionError::NoApiKey { provider });
+            };
+            let request = open_ai::stream_completion(
+                http_client.as_ref(),
+                provider.0.as_str(),
+                &api_url,
+                &api_key,
+                request,
+            );
+            let response = request.await?;
+            Ok(response)
+        });
+
+        async move { Ok(future.await?.boxed()) }.boxed()
+    }
+}
+
+impl LanguageModel for AvianLanguageModel {
+    fn id(&self) -> LanguageModelId {
+        self.id.clone()
+    }
+
+    fn name(&self) -> LanguageModelName {
+        LanguageModelName::from(self.model.display_name().to_string())
+    }
+
+    fn provider_id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn provider_name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn supports_tools(&self) -> bool {
+        self.model.supports_tool()
+    }
+
+    fn supports_images(&self) -> bool {
+        self.model.supports_images()
+    }
+
+    fn supports_streaming_tools(&self) -> bool {
+        true
+    }
+
+    fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
+        match choice {
+            LanguageModelToolChoice::Auto
+            | LanguageModelToolChoice::Any
+            | LanguageModelToolChoice::None => true,
+        }
+    }
+    fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {
+        if self.model.requires_json_schema_subset() {
+            LanguageModelToolSchemaFormat::JsonSchemaSubset
+        } else {
+            LanguageModelToolSchemaFormat::JsonSchema
+        }
+    }
+
+    fn telemetry_id(&self) -> String {
+        format!("avian/{}", self.model.id())
+    }
+
+    fn max_token_count(&self) -> u64 {
+        self.model.max_token_count()
+    }
+
+    fn max_output_tokens(&self) -> Option<u64> {
+        self.model.max_output_tokens()
+    }
+
+    fn supports_split_token_display(&self) -> bool {
+        true
+    }
+
+    fn count_tokens(
+        &self,
+        request: LanguageModelRequest,
+        cx: &App,
+    ) -> BoxFuture<'static, Result<u64>> {
+        count_avian_tokens(request, self.model.clone(), cx)
+    }
+
+    fn stream_completion(
+        &self,
+        request: LanguageModelRequest,
+        cx: &AsyncApp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            futures::stream::BoxStream<
+                'static,
+                Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+            >,
+            LanguageModelCompletionError,
+        >,
+    > {
+        let request = crate::provider::open_ai::into_open_ai(
+            request,
+            self.model.id(),
+            self.model.supports_parallel_tool_calls(),
+            self.model.supports_prompt_cache_key(),
+            self.max_output_tokens(),
+            None,
+        );
+        let completions = self.stream_completion(request, cx);
+        async move {
+            let mapper = crate::provider::open_ai::OpenAiEventMapper::new();
+            Ok(mapper.map_stream(completions.await?).boxed())
+        }
+        .boxed()
+    }
+}
+
+pub fn count_avian_tokens(
+    request: LanguageModelRequest,
+    model: Model,
+    cx: &App,
+) -> BoxFuture<'static, Result<u64>> {
+    cx.background_spawn(async move {
+        let messages = request
+            .messages
+            .into_iter()
+            .map(|message| tiktoken_rs::ChatCompletionRequestMessage {
+                role: match message.role {
+                    Role::User => "user".into(),
+                    Role::Assistant => "assistant".into(),
+                    Role::System => "system".into(),
+                },
+                content: Some(message.string_contents()),
+                name: None,
+                function_call: None,
+            })
+            .collect::<Vec<_>>();
+
+        let model_name = if model.max_token_count() >= 100_000 {
+            "gpt-4o"
+        } else {
+            "gpt-4"
+        };
+        tiktoken_rs::num_tokens_from_messages(model_name, &messages).map(|tokens| tokens as u64)
+    })
+    .boxed()
+}
+
+struct ConfigurationView {
+    api_key_editor: Entity<InputField>,
+    state: Entity<State>,
+    load_credentials_task: Option<Task<()>>,
+}
+
+impl ConfigurationView {
+    fn new(state: Entity<State>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let api_key_editor = cx.new(|cx| {
+            InputField::new(
+                window,
+                cx,
+                "avian-0000000000000000000000000000000000000000000000000",
+            )
+            .label("API key")
+        });
+
+        cx.observe(&state, |_, _, cx| {
+            cx.notify();
+        })
+        .detach();
+
+        let load_credentials_task = Some(cx.spawn_in(window, {
+            let state = state.clone();
+            async move |this, cx| {
+                if let Some(task) = Some(state.update(cx, |state, cx| state.authenticate(cx))) {
+                    // We don't log an error, because "not signed in" is also an error.
+                    let _ = task.await;
+                }
+                this.update(cx, |this, cx| {
+                    this.load_credentials_task = None;
+                    cx.notify();
+                })
+                .log_err();
+            }
+        }));
+
+        Self {
+            api_key_editor,
+            state,
+            load_credentials_task,
+        }
+    }
+
+    fn save_api_key(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        let api_key = self.api_key_editor.read(cx).text(cx).trim().to_string();
+        if api_key.is_empty() {
+            return;
+        }
+
+        // url changes can cause the editor to be displayed again
+        self.api_key_editor
+            .update(cx, |editor, cx| editor.set_text("", window, cx));
+
+        let state = self.state.clone();
+        cx.spawn_in(window, async move |_, cx| {
+            state
+                .update(cx, |state, cx| state.set_api_key(Some(api_key), cx))
+                .await
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn reset_api_key(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.api_key_editor
+            .update(cx, |input, cx| input.set_text("", window, cx));
+
+        let state = self.state.clone();
+        cx.spawn_in(window, async move |_, cx| {
+            state
+                .update(cx, |state, cx| state.set_api_key(None, cx))
+                .await
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn should_render_editor(&self, cx: &mut Context<Self>) -> bool {
+        !self.state.read(cx).is_authenticated()
+    }
+}
+
+impl Render for ConfigurationView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let env_var_set = self.state.read(cx).api_key_state.is_from_env_var();
+        let configured_card_label = if env_var_set {
+            format!("API key set in {API_KEY_ENV_VAR_NAME} environment variable")
+        } else {
+            let api_url = AvianLanguageModelProvider::api_url(cx);
+            if api_url == AVIAN_API_URL {
+                "API key configured".to_string()
+            } else {
+                format!("API key configured for {}", api_url)
+            }
+        };
+
+        let api_key_section = if self.should_render_editor(cx) {
+            v_flex()
+                .on_action(cx.listener(Self::save_api_key))
+                .child(Label::new("To use Zed's agent with Avian, you need to add an API key. Follow these steps:"))
+                .child(
+                    List::new()
+                        .child(
+                            ListBulletItem::new("")
+                                .child(Label::new("Create one by visiting"))
+                                .child(ButtonLink::new("Avian dashboard", "https://avian.io/dashboard"))
+                        )
+                        .child(
+                            ListBulletItem::new("Paste your API key below and hit enter to start using the agent")
+                        ),
+                )
+                .child(self.api_key_editor.clone())
+                .child(
+                    Label::new(format!(
+                        "You can also set the {API_KEY_ENV_VAR_NAME} environment variable and restart Zed."
+                    ))
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+                )
+                .into_any_element()
+        } else {
+            ConfiguredApiCard::new(configured_card_label)
+                .disabled(env_var_set)
+                .when(env_var_set, |this| {
+                    this.tooltip_label(format!("To reset your API key, unset the {API_KEY_ENV_VAR_NAME} environment variable."))
+                })
+                .on_click(cx.listener(|this, _, window, cx| this.reset_api_key(window, cx)))
+                .into_any_element()
+        };
+
+        if self.load_credentials_task.is_some() {
+            div().child(Label::new("Loading credentials...")).into_any()
+        } else {
+            v_flex().size_full().child(api_key_section).into_any()
+        }
+    }
+}

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -4,17 +4,18 @@ use collections::HashMap;
 use settings::RegisterSetting;
 
 use crate::provider::{
-    anthropic::AnthropicSettings, bedrock::AmazonBedrockSettings, cloud::ZedDotDevSettings,
-    deepseek::DeepSeekSettings, google::GoogleSettings, lmstudio::LmStudioSettings,
-    mistral::MistralSettings, ollama::OllamaSettings, open_ai::OpenAiSettings,
-    open_ai_compatible::OpenAiCompatibleSettings, open_router::OpenRouterSettings,
-    opencode::OpenCodeSettings, vercel::VercelSettings, vercel_ai_gateway::VercelAiGatewaySettings,
-    x_ai::XAiSettings,
+    anthropic::AnthropicSettings, avian::AvianSettings, bedrock::AmazonBedrockSettings,
+    cloud::ZedDotDevSettings, deepseek::DeepSeekSettings, google::GoogleSettings,
+    lmstudio::LmStudioSettings, mistral::MistralSettings, ollama::OllamaSettings,
+    open_ai::OpenAiSettings, open_ai_compatible::OpenAiCompatibleSettings,
+    open_router::OpenRouterSettings, opencode::OpenCodeSettings, vercel::VercelSettings,
+    vercel_ai_gateway::VercelAiGatewaySettings, x_ai::XAiSettings,
 };
 
 #[derive(Debug, RegisterSetting)]
 pub struct AllLanguageModelSettings {
     pub anthropic: AnthropicSettings,
+    pub avian: AvianSettings,
     pub bedrock: AmazonBedrockSettings,
     pub deepseek: DeepSeekSettings,
     pub google: GoogleSettings,
@@ -37,6 +38,7 @@ impl settings::Settings for AllLanguageModelSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let language_models = content.language_models.clone().unwrap();
         let anthropic = language_models.anthropic.unwrap();
+        let avian = language_models.avian.unwrap();
         let bedrock = language_models.bedrock.unwrap();
         let deepseek = language_models.deepseek.unwrap();
         let google = language_models.google.unwrap();
@@ -55,6 +57,10 @@ impl settings::Settings for AllLanguageModelSettings {
             anthropic: AnthropicSettings {
                 api_url: anthropic.api_url.unwrap(),
                 available_models: anthropic.available_models.unwrap_or_default(),
+            },
+            avian: AvianSettings {
+                api_url: avian.api_url.unwrap(),
+                available_models: avian.available_models.unwrap_or_default(),
             },
             bedrock: AmazonBedrockSettings {
                 available_models: bedrock.available_models.unwrap_or_default(),

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
 pub struct AllLanguageModelSettingsContent {
     pub anthropic: Option<AnthropicSettingsContent>,
+    pub avian: Option<AvianSettingsContent>,
     pub bedrock: Option<AmazonBedrockSettingsContent>,
     pub deepseek: Option<DeepseekSettingsContent>,
     pub google: Option<GoogleSettingsContent>,
@@ -355,6 +356,26 @@ pub struct GoogleAvailableModel {
     pub display_name: Option<String>,
     pub max_tokens: u64,
     pub mode: Option<ModelMode>,
+}
+
+#[with_fallible_options]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
+pub struct AvianSettingsContent {
+    pub api_url: Option<String>,
+    pub available_models: Option<Vec<AvianAvailableModel>>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct AvianAvailableModel {
+    pub name: String,
+    pub display_name: Option<String>,
+    pub max_tokens: u64,
+    pub max_output_tokens: Option<u64>,
+    pub max_completion_tokens: Option<u64>,
+    pub supports_images: Option<bool>,
+    pub supports_tools: Option<bool>,
+    pub parallel_tool_calls: Option<bool>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
## Summary

- Adds [Avian](https://avian.io) as a built-in OpenAI-compatible language model provider
- Avian offers affordable inference for frontier open-source models:
  - **DeepSeek V3.2** (164K context) — $0.14/$0.28 per M tokens
  - **Kimi K2.5** (128K context) — $0.14/$0.28 per M tokens
  - **GLM-5** (128K context) — $0.25/$0.50 per M tokens
  - **MiniMax M2.5** (1M context) — $0.15/$0.30 per M tokens
- API endpoint: `https://api.avian.io/v1`
- Uses the same OpenAI-compatible streaming pattern as xAI (via `open_ai::stream_completion` and `OpenAiEventMapper`)

## Changes

- **`crates/avian/`** — New model definition crate with model IDs, display names, context windows, and capability flags
- **`crates/language_model/src/provider/avian.rs`** — Provider ID and name constants (`AVIAN_PROVIDER_ID`, `AVIAN_PROVIDER_NAME`)
- **`crates/language_models/src/provider/avian.rs`** — Full provider implementation: API key auth (`AVIAN_API_KEY` env var), settings, rate limiter, token counting, streaming completion, and configuration UI
- **`crates/settings_content/src/language_model.rs`** — `AvianSettingsContent` and `AvianAvailableModel` for the settings schema
- **`crates/language_models/src/settings.rs`** — `AvianSettings` wired into `AllLanguageModelSettings`
- **`crates/language_models/src/language_models.rs`** — Provider registered in `register_language_model_providers`
- **`crates/icons/src/icons.rs`** + **`assets/icons/ai_avian.svg`** — Provider icon

## Test plan

- [ ] Verify the project compiles with `cargo check -p language_models`
- [ ] Verify the Avian provider appears in the model selector dropdown
- [ ] Verify API key entry flow works (enter key, env var, reset)
- [ ] Verify streaming completions work against `https://api.avian.io/v1`
- [ ] Verify custom model configuration via settings JSON