### PR TITLE
sidebar: Adjust "Add Local Project" button behavior

### DIFF
--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -411,7 +411,10 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                 .border_t_1()
                 .border_color(cx.theme().colors().border_variant)
                 .child({
-                    let open_action = workspace::Open::default();
+                    let open_action = workspace::Open {
+                        create_new_window: false,
+                    };
+
                     Button::new("open_local_folder", "Add Local Project")
                         .key_binding(KeyBinding::for_action_in(&open_action, &focus_handle, cx))
                         .on_click(move |_, window, cx| {

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -417,9 +417,10 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
 
                     Button::new("open_local_folder", "Add Local Project")
                         .key_binding(KeyBinding::for_action_in(&open_action, &focus_handle, cx))
-                        .on_click(move |_, window, cx| {
-                            window.dispatch_action(open_action.boxed_clone(), cx)
-                        })
+                        .on_click(cx.listener(move |_, _, window, cx| {
+                            window.dispatch_action(open_action.boxed_clone(), cx);
+                            cx.emit(DismissEvent);
+                        }))
                 })
                 .child(
                     Button::new("open_remote_folder", "Add Remote Project")
@@ -430,7 +431,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                             },
                             cx,
                         ))
-                        .on_click(|_, window, cx| {
+                        .on_click(cx.listener(|_, _, window, cx| {
                             window.dispatch_action(
                                 OpenRemote {
                                     from_existing_connection: false,
@@ -438,8 +439,9 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                                 }
                                 .boxed_clone(),
                                 cx,
-                            )
-                        }),
+                            );
+                            cx.emit(DismissEvent);
+                        })),
                 )
                 .into_any(),
         )

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -656,13 +656,25 @@ impl From<WorkspaceId> for i64 {
     }
 }
 
-fn prompt_and_open_paths(app_state: Arc<AppState>, options: PathPromptOptions, cx: &mut App) {
+fn prompt_and_open_paths(
+    app_state: Arc<AppState>,
+    options: PathPromptOptions,
+    create_new_window: bool,
+    cx: &mut App,
+) {
     if let Some(workspace_window) = local_workspace_windows(cx).into_iter().next() {
         workspace_window
             .update(cx, |multi_workspace, window, cx| {
                 let workspace = multi_workspace.workspace().clone();
                 workspace.update(cx, |workspace, cx| {
-                    prompt_for_open_path_and_open(workspace, app_state, options, true, window, cx);
+                    prompt_for_open_path_and_open(
+                        workspace,
+                        app_state,
+                        options,
+                        create_new_window,
+                        window,
+                        cx,
+                    );
                 });
             })
             .ok();
@@ -682,7 +694,14 @@ fn prompt_and_open_paths(app_state: Arc<AppState>, options: PathPromptOptions, c
                 window.activate_window();
                 let workspace = multi_workspace.workspace().clone();
                 workspace.update(cx, |workspace, cx| {
-                    prompt_for_open_path_and_open(workspace, app_state, options, true, window, cx);
+                    prompt_for_open_path_and_open(
+                        workspace,
+                        app_state,
+                        options,
+                        create_new_window,
+                        window,
+                        cx,
+                    );
                 });
             })?;
             anyhow::Ok(())
@@ -743,7 +762,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
 
     cx.on_action(|_: &CloseWindow, cx| Workspace::close_global(cx))
         .on_action(|_: &Reload, cx| reload(cx))
-        .on_action(|_: &Open, cx: &mut App| {
+        .on_action(|action: &Open, cx: &mut App| {
             let app_state = AppState::global(cx);
             prompt_and_open_paths(
                 app_state,
@@ -753,6 +772,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
                     multiple: true,
                     prompt: None,
                 },
+                action.create_new_window,
                 cx,
             );
         })
@@ -767,6 +787,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
                     multiple: true,
                     prompt: None,
                 },
+                true,
                 cx,
             );
         });


### PR DESCRIPTION
This PR makes it so using that button from the sidebar's recent projects picker _does not_ add a new window with that project, but rather, add it to the current multi-workspace/sidebar. Previously, the `Open` action was defaulting to true even if `false` was passed to its `create_new_window` condition.

Release Notes:

- N/A
