### PR TITLE
agent_ui: Add padding to markdown output in card layout

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7411,9 +7411,8 @@ impl ThreadView {
             .gap_2()
             .map(|this| {
                 if card_layout {
-                    this.when(context_ix > 0, |this| {
-                        this.pt_2()
-                            .border_t_1()
+                    this.p_2().when(context_ix > 0, |this| {
+                        this.border_t_1()
                             .border_color(self.tool_card_border_color(cx))
                     })
                 } else {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53191

Release Notes:

- Added padding to markdown output when rendered in card layout.

Before:
<img width="627" height="437" alt="Screenshot 2026-04-01 at 3 32" src="https://github.com/user-attachments/assets/6fbd31f0-80b5-4c63-b9a4-d151bd28cf31" />

After:
<img width="666" height="400" alt="Screenshot 2026-04-05 at 4 47 38 PM" src="https://github.com/user-attachments/assets/3128532a-bfcf-4308-aec5-3981201001ab" />