### PR TITLE
dev_container: Fix alias injection for multi-stage Dockerfiles

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -2249,7 +2249,8 @@ chmod +x ./install.sh
 fn dockerfile_alias(dockerfile_content: &str) -> Option<String> {
     dockerfile_content
         .lines()
-        .find(|line| line.starts_with("FROM"))
+        .filter(|line| line.starts_with("FROM"))
+        .last()
         .and_then(|line| {
             let words: Vec<&str> = line.split(" ").collect();
             if words.len() > 2 && words[words.len() - 2].to_lowercase() == "as" {
@@ -2264,10 +2265,17 @@ fn dockerfile_inject_alias(dockerfile_content: &str, alias: &str) -> String {
     if dockerfile_alias(dockerfile_content).is_some() {
         dockerfile_content.to_string()
     } else {
+        let last_from_idx = dockerfile_content
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| line.starts_with("FROM"))
+            .last()
+            .map(|(idx, _)| idx);
         dockerfile_content
             .lines()
-            .map(|line| {
-                if line.starts_with("FROM") {
+            .enumerate()
+            .map(|(idx, line)| {
+                if Some(idx) == last_from_idx {
                     format!("{} AS {}", line, alias)
                 } else {
                     line.to_string()


### PR DESCRIPTION
In multi-stage Dockerfiles, the alias injection logic looked at the first FROM line to detect and inject stage aliases. For Dockerfiles with an aliased intermediate stage (e.g. `FROM ubuntu:24.04 AS builder`) followed by an unaliased final stage (e.g. `FROM ${BASE_IMAGE}`), the code would see the first stage's alias and skip injection entirely. This left the final stage without the `dev_container_auto_added_stage_label` alias that the feature injection Dockerfile depends on. The fix targets the last FROM line instead, which is always the stage that produces the output image.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed dev container builds failing when the Dockerfile uses multi-stage builds with aliased intermediate stages.