### PR TITLE
terminal_view: Reset cursor blink on `SendText` and `SendKeystroke` actions

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -850,6 +850,7 @@ impl TerminalView {
 
     fn send_text(&mut self, text: &SendText, _: &mut Window, cx: &mut Context<Self>) {
         self.clear_bell(cx);
+        self.blink_manager.update(cx, BlinkManager::pause_blinking);
         self.terminal.update(cx, |term, _| {
             term.input(text.0.to_string().into_bytes());
         });
@@ -858,6 +859,7 @@ impl TerminalView {
     fn send_keystroke(&mut self, text: &SendKeystroke, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(keystroke) = Keystroke::parse(&text.0).log_err() {
             self.clear_bell(cx);
+            self.blink_manager.update(cx, BlinkManager::pause_blinking);
             self.process_keystroke(&keystroke, cx);
         }
     }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53115

Release Notes:

- Fixed terminal cursor blink not resetting when navigating with action-bound keys (e.g., alt+left/right on macOS, alt+b/f on Linux)

## Demo

### Before the fix
The cursor stays invisible after word-jumping because the blink cycle keeps going without resetting.

https://github.com/user-attachments/assets/00dbdba6-d793-4a23-abcc-37887f4d1262



### After the fix
The cursor shows up at the new position right after each word-jump, then blinks again as expected.


https://github.com/user-attachments/assets/48d5906c-4899-4f4a-adbd-5908ebea0cfb

