### PR TITLE
dev_container: Preserve build context for docker-compose Dockerfiles

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -876,10 +876,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                                     .as_ref()
                                     .and_then(|b| b.context.clone())
                                     .unwrap_or_else(|| {
-                                        features_build_info
-                                            .empty_context_dir
-                                            .display()
-                                            .to_string()
+                                        features_build_info.empty_context_dir.display().to_string()
                                     }),
                             ),
                             dockerfile: Some(dockerfile_path.display().to_string()),

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -871,7 +871,16 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                         labels: None,
                         build: Some(DockerComposeServiceBuild {
                             context: Some(
-                                features_build_info.empty_context_dir.display().to_string(),
+                                main_service
+                                    .build
+                                    .as_ref()
+                                    .and_then(|b| b.context.clone())
+                                    .unwrap_or_else(|| {
+                                        features_build_info
+                                            .empty_context_dir
+                                            .display()
+                                            .to_string()
+                                    }),
                             ),
                             dockerfile: Some(dockerfile_path.display().to_string()),
                             args: Some(build_args),

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -3541,6 +3541,27 @@ ENV DOCKER_BUILDKIT=1
 "#
         );
 
+        let build_override = files
+            .iter()
+            .find(|f| {
+                f.file_name()
+                    .is_some_and(|s| s.display().to_string() == "docker_compose_build.json")
+            })
+            .expect("to be found");
+        let build_override = test_dependencies.fs.load(build_override).await.unwrap();
+        let build_config: DockerComposeConfig =
+            serde_json_lenient::from_str(&build_override).unwrap();
+        let build_context = build_config
+            .services
+            .get("app")
+            .and_then(|s| s.build.as_ref())
+            .and_then(|b| b.context.clone())
+            .expect("build override should have a context");
+        assert_eq!(
+            build_context, ".",
+            "build override should preserve the original build context from docker-compose.yml"
+        );
+
         let runtime_override = files
             .iter()
             .find(|f| {


### PR DESCRIPTION
When a Docker Compose service specifies a build context, the generated override file was replacing it with an empty context directory. This meant Dockerfiles that reference files relative to their build context (e.g. `COPY . /app`) would fail. The fix preserves the original build context from the compose service, falling back to the empty context directory only when no context was specified.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed docker compose Dockerfile build context not being preserved in dev_container integration.