### PR TITLE
agent_panel: Allow dismissing the worktree error callout

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -4119,9 +4119,20 @@ impl AgentPanel {
             ),
             WorktreeCreationStatus::Error(message) => Some(
                 Callout::new()
-                    .icon(IconName::Warning)
-                    .severity(Severity::Warning)
-                    .title(message.clone())
+                    .icon(IconName::XCircleFilled)
+                    .severity(Severity::Error)
+                    .title("Worktree Creation Error")
+                    .description(message.clone())
+                    .border_position(ui::BorderPosition::Bottom)
+                    .dismiss_action(
+                        IconButton::new("dismiss-worktree-error", IconName::Close)
+                            .icon_size(IconSize::Small)
+                            .tooltip(Tooltip::text("Dismiss"))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.worktree_creation_status = None;
+                                cx.notify();
+                            })),
+                    )
                     .into_any_element(),
             ),
         }


### PR DESCRIPTION
This error callout here wasn't dismissible before:

<img width="600" height="2154" alt="Screenshot 2026-04-08 at 5  49@2x" src="https://github.com/user-attachments/assets/4e9df452-9970-4145-a13d-75d5e0adee8b" />

Release Notes:

- N/A
