### PR TITLE
editor: Fix toggle comment on HTML closing tags

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16491,8 +16491,50 @@ impl Editor {
                 let start_column = snapshot
                     .indent_size_for_line(MultiBufferRow(selection.start.row))
                     .len;
+
+                let target_column = {
+                    let start_language = if let Some(language) =
+                        snapshot.language_scope_at(Point::new(selection.start.row, start_column))
+                    {
+                        language
+                    } else {
+                        continue;
+                    };
+
+                    let end_language = if let Some(language) =
+                        snapshot.language_scope_at(Point::new(selection.end.row, selection.end.column))
+                    {
+                        language
+                    } else {
+                        continue;
+                    };
+
+                    let mut tokens = Vec::new();
+                    for language in [&start_language, &end_language] {
+                        tokens.extend(language.line_comment_prefixes().iter().cloned());
+                        if let Some(block) = language.block_comment() {
+                            tokens.push(block.start.clone());
+                        }
+                    }
+                    tokens.sort_by(|a, b| b.len().cmp(&a.len()));
+                    tokens.dedup();
+
+                    let line = snapshot.text_for_range(
+                        Point::new(selection.start.row, start_column)
+                            ..Point::new(selection.start.row, snapshot.line_len(MultiBufferRow(selection.start.row)))
+                    ).collect::<String>();
+                    let mut stripped = line.as_str();
+                    for token in &tokens {
+                        stripped = stripped.trim_start_matches(token.as_ref());
+                        // Trim space after the token
+                        stripped = stripped.trim_start();
+                    }
+
+                    start_column + (line.len() - stripped.len()) as u32
+                };
+
                 let language = if let Some(language) =
-                    snapshot.language_scope_at(Point::new(selection.start.row, start_column))
+                    snapshot.language_scope_at(Point::new(selection.start.row, target_column))
                 {
                     language
                 } else {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -18751,6 +18751,38 @@ async fn test_toggle_block_comment(cx: &mut TestAppContext) {
         "#
         .unindent(),
     );
+
+    // Commenting a </script> closing tag should use HTML block comments,
+    // not JS line comments, even though the tag closes a JS injection.
+    cx.set_state(indoc! {"
+        <script>
+            const x = 1;
+        «</script>ˇ»
+    "});
+
+    cx.update_editor(|e, window, cx| e.toggle_comments(&ToggleComments::default(), window, cx));
+
+    cx.assert_editor_state(indoc! {"
+        <script>
+            const x = 1;
+        <!-- «</script>ˇ» -->
+    "});
+
+    // Uncommenting a <!-- </script> --> should use HTML block comments,
+    // not JS line comments, even though the injection appears unclosed.
+    cx.set_state(indoc! {"
+        <script>
+            const x = 1;
+        <!-- «</script>ˇ» -->
+    "});
+
+    cx.update_editor(|e, window, cx| e.toggle_comments(&ToggleComments::default(), window, cx));
+
+    cx.assert_editor_state(indoc! {"
+        <script>
+            const x = 1;
+        «</script>ˇ»
+    "});
 }
 
 #[gpui::test]


### PR DESCRIPTION
## Summary

The toggle_comments function would just consider the language at `selection.start`. Since the `</style>` or `</script>` were commented, the language at selection.start would be either css or js, which would result in wrapping the `<!-- </style> -->` inside css comments (`/* <!-- </style> --> */`) instead of removing the HTML comments (`</style>`).

Now it takes into account the comment tokens from both neighbor languages, strips them (if they exist) and uses the language inside.

I've added tests to assert this behaviour

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #52001 

Release Notes:

- N/A
