### PR TITLE
Add auto_install setting for Node binary downloads

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -729,7 +729,11 @@ where
 
             if !binary_options.allow_binary_download {
                 return (
-                    Err(anyhow::anyhow!("downloading language servers disabled")),
+                    Err(anyhow::anyhow!(
+                        "Language server \"{}\" not found and auto-install is disabled. \
+                         Install it manually or set `\"node\": {{\"auto_install\": true}}` in settings.",
+                        self.name()
+                    )),
                     None,
                 );
             }

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -183,25 +183,23 @@ impl NodeRuntime {
             }
         } else if let Some(system_node_error) = system_node_error {
             // failure case not cached, since it's cheap to check again
-            //
-            // TODO: When support is added for setting `options.allow_binary_download`, update this
-            // error message.
             return Box::new(UnavailableNodeRuntime {
                 error_message: format!(
-                    "failure while checking system Node.js from PATH: {}",
+                    "Node.js not found on system and auto-install is disabled: {}. \
+                     Install Node.js manually or set `\"node\": {{\"auto_install\": true}}` in settings.",
                     system_node_error
                 )
                 .into(),
             });
         } else {
             // failure case is cached because it will always happen with these options
-            //
-            // TODO: When support is added for setting `options.allow_binary_download`, update this
-            // error message.
             Box::new(UnavailableNodeRuntime {
-                error_message: "`node` settings do not allow any way to use Node.js"
-                    .to_string()
-                    .into(),
+                error_message:
+                    "Node.js auto-install is disabled and no system Node.js is configured. \
+                     Set `\"node\": {\"path\": \"/path/to/node\"}` or \
+                     `\"node\": {\"auto_install\": true}` in settings."
+                        .to_string()
+                        .into(),
             })
         };
 

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -106,6 +106,9 @@ pub struct NodeBinarySettings {
     pub npm_path: Option<String>,
     /// If enabled, Zed will download its own copy of Node.
     pub ignore_system_version: bool,
+    /// Whether Zed may automatically download Node if it isn't found on the
+    /// system.
+    pub auto_install: bool,
 }
 
 impl From<settings::NodeBinarySettings> for NodeBinarySettings {
@@ -114,6 +117,7 @@ impl From<settings::NodeBinarySettings> for NodeBinarySettings {
             path: settings.path,
             npm_path: settings.npm_path,
             ignore_system_version: settings.ignore_system_version.unwrap_or(false),
+            auto_install: settings.auto_install.unwrap_or(true),
         }
     }
 }

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -1102,8 +1102,7 @@ fn initialize_settings(
             log::info!("Got new node settings: {new_node_settings:?}");
             let options = NodeBinaryOptions {
                 allow_path_lookup: !new_node_settings.ignore_system_version,
-                // TODO: Implement this setting
-                allow_binary_download: true,
+                allow_binary_download: new_node_settings.auto_install,
                 use_paths: new_node_settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = new_node_settings

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -736,6 +736,13 @@ pub struct NodeBinarySettings {
     pub npm_path: Option<String>,
     /// If enabled, Zed will download its own copy of Node.
     pub ignore_system_version: Option<bool>,
+    /// Whether Zed may automatically download Node if it isn't
+    /// found on the system. Set to `false` to prevent any
+    /// automatic downloads. When disabled, Zed will only use a
+    /// Node binary found on your PATH or at the configured `path`.
+    ///
+    /// Default: true
+    pub auto_install: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -517,8 +517,7 @@ fn main() {
             let settings = &ProjectSettings::get_global(cx).node;
             let options = NodeBinaryOptions {
                 allow_path_lookup: !settings.ignore_system_version,
-                // TODO: Expose this setting
-                allow_binary_download: true,
+                allow_binary_download: settings.auto_install,
                 use_paths: settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = settings


### PR DESCRIPTION
Zed currently downloads Node.js and language server binaries automatically with no way for users to opt out. This is a security and privacy concern for enterprise environments, air-gapped networks, metered connections, and compliance-aware organizations.

The `allow_binary_download` gate already exists in the language server binary resolution path — it was simply hardcoded to `true` with TODO comments asking for the setting to be exposed.

## Changes

- Add `node.auto_install` setting (default: `true`) to `NodeBinarySettings` in the settings schema
- Wire the setting through to `NodeBinaryOptions` in both the main app (`main.rs:521`) and the remote server (`server.rs:1106`), replacing the hardcoded `true` values
- Resolve the TODO comments that asked for this setting to be exposed
- When auto-install is disabled and no Node binary is found, error messages now guide the user to either install Node manually or configure a custom path

## Usage

```json
{
  "node": {
    "auto_install": false,
    "path": "/usr/local/bin/node"
  }
}
```

Setting `auto_install` to `false` prevents Zed from downloading Node.js. Users can point to an existing installation via `path`, or rely on the system PATH. The default remains `true` for backward compatibility.

Closes #12589

Release Notes:

- Added `node.auto_install` setting to control automatic Node.js binary downloads. Set to `false` to prevent Zed from downloading Node.js, useful for enterprise environments or restricted networks.