### PR TITLE
agent: Restore profile startup defaults

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -49,6 +49,7 @@ use prompt_store::{
 use serde::{Deserialize, Serialize};
 use settings::{LanguageModelSelection, update_settings_file};
 use std::any::Any;
+use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
@@ -83,6 +84,8 @@ struct Session {
     acp_thread: Entity<acp_thread::AcpThread>,
     project_id: EntityId,
     pending_save: Task<Result<()>>,
+    model_updates_tx: Rc<RefCell<watch::Sender<()>>>,
+    model_updates_rx: watch::Receiver<()>,
     _subscriptions: Vec<Subscription>,
     ref_count: usize,
 }
@@ -97,19 +100,17 @@ pub struct LanguageModels {
     models: HashMap<acp::ModelId, Arc<dyn LanguageModel>>,
     /// Cached list for returning language model information
     model_list: acp_thread::AgentModelList,
-    refresh_models_rx: watch::Receiver<()>,
     refresh_models_tx: watch::Sender<()>,
     _authenticate_all_providers_task: Task<()>,
 }
 
 impl LanguageModels {
     fn new(cx: &mut App) -> Self {
-        let (refresh_models_tx, refresh_models_rx) = watch::channel(());
+        let (refresh_models_tx, _refresh_models_rx) = watch::channel(());
 
         let mut this = Self {
             models: HashMap::default(),
             model_list: acp_thread::AgentModelList::Grouped(IndexMap::default()),
-            refresh_models_rx,
             refresh_models_tx,
             _authenticate_all_providers_task: Self::authenticate_all_language_model_providers(cx),
         };
@@ -162,10 +163,6 @@ impl LanguageModels {
         self.models = models;
         self.model_list = acp_thread::AgentModelList::Grouped(language_model_list);
         self.refresh_models_tx.send(()).ok();
-    }
-
-    fn watch(&self) -> watch::Receiver<()> {
-        self.refresh_models_rx.clone()
     }
 
     pub fn model_from_id(&self, model_id: &acp::ModelId) -> Option<Arc<dyn LanguageModel>> {
@@ -368,6 +365,8 @@ impl NativeAgent {
 
         let registry = LanguageModelRegistry::read_global(cx);
         let summarization_model = registry.thread_summary_model(cx).map(|c| c.model);
+        let (model_updates_tx, model_updates_rx) = watch::channel(());
+        let model_updates_tx = Rc::new(RefCell::new(model_updates_tx));
 
         let weak = cx.weak_entity();
         let weak_thread = thread_handle.downgrade();
@@ -383,9 +382,13 @@ impl NativeAgent {
             )
         });
 
+        let model_updates_tx_for_thread = model_updates_tx.clone();
         let subscriptions = vec![
             cx.subscribe(&thread_handle, Self::handle_thread_title_updated),
             cx.subscribe(&thread_handle, Self::handle_thread_token_usage_updated),
+            cx.subscribe(&thread_handle, move |_, _, _: &ModelChanged, _cx| {
+                model_updates_tx_for_thread.borrow_mut().send(()).ok();
+            }),
             cx.observe(&thread_handle, move |this, thread, cx| {
                 this.save_thread(thread, cx)
             }),
@@ -397,6 +400,8 @@ impl NativeAgent {
                 thread: thread_handle,
                 acp_thread: acp_thread.clone(),
                 project_id,
+                model_updates_tx,
+                model_updates_rx,
                 _subscriptions: subscriptions,
                 pending_save: Task::ready(Ok(())),
                 ref_count,
@@ -770,6 +775,7 @@ impl NativeAgent {
                     }
                 }
             });
+            session.model_updates_tx.borrow_mut().send(()).ok();
         }
     }
 
@@ -1483,7 +1489,12 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
     }
 
     fn watch(&self, cx: &mut App) -> Option<watch::Receiver<()>> {
-        Some(self.connection.0.read(cx).models.watch())
+        self.connection
+            .0
+            .read(cx)
+            .sessions
+            .get(&self.session_id)
+            .map(|session| session.model_updates_rx.clone())
     }
 
     fn should_render_footer(&self) -> bool {
@@ -2195,15 +2206,17 @@ mod internal_tests {
 
     use super::*;
     use acp_thread::{AgentConnection, AgentModelGroupName, AgentModelInfo, MentionUri};
+    use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings};
     use fs::FakeFs;
     use gpui::TestAppContext;
     use indoc::formatdoc;
     use language_model::fake_provider::{FakeLanguageModel, FakeLanguageModelProvider};
     use language_model::{
-        LanguageModelCompletionEvent, LanguageModelProviderId, LanguageModelProviderName,
+        LanguageModelCompletionEvent, LanguageModelId, LanguageModelProviderId,
+        LanguageModelProviderName,
     };
     use serde_json::json;
-    use settings::SettingsStore;
+    use settings::{LanguageModelProviderSetting, Settings, SettingsStore};
     use util::{path, rel_path::rel_path};
 
     #[gpui::test]
@@ -2556,6 +2569,67 @@ mod internal_tests {
     }
 
     #[gpui::test]
+    async fn test_new_session_uses_profile_reasoning_defaults_after_registry_sync(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/", json!({ "a": {} })).await;
+        let project = Project::test(fs.clone(), [path!("/a").as_ref()], cx).await;
+
+        let (global_selection, profile_selection) = install_profile_default_test_models(cx);
+        override_profile_and_global_models(global_selection, profile_selection.clone(), cx);
+
+        let selected = language_model::SelectedModel {
+            provider: LanguageModelProviderId::from(profile_selection.provider.0.clone()),
+            model: LanguageModelId::from(profile_selection.model.clone()),
+        };
+        cx.update(|cx| {
+            LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+                registry.select_default_model(Some(&selected), cx);
+            });
+        });
+
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+        let connection = Rc::new(NativeAgentConnection(agent.clone()));
+        let acp_thread = cx
+            .update(|cx| {
+                connection.clone().new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/a")]),
+                    cx,
+                )
+            })
+            .await
+            .expect("new session should succeed");
+        let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+        let thread = agent.read_with(cx, |agent, _| {
+            agent
+                .sessions
+                .get(&session_id)
+                .expect("session should exist")
+                .thread
+                .clone()
+        });
+
+        thread.read_with(cx, |thread, _| {
+            let model = thread.model().expect("thread should have a model");
+            assert_eq!(model.id().0.as_ref(), "profile-model");
+            assert!(
+                thread.thinking_enabled(),
+                "thinking should come from the active profile selection"
+            );
+            assert_eq!(
+                thread.thinking_effort().map(|effort| effort.as_str()),
+                Some("high"),
+                "thinking effort should come from the active profile selection"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_summarization_model_survives_transient_registry_clearing(
         cx: &mut TestAppContext,
     ) {
@@ -2671,6 +2745,9 @@ mod internal_tests {
                 "thinking should be enabled after selecting thinking model"
             );
         });
+        thread.update(cx, |thread, cx| {
+            thread.set_thinking_effort(Some("high".to_string()), cx);
+        });
 
         // Send a message so the thread gets persisted.
         let send = acp_thread.update(cx, |thread, cx| thread.send(vec!["Hello".into()], cx));
@@ -2707,6 +2784,11 @@ mod internal_tests {
             assert!(
                 thread.thinking_enabled(),
                 "thinking_enabled should be preserved when reloading a thread with a thinking model"
+            );
+            assert_eq!(
+                thread.thinking_effort().map(|effort| effort.as_str()),
+                Some("high"),
+                "thinking_effort should be preserved when reloading a thread"
             );
         });
 
@@ -3393,6 +3475,79 @@ mod internal_tests {
                 .map(|entry| (entry.id.clone(), entry.title.to_string()))
                 .collect::<Vec<_>>()
         })
+    }
+
+    fn test_selection(
+        provider: &str,
+        model: &str,
+        enable_thinking: bool,
+        effort: Option<&str>,
+    ) -> LanguageModelSelection {
+        LanguageModelSelection {
+            provider: LanguageModelProviderSetting(provider.to_string()),
+            model: model.to_string(),
+            enable_thinking,
+            effort: effort.map(ToOwned::to_owned),
+            speed: None,
+        }
+    }
+
+    fn install_profile_default_test_models(
+        cx: &mut TestAppContext,
+    ) -> (LanguageModelSelection, LanguageModelSelection) {
+        let provider_id = "test-provider";
+        let global_selection = test_selection(provider_id, "global-model", false, Some("low"));
+        let profile_selection = test_selection(provider_id, "profile-model", true, Some("high"));
+        let global_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+            provider_id,
+            "global-model",
+            "Global Model",
+            false,
+        ));
+        let profile_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+            provider_id,
+            "profile-model",
+            "Profile Model",
+            true,
+        ));
+
+        cx.update(|cx| {
+            let provider = Arc::new(
+                FakeLanguageModelProvider::new(
+                    LanguageModelProviderId::from(provider_id.to_string()),
+                    LanguageModelProviderName::from("Test Provider".to_string()),
+                )
+                .with_models(vec![global_model, profile_model]),
+            );
+            LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+                registry.register_provider(provider, cx);
+            });
+        });
+
+        (global_selection, profile_selection)
+    }
+
+    fn override_profile_and_global_models(
+        global_selection: LanguageModelSelection,
+        profile_selection: LanguageModelSelection,
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let mut settings = AgentSettings::get_global(cx).clone();
+            settings.default_profile = AgentProfileId("profile-a".into());
+            settings.default_model = Some(global_selection);
+            settings.profiles.insert(
+                AgentProfileId("profile-a".into()),
+                AgentProfileSettings {
+                    name: "Profile A".into(),
+                    tools: Default::default(),
+                    enable_all_context_servers: false,
+                    context_servers: Default::default(),
+                    default_model: Some(profile_selection),
+                },
+            );
+            AgentSettings::override_global(settings, cx);
+        });
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -6,6 +6,7 @@ use acp_thread::{
 use agent_client_protocol::{self as acp};
 use agent_settings::AgentProfileId;
 use anyhow::Result;
+use chrono::Utc;
 use client::{Client, RefreshLlmTokenListener, UserStore};
 use collections::IndexMap;
 use context_server::{ContextServer, ContextServerCommand, ContextServerId};
@@ -26,10 +27,11 @@ use gpui::{
 use indoc::indoc;
 use language_model::{
     CompletionIntent, LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent,
-    LanguageModelId, LanguageModelProviderName, LanguageModelRegistry, LanguageModelRequest,
-    LanguageModelRequestMessage, LanguageModelToolResult, LanguageModelToolSchemaFormat,
-    LanguageModelToolUse, MessageContent, Role, StopReason, TokenUsage,
-    fake_provider::FakeLanguageModel,
+    LanguageModelId, LanguageModelProviderId, LanguageModelProviderName, LanguageModelRegistry,
+    LanguageModelRequest, LanguageModelRequestMessage, LanguageModelToolResult,
+    LanguageModelToolSchemaFormat, LanguageModelToolUse, MessageContent, Role, StopReason,
+    TokenUsage,
+    fake_provider::{FakeLanguageModel, FakeLanguageModelProvider},
 };
 use pretty_assertions::assert_eq;
 use project::{
@@ -40,7 +42,7 @@ use reqwest_client::ReqwestClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use settings::{Settings, SettingsStore};
+use settings::{LanguageModelProviderSetting, LanguageModelSelection, Settings, SettingsStore};
 use std::{
     path::Path,
     pin::Pin,
@@ -61,6 +63,124 @@ pub(crate) fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
+    });
+}
+
+fn test_selection(provider: &str, model: &str) -> LanguageModelSelection {
+    LanguageModelSelection {
+        provider: LanguageModelProviderSetting(provider.to_string()),
+        model: model.to_string(),
+        enable_thinking: false,
+        effort: None,
+        speed: None,
+    }
+}
+
+fn install_test_language_models(
+    cx: &mut TestAppContext,
+) -> (LanguageModelSelection, LanguageModelSelection) {
+    let (global_selection, profile_selection, _global_model, _profile_model) =
+        install_test_language_models_with_handles(cx);
+    (global_selection, profile_selection)
+}
+
+fn install_test_language_models_with_handles(
+    cx: &mut TestAppContext,
+) -> (
+    LanguageModelSelection,
+    LanguageModelSelection,
+    Arc<FakeLanguageModel>,
+    Arc<FakeLanguageModel>,
+) {
+    let provider_id = "test-provider";
+    let global_selection = test_selection(provider_id, "global-model");
+    let profile_selection = test_selection(provider_id, "profile-model");
+    let global_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+        provider_id,
+        "global-model",
+        "Global Model",
+        false,
+    ));
+    let profile_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+        provider_id,
+        "profile-model",
+        "Profile Model",
+        false,
+    ));
+
+    cx.update(|cx| {
+        LanguageModelRegistry::test(cx);
+        let provider = Arc::new(
+            FakeLanguageModelProvider::new(
+                LanguageModelProviderId::from(provider_id.to_string()),
+                LanguageModelProviderName::from("Test Provider".to_string()),
+            )
+            .with_models(vec![global_model.clone(), profile_model.clone()]),
+        );
+
+        LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+            registry.register_provider(provider, cx);
+        });
+    });
+
+    (
+        global_selection,
+        profile_selection,
+        global_model,
+        profile_model,
+    )
+}
+
+fn override_profile_and_global_models(
+    global_selection: LanguageModelSelection,
+    profile_selection: Option<LanguageModelSelection>,
+    cx: &mut TestAppContext,
+) {
+    cx.update(|cx| {
+        let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
+        settings.default_profile = AgentProfileId("profile-a".into());
+        settings.default_model = Some(global_selection.clone());
+        settings.profiles.insert(
+            AgentProfileId("profile-a".into()),
+            agent_settings::AgentProfileSettings {
+                name: "Profile A".into(),
+                tools: Default::default(),
+                enable_all_context_servers: false,
+                context_servers: Default::default(),
+                default_model: profile_selection,
+            },
+        );
+        agent_settings::AgentSettings::override_global(settings, cx);
+
+        let selected = language_model::SelectedModel {
+            provider: LanguageModelProviderId::from(global_selection.provider.0.clone()),
+            model: LanguageModelId::from(global_selection.model.clone()),
+        };
+        LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+            registry.select_default_model(Some(&selected), cx);
+        });
+    });
+}
+
+fn insert_test_profile(
+    profile_id: &str,
+    name: &str,
+    default_model: Option<LanguageModelSelection>,
+    cx: &mut TestAppContext,
+) {
+    cx.update(|cx| {
+        let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
+        settings.profiles.insert(
+            AgentProfileId(profile_id.to_string().into()),
+            agent_settings::AgentProfileSettings {
+                name: name.to_string().into(),
+                tools: Default::default(),
+                enable_all_context_servers: false,
+                context_servers: Default::default(),
+                default_model,
+            },
+        );
+        agent_settings::AgentSettings::override_global(settings, cx);
     });
 }
 
@@ -4083,6 +4203,213 @@ fn stop_events(result_events: Vec<Result<ThreadEvent>>) -> Vec<acp::StopReason> 
             _ => None,
         })
         .collect()
+}
+
+#[gpui::test]
+async fn test_from_db_prefers_profile_default_model_over_global_default(cx: &mut TestAppContext) {
+    init_test(cx);
+    let (global_selection, profile_selection) = install_test_language_models(cx);
+    override_profile_and_global_models(global_selection, Some(profile_selection), cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/test", json!({})).await;
+    let project = Project::test(fs.clone(), [Path::new("/test")], cx).await;
+    let project_context = cx.new(|_cx| ProjectContext::default());
+    let context_server_store = project.read_with(cx, |project, _| project.context_server_store());
+    let context_server_registry =
+        cx.new(|cx| ContextServerRegistry::new(context_server_store.clone(), cx));
+
+    let db_thread = DbThread {
+        title: "Thread".into(),
+        messages: Vec::new(),
+        updated_at: Utc::now(),
+        detailed_summary: None,
+        initial_project_snapshot: None,
+        cumulative_token_usage: Default::default(),
+        request_token_usage: Default::default(),
+        model: None,
+        profile: Some(AgentProfileId("profile-a".into())),
+        imported: false,
+        subagent_context: None,
+        speed: None,
+        thinking_enabled: true,
+        thinking_effort: Some("high".to_string()),
+        draft_prompt: None,
+        ui_scroll_position: None,
+    };
+
+    let thread = cx.new(|cx| {
+        Thread::from_db(
+            acp::SessionId::new("session-1".to_string()),
+            db_thread,
+            project.clone(),
+            project_context,
+            context_server_registry,
+            Templates::new(),
+            cx,
+        )
+    });
+
+    cx.update(|cx| {
+        let thread = thread.read(cx);
+        let model = thread.model().expect("thread should have a model");
+        assert_eq!(model.id().0.as_ref(), "profile-model");
+        assert!(
+            thread.thinking_enabled(),
+            "from_db should preserve stored thinking_enabled"
+        );
+        assert_eq!(
+            thread.thinking_effort().map(|effort| effort.as_str()),
+            Some("high"),
+            "from_db should preserve stored thinking_effort"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_profile_switch_updates_model_selector_watch(cx: &mut TestAppContext) {
+    init_test(cx);
+    let (global_selection, profile_selection) = install_test_language_models(cx);
+    override_profile_and_global_models(global_selection, Some(profile_selection.clone()), cx);
+    insert_test_profile("profile-b", "Profile B", Some(profile_selection), cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/test", json!({})).await;
+    let project = Project::test(fs.clone(), [Path::new("/test")], cx).await;
+    let thread_store = cx.new(|cx| ThreadStore::new(cx));
+    let agent = cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs, cx));
+    let connection = Rc::new(NativeAgentConnection(agent.clone()));
+
+    let acp_thread = cx
+        .update(|cx| {
+            connection.clone().new_session(
+                project.clone(),
+                PathList::new(&[Path::new("/test")]),
+                cx,
+            )
+        })
+        .await
+        .expect("new session should succeed");
+    let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+
+    let selector = connection
+        .model_selector(&session_id)
+        .expect("model selector should exist");
+    let initial_model = cx
+        .update(|cx| selector.selected_model(cx))
+        .await
+        .expect("initial selected model should be available");
+    assert_eq!(initial_model.id.0.as_ref(), "test-provider/global-model");
+    let mut updates = cx.update(|cx| selector.watch(cx).expect("watch receiver should exist"));
+
+    let thread = agent.read_with(cx, |agent, _| {
+        agent
+            .sessions
+            .get(&session_id)
+            .expect("session should exist")
+            .thread
+            .clone()
+    });
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("profile-b".into()), cx);
+    });
+
+    let timeout = cx.background_executor.timer(Duration::from_secs(5));
+    futures::select! {
+        update = updates.recv().fuse() => {
+            update.expect("profile switch should notify model selector watchers");
+        }
+        _ = timeout.fuse() => {
+            panic!("timed out waiting for model selector watch after switching profiles");
+        }
+    }
+
+    let selected_model = cx
+        .update(|cx| selector.selected_model(cx))
+        .await
+        .expect("selected model should be available");
+    assert_eq!(selected_model.id.0.as_ref(), "test-provider/profile-model");
+}
+
+#[gpui::test]
+async fn test_profile_without_default_model_persists_across_reload(cx: &mut TestAppContext) {
+    init_test(cx);
+    let (global_selection, profile_selection, global_model, _profile_model) =
+        install_test_language_models_with_handles(cx);
+    override_profile_and_global_models(global_selection, Some(profile_selection), cx);
+    insert_test_profile("profile-b", "Profile B", None, cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/test", json!({})).await;
+    let project = Project::test(fs.clone(), [Path::new("/test")], cx).await;
+    let thread_store = cx.new(|cx| ThreadStore::new(cx));
+    let agent = cx.update(|cx| {
+        NativeAgent::new(thread_store.clone(), Templates::new(), None, fs.clone(), cx)
+    });
+    let connection = Rc::new(NativeAgentConnection(agent.clone()));
+
+    let acp_thread = cx
+        .update(|cx| {
+            connection.clone().new_session(
+                project.clone(),
+                PathList::new(&[Path::new("/test")]),
+                cx,
+            )
+        })
+        .await
+        .expect("new session should succeed");
+    let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+    let thread = agent.read_with(cx, |agent, _| {
+        agent
+            .sessions
+            .get(&session_id)
+            .expect("session should exist")
+            .thread
+            .clone()
+    });
+
+    let send = thread
+        .update(cx, |thread, cx| {
+            thread.send(UserMessageId::new(), ["hello"], cx)
+        })
+        .expect("send should start");
+    cx.run_until_parked();
+    global_model.send_last_completion_stream_text_chunk("done");
+    global_model.end_last_completion_stream();
+    send.collect::<Vec<_>>().await;
+    cx.run_until_parked();
+
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("profile-b".into()), cx);
+    });
+    cx.run_until_parked();
+
+    cx.update(|cx| connection.clone().close_session(&session_id, cx))
+        .await
+        .expect("close should succeed");
+
+    let reopened_acp_thread = agent
+        .update(cx, |agent, cx| {
+            agent.open_thread(session_id.clone(), project.clone(), cx)
+        })
+        .await
+        .expect("reopen should succeed");
+    let reopened_thread = agent.read_with(cx, |agent, _| {
+        agent
+            .sessions
+            .get(&session_id)
+            .expect("reopened session should exist")
+            .thread
+            .clone()
+    });
+
+    reopened_thread.read_with(cx, |thread, _| {
+        assert_eq!(thread.profile().as_str(), "profile-b");
+        let model = thread.model().expect("saved model should be restored");
+        assert_eq!(model.id().0.as_ref(), "global-model");
+    });
+
+    drop(reopened_acp_thread);
 }
 
 struct ThreadTest {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1044,20 +1044,15 @@ impl Thread {
         action_log: Entity<ActionLog>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let settings = AgentSettings::get_global(cx);
-        let profile_id = settings.default_profile.clone();
-        let enable_thinking = settings
-            .default_model
+        let profile_id = AgentSettings::get_global(cx).default_profile.clone();
+        let default_selection = Self::default_model_selection(&profile_id, cx);
+        let enable_thinking = default_selection
             .as_ref()
             .is_some_and(|model| model.enable_thinking);
-        let thinking_effort = settings
-            .default_model
+        let thinking_effort = default_selection
             .as_ref()
             .and_then(|model| model.effort.clone());
-        let speed = settings
-            .default_model
-            .as_ref()
-            .and_then(|model| model.speed);
+        let speed = default_selection.as_ref().and_then(|model| model.speed);
         let (prompt_capabilities_tx, prompt_capabilities_rx) =
             watch::channel(Self::prompt_capabilities(model.as_deref()));
         Self {
@@ -1273,7 +1268,6 @@ impl Thread {
                     };
                     registry.select_model(&model, cx)
                 })
-                .or_else(|| registry.default_model())
                 .map(|model| model.model)
         });
 
@@ -1441,6 +1435,7 @@ impl Thread {
                 .ok();
         }
 
+        cx.emit(ModelChanged);
         cx.notify()
     }
 
@@ -1604,14 +1599,20 @@ impl Thread {
         self.profile_id = profile_id.clone();
 
         // Swap to the profile's preferred model when available.
+        let mut notified = false;
         if let Some(model) = Self::resolve_profile_model(&self.profile_id, cx) {
             self.set_model(model, cx);
+            notified = true;
         }
 
         for subagent in &self.running_subagents {
             subagent
                 .update(cx, |thread, cx| thread.set_profile(profile_id.clone(), cx))
                 .ok();
+        }
+
+        if !notified {
+            cx.notify();
         }
     }
 
@@ -1732,6 +1733,20 @@ impl Thread {
             .default_model
             .clone()?;
         Self::resolve_model_from_selection(&selection, cx)
+    }
+
+    /// Keep startup reasoning defaults aligned with the same profile-or-global selection used for
+    /// the thread's default model.
+    fn default_model_selection(
+        profile_id: &AgentProfileId,
+        cx: &App,
+    ) -> Option<LanguageModelSelection> {
+        let settings = AgentSettings::get_global(cx);
+        settings
+            .profiles
+            .get(profile_id)
+            .and_then(|profile| profile.default_model.clone())
+            .or_else(|| settings.default_model.clone())
     }
 
     /// Translate a stored model selection into the configured model from the registry.
@@ -3177,6 +3192,10 @@ impl RunningTurn {
 pub struct TokenUsageUpdated(pub Option<acp_thread::TokenUsage>);
 
 impl EventEmitter<TokenUsageUpdated> for Thread {}
+
+pub struct ModelChanged;
+
+impl EventEmitter<ModelChanged> for Thread {}
 
 pub struct TitleUpdated;
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -5145,8 +5145,10 @@ mod tests {
         active_session_id, active_thread_id, open_thread_with_connection,
         open_thread_with_custom_connection, send_message,
     };
+    use crate::thread_metadata_store::{ThreadId, ThreadMetadata, WorktreePaths};
     use acp_thread::{AgentConnection, StubAgentConnection, ThreadStatus, UserMessageId};
     use action_log::ActionLog;
+    use agent::{NativeAgent, NativeAgentConnection, Templates};
     use agent_servers::CODEX_ID;
     use anyhow::Result;
     use feature_flags::FeatureFlagAppExt;
@@ -5430,6 +5432,120 @@ mod tests {
         });
     }
 
+    #[gpui::test]
+    #[ignore = "requires native agent server filesystem access in the test harness"]
+    async fn test_native_thread_session_round_trip_with_thread_store(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            cx.update_flags(true, vec!["agent-v2".to_string()]);
+            agent::ThreadStore::init_global(cx);
+            agent_settings::AgentSettings::register(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            project::DisableAiSettings::register(cx);
+            language::language_settings::AllLanguageSettings::register(cx);
+            prompt_store::init(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/test", json!({})).await;
+        cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+        let project = Project::test(fs.clone(), [Path::new("/test")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let workspace_id = workspace
+            .read_with(cx, |workspace, _cx| workspace.database_id())
+            .expect("workspace should have a database id");
+
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+        let thread_store = cx.update(|_, cx| agent::ThreadStore::global(cx));
+        let agent = cx
+            .update(|_, cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+        let connection = Rc::new(NativeAgentConnection(agent.clone()));
+        let work_dirs = PathList::new(&[Path::new("/test")]);
+        let acp_thread = cx
+            .update(|_, cx| {
+                connection
+                    .clone()
+                    .new_session(project.clone(), work_dirs.clone(), cx)
+            })
+            .await
+            .expect("new native session should succeed");
+        let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+        let native_thread = cx
+            .update(|_, cx| connection.thread(&session_id, cx))
+            .expect("native thread should exist");
+
+        let db_thread = native_thread
+            .update(cx, |thread, cx| thread.to_db(cx))
+            .await;
+        let thread_title = db_thread.title.to_string();
+        let metadata = ThreadMetadata {
+            thread_id: ThreadId::new(),
+            session_id: Some(session_id.clone()),
+            agent_id: agent::ZED_AGENT_ID.clone(),
+            title: Some(db_thread.title.clone()),
+            updated_at: db_thread.updated_at,
+            created_at: Some(db_thread.updated_at),
+            worktree_paths: WorktreePaths::from_folder_paths(&work_dirs),
+            remote_connection: None,
+            archived: false,
+        };
+        let save_task = cx.update(|_, cx| {
+            let thread_store = agent::ThreadStore::global(cx);
+            thread_store.update(cx, |store, cx| {
+                store.save_thread(session_id.clone(), db_thread, work_dirs.clone(), cx)
+            })
+        });
+        save_task
+            .await
+            .expect("thread should save to the thread store");
+        cx.update(|_, cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.save(metadata, cx);
+            });
+        });
+        let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
+        save_serialized_panel(
+            workspace_id,
+            SerializedAgentPanel {
+                selected_agent: Some(Agent::NativeAgent),
+                last_active_thread: Some(SerializedActiveThread {
+                    session_id: Some(session_id.0.to_string()),
+                    agent_type: Agent::NativeAgent,
+                    title: Some(thread_title),
+                    work_dirs: Some(work_dirs.serialize()),
+                }),
+                draft_thread_prompt: None,
+            },
+            kvp,
+        )
+        .await
+        .expect("panel state should save");
+
+        let async_cx = cx.update(|window, cx| window.to_async(cx));
+        let loaded_panel = AgentPanel::load(workspace.downgrade(), async_cx)
+            .await
+            .expect("panel load should succeed");
+        cx.run_until_parked();
+
+        loaded_panel.read_with(cx, |panel, cx| {
+            let restored_thread = panel
+                .active_agent_thread(cx)
+                .expect("native thread should be restored after load");
+            assert_eq!(restored_thread.read(cx).session_id(), &session_id);
+        });
+    }
+
+    // Simple regression test
     #[gpui::test]
     async fn test_non_native_thread_without_metadata_is_not_restored(cx: &mut TestAppContext) {
         init_test(cx);

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -708,7 +708,12 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         }
     }
 
-    let default = settings.default_model.as_ref().map(to_selected_model);
+    let default = settings
+        .profiles
+        .get(&settings.default_profile)
+        .and_then(|profile| profile.default_model.as_ref())
+        .or(settings.default_model.as_ref())
+        .map(to_selected_model);
     let inline_assistant = settings
         .inline_assistant_model
         .as_ref()
@@ -739,15 +744,110 @@ fn update_active_language_model_from_settings(cx: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use acp_thread::AgentConnection;
+    use agent::{NativeAgent, NativeAgentConnection, Templates, ThreadStore};
+    use agent_settings::AgentProfileSettings;
     use agent_settings::{AgentProfileId, AgentSettings};
     use command_palette_hooks::CommandPaletteFilter;
     use db::kvp::KeyValueStore;
     use editor::actions::AcceptEditPrediction;
+    use fs::FakeFs;
     use gpui::{BorrowAppContext, TestAppContext, px};
-    use project::DisableAiSettings;
-    use settings::{
-        DockPosition, NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, Settings, SettingsStore,
+    use language_model::fake_provider::{FakeLanguageModel, FakeLanguageModelProvider};
+    use language_model::{
+        LanguageModelProviderId, LanguageModelProviderName, LanguageModelRegistry,
     };
+    use project::DisableAiSettings;
+    use project::Project;
+    use serde_json::json;
+    use settings::{
+        DockPosition, LanguageModelProviderSetting, NotifyWhenAgentWaiting, PlaySoundWhenAgentDone,
+        Settings, SettingsStore,
+    };
+    use std::path::Path;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    fn init_agent_settings_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let store = SettingsStore::test(cx);
+            cx.set_global(store);
+            AgentSettings::register(cx);
+            DisableAiSettings::register(cx);
+            AllLanguageSettings::register(cx);
+            LanguageModelRegistry::test(cx);
+        });
+    }
+
+    fn test_selection(provider: &str, model: &str) -> LanguageModelSelection {
+        LanguageModelSelection {
+            provider: LanguageModelProviderSetting(provider.to_string()),
+            model: model.to_string(),
+            enable_thinking: false,
+            effort: None,
+            speed: None,
+        }
+    }
+
+    fn install_test_language_models(
+        cx: &mut TestAppContext,
+    ) -> (LanguageModelSelection, LanguageModelSelection) {
+        let provider_id = "test-provider";
+        let global_selection = test_selection(provider_id, "global-model");
+        let profile_selection = test_selection(provider_id, "profile-model");
+
+        cx.update(|cx| {
+            let provider = Arc::new(
+                FakeLanguageModelProvider::new(
+                    LanguageModelProviderId::from(provider_id.to_string()),
+                    LanguageModelProviderName::from("Test Provider".to_string()),
+                )
+                .with_models(vec![
+                    Arc::new(FakeLanguageModel::with_id_and_thinking(
+                        provider_id,
+                        "global-model",
+                        "Global Model",
+                        false,
+                    )),
+                    Arc::new(FakeLanguageModel::with_id_and_thinking(
+                        provider_id,
+                        "profile-model",
+                        "Profile Model",
+                        false,
+                    )),
+                ]),
+            );
+
+            LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+                registry.register_provider(provider, cx);
+            });
+        });
+
+        (global_selection, profile_selection)
+    }
+
+    fn override_profile_and_global_models(
+        global_selection: LanguageModelSelection,
+        profile_selection: Option<LanguageModelSelection>,
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let mut settings = AgentSettings::get_global(cx).clone();
+            settings.default_profile = AgentProfileId("profile-a".into());
+            settings.default_model = Some(global_selection);
+            settings.profiles.insert(
+                AgentProfileId("profile-a".into()),
+                AgentProfileSettings {
+                    name: "Profile A".into(),
+                    tools: Default::default(),
+                    enable_all_context_servers: false,
+                    context_servers: Default::default(),
+                    default_model: profile_selection,
+                },
+            );
+            AgentSettings::override_global(settings, cx);
+        });
+    }
 
     #[gpui::test]
     fn test_agent_command_palette_visibility(cx: &mut TestAppContext) {
@@ -973,6 +1073,86 @@ mod tests {
         );
     }
 
+    #[gpui::test]
+    fn test_update_active_language_model_from_settings_prefers_profile_default(
+        cx: &mut TestAppContext,
+    ) {
+        init_agent_settings_test(cx);
+        let (global_selection, profile_selection) = install_test_language_models(cx);
+        override_profile_and_global_models(global_selection, Some(profile_selection), cx);
+
+        cx.update(update_active_language_model_from_settings);
+
+        cx.update(|cx| {
+            let default_model = LanguageModelRegistry::read_global(cx)
+                .default_model()
+                .expect("registry default model should be set");
+            assert_eq!(default_model.model.id().0.as_ref(), "profile-model");
+        });
+    }
+
+    #[gpui::test]
+    fn test_update_active_language_model_from_settings_falls_back_to_global_default(
+        cx: &mut TestAppContext,
+    ) {
+        init_agent_settings_test(cx);
+        let (global_selection, _profile_selection) = install_test_language_models(cx);
+        override_profile_and_global_models(global_selection, None, cx);
+
+        cx.update(update_active_language_model_from_settings);
+
+        cx.update(|cx| {
+            let default_model = LanguageModelRegistry::read_global(cx)
+                .default_model()
+                .expect("registry default model should be set");
+            assert_eq!(default_model.model.id().0.as_ref(), "global-model");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_new_session_uses_profile_default_model_after_registry_sync(
+        cx: &mut TestAppContext,
+    ) {
+        init_agent_settings_test(cx);
+        let (global_selection, profile_selection) = install_test_language_models(cx);
+        override_profile_and_global_models(global_selection, Some(profile_selection), cx);
+        cx.update(update_active_language_model_from_settings);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/test", json!({})).await;
+        let project = Project::test(fs.clone(), [Path::new("/test")], cx).await;
+
+        let thread_store = cx.update(|cx| {
+            ThreadStore::init_global(cx);
+            ThreadStore::global(cx)
+        });
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+        let connection = Rc::new(NativeAgentConnection(agent.clone()));
+        let acp_thread = cx
+            .update(|cx| {
+                connection.clone().new_session(
+                    project.clone(),
+                    util::path_list::PathList::new(&[Path::new("/test")]),
+                    cx,
+                )
+            })
+            .await
+            .expect("new session should succeed");
+        let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+
+        let selected_model = cx
+            .update(|cx| {
+                connection
+                    .model_selector(&session_id)
+                    .expect("model selector should exist")
+                    .selected_model(cx)
+            })
+            .await
+            .expect("selected model should be available");
+
+        assert_eq!(selected_model.id.0.as_ref(), "test-provider/profile-model");
+    }
     #[test]
     fn test_deserialize_external_agent_variants() {
         assert_eq!(

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -478,7 +478,7 @@ impl LanguageModelRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fake_provider::FakeLanguageModelProvider;
+    use crate::fake_provider::{FakeLanguageModel, FakeLanguageModelProvider};
 
     #[gpui::test]
     fn test_register_providers(cx: &mut App) {
@@ -656,5 +656,151 @@ mod tests {
         });
 
         assert_eq!(registry.read(cx).visible_providers().len(), 1);
+    }
+
+    #[gpui::test]
+    fn test_auxiliary_models_fall_back_to_default_model(cx: &mut App) {
+        let registry = cx.new(|_| LanguageModelRegistry::default());
+        let provider_id = LanguageModelProviderId::from("test-provider".to_string());
+        let provider = Arc::new(
+            FakeLanguageModelProvider::new(
+                provider_id.clone(),
+                crate::LanguageModelProviderName::from("Test Provider".to_string()),
+            )
+            .with_models(vec![
+                Arc::new(FakeLanguageModel::with_id_and_thinking(
+                    "test-provider",
+                    "default-model",
+                    "Default Model",
+                    false,
+                )),
+                Arc::new(FakeLanguageModel::with_id_and_thinking(
+                    "test-provider",
+                    "alternate-model",
+                    "Alternate Model",
+                    false,
+                )),
+            ]),
+        );
+
+        registry.update(cx, |registry, cx| {
+            registry.register_provider(provider, cx);
+            registry.select_default_model(
+                Some(&SelectedModel {
+                    provider: provider_id.clone(),
+                    model: LanguageModelId::from("default-model".to_string()),
+                }),
+                cx,
+            );
+        });
+
+        let registry = registry.read(cx);
+        assert_eq!(
+            registry
+                .inline_assistant_model()
+                .expect("inline assistant should fall back to the default model")
+                .model
+                .id()
+                .0
+                .as_ref(),
+            "default-model"
+        );
+        assert_eq!(
+            registry
+                .commit_message_model(cx)
+                .expect("commit message should fall back to the default model")
+                .model
+                .id()
+                .0
+                .as_ref(),
+            "default-model"
+        );
+        assert_eq!(
+            registry
+                .thread_summary_model(cx)
+                .expect("thread summary should fall back to the default model")
+                .model
+                .id()
+                .0
+                .as_ref(),
+            "default-model"
+        );
+    }
+
+    #[gpui::test]
+    fn test_auxiliary_models_prefer_explicit_overrides(cx: &mut App) {
+        let registry = cx.new(|_| LanguageModelRegistry::default());
+        let provider_id = LanguageModelProviderId::from("test-provider".to_string());
+        let provider = Arc::new(
+            FakeLanguageModelProvider::new(
+                provider_id.clone(),
+                crate::LanguageModelProviderName::from("Test Provider".to_string()),
+            )
+            .with_models(vec![
+                Arc::new(FakeLanguageModel::with_id_and_thinking(
+                    "test-provider",
+                    "default-model",
+                    "Default Model",
+                    false,
+                )),
+                Arc::new(FakeLanguageModel::with_id_and_thinking(
+                    "test-provider",
+                    "alternate-model",
+                    "Alternate Model",
+                    false,
+                )),
+            ]),
+        );
+
+        registry.update(cx, |registry, cx| {
+            registry.register_provider(provider, cx);
+            registry.select_default_model(
+                Some(&SelectedModel {
+                    provider: provider_id.clone(),
+                    model: LanguageModelId::from("default-model".to_string()),
+                }),
+                cx,
+            );
+
+            let explicit = SelectedModel {
+                provider: provider_id.clone(),
+                model: LanguageModelId::from("alternate-model".to_string()),
+            };
+            registry.select_inline_assistant_model(Some(&explicit), cx);
+            registry.select_commit_message_model(Some(&explicit), cx);
+            registry.select_thread_summary_model(Some(&explicit), cx);
+        });
+
+        let registry = registry.read(cx);
+        assert_eq!(
+            registry
+                .inline_assistant_model()
+                .expect("inline assistant override should be returned")
+                .model
+                .id()
+                .0
+                .as_ref(),
+            "alternate-model"
+        );
+        assert_eq!(
+            registry
+                .commit_message_model(cx)
+                .expect("commit message override should be returned")
+                .model
+                .id()
+                .0
+                .as_ref(),
+            "alternate-model"
+        );
+        assert_eq!(
+            registry
+                .thread_summary_model(cx)
+                .expect("thread summary override should be returned")
+                .model
+                .id()
+                .0
+                .as_ref(),
+            "alternate-model"
+        );
     }
 }


### PR DESCRIPTION
- Keep new agent sessions aligned with the active profile's default model for `enable_thinking` and `effort` instead of always reading the global default.
- Make the agent UI prefer the active profile's default model on startup while preserving stored thinking state when reloading saved threads.
- Add regression coverage for profile-default restoration and for auxiliary model fallback behavior in the language model registry.

## Supporting evidences included
### Current settings
```
...
"agent": {
    "default_model": {
      "provider": "openrouter",
      "model": "arcee-ai/trinity-large-thinking",
      "enable_thinking": true,
    },
...
"profiles": {
      "ask": {
        "name": "Ask",
        "default_model": {
          "model": "openai/gpt-5.4-mini",
          "provider": "openrouter",
          "effort": "high",
        },
...
"write": {
        "name": "Write",
        "default_model": {
          "provider": "openrouter",
          "model": "openai/gpt-5.4-nano",
        },
```

### On profile change right model has been selected
<img width="673" height="129" alt="image" src="https://github.com/user-attachments/assets/40e59f45-4eb5-4b89-aac6-1309f432129c" />
<img width="675" height="129" alt="image" src="https://github.com/user-attachments/assets/f015652f-39cc-476a-afaf-0dea0e8f1553" />

### Existing thread behavior
Started a conversation with a different model
<img width="674" height="128" alt="image" src="https://github.com/user-attachments/assets/24a31288-fe3f-425f-9311-185e756962da" />

Started a new zed agent which used last profile with profile's default model
<img width="673" height="164" alt="image" src="https://github.com/user-attachments/assets/910e232d-1f5a-48ad-bd30-f492863d1f8d" />

Went back to previous conversation. Last profile and model has been restored from the database
<img width="677" height="773" alt="image" src="https://github.com/user-attachments/assets/5b67eb12-46eb-46b2-9c92-65231f96af60" />

### A video overview of previous actions
https://github.com/user-attachments/assets/9d6de8d0-5fd7-49ce-a010-7f07fbdc864e

### Complete restart behavior
https://github.com/user-attachments/assets/462dfd75-7bb1-4042-aa69-4c6288ff914f

Fixes #48451 

Release Notes:
- Fixed agent profile defaults being ignored on startup or reload for model selection and reasoning settings.