### PR TITLE
collab_panel: Make channel items have a fixed height

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1181,6 +1181,7 @@ impl CollabPanel {
         .into();
 
         ListItem::new(project_id as usize)
+            .height(rems_from_px(24.))
             .toggle_state(is_selected)
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.workspace
@@ -1221,6 +1222,7 @@ impl CollabPanel {
         let id = peer_id.map_or(usize::MAX, |id| id.as_u64() as usize);
 
         ListItem::new(("screen", id))
+            .height(rems_from_px(24.))
             .toggle_state(is_selected)
             .start_slot(
                 h_flex()
@@ -1267,6 +1269,7 @@ impl CollabPanel {
         let has_channel_buffer_changed = channel_store.has_channel_buffer_changed(channel_id);
 
         ListItem::new("channel-notes")
+            .height(rems_from_px(24.))
             .toggle_state(is_selected)
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.open_channel_notes(channel_id, window, cx);
@@ -3207,9 +3210,12 @@ impl CollabPanel {
             (IconName::Star, Color::Default, "Add to Favorites")
         };
 
+        let height = rems_from_px(24.);
+
         h_flex()
             .id(ix)
             .group("")
+            .h(height)
             .w_full()
             .overflow_hidden()
             .when(!channel.is_root_channel(), |el| {
@@ -3239,6 +3245,7 @@ impl CollabPanel {
             )
             .child(
                 ListItem::new(ix)
+                    .height(height)
                     // Add one level of depth for the disclosure arrow.
                     .indent_level(depth + 1)
                     .indent_step_size(px(20.))

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -52,7 +52,7 @@ pub struct ListItem {
     overflow_x: bool,
     focused: Option<bool>,
     docked_right: bool,
-    height: Option<Pixels>,
+    height: Option<DefiniteLength>,
 }
 
 impl ListItem {
@@ -207,8 +207,8 @@ impl ListItem {
         self
     }
 
-    pub fn height(mut self, height: Pixels) -> Self {
-        self.height = Some(height);
+    pub fn height(mut self, height: impl Into<DefiniteLength>) -> Self {
+        self.height = Some(height.into());
         self
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/53290

This PR fixes a mistake I pushed before of making the `ListItem`'s height method take pixels instead of a scalable unit like rems. Now, it takes `DefiniteLength` which can house both values, meaning we should be clear to set an explicit height for all of these items while still preserving font-size scaling. 

Release Notes:

- N/A
