### PR TITLE
docs: Update models page with new GPT models and corrected pricing

### DIFF
--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -1,11 +1,13 @@
 ---
 title: AI Models and Pricing - Zed
-description: AI models available via Zed Pro including Claude, GPT-5.2, Gemini 3.1 Pro, and Grok. Pricing, context windows, and tool call support.
+description: AI models available via Zed Pro including Claude, GPT-5.4, Gemini 3.1 Pro, and Grok. Pricing, context windows, and tool call support.
 ---
 
 # Models
 
 Zed's plans offer hosted versions of major LLMs with higher rate limits than direct API access. Model availability is updated regularly. To use your own API keys instead, see [LLM Providers](./llm-providers.md). For general setup, see [Configuration](./configuration.md).
+
+> **Note:** Claude Opus models and GPT-5.4 pro are not available on the [Student plan](./plans-and-usage.md#student).
 
 | Model                  | Provider  | Token Type          | Provider Price per 1M tokens | Zed Price per 1M tokens |
 | ---------------------- | --------- | ------------------- | ---------------------------- | ----------------------- |
@@ -29,12 +31,20 @@ Zed's plans offer hosted versions of major LLMs with higher rate limits than dir
 |                        | Anthropic | Output              | $5.00                        | $5.50                   |
 |                        | Anthropic | Input - Cache Write | $1.25                        | $1.375                  |
 |                        | Anthropic | Input - Cache Read  | $0.10                        | $0.11                   |
-| GPT-5.2                | OpenAI    | Input               | $1.25                        | $1.375                  |
-|                        | OpenAI    | Output              | $10.00                       | $11.00                  |
-|                        | OpenAI    | Cached Input        | $0.125                       | $0.1375                 |
-| GPT-5.2 Codex          | OpenAI    | Input               | $1.25                        | $1.375                  |
-|                        | OpenAI    | Output              | $10.00                       | $11.00                  |
-|                        | OpenAI    | Cached Input        | $0.125                       | $0.1375                 |
+| GPT-5.4 pro            | OpenAI    | Input               | $30.00                       | $33.00                  |
+|                        | OpenAI    | Output              | $180.00                      | $198.00                 |
+| GPT-5.4                | OpenAI    | Input               | $2.50                        | $2.75                   |
+|                        | OpenAI    | Output              | $15.00                       | $16.50                  |
+|                        | OpenAI    | Cached Input        | $0.025                       | $0.0275                 |
+| GPT-5.3-Codex          | OpenAI    | Input               | $1.75                        | $1.925                  |
+|                        | OpenAI    | Output              | $14.00                       | $15.40                  |
+|                        | OpenAI    | Cached Input        | $0.175                       | $0.1925                 |
+| GPT-5.2                | OpenAI    | Input               | $1.75                        | $1.925                  |
+|                        | OpenAI    | Output              | $14.00                       | $15.40                  |
+|                        | OpenAI    | Cached Input        | $0.175                       | $0.1925                 |
+| GPT-5.2-Codex          | OpenAI    | Input               | $1.75                        | $1.925                  |
+|                        | OpenAI    | Output              | $14.00                       | $15.40                  |
+|                        | OpenAI    | Cached Input        | $0.175                       | $0.1925                 |
 | GPT-5 mini             | OpenAI    | Input               | $0.25                        | $0.275                  |
 |                        | OpenAI    | Output              | $2.00                        | $2.20                   |
 |                        | OpenAI    | Cached Input        | $0.025                       | $0.0275                 |
@@ -43,8 +53,8 @@ Zed's plans offer hosted versions of major LLMs with higher rate limits than dir
 |                        | OpenAI    | Cached Input        | $0.005                       | $0.0055                 |
 | Gemini 3.1 Pro         | Google    | Input               | $2.00                        | $2.20                   |
 |                        | Google    | Output              | $12.00                       | $13.20                  |
-| Gemini 3 Flash         | Google    | Input               | $0.30                        | $0.33                   |
-|                        | Google    | Output              | $2.50                        | $2.75                   |
+| Gemini 3 Flash         | Google    | Input               | $0.50                        | $0.55                   |
+|                        | Google    | Output              | $3.00                        | $3.30                   |
 | Grok 4                 | X.ai      | Input               | $3.00                        | $3.30                   |
 |                        | X.ai      | Output              | $15.00                       | $16.5                   |
 |                        | X.ai      | Cached Input        | $0.75                        | $0.825                  |
@@ -65,7 +75,7 @@ As of February 19, 2026, Zed Pro serves newer model versions in place of the ret
 - Claude Opus 4.1 → Claude Opus 4.5 or Claude Opus 4.6
 - Claude Sonnet 4 → Claude Sonnet 4.5 or Claude Sonnet 4.6
 - Claude Sonnet 3.7 (retired Feb 19) → Claude Sonnet 4.5 or Claude Sonnet 4.6
-- GPT-5.1 and GPT-5 → GPT-5.2 or GPT-5.2 Codex
+- GPT-5.1 and GPT-5 → GPT-5.2 or GPT-5.2-Codex
 - Gemini 2.5 Pro → Gemini 3.1 Pro
 - Gemini 3 Pro → Gemini 3.1 Pro
 - Gemini 2.5 Flash → Gemini 3 Flash
@@ -80,21 +90,28 @@ Any usage of a Zed-hosted model will be billed at the Zed Price (rightmost colum
 
 A context window is the maximum span of text and code an LLM can consider at once, including both the input prompt and output generated by the model.
 
-| Model             | Provider  | Zed-Hosted Context Window |
-| ----------------- | --------- | ------------------------- |
-| Claude Opus 4.5   | Anthropic | 200k                      |
-| Claude Opus 4.6   | Anthropic | 1M                        |
-| Claude Sonnet 4.5 | Anthropic | 200k                      |
-| Claude Sonnet 4.6 | Anthropic | 1M                        |
-| Claude Haiku 4.5  | Anthropic | 200k                      |
-| GPT-5.2           | OpenAI    | 400k                      |
-| GPT-5.2 Codex     | OpenAI    | 400k                      |
-| GPT-5 mini        | OpenAI    | 400k                      |
-| GPT-5 nano        | OpenAI    | 400k                      |
-| Gemini 3.1 Pro    | Google    | 200k                      |
-| Gemini 3 Flash    | Google    | 200k                      |
+| Model                       | Provider  | Zed-Hosted Context Window |
+| --------------------------- | --------- | ------------------------- |
+| Claude Opus 4.5             | Anthropic | 200k                      |
+| Claude Opus 4.6             | Anthropic | 1M                        |
+| Claude Sonnet 4.5           | Anthropic | 200k                      |
+| Claude Sonnet 4.6           | Anthropic | 1M                        |
+| Claude Haiku 4.5            | Anthropic | 200k                      |
+| GPT-5.4 pro                 | OpenAI    | 400k                      |
+| GPT-5.4                     | OpenAI    | 400k                      |
+| GPT-5.3-Codex               | OpenAI    | 400k                      |
+| GPT-5.2                     | OpenAI    | 400k                      |
+| GPT-5.2-Codex               | OpenAI    | 400k                      |
+| GPT-5 mini                  | OpenAI    | 400k                      |
+| GPT-5 nano                  | OpenAI    | 400k                      |
+| Gemini 3.1 Pro              | Google    | 200k                      |
+| Gemini 3 Flash              | Google    | 200k                      |
+| Grok 4                      | X.ai      | 128k                      |
+| Grok 4 Fast                 | X.ai      | 128k                      |
+| Grok 4 Fast (Non-Reasoning) | X.ai      | 128k                      |
+| Grok Code Fast 1            | X.ai      | 256k                      |
 
-> Context window limits for hosted Gemini 3.1 Pro/3 Pro/Flash may increase in future releases.
+> Context window limits for hosted Gemini 3.1 Pro/3 Flash may increase in future releases.
 
 Each Agent thread in Zed maintains its own context window.
 The more prompts, attached files, and responses included in a session, the larger the context window grows.


### PR DESCRIPTION
Syncs the models docs page with what `crates/billing/src/plans.rs` and `crates/llm_api/src/features/list_models.rs` actually serve.

## Changes

**New models added:**
- GPT-5.4 pro (Pro/Business only): $30/$180 input/output, no cache, 400k context
- GPT-5.4: $2.50/$15 input/output, $0.025 cached, 400k context
- GPT-5.3-Codex: $1.75/$14 input/output, $0.175 cached, 400k context

**Pricing corrected:**
- GPT-5.2 + GPT-5.2-Codex: input $1.25 → $1.75, output $10 → $14, cached $0.125 → $0.175
- Gemini 3 Flash: input $0.30 → $0.50, output $2.50 → $3.00

**Other fixes:**
- Student plan note updated to include GPT-5.4 pro restriction
- Grok context windows added to the context window table (128k / 256k for Grok Code Fast 1)
- "GPT-5.2 Codex" renamed to "GPT-5.2-Codex" to match `display_name` in code
- Removed retired "Gemini 3 Pro" from context window footnote

Release Notes:

- N/A