### PR TITLE
rules_library: Fix hover selecting active rule

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -121,6 +121,9 @@ pub trait PickerDelegate: Sized + 'static {
     ) -> bool {
         true
     }
+    fn select_on_hover(&self) -> bool {
+        true
+    }
 
     // Allows binding some optional effect to when the selection changes.
     fn selected_index_changed(
@@ -788,12 +791,14 @@ impl<D: PickerDelegate> Picker<D> {
                     this.handle_click(ix, event.modifiers.platform, window, cx)
                 }),
             )
-            .on_hover(cx.listener(move |this, hovered: &bool, window, cx| {
-                if *hovered {
-                    this.set_selected_index(ix, None, false, window, cx);
-                    cx.notify();
-                }
-            }))
+            .when(self.delegate.select_on_hover(), |this| {
+                this.on_hover(cx.listener(move |this, hovered: &bool, window, cx| {
+                    if *hovered {
+                        this.set_selected_index(ix, None, false, window, cx);
+                        cx.notify();
+                    }
+                }))
+            })
             .children(self.delegate.render_match(
                 ix,
                 ix == self.delegate.selected_index(),

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -225,6 +225,10 @@ impl PickerDelegate for RulePickerDelegate {
         }
     }
 
+    fn select_on_hover(&self) -> bool {
+        false
+    }
+
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
         "Search…".into()
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/53159

Recently, we changed the behavior of pickers so that hovering matches would also select them. This makes sense for most pickers that are used as "regular" pickers, but we have some in Zed that are not. A great example of one is the rules library, which sort of became way less usable with this behavior. So, this PR introduces a simple bool trait method to the picker so that we can turn this behavior off whenever necessary. The rules library kicks off as the only instance of it being turned off.

Release Notes:

- Fix navigation within the rules library making it so hovering the sidebar doesn't activate the visible rule.
