### PR TITLE
sidebar: Fix focus movement to protect zoomed in panels

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -514,21 +514,9 @@ impl MultiWorkspace {
         if let Some(previous_focus) = focus_handle {
             previous_focus.focus(window, cx);
         } else {
-            self.focus_zoomed_panel_or_center_pane(window, cx);
+            let pane = self.workspace().read(cx).active_pane().clone();
+            window.focus(&pane.read(cx).focus_handle(cx), cx);
         }
-    }
-
-    fn focus_zoomed_panel_or_center_pane(&self, window: &mut Window, cx: &mut App) {
-        let workspace = self.workspace().read(cx);
-        if let Some(zoomed_position) = workspace.zoomed_position {
-            let dock = workspace.dock_at_position(zoomed_position).read(cx);
-            if let Some(panel) = dock.active_panel() {
-                panel.panel_focus_handle(cx).focus(window, cx);
-                return;
-            }
-        }
-        let pane = workspace.active_pane().clone();
-        window.focus(&pane.read(cx).focus_handle(cx), cx);
     }
 
     pub fn close_window(&mut self, _: &CloseWindow, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -491,7 +491,15 @@ impl MultiWorkspace {
                 workspace.set_sidebar_focus_handle(None);
             });
         }
-        self.restore_previous_focus(true, window, cx);
+        let sidebar_has_focus = self
+            .sidebar
+            .as_ref()
+            .is_some_and(|s| s.focus_handle(cx).contains_focused(window, cx));
+        if sidebar_has_focus {
+            self.restore_previous_focus(true, window, cx);
+        } else {
+            self.previous_focus_handle.take();
+        }
         self.serialize(cx);
         cx.notify();
     }
@@ -506,9 +514,21 @@ impl MultiWorkspace {
         if let Some(previous_focus) = focus_handle {
             previous_focus.focus(window, cx);
         } else {
-            let pane = self.workspace().read(cx).active_pane().clone();
-            window.focus(&pane.read(cx).focus_handle(cx), cx);
+            self.focus_zoomed_panel_or_center_pane(window, cx);
         }
+    }
+
+    fn focus_zoomed_panel_or_center_pane(&self, window: &mut Window, cx: &mut App) {
+        let workspace = self.workspace().read(cx);
+        if let Some(zoomed_position) = workspace.zoomed_position {
+            let dock = workspace.dock_at_position(zoomed_position).read(cx);
+            if let Some(panel) = dock.active_panel() {
+                panel.panel_focus_handle(cx).focus(window, cx);
+                return;
+            }
+        }
+        let pane = workspace.active_pane().clone();
+        window.focus(&pane.read(cx).focus_handle(cx), cx);
     }
 
     pub fn close_window(&mut self, _: &CloseWindow, window: &mut Window, cx: &mut Context<Self>) {


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/53283. That PR replaced _where_ focus goes — from "always the center pane" to "the saved element." But it didn't fix _when_ focus moves — it still moves every time the sidebar closes, unconditionally. The problem is the saved focus can be wrong... it's saved when the sidebar opens, but then it can go to somewhere else after. An example:

1. Open sidebar → save focus (center pane), focus sidebar
2. Open agent panel from sidebar → focus moves to agent panel
3. Close sidebar → restore saved focus → **focuses center pane** (that's what was saved in step 1, not the agent panel)

Effectively, this would still cause the agent panel to auto-dismiss. This PR fixes it by no moving focus at all if the sidebar doesn't have it. If the user already moved focus to the agent panel, there's nothing to "restore".

Release Notes:

- N/A
