### PR TITLE
settings_ui: Fix hover popover delay setting's json_path

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1758,7 +1758,7 @@ fn editor_page() -> SettingsPage {
                 title: "Delay",
                 description: "Time to wait in milliseconds before showing the informational hover box.",
                 field: Box::new(SettingField {
-                    json_path: Some("hover_popover_enabled"),
+                    json_path: Some("hover_popover_delay"),
                     pick: |settings_content| settings_content.editor.hover_popover_delay.as_ref(),
                     write: |settings_content, value| {
                         settings_content.editor.hover_popover_delay = value;


### PR DESCRIPTION
The "Hover Popover → Delay" setting item had its json_path set to "hover_popover_enabled" (copy-paste error from the item above it), introduced in #40739. This caused:

- "Copy Link" generating a wrong zed://settings/hover_popover_enabled URL
- #hover_popover_delay filter returning no results in settings search
- Telemetry reporting delay changes as hover_popover_enabled

The pick/write closures were always correct, so the setting itself functioned normally.

after the fix, filter works correctly

<img width="1793" height="752" alt="image" src="https://github.com/user-attachments/assets/b7c459bf-c0d6-4988-ae87-087e859c6666" />

and the copy link button return the correct result
<img width="1787" height="120" alt="image" src="https://github.com/user-attachments/assets/e2184f89-c400-453b-8e7d-f8ef8771e1d6" />

Release Notes:

- Fixed an issue where "Hover Popover Delay" setting could not be searched or linked correctly in the settings UI.
