### PR TITLE
debugger: Add hover tree UI

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -973,6 +973,20 @@
     },
   },
   {
+    "context": "Editor && DebuggerHover && VimControl && (vim_mode == normal || vim_mode == helix_normal)",
+    "bindings": {
+      "escape": "editor::Cancel",
+      "h": "editor::DebuggerHoverCollapseSelected",
+      "j": "editor::DebuggerHoverSelectNext",
+      "k": "editor::DebuggerHoverSelectPrevious",
+      "l": "editor::DebuggerHoverExpandSelected",
+      "left": "editor::DebuggerHoverCollapseSelected",
+      "down": "editor::DebuggerHoverSelectNext",
+      "up": "editor::DebuggerHoverSelectPrevious",
+      "right": "editor::DebuggerHoverExpandSelected"
+    }
+  },
+  {
     // netrw compatibility
     "context": "ProjectPanel && not_editing",
     "bindings": {

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -21,6 +21,8 @@ mod dap_logger;
 #[cfg(test)]
 mod debugger_panel;
 #[cfg(test)]
+mod hover_values;
+#[cfg(test)]
 mod inline_values;
 #[cfg(test)]
 mod module_list;

--- a/crates/debugger_ui/src/tests/hover_values.rs
+++ b/crates/debugger_ui/src/tests/hover_values.rs
@@ -1,0 +1,678 @@
+use dap::{
+    StackFrame, Variable,
+    requests::{Evaluate, Scopes, StackTrace, Threads, Variables},
+};
+use editor::{
+    Editor, EditorMode, MultiBuffer, MultiBufferOffset, SelectionEffects,
+    actions::{
+        Cancel as CancelAction, DebuggerHoverExpandSelected, DebuggerHoverSelectNext,
+        Hover as HoverAction,
+    },
+};
+use gpui::{BackgroundExecutor, Focusable as _, Modifiers, TestAppContext, VisualTestContext};
+use language::rust_lang;
+use project::{FakeFs, Project};
+use serde_json::json;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use util::path;
+
+use crate::{
+    debugger_panel::DebugPanel,
+    tests::{init_test, init_test_workspace, start_debug_session},
+};
+
+const SOURCE: &str =
+    "fn main() {\n    let value = 42;\n    let x = value + 1;\n    println!(\"{}\", x);\n}\n";
+
+fn trigger_hover(editor: &gpui::Entity<Editor>, cx: &mut VisualTestContext, offset: usize) {
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selection| {
+            selection.select_ranges([MultiBufferOffset(offset)..MultiBufferOffset(offset)])
+        });
+        editor::hover_popover::hover(editor, &HoverAction, window, cx);
+    });
+}
+
+fn focus_editor(editor: &gpui::Entity<Editor>, cx: &mut VisualTestContext) {
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+    });
+}
+
+fn editor_has_focus(editor: &gpui::Entity<Editor>, cx: &mut VisualTestContext) -> bool {
+    cx.update(|window, app| {
+        editor.read_with(app, |editor, cx| editor.focus_handle(cx).is_focused(window))
+    })
+}
+
+fn hover_uses_keyboard_grace<C: gpui::AppContext>(editor: &gpui::Entity<Editor>, cx: &C) -> bool {
+    editor.read_with(cx, |editor, _| {
+        editor
+            .hover_state
+            .info_popovers
+            .first()
+            .is_some_and(|popover| *popover.keyboard_grace.borrow())
+    })
+}
+
+fn hover_is_visible<C: gpui::AppContext>(editor: &gpui::Entity<Editor>, cx: &C) -> bool {
+    editor.read_with(cx, |editor, _| editor.hover_state.visible())
+}
+
+fn hover_has_markdown_content<C: gpui::AppContext>(editor: &gpui::Entity<Editor>, cx: &C) -> bool {
+    editor.read_with(cx, |editor, _| {
+        editor
+            .hover_state
+            .info_popovers
+            .first()
+            .is_some_and(|popover| popover.parsed_content.is_some())
+    })
+}
+
+#[gpui::test]
+async fn test_hover_values_after_debugger_stop_when_hover_is_retriggered(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(path!("/project"), json!({ "main.rs": SOURCE }))
+        .await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    workspace
+        .update(cx, |workspace, window, cx| {
+            workspace.focus_panel::<DebugPanel>(window, cx)
+        })
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+    client.on_request::<StackTrace, _>(move |_, _| {
+        Ok(dap::StackTraceResponse {
+            stack_frames: vec![StackFrame {
+                id: 1,
+                name: "Stack Frame 1".into(),
+                source: Some(dap::Source {
+                    name: Some("main.rs".into()),
+                    path: Some(path!("/project/main.rs").into()),
+                    source_reference: None,
+                    presentation_hint: None,
+                    origin: None,
+                    sources: None,
+                    adapter_data: None,
+                    checksums: None,
+                }),
+                line: 3,
+                column: 1,
+                end_line: None,
+                end_column: None,
+                can_restart: None,
+                instruction_pointer_reference: None,
+                module_id: None,
+                presentation_hint: None,
+            }],
+            total_frames: None,
+        })
+    });
+    client.on_request::<Scopes, _>(move |_, _| Ok(dap::ScopesResponse { scopes: vec![] }));
+    client.on_request::<Evaluate, _>(move |_, args| {
+        assert_eq!(args.expression, "value");
+        assert_eq!(args.context, Some(dap::EvaluateArgumentsContext::Hover));
+        Ok(dap::EvaluateResponse {
+            result: "42".into(),
+            type_: Some("i32".into()),
+            presentation_hint: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+            value_location_reference: None,
+        })
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/project/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+    cx.run_until_parked();
+
+    let (editor, editor_cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer.clone(), cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    editor_cx.run_until_parked();
+
+    let hover_offset = SOURCE.find("value + 1").unwrap();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+    assert!(editor_cx.debug_bounds("debugger-hover-node-root").is_none());
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    editor_cx.run_until_parked();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+
+    assert!(
+        editor_cx.debug_bounds("debugger-hover-node-root").is_some(),
+        "expected visible debugger hover tree after stop"
+    );
+    assert!(
+        editor_cx
+            .debug_bounds("debugger-hover-toggle-root")
+            .is_none(),
+        "expected scalar hover to render without a disclosure toggle"
+    );
+    assert!(
+        !hover_has_markdown_content(&editor, editor_cx),
+        "expected debugger hover to render without the old markdown value block"
+    );
+    let root_bounds = editor_cx
+        .debug_bounds("debugger-hover-node-root")
+        .expect("expected debugger hover root bounds");
+    assert!(
+        root_bounds.size.width >= gpui::px(300.),
+        "expected debugger hover to reserve enough width for its columns, got {:?}",
+        root_bounds.size.width
+    );
+    let value_bounds = editor_cx
+        .debug_bounds("debugger-hover-node-root-value-container")
+        .expect("expected debugger hover value bounds");
+    assert!(
+        value_bounds.size.width >= gpui::px(48.),
+        "expected debugger hover to keep short values visible"
+    );
+}
+
+#[gpui::test]
+async fn test_hover_values_load_children_on_expand(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(executor);
+    let source = format!(
+        "fn main() {{\n{}{indent}let value = 42;\n{indent}let x = value + 1;\n}}\n",
+        "\n".repeat(20),
+        indent = "    "
+    );
+    fs.insert_tree(path!("/project"), json!({ "main.rs": source }))
+        .await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    workspace
+        .update(cx, |workspace, window, cx| {
+            workspace.focus_panel::<DebugPanel>(window, cx)
+        })
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+    client.on_request::<StackTrace, _>(move |_, _| {
+        Ok(dap::StackTraceResponse {
+            stack_frames: vec![StackFrame {
+                id: 1,
+                name: "Stack Frame 1".into(),
+                source: Some(dap::Source {
+                    name: Some("main.rs".into()),
+                    path: Some(path!("/project/main.rs").into()),
+                    source_reference: None,
+                    presentation_hint: None,
+                    origin: None,
+                    sources: None,
+                    adapter_data: None,
+                    checksums: None,
+                }),
+                line: 3,
+                column: 1,
+                end_line: None,
+                end_column: None,
+                can_restart: None,
+                instruction_pointer_reference: None,
+                module_id: None,
+                presentation_hint: None,
+            }],
+            total_frames: None,
+        })
+    });
+    client.on_request::<Scopes, _>(move |_, _| Ok(dap::ScopesResponse { scopes: vec![] }));
+    client.on_request::<Evaluate, _>(move |_, args| {
+        assert_eq!(args.expression, "value");
+        assert_eq!(args.context, Some(dap::EvaluateArgumentsContext::Hover));
+        Ok(dap::EvaluateResponse {
+            result: "Point { x: 42 }".into(),
+            type_: Some("Point".into()),
+            presentation_hint: None,
+            variables_reference: 1,
+            named_variables: Some(1),
+            indexed_variables: None,
+            memory_reference: None,
+            value_location_reference: None,
+        })
+    });
+
+    let variables_request_count = Arc::new(AtomicUsize::new(0));
+    client.on_request::<Variables, _>({
+        let variables_request_count = variables_request_count.clone();
+        move |_, args| {
+            variables_request_count.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(args.variables_reference, 1);
+            Ok(dap::VariablesResponse {
+                variables: vec![Variable {
+                    name: "x".into(),
+                    value: "42".into(),
+                    type_: Some("i32".into()),
+                    presentation_hint: None,
+                    evaluate_name: None,
+                    variables_reference: 0,
+                    named_variables: None,
+                    indexed_variables: None,
+                    memory_reference: None,
+                    declaration_location_reference: None,
+                    value_location_reference: None,
+                }],
+            })
+        }
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/project/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+    cx.run_until_parked();
+
+    let (editor, editor_cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer.clone(), cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    editor_cx.run_until_parked();
+    focus_editor(&editor, editor_cx);
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    editor_cx.run_until_parked();
+    editor_cx.simulate_resize(gpui::size(gpui::px(320.), gpui::px(110.)));
+
+    let hover_offset = source.find("value + 1").unwrap();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+
+    assert!(editor_cx.debug_bounds("debugger-hover-node-root").is_some());
+    assert!(editor_cx.debug_bounds("debugger-hover-node-0").is_none());
+    assert_eq!(variables_request_count.load(Ordering::SeqCst), 0);
+    assert!(editor_has_focus(&editor, editor_cx));
+    assert!(hover_uses_keyboard_grace(&editor, editor_cx));
+
+    let root_bounds = editor_cx
+        .debug_bounds("debugger-hover-node-root")
+        .expect("expected root hover row bounds");
+    editor_cx.simulate_click(root_bounds.center(), Modifiers::none());
+    editor_cx.refresh().unwrap();
+    editor_cx.run_until_parked();
+
+    let expanded_root_bounds = editor_cx
+        .debug_bounds("debugger-hover-node-root")
+        .expect("expected root hover row bounds after expanding");
+
+    assert_eq!(variables_request_count.load(Ordering::SeqCst), 1);
+    assert!(editor_cx.debug_bounds("debugger-hover-node-0").is_some());
+    assert_eq!(
+        root_bounds.origin, expanded_root_bounds.origin,
+        "expected debugger hover root row to stay in place when expanding"
+    );
+    assert!(editor_has_focus(&editor, editor_cx));
+    assert!(!hover_uses_keyboard_grace(&editor, editor_cx));
+
+    editor.update_in(editor_cx, |editor, window, cx| {
+        editor.cancel(&CancelAction, window, cx);
+    });
+    editor_cx.refresh().unwrap();
+    editor_cx.run_until_parked();
+
+    assert!(!hover_is_visible(&editor, editor_cx));
+}
+
+#[gpui::test]
+async fn test_hover_values_expand_with_keyboard_action(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(path!("/project"), json!({ "main.rs": SOURCE }))
+        .await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    workspace
+        .update(cx, |workspace, window, cx| {
+            workspace.focus_panel::<DebugPanel>(window, cx)
+        })
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+    client.on_request::<StackTrace, _>(move |_, _| {
+        Ok(dap::StackTraceResponse {
+            stack_frames: vec![StackFrame {
+                id: 1,
+                name: "Stack Frame 1".into(),
+                source: Some(dap::Source {
+                    name: Some("main.rs".into()),
+                    path: Some(path!("/project/main.rs").into()),
+                    source_reference: None,
+                    presentation_hint: None,
+                    origin: None,
+                    sources: None,
+                    adapter_data: None,
+                    checksums: None,
+                }),
+                line: 3,
+                column: 1,
+                end_line: None,
+                end_column: None,
+                can_restart: None,
+                instruction_pointer_reference: None,
+                module_id: None,
+                presentation_hint: None,
+            }],
+            total_frames: None,
+        })
+    });
+    client.on_request::<Scopes, _>(move |_, _| Ok(dap::ScopesResponse { scopes: vec![] }));
+    client.on_request::<Evaluate, _>(move |_, args| {
+        assert_eq!(args.expression, "value");
+        assert_eq!(args.context, Some(dap::EvaluateArgumentsContext::Hover));
+        Ok(dap::EvaluateResponse {
+            result: "Point { x: 42 }".into(),
+            type_: Some("Point".into()),
+            presentation_hint: None,
+            variables_reference: 1,
+            named_variables: Some(1),
+            indexed_variables: None,
+            memory_reference: None,
+            value_location_reference: None,
+        })
+    });
+    client.on_request::<Variables, _>(move |_, args| {
+        assert_eq!(args.variables_reference, 1);
+        Ok(dap::VariablesResponse {
+            variables: vec![Variable {
+                name: "x".into(),
+                value: "42".into(),
+                type_: Some("i32".into()),
+                presentation_hint: None,
+                evaluate_name: None,
+                variables_reference: 0,
+                named_variables: None,
+                indexed_variables: None,
+                memory_reference: None,
+                declaration_location_reference: None,
+                value_location_reference: None,
+            }],
+        })
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/project/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+    cx.run_until_parked();
+
+    let (editor, editor_cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer.clone(), cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    editor_cx.run_until_parked();
+    focus_editor(&editor, editor_cx);
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    editor_cx.run_until_parked();
+    let hover_offset = SOURCE.find("value + 1").unwrap();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+
+    assert!(hover_uses_keyboard_grace(&editor, editor_cx));
+    assert!(editor_cx.debug_bounds("debugger-hover-node-0").is_none());
+
+    editor_cx.dispatch_action(DebuggerHoverExpandSelected);
+    editor_cx.run_until_parked();
+
+    assert!(editor_cx.debug_bounds("debugger-hover-node-0").is_some());
+}
+
+#[gpui::test]
+async fn test_hover_values_keyboard_selection_scrolls_into_view(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(path!("/project"), json!({ "main.rs": SOURCE }))
+        .await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    workspace
+        .update(cx, |workspace, window, cx| {
+            workspace.focus_panel::<DebugPanel>(window, cx)
+        })
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+    client.on_request::<StackTrace, _>(move |_, _| {
+        Ok(dap::StackTraceResponse {
+            stack_frames: vec![StackFrame {
+                id: 1,
+                name: "Stack Frame 1".into(),
+                source: Some(dap::Source {
+                    name: Some("main.rs".into()),
+                    path: Some(path!("/project/main.rs").into()),
+                    source_reference: None,
+                    presentation_hint: None,
+                    origin: None,
+                    sources: None,
+                    adapter_data: None,
+                    checksums: None,
+                }),
+                line: 3,
+                column: 1,
+                end_line: None,
+                end_column: None,
+                can_restart: None,
+                instruction_pointer_reference: None,
+                module_id: None,
+                presentation_hint: None,
+            }],
+            total_frames: None,
+        })
+    });
+    client.on_request::<Scopes, _>(move |_, _| Ok(dap::ScopesResponse { scopes: vec![] }));
+    client.on_request::<Evaluate, _>(move |_, args| {
+        assert_eq!(args.expression, "value");
+        assert_eq!(args.context, Some(dap::EvaluateArgumentsContext::Hover));
+        Ok(dap::EvaluateResponse {
+            result: "Point { x: 42 }".into(),
+            type_: Some("Point".into()),
+            presentation_hint: None,
+            variables_reference: 1,
+            named_variables: Some(10),
+            indexed_variables: None,
+            memory_reference: None,
+            value_location_reference: None,
+        })
+    });
+    client.on_request::<Variables, _>(move |_, args| {
+        assert_eq!(args.variables_reference, 1);
+        Ok(dap::VariablesResponse {
+            variables: (0..10)
+                .map(|index| Variable {
+                    name: format!("field_{index}"),
+                    value: format!("{index}"),
+                    type_: Some("i32".into()),
+                    presentation_hint: None,
+                    evaluate_name: None,
+                    variables_reference: 0,
+                    named_variables: None,
+                    indexed_variables: None,
+                    memory_reference: None,
+                    declaration_location_reference: None,
+                    value_location_reference: None,
+                })
+                .collect(),
+        })
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/project/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+    cx.run_until_parked();
+
+    let (editor, editor_cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer.clone(), cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    editor_cx.run_until_parked();
+    focus_editor(&editor, editor_cx);
+    editor_cx.simulate_resize(gpui::size(gpui::px(320.), gpui::px(110.)));
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    editor_cx.run_until_parked();
+    let hover_offset = SOURCE.find("value + 1").unwrap();
+    trigger_hover(&editor, editor_cx, hover_offset);
+    editor_cx.run_until_parked();
+    editor_cx.dispatch_action(DebuggerHoverExpandSelected);
+    editor_cx.run_until_parked();
+
+    let initial_scroll_offset = editor.update(editor_cx, |editor, _| {
+        editor.hover_state.info_popovers[0].scroll_handle.offset()
+    });
+
+    for _ in 0..8 {
+        editor_cx.dispatch_action(DebuggerHoverSelectNext);
+        editor_cx.run_until_parked();
+    }
+
+    let final_scroll_offset = editor.update(editor_cx, |editor, _| {
+        editor.hover_state.info_popovers[0].scroll_handle.offset()
+    });
+
+    assert!(
+        final_scroll_offset.y < initial_scroll_offset.y,
+        "expected debugger hover to scroll downward as selection moves out of view"
+    );
+}

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -622,6 +622,14 @@ actions!(
         HalfPageUp,
         /// Shows hover information for the symbol at cursor.
         Hover,
+        /// Expands the selected debugger hover entry.
+        DebuggerHoverExpandSelected,
+        /// Collapses the selected debugger hover entry.
+        DebuggerHoverCollapseSelected,
+        /// Selects the next debugger hover entry.
+        DebuggerHoverSelectNext,
+        /// Selects the previous debugger hover entry.
+        DebuggerHoverSelectPrevious,
         /// Increases indentation of selected lines.
         Indent,
         /// Inserts a UUID v4 at cursor position.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2695,6 +2695,10 @@ impl Editor {
             key_context.add("showing_signature_help");
         }
 
+        if self.hover_state.keyboard_debugger_hover_active() {
+            key_context.add("DebuggerHover");
+        }
+
         // Disable vim contexts when a sub-editor (e.g. rename/inline assistant) is focused.
         if !self.focus_handle(cx).contains_focused(window, cx)
             || (self.is_focused(window) || self.mouse_menu_is_focused(window, cx))

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -292,6 +292,10 @@ impl EditorElement {
         register_action(editor, window, Editor::select_page_up);
         register_action(editor, window, Editor::cancel);
         register_action(editor, window, Editor::blame_hover);
+        register_action(editor, window, Editor::debugger_hover_expand_selected);
+        register_action(editor, window, Editor::debugger_hover_collapse_selected);
+        register_action(editor, window, Editor::debugger_hover_select_next);
+        register_action(editor, window, Editor::debugger_hover_select_previous);
         register_action(editor, window, Editor::next_snippet_tabstop);
         register_action(editor, window, Editor::previous_snippet_tabstop);
         register_action(editor, window, Editor::copy);
@@ -4366,7 +4370,7 @@ impl EditorElement {
 
         let mut overall_height = Pixels::ZERO;
 
-        let measured_hover_popovers = hover_popovers
+        let mut measured_hover_popovers = hover_popovers
             .into_iter()
             .with_position()
             .map(|(position, mut hover_popover)| {
@@ -4388,6 +4392,14 @@ impl EditorElement {
                 }
             })
             .collect::<Vec<_>>();
+
+        let (is_single_debugger_hover, stable_debugger_hover_origin) = {
+            let editor = self.editor.read(cx);
+            (
+                editor.hover_state.is_single_debugger_hover(),
+                editor.hover_state.stable_debugger_hover_origin(),
+            )
+        };
 
         fn draw_occluder(
             width: Pixels,
@@ -4470,7 +4482,7 @@ impl EditorElement {
             })
         };
 
-        let can_place_below = || {
+        let can_place_below = {
             let mut current_y = hovered_point.y + line_height;
             measured_hover_popovers.iter().all(|popover| {
                 let size = popover.size;
@@ -4481,10 +4493,35 @@ impl EditorElement {
             })
         };
 
+        if is_single_debugger_hover
+            && measured_hover_popovers.len() == 1
+            && let Some(popover) = measured_hover_popovers.pop()
+        {
+            let popover_origin = stable_debugger_hover_origin.unwrap_or_else(|| {
+                if can_place_below {
+                    point(
+                        hovered_point.x + popover.horizontal_offset,
+                        hovered_point.y + line_height,
+                    )
+                } else {
+                    point(
+                        hovered_point.x + popover.horizontal_offset,
+                        hovered_point.y - popover.size.height,
+                    )
+                }
+            });
+
+            window.defer_draw(popover.element, popover_origin, 2, None);
+            self.editor.update(cx, |editor, _| {
+                editor.hover_state.stable_debugger_hover_origin = Some(popover_origin);
+            });
+            return;
+        }
+
         if can_place_above {
             // try placing above hovered point
             place_popovers_above(hovered_point, measured_hover_popovers, window, cx);
-        } else if can_place_below() {
+        } else if can_place_below {
             // try placing below hovered point
             place_popovers_below(
                 hovered_point,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -7,28 +7,35 @@ use crate::{
     movement::TextLayoutDetails,
     scroll::ScrollAmount,
 };
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow};
+use dap::client::SessionId;
 use gpui::{
     AnyElement, App, AsyncWindowContext, Bounds, Context, Entity, Focusable as _, FontWeight, Hsla,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, Pixels, ScrollHandle, Size,
-    StatefulInteractiveElement, StyleRefinement, Styled, Subscription, Task, TaskExt,
-    TextStyleRefinement, Window, canvas, div, px,
+    InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels,
+    ScrollHandle, Size, StatefulInteractiveElement, StyleRefinement, Styled, Subscription, Task,
+    TaskExt, TextStyleRefinement, WeakEntity, Window, canvas, div, px,
 };
 use itertools::Itertools;
 use language::{DiagnosticEntry, Language, LanguageRegistry};
 use lsp::DiagnosticSeverity;
 use markdown::{CopyButtonVisibility, Markdown, MarkdownElement, MarkdownStyle};
 use multi_buffer::{MultiBufferOffset, ToOffset, ToPoint};
-use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart};
+use project::{
+    DebuggerHoverData, DebuggerHoverVariable, HoverBlock, HoverBlockKind, InlayHintLabelPart,
+    Project,
+};
 use settings::Settings;
 use std::{
     borrow::Cow,
     cell::{Cell, RefCell},
+    collections::HashMap,
 };
 use std::{ops::Range, sync::Arc, time::Duration};
 use std::{path::PathBuf, rc::Rc};
 use theme_settings::ThemeSettings;
-use ui::{CopyButton, Scrollbars, WithScrollbar, prelude::*, theme_is_transparent};
+use ui::{
+    CopyButton, Disclosure, Scrollbars, Tooltip, WithScrollbar, prelude::*, theme_is_transparent,
+};
 use url::Url;
 use util::TryFutureExt;
 use workspace::{OpenOptions, OpenVisible, Workspace};
@@ -201,6 +208,7 @@ pub fn hover_at_inlay(
                     .await;
                 this.update(cx, |this, _| {
                     this.hover_state.diagnostic_popover = None;
+                    this.hover_state.stable_debugger_hover_origin = None;
                 })?;
 
                 let language_registry = project.read_with(cx, |p, _| p.languages().clone());
@@ -221,15 +229,17 @@ pub fn hover_at_inlay(
                 let hover_popover = InfoPopover {
                     symbol_range: RangeInEditor::Inlay(inlay_hover.range.clone()),
                     parsed_content,
+                    debugger_hover: None,
                     scroll_handle,
                     keyboard_grace: Rc::new(RefCell::new(false)),
                     anchor: None,
                     last_bounds: Rc::new(Cell::new(None)),
-                    _subscription: subscription,
+                    _subscriptions: subscription.into_iter().collect(),
                 };
 
                 this.update(cx, |this, cx| {
                     // TODO: no background highlights happen for inlays currently
+                    this.hover_state.stable_debugger_hover_origin = None;
                     this.hover_state.info_popovers = vec![hover_popover];
                     cx.notify();
                 })?;
@@ -255,6 +265,7 @@ pub fn hide_hover(editor: &mut Editor, cx: &mut Context<Editor>) -> bool {
     editor.hover_state.info_task = None;
     editor.hover_state.hiding_delay_task = None;
     editor.hover_state.closest_mouse_distance = None;
+    editor.hover_state.stable_debugger_hover_origin = None;
 
     editor.clear_background_highlights(HighlightKey::HoverState, cx);
 
@@ -291,6 +302,7 @@ fn show_hover(
     let language_registry = editor
         .project()
         .map(|project| project.read(cx).languages().clone());
+    let debugger_project = editor.project().map(|project| project.downgrade());
     let provider = editor.semantics_provider.clone()?;
 
     editor.hover_state.hiding_delay_task = None;
@@ -468,35 +480,42 @@ fn show_hover(
             } else {
                 Vec::new()
             };
+            let show_debugger_hover_only = hovers_response
+                .iter()
+                .any(|hover_result| hover_result.debugger_value.is_some());
             let snapshot = this.update_in(cx, |this, window, cx| this.snapshot(window, cx))?;
             let mut hover_highlights = Vec::with_capacity(hovers_response.len());
             let mut info_popovers = Vec::with_capacity(
                 hovers_response.len() + if invisible_char.is_some() { 1 } else { 0 },
             );
 
-            if let Some((invisible, range)) = invisible_char {
+            if !show_debugger_hover_only && let Some((invisible, range)) = invisible_char {
                 let blocks = vec![HoverBlock {
                     text: format!("Unicode character U+{:02X}", invisible as u32),
                     kind: HoverBlockKind::PlainText,
                 }];
                 let parsed_content = parse_blocks(&blocks, language_registry.as_ref(), None, cx);
                 let scroll_handle = ScrollHandle::new();
-                let subscription = this
+                let subscriptions = this
                     .update(cx, |_, cx| {
-                        parsed_content.as_ref().map(|parsed_content| {
-                            cx.observe(parsed_content, |_, _, cx| cx.notify())
-                        })
+                        parsed_content
+                            .as_ref()
+                            .map(|parsed_content| {
+                                vec![cx.observe(parsed_content, |_, _, cx| cx.notify())]
+                            })
+                            .unwrap_or_default()
                     })
                     .ok()
-                    .flatten();
+                    .unwrap_or_default();
                 info_popovers.push(InfoPopover {
                     symbol_range: RangeInEditor::Text(range),
                     parsed_content,
+                    debugger_hover: None,
                     scroll_handle,
                     keyboard_grace: Rc::new(RefCell::new(ignore_timeout)),
                     anchor: Some(anchor),
                     last_bounds: Rc::new(Cell::new(None)),
-                    _subscription: subscription,
+                    _subscriptions: subscriptions,
                 })
             }
 
@@ -522,9 +541,19 @@ fn show_hover(
             };
 
             for hover_result in hovers_response {
+                if show_debugger_hover_only && hover_result.debugger_value.is_none() {
+                    continue;
+                }
+
+                let project::Hover {
+                    contents: blocks,
+                    range: hover_range,
+                    language,
+                    debugger_value,
+                } = hover_result;
+
                 // Create symbol range of anchors for highlighting and filtering of future requests.
-                let range = hover_result
-                    .range
+                let range = hover_range
                     .and_then(|range| {
                         let range = snapshot
                             .buffer_snapshot()
@@ -538,55 +567,71 @@ fn show_hover(
                     })
                     .unwrap_or_else(|| anchor..anchor);
 
-                let blocks = hover_result.contents;
-                let language = hover_result.language;
-                let parsed_content =
-                    parse_blocks(&blocks, language_registry.as_ref(), language, cx);
+                let parsed_content = if show_debugger_hover_only {
+                    None
+                } else {
+                    parse_blocks(&blocks, language_registry.as_ref(), language, cx)
+                };
+                let debugger_hover =
+                    build_debugger_hover_view(debugger_value, debugger_project.clone(), cx);
+                if parsed_content.is_none() && debugger_hover.is_none() {
+                    continue;
+                }
                 let scroll_handle = ScrollHandle::new();
                 hover_highlights.push(range.clone());
-                let subscription = this
+                let subscriptions = this
                     .update(cx, |_, cx| {
-                        parsed_content.as_ref().map(|parsed_content| {
-                            cx.observe(parsed_content, |_, _, cx| cx.notify())
-                        })
+                        let mut subscriptions = Vec::new();
+                        if let Some(parsed_content) = parsed_content.as_ref() {
+                            subscriptions.push(cx.observe(parsed_content, |_, _, cx| cx.notify()));
+                        }
+                        if let Some(debugger_hover) = debugger_hover.as_ref() {
+                            subscriptions.push(cx.observe(debugger_hover, |_, _, cx| cx.notify()));
+                        }
+                        subscriptions
                     })
                     .ok()
-                    .flatten();
+                    .unwrap_or_default();
                 info_popovers.push(InfoPopover {
                     symbol_range: RangeInEditor::Text(range),
                     parsed_content,
+                    debugger_hover,
                     scroll_handle,
                     keyboard_grace: Rc::new(RefCell::new(ignore_timeout)),
                     anchor: Some(anchor),
                     last_bounds: Rc::new(Cell::new(None)),
-                    _subscription: subscription,
+                    _subscriptions: subscriptions,
                 });
             }
 
-            for (multi_buffer_range, tooltip) in doc_link_tooltips {
-                let blocks = vec![HoverBlock {
-                    text: tooltip.to_string(),
-                    kind: HoverBlockKind::Markdown,
-                }];
-                let parsed_content = parse_blocks(&blocks, language_registry.as_ref(), None, cx);
-                let scroll_handle = ScrollHandle::new();
-                let subscription = this
-                    .update(cx, |_, cx| {
-                        parsed_content.as_ref().map(|parsed_content| {
-                            cx.observe(parsed_content, |_, _, cx| cx.notify())
+            if !show_debugger_hover_only {
+                for (multi_buffer_range, tooltip) in doc_link_tooltips {
+                    let blocks = vec![HoverBlock {
+                        text: tooltip.to_string(),
+                        kind: HoverBlockKind::Markdown,
+                    }];
+                    let parsed_content =
+                        parse_blocks(&blocks, language_registry.as_ref(), None, cx);
+                    let scroll_handle = ScrollHandle::new();
+                    let subscription = this
+                        .update(cx, |_, cx| {
+                            parsed_content.as_ref().map(|parsed_content| {
+                                cx.observe(parsed_content, |_, _, cx| cx.notify())
+                            })
                         })
-                    })
-                    .ok()
-                    .flatten();
-                info_popovers.push(InfoPopover {
-                    symbol_range: RangeInEditor::Text(multi_buffer_range),
-                    parsed_content,
-                    scroll_handle,
-                    keyboard_grace: Rc::new(RefCell::new(ignore_timeout)),
-                    anchor: Some(anchor),
-                    last_bounds: Rc::new(Cell::new(None)),
-                    _subscription: subscription,
-                });
+                        .ok()
+                        .flatten();
+                    info_popovers.push(InfoPopover {
+                        symbol_range: RangeInEditor::Text(multi_buffer_range),
+                        parsed_content,
+                        debugger_hover: None,
+                        scroll_handle,
+                        keyboard_grace: Rc::new(RefCell::new(ignore_timeout)),
+                        anchor: Some(anchor),
+                        last_bounds: Rc::new(Cell::new(None)),
+                        _subscriptions: subscription.into_iter().collect(),
+                    });
+                }
             }
 
             this.update_in(cx, |editor, window, cx| {
@@ -602,6 +647,10 @@ fn show_hover(
                     );
                 }
 
+                if show_debugger_hover_only {
+                    editor.hover_state.diagnostic_popover = None;
+                }
+                editor.hover_state.stable_debugger_hover_origin = None;
                 editor.hover_state.info_popovers = info_popovers;
                 cx.notify();
                 window.refresh();
@@ -672,6 +721,10 @@ fn parse_blocks(
         })
         .join("\n\n");
 
+    if combined_text.trim().is_empty() {
+        return None;
+    }
+
     cx.new_window_entity(|_window, cx| {
         Markdown::new(
             combined_text.into(),
@@ -681,6 +734,552 @@ fn parse_blocks(
         )
     })
     .ok()
+}
+
+fn build_debugger_hover_view(
+    debugger_value: Option<DebuggerHoverData>,
+    project: Option<WeakEntity<Project>>,
+    cx: &mut AsyncWindowContext,
+) -> Option<Entity<DebuggerHoverView>> {
+    let debugger_value = debugger_value?;
+
+    cx.new_window_entity(|_window, _cx| DebuggerHoverView::new(debugger_value, project))
+        .ok()
+}
+
+enum DebuggerHoverChildren {
+    Unsupported,
+    Unloaded,
+    Loading,
+    Loaded(Vec<DebuggerHoverNode>),
+    Failed(String),
+}
+
+struct DebuggerHoverNode {
+    variable: DebuggerHoverVariable,
+    is_expanded: bool,
+    children: DebuggerHoverChildren,
+    load_task: Option<Task<()>>,
+}
+
+impl DebuggerHoverNode {
+    fn new(variable: DebuggerHoverVariable) -> Self {
+        let children = if variable.has_children() {
+            DebuggerHoverChildren::Unloaded
+        } else {
+            DebuggerHoverChildren::Unsupported
+        };
+
+        Self {
+            variable,
+            is_expanded: false,
+            children,
+            load_task: None,
+        }
+    }
+
+    fn has_children(&self) -> bool {
+        self.variable.has_children()
+    }
+}
+
+struct DebuggerHoverView {
+    project: Option<WeakEntity<Project>>,
+    session_id: SessionId,
+    root: DebuggerHoverNode,
+    selected_path: Vec<usize>,
+    row_bounds: Rc<RefCell<HashMap<Vec<usize>, Bounds<Pixels>>>>,
+}
+
+struct DebuggerHoverVariableColors {
+    name: Option<Hsla>,
+    value: Option<Hsla>,
+    type_name: Option<Hsla>,
+}
+
+const DEBUGGER_HOVER_NAME_FLEX_BASIS: f32 = 0.36;
+const DEBUGGER_HOVER_MIN_WIDTH: Pixels = px(320.0);
+const DEBUGGER_HOVER_VALUE_MIN_WIDTH: Pixels = px(48.0);
+const DEBUGGER_HOVER_ROOT_TYPE_MAX_WIDTH: Pixels = px(120.0);
+
+impl DebuggerHoverView {
+    fn new(debugger_value: DebuggerHoverData, project: Option<WeakEntity<Project>>) -> Self {
+        Self {
+            project,
+            session_id: debugger_value.session_id,
+            root: DebuggerHoverNode::new(debugger_value.root),
+            selected_path: Vec::new(),
+            row_bounds: Rc::new(RefCell::new(HashMap::default())),
+        }
+    }
+
+    fn node_mut(&mut self, path: &[usize]) -> Option<&mut DebuggerHoverNode> {
+        let mut node = &mut self.root;
+        for index in path {
+            match &mut node.children {
+                DebuggerHoverChildren::Loaded(children) => node = children.get_mut(*index)?,
+                DebuggerHoverChildren::Unsupported
+                | DebuggerHoverChildren::Unloaded
+                | DebuggerHoverChildren::Loading
+                | DebuggerHoverChildren::Failed(_) => return None,
+            }
+        }
+
+        Some(node)
+    }
+
+    fn toggle_node(&mut self, path: Vec<usize>, cx: &mut Context<Self>) {
+        let Some(node) = self.node_mut(&path) else {
+            return;
+        };
+
+        if !node.has_children() {
+            return;
+        }
+
+        node.is_expanded = !node.is_expanded;
+        let should_load = node.is_expanded
+            && matches!(
+                node.children,
+                DebuggerHoverChildren::Unloaded | DebuggerHoverChildren::Failed(_)
+            );
+        let variables_reference = node.variable.variables_reference;
+        if should_load {
+            node.children = DebuggerHoverChildren::Loading;
+        }
+
+        cx.notify();
+
+        if should_load {
+            self.load_children(path, variables_reference, cx);
+        }
+    }
+
+    fn load_children(
+        &mut self,
+        path: Vec<usize>,
+        variables_reference: u64,
+        cx: &mut Context<Self>,
+    ) {
+        let project = self.project.clone();
+        let session_id = self.session_id;
+        let Some(node) = self.node_mut(&path) else {
+            return;
+        };
+
+        node.load_task = Some(cx.spawn(async move |this, cx| {
+            let result = match project {
+                Some(project) => match project.update(cx, |project, cx| {
+                    project.load_debugger_hover_children(session_id, variables_reference, cx)
+                }) {
+                    Ok(task) => task.await.map_err(|error| error.to_string()),
+                    Err(error) => Err(error.to_string()),
+                },
+                None => Err(anyhow!("project is no longer available").to_string()),
+            };
+
+            this.update(cx, |this, cx| {
+                let Some(node) = this.node_mut(&path) else {
+                    return;
+                };
+
+                node.load_task.take();
+                node.children = match result {
+                    Ok(children) => DebuggerHoverChildren::Loaded(
+                        children.into_iter().map(DebuggerHoverNode::new).collect(),
+                    ),
+                    Err(error) => DebuggerHoverChildren::Failed(error),
+                };
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn visible_paths(&self) -> Vec<Vec<usize>> {
+        fn collect(node: &DebuggerHoverNode, path: &mut Vec<usize>, out: &mut Vec<Vec<usize>>) {
+            out.push(path.clone());
+
+            if !node.is_expanded {
+                return;
+            }
+
+            if let DebuggerHoverChildren::Loaded(children) = &node.children {
+                for (index, child) in children.iter().enumerate() {
+                    path.push(index);
+                    collect(child, path, out);
+                    path.pop();
+                }
+            }
+        }
+
+        let mut out = Vec::new();
+        collect(&self.root, &mut Vec::new(), &mut out);
+        out
+    }
+
+    fn select_path(&mut self, path: Vec<usize>, cx: &mut Context<Self>) {
+        self.selected_path = path;
+        cx.notify();
+    }
+
+    fn select_next(&mut self, cx: &mut Context<Self>) {
+        let visible_paths = self.visible_paths();
+        let Some(index) = visible_paths
+            .iter()
+            .position(|path| path == &self.selected_path)
+        else {
+            self.selected_path = Vec::new();
+            cx.notify();
+            return;
+        };
+
+        if let Some(path) = visible_paths.get(index + 1) {
+            self.selected_path = path.clone();
+            cx.notify();
+        }
+    }
+
+    fn select_previous(&mut self, cx: &mut Context<Self>) {
+        let visible_paths = self.visible_paths();
+        let Some(index) = visible_paths
+            .iter()
+            .position(|path| path == &self.selected_path)
+        else {
+            self.selected_path = Vec::new();
+            cx.notify();
+            return;
+        };
+
+        if let Some(path) = index
+            .checked_sub(1)
+            .and_then(|previous_index| visible_paths.get(previous_index))
+        {
+            self.selected_path = path.clone();
+            cx.notify();
+        }
+    }
+
+    fn expand_selected(&mut self, cx: &mut Context<Self>) {
+        let path = self.selected_path.clone();
+        let Some(node) = self.node_mut(&path) else {
+            return;
+        };
+
+        if !node.has_children() {
+            return;
+        }
+
+        if !node.is_expanded {
+            self.toggle_node(path, cx);
+            return;
+        }
+
+        if let DebuggerHoverChildren::Loaded(children) = &node.children
+            && !children.is_empty()
+        {
+            let mut child_path = path;
+            child_path.push(0);
+            self.selected_path = child_path;
+            cx.notify();
+        }
+    }
+
+    fn collapse_selected(&mut self, cx: &mut Context<Self>) {
+        let path = self.selected_path.clone();
+        let Some(node) = self.node_mut(&path) else {
+            return;
+        };
+
+        if node.is_expanded {
+            self.toggle_node(path, cx);
+            return;
+        }
+
+        if !self.selected_path.is_empty() {
+            self.selected_path.pop();
+            cx.notify();
+        }
+    }
+
+    fn selected_row_bounds(&self) -> Option<Bounds<Pixels>> {
+        self.row_bounds.borrow().get(&self.selected_path).copied()
+    }
+
+    fn render_entries(
+        &self,
+        node: &DebuggerHoverNode,
+        depth: usize,
+        path: &[usize],
+        cx: &mut Context<Self>,
+    ) -> Vec<AnyElement> {
+        let mut entries = vec![self.render_node(node, depth, path, cx)];
+
+        if node.is_expanded {
+            match &node.children {
+                DebuggerHoverChildren::Loaded(children) => {
+                    for (index, child) in children.iter().enumerate() {
+                        let mut child_path = path.to_vec();
+                        child_path.push(index);
+                        entries.extend(self.render_entries(child, depth + 1, &child_path, cx));
+                    }
+                }
+                DebuggerHoverChildren::Loading => {
+                    entries.push(self.render_status_row("Loading…", depth + 1, cx));
+                }
+                DebuggerHoverChildren::Failed(error) => {
+                    entries.push(self.render_status_row(error, depth + 1, cx));
+                }
+                DebuggerHoverChildren::Unsupported | DebuggerHoverChildren::Unloaded => {}
+            }
+        }
+
+        entries
+    }
+
+    fn render_status_row(&self, message: &str, depth: usize, cx: &mut Context<Self>) -> AnyElement {
+        div()
+            .w_full()
+            .min_h_5()
+            .pl(px(depth as f32 * 14.0 + 18.0))
+            .pr_1()
+            .flex()
+            .items_center()
+            .text_ui_sm(cx)
+            .font_buffer(cx)
+            .child(
+                Label::new(message.to_string())
+                    .single_line()
+                    .truncate()
+                    .color(Color::Muted),
+            )
+            .into_any_element()
+    }
+
+    fn render_node(
+        &self,
+        node: &DebuggerHoverNode,
+        depth: usize,
+        path: &[usize],
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let path = path.to_vec();
+        let row_selector = debugger_hover_row_selector(&path);
+        let toggle_selector = debugger_hover_toggle_selector(&path);
+        let value_container_selector = format!("{row_selector}-value-container");
+        let is_expandable = node.has_children();
+        let is_selected = self.selected_path == path;
+        let variable_colors = debugger_hover_variable_colors(cx);
+        let row_bounds = self.row_bounds.clone();
+        let row_bounds_path = path.clone();
+
+        div()
+            .w_full()
+            .debug_selector(|| row_selector.clone())
+            .rounded_sm()
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        row_bounds
+                            .borrow_mut()
+                            .insert(row_bounds_path.clone(), bounds);
+                    },
+                    |_, _, _, _| {},
+                )
+                .absolute()
+                .size_full(),
+            )
+            .when(!is_expandable, |this| {
+                this.on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener({
+                        let path = path.clone();
+                        move |this, _: &MouseDownEvent, _window, cx| {
+                            this.select_path(path.clone(), cx);
+                        }
+                    }),
+                )
+            })
+            .when(is_expandable, |this| {
+                this.cursor_pointer().on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener({
+                        let path = path.clone();
+                        move |this, _: &MouseDownEvent, window, cx| {
+                            window.prevent_default();
+                            this.select_path(path.clone(), cx);
+                            this.toggle_node(path.clone(), cx)
+                        }
+                    }),
+                )
+            })
+            .child(
+                h_flex()
+                    .w_full()
+                    .min_h_5()
+                    .items_center()
+                    .gap_1()
+                    .rounded_sm()
+                    .px_1()
+                    .when(is_selected, |this| {
+                        this.bg(cx.theme().colors().ghost_element_selected)
+                    })
+                    .hover(|style| style.bg(cx.theme().colors().ghost_element_hover))
+                    .pl(px(depth as f32 * 14.0))
+                    .child(if is_expandable {
+                        div()
+                            .debug_selector(|| toggle_selector.clone())
+                            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                            .child(
+                                Disclosure::new(toggle_selector.clone(), node.is_expanded)
+                                    .on_click(cx.listener({
+                                        let path = path.clone();
+                                        move |this, _, window, cx| {
+                                            window.prevent_default();
+                                            this.toggle_node(path.clone(), cx)
+                                        }
+                                    })),
+                            )
+                            .into_any_element()
+                    } else {
+                        div().w_4().flex_none().into_any_element()
+                    })
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .min_w_0()
+                            .gap_0p5()
+                            .text_ui_sm(cx)
+                            .font_buffer(cx)
+                            .child(
+                                div()
+                                    .id(format!("{row_selector}-name"))
+                                    .min_w_0()
+                                    .flex_grow_1()
+                                    .flex_shrink_1()
+                                    .flex_basis(gpui::relative(DEBUGGER_HOVER_NAME_FLEX_BASIS))
+                                    .overflow_hidden()
+                                    .tooltip(Tooltip::text(node.variable.name.clone()))
+                                    .child(
+                                        Label::new(node.variable.name.clone())
+                                            .single_line()
+                                            .truncate()
+                                            .when_some(variable_colors.name, |this, color| {
+                                                this.color(Color::from(color))
+                                            }),
+                                    ),
+                            )
+                            .child(
+                                h_flex()
+                                    .debug_selector(move || value_container_selector.clone())
+                                    .min_w(DEBUGGER_HOVER_VALUE_MIN_WIDTH)
+                                    .flex_shrink_1()
+                                    .overflow_hidden()
+                                    .gap_0p5()
+                                    .child(Label::new("=").single_line().color(Color::Muted))
+                                    .child(
+                                        div()
+                                            .id(format!("{row_selector}-value"))
+                                            .min_w_0()
+                                            .overflow_hidden()
+                                            .tooltip(Tooltip::text(node.variable.value.clone()))
+                                            .child(
+                                                Label::new(node.variable.value.clone())
+                                                    .single_line()
+                                                    .truncate()
+                                                    .color(Color::Muted)
+                                                    .when_some(
+                                                        variable_colors.value,
+                                                        |this, color| {
+                                                            this.color(Color::from(color))
+                                                        },
+                                                    ),
+                                            ),
+                                    ),
+                            )
+                            .children(
+                                debugger_hover_type_suffix(
+                                    depth,
+                                    node.variable.type_name.as_deref(),
+                                )
+                                .map(|type_name| {
+                                    div()
+                                        .min_w_0()
+                                        .max_w(DEBUGGER_HOVER_ROOT_TYPE_MAX_WIDTH)
+                                        .flex_shrink_1()
+                                        .overflow_hidden()
+                                        .child(
+                                            Label::new(type_name)
+                                                .single_line()
+                                                .truncate_start()
+                                                .color(Color::Muted)
+                                                .when_some(
+                                                    variable_colors.type_name,
+                                                    |this, color| this.color(Color::from(color)),
+                                                ),
+                                        )
+                                }),
+                            ),
+                    ),
+            )
+            .into_any_element()
+    }
+}
+
+fn debugger_hover_variable_colors(cx: &App) -> DebuggerHoverVariableColors {
+    let syntax = cx.theme().syntax();
+    let colors = cx.theme().colors();
+    let syntax_color_for = |name| syntax.style_for_name(name).and_then(|style| style.color);
+
+    DebuggerHoverVariableColors {
+        name: syntax_color_for("variable").or(Some(colors.text)),
+        value: syntax_color_for("variable.special").or(Some(colors.text_accent)),
+        type_name: syntax_color_for("type").or(Some(colors.text_muted)),
+    }
+}
+
+fn debugger_hover_type_suffix(depth: usize, type_name: Option<&str>) -> Option<String> {
+    if depth > 0 {
+        return None;
+    }
+
+    type_name
+        .filter(|type_name| !type_name.is_empty())
+        .map(|type_name| format!(": {type_name}"))
+}
+
+impl Render for DebuggerHoverView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.row_bounds.borrow_mut().clear();
+        let rows = self.render_entries(&self.root, 0, &[], cx);
+        v_flex()
+            .id("debugger-hover-view")
+            .w_full()
+            .gap_0()
+            .children(rows)
+    }
+}
+
+fn debugger_hover_row_selector(path: &[usize]) -> String {
+    if path.is_empty() {
+        "debugger-hover-node-root".to_string()
+    } else {
+        format!(
+            "debugger-hover-node-{}",
+            path.iter().map(|index| index.to_string()).join("-")
+        )
+    }
+}
+
+fn debugger_hover_toggle_selector(path: &[usize]) -> String {
+    if path.is_empty() {
+        "debugger-hover-toggle-root".to_string()
+    } else {
+        format!(
+            "debugger-hover-toggle-{}",
+            path.iter().map(|index| index.to_string()).join("-")
+        )
+    }
 }
 
 pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
@@ -884,11 +1483,40 @@ pub struct HoverState {
     pub info_task: Option<Task<Option<()>>>,
     pub closest_mouse_distance: Option<Pixels>,
     pub hiding_delay_task: Option<Task<()>>,
+    pub stable_debugger_hover_origin: Option<gpui::Point<Pixels>>,
 }
 
 impl HoverState {
     pub fn visible(&self) -> bool {
         !self.info_popovers.is_empty() || self.diagnostic_popover.is_some()
+    }
+
+    pub fn is_single_debugger_hover(&self) -> bool {
+        let [info_popover] = self.info_popovers.as_slice() else {
+            return false;
+        };
+
+        self.diagnostic_popover.is_none()
+            && info_popover.debugger_hover.is_some()
+            && info_popover.parsed_content.is_none()
+    }
+
+    pub fn stable_debugger_hover_origin(&self) -> Option<gpui::Point<Pixels>> {
+        self.is_single_debugger_hover()
+            .then_some(self.stable_debugger_hover_origin)
+            .flatten()
+    }
+
+    fn keyboard_debugger_hover(&self) -> Option<Entity<DebuggerHoverView>> {
+        self.info_popovers.iter().find_map(|info_popover| {
+            (*info_popover.keyboard_grace.borrow())
+                .then_some(info_popover.debugger_hover.clone())
+                .flatten()
+        })
+    }
+
+    pub fn keyboard_debugger_hover_active(&self) -> bool {
+        self.keyboard_debugger_hover().is_some()
     }
 
     pub fn is_mouse_getting_closer(&mut self, mouse_position: gpui::Point<Pixels>) -> bool {
@@ -1041,14 +1669,103 @@ impl HoverState {
     }
 }
 
+impl Editor {
+    fn ensure_debugger_hover_selection_visible(&mut self, cx: &mut Context<Self>) {
+        let Some((debugger_hover, scroll_handle)) =
+            self.hover_state
+                .info_popovers
+                .iter()
+                .find_map(|info_popover| {
+                    if !*info_popover.keyboard_grace.borrow() {
+                        return None;
+                    }
+
+                    info_popover
+                        .debugger_hover
+                        .clone()
+                        .map(|debugger_hover| (debugger_hover, info_popover.scroll_handle.clone()))
+                })
+        else {
+            return;
+        };
+
+        let Some(selected_bounds) = debugger_hover.read(cx).selected_row_bounds() else {
+            return;
+        };
+        let viewport_bounds = scroll_handle.bounds();
+        let mut scroll_offset = scroll_handle.offset();
+        let initial_offset = scroll_offset;
+
+        if selected_bounds.top() < viewport_bounds.top() {
+            scroll_offset.y += viewport_bounds.top() - selected_bounds.top();
+        } else if selected_bounds.bottom() > viewport_bounds.bottom() {
+            scroll_offset.y += viewport_bounds.bottom() - selected_bounds.bottom();
+        }
+
+        if scroll_offset != initial_offset {
+            scroll_handle.set_offset(scroll_offset);
+            cx.notify();
+        }
+    }
+
+    pub fn debugger_hover_expand_selected(
+        &mut self,
+        _: &crate::actions::DebuggerHoverExpandSelected,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(debugger_hover) = self.hover_state.keyboard_debugger_hover() {
+            debugger_hover.update(cx, |debugger_hover, cx| debugger_hover.expand_selected(cx));
+        }
+    }
+
+    pub fn debugger_hover_collapse_selected(
+        &mut self,
+        _: &crate::actions::DebuggerHoverCollapseSelected,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(debugger_hover) = self.hover_state.keyboard_debugger_hover() {
+            debugger_hover.update(cx, |debugger_hover, cx| {
+                debugger_hover.collapse_selected(cx)
+            });
+        }
+    }
+
+    pub fn debugger_hover_select_next(
+        &mut self,
+        _: &crate::actions::DebuggerHoverSelectNext,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(debugger_hover) = self.hover_state.keyboard_debugger_hover() {
+            debugger_hover.update(cx, |debugger_hover, cx| debugger_hover.select_next(cx));
+            self.ensure_debugger_hover_selection_visible(cx);
+        }
+    }
+
+    pub fn debugger_hover_select_previous(
+        &mut self,
+        _: &crate::actions::DebuggerHoverSelectPrevious,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(debugger_hover) = self.hover_state.keyboard_debugger_hover() {
+            debugger_hover.update(cx, |debugger_hover, cx| debugger_hover.select_previous(cx));
+            self.ensure_debugger_hover_selection_visible(cx);
+        }
+    }
+}
+
 pub struct InfoPopover {
     pub symbol_range: RangeInEditor,
     pub parsed_content: Option<Entity<Markdown>>,
+    debugger_hover: Option<Entity<DebuggerHoverView>>,
     pub scroll_handle: ScrollHandle,
     pub keyboard_grace: Rc<RefCell<bool>>,
     pub anchor: Option<Anchor>,
     pub last_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
-    _subscription: Option<Subscription>,
+    _subscriptions: Vec<Subscription>,
 }
 
 impl InfoPopover {
@@ -1062,6 +1779,9 @@ impl InfoPopover {
         let this = cx.entity().downgrade();
         let this2 = this.clone();
         let bounds_cell = self.last_bounds.clone();
+        let parsed_content = self.parsed_content.clone();
+        let debugger_hover = self.debugger_hover.clone();
+        let debugger_hover_only = debugger_hover.is_some() && parsed_content.is_none();
         div()
             .id("info_popover")
             .occlude()
@@ -1095,43 +1815,70 @@ impl InfoPopover {
                 *keyboard_grace = false;
                 cx.stop_propagation();
             })
-            .when_some(self.parsed_content.clone(), |this, markdown| {
-                this.child(
-                    div()
-                        .id("info-md-container")
-                        .overflow_y_scroll()
-                        .max_w(max_size.width)
-                        .max_h(max_size.height)
-                        .track_scroll(&self.scroll_handle)
-                        .child(
-                            MarkdownElement::new(markdown, hover_markdown_style(window, cx))
-                                .scroll_handle(self.scroll_handle.clone())
-                                .code_block_renderer(markdown::CodeBlockRenderer::Default {
-                                    copy_button_visibility: CopyButtonVisibility::Hidden,
-                                    wrap_button_visibility: markdown::WrapButtonVisibility::Hidden,
-                                    border: false,
-                                })
-                                .on_url_click(move |link, window, cx| {
-                                    open_markdown_url(
-                                        this2
-                                            .read_with(cx, |editor, _| editor.workspace())
-                                            .ok()
-                                            .flatten(),
-                                        link,
-                                        window,
-                                        cx,
-                                    )
-                                })
-                                .p_2(),
-                        ),
-                )
-                .custom_scrollbars(
-                    Scrollbars::for_settings::<EditorSettingsScrollbarProxy>()
-                        .tracked_scroll_handle(&self.scroll_handle),
-                    window,
-                    cx,
-                )
-            })
+            .when(
+                parsed_content.is_some() || debugger_hover.is_some(),
+                |this| {
+                    this.child(
+                        div()
+                            .id("info-content-container")
+                            .overflow_y_scroll()
+                            .max_w(max_size.width)
+                            .max_h(max_size.height)
+                            .when(debugger_hover_only, |this| {
+                                this.min_w(DEBUGGER_HOVER_MIN_WIDTH.min(max_size.width))
+                            })
+                            .track_scroll(&self.scroll_handle)
+                            .child(
+                                v_flex()
+                                    .w_full()
+                                    .when(debugger_hover_only, |this| this.gap_0().p_1())
+                                    .when(!debugger_hover_only, |this| this.gap_2().p_2())
+                                    .when_some(debugger_hover, |this, debugger_hover| {
+                                        this.child(debugger_hover)
+                                    })
+                                    .when_some(parsed_content, |this, markdown| {
+                                        this.child(
+                                            MarkdownElement::new(
+                                                markdown,
+                                                hover_markdown_style(window, cx),
+                                            )
+                                            .scroll_handle(self.scroll_handle.clone())
+                                            .code_block_renderer(
+                                                markdown::CodeBlockRenderer::Default {
+                                                    copy_button_visibility:
+                                                        CopyButtonVisibility::Hidden,
+                                                    wrap_button_visibility:
+                                                        markdown::WrapButtonVisibility::Hidden,
+                                                    border: false,
+                                                },
+                                            )
+                                            .on_url_click(move |link, window, cx| {
+                                                open_markdown_url(
+                                                    this2
+                                                        .read_with(cx, |editor, _| {
+                                                            editor.workspace()
+                                                        })
+                                                        .ok()
+                                                        .flatten(),
+                                                    link,
+                                                    window,
+                                                    cx,
+                                                )
+                                            }),
+                                        )
+                                    }),
+                            )
+                            .when(!debugger_hover_only, |this| {
+                                this.custom_scrollbars(
+                                    Scrollbars::for_settings::<EditorSettingsScrollbarProxy>()
+                                        .tracked_scroll_handle(&self.scroll_handle),
+                                    window,
+                                    cx,
+                                )
+                            }),
+                    )
+                },
+            )
             .into_any_element()
     }
 
@@ -1272,19 +2019,29 @@ mod tests {
         actions::ConfirmCompletion,
         editor_tests::{handle_completion_request, init_test},
         inlays::inlay_hints::tests::{cached_hint_labels, visible_hint_labels},
-        test::editor_lsp_test_context::EditorLspTestContext,
+        test::{
+            editor_lsp_test_context::EditorLspTestContext, editor_test_context::EditorTestContext,
+        },
     };
-    use collections::BTreeSet;
+    use collections::{BTreeSet, HashMap, HashSet};
+    use futures::future::Shared;
     use futures::stream::StreamExt;
     use gpui::App;
     use indoc::indoc;
+    use language::{Buffer, BufferRow};
     use markdown::parser::MarkdownEvent;
-    use project::InlayId;
+    use project::{
+        DocumentHighlight, Hover as ProjectHover, InlayHint, InlayId, InvalidationStrategy,
+        LocationLink, ProjectTransaction,
+        lsp_store::{BufferSemanticTokens, CacheInlayHints, RefreshForServer},
+    };
     use settings::InlayHintSettingsContent;
     use settings::{DelayMs, SettingsStore};
     use std::sync::atomic;
     use std::sync::atomic::AtomicUsize;
+    use std::{ops::Range, rc::Rc, sync::Arc};
     use text::Bias;
+    use text::BufferId;
 
     fn get_hover_popover_delay(cx: &gpui::TestAppContext) -> u64 {
         cx.read(|cx: &App| -> u64 { EditorSettings::get_global(cx).hover_popover_delay.0 })
@@ -1328,6 +2085,109 @@ mod tests {
         assert!(!rendered.contains('\t'));
         // And the full rendering matches the source exactly.
         assert_eq!(rendered, text);
+    }
+
+    #[derive(Clone)]
+    struct TestHoverSemanticsProvider {
+        hover_response: Vec<ProjectHover>,
+    }
+
+    impl crate::SemanticsProvider for TestHoverSemanticsProvider {
+        fn hover(
+            &self,
+            _buffer: &Entity<Buffer>,
+            _position: text::Anchor,
+            _cx: &mut App,
+        ) -> Option<Task<Option<Vec<ProjectHover>>>> {
+            Some(Task::ready(Some(self.hover_response.clone())))
+        }
+
+        fn inline_values(
+            &self,
+            _buffer_handle: Entity<Buffer>,
+            _range: Range<text::Anchor>,
+            _cx: &mut App,
+        ) -> Option<Task<anyhow::Result<Vec<InlayHint>>>> {
+            None
+        }
+
+        fn applicable_inlay_chunks(
+            &self,
+            _buffer: &Entity<Buffer>,
+            _ranges: &[Range<text::Anchor>],
+            _cx: &mut App,
+        ) -> Vec<Range<BufferRow>> {
+            Vec::new()
+        }
+
+        fn invalidate_inlay_hints(&self, _for_buffers: &HashSet<BufferId>, _cx: &mut App) {}
+
+        fn inlay_hints(
+            &self,
+            _invalidate: InvalidationStrategy,
+            _buffer: Entity<Buffer>,
+            _ranges: Vec<Range<text::Anchor>>,
+            _known_chunks: Option<(clock::Global, HashSet<Range<BufferRow>>)>,
+            _cx: &mut App,
+        ) -> Option<HashMap<Range<BufferRow>, Task<anyhow::Result<CacheInlayHints>>>> {
+            None
+        }
+
+        fn semantic_tokens(
+            &self,
+            _buffer: Entity<Buffer>,
+            _refresh: Option<RefreshForServer>,
+            _cx: &mut App,
+        ) -> Option<Shared<Task<std::result::Result<BufferSemanticTokens, Arc<anyhow::Error>>>>>
+        {
+            None
+        }
+
+        fn supports_inlay_hints(&self, _buffer: &Entity<Buffer>, _cx: &mut App) -> bool {
+            false
+        }
+
+        fn supports_semantic_tokens(&self, _buffer: &Entity<Buffer>, _cx: &mut App) -> bool {
+            false
+        }
+
+        fn document_highlights(
+            &self,
+            _buffer: &Entity<Buffer>,
+            _position: text::Anchor,
+            _cx: &mut App,
+        ) -> Option<Task<anyhow::Result<Vec<DocumentHighlight>>>> {
+            None
+        }
+
+        fn definitions(
+            &self,
+            _buffer: &Entity<Buffer>,
+            _position: text::Anchor,
+            _kind: crate::GotoDefinitionKind,
+            _cx: &mut App,
+        ) -> Option<Task<anyhow::Result<Option<Vec<LocationLink>>>>> {
+            None
+        }
+
+        fn range_for_rename(
+            &self,
+            _buffer: &Entity<Buffer>,
+            _position: text::Anchor,
+            _cx: &mut App,
+        ) -> Task<anyhow::Result<Option<Range<text::Anchor>>>> {
+            Task::ready(Ok(None))
+        }
+
+        fn perform_rename(
+            &self,
+            _buffer: &Entity<Buffer>,
+            _position: text::Anchor,
+            _new_name: String,
+            _cx: &mut App,
+        ) -> Option<Task<anyhow::Result<ProjectTransaction>>> {
+            None
+        }
     }
 
     impl InfoPopover {
@@ -1522,6 +2382,92 @@ mod tests {
         cx.editor(|editor, _, _| {
             assert!(!editor.hover_state.visible());
         });
+    }
+
+    #[gpui::test]
+    async fn test_debugger_hover_hides_lsp_markdown_content(cx: &mut gpui::TestAppContext) {
+        init_test(cx, |_| {});
+
+        let mut editor_cx = EditorTestContext::new(cx).await;
+        editor_cx.set_state("let value = ˇpoint.x;\n");
+
+        editor_cx.update_editor(|editor, _, _| {
+            editor.set_semantics_provider(Some(Rc::new(TestHoverSemanticsProvider {
+                hover_response: vec![
+                    ProjectHover {
+                        contents: vec![HoverBlock {
+                            text: "Other hover content that should be removed".to_string(),
+                            kind: HoverBlockKind::Markdown,
+                        }],
+                        range: None,
+                        language: None,
+                        debugger_value: None,
+                    },
+                    ProjectHover {
+                        contents: vec![HoverBlock {
+                            text: "Constructor documentation that should stay hidden".to_string(),
+                            kind: HoverBlockKind::Markdown,
+                        }],
+                        range: None,
+                        language: None,
+                        debugger_value: Some(DebuggerHoverData {
+                            session_id: SessionId(1),
+                            root: DebuggerHoverVariable {
+                                name: "point".to_string(),
+                                value: "Point { x: 42 }".to_string(),
+                                type_name: Some("Point".to_string()),
+                                variables_reference: 0,
+                            },
+                        }),
+                    },
+                ],
+            })));
+        });
+
+        editor_cx.update_editor(|editor, window, cx| hover(editor, &Hover, window, cx));
+        editor_cx.run_until_parked();
+
+        editor_cx.update_editor(|editor, _, _| {
+            assert_eq!(editor.hover_state.info_popovers.len(), 1);
+            let popover = editor
+                .hover_state
+                .info_popovers
+                .first()
+                .expect("expected debugger hover popover");
+
+            assert!(popover.debugger_hover.is_some());
+            assert!(
+                popover.parsed_content.is_none(),
+                "expected debugger hover to suppress markdown content"
+            );
+        });
+    }
+
+    #[test]
+    fn test_debugger_hover_type_suffix_is_inline() {
+        assert_eq!(debugger_hover_type_suffix(0, None), None);
+        assert_eq!(
+            debugger_hover_type_suffix(0, Some("Point")),
+            Some(": Point".to_string())
+        );
+        assert_eq!(debugger_hover_type_suffix(1, Some("Point")), None);
+    }
+
+    #[gpui::test]
+    fn test_debugger_hover_variable_colors_use_theme_syntax(cx: &mut gpui::TestAppContext) {
+        init_test(cx, |_| {});
+
+        let colors = cx.read(|cx: &App| debugger_hover_variable_colors(cx));
+
+        assert!(colors.name.is_some());
+        assert!(colors.value.is_some());
+        assert!(colors.type_name.is_some());
+    }
+
+    #[test]
+    fn test_debugger_hover_name_basis_stays_compact() {
+        assert!(DEBUGGER_HOVER_NAME_FLEX_BASIS > 0.25);
+        assert!(DEBUGGER_HOVER_NAME_FLEX_BASIS < 0.5);
     }
 
     #[gpui::test]

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2623,6 +2623,119 @@ impl Session {
         })
     }
 
+    pub fn evaluate_hover_expression(
+        &self,
+        stack_frame_id: StackFrameId,
+        expression: String,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<dap::EvaluateResponse>> {
+        let session = cx.entity();
+        cx.spawn(async move |_, cx| {
+            let hover_eval_task = session.read_with(cx, |session, _| {
+                session.state.request_dap(EvaluateCommand {
+                    expression: expression.clone(),
+                    frame_id: Some(stack_frame_id),
+                    source: None,
+                    context: Some(EvaluateArgumentsContext::Hover),
+                })
+            });
+
+            match hover_eval_task.await {
+                Ok(response) => Some(response),
+                Err(error) => {
+                    log::debug!(
+                        "Falling back to EvaluateArgumentsContext::Variables after hover evaluation failed: {error:#}"
+                    );
+
+                    let variables_eval_task = session.read_with(cx, |session, _| {
+                        session.state.request_dap(EvaluateCommand {
+                            expression,
+                            frame_id: Some(stack_frame_id),
+                            source: None,
+                            context: Some(EvaluateArgumentsContext::Variables),
+                        })
+                    });
+
+                    variables_eval_task.await.log_err()
+                }
+            }
+        })
+    }
+
+    pub fn load_hover_children(
+        &self,
+        variables_reference: VariableReference,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Vec<dap::Variable>>> {
+        if let Some(cached_variables) = self
+            .session_state()
+            .variables
+            .get(&variables_reference)
+            .cloned()
+        {
+            return Task::ready(Ok(cached_variables));
+        }
+
+        let session = cx.entity();
+        cx.spawn(async move |_, cx| {
+            let request = session.read_with(cx, |session, _| {
+                session.state.request_dap(VariablesCommand {
+                    variables_reference,
+                    filter: None,
+                    start: None,
+                    count: None,
+                    format: None,
+                })
+            });
+
+            let mut variables = request.await?;
+
+            session.update(cx, |session, cx| {
+                session.normalize_variables(&mut variables);
+                session
+                    .active_snapshot
+                    .variables
+                    .insert(variables_reference, variables.clone());
+                cx.emit(SessionEvent::Variables);
+                cx.emit(SessionEvent::InvalidateInlineValue);
+            });
+
+            Ok(variables)
+        })
+    }
+
+    fn normalize_variables(&self, variables: &mut [dap::Variable]) {
+        if self.adapter.0.as_ref() == "Debugpy" {
+            for variable in variables.iter_mut() {
+                if variable.type_ == Some("str".into()) {
+                    // Debugpy returns Python repr() escaping for string variables.
+                    let mut unescaped = String::with_capacity(variable.value.len());
+                    let mut chars = variable.value.chars();
+                    while let Some(character) = chars.next() {
+                        if character != '\\' {
+                            unescaped.push(character);
+                        } else {
+                            match chars.next() {
+                                Some('\\') => unescaped.push('\\'),
+                                Some('n') => unescaped.push('\n'),
+                                Some('t') => unescaped.push('\t'),
+                                Some('r') => unescaped.push('\r'),
+                                Some('\'') => unescaped.push('\''),
+                                Some('"') => unescaped.push('"'),
+                                Some(character) => {
+                                    unescaped.push('\\');
+                                    unescaped.push(character);
+                                }
+                                None => {}
+                            }
+                        }
+                    }
+                    variable.value = unescaped;
+                }
+            }
+        }
+    }
+
     pub fn refresh_watchers(&mut self, frame_id: u64, cx: &mut Context<Self>) {
         let watches = self.watchers.clone();
         for (_, watch) in watches.into_iter() {
@@ -2655,35 +2768,7 @@ impl Session {
                     return;
                 };
 
-                if this.adapter.0.as_ref() == "Debugpy" {
-                    for variable in variables.iter_mut() {
-                        if variable.type_ == Some("str".into()) {
-                            // reverse Python repr() escaping
-                            let mut unescaped = String::with_capacity(variable.value.len());
-                            let mut chars = variable.value.chars();
-                            while let Some(c) = chars.next() {
-                                if c != '\\' {
-                                    unescaped.push(c);
-                                } else {
-                                    match chars.next() {
-                                        Some('\\') => unescaped.push('\\'),
-                                        Some('n') => unescaped.push('\n'),
-                                        Some('t') => unescaped.push('\t'),
-                                        Some('r') => unescaped.push('\r'),
-                                        Some('\'') => unescaped.push('\''),
-                                        Some('"') => unescaped.push('"'),
-                                        Some(c) => {
-                                            unescaped.push('\\');
-                                            unescaped.push(c);
-                                        }
-                                        None => {}
-                                    }
-                                }
-                            }
-                            variable.value = unescaped;
-                        }
-                    }
-                }
+                this.normalize_variables(&mut variables);
 
                 this.active_snapshot
                     .variables

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2402,6 +2402,7 @@ impl LspCommand for GetHover {
             contents,
             range,
             language,
+            debugger_value: None,
         }))
     }
 
@@ -2525,6 +2526,7 @@ impl LspCommand for GetHover {
             contents,
             range,
             language,
+            debugger_value: None,
         }))
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -62,7 +62,10 @@ use client::{
 };
 use clock::ReplicaId;
 
-use dap::client::DebugAdapterClient;
+use dap::{
+    VariableReference,
+    client::{DebugAdapterClient, SessionId},
+};
 
 use collections::{BTreeSet, HashMap, HashSet, IndexSet};
 use debounced_delay::DebouncedDelay;
@@ -892,16 +895,58 @@ pub enum HoverBlockKind {
     Code { language: String },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebuggerHoverVariable {
+    pub name: String,
+    pub value: String,
+    pub type_name: Option<String>,
+    pub variables_reference: VariableReference,
+}
+
+impl DebuggerHoverVariable {
+    fn from_evaluate_response(expression: String, response: &dap::EvaluateResponse) -> Self {
+        Self {
+            name: expression,
+            value: response.result.clone(),
+            type_name: response
+                .type_
+                .clone()
+                .filter(|type_name| !type_name.is_empty()),
+            variables_reference: response.variables_reference,
+        }
+    }
+
+    fn from_dap_variable(variable: dap::Variable) -> Self {
+        Self {
+            name: variable.name,
+            value: variable.value,
+            type_name: variable.type_.filter(|type_name| !type_name.is_empty()),
+            variables_reference: variable.variables_reference,
+        }
+    }
+
+    pub fn has_children(&self) -> bool {
+        self.variables_reference != 0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebuggerHoverData {
+    pub session_id: SessionId,
+    pub root: DebuggerHoverVariable,
+}
+
 #[derive(Debug, Clone)]
 pub struct Hover {
     pub contents: Vec<HoverBlock>,
     pub range: Option<Range<language::Anchor>>,
     pub language: Option<Arc<Language>>,
+    pub debugger_value: Option<DebuggerHoverData>,
 }
 
 impl Hover {
     pub fn is_empty(&self) -> bool {
-        self.contents.iter().all(|block| block.text.is_empty())
+        self.contents.iter().all(|block| block.text.is_empty()) && self.debugger_value.is_none()
     }
 }
 
@@ -4484,8 +4529,78 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Option<Vec<Hover>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.lsp_store
-            .update(cx, |lsp_store, cx| lsp_store.hover(buffer, position, cx))
+        let lsp_hover = self
+            .lsp_store
+            .update(cx, |lsp_store, cx| lsp_store.hover(buffer, position, cx));
+
+        let debug_hover =
+            self.active_debug_session(cx)
+                .and_then(|(session, active_stack_frame)| {
+                    let buffer_path = BreakpointStore::abs_path_from_buffer(buffer, cx)?;
+                    if buffer_path.as_ref() != active_stack_frame.path.as_ref() {
+                        return None;
+                    }
+
+                    let snapshot = buffer.read(cx).snapshot();
+                    let (expression, range) = hovered_debug_expression(&snapshot, position)?;
+                    let stack_frame_id = active_stack_frame.stack_frame_id;
+                    let session_id = session.read(cx).session_id();
+                    let evaluate = session.update(cx, |session, cx| {
+                        session.evaluate_hover_expression(stack_frame_id, expression.clone(), cx)
+                    });
+
+                    Some((evaluate, range, session_id, expression))
+                });
+
+        match debug_hover {
+            Some((evaluate, range, session_id, expression)) => cx.background_spawn(async move {
+                let mut hovers = lsp_hover.await.unwrap_or_default();
+                if let Some(response) = evaluate.await {
+                    let debugger_value = DebuggerHoverData {
+                        session_id,
+                        root: DebuggerHoverVariable::from_evaluate_response(expression, &response),
+                    };
+
+                    if let Some(existing_hover) = hovers.first_mut() {
+                        existing_hover.debugger_value = Some(debugger_value);
+                        existing_hover.range.get_or_insert(range);
+                    } else {
+                        hovers.push(Hover {
+                            contents: Vec::new(),
+                            range: Some(range),
+                            language: None,
+                            debugger_value: Some(debugger_value),
+                        });
+                    }
+                }
+
+                Some(hovers)
+            }),
+            None => lsp_hover,
+        }
+    }
+
+    pub fn load_debugger_hover_children(
+        &self,
+        session_id: SessionId,
+        variables_reference: VariableReference,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Vec<DebuggerHoverVariable>>> {
+        let Some(session) = self.dap_store.read(cx).session_by_id(session_id) else {
+            return Task::ready(Err(anyhow!("debug session is no longer available")));
+        };
+
+        let task = session.update(cx, |session, cx| {
+            session.load_hover_children(variables_reference, cx)
+        });
+
+        cx.spawn(async move |_, _| {
+            let variables = task.await?;
+            Ok(variables
+                .into_iter()
+                .map(DebuggerHoverVariable::from_dap_variable)
+                .collect())
+        })
     }
 
     pub fn linked_edits(
@@ -6777,6 +6892,84 @@ fn proto_to_prompt(level: proto::language_server_prompt_request::Level) -> gpui:
         proto::language_server_prompt_request::Level::Warning(_) => gpui::PromptLevel::Warning,
         proto::language_server_prompt_request::Level::Critical(_) => gpui::PromptLevel::Critical,
     }
+}
+
+fn hovered_debug_expression(
+    snapshot: &language::BufferSnapshot,
+    position: PointUtf16,
+) -> Option<(String, Range<Anchor>)> {
+    hovered_debug_variable_expression(snapshot, position)
+        .or_else(|| hovered_debug_member_expression(snapshot, position))
+}
+
+fn hovered_debug_variable_expression(
+    snapshot: &language::BufferSnapshot,
+    position: PointUtf16,
+) -> Option<(String, Range<Anchor>)> {
+    let offset = snapshot.point_utf16_to_offset(position);
+
+    snapshot
+        .debug_variables_query(offset..offset)
+        .filter_map(|(range, capture_kind)| {
+            (capture_kind == language::DebuggerTextObject::Variable
+                && range.start <= offset
+                && offset <= range.end)
+                .then(|| {
+                    let expression = snapshot.text_for_range(range.clone()).collect::<String>();
+                    let anchor_range =
+                        snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end);
+                    (expression, anchor_range, range.end - range.start)
+                })
+        })
+        .min_by_key(|(_, _, len)| *len)
+        .map(|(expression, range, _)| (expression, range))
+}
+
+fn hovered_debug_member_expression(
+    snapshot: &language::BufferSnapshot,
+    position: PointUtf16,
+) -> Option<(String, Range<Anchor>)> {
+    let offset = snapshot.point_utf16_to_offset(position);
+    let mut node = snapshot.syntax_ancestor(offset..offset)?;
+    let mut best_match = None;
+
+    loop {
+        let byte_range = node.byte_range();
+        if byte_range.start > offset || offset > byte_range.end {
+            break;
+        }
+
+        let expression = snapshot
+            .text_for_range(byte_range.clone())
+            .collect::<String>();
+        if looks_like_debug_hover_member_expression(&expression) {
+            best_match = Some((
+                expression,
+                snapshot.anchor_before(byte_range.start)..snapshot.anchor_after(byte_range.end),
+            ));
+        }
+
+        let Some(parent) = node.parent() else {
+            break;
+        };
+        node = parent;
+    }
+
+    best_match
+}
+
+fn looks_like_debug_hover_member_expression(expression: &str) -> bool {
+    !expression.is_empty()
+        && expression.len() <= 128
+        && !expression.contains(char::is_whitespace)
+        && (expression.contains('.') || expression.contains('[') || expression.contains("->"))
+        && expression.chars().all(|char| {
+            char.is_alphanumeric()
+                || matches!(
+                    char,
+                    '_' | '.' | '[' | ']' | '(' | ')' | '"' | '\'' | '-' | '>'
+                )
+        })
 }
 
 fn provide_inline_values(

--- a/crates/project/tests/integration/debugger.rs
+++ b/crates/project/tests/integration/debugger.rs
@@ -293,6 +293,344 @@ mod python_locator {
     }
 }
 
+mod hover {
+    use std::{path::Path, sync::Arc};
+
+    use dap::{
+        DapRegistry, EvaluateArgumentsContext, Variable,
+        adapters::{DebugAdapterName, DebugTaskDefinition},
+        client::DebugAdapterClient,
+        requests::{Evaluate, Variables},
+    };
+    use fs::FakeFs;
+    use futures::StreamExt as _;
+    use gpui::{BackgroundExecutor, Entity, TestAppContext};
+    use language::{Buffer, FakeLspAdapter, ToPointUtf16, rust_lang};
+    use parking_lot::Mutex;
+    use project::{
+        Project,
+        debugger::{
+            breakpoint_store::ActiveStackFrame,
+            session::{Session, SessionQuirks, ThreadId},
+        },
+    };
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use task::SharedTaskContext;
+    use util::path;
+
+    use crate::init_test;
+
+    const SOURCE: &str = "fn main() {
+    let value = 42;
+    let x = value + 1;
+    println!(\"{}\", x);
+}
+";
+
+    async fn init_project(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) -> Entity<Project> {
+        init_test(cx);
+        cx.executor().allow_parking();
+        cx.update(|cx| DapRegistry::global(cx).add_adapter(Arc::new(dap::FakeAdapter::new())));
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(path!("/project"), json!({ "main.rs": SOURCE }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        project
+            .read_with(cx, |project, _| project.languages().clone())
+            .add(rust_lang());
+        project
+    }
+
+    async fn boot_session<T: Fn(&Arc<DebugAdapterClient>) + 'static>(
+        project: &Entity<Project>,
+        configure: T,
+        cx: &mut TestAppContext,
+    ) -> Entity<Session> {
+        let worktree = project.update(cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .next()
+                .expect("test project should have one worktree")
+        });
+        let _subscription = project::debugger::test::intercept_debug_sessions(cx, configure);
+        let dap_store = project.read_with(cx, |project, _| project.dap_store());
+        let (session, boot_task) = dap_store.update(cx, |dap_store, cx| {
+            let session = dap_store.new_session(
+                None,
+                DebugAdapterName(dap::FakeAdapter::ADAPTER_NAME.into()),
+                SharedTaskContext::default(),
+                None,
+                SessionQuirks::default(),
+                cx,
+            );
+            let boot_task = dap_store.boot_session(
+                session.clone(),
+                DebugTaskDefinition {
+                    adapter: dap::FakeAdapter::ADAPTER_NAME.into(),
+                    label: "test".into(),
+                    config: json!({ "request": "launch" }),
+                    tcp_connection: None,
+                },
+                worktree,
+                cx,
+            );
+            (session, boot_task)
+        });
+        boot_task.await.expect("session should boot");
+        cx.run_until_parked();
+        session
+    }
+
+    fn set_active_stack_frame(
+        project: &Entity<Project>,
+        session: &Entity<Session>,
+        buffer: &Entity<Buffer>,
+        cx: &mut TestAppContext,
+    ) {
+        let session_id = session.read_with(cx, |session, _| session.session_id());
+        let position = buffer.read_with(cx, |buffer, _| buffer.snapshot().anchor_before(0));
+        project.update(cx, |project, cx| {
+            project.breakpoint_store().update(cx, |store, cx| {
+                store.set_active_position(
+                    ActiveStackFrame {
+                        session_id,
+                        thread_id: ThreadId(1),
+                        stack_frame_id: 1,
+                        path: Arc::<Path>::from(Path::new(path!("/project/main.rs"))),
+                        position,
+                    },
+                    cx,
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    async fn test_hover_merges_debug_value_before_lsp_hover(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let project = init_project(executor, cx).await;
+        let evaluation_contexts = Arc::new(Mutex::new(Vec::new()));
+        let languages = project.read_with(cx, |project, _| project.languages().clone());
+        let mut fake_servers = languages.register_fake_lsp(
+            "Rust",
+            FakeLspAdapter {
+                capabilities: lsp::ServerCapabilities {
+                    hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                    ..lsp::ServerCapabilities::default()
+                },
+                ..FakeLspAdapter::default()
+            },
+        );
+        let session = boot_session(
+            &project,
+            {
+                let evaluation_contexts = evaluation_contexts.clone();
+                move |client| {
+                    let evaluation_contexts = evaluation_contexts.clone();
+                    client.on_request::<Evaluate, _>(move |_, args| {
+                        let context = args.context.clone();
+                        evaluation_contexts
+                            .lock()
+                            .push((args.expression.clone(), context.clone()));
+
+                        match context {
+                            Some(EvaluateArgumentsContext::Hover) => Err(dap::ErrorResponse {
+                                error: Some(dap::Message {
+                                    id: 1,
+                                    format: "hover unsupported".into(),
+                                    variables: None,
+                                    send_telemetry: None,
+                                    show_user: None,
+                                    url: None,
+                                    url_label: None,
+                                }),
+                            }),
+                            Some(EvaluateArgumentsContext::Variables) => {
+                                Ok(dap::EvaluateResponse {
+                                    result: "42".into(),
+                                    type_: Some("i32".into()),
+                                    presentation_hint: None,
+                                    variables_reference: 0,
+                                    named_variables: None,
+                                    indexed_variables: None,
+                                    memory_reference: None,
+                                    value_location_reference: None,
+                                })
+                            }
+                            other => panic!("unexpected evaluate context: {other:?}"),
+                        }
+                    });
+                }
+            },
+            cx,
+        )
+        .await;
+
+        let (buffer, _handle) = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer_with_lsp(path!("/project/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+        fake_servers
+            .next()
+            .await
+            .expect("failed to get language server")
+            .set_request_handler::<lsp::request::HoverRequest, _, _>(move |_, _| async move {
+                Ok(Some(lsp::Hover {
+                    contents: lsp::HoverContents::Scalar(lsp::MarkedString::String(
+                        "lsp hover".to_string(),
+                    )),
+                    range: None,
+                }))
+            });
+
+        set_active_stack_frame(&project, &session, &buffer, cx);
+        let hover_offset = SOURCE.find("value + 1").unwrap();
+        let hover_position = buffer.read_with(cx, |buffer, _| hover_offset.to_point_utf16(buffer));
+        let hover = project
+            .update(cx, |project, cx| project.hover(&buffer, hover_position, cx))
+            .await
+            .and_then(|mut hovers| hovers.pop())
+            .expect("expected merged hover");
+        let debugger_value = hover
+            .debugger_value
+            .expect("expected debugger hover payload");
+
+        assert_eq!(
+            hover
+                .contents
+                .into_iter()
+                .map(|block| block.text)
+                .collect::<Vec<_>>(),
+            vec!["lsp hover".to_string()]
+        );
+        assert_eq!(debugger_value.root.name, "value");
+        assert_eq!(debugger_value.root.value, "42");
+        assert_eq!(debugger_value.root.type_name.as_deref(), Some("i32"));
+        assert_eq!(debugger_value.root.variables_reference, 0);
+        assert_eq!(
+            *evaluation_contexts.lock(),
+            vec![
+                ("value".to_string(), Some(EvaluateArgumentsContext::Hover),),
+                (
+                    "value".to_string(),
+                    Some(EvaluateArgumentsContext::Variables),
+                ),
+            ]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_hover_children_are_loaded_on_demand_and_cached(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let project = init_project(executor, cx).await;
+        let variables_request_count = Arc::new(AtomicUsize::new(0));
+        let session = boot_session(
+            &project,
+            {
+                let variables_request_count = variables_request_count.clone();
+                move |client| {
+                    client.on_request::<Evaluate, _>(move |_, args| {
+                        assert_eq!(args.expression, "value");
+                        assert_eq!(args.context, Some(EvaluateArgumentsContext::Hover));
+                        Ok(dap::EvaluateResponse {
+                            result: "Point { x: 42 }".into(),
+                            type_: Some("Point".into()),
+                            presentation_hint: None,
+                            variables_reference: 1,
+                            named_variables: Some(1),
+                            indexed_variables: None,
+                            memory_reference: None,
+                            value_location_reference: None,
+                        })
+                    });
+
+                    let variables_request_count = variables_request_count.clone();
+                    client.on_request::<Variables, _>(move |_, args| {
+                        variables_request_count.fetch_add(1, Ordering::SeqCst);
+                        assert_eq!(args.variables_reference, 1);
+                        Ok(dap::VariablesResponse {
+                            variables: vec![Variable {
+                                name: "x".into(),
+                                value: "42".into(),
+                                type_: Some("i32".into()),
+                                presentation_hint: None,
+                                evaluate_name: None,
+                                variables_reference: 0,
+                                named_variables: None,
+                                indexed_variables: None,
+                                memory_reference: None,
+                                declaration_location_reference: None,
+                                value_location_reference: None,
+                            }],
+                        })
+                    });
+                }
+            },
+            cx,
+        )
+        .await;
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+        buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+
+        set_active_stack_frame(&project, &session, &buffer, cx);
+        let hover_offset = SOURCE.find("value + 1").unwrap();
+        let hover_position = buffer.read_with(cx, |buffer, _| hover_offset.to_point_utf16(buffer));
+        let debugger_value = project
+            .update(cx, |project, cx| project.hover(&buffer, hover_position, cx))
+            .await
+            .and_then(|mut hovers| hovers.pop())
+            .and_then(|hover| hover.debugger_value)
+            .expect("expected debugger hover payload");
+
+        let children = project
+            .update(cx, |project, cx| {
+                project.load_debugger_hover_children(
+                    debugger_value.session_id,
+                    debugger_value.root.variables_reference,
+                    cx,
+                )
+            })
+            .await
+            .expect("expected first child load to succeed");
+        assert_eq!(variables_request_count.load(Ordering::SeqCst), 1);
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "x");
+        assert_eq!(children[0].value, "42");
+        assert_eq!(children[0].type_name.as_deref(), Some("i32"));
+        assert_eq!(children[0].variables_reference, 0);
+
+        let cached_children = project
+            .update(cx, |project, cx| {
+                project.load_debugger_hover_children(
+                    debugger_value.session_id,
+                    debugger_value.root.variables_reference,
+                    cx,
+                )
+            })
+            .await
+            .expect("expected cached child load to succeed");
+        assert_eq!(variables_request_count.load(Ordering::SeqCst), 1);
+        assert_eq!(cached_children, children);
+    }
+}
+
 mod memory {
     use project::debugger::{
         MemoryCell,


### PR DESCRIPTION
Closes #32932

## Summary

- Render debugger hover values as an expandable tree.
- Load child variables on demand and cache them in the debug session.
- Keep debugger hover content stable while expanding and suppress unrelated hover content.
- Support mouse, keyboard, Vim, and Helix navigation, including Escape to close.
- Preserve short values with a wider responsive layout and truncation tooltips.

## Testing

- `cargo test -p editor debugger_hover -- --nocapture`
- `cargo test -p debugger_ui hover_values -- --nocapture`
- `cargo test -p project test_hover_ -- --nocapture`
- `cargo test -p vim test_digraph_keymap_conflict -- --nocapture`

## Demo

https://github.com/user-attachments/assets/dfb6d4d7-b52e-45a3-b921-dc14719ccd50

Release Notes:

- Improved debugger hovers with an expandable, keyboard-accessible variable tree.
