### PR TITLE
agent: Fix panel prompt footer layout in full screen

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3165,12 +3165,14 @@ impl ThreadView {
             .child(
                 v_flex()
                     .flex_1()
+                    .min_h_0()
                     .w_full()
                     .max_w(max_content_width)
                     .mx_auto()
                     .child(
                         v_flex()
                             .relative()
+                            .min_h_0()
                             .size_full()
                             .when(v2_empty_state, |this| this.flex_1())
                             .pt_1()
@@ -3208,36 +3210,39 @@ impl ThreadView {
                                         ),
                                 )
                             }),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .w_full()
+                    .max_w(max_content_width)
+                    .mx_auto()
+                    .flex_none()
+                    .flex_wrap()
+                    .justify_between()
+                    .child(
+                        h_flex()
+                            .gap_0p5()
+                            .child(self.render_add_context_button(cx))
+                            .child(self.render_follow_toggle(cx))
+                            .children(self.render_fast_mode_control(cx))
+                            .children(self.render_thinking_control(cx)),
                     )
                     .child(
                         h_flex()
-                            .flex_none()
-                            .flex_wrap()
-                            .justify_between()
-                            .child(
-                                h_flex()
-                                    .gap_0p5()
-                                    .child(self.render_add_context_button(cx))
-                                    .child(self.render_follow_toggle(cx))
-                                    .children(self.render_fast_mode_control(cx))
-                                    .children(self.render_thinking_control(cx)),
-                            )
-                            .child(
-                                h_flex()
-                                    .gap_1()
-                                    .children(self.render_token_usage(cx))
-                                    .children(self.profile_selector.clone())
-                                    .map(|this| {
-                                        // Either config_options_view OR (mode_selector + model_selector)
-                                        match self.config_options_view.clone() {
-                                            Some(config_view) => this.child(config_view),
-                                            None => this
-                                                .children(self.mode_selector.clone())
-                                                .children(self.model_selector.clone()),
-                                        }
-                                    })
-                                    .child(self.render_send_button(cx)),
-                            ),
+                            .gap_1()
+                            .children(self.render_token_usage(cx))
+                            .children(self.profile_selector.clone())
+                            .map(|this| {
+                                // Either config_options_view OR (mode_selector + model_selector)
+                                match self.config_options_view.clone() {
+                                    Some(config_view) => this.child(config_view),
+                                    None => this
+                                        .children(self.mode_selector.clone())
+                                        .children(self.model_selector.clone()),
+                                }
+                            })
+                            .child(self.render_send_button(cx)),
                     ),
             )
             .into_any()


### PR DESCRIPTION
### Summary

Keep the prompt editor’s max-width centering, but move the footer controls out of the same flexible wrapper as the full-height editor and add `min_h_0()` shrink guards so the editor no longer overlaps the footer in zoomed/full-screen mode.


#### Before
<img width="1624" height="1061" alt="Screenshot 2026-04-07 at 8 39 03 PM" src="https://github.com/user-attachments/assets/db889fcd-af8a-4297-a1f9-0acb84e6ead3" />

#### After
<img width="1624" height="976" alt="Screenshot 2026-04-07 at 9 14 52 PM" src="https://github.com/user-attachments/assets/ddae7fd4-e720-432d-b84d-45f667aa7dce" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
