### PR TITLE
themes: Make One Dark `syntax.link_text.font_style` italic

### DIFF
--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -261,7 +261,7 @@
           },
           "link_text": {
             "color": "#73ade9ff",
-            "font_style": "normal",
+            "font_style": "italic",
             "font_weight": null
           },
           "link_uri": {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53219 

Updates the built-in **One Dark** theme so `syntax.link_text.font_style` is `italic`, matching other built-in themes.

Release Notes:

- Fixed One Dark `link_text` not italic
