### PR TITLE
dev_container: Fix various startup issues

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -8,7 +8,7 @@ use std::{
 
 use fs::Fs;
 use http_client::HttpClient;
-use util::{ResultExt, command::Command};
+use util::{ResultExt, command::Command, paths::normalize_lexically};
 
 use crate::{
     DevContainerConfig, DevContainerContext,
@@ -229,13 +229,51 @@ impl DevContainerManifest {
                 else {
                     return None;
                 };
-                main_service
-                    .build
-                    .and_then(|b| b.dockerfile)
-                    .map(|dockerfile| self.config_directory.join(dockerfile))
+                main_service.build.as_ref().and_then(|build| {
+                    self.resolve_compose_dockerfile_path(&docker_compose_manifest, build)
+                })
             }
             DevContainerBuildType::None => None,
         }
+    }
+
+    fn resolve_compose_dockerfile_path(
+        &self,
+        docker_compose_manifest: &DockerComposeResources,
+        build: &DockerComposeServiceBuild,
+    ) -> Option<PathBuf> {
+        let dockerfile = PathBuf::from(build.dockerfile.as_ref()?);
+        if dockerfile.is_absolute() {
+            return Some(dockerfile);
+        }
+
+        let context_directory =
+            self.resolve_compose_build_context_path(docker_compose_manifest, build)?;
+
+        let path = context_directory.join(dockerfile);
+        Some(normalize_lexically(&path).unwrap_or(path))
+    }
+
+    fn resolve_compose_build_context_path(
+        &self,
+        docker_compose_manifest: &DockerComposeResources,
+        build: &DockerComposeServiceBuild,
+    ) -> Option<PathBuf> {
+        let compose_directory = docker_compose_manifest.files.first()?.parent()?;
+        let context_directory = build
+            .context
+            .as_ref()
+            .map(PathBuf::from)
+            .map(|context| {
+                if context.is_absolute() {
+                    context
+                } else {
+                    compose_directory.join(context)
+                }
+            })
+            .unwrap_or_else(|| compose_directory.to_path_buf());
+
+        Some(normalize_lexically(&context_directory).unwrap_or(context_directory))
     }
 
     fn generate_features_image_tag(&self, dockerfile_build_path: String) -> String {
@@ -277,19 +315,13 @@ impl DevContainerManifest {
             let docker_compose_manifest = self.docker_compose_manifest().await?;
             let (_, main_service) = find_primary_service(&docker_compose_manifest, &self)?;
 
-            if let Some(dockerfile) = main_service
-                .build
-                .as_ref()
-                .and_then(|b| b.dockerfile.as_ref())
-            {
-                let dockerfile_contents = self
-                    .fs
-                    .load(&self.config_directory.join(dockerfile))
-                    .await
-                    .map_err(|e| {
-                        log::error!("Error reading dockerfile: {e}");
-                        DevContainerError::DevContainerParseFailed
-                    })?;
+            if let Some(dockerfile_path) = main_service.build.as_ref().and_then(|build| {
+                self.resolve_compose_dockerfile_path(&docker_compose_manifest, build)
+            }) {
+                let dockerfile_contents = self.fs.load(&dockerfile_path).await.map_err(|e| {
+                    log::error!("Error reading dockerfile: {e}");
+                    DevContainerError::DevContainerParseFailed
+                })?;
                 return image_from_dockerfile(self, dockerfile_contents);
             }
             if let Some(image) = &main_service.image {
@@ -774,7 +806,10 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
         };
         let docker_compose_full_paths = docker_compose_files
             .iter()
-            .map(|relative| self.config_directory.join(relative))
+            .map(|relative| {
+                let path = self.config_directory.join(relative);
+                normalize_lexically(&path).unwrap_or(path)
+            })
             .collect::<Vec<PathBuf>>();
 
         let Some(config) = self
@@ -826,8 +861,16 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             }
 
             let dockerfile_path = &features_build_info.dockerfile_path;
+            let original_build = main_service
+                .build
+                .as_ref()
+                .ok_or(DevContainerError::DevContainerParseFailed)?;
+            let original_context_directory = self
+                .resolve_compose_build_context_path(&docker_compose_resources, original_build)
+                .ok_or(DevContainerError::DevContainerParseFailed)?;
 
-            let build_args = if !supports_buildkit {
+            let mut build_args = original_build.args.clone().unwrap_or_default();
+            let feature_build_args = if !supports_buildkit {
                 HashMap::from([
                     (
                         "_DEV_CONTAINERS_BASE_IMAGE".to_string(),
@@ -845,17 +888,23 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                     ("_DEV_CONTAINERS_IMAGE_USER".to_string(), "root".to_string()),
                 ])
             };
+            build_args.extend(feature_build_args);
 
             let additional_contexts = if !supports_buildkit {
-                None
+                original_build.additional_contexts.clone()
             } else {
-                Some(HashMap::from([(
+                let mut additional_contexts = original_build
+                    .additional_contexts
+                    .clone()
+                    .unwrap_or_default();
+                additional_contexts.insert(
                     "dev_containers_feature_content_source".to_string(),
                     features_build_info
                         .features_content_dir
                         .display()
                         .to_string(),
-                )]))
+                );
+                Some(additional_contexts)
             };
 
             let build_override = DockerComposeConfig {
@@ -869,9 +918,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                         security_opt: None,
                         labels: None,
                         build: Some(DockerComposeServiceBuild {
-                            context: Some(
-                                features_build_info.empty_context_dir.display().to_string(),
-                            ),
+                            context: Some(original_context_directory.display().to_string()),
                             dockerfile: Some(dockerfile_path.display().to_string()),
                             args: Some(build_args),
                             additional_contexts,
@@ -2289,26 +2336,23 @@ fn get_remote_user_from_config(
         remote_user: Some(user),
         ..
     } = &devcontainer.dev_container()
+        && !user.trim().is_empty()
     {
         return Ok(user.clone());
     }
-    let Some(metadata) = &docker_config.config.labels.metadata else {
-        log::error!("Could not locate metadata");
-        return Err(DevContainerError::ContainerNotValid(
-            docker_config.id.clone(),
-        ));
-    };
-    for metadatum in metadata {
-        if let Some(remote_user) = metadatum.get("remoteUser") {
-            if let Some(remote_user_str) = remote_user.as_str() {
+
+    if let Some(metadata) = &docker_config.config.labels.metadata {
+        for metadatum in metadata {
+            if let Some(remote_user) = metadatum.get("remoteUser")
+                && let Some(remote_user_str) = remote_user.as_str()
+                && !remote_user_str.trim().is_empty()
+            {
                 return Ok(remote_user_str.to_string());
             }
         }
     }
-    log::error!("Could not locate the remote user");
-    Err(DevContainerError::ContainerNotValid(
-        docker_config.id.clone(),
-    ))
+
+    get_container_user_from_config(docker_config, devcontainer)
 }
 
 // This should come from spec - see the docs
@@ -2316,23 +2360,28 @@ fn get_container_user_from_config(
     docker_config: &DockerInspect,
     devcontainer: &DevContainerManifest,
 ) -> Result<String, DevContainerError> {
-    if let Some(user) = &devcontainer.dev_container().container_user {
+    if let Some(user) = &devcontainer.dev_container().container_user
+        && !user.trim().is_empty()
+    {
         return Ok(user.to_string());
     }
     if let Some(metadata) = &docker_config.config.labels.metadata {
         for metadatum in metadata {
-            if let Some(container_user) = metadatum.get("containerUser") {
-                if let Some(container_user_str) = container_user.as_str() {
-                    return Ok(container_user_str.to_string());
-                }
+            if let Some(container_user) = metadatum.get("containerUser")
+                && let Some(container_user_str) = container_user.as_str()
+                && !container_user_str.trim().is_empty()
+            {
+                return Ok(container_user_str.to_string());
             }
         }
     }
-    if let Some(image_user) = &docker_config.config.image_user {
+    if let Some(image_user) = &docker_config.config.image_user
+        && !image_user.trim().is_empty()
+    {
         return Ok(image_user.to_string());
     }
 
-    Err(DevContainerError::DevContainerParseFailed)
+    Ok("root".to_string())
 }
 
 #[cfg(test)]
@@ -2565,6 +2614,61 @@ mod test {
         assert!(remote_user.is_ok());
         let remote_user = remote_user.expect("ok");
         assert_eq!(&remote_user, "vsCode")
+    }
+
+    #[gpui::test]
+    async fn should_get_remote_user_from_container_user_when_remote_user_is_missing(
+        cx: &mut TestAppContext,
+    ) {
+        let (_, devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, "{}").await.unwrap();
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "containerUser".to_string(),
+            serde_json_lenient::Value::String("node".to_string()),
+        );
+        let given_docker_config = DockerInspect {
+            id: "docker_id".to_string(),
+            config: DockerInspectConfig {
+                labels: DockerConfigLabels {
+                    metadata: Some(vec![metadata]),
+                },
+                image_user: None,
+                env: Vec::new(),
+            },
+            mounts: None,
+            state: None,
+        };
+
+        let remote_user = get_remote_user_from_config(&given_docker_config, &devcontainer_manifest);
+
+        assert!(remote_user.is_ok());
+        let remote_user = remote_user.expect("ok");
+        assert_eq!(&remote_user, "node");
+    }
+
+    #[gpui::test]
+    async fn should_get_remote_user_from_root_when_no_user_metadata_is_available(
+        cx: &mut TestAppContext,
+    ) {
+        let (_, devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, "{}").await.unwrap();
+        let given_docker_config = DockerInspect {
+            id: "docker_id".to_string(),
+            config: DockerInspectConfig {
+                labels: DockerConfigLabels { metadata: None },
+                image_user: Some(String::new()),
+                env: Vec::new(),
+            },
+            mounts: None,
+            state: None,
+        };
+
+        let remote_user = get_remote_user_from_config(&given_docker_config, &devcontainer_manifest);
+
+        assert!(remote_user.is_ok());
+        let remote_user = remote_user.expect("ok");
+        assert_eq!(&remote_user, "root");
     }
 
     #[test]
@@ -3744,6 +3848,131 @@ ENV DOCKER_BUILDKIT=1
         );
     }
 
+    #[gpui::test]
+    async fn test_resolves_compose_dockerfile_outside_devcontainer_directory(
+        cx: &mut TestAppContext,
+    ) {
+        let given_devcontainer_contents = r#"
+            {
+              "name": "Sample App",
+              "dockerComposeFile": ["../docker-compose.zed.yml"],
+              "service": "dev",
+              "workspaceFolder": "/opt/"
+            }
+            "#;
+        let (test_dependencies, mut devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, given_devcontainer_contents)
+                .await
+                .unwrap();
+
+        test_dependencies
+            .fs
+            .atomic_write(
+                PathBuf::from(TEST_PROJECT_PATH).join("docker/Dockerfile"),
+                "FROM mcr.microsoft.com/devcontainers/rust:2-1-bookworm".to_string(),
+            )
+            .await
+            .unwrap();
+
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+
+        assert_eq!(
+            devcontainer_manifest.dockerfile_location().await,
+            Some(PathBuf::from(TEST_PROJECT_PATH).join("docker/Dockerfile"))
+        );
+        assert_eq!(
+            devcontainer_manifest
+                .get_base_image_from_config()
+                .await
+                .unwrap(),
+            "mcr.microsoft.com/devcontainers/rust:2-1-bookworm"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[gpui::test]
+    async fn test_spawns_compose_devcontainer_without_remote_user_metadata(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let given_devcontainer_contents = r#"
+            {
+              "name": "Sample App",
+              "dockerComposeFile": ["../docker/docker-compose.yml"],
+              "service": "dev",
+              "workspaceFolder": "/opt/"
+            }
+            "#;
+        let (test_dependencies, mut devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, given_devcontainer_contents)
+                .await
+                .unwrap();
+
+        test_dependencies
+            .fs
+            .atomic_write(
+                PathBuf::from(TEST_PROJECT_PATH).join("docker/Dockerfile"),
+                "FROM rust:1.91.1-bookworm".to_string(),
+            )
+            .await
+            .unwrap();
+
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+
+        let devcontainer_up = devcontainer_manifest.build_and_run().await.unwrap();
+
+        assert_eq!(devcontainer_up.remote_user, "node");
+
+        let build_override = test_dependencies
+            .fs
+            .files()
+            .into_iter()
+            .find(|path| {
+                path.file_name()
+                    .is_some_and(|name| name == "docker_compose_build.json")
+            })
+            .expect("compose build override should be generated");
+        let build_override_contents = test_dependencies.fs.load(&build_override).await.unwrap();
+        let build_override: DockerComposeConfig =
+            serde_json_lenient::from_str(&build_override_contents).unwrap();
+        let build_override_service = build_override.services.get("dev").unwrap();
+        let build_override_build = build_override_service.build.as_ref().unwrap();
+
+        assert_eq!(
+            build_override_build.context.as_deref(),
+            Some(TEST_PROJECT_PATH)
+        );
+        assert_eq!(
+            build_override_build.args.as_ref().unwrap().get("USER_UID"),
+            Some(&"501".to_string())
+        );
+        assert_eq!(
+            build_override_build.args.as_ref().unwrap().get("USER_GID"),
+            Some(&"20".to_string())
+        );
+        assert_eq!(
+            build_override_build.args.as_ref().unwrap().get("WORKDIR"),
+            Some(&"/opt/".to_string())
+        );
+
+        let builtin_env = test_dependencies
+            .fs
+            .files()
+            .into_iter()
+            .find(|path| {
+                path.file_name()
+                    .is_some_and(|name| name == "devcontainer-features.builtin.env")
+            })
+            .expect("builtin env should be generated");
+        let builtin_env_contents = test_dependencies.fs.load(&builtin_env).await.unwrap();
+
+        assert_eq!(
+            builtin_env_contents,
+            "_CONTAINER_USER=root\n_REMOTE_USER=root\n"
+        );
+    }
+
     #[cfg(not(target_os = "windows"))]
     #[gpui::test]
     async fn test_spawns_devcontainer_with_docker_compose_and_podman(cx: &mut TestAppContext) {
@@ -4315,6 +4544,19 @@ chmod +x ./install.sh
                     state: None,
                 });
             }
+            if id == "rust:1.91.1-bookworm" {
+                return Ok(DockerInspect {
+                    id: "sha256:331d6556baf032897f36a9ef4b52688d7f4809d14927dab9fb2400651e4aaa89"
+                        .to_string(),
+                    config: DockerInspectConfig {
+                        labels: DockerConfigLabels { metadata: None },
+                        image_user: Some(String::new()),
+                        env: Vec::new(),
+                    },
+                    mounts: None,
+                    state: None,
+                });
+            }
             if id.starts_with("cli_") {
                 return Ok(DockerInspect {
                     id: "sha256:610e6cfca95280188b021774f8cf69dd6f49bdb6eebc34c5ee2010f4d51cc105"
@@ -4372,6 +4614,19 @@ chmod +x ./install.sh
                     state: None,
                 });
             }
+            if id.starts_with("sample-") {
+                return Ok(DockerInspect {
+                    id: "sha256:16b0d4f4d2f1d3615d4050f6c53b82854f4ca7d4cc7d7d0d2479300fd7cf3984"
+                        .to_string(),
+                    config: DockerInspectConfig {
+                        labels: DockerConfigLabels { metadata: None },
+                        image_user: Some(String::new()),
+                        env: Vec::new(),
+                    },
+                    mounts: None,
+                    state: None,
+                });
+            }
 
             Err(DevContainerError::DockerNotAvailable)
         }
@@ -4379,6 +4634,66 @@ chmod +x ./install.sh
             &self,
             config_files: &Vec<PathBuf>,
         ) -> Result<Option<DockerComposeConfig>, DevContainerError> {
+            if config_files.len() == 1
+                && config_files.get(0)
+                    == Some(&PathBuf::from(
+                        "/path/to/local/project/docker/docker-compose.yml",
+                    ))
+            {
+                return Ok(Some(DockerComposeConfig {
+                    name: Some("sample".to_string()),
+                    services: HashMap::from([(
+                        "dev".to_string(),
+                        DockerComposeService {
+                            build: Some(DockerComposeServiceBuild {
+                                context: Some("..".to_string()),
+                                dockerfile: Some("docker/Dockerfile".to_string()),
+                                args: Some(HashMap::from([
+                                    ("USER_UID".to_string(), "501".to_string()),
+                                    ("USER_GID".to_string(), "20".to_string()),
+                                    ("WORKDIR".to_string(), "/opt/".to_string()),
+                                ])),
+                                additional_contexts: None,
+                            }),
+                            volumes: vec![MountDefinition {
+                                source: "../".to_string(),
+                                target: "/opt/".to_string(),
+                                mount_type: Some("bind".to_string()),
+                            }],
+                            ..Default::default()
+                        },
+                    )]),
+                    volumes: HashMap::new(),
+                }));
+            }
+            if config_files.len() == 1
+                && config_files.get(0)
+                    == Some(&PathBuf::from(
+                        "/path/to/local/project/docker-compose.zed.yml",
+                    ))
+            {
+                return Ok(Some(DockerComposeConfig {
+                    name: None,
+                    services: HashMap::from([(
+                        "dev".to_string(),
+                        DockerComposeService {
+                            build: Some(DockerComposeServiceBuild {
+                                context: Some(".".to_string()),
+                                dockerfile: Some("docker/Dockerfile".to_string()),
+                                args: None,
+                                additional_contexts: None,
+                            }),
+                            volumes: vec![MountDefinition {
+                                source: ".".to_string(),
+                                target: "/opt".to_string(),
+                                mount_type: Some("bind".to_string()),
+                            }],
+                            ..Default::default()
+                        },
+                    )]),
+                    volumes: HashMap::new(),
+                }));
+            }
             if config_files.len() == 1
                 && config_files.get(0)
                     == Some(&PathBuf::from(

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -35,6 +35,7 @@ pub(crate) struct DockerInspect {
 pub(crate) struct DockerConfigLabels {
     #[serde(
         rename = "devcontainer.metadata",
+        default,
         deserialize_with = "deserialize_metadata"
     )]
     pub(crate) metadata: Option<Vec<HashMap<String, serde_json_lenient::Value>>>,
@@ -99,6 +100,7 @@ pub(crate) struct DockerComposeService {
     pub(crate) build: Option<DockerComposeServiceBuild>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) privileged: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) volumes: Vec<MountDefinition>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) env_file: Option<Vec<String>>,
@@ -118,6 +120,7 @@ pub(crate) struct DockerComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) name: Option<String>,
     pub(crate) services: HashMap<String, DockerComposeService>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub(crate) volumes: HashMap<String, DockerComposeVolume>,
 }
 
@@ -417,8 +420,8 @@ mod test {
         command_json::deserialize_json_output,
         devcontainer_json::MountDefinition,
         docker::{
-            Docker, DockerComposeConfig, DockerComposeService, DockerComposeVolume, DockerInspect,
-            DockerPs, get_remote_dir_from_config,
+            Docker, DockerComposeConfig, DockerComposeService, DockerComposeServiceBuild,
+            DockerComposeVolume, DockerInspect, DockerPs, get_remote_dir_from_config,
         },
     };
 
@@ -774,6 +777,39 @@ mod test {
     }
 
     #[test]
+    fn should_deserialize_docker_inspect_without_devcontainer_metadata() {
+        let given_config = r#"
+    {
+      "Id": "sha256:plain-image",
+      "Config": {
+        "User": "",
+        "Env": [
+          "PATH=/usr/local/bin:/usr/bin:/bin"
+        ],
+        "Labels": {
+          "org.opencontainers.image.ref.name": "rust",
+          "org.opencontainers.image.version": "1.91.1-bookworm"
+        }
+      },
+      "Mounts": [],
+      "State": {
+        "Running": false
+      }
+    }
+                "#;
+
+        let config = serde_json_lenient::from_str::<DockerInspect>(given_config).unwrap();
+
+        assert_eq!(config.id, "sha256:plain-image");
+        assert_eq!(config.config.labels.metadata, None);
+        assert_eq!(config.config.image_user, Some(String::new()));
+        assert_eq!(
+            config.config.env,
+            vec!["PATH=/usr/local/bin:/usr/bin:/bin".to_string()]
+        );
+    }
+
+    #[test]
     fn should_deserialize_docker_compose_config() {
         let given_config = r#"
     {
@@ -891,6 +927,86 @@ mod test {
                     name: "devcontainer_postgres-data".to_string(),
                 },
             )]),
+        };
+
+        assert_eq!(docker_compose_config, expected_config);
+    }
+
+    #[test]
+    fn should_deserialize_docker_compose_config_without_top_level_volumes() {
+        let given_config = r#"
+    {
+        "name": "sample-devcontainer",
+        "services": {
+            "dev": {
+                "build": {
+                    "context": "/workspace/project",
+                    "dockerfile": "docker/Dockerfile",
+                    "args": {
+                        "WORKDIR": "/opt/"
+                    },
+                    "target": "dev"
+                },
+                "command": null,
+                "entrypoint": null,
+                "environment": {
+                    "HOME": "/home/user"
+                },
+                "stdin_open": true,
+                "tty": true,
+                "volumes": [
+                    {
+                        "type": "bind",
+                        "source": "/workspace/project",
+                        "target": "/opt",
+                        "bind": {}
+                    },
+                    {
+                        "type": "bind",
+                        "source": "/workspace/project/tmp/home/dev",
+                        "target": "/home/user",
+                        "bind": {}
+                    }
+                ],
+                "working_dir": "/opt/"
+            }
+        }
+    }
+                "#;
+
+        let docker_compose_config: DockerComposeConfig =
+            serde_json_lenient::from_str(given_config).unwrap();
+
+        let expected_config = DockerComposeConfig {
+            name: Some("sample-devcontainer".to_string()),
+            services: HashMap::from([(
+                "dev".to_string(),
+                DockerComposeService {
+                    volumes: vec![
+                        MountDefinition {
+                            mount_type: Some("bind".to_string()),
+                            source: "/workspace/project".to_string(),
+                            target: "/opt".to_string(),
+                        },
+                        MountDefinition {
+                            mount_type: Some("bind".to_string()),
+                            source: "/workspace/project/tmp/home/dev".to_string(),
+                            target: "/home/user".to_string(),
+                        },
+                    ],
+                    build: Some(DockerComposeServiceBuild {
+                        context: Some("/workspace/project".to_string()),
+                        dockerfile: Some("docker/Dockerfile".to_string()),
+                        args: Some(HashMap::from([(
+                            "WORKDIR".to_string(),
+                            "/opt/".to_string(),
+                        )])),
+                        additional_contexts: None,
+                    }),
+                    ..Default::default()
+                },
+            )]),
+            volumes: HashMap::new(),
         };
 
         assert_eq!(docker_compose_config, expected_config);

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -31,7 +31,7 @@ pub(crate) struct DockerInspect {
     pub(crate) state: Option<DockerState>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Default)]
 pub(crate) struct DockerConfigLabels {
     #[serde(
         rename = "devcontainer.metadata",
@@ -44,6 +44,7 @@ pub(crate) struct DockerConfigLabels {
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct DockerInspectConfig {
+    #[serde(default)]
     pub(crate) labels: DockerConfigLabels,
     #[serde(rename = "User")]
     pub(crate) image_user: Option<String>,
@@ -806,6 +807,66 @@ mod test {
         assert_eq!(
             config.config.env,
             vec!["PATH=/usr/local/bin:/usr/bin:/bin".to_string()]
+        );
+    }
+
+    #[test]
+    fn should_deserialize_docker_inspect_without_labels() {
+        let given_config = r#"
+    {
+      "Id": "sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a",
+      "RepoTags": [
+        "debian:bookworm-slim"
+      ],
+      "Comment": "debuerreotype 0.17",
+      "Created": "2026-03-16T00:00:00Z",
+      "Config": {
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Cmd": [
+          "bash"
+        ]
+      },
+      "Architecture": "arm64",
+      "Variant": "v8",
+      "Os": "linux",
+      "Size": 28126134,
+      "RootFS": {
+        "Type": "layers",
+        "Layers": [
+          "sha256:6ef58325ba0a417962b349e6810a7177443d67fed7462c1d19da22af8b7197e0"
+        ]
+      },
+      "Metadata": {
+        "LastTagTime": "2026-04-04T17:20:41.064173713Z"
+      },
+      "Descriptor": {
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "digest": "sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a",
+        "size": 8560
+      },
+      "Identity": {
+        "Pull": [
+          {
+            "Repository": "docker.io/library/debian"
+          }
+        ]
+      }
+    }
+                "#;
+
+        let config = serde_json_lenient::from_str::<DockerInspect>(given_config).unwrap();
+
+        assert_eq!(
+            config.id,
+            "sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a"
+        );
+        assert_eq!(config.config.labels.metadata, None);
+        assert_eq!(config.config.image_user, None);
+        assert_eq!(
+            config.config.env,
+            vec!["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()]
         );
     }
 

--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -182,6 +182,77 @@ fn handle_rpc_messages_over_child_process_stdio(
 }
 
 #[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
+fn remote_server_source_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("remote crate should live two levels below the workspace root")
+        .to_path_buf()
+}
+
+#[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
+fn remote_server_binary_path(
+    workspace_root: &std::path::Path,
+    triple: &str,
+    platform: &crate::RemotePlatform,
+    compressed: bool,
+) -> std::path::PathBuf {
+    let binary_path = workspace_root
+        .join("target")
+        .join("remote_server")
+        .join(triple)
+        .join("debug")
+        .join("remote_server")
+        .with_extension(if platform.os.is_windows() { "exe" } else { "" });
+
+    if compressed {
+        binary_path.with_extension(if platform.os.is_windows() {
+            "zip"
+        } else {
+            "gz"
+        })
+    } else {
+        binary_path
+    }
+}
+
+#[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
+async fn active_rustup_toolchain(
+    rustup_path: &std::path::Path,
+    workspace_root: &std::path::Path,
+) -> Result<String> {
+    use util::command::new_command;
+
+    let output = new_command(rustup_path)
+        .current_dir(workspace_root)
+        .args(["show", "active-toolchain"])
+        .output()
+        .await?;
+    anyhow::ensure!(
+        output.status.success(),
+        "Failed to determine active rustup toolchain: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let toolchain = stdout
+        .split_whitespace()
+        .next()
+        .context("rustup show active-toolchain returned no toolchain")?;
+    Ok(toolchain.to_string())
+}
+
+#[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
+fn rustup_toolchain_cargo_command(
+    rustup_path: &std::path::Path,
+    active_toolchain: &str,
+) -> util::command::Command {
+    let mut command = util::command::new_command(rustup_path);
+    command.args(["run", active_toolchain, "cargo"]);
+    command
+}
+
+#[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
 async fn build_remote_server_from_source(
     platform: &crate::RemotePlatform,
     delegate: &dyn crate::RemoteClientDelegate,
@@ -189,7 +260,6 @@ async fn build_remote_server_from_source(
     cx: &mut AsyncApp,
 ) -> Result<Option<std::path::PathBuf>> {
     use std::env::VarError;
-    use std::path::Path;
     use util::command::{Command, Stdio, new_command};
 
     if let Ok(path) = std::env::var("ZED_COPY_REMOTE_SERVER") {
@@ -267,14 +337,20 @@ async fn build_remote_server_from_source(
         rust_flags.push_str(" -C link-arg=-fuse-ld=mold");
     }
 
+    let workspace_root = remote_server_source_root();
+    let rustup = which("rustup", cx)
+        .await?
+        .context("rustup not found on $PATH, install rustup (see https://rustup.rs/)")?;
+    let active_toolchain = active_rustup_toolchain(&rustup, &workspace_root).await?;
+
     if platform.arch.as_str() == std::env::consts::ARCH
         && platform.os.as_str() == std::env::consts::OS
     {
         delegate.set_status(Some("Building remote server binary from source"), cx);
         log::info!("building remote server binary from source");
         run_cmd(
-            new_command("cargo")
-                .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."))
+            rustup_toolchain_cargo_command(&rustup, &active_toolchain)
+                .current_dir(&workspace_root)
                 .args([
                     "build",
                     "--package",
@@ -298,17 +374,28 @@ async fn build_remote_server_from_source(
             });
         }
 
-        let rustup = which("rustup", cx)
-            .await?
-            .context("rustup not found on $PATH, install rustup (see https://rustup.rs/)")?;
         delegate.set_status(Some("Adding rustup target for cross-compilation"), cx);
         log::info!("adding rustup target");
-        run_cmd(new_command(rustup).args(["target", "add"]).arg(&triple)).await?;
+        run_cmd(
+            new_command(&rustup)
+                .current_dir(&workspace_root)
+                .args(["target", "add"])
+                .args(["--toolchain", &active_toolchain])
+                .arg(&triple),
+        )
+        .await?;
 
         if which("cargo-zigbuild", cx).await?.is_none() {
             delegate.set_status(Some("Installing cargo-zigbuild for cross-compilation"), cx);
             log::info!("installing cargo-zigbuild");
-            run_cmd(new_command("cargo").args(["install", "--locked", "cargo-zigbuild"])).await?;
+            run_cmd(
+                rustup_toolchain_cargo_command(&rustup, &active_toolchain).args([
+                    "install",
+                    "--locked",
+                    "cargo-zigbuild",
+                ]),
+            )
+            .await?;
         }
 
         delegate.set_status(
@@ -319,7 +406,8 @@ async fn build_remote_server_from_source(
         );
         log::info!("building remote binary from source for {triple} with Zig");
         run_cmd(
-            new_command("cargo")
+            rustup_toolchain_cargo_command(&rustup, &active_toolchain)
+                .current_dir(&workspace_root)
                 .args([
                     "zigbuild",
                     "--package",
@@ -335,12 +423,7 @@ async fn build_remote_server_from_source(
         )
         .await?;
     };
-    let bin_path = Path::new("target")
-        .join("remote_server")
-        .join(&triple)
-        .join("debug")
-        .join("remote_server")
-        .with_extension(if platform.os.is_windows() { "exe" } else { "" });
+    let bin_path = remote_server_binary_path(&workspace_root, &triple, platform, false);
 
     let path = if !build_remote_server.contains("nocompress") {
         delegate.set_status(Some("Compressing binary"), cx);
@@ -371,7 +454,7 @@ async fn build_remote_server_from_source(
             zip_path
         };
 
-        std::env::current_dir()?.join(archive_path)
+        archive_path
     } else {
         bin_path
     };
@@ -401,6 +484,7 @@ async fn which(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn test_parse_platform() {
@@ -464,5 +548,35 @@ mod tests {
         );
         assert_eq!(parse_shell("", "sh"), "sh");
         assert_eq!(parse_shell("\n", "sh"), "sh");
+    }
+
+    #[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
+    #[test]
+    fn test_remote_server_binary_path_uses_workspace_root() {
+        let workspace_root = Path::new("/workspace/zed");
+        let triple = "aarch64-unknown-linux-musl";
+        let platform = RemotePlatform {
+            os: RemoteOs::Linux,
+            arch: RemoteArch::Aarch64,
+        };
+
+        assert_eq!(
+            remote_server_binary_path(workspace_root, triple, &platform, false),
+            Path::new("/workspace/zed")
+                .join("target")
+                .join("remote_server")
+                .join(triple)
+                .join("debug")
+                .join("remote_server")
+        );
+        assert_eq!(
+            remote_server_binary_path(workspace_root, triple, &platform, true),
+            Path::new("/workspace/zed")
+                .join("target")
+                .join("remote_server")
+                .join(triple)
+                .join("debug")
+                .join("remote_server.gz")
+        );
     }
 }

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -425,10 +425,7 @@ impl DockerExecConnection {
         chown_command.arg("exec");
         chown_command.arg(connection_options.container_id);
         chown_command.arg("chown");
-        chown_command.arg(format!(
-            "{}:{}",
-            connection_options.remote_user, connection_options.remote_user,
-        ));
+        chown_command.arg(&connection_options.remote_user);
         chown_command.arg(&dst_path);
 
         let output = chown_command.output().await?;

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -52,10 +52,23 @@ For a release build:
 cargo run --release
 ```
 
+if you need **dev container**:
+
+```sh
+cargo run --release --features remote/build-remote-server-binary
+```
+
 And to run the tests:
 
 ```sh
 cargo test --workspace
+```
+
+or Install it locally:
+
+```sh
+cargo install --path crates/zed --features remote/build-remote-server-binary
+cargo build --path crates/zed --release --features remote/build-remote-server-binary
 ```
 
 ## Visual Regression Tests


### PR DESCRIPTION
# Summary

  This merge request fixes multiple dev-container startup issues.

  It improves Docker Compose path resolution, preserves compose build configuration when generating
  feature builds, hardens remote user detection, and fixes Docker inspect parsing for images that omit
  Config.Labels. Together, these changes make dev containers more reliable across a wider range of
  setups, including plain base images such as debian:bookworm-slim.

# Per-Commit Breakdown

1. 43dc3cbcd1 devcontainer fixed
     This commit contains the main dev-container fixes.
    - Fixes Docker Compose dockerfile and build-context resolution, including cases where the Dockerfile lives outside the .devcontainer directory.
    - Preserves compose build args, volumes, and additional contexts when Zed generates feature-build overrides.
    - Improves remote user resolution by falling back through remoteUser, containerUser, image user, and finally root.
    - Fixes Docker chown invocation to use the resolved remote user correctly.
    - Updates remote server build logic to use the active rustup toolchain and stable workspace-root binary paths.
    - Adds regression coverage for compose configs, remote user fallback, and remote server path
        handling.
2. 0220310b3d dont require labels
  This commit fixes startup for images whose docker inspect output does not include Config.Labels.
    - Makes Docker inspect deserialization tolerant of missing Labels.
    - Adds a regression test based on a real debian:bookworm-slim inspect payload.
    - Prevents dev-container startup from failing with missing field Labels on plain images.

# Why These Changes Were Needed

Dev container startup was failing in several valid configurations:

- some Docker Compose setups used dockerfiles or build contexts that were not resolved correctly
- some images did not provide enough metadata for strict remote-user resolution
- some base images omitted Config.Labels entirely, which caused Docker inspect deserialization to fail

These changes make the implementation more tolerant of real-world Docker and Compose outputs while keeping the existing dev-container flow intact.

# Release Notes
- Fixed dev container startup for Docker Compose setups with non-standard dockerfile/build-context
    layouts and for images whose docker inspect output omits Config.Labels
