### PR TITLE
Compile tree-sitter with opt-level 3 in dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -899,6 +899,7 @@ syn = { opt-level = 3 }
 proc-macro2 = { opt-level = 3 }
 # proc-macros end
 
+tree-sitter = { opt-level = 3 }
 taffy = { opt-level = 3 }
 resvg = { opt-level = 3 }
 wasmtime = { opt-level = 3 }


### PR DESCRIPTION
tree-sitter query compilation (used to set up language grammars) is a significant bottleneck in test setup. Profiling showed rust_lang() creation taking ~270ms per test in dev builds, with nearly all time spent in tree-sitter's query compiler.

With opt-level = 3, this drops to ~63ms locally — a 4x speedup on that step. Across hundreds of tests that create language grammars (vim, editor, collab, etc.), this ought to save substantial CI time.



Release Notes:

- N/A or Added/Fixed/Improved ...
