### PR TITLE
Disable code actions button when buffer search bar is focused

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -745,6 +745,10 @@ impl BufferSearchBar {
         self.query_editor_focused
     }
 
+    pub fn has_focused_editor(&self) -> bool {
+        self.query_editor_focused || self.replacement_editor_focused
+    }
+
     pub fn register(registrar: &mut impl SearchActionsRegistrar) {
         registrar.register_handler(ForDeployed(|this, _: &FocusSearch, window, cx| {
             this.query_editor.focus_handle(cx).focus(window, cx);

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -131,7 +131,12 @@ impl Render for QuickActionBar {
             editor_value.edit_predictions_enabled_at_cursor(cx);
         let supports_minimap = editor_value.supports_minimap(cx);
         let minimap_enabled = supports_minimap && editor_value.minimap().is_some();
-        let has_available_code_actions = editor_value.has_available_code_actions();
+        let search_bar_focused = {
+            let search_bar = self.buffer_search_bar.read(cx);
+            !search_bar.is_dismissed() && search_bar.has_focused_editor()
+        };
+        let has_available_code_actions =
+            !search_bar_focused && editor_value.has_available_code_actions();
         let code_action_enabled = editor_value.code_actions_enabled_for_toolbar(cx);
         let focus_handle = editor_value.focus_handle(cx);
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53210

Release Notes:

- Fixed code actions toolbar button flickering when using Find to jump between search results