### PR TITLE
gpui: Add is_scrollbar_dragging() accessor to ListState

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -694,6 +694,16 @@ impl ListState {
         self.0.borrow_mut().scrollbar_drag_start_height.take();
     }
 
+    /// Returns `true` if the scrollbar is currently being dragged.
+    ///
+    /// This is set between [`scrollbar_drag_started`](Self::scrollbar_drag_started)
+    /// and [`scrollbar_drag_ended`](Self::scrollbar_drag_ended) calls. Useful for
+    /// consumers that need to distinguish scrollbar drags from wheel/trackpad scrolls,
+    /// e.g. to suppress auto-scroll behavior during manual positioning.
+    pub fn is_scrollbar_dragging(&self) -> bool {
+        self.0.borrow().scrollbar_drag_start_height.is_some()
+    }
+
     /// Set the offset from the scrollbar
     pub fn set_offset_from_scrollbar(&self, point: Point<Pixels>) {
         self.0.borrow_mut().set_offset_from_scrollbar(point);


### PR DESCRIPTION
## Summary

Expose whether the scrollbar is currently being dragged via a new `is_scrollbar_dragging()` method on `ListState`.

This returns `true` between `scrollbar_drag_started()` and `scrollbar_drag_ended()` calls. It lets consumers distinguish scrollbar drags from wheel/trackpad scrolls, which is useful for suppressing auto-scroll or follow-tail behavior during manual scrollbar positioning.

## Test plan

- [x] Code review — one-liner accessor, delegates to existing `scrollbar_drag_start_height` field
- [ ] Verify compilation with `cargo check -p gpui`

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)