### PR TITLE
Gate `Format Selections` on whether the active formatter can actually format ranges

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -552,11 +552,13 @@ actions!(
         Format,
         /// Formats only the selected text.
         ///
+        /// This action is only available when the active formatter can format ranges.
         /// When using a language server, this sends an LSP range formatting request for each
-        /// selection. When using Prettier, Prettier's own range formatting is used to format the
-        /// encompassing range of all selections, and resulting edits outside the selected ranges
-        /// are discarded. External command formatters do not support range formatting and are
-        /// skipped.
+        /// selection, and is hidden when the selected buffer's configured language server does
+        /// not advertise range-formatting support. When using Prettier, Prettier's own range
+        /// formatting is used to format the encompassing range of all selections, and resulting
+        /// edits outside the selected ranges are discarded. External command formatters do not
+        /// support range formatting and are skipped.
         FormatSelections,
         /// Goes to the declaration of the symbol at cursor.
         GoToDeclaration,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19605,11 +19605,11 @@ impl Editor {
         let snapshot = multi_buffer.snapshot(cx);
 
         self.selections
-            .disjoint_anchors_arc()
-            .iter()
-            .filter(|selection| selection.start != selection.end)
-            .flat_map(|selection| snapshot.buffer_ids_for_range(selection.range()))
-            .filter_map(|buffer_id| multi_buffer.buffer(buffer_id))
+            .disjoint_anchor_ranges()
+            .filter(|range| range.start != range.end)
+            .flat_map(|range| [range.start, range.end])
+            .filter_map(|anchor| snapshot.anchor_to_buffer_anchor(anchor))
+            .filter_map(|(_, buffer_snapshot)| multi_buffer.buffer(buffer_snapshot.remote_id()))
             .any(|buffer| project.supports_range_formatting(&buffer, cx))
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19610,8 +19610,6 @@ impl Editor {
             .filter(|selection| selection.start != selection.end)
             .flat_map(|selection| snapshot.buffer_ids_for_range(selection.range()))
             .filter_map(|buffer_id| multi_buffer.buffer(buffer_id))
-            .collect::<HashSet<_>>()
-            .into_iter()
             .any(|buffer| project.supports_range_formatting(&buffer, cx))
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -253,6 +253,7 @@ pub(crate) const CURSORS_VISIBLE_FOR: Duration = Duration::from_millis(2000);
 #[doc(hidden)]
 pub const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
 pub const SELECTION_HIGHLIGHT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
+pub const FORMAT_SELECTIONS_AVAILABILITY_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub(crate) const CODE_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const FORMAT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -1216,6 +1217,8 @@ pub struct Editor {
     quick_selection_highlight_task: Option<(Range<Anchor>, Task<()>)>,
     debounced_selection_highlight_task: Option<(Range<Anchor>, Task<()>)>,
     debounced_selection_highlight_complete: bool,
+    format_selections_available: bool,
+    format_selections_availability_task: Task<()>,
     document_highlights_task: Option<Task<()>>,
     linked_editing_range_task: Option<Task<Option<()>>>,
     linked_edit_ranges: linked_editing_ranges::LinkedEditingRanges,
@@ -2146,6 +2149,9 @@ impl Editor {
                 project,
                 window,
                 |editor, _, event, window, cx| match event {
+                    project::Event::LanguageServerAdded(..) => {
+                        editor.refresh_format_selections_availability(false, cx);
+                    }
                     project::Event::RefreshCodeLens => {
                         // we always query lens with actions, without storing them, always refreshing them
                     }
@@ -2179,6 +2185,7 @@ impl Editor {
                         editor.register_visible_buffers(cx);
                         editor.invalidate_semantic_tokens(None);
                         editor.refresh_runnables(None, window, cx);
+                        editor.refresh_format_selections_availability(false, cx);
                         editor.update_lsp_data(None, window, cx);
                         editor.refresh_inlay_hints(InlayHintRefreshReason::ServerRemoved, cx);
                     }
@@ -2209,6 +2216,7 @@ impl Editor {
                         if editor.buffer().read(cx).buffer(buffer_id).is_some() {
                             editor.register_buffer(buffer_id, cx);
                             editor.refresh_runnables(Some(buffer_id), window, cx);
+                            editor.refresh_format_selections_availability(false, cx);
                             editor.update_lsp_data(Some(buffer_id), window, cx);
                             editor.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
                             refresh_linked_ranges(editor, window, cx);
@@ -2271,6 +2279,11 @@ impl Editor {
                                 cx,
                             );
                         }
+                    }
+
+                    project::Event::DisconnectedFromHost
+                    | project::Event::DisconnectedFromRemote { .. } => {
+                        editor.refresh_format_selections_availability(false, cx);
                     }
 
                     _ => {}
@@ -2458,6 +2471,8 @@ impl Editor {
             quick_selection_highlight_task: None,
             debounced_selection_highlight_task: None,
             debounced_selection_highlight_complete: false,
+            format_selections_available: false,
+            format_selections_availability_task: Task::ready(()),
             document_highlights_task: None,
             linked_editing_range_task: None,
             pending_rename: None,
@@ -2754,6 +2769,8 @@ impl Editor {
             }
             editor.report_editor_event(ReportEditorEvent::EditorOpened, None, cx);
         }
+
+        editor.refresh_format_selections_availability(false, cx);
 
         editor
     }
@@ -3681,6 +3698,7 @@ impl Editor {
         }
 
         let selection_anchors = self.selections.disjoint_anchors_arc();
+        self.refresh_format_selections_availability(true, cx);
 
         if self.focus_handle.is_focused(window) && self.leader_id.is_none() {
             self.buffer.update(cx, |buffer, cx| {
@@ -19591,6 +19609,66 @@ impl Editor {
         self.pending_rename.as_ref()
     }
 
+    fn enable_format_selections(&self) -> bool {
+        self.format_selections_available
+    }
+
+    fn can_format_selections(&self, cx: &App) -> bool {
+        if !self.mode.is_full() {
+            return false;
+        }
+
+        let Some(project) = &self.project else {
+            return false;
+        };
+
+        let selected_buffers = {
+            let multi_buffer = self.buffer.read(cx);
+            let snapshot = multi_buffer.snapshot(cx);
+            let selected_buffer_ids = self
+                .selections
+                .disjoint_anchors_arc()
+                .iter()
+                .filter(|selection| selection.start != selection.end)
+                .flat_map(|selection| snapshot.buffer_ids_for_range(selection.range()))
+                .collect::<HashSet<_>>();
+
+            selected_buffer_ids
+                .into_iter()
+                .filter_map(|buffer_id| multi_buffer.buffer(buffer_id))
+                .collect::<Vec<_>>()
+        };
+
+        if selected_buffers.is_empty() {
+            return false;
+        }
+
+        let project = project.read(cx);
+        selected_buffers
+            .into_iter()
+            .any(|buffer| project.supports_range_formatting(&buffer, cx))
+    }
+
+    fn refresh_format_selections_availability(&mut self, debounce: bool, cx: &mut Context<Self>) {
+        self.format_selections_availability_task = cx.spawn(async move |editor, cx| {
+            if debounce {
+                cx.background_executor()
+                    .timer(FORMAT_SELECTIONS_AVAILABILITY_DEBOUNCE_TIMEOUT)
+                    .await;
+            }
+
+            editor
+                .update(cx, |editor, cx| {
+                    let is_available = editor.can_format_selections(cx);
+                    if editor.format_selections_available != is_available {
+                        editor.format_selections_available = is_available;
+                        cx.notify();
+                    }
+                })
+                .ok();
+        });
+    }
+
     fn format(
         &mut self,
         _: &Format,
@@ -19619,6 +19697,10 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        if !self.can_format_selections(cx) {
+            return None;
+        }
+
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
 
         let project = match &self.project {
@@ -24487,6 +24569,7 @@ impl Editor {
                 ranges,
                 path_key,
             } => {
+                self.refresh_format_selections_availability(false, cx);
                 self.refresh_document_highlights(cx);
                 let buffer_id = buffer.read(cx).remote_id();
                 if self.buffer.read(cx).diff_for(buffer_id).is_none()
@@ -24517,6 +24600,7 @@ impl Editor {
                 });
             }
             multi_buffer::Event::BuffersRemoved { removed_buffer_ids } => {
+                self.refresh_format_selections_availability(false, cx);
                 if let Some(inlay_hints) = &mut self.inlay_hints {
                     inlay_hints.remove_inlay_chunk_data(removed_buffer_ids);
                 }
@@ -24563,6 +24647,7 @@ impl Editor {
                 self.refresh_runnables(None, window, cx);
             }
             multi_buffer::Event::LanguageChanged(buffer_id, is_fresh_language) => {
+                self.refresh_format_selections_availability(false, cx);
                 if !is_fresh_language {
                     self.registered_buffers.remove(&buffer_id);
                 }
@@ -24699,6 +24784,7 @@ impl Editor {
         self.refresh_runnables(None, window, cx);
         self.update_edit_prediction_settings(cx);
         self.refresh_edit_prediction(true, false, window, cx);
+        self.refresh_format_selections_availability(false, cx);
         self.refresh_inline_values(cx);
 
         let old_cursor_shape = self.cursor_shape;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -253,7 +253,6 @@ pub(crate) const CURSORS_VISIBLE_FOR: Duration = Duration::from_millis(2000);
 #[doc(hidden)]
 pub const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
 pub const SELECTION_HIGHLIGHT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
-pub const FORMAT_SELECTIONS_AVAILABILITY_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub(crate) const CODE_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const FORMAT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -1217,8 +1216,6 @@ pub struct Editor {
     quick_selection_highlight_task: Option<(Range<Anchor>, Task<()>)>,
     debounced_selection_highlight_task: Option<(Range<Anchor>, Task<()>)>,
     debounced_selection_highlight_complete: bool,
-    format_selections_available: bool,
-    format_selections_availability_task: Task<()>,
     document_highlights_task: Option<Task<()>>,
     linked_editing_range_task: Option<Task<Option<()>>>,
     linked_edit_ranges: linked_editing_ranges::LinkedEditingRanges,
@@ -2149,9 +2146,6 @@ impl Editor {
                 project,
                 window,
                 |editor, _, event, window, cx| match event {
-                    project::Event::LanguageServerAdded(..) => {
-                        editor.refresh_format_selections_availability(false, cx);
-                    }
                     project::Event::RefreshCodeLens => {
                         // we always query lens with actions, without storing them, always refreshing them
                     }
@@ -2185,7 +2179,6 @@ impl Editor {
                         editor.register_visible_buffers(cx);
                         editor.invalidate_semantic_tokens(None);
                         editor.refresh_runnables(None, window, cx);
-                        editor.refresh_format_selections_availability(false, cx);
                         editor.update_lsp_data(None, window, cx);
                         editor.refresh_inlay_hints(InlayHintRefreshReason::ServerRemoved, cx);
                     }
@@ -2216,7 +2209,6 @@ impl Editor {
                         if editor.buffer().read(cx).buffer(buffer_id).is_some() {
                             editor.register_buffer(buffer_id, cx);
                             editor.refresh_runnables(Some(buffer_id), window, cx);
-                            editor.refresh_format_selections_availability(false, cx);
                             editor.update_lsp_data(Some(buffer_id), window, cx);
                             editor.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
                             refresh_linked_ranges(editor, window, cx);
@@ -2279,11 +2271,6 @@ impl Editor {
                                 cx,
                             );
                         }
-                    }
-
-                    project::Event::DisconnectedFromHost
-                    | project::Event::DisconnectedFromRemote { .. } => {
-                        editor.refresh_format_selections_availability(false, cx);
                     }
 
                     _ => {}
@@ -2471,8 +2458,6 @@ impl Editor {
             quick_selection_highlight_task: None,
             debounced_selection_highlight_task: None,
             debounced_selection_highlight_complete: false,
-            format_selections_available: false,
-            format_selections_availability_task: Task::ready(()),
             document_highlights_task: None,
             linked_editing_range_task: None,
             pending_rename: None,
@@ -2769,8 +2754,6 @@ impl Editor {
             }
             editor.report_editor_event(ReportEditorEvent::EditorOpened, None, cx);
         }
-
-        editor.refresh_format_selections_availability(false, cx);
 
         editor
     }
@@ -3698,7 +3681,6 @@ impl Editor {
         }
 
         let selection_anchors = self.selections.disjoint_anchors_arc();
-        self.refresh_format_selections_availability(true, cx);
 
         if self.focus_handle.is_focused(window) && self.leader_id.is_none() {
             self.buffer.update(cx, |buffer, cx| {
@@ -19609,10 +19591,6 @@ impl Editor {
         self.pending_rename.as_ref()
     }
 
-    fn enable_format_selections(&self) -> bool {
-        self.format_selections_available
-    }
-
     fn can_format_selections(&self, cx: &App) -> bool {
         if !self.mode.is_full() {
             return false;
@@ -19622,51 +19600,19 @@ impl Editor {
             return false;
         };
 
-        let selected_buffers = {
-            let multi_buffer = self.buffer.read(cx);
-            let snapshot = multi_buffer.snapshot(cx);
-            let selected_buffer_ids = self
-                .selections
-                .disjoint_anchors_arc()
-                .iter()
-                .filter(|selection| selection.start != selection.end)
-                .flat_map(|selection| snapshot.buffer_ids_for_range(selection.range()))
-                .collect::<HashSet<_>>();
-
-            selected_buffer_ids
-                .into_iter()
-                .filter_map(|buffer_id| multi_buffer.buffer(buffer_id))
-                .collect::<Vec<_>>()
-        };
-
-        if selected_buffers.is_empty() {
-            return false;
-        }
-
         let project = project.read(cx);
-        selected_buffers
+        let multi_buffer = self.buffer.read(cx);
+        let snapshot = multi_buffer.snapshot(cx);
+
+        self.selections
+            .disjoint_anchors_arc()
+            .iter()
+            .filter(|selection| selection.start != selection.end)
+            .flat_map(|selection| snapshot.buffer_ids_for_range(selection.range()))
+            .filter_map(|buffer_id| multi_buffer.buffer(buffer_id))
+            .collect::<HashSet<_>>()
             .into_iter()
             .any(|buffer| project.supports_range_formatting(&buffer, cx))
-    }
-
-    fn refresh_format_selections_availability(&mut self, debounce: bool, cx: &mut Context<Self>) {
-        self.format_selections_availability_task = cx.spawn(async move |editor, cx| {
-            if debounce {
-                cx.background_executor()
-                    .timer(FORMAT_SELECTIONS_AVAILABILITY_DEBOUNCE_TIMEOUT)
-                    .await;
-            }
-
-            editor
-                .update(cx, |editor, cx| {
-                    let is_available = editor.can_format_selections(cx);
-                    if editor.format_selections_available != is_available {
-                        editor.format_selections_available = is_available;
-                        cx.notify();
-                    }
-                })
-                .ok();
-        });
     }
 
     fn format(
@@ -19697,10 +19643,6 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
-        if !self.can_format_selections(cx) {
-            return None;
-        }
-
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
 
         let project = match &self.project {
@@ -24569,7 +24511,6 @@ impl Editor {
                 ranges,
                 path_key,
             } => {
-                self.refresh_format_selections_availability(false, cx);
                 self.refresh_document_highlights(cx);
                 let buffer_id = buffer.read(cx).remote_id();
                 if self.buffer.read(cx).diff_for(buffer_id).is_none()
@@ -24600,7 +24541,6 @@ impl Editor {
                 });
             }
             multi_buffer::Event::BuffersRemoved { removed_buffer_ids } => {
-                self.refresh_format_selections_availability(false, cx);
                 if let Some(inlay_hints) = &mut self.inlay_hints {
                     inlay_hints.remove_inlay_chunk_data(removed_buffer_ids);
                 }
@@ -24647,7 +24587,6 @@ impl Editor {
                 self.refresh_runnables(None, window, cx);
             }
             multi_buffer::Event::LanguageChanged(buffer_id, is_fresh_language) => {
-                self.refresh_format_selections_availability(false, cx);
                 if !is_fresh_language {
                     self.registered_buffers.remove(&buffer_id);
                 }
@@ -24784,7 +24723,6 @@ impl Editor {
         self.refresh_runnables(None, window, cx);
         self.update_edit_prediction_settings(cx);
         self.refresh_edit_prediction(true, false, window, cx);
-        self.refresh_format_selections_availability(false, cx);
         self.refresh_inline_values(cx);
 
         let old_cursor_shape = self.cursor_shape;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14255,10 +14255,7 @@ async fn setup_range_format_test(
     .await
 }
 
-fn wait_for_format_selections_availability(cx: &mut VisualTestContext) {
-    cx.executor().run_until_parked();
-    cx.executor()
-        .advance_clock(FORMAT_SELECTIONS_AVAILABILITY_DEBOUNCE_TIMEOUT);
+fn refresh_editor_actions(cx: &mut VisualTestContext) {
     cx.executor().run_until_parked();
     cx.update(|window, cx| {
         let _ = window.draw(cx);
@@ -14278,7 +14275,7 @@ async fn test_format_selections_action_available_when_range_formatting_is_suppor
         });
     });
 
-    wait_for_format_selections_availability(cx);
+    refresh_editor_actions(cx);
 
     assert!(cx.update(|window, cx| { window.is_action_available(&FormatSelections, cx) }));
 }
@@ -14304,13 +14301,15 @@ async fn test_format_selections_action_hidden_without_range_formatting_support(
         });
     });
 
-    wait_for_format_selections_availability(cx);
+    refresh_editor_actions(cx);
 
     assert!(!cx.update(|window, cx| { window.is_action_available(&FormatSelections, cx) }));
 }
 
 #[gpui::test]
-async fn test_format_selections_is_noop_without_range_capable_formatter(cx: &mut TestAppContext) {
+async fn test_format_selections_action_hidden_without_range_capable_formatter(
+    cx: &mut TestAppContext,
+) {
     init_test(cx, |settings| {
         settings.defaults.formatter = Some(FormatterList::Single(Formatter::External {
             command: "awk".into(),
@@ -14357,16 +14356,9 @@ async fn test_format_selections_is_noop_without_range_capable_formatter(cx: &mut
         });
     });
 
-    wait_for_format_selections_availability(cx);
+    refresh_editor_actions(cx);
 
     assert!(!cx.update(|window, cx| { window.is_action_available(&FormatSelections, cx) }));
-    assert!(
-        editor
-            .update_in(cx, |editor, window, cx| {
-                editor.format_selections(&FormatSelections, window, cx)
-            })
-            .is_none()
-    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14191,8 +14191,9 @@ async fn test_autosave_with_dirty_buffers(cx: &mut TestAppContext) {
     );
 }
 
-async fn setup_range_format_test(
+async fn setup_range_format_test_with_capabilities(
     cx: &mut TestAppContext,
+    capabilities: lsp::ServerCapabilities,
 ) -> (
     Entity<Project>,
     Entity<Editor>,
@@ -14209,6 +14210,121 @@ async fn setup_range_format_test(
     let language_registry = project.read_with(cx, |project, _| project.languages().clone());
     language_registry.add(rust_lang());
     let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), buffer, window, cx)
+    });
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+    });
+
+    let fake_server = fake_servers.next().await.unwrap();
+
+    (project, editor, cx, fake_server)
+}
+
+async fn setup_range_format_test(
+    cx: &mut TestAppContext,
+) -> (
+    Entity<Project>,
+    Entity<Editor>,
+    &mut gpui::VisualTestContext,
+    lsp::FakeLanguageServer,
+) {
+    setup_range_format_test_with_capabilities(
+        cx,
+        lsp::ServerCapabilities {
+            document_range_formatting_provider: Some(lsp::OneOf::Left(true)),
+            ..lsp::ServerCapabilities::default()
+        },
+    )
+    .await
+}
+
+fn wait_for_format_selections_availability(cx: &mut VisualTestContext) {
+    cx.executor().run_until_parked();
+    cx.executor()
+        .advance_clock(FORMAT_SELECTIONS_AVAILABILITY_DEBOUNCE_TIMEOUT);
+    cx.executor().run_until_parked();
+    cx.update(|window, cx| {
+        let _ = window.draw(cx);
+    });
+}
+
+#[gpui::test]
+async fn test_format_selections_action_available_when_range_formatting_is_supported(
+    cx: &mut TestAppContext,
+) {
+    let (_, editor, cx, _) = setup_range_format_test(cx).await;
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("one\ntwo\nthree\n", window, cx);
+        editor.change_selections(SelectionEffects::default(), window, cx, |s| {
+            s.select_ranges([Point::new(0, 0)..Point::new(1, 0)]);
+        });
+    });
+
+    wait_for_format_selections_availability(cx);
+
+    assert!(cx.update(|window, cx| { window.is_action_available(&FormatSelections, cx) }));
+}
+
+#[gpui::test]
+async fn test_format_selections_action_hidden_without_range_formatting_support(
+    cx: &mut TestAppContext,
+) {
+    let (_, editor, cx, _) = setup_range_format_test_with_capabilities(
+        cx,
+        lsp::ServerCapabilities {
+            document_formatting_provider: Some(lsp::OneOf::Left(true)),
+            document_range_formatting_provider: Some(lsp::OneOf::Left(false)),
+            ..lsp::ServerCapabilities::default()
+        },
+    )
+    .await;
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("one\ntwo\nthree\n", window, cx);
+        editor.change_selections(SelectionEffects::default(), window, cx, |s| {
+            s.select_ranges([Point::new(0, 0)..Point::new(1, 0)]);
+        });
+    });
+
+    wait_for_format_selections_availability(cx);
+
+    assert!(!cx.update(|window, cx| { window.is_action_available(&FormatSelections, cx) }));
+}
+
+#[gpui::test]
+async fn test_format_selections_is_noop_without_range_capable_formatter(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.formatter = Some(FormatterList::Single(Formatter::External {
+            command: "awk".into(),
+            arguments: Some(vec!["{ print }".to_string()]),
+        }));
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.rs"), Default::default()).await;
+
+    let project = Project::test(fs, [path!("/").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _ = language_registry.register_fake_lsp(
         "Rust",
         FakeLspAdapter {
             capabilities: lsp::ServerCapabilities {
@@ -14230,10 +14346,27 @@ async fn setup_range_format_test(
     let (editor, cx) = cx.add_window_view(|window, cx| {
         build_editor_with_project(project.clone(), buffer, window, cx)
     });
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+    });
 
-    let fake_server = fake_servers.next().await.unwrap();
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("one\ntwo\nthree\n", window, cx);
+        editor.change_selections(SelectionEffects::default(), window, cx, |s| {
+            s.select_ranges([Point::new(0, 0)..Point::new(1, 0)]);
+        });
+    });
 
-    (project, editor, cx, fake_server)
+    wait_for_format_selections_availability(cx);
+
+    assert!(!cx.update(|window, cx| { window.is_action_available(&FormatSelections, cx) }));
+    assert!(
+        editor
+            .update_in(cx, |editor, window, cx| {
+                editor.format_selections(&FormatSelections, window, cx)
+            })
+            .is_none()
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -552,7 +552,7 @@ impl EditorElement {
                 cx.propagate();
             }
         });
-        if editor.read(cx).enable_format_selections() {
+        if editor.read(cx).can_format_selections(cx) {
             register_action(editor, window, |editor, action, window, cx| {
                 if let Some(task) = editor.format_selections(action, window, cx) {
                     editor.detach_and_notify_err(task, window, cx);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -552,13 +552,15 @@ impl EditorElement {
                 cx.propagate();
             }
         });
-        register_action(editor, window, |editor, action, window, cx| {
-            if let Some(task) = editor.format_selections(action, window, cx) {
-                editor.detach_and_notify_err(task, window, cx);
-            } else {
-                cx.propagate();
-            }
-        });
+        if editor.read(cx).enable_format_selections() {
+            register_action(editor, window, |editor, action, window, cx| {
+                if let Some(task) = editor.format_selections(action, window, cx) {
+                    editor.detach_and_notify_err(task, window, cx);
+                } else {
+                    cx.propagate();
+                }
+            });
+        }
         register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.organize_imports(action, window, cx) {
                 editor.detach_and_notify_err(task, window, cx);

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -219,6 +219,7 @@ pub fn deploy_context_menu(
 
         let evaluate_selection = window.is_action_available(&EvaluateSelectedText, cx);
         let run_to_cursor = window.is_action_available(&RunToCursor, cx);
+        let format_selections = window.is_action_available(&FormatSelections, cx);
         let disable_ai = DisableAiSettings::is_ai_disabled_for_buffer(
             editor.buffer.read(cx).as_singleton().as_ref(),
             cx,
@@ -266,7 +267,7 @@ pub fn deploy_context_menu(
                 .separator()
                 .action("Rename Symbol", Box::new(Rename))
                 .action("Format Buffer", Box::new(Format))
-                .when(has_selections, |cx| {
+                .when(format_selections, |cx| {
                     cx.action("Format Selections", Box::new(FormatSelections))
                 })
                 .action(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5038,10 +5038,7 @@ impl LspStore {
             return HashSet::default();
         };
 
-        let settings = {
-            let buffer = buffer.read(cx);
-            LanguageSettings::for_buffer(&buffer, cx).into_owned()
-        };
+        let settings = LanguageSettings::for_buffer(buffer.read(cx), cx);
         if !settings.enable_language_server {
             return HashSet::default();
         }
@@ -5103,56 +5100,43 @@ impl LspStore {
         self.check_if_any_relevant_server_matches(buffer, |_, capabilities| check(capabilities), cx)
     }
 
-    fn formatter_supports_range_formatting(
-        &self,
-        formatter: &Formatter,
-        buffer: &Entity<Buffer>,
-        settings: &LanguageSettings,
-        cx: &App,
-    ) -> bool {
-        match formatter {
-            Formatter::None => false,
-            Formatter::Auto => {
-                settings.prettier.allowed
-                    || self.check_if_capable_for_proto_request(
+    pub fn supports_range_formatting(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {
+        let settings = LanguageSettings::for_buffer(buffer.read(cx), cx);
+        settings.formatter.as_ref().iter().any(|formatter| {
+            match formatter {
+                Formatter::None => false,
+                Formatter::Auto => {
+                    settings.prettier.allowed
+                        || self.check_if_capable_for_proto_request(
+                            buffer,
+                            server_capabilities_support_range_formatting,
+                            cx,
+                        )
+                }
+                Formatter::Prettier => true,
+                Formatter::External { .. } => false,
+                Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current) => {
+                    self.check_if_capable_for_proto_request(
                         buffer,
                         server_capabilities_support_range_formatting,
                         cx,
                     )
-            }
-            Formatter::Prettier => true,
-            Formatter::External { .. } => false,
-            Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current) => self
-                .check_if_capable_for_proto_request(
+                }
+                Formatter::LanguageServer(
+                    settings::LanguageServerFormatterSpecifier::Specific { name },
+                ) => self.check_if_any_relevant_server_matches(
                     buffer,
-                    server_capabilities_support_range_formatting,
+                    |server_status, capabilities| {
+                        server_status.name.0.as_ref() == name
+                            && server_capabilities_support_range_formatting(capabilities)
+                    },
                     cx,
                 ),
-            Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Specific {
-                name,
-            }) => self.check_if_any_relevant_server_matches(
-                buffer,
-                |server_status, capabilities| {
-                    server_status.name.0.as_ref() == name
-                        && server_capabilities_support_range_formatting(capabilities)
-                },
-                cx,
-            ),
-            // `FormatSelections` should only surface when a formatter can honor the
-            // selected ranges. Code actions can still run as part of formatting, but
-            // they operate on the whole buffer rather than the selected text.
-            Formatter::CodeAction(_) => false,
-        }
-    }
-
-    pub fn supports_range_formatting(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {
-        let settings = {
-            let buffer = buffer.read(cx);
-            LanguageSettings::for_buffer(&buffer, cx).into_owned()
-        };
-
-        settings.formatter.as_ref().iter().any(|formatter| {
-            self.formatter_supports_range_formatting(formatter, buffer, &settings, cx)
+                // `FormatSelections` should only surface when a formatter can honor the
+                // selected ranges. Code actions can still run as part of formatting, but
+                // they operate on the whole buffer rather than the selected text.
+                Formatter::CodeAction(_) => false,
+            }
         })
     }
 
@@ -5170,12 +5154,12 @@ impl LspStore {
             .filter_map(|server_id| {
                 Some((
                     server_id,
-                    self.language_server_statuses.get(&server_id)?.name.clone(),
+                    &self.language_server_statuses.get(&server_id)?.name,
                     self.lsp_server_capabilities.get(&server_id)?,
                 ))
             })
             .filter(|(_, server_name, capabilities)| check(server_name, capabilities))
-            .map(|(server_id, server_name, _)| (server_id, server_name))
+            .map(|(server_id, server_name, _)| (server_id, server_name.clone()))
             .collect()
     }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2337,12 +2337,20 @@ impl LocalLspStore {
         }
     }
 
+    fn server_capabilities_support_range_formatting(
+        capabilities: &lsp::ServerCapabilities,
+    ) -> bool {
+        matches!(
+            capabilities.document_range_formatting_provider.as_ref(),
+            Some(provider) if *provider != OneOf::Left(false)
+        )
+    }
+
     fn server_supports_formatting(server: &Arc<LanguageServer>) -> bool {
         let capabilities = server.capabilities();
         let formatting = capabilities.document_formatting_provider.as_ref();
-        let range_formatting = capabilities.document_range_formatting_provider.as_ref();
         matches!(formatting, Some(p) if *p != OneOf::Left(false))
-            || matches!(range_formatting, Some(p) if *p != OneOf::Left(false))
+            || Self::server_capabilities_support_range_formatting(&capabilities)
     }
 
     async fn format_via_lsp(
@@ -5003,17 +5011,13 @@ impl LspStore {
         )
     }
 
-    fn check_if_capable_for_proto_request<F>(
+    fn relevant_server_ids_for_capability_check(
         &self,
         buffer: &Entity<Buffer>,
-        check: F,
         cx: &App,
-    ) -> bool
-    where
-        F: FnMut(&lsp::ServerCapabilities) -> bool,
-    {
+    ) -> Vec<LanguageServerId> {
         let Some(language) = buffer.read(cx).language().cloned() else {
-            return false;
+            return Vec::new();
         };
         let registered_language_servers = self
             .languages
@@ -5030,10 +5034,103 @@ impl LspStore {
                 // but only loaded on the server side)
                 let is_relevant = registered_language_servers.contains(&server_status.name)
                     || self.languages.is_lsp_adapter_available(&server_status.name);
-                is_relevant.then_some(server_id)
+                is_relevant.then_some(*server_id)
             })
-            .filter_map(|server_id| self.lsp_server_capabilities.get(server_id))
-            .any(check)
+            .collect()
+    }
+
+    fn check_if_any_relevant_server_matches<F>(
+        &self,
+        buffer: &Entity<Buffer>,
+        mut check: F,
+        cx: &App,
+    ) -> bool
+    where
+        F: FnMut(&LanguageServerStatus, &lsp::ServerCapabilities) -> bool,
+    {
+        self.relevant_server_ids_for_capability_check(buffer, cx)
+            .into_iter()
+            .filter_map(|server_id| {
+                Some((
+                    self.language_server_statuses.get(&server_id)?,
+                    self.lsp_server_capabilities.get(&server_id)?,
+                ))
+            })
+            .any(|(server_status, capabilities)| check(server_status, capabilities))
+    }
+
+    fn check_if_capable_for_proto_request<F>(
+        &self,
+        buffer: &Entity<Buffer>,
+        mut check: F,
+        cx: &App,
+    ) -> bool
+    where
+        F: FnMut(&lsp::ServerCapabilities) -> bool,
+    {
+        self.check_if_any_relevant_server_matches(buffer, |_, capabilities| check(capabilities), cx)
+    }
+
+    fn server_capabilities_support_range_formatting(
+        capabilities: &lsp::ServerCapabilities,
+    ) -> bool {
+        matches!(
+            capabilities.document_range_formatting_provider.as_ref(),
+            Some(provider) if *provider != OneOf::Left(false)
+        )
+    }
+
+    fn formatter_supports_range_formatting(
+        &self,
+        formatter: &Formatter,
+        buffer: &Entity<Buffer>,
+        settings: &LanguageSettings,
+        cx: &App,
+    ) -> bool {
+        match formatter {
+            Formatter::None => false,
+            Formatter::Auto => {
+                settings.prettier.allowed
+                    || self.check_if_capable_for_proto_request(
+                        buffer,
+                        Self::server_capabilities_support_range_formatting,
+                        cx,
+                    )
+            }
+            Formatter::Prettier => true,
+            Formatter::External { .. } => false,
+            Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current) => self
+                .check_if_capable_for_proto_request(
+                    buffer,
+                    Self::server_capabilities_support_range_formatting,
+                    cx,
+                ),
+            Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Specific {
+                name,
+            }) => self.check_if_any_relevant_server_matches(
+                buffer,
+                |server_status, capabilities| {
+                    server_status.name.0.as_ref() == name
+                        && Self::server_capabilities_support_range_formatting(capabilities)
+                },
+                cx,
+            ),
+            // `FormatSelections` should only surface when a formatter can honor the
+            // selected ranges. Code actions can still run as part of formatting, but
+            // they operate on the whole buffer rather than the selected text.
+            Formatter::CodeAction(_) => false,
+        }
+    }
+
+    pub fn supports_range_formatting(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {
+        let settings = {
+            let buffer = buffer.read(cx);
+            LanguageSettings::for_buffer(&buffer, cx).into_owned()
+        };
+
+        settings.formatter.as_ref().iter().any(|formatter| {
+            self.formatter_supports_range_formatting(formatter, buffer, &settings, cx)
+        })
     }
 
     fn all_capable_for_proto_request<F>(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3964,7 +3964,6 @@ pub struct LspStore {
     pub lsp_server_capabilities: HashMap<LanguageServerId, lsp::ServerCapabilities>,
     semantic_token_config: SemanticTokenConfig,
     lsp_data: HashMap<BufferId, BufferLspData>,
-    registered_language_servers_by_buffer: HashMap<BufferId, HashSet<LanguageServerId>>,
     buffer_reload_tasks: HashMap<BufferId, Task<anyhow::Result<()>>>,
     next_hint_id: Arc<AtomicUsize>,
 }
@@ -4293,7 +4292,6 @@ impl LspStore {
             lsp_server_capabilities: HashMap::default(),
             semantic_token_config: SemanticTokenConfig::new(cx),
             lsp_data: HashMap::default(),
-            registered_language_servers_by_buffer: HashMap::default(),
             buffer_reload_tasks: HashMap::default(),
             next_hint_id: Arc::default(),
             active_entry: None,
@@ -4357,7 +4355,6 @@ impl LspStore {
             semantic_token_config: SemanticTokenConfig::new(cx),
             next_hint_id: Arc::default(),
             lsp_data: HashMap::default(),
-            registered_language_servers_by_buffer: HashMap::default(),
             buffer_reload_tasks: HashMap::default(),
             active_entry: None,
 
@@ -4378,7 +4375,6 @@ impl LspStore {
             }
             BufferStoreEvent::BufferChangedFilePath { buffer, old_file } => {
                 let buffer_id = buffer.read(cx).remote_id();
-                self.clear_language_server_registrations_for_buffer(buffer_id);
                 if let Some(local) = self.as_local_mut()
                     && let Some(old_file) = File::from_dyn(old_file.as_ref())
                 {
@@ -5021,9 +5017,6 @@ impl LspStore {
                 .copied()
                 .collect();
         }
-        if let Some(server_ids) = self.registered_language_servers_by_buffer.get(&buffer_id) {
-            return server_ids.iter().copied().collect();
-        }
 
         let relevant_language_servers = self.relevant_server_names_for_capability_check(buffer, cx);
         self.language_server_statuses
@@ -5184,22 +5177,6 @@ impl LspStore {
             .filter(|(_, server_name, capabilities)| check(server_name, capabilities))
             .map(|(server_id, server_name, _)| (server_id, server_name))
             .collect()
-    }
-
-    fn track_language_server_registration_for_buffer(
-        &mut self,
-        buffer_id: BufferId,
-        language_server_id: LanguageServerId,
-    ) {
-        self.registered_language_servers_by_buffer
-            .entry(buffer_id)
-            .or_default()
-            .insert(language_server_id);
-    }
-
-    fn clear_language_server_registrations_for_buffer(&mut self, buffer_id: BufferId) {
-        self.registered_language_servers_by_buffer
-            .remove(&buffer_id);
     }
 
     pub fn request_lsp<R>(
@@ -9783,27 +9760,8 @@ impl LspStore {
                     lsp_store.disk_based_diagnostics_finished(language_server_id, cx)
                 }
 
-                proto::update_language_server::Variant::RegisteredForBuffer(update) => {
-                    if let Ok(buffer_id) = BufferId::new(update.buffer_id) {
-                        lsp_store.track_language_server_registration_for_buffer(
-                            buffer_id,
-                            language_server_id,
-                        );
-                    }
-                    cx.emit(LspStoreEvent::LanguageServerUpdate {
-                        language_server_id,
-                        name: envelope
-                            .payload
-                            .server_name
-                            .map(SharedString::new)
-                            .map(LanguageServerName),
-                        message: proto::update_language_server::Variant::RegisteredForBuffer(
-                            update,
-                        ),
-                    });
-                }
-
                 non_lsp @ proto::update_language_server::Variant::StatusUpdate(_)
+                | non_lsp @ proto::update_language_server::Variant::RegisteredForBuffer(_)
                 | non_lsp @ proto::update_language_server::Variant::MetadataUpdated(_) => {
                     cx.emit(LspStoreEvent::LanguageServerUpdate {
                         language_server_id,
@@ -12330,11 +12288,6 @@ impl LspStore {
         for lsp_data in self.lsp_data.values_mut() {
             lsp_data.remove_server_data(for_server);
         }
-        self.registered_language_servers_by_buffer
-            .retain(|_, servers| {
-                servers.remove(&for_server);
-                !servers.is_empty()
-            });
         if let Some(local) = self.as_local_mut() {
             local.buffer_pull_diagnostics_result_ids.remove(&for_server);
             local

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3973,6 +3973,7 @@ pub struct LspStore {
     pub lsp_server_capabilities: HashMap<LanguageServerId, lsp::ServerCapabilities>,
     semantic_token_config: SemanticTokenConfig,
     lsp_data: HashMap<BufferId, BufferLspData>,
+    registered_language_servers_by_buffer: HashMap<BufferId, HashSet<LanguageServerId>>,
     buffer_reload_tasks: HashMap<BufferId, Task<anyhow::Result<()>>>,
     next_hint_id: Arc<AtomicUsize>,
 }
@@ -4301,6 +4302,7 @@ impl LspStore {
             lsp_server_capabilities: HashMap::default(),
             semantic_token_config: SemanticTokenConfig::new(cx),
             lsp_data: HashMap::default(),
+            registered_language_servers_by_buffer: HashMap::default(),
             buffer_reload_tasks: HashMap::default(),
             next_hint_id: Arc::default(),
             active_entry: None,
@@ -4364,6 +4366,7 @@ impl LspStore {
             semantic_token_config: SemanticTokenConfig::new(cx),
             next_hint_id: Arc::default(),
             lsp_data: HashMap::default(),
+            registered_language_servers_by_buffer: HashMap::default(),
             buffer_reload_tasks: HashMap::default(),
             active_entry: None,
 
@@ -4384,6 +4387,7 @@ impl LspStore {
             }
             BufferStoreEvent::BufferChangedFilePath { buffer, old_file } => {
                 let buffer_id = buffer.read(cx).remote_id();
+                self.clear_language_server_registrations_for_buffer(buffer_id);
                 if let Some(local) = self.as_local_mut()
                     && let Some(old_file) = File::from_dyn(old_file.as_ref())
                 {
@@ -5016,26 +5020,70 @@ impl LspStore {
         buffer: &Entity<Buffer>,
         cx: &App,
     ) -> Vec<LanguageServerId> {
+        let buffer_id = buffer.read(cx).remote_id();
+        if let Some(local) = self.as_local() {
+            return local
+                .buffers_opened_in_servers
+                .get(&buffer_id)
+                .into_iter()
+                .flatten()
+                .copied()
+                .collect();
+        }
+        if let Some(server_ids) = self.registered_language_servers_by_buffer.get(&buffer_id) {
+            return server_ids.iter().copied().collect();
+        }
+
+        let relevant_language_servers = self.relevant_server_names_for_capability_check(buffer, cx);
+        self.language_server_statuses
+            .iter()
+            .filter_map(|(server_id, server_status)| {
+                relevant_language_servers
+                    .contains(&server_status.name)
+                    .then_some(*server_id)
+            })
+            .collect()
+    }
+
+    fn relevant_server_names_for_capability_check(
+        &self,
+        buffer: &Entity<Buffer>,
+        cx: &App,
+    ) -> HashSet<LanguageServerName> {
         let Some(language) = buffer.read(cx).language().cloned() else {
-            return Vec::new();
+            return HashSet::default();
         };
-        let registered_language_servers = self
+
+        let settings = {
+            let buffer = buffer.read(cx);
+            LanguageSettings::for_buffer(&buffer, cx).into_owned()
+        };
+        if !settings.enable_language_server {
+            return HashSet::default();
+        }
+
+        let mut available_language_servers = self
             .languages
             .lsp_adapters(&language.name())
             .into_iter()
             .map(|lsp_adapter| lsp_adapter.name())
-            .collect::<HashSet<_>>();
-        self.language_server_statuses
-            .iter()
-            .filter_map(|(server_id, server_status)| {
-                // Include servers that are either registered for this language OR
-                // available to be loaded (for SSH remote mode where adapters like
-                // ty/pylsp/pyright are registered via register_available_lsp_adapter
-                // but only loaded on the server side)
-                let is_relevant = registered_language_servers.contains(&server_status.name)
-                    || self.languages.is_lsp_adapter_available(&server_status.name);
-                is_relevant.then_some(*server_id)
-            })
+            .collect::<Vec<_>>();
+
+        for configured_language_server in &settings.language_servers {
+            if configured_language_server == "..." || configured_language_server.starts_with('!') {
+                continue;
+            }
+
+            let configured_language_server =
+                LanguageServerName(configured_language_server.clone().into());
+            if !available_language_servers.contains(&configured_language_server) {
+                available_language_servers.push(configured_language_server);
+            }
+        }
+
+        settings
+            .customized_language_servers(&available_language_servers)
+            .into_iter()
             .collect()
     }
 
@@ -5142,34 +5190,51 @@ impl LspStore {
     where
         F: FnMut(&lsp::LanguageServerName, &lsp::ServerCapabilities) -> bool,
     {
-        let Some(language) = buffer.read(cx).language().cloned() else {
-            return Vec::default();
-        };
-        let registered_language_servers = self
-            .languages
-            .lsp_adapters(&language.name())
+        self.relevant_server_ids_for_capability_check(buffer, cx)
             .into_iter()
-            .map(|lsp_adapter| lsp_adapter.name())
-            .collect::<HashSet<_>>();
-        self.language_server_statuses
-            .iter()
-            .filter_map(|(server_id, server_status)| {
-                // Include servers that are either registered for this language OR
-                // available to be loaded (for SSH remote mode where adapters like
-                // ty/pylsp/pyright are registered via register_available_lsp_adapter
-                // but only loaded on the server side)
-                let is_relevant = registered_language_servers.contains(&server_status.name)
-                    || self.languages.is_lsp_adapter_available(&server_status.name);
-                is_relevant.then_some((server_id, &server_status.name))
-            })
-            .filter_map(|(server_id, server_name)| {
-                self.lsp_server_capabilities
-                    .get(server_id)
-                    .map(|c| (server_id, server_name, c))
+            .filter_map(|server_id| {
+                Some((
+                    server_id,
+                    self.language_server_statuses.get(&server_id)?.name.clone(),
+                    self.lsp_server_capabilities.get(&server_id)?,
+                ))
             })
             .filter(|(_, server_name, capabilities)| check(server_name, capabilities))
-            .map(|(server_id, server_name, _)| (*server_id, server_name.clone()))
+            .map(|(server_id, server_name, _)| (server_id, server_name))
             .collect()
+    }
+
+    fn track_language_server_registration_for_buffer(
+        &mut self,
+        buffer_id: BufferId,
+        language_server_id: LanguageServerId,
+    ) {
+        self.registered_language_servers_by_buffer
+            .entry(buffer_id)
+            .or_default()
+            .insert(language_server_id);
+    }
+
+    fn remove_language_server_registration_for_buffer(
+        &mut self,
+        buffer_id: BufferId,
+        language_server_id: LanguageServerId,
+    ) {
+        if let Some(language_servers) = self
+            .registered_language_servers_by_buffer
+            .get_mut(&buffer_id)
+        {
+            language_servers.remove(&language_server_id);
+            if language_servers.is_empty() {
+                self.registered_language_servers_by_buffer
+                    .remove(&buffer_id);
+            }
+        }
+    }
+
+    fn clear_language_server_registrations_for_buffer(&mut self, buffer_id: BufferId) {
+        self.registered_language_servers_by_buffer
+            .remove(&buffer_id);
     }
 
     pub fn request_lsp<R>(
@@ -9753,8 +9818,27 @@ impl LspStore {
                     lsp_store.disk_based_diagnostics_finished(language_server_id, cx)
                 }
 
+                proto::update_language_server::Variant::RegisteredForBuffer(update) => {
+                    if let Ok(buffer_id) = BufferId::new(update.buffer_id) {
+                        lsp_store.track_language_server_registration_for_buffer(
+                            buffer_id,
+                            language_server_id,
+                        );
+                    }
+                    cx.emit(LspStoreEvent::LanguageServerUpdate {
+                        language_server_id,
+                        name: envelope
+                            .payload
+                            .server_name
+                            .map(SharedString::new)
+                            .map(LanguageServerName),
+                        message: proto::update_language_server::Variant::RegisteredForBuffer(
+                            update,
+                        ),
+                    });
+                }
+
                 non_lsp @ proto::update_language_server::Variant::StatusUpdate(_)
-                | non_lsp @ proto::update_language_server::Variant::RegisteredForBuffer(_)
                 | non_lsp @ proto::update_language_server::Variant::MetadataUpdated(_) => {
                     cx.emit(LspStoreEvent::LanguageServerUpdate {
                         language_server_id,
@@ -12280,6 +12364,16 @@ impl LspStore {
         self.semantic_token_config.remove_server_data(for_server);
         for lsp_data in self.lsp_data.values_mut() {
             lsp_data.remove_server_data(for_server);
+        }
+        let buffer_ids = self
+            .registered_language_servers_by_buffer
+            .iter()
+            .filter_map(|(buffer_id, language_servers)| {
+                language_servers.contains(&for_server).then_some(*buffer_id)
+            })
+            .collect::<Vec<_>>();
+        for buffer_id in buffer_ids {
+            self.remove_language_server_registration_for_buffer(buffer_id, for_server);
         }
         if let Some(local) = self.as_local_mut() {
             local.buffer_pull_diagnostics_result_ids.remove(&for_server);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5043,24 +5043,12 @@ impl LspStore {
             return HashSet::default();
         }
 
-        let mut available_language_servers = self
+        let available_language_servers = self
             .languages
             .lsp_adapters(&language.name())
             .into_iter()
             .map(|lsp_adapter| lsp_adapter.name())
             .collect::<Vec<_>>();
-
-        for configured_language_server in &settings.language_servers {
-            if configured_language_server == "..." || configured_language_server.starts_with('!') {
-                continue;
-            }
-
-            let configured_language_server =
-                LanguageServerName(configured_language_server.clone().into());
-            if !available_language_servers.contains(&configured_language_server) {
-                available_language_servers.push(configured_language_server);
-            }
-        }
 
         settings
             .customized_language_servers(&available_language_servers)

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5018,41 +5018,26 @@ impl LspStore {
                 .collect();
         }
 
-        let relevant_language_servers = self.relevant_server_names_for_capability_check(buffer, cx);
-        self.language_server_statuses
-            .iter()
-            .filter_map(|(server_id, server_status)| {
-                relevant_language_servers
-                    .contains(&server_status.name)
-                    .then_some(*server_id)
-            })
-            .collect()
-    }
-
-    fn relevant_server_names_for_capability_check(
-        &self,
-        buffer: &Entity<Buffer>,
-        cx: &App,
-    ) -> HashSet<LanguageServerName> {
         let Some(language) = buffer.read(cx).language().cloned() else {
-            return HashSet::default();
+            return Vec::default();
         };
-
-        let settings = LanguageSettings::for_buffer(buffer.read(cx), cx);
-        if !settings.enable_language_server {
-            return HashSet::default();
-        }
-
-        let available_language_servers = self
+        let registered_language_servers = self
             .languages
             .lsp_adapters(&language.name())
             .into_iter()
             .map(|lsp_adapter| lsp_adapter.name())
-            .collect::<Vec<_>>();
-
-        settings
-            .customized_language_servers(&available_language_servers)
-            .into_iter()
+            .collect::<HashSet<_>>();
+        self.language_server_statuses
+            .iter()
+            .filter_map(|(server_id, server_status)| {
+                // Include servers that are either registered for this language OR
+                // available to be loaded (for SSH remote mode where adapters like
+                // ty/pylsp/pyright are registered via register_available_lsp_adapter
+                // but only loaded on the server side)
+                let is_relevant = registered_language_servers.contains(&server_status.name)
+                    || self.languages.is_lsp_adapter_available(&server_status.name);
+                is_relevant.then_some(*server_id)
+            })
             .collect()
     }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2337,20 +2337,11 @@ impl LocalLspStore {
         }
     }
 
-    fn server_capabilities_support_range_formatting(
-        capabilities: &lsp::ServerCapabilities,
-    ) -> bool {
-        matches!(
-            capabilities.document_range_formatting_provider.as_ref(),
-            Some(provider) if *provider != OneOf::Left(false)
-        )
-    }
-
     fn server_supports_formatting(server: &Arc<LanguageServer>) -> bool {
         let capabilities = server.capabilities();
         let formatting = capabilities.document_formatting_provider.as_ref();
         matches!(formatting, Some(p) if *p != OneOf::Left(false))
-            || Self::server_capabilities_support_range_formatting(&capabilities)
+            || server_capabilities_support_range_formatting(&capabilities)
     }
 
     async fn format_via_lsp(
@@ -5119,15 +5110,6 @@ impl LspStore {
         self.check_if_any_relevant_server_matches(buffer, |_, capabilities| check(capabilities), cx)
     }
 
-    fn server_capabilities_support_range_formatting(
-        capabilities: &lsp::ServerCapabilities,
-    ) -> bool {
-        matches!(
-            capabilities.document_range_formatting_provider.as_ref(),
-            Some(provider) if *provider != OneOf::Left(false)
-        )
-    }
-
     fn formatter_supports_range_formatting(
         &self,
         formatter: &Formatter,
@@ -5141,7 +5123,7 @@ impl LspStore {
                 settings.prettier.allowed
                     || self.check_if_capable_for_proto_request(
                         buffer,
-                        Self::server_capabilities_support_range_formatting,
+                        server_capabilities_support_range_formatting,
                         cx,
                     )
             }
@@ -5150,7 +5132,7 @@ impl LspStore {
             Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current) => self
                 .check_if_capable_for_proto_request(
                     buffer,
-                    Self::server_capabilities_support_range_formatting,
+                    server_capabilities_support_range_formatting,
                     cx,
                 ),
             Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Specific {
@@ -5159,7 +5141,7 @@ impl LspStore {
                 buffer,
                 |server_status, capabilities| {
                     server_status.name.0.as_ref() == name
-                        && Self::server_capabilities_support_range_formatting(capabilities)
+                        && server_capabilities_support_range_formatting(capabilities)
                 },
                 cx,
             ),
@@ -5213,23 +5195,6 @@ impl LspStore {
             .entry(buffer_id)
             .or_default()
             .insert(language_server_id);
-    }
-
-    fn remove_language_server_registration_for_buffer(
-        &mut self,
-        buffer_id: BufferId,
-        language_server_id: LanguageServerId,
-    ) {
-        if let Some(language_servers) = self
-            .registered_language_servers_by_buffer
-            .get_mut(&buffer_id)
-        {
-            language_servers.remove(&language_server_id);
-            if language_servers.is_empty() {
-                self.registered_language_servers_by_buffer
-                    .remove(&buffer_id);
-            }
-        }
     }
 
     fn clear_language_server_registrations_for_buffer(&mut self, buffer_id: BufferId) {
@@ -12365,16 +12330,11 @@ impl LspStore {
         for lsp_data in self.lsp_data.values_mut() {
             lsp_data.remove_server_data(for_server);
         }
-        let buffer_ids = self
-            .registered_language_servers_by_buffer
-            .iter()
-            .filter_map(|(buffer_id, language_servers)| {
-                language_servers.contains(&for_server).then_some(*buffer_id)
-            })
-            .collect::<Vec<_>>();
-        for buffer_id in buffer_ids {
-            self.remove_language_server_registration_for_buffer(buffer_id, for_server);
-        }
+        self.registered_language_servers_by_buffer
+            .retain(|_, servers| {
+                servers.remove(&for_server);
+                !servers.is_empty()
+            });
         if let Some(local) = self.as_local_mut() {
             local.buffer_pull_diagnostics_result_ids.remove(&for_server);
             local
@@ -13476,6 +13436,13 @@ fn parse_register_capabilities<T: serde::de::DeserializeOwned>(
         Some(options) => OneOf::Right(serde_json::from_value::<T>(options)?),
         None => OneOf::Left(true),
     })
+}
+
+fn server_capabilities_support_range_formatting(capabilities: &lsp::ServerCapabilities) -> bool {
+    matches!(
+        capabilities.document_range_formatting_provider.as_ref(),
+        Some(provider) if *provider != OneOf::Left(false)
+    )
 }
 
 fn subscribe_to_binary_statuses(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4084,6 +4084,12 @@ impl Project {
         })
     }
 
+    pub fn supports_range_formatting(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {
+        self.lsp_store
+            .read(cx)
+            .supports_range_formatting(buffer, cx)
+    }
+
     pub fn definitions<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -45,7 +45,7 @@ use language::{
     LanguageConfig, LanguageMatcher, LanguageName, LineEnding, ManifestName, ManifestProvider,
     ManifestQuery, OffsetRangeExt, Point, ToPoint, Toolchain, ToolchainList, ToolchainLister,
     ToolchainMetadata,
-    language_settings::{LanguageSettings, LanguageSettingsContent},
+    language_settings::{Formatter, FormatterList, LanguageSettings, LanguageSettingsContent},
     markdown_lang, rust_lang, tree_sitter_typescript,
 };
 use lsp::{
@@ -4899,6 +4899,85 @@ async fn test_completions_with_carriage_returns(cx: &mut gpui::TestAppContext) {
         .collect::<Vec<_>>();
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "fully\nQualified\nName");
+}
+
+#[gpui::test]
+async fn test_supports_range_formatting_ignores_unrelated_language_servers(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.formatter = Some(FormatterList::Single(
+                    Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current),
+                ));
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "a.ts": "",
+            "b.rs": "",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(typescript_lang());
+    language_registry.add(rust_lang());
+
+    let mut typescript_language_servers = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            name: "typescript-fake-language-server",
+            capabilities: lsp::ServerCapabilities {
+                document_range_formatting_provider: Some(lsp::OneOf::Left(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+    let mut rust_language_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            name: "rust-fake-language-server",
+            capabilities: lsp::ServerCapabilities {
+                document_formatting_provider: Some(lsp::OneOf::Left(true)),
+                document_range_formatting_provider: Some(lsp::OneOf::Left(false)),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let (typescript_buffer, _typescript_handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/a.ts"), cx)
+        })
+        .await
+        .unwrap();
+    let (rust_buffer, _rust_handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/b.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let _typescript_language_server = typescript_language_servers.next().await.unwrap();
+    let _rust_language_server = rust_language_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    assert!(project.read_with(cx, |project, cx| {
+        project.supports_range_formatting(&typescript_buffer, cx)
+    }));
+    assert!(!project.read_with(cx, |project, cx| {
+        project.supports_range_formatting(&rust_buffer, cx)
+    }));
 }
 
 #[gpui::test(iterations = 10)]

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -356,12 +356,17 @@ To run linter fixes automatically on save:
 Zed supports formatting only the selected text via `editor: format selections` ({#kb editor::FormatSelections}). How
 this works depends on the configured formatter:
 
-- **Language server**: Sends an LSP range formatting request for each selection. This provides the most precise
-  selection-only formatting.
+- The action is only shown when the active formatter can actually format ranges for at least one
+  selected buffer.
+- **Language server**: Sends an LSP range formatting request for each selection. This provides the
+  most precise selection-only formatting, and is only available when the configured language server
+  advertises range-formatting support.
 - **Prettier**: Uses Prettier's built-in range formatting to format the encompassing range of all selections. Any
   resulting edits that fall outside the selected ranges are discarded, so only the selected code is modified.
 - **External commands**: External command formatters do not support range formatting and are skipped when formatting
   selections.
+- **Code action formatters**: Code actions operate on the whole buffer, so they do not enable
+  `format selections` on their own.
 
 ### Integrating Formatting and Linting
 


### PR DESCRIPTION
## What Changed

- compute range-format support from formatter configuration and language-server capabilities
- show `Format Selections` only when at least one selected buffer has a range-capable formatter
- keep Prettier-supported range formatting available without depending on LSP support
- hide the action for formatter modes that cannot honor selections, such as external-command and code-action formatters
- keep the action handler safe by rechecking support and returning early when range formatting is unavailable
- restrict capability checks to the servers actually registered for the current buffer
- add regression coverage for supported, unsupported, and mixed-server cases
- document when `Format Selections` is available in both action docs and user docs


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #25796

Release Notes:
- Improved `Format Selections` so it is only shown when the active formatter supports range formatting.

Testing I did:

Here are the formatters I used:
<img width="829" height="434" alt="Screenshot_20260405_102047" src="https://github.com/user-attachments/assets/cae4a238-277e-4188-873f-189e9f098699" />

Note: I've chosen three formatters:
1. Prettier, which supports range formatting
2. clangd (LSP) which also supports range formatting
3. gopls which do not support range formatting

[Screencast_20260405_102431.webm](https://github.com/user-attachments/assets/69ce3f95-0b73-46a0-853d-3b5be6329dde)
