### PR TITLE
Fix direnv not loading in Claude Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "util",
  "uuid",
  "watch",
+ "workspace",
  "zed_credentials_provider",
 ]
 

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -67,4 +67,6 @@ indoc.workspace = true
 acp_thread = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 gpui_tokio.workspace = true
+project = { workspace = true, features = ["test-support"] }
 reqwest_client = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -187,6 +187,67 @@ pub async fn connect(
 
 const MINIMUM_SUPPORTED_VERSION: acp::ProtocolVersion = acp::ProtocolVersion::V1;
 
+/// Resolved project context for spawning an agent server subprocess.
+///
+/// Contains the merged environment (project env as base, command-specific on top)
+/// and the working directory. Produced by [`resolve_agent_context`] and consumed
+/// by [`AcpConnection::stdio`] when building the actual process command.
+pub struct AgentContext {
+    pub path: PathBuf,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub cwd: Option<PathBuf>,
+}
+
+impl AgentContext {
+    pub fn into_command(self, cx: &mut AsyncApp) -> std::process::Command {
+        let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
+        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
+        let mut command =
+            builder.build_std_command(Some(self.path.display().to_string()), &self.args);
+        command.envs(self.env);
+        if let Some(cwd) = self.cwd {
+            command.current_dir(cwd);
+        }
+        command
+    }
+}
+
+/// Resolves the project environment (e.g. from direnv), working directory,
+/// and command details for spawning an agent server subprocess.
+///
+/// Project environment is applied first as a base layer, then command-specific
+/// env vars are applied on top, so explicit agent configuration takes precedence.
+pub async fn resolve_agent_context(
+    project: &Entity<Project>,
+    command: AgentServerCommand,
+    cx: &mut AsyncApp,
+) -> AgentContext {
+    let (env_task, cwd) = project.update(cx, |project, cx| {
+        let env_task = project
+            .environment()
+            .update(cx, |env, cx| env.default_environment(cx));
+        let cwd = if project.is_local() {
+            project
+                .default_path_list(cx)
+                .ordered_paths()
+                .next()
+                .cloned()
+        } else {
+            None
+        };
+        (env_task, cwd)
+    });
+    let mut env = env_task.await.unwrap_or_default();
+    env.extend(command.env.into_iter().flatten());
+    AgentContext {
+        path: command.path,
+        args: command.args,
+        env,
+        cwd,
+    }
+}
+
 impl AcpConnection {
     pub async fn stdio(
         agent_id: AgentId,
@@ -197,42 +258,18 @@ impl AcpConnection {
         default_config_options: HashMap<String, String>,
         cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let (env_task, cwd) = project.update(cx, |project, cx| {
-            let env_task = project
-                .environment()
-                .update(cx, |env, cx| env.default_environment(cx));
-            let cwd = if project.is_local() {
-                project
-                    .default_path_list(cx)
-                    .ordered_paths()
-                    .next()
-                    .cloned()
-            } else {
-                None
-            };
-            (env_task, cwd)
-        });
-        let project_env = env_task.await.unwrap_or_default();
-
-        let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
-        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
-        let mut child =
-            builder.build_std_command(Some(command.path.display().to_string()), &command.args);
-        child.envs(project_env.iter());
-        child.envs(command.env.iter().flatten());
-        if let Some(cwd) = cwd {
-            child.current_dir(cwd);
-        }
-        let mut child = Child::spawn(child, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
-
-        let stdout = child.stdout.take().context("Failed to take stdout")?;
-        let stdin = child.stdin.take().context("Failed to take stdin")?;
-        let stderr = child.stderr.take().context("Failed to take stderr")?;
         log::debug!(
             "Spawning external agent server: {:?}, {:?}",
             command.path,
             command.args
         );
+        let context = resolve_agent_context(&project, command.clone(), cx).await;
+        let child = context.into_command(cx);
+        let mut child = Child::spawn(child, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
+
+        let stdout = child.stdout.take().context("Failed to take stdout")?;
+        let stdin = child.stdin.take().context("Failed to take stdin")?;
+        let stderr = child.stderr.take().context("Failed to take stderr")?;
         log::trace!("Spawned (pid: {})", child.id());
 
         let sessions = Rc::new(RefCell::new(HashMap::default()));
@@ -1081,6 +1118,69 @@ fn map_acp_error(err: acp::Error) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Verifies that `resolve_agent_context` incorporates the project environment
+    /// (e.g. from direnv) into the agent's environment, alongside agent-specific env.
+    #[gpui::test]
+    async fn test_resolve_agent_context_includes_project_environment(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+
+        let fs = project::FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree("/project", serde_json::json!({"src": {}}))
+            .await;
+        let project = Project::test(fs, [std::path::Path::new("/project")], cx).await;
+
+        let mut project_env = collections::HashMap::default();
+        project_env.insert("DIRENV_VAR".to_string(), "from_direnv".to_string());
+        project_env.insert("CUSTOM_PATH".to_string(), "/direnv/bin".to_string());
+
+        project.update(cx, |project, cx| {
+            project.environment().update(cx, |env, _cx| {
+                env.set_cli_environment(project_env);
+            });
+        });
+
+        let command = AgentServerCommand {
+            path: PathBuf::from("agent-binary"),
+            args: vec![],
+            env: Some(
+                [("AGENT_SPECIFIC".to_string(), "from_agent".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+        };
+
+        let context = cx
+            .update(|cx| {
+                let project = project.clone();
+                let command = command.clone();
+                cx.spawn(async move |mut cx| {
+                    resolve_agent_context(&project, command, &mut cx).await
+                })
+            })
+            .await;
+
+        assert_eq!(
+            context.env.get("DIRENV_VAR").map(|s| s.as_str()),
+            Some("from_direnv"),
+            "Project environment variables (e.g. from direnv) should be included"
+        );
+        assert_eq!(
+            context.env.get("CUSTOM_PATH").map(|s| s.as_str()),
+            Some("/direnv/bin"),
+            "Project PATH-like variables should be included"
+        );
+        assert_eq!(
+            context.env.get("AGENT_SPECIFIC").map(|s| s.as_str()),
+            Some("from_agent"),
+            "Agent-specific environment variables should be included"
+        );
+    }
 
     #[test]
     fn terminal_auth_task_reuses_command_and_merges_args_and_env() {

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -213,6 +213,56 @@ impl AgentContext {
     }
 }
 
+/// Returns true if the given environment variable key holds a path list
+/// (colon-separated on Unix, semicolon-separated on Windows) that should
+/// be concatenated rather than overwritten when merging environments.
+fn is_path_list_var(key: &str) -> bool {
+    matches!(
+        key,
+        "PATH"
+            | "LD_LIBRARY_PATH"
+            | "DYLD_LIBRARY_PATH"
+            | "DYLD_FALLBACK_LIBRARY_PATH"
+            | "LIBRARY_PATH"
+            | "PKG_CONFIG_PATH"
+            | "CPATH"
+            | "C_INCLUDE_PATH"
+            | "CPLUS_INCLUDE_PATH"
+            | "MANPATH"
+            | "INFOPATH"
+            | "XDG_DATA_DIRS"
+            | "XDG_CONFIG_DIRS"
+            | "PYTHONPATH"
+            | "NODE_PATH"
+            | "GEM_PATH"
+            | "GOPATH"
+            | "CLASSPATH"
+            | "CMAKE_PREFIX_PATH"
+    )
+}
+
+/// Merges two environments. For path-list variables (PATH, LD_LIBRARY_PATH, etc.),
+/// values are concatenated with the project environment taking precedence (prepended).
+/// For all other variables, the project environment wins over the command environment.
+fn merge_environments(
+    project_env: HashMap<String, String>,
+    command_env: HashMap<String, String>,
+) -> HashMap<String, String> {
+    let path_separator = if cfg!(windows) { ";" } else { ":" };
+
+    let mut merged = command_env;
+    for (key, project_value) in project_env {
+        if is_path_list_var(&key) {
+            if let Some(command_value) = merged.remove(&key) {
+                merged.insert(key, format!("{project_value}{path_separator}{command_value}"));
+                continue;
+            }
+        }
+        merged.insert(key, project_value);
+    }
+    merged
+}
+
 /// Resolves the project environment (e.g. from direnv), working directory,
 /// and command details for spawning an agent server subprocess.
 ///
@@ -238,8 +288,9 @@ pub async fn resolve_agent_context(
         };
         (env_task, cwd)
     });
-    let mut env = env_task.await.unwrap_or_default();
-    env.extend(command.env.into_iter().flatten());
+    let project_env = env_task.await.unwrap_or_default();
+    let command_env: HashMap<String, String> = command.env.into_iter().flatten().collect();
+    let env = merge_environments(project_env, command_env);
     AgentContext {
         path: command.path,
         args: command.args,
@@ -1119,12 +1170,13 @@ fn map_acp_error(err: acp::Error) -> anyhow::Error {
 mod tests {
     use super::*;
 
-    /// Verifies that `resolve_agent_context` incorporates the project environment
-    /// (e.g. from direnv) into the agent's environment, alongside agent-specific env.
+    /// Verifies that `resolve_agent_context` correctly merges the project environment
+    /// (e.g. from direnv) with the agent's command environment:
+    /// - Both project-only and agent-only variables are present
+    /// - PATH-like variables are concatenated (project env prepended)
+    /// - Non-path variables use the project env value when both define the same key
     #[gpui::test]
-    async fn test_resolve_agent_context_includes_project_environment(
-        cx: &mut gpui::TestAppContext,
-    ) {
+    async fn test_resolve_agent_context_merges_environments(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| {
             let settings_store = settings::SettingsStore::test(cx);
             cx.set_global(settings_store);
@@ -1137,7 +1189,8 @@ mod tests {
 
         let mut project_env = collections::HashMap::default();
         project_env.insert("DIRENV_VAR".to_string(), "from_direnv".to_string());
-        project_env.insert("CUSTOM_PATH".to_string(), "/direnv/bin".to_string());
+        project_env.insert("PATH".to_string(), "/direnv/bin:/usr/bin".to_string());
+        project_env.insert("SHARED_VAR".to_string(), "from_project".to_string());
 
         project.update(cx, |project, cx| {
             project.environment().update(cx, |env, _cx| {
@@ -1149,16 +1202,19 @@ mod tests {
             path: PathBuf::from("agent-binary"),
             args: vec![],
             env: Some(
-                [("AGENT_SPECIFIC".to_string(), "from_agent".to_string())]
-                    .into_iter()
-                    .collect(),
+                [
+                    ("AGENT_SPECIFIC".to_string(), "from_agent".to_string()),
+                    ("PATH".to_string(), "/agent/bin".to_string()),
+                    ("SHARED_VAR".to_string(), "from_agent".to_string()),
+                ]
+                .into_iter()
+                .collect(),
             ),
         };
 
         let context = cx
             .update(|cx| {
                 let project = project.clone();
-                let command = command.clone();
                 cx.spawn(async move |mut cx| {
                     resolve_agent_context(&project, command, &mut cx).await
                 })
@@ -1168,17 +1224,22 @@ mod tests {
         assert_eq!(
             context.env.get("DIRENV_VAR").map(|s| s.as_str()),
             Some("from_direnv"),
-            "Project environment variables (e.g. from direnv) should be included"
-        );
-        assert_eq!(
-            context.env.get("CUSTOM_PATH").map(|s| s.as_str()),
-            Some("/direnv/bin"),
-            "Project PATH-like variables should be included"
+            "Project-only variables should be present"
         );
         assert_eq!(
             context.env.get("AGENT_SPECIFIC").map(|s| s.as_str()),
             Some("from_agent"),
-            "Agent-specific environment variables should be included"
+            "Agent-only variables should be present"
+        );
+        assert_eq!(
+            context.env.get("PATH").map(|s| s.as_str()),
+            Some("/direnv/bin:/usr/bin:/agent/bin"),
+            "PATH should be concatenated with project env prepended"
+        );
+        assert_eq!(
+            context.env.get("SHARED_VAR").map(|s| s.as_str()),
+            Some("from_project"),
+            "Non-path variables should use project env value when both define the same key"
         );
     }
 

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -197,13 +197,11 @@ impl AcpConnection {
         default_config_options: HashMap<String, String>,
         cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
-        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
-        let mut child =
-            builder.build_std_command(Some(command.path.display().to_string()), &command.args);
-        child.envs(command.env.iter().flatten());
-        if let Some(cwd) = project.update(cx, |project, cx| {
-            if project.is_local() {
+        let (env_task, cwd) = project.update(cx, |project, cx| {
+            let env_task = project
+                .environment()
+                .update(cx, |env, cx| env.default_environment(cx));
+            let cwd = if project.is_local() {
                 project
                     .default_path_list(cx)
                     .ordered_paths()
@@ -211,8 +209,18 @@ impl AcpConnection {
                     .cloned()
             } else {
                 None
-            }
-        }) {
+            };
+            (env_task, cwd)
+        });
+        let project_env = env_task.await.unwrap_or_default();
+
+        let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
+        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
+        let mut child =
+            builder.build_std_command(Some(command.path.display().to_string()), &command.args);
+        child.envs(project_env.iter());
+        child.envs(command.env.iter().flatten());
+        if let Some(cwd) = cwd {
             child.current_dir(cwd);
         }
         let mut child = Child::spawn(child, Stdio::piped(), Stdio::piped(), Stdio::piped())?;

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -25,7 +25,6 @@ use sha2::{Digest, Sha256};
 use url::Url;
 use util::{ResultExt as _, debug_panic};
 
-use crate::ProjectEnvironment;
 use crate::agent_registry_store::{AgentRegistryStore, RegistryAgent, RegistryTargetConfig};
 
 use crate::worktree_store::WorktreeStore;
@@ -150,7 +149,6 @@ enum AgentServerStoreState {
     Local {
         node_runtime: NodeRuntime,
         fs: Arc<dyn Fs>,
-        project_environment: Entity<ProjectEnvironment>,
         downstream_client: Option<(u64, AnyProtoClient)>,
         settings: Option<AllAgentServersSettings>,
         http_client: Arc<dyn HttpClient>,
@@ -411,7 +409,6 @@ impl AgentServerStore {
         let AgentServerStoreState::Local {
             node_runtime,
             fs,
-            project_environment,
             downstream_client,
             settings: old_settings,
             http_client,
@@ -492,7 +489,6 @@ impl AgentServerStore {
                         fs: fs.clone(),
                         http_client: http_client.clone(),
                         node_runtime: node_runtime.clone(),
-                        project_environment: project_environment.clone(),
                         extension_id: Arc::from(&*entry.extension_id),
                         targets: entry.targets.clone(),
                         env,
@@ -516,7 +512,6 @@ impl AgentServerStore {
                         ExternalAgentEntry::new(
                             Box::new(LocalCustomAgent {
                                 command: command.clone(),
-                                project_environment: project_environment.clone(),
                             }) as Box<dyn ExternalAgentServer>,
                             ExternalAgentSource::Custom,
                             None,
@@ -550,7 +545,6 @@ impl AgentServerStore {
                                         fs: fs.clone(),
                                         http_client: http_client.clone(),
                                         node_runtime: node_runtime.clone(),
-                                        project_environment: project_environment.clone(),
                                         registry_id: Arc::from(name.as_str()),
                                         version: agent.metadata.version.clone(),
                                         targets: agent.targets.clone(),
@@ -570,7 +564,6 @@ impl AgentServerStore {
                                 ExternalAgentEntry::new(
                                     Box::new(LocalRegistryNpxAgent {
                                         node_runtime: node_runtime.clone(),
-                                        project_environment: project_environment.clone(),
                                         version: agent.metadata.version.clone(),
                                         package: agent.package.clone(),
                                         args: agent.args.clone(),
@@ -636,7 +629,6 @@ impl AgentServerStore {
     pub fn local(
         node_runtime: NodeRuntime,
         fs: Arc<dyn Fs>,
-        project_environment: Entity<ProjectEnvironment>,
         http_client: Arc<dyn HttpClient>,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -652,7 +644,6 @@ impl AgentServerStore {
             state: AgentServerStoreState::Local {
                 node_runtime,
                 fs,
-                project_environment,
                 http_client,
                 downstream_client: None,
                 settings: None,
@@ -1139,7 +1130,6 @@ pub struct LocalExtensionArchiveAgent {
     pub fs: Arc<dyn Fs>,
     pub http_client: Arc<dyn HttpClient>,
     pub node_runtime: NodeRuntime,
-    pub project_environment: Entity<ProjectEnvironment>,
     pub extension_id: Arc<str>,
     pub agent_id: Arc<str>,
     pub targets: HashMap<String, extension::TargetConfig>,
@@ -1171,24 +1161,14 @@ impl ExternalAgentServer for LocalExtensionArchiveAgent {
         let fs = self.fs.clone();
         let http_client = self.http_client.clone();
         let node_runtime = self.node_runtime.clone();
-        let project_environment = self.project_environment.downgrade();
         let extension_id = self.extension_id.clone();
         let agent_id = self.agent_id.clone();
         let targets = self.targets.clone();
         let base_env = self.env.clone();
         let version = self.version.clone();
 
-        cx.spawn(async move |cx| {
-            // Get project environment
-            let mut env = project_environment
-                .update(cx, |project_environment, cx| {
-                    project_environment.default_environment(cx)
-                })?
-                .await
-                .unwrap_or_default();
-
-            // Merge manifest env and extra env
-            env.extend(base_env);
+        cx.spawn(async move |_cx| {
+            let mut env = base_env;
             env.extend(extra_env);
 
             let cache_key = format!("{}/{}", extension_id, agent_id);
@@ -1332,7 +1312,6 @@ struct LocalRegistryArchiveAgent {
     fs: Arc<dyn Fs>,
     http_client: Arc<dyn HttpClient>,
     node_runtime: NodeRuntime,
-    project_environment: Entity<ProjectEnvironment>,
     registry_id: Arc<str>,
     version: SharedString,
     targets: HashMap<String, RegistryTargetConfig>,
@@ -1363,20 +1342,12 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
         let fs = self.fs.clone();
         let http_client = self.http_client.clone();
         let node_runtime = self.node_runtime.clone();
-        let project_environment = self.project_environment.downgrade();
         let registry_id = self.registry_id.clone();
         let targets = self.targets.clone();
         let settings_env = self.env.clone();
         let version = self.version.clone();
 
-        cx.spawn(async move |cx| {
-            let mut env = project_environment
-                .update(cx, |project_environment, cx| {
-                    project_environment.default_environment(cx)
-                })?
-                .await
-                .unwrap_or_default();
-
+        cx.spawn(async move |_cx| {
             let dir = paths::external_agents_dir()
                 .join("registry")
                 .join(registry_id.as_ref());
@@ -1413,7 +1384,7 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
                 )
             })?;
 
-            env.extend(target_config.env.clone());
+            let mut env = target_config.env.clone();
             env.extend(extra_env);
             env.extend(settings_env);
 
@@ -1507,7 +1478,6 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
 
 struct LocalRegistryNpxAgent {
     node_runtime: NodeRuntime,
-    project_environment: Entity<ProjectEnvironment>,
     version: SharedString,
     package: SharedString,
     args: Vec<String>,
@@ -1537,20 +1507,12 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
     ) -> Task<Result<AgentServerCommand>> {
         self.new_version_available_tx = new_version_available_tx;
         let node_runtime = self.node_runtime.clone();
-        let project_environment = self.project_environment.downgrade();
         let package = self.package.clone();
         let args = self.args.clone();
         let distribution_env = self.distribution_env.clone();
         let settings_env = self.settings_env.clone();
 
-        cx.spawn(async move |cx| {
-            let mut env = project_environment
-                .update(cx, |project_environment, cx| {
-                    project_environment.default_environment(cx)
-                })?
-                .await
-                .unwrap_or_default();
-
+        cx.spawn(async move |_cx| {
             let mut exec_args = vec!["--yes".to_string(), "--".to_string(), package.to_string()];
             exec_args.extend(args);
 
@@ -1561,7 +1523,7 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
                 )
                 .await?;
 
-            env.extend(npm_command.env);
+            let mut env: HashMap<String, String> = npm_command.env.into_iter().collect();
             env.extend(distribution_env);
             env.extend(extra_env);
             env.extend(settings_env);
@@ -1586,7 +1548,6 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
 }
 
 struct LocalCustomAgent {
-    project_environment: Entity<ProjectEnvironment>,
     command: AgentServerCommand,
 }
 
@@ -1595,22 +1556,13 @@ impl ExternalAgentServer for LocalCustomAgent {
         &mut self,
         extra_env: HashMap<String, String>,
         _new_version_available_tx: Option<watch::Sender<Option<String>>>,
-        cx: &mut AsyncApp,
+        _cx: &mut AsyncApp,
     ) -> Task<Result<AgentServerCommand>> {
         let mut command = self.command.clone();
-        let project_environment = self.project_environment.downgrade();
-        cx.spawn(async move |cx| {
-            let mut env = project_environment
-                .update(cx, |project_environment, cx| {
-                    project_environment.default_environment(cx)
-                })?
-                .await
-                .unwrap_or_default();
-            env.extend(command.env.unwrap_or_default());
-            env.extend(extra_env);
-            command.env = Some(env);
-            Ok(command)
-        })
+        let mut env = command.env.unwrap_or_default();
+        env.extend(extra_env);
+        command.env = Some(env);
+        Task::ready(Ok(command))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -1902,7 +1854,6 @@ mod tests {
     use crate::agent_registry_store::{
         AgentRegistryStore, RegistryAgent, RegistryAgentMetadata, RegistryNpxAgent,
     };
-    use crate::worktree_store::{WorktreeIdCounter, WorktreeStore};
     use gpui::{AppContext as _, TestAppContext};
     use node_runtime::NodeRuntime;
     use settings::Settings as _;
@@ -1969,18 +1920,12 @@ mod tests {
     fn create_agent_server_store(cx: &mut TestAppContext) -> gpui::Entity<AgentServerStore> {
         cx.update(|cx| {
             let fs: Arc<dyn Fs> = fs::FakeFs::new(cx.background_executor().clone());
-            let worktree_store =
-                cx.new(|cx| WorktreeStore::local(false, fs.clone(), WorktreeIdCounter::get(cx)));
-            let project_environment = cx.new(|cx| {
-                crate::ProjectEnvironment::new(None, worktree_store.downgrade(), None, false, cx)
-            });
             let http_client = http_client::FakeHttpClient::with_404_response();
 
             cx.new(|cx| {
                 AgentServerStore::local(
                     NodeRuntime::unavailable(),
                     fs,
-                    project_environment,
                     http_client,
                     cx,
                 )

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -67,10 +67,15 @@ impl ProjectEnvironment {
         }
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn set_cli_environment(&mut self, env: HashMap<String, String>) {
+        self.cli_environment = Some(env);
+    }
+
     /// Returns the inherited CLI environment, if this project was opened from the Zed CLI.
     pub(crate) fn get_cli_environment(&self) -> Option<HashMap<String, String>> {
         if cfg!(any(test, feature = "test-support")) {
-            return Some(HashMap::default());
+            return Some(self.cli_environment.clone().unwrap_or_default());
         }
         if let Some(mut env) = self.cli_environment.clone() {
             set_origin_marker(&mut env, EnvironmentOrigin::Cli);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1286,7 +1286,6 @@ impl Project {
                 AgentServerStore::local(
                     node.clone(),
                     fs.clone(),
-                    environment.clone(),
                     client.http_client(),
                     cx,
                 )

--- a/crates/project/tests/integration/extension_agent_tests.rs
+++ b/crates/project/tests/integration/extension_agent_tests.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use collections::HashMap;
-use gpui::{AppContext, AsyncApp, SharedString, Task, TestAppContext};
+use gpui::{AsyncApp, SharedString, Task, TestAppContext};
 use node_runtime::NodeRuntime;
-use project::worktree_store::WorktreeStore;
-use project::{agent_server_store::*, worktree_store::WorktreeIdCounter};
+use project::agent_server_store::*;
 use std::{any::Any, path::PathBuf, sync::Arc};
 
 #[test]
@@ -129,17 +128,11 @@ fn archive_launcher_constructs_with_all_fields() {
 async fn archive_agent_uses_extension_and_agent_id_for_cache_key(cx: &mut TestAppContext) {
     let fs = fs::FakeFs::new(cx.background_executor.clone());
     let http_client = http_client::FakeHttpClient::with_404_response();
-    let worktree_store =
-        cx.new(|cx| WorktreeStore::local(false, fs.clone(), WorktreeIdCounter::get(cx)));
-    let project_environment = cx.new(|cx| {
-        crate::ProjectEnvironment::new(None, worktree_store.downgrade(), None, false, cx)
-    });
 
     let agent = LocalExtensionArchiveAgent {
         fs,
         http_client,
         node_runtime: node_runtime::NodeRuntime::unavailable(),
-        project_environment,
         extension_id: Arc::from("my-extension"),
         agent_id: Arc::from("my-agent"),
         version: Some(SharedString::from("1.0.0")),
@@ -213,17 +206,11 @@ async fn test_node_command_uses_managed_runtime(cx: &mut TestAppContext) {
     let fs = fs::FakeFs::new(cx.background_executor.clone());
     let http_client = http_client::FakeHttpClient::with_404_response();
     let node_runtime = NodeRuntime::unavailable();
-    let worktree_store =
-        cx.new(|cx| WorktreeStore::local(false, fs.clone(), WorktreeIdCounter::get(cx)));
-    let project_environment = cx.new(|cx| {
-        crate::ProjectEnvironment::new(None, worktree_store.downgrade(), None, false, cx)
-    });
 
     let agent = LocalExtensionArchiveAgent {
         fs: fs.clone(),
         http_client,
         node_runtime,
-        project_environment,
         extension_id: Arc::from("node-extension"),
         agent_id: Arc::from("node-agent"),
         version: Some(SharedString::from("1.0.0")),
@@ -259,17 +246,11 @@ async fn test_commands_run_in_extraction_directory(cx: &mut TestAppContext) {
     let fs = fs::FakeFs::new(cx.background_executor.clone());
     let http_client = http_client::FakeHttpClient::with_404_response();
     let node_runtime = NodeRuntime::unavailable();
-    let worktree_store =
-        cx.new(|cx| WorktreeStore::local(false, fs.clone(), WorktreeIdCounter::get(cx)));
-    let project_environment = cx.new(|cx| {
-        crate::ProjectEnvironment::new(None, worktree_store.downgrade(), None, false, cx)
-    });
 
     let agent = LocalExtensionArchiveAgent {
         fs: fs.clone(),
         http_client,
         node_runtime,
-        project_environment,
         extension_id: Arc::from("test-ext"),
         agent_id: Arc::from("test-agent"),
         version: Some(SharedString::from("1.0.0")),

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -236,7 +236,6 @@ impl HeadlessProject {
             let mut agent_server_store = AgentServerStore::local(
                 node_runtime.clone(),
                 fs.clone(),
-                environment.clone(),
                 http_client.clone(),
                 cx,
             );


### PR DESCRIPTION
The previous fix added the environment in get_command, duplicating the logic for each implementation.

This fix restores get_command to only be concerned about the agent and not the project.

Instead we extend the local env handling already present in stdio() to also take care of direnv environment setup and not just setting of the current working directory.

This way we have a clean separation of concerns and have a solution that should work for all agents. get_command gets you the command for running the agent, setting up a local project specific environment is the duty of the caller.

This refactor also makes testing much easier, as we can now test in isolation and be reasonably sure it will work for all agents. 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes https://github.com/zed-industries/zed/issues/38988

Release Notes:

- Fixed Claude Code not loading the direnv environment. It should now work for all agents.
