### PR TITLE
Open project panel when selecting icon theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17515,6 +17515,7 @@ dependencies = [
  "gpui",
  "log",
  "picker",
+ "project_panel",
  "serde",
  "settings",
  "telemetry",

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -18,6 +18,7 @@ fuzzy.workspace = true
 gpui.workspace = true
 log.workspace = true
 picker.workspace = true
+project_panel.workspace = true
 serde.workspace = true
 settings.workspace = true
 telemetry.workspace = true

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -13,6 +13,7 @@ use theme::{Appearance, SystemAppearance, Theme, ThemeMeta, ThemeRegistry};
 use theme_settings::{
     ThemeAppearanceMode, ThemeName, ThemeSelection, ThemeSettings, appearance_to_mode,
 };
+use project_panel::ProjectPanel;
 use ui::{ListItem, ListItemSpacing, prelude::*, v_flex};
 use util::ResultExt;
 use workspace::{ModalView, Workspace, ui::HighlightedLabel, with_active_or_new_workspace};
@@ -67,6 +68,8 @@ fn toggle_icon_theme_selector(
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
+    workspace.open_panel::<ProjectPanel>(window, cx);
+
     let fs = workspace.app_state().fs.clone();
     workspace.toggle_modal(window, cx, |window, cx| {
         let delegate = IconThemeSelectorDelegate::new(


### PR DESCRIPTION
Self-Review Checklist:
  - [x] I've reviewed my own diff for quality, security, and
  reliability
  - [ ] Unsafe blocks (if any) have justifying comments
  - [x] The content is consistent with the [UI/UX
  checklist](https://github.com/zed-industries/zed/blob/main/CONTR
  IBUTING.md#uiux-checklist)
  - [ ] Tests cover the new/changed behavior
  - [x] Performance impact has been considered and is acceptable

  Closes #ISSUE

  Release Notes:
  - Fixed icon theme selector not showing file icons by
  automatically opening the project panel