### PR TITLE
docs: add instructions to ensure Metal Toolchain is available for dev on macOS

### DIFF
--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -30,6 +30,12 @@ Clone the [Zed repository](https://github.com/zed-industries/zed).
   sudo xcodebuild -license accept
   ```
 
+- Ensure Metal Toolchain is available:
+
+  ```sh
+  xcodebuild -downloadComponent MetalToolchain
+  ```
+
 - Install `cmake` (required by [a dependency](https://docs.rs/wasmtime-c-api-impl/latest/wasmtime_c_api/))
 
   ```sh


### PR DESCRIPTION
There is a missing step in the `docs --> developement --> macos.md` for setting up a dev env. 
On newer macOS & Xcode, appearantly the Metal Toolchain is not installed by default when installing Xcode (+ default Mac components). I recently went through the steps on two Macs and both times I got the error below while compiling Zed for the first time.

Not a big deal since the error tells you how to fix it, but still think this can be added to the docs.

```log
error: gpui_macos@0.1.0: metal shader compilation failed:
error: failed to run custom build command for `gpui_macos v0.1.0 (/Users/taha/Developer/zed/crates/gpui_macos)`

Caused by:
  process didn't exit successfully: `/Users/taha/Developer/zed/target/debug/build/gpui_macos-9167a91f3a93615c/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=/Users/taha/Developer/zed/crates/gpui/src/scene.rs
  cargo:rerun-if-changed=/Users/taha/Developer/zed/crates/gpui/src/geometry.rs
  cargo:rerun-if-changed=/Users/taha/Developer/zed/crates/gpui/src/color.rs
  cargo:rerun-if-changed=/Users/taha/Developer/zed/crates/gpui/src/window.rs
  cargo:rerun-if-changed=/Users/taha/Developer/zed/crates/gpui/src/platform.rs
  cargo:rerun-if-changed=/Users/taha/Developer/zed/crates/gpui_macos/src/metal_renderer.rs
  cargo:rerun-if-changed=./src/shaders.metal
  cargo::error=metal shader compilation failed:
  error: error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain

warning: build failed, waiting for other jobs to finish...
```

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable
- [x] Prettier check passed.

Release Notes:

- Improved Documentation for macOS development dependencies.
