### PR TITLE
Inherit parent thread settings when spawning subagents

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -999,6 +999,7 @@ impl Thread {
             parent_thread_id: parent_thread.read(cx).id().clone(),
             depth: parent_thread.read(cx).depth() + 1,
         });
+        thread.inherit_parent_settings(parent_thread, cx);
         thread
     }
 
@@ -1083,6 +1084,19 @@ impl Thread {
             ui_scroll_position: None,
             running_subagents: Vec::new(),
         }
+    }
+
+    /// Copies runtime-mutable settings from the parent thread so that
+    /// subagents start with the same configuration the user selected.
+    /// Every property that `set_*` propagates to `running_subagents`
+    /// should be inherited here as well.
+    fn inherit_parent_settings(&mut self, parent_thread: &Entity<Thread>, cx: &mut Context<Self>) {
+        let parent = parent_thread.read(cx);
+        self.speed = parent.speed;
+        self.thinking_enabled = parent.thinking_enabled;
+        self.thinking_effort = parent.thinking_effort.clone();
+        self.summarization_model = parent.summarization_model.clone();
+        self.profile_id = parent.profile_id.clone();
     }
 
     pub fn id(&self) -> &acp::SessionId {
@@ -4264,6 +4278,30 @@ mod tests {
                     "Subagent thinking effort should be None after parent clears it"
                 );
             }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_subagent_inherits_settings_at_creation(cx: &mut TestAppContext) {
+        let (parent, _event_stream) = setup_thread_for_test(cx).await;
+
+        cx.update(|cx| {
+            parent.update(cx, |thread, cx| {
+                thread.set_speed(Speed::Fast, cx);
+                thread.set_thinking_enabled(true, cx);
+                thread.set_thinking_effort(Some("high".to_string()), cx);
+                thread.set_profile(AgentProfileId("custom-profile".into()), cx);
+            });
+        });
+
+        let subagents = setup_parent_with_subagents(cx, &parent, 1);
+
+        cx.update(|cx| {
+            let sub = subagents[0].read(cx);
+            assert_eq!(sub.speed(), Some(Speed::Fast));
+            assert!(sub.thinking_enabled());
+            assert_eq!(sub.thinking_effort().map(|s| s.as_str()), Some("high"));
+            assert_eq!(sub.profile(), &AgentProfileId("custom-profile".into()));
         });
     }
 


### PR DESCRIPTION
When a subagent was spawned while the parent had runtime-modified settings (fast mode, thinking, etc.), the subagent would start with defaults from `AgentSettings` instead of inheriting the parent's current values.

This adds `inherit_parent_settings` as a single place in `Thread::new_subagent` that copies all runtime-mutable settings from the parent:

- `speed`
- `thinking_enabled`
- `thinking_effort`
- `summarization_model`
- `profile_id`

These are the same properties that `set_*` methods already propagate to `running_subagents` — this fix ensures they're also inherited at creation time.

cc @benbrandt

Release Notes:

- N/A