### PR TITLE
ci: Continue on error if non-blocking compliance step fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,6 +315,7 @@ jobs:
       env:
         GITHUB_APP_ID: ${{ secrets.ZED_ZIPPY_APP_ID }}
         GITHUB_APP_KEY: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
+      continue-on-error: true
     - name: '@actions/upload-artifact compliance-report.md'
       if: always()
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -226,6 +226,7 @@ fn compliance_check() -> NamedJob {
             "#,
         })
         .id("run-compliance-check")
+        .continue_on_error(true)
         .add_env(("GITHUB_APP_ID", vars::ZED_ZIPPY_APP_ID))
         .add_env(("GITHUB_APP_KEY", vars::ZED_ZIPPY_APP_PRIVATE_KEY))
     }

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -226,9 +226,9 @@ fn compliance_check() -> NamedJob {
             "#,
         })
         .id("run-compliance-check")
-        .continue_on_error(true)
         .add_env(("GITHUB_APP_ID", vars::ZED_ZIPPY_APP_ID))
         .add_env(("GITHUB_APP_KEY", vars::ZED_ZIPPY_APP_PRIVATE_KEY))
+        .continue_on_error(true)
     }
 
     let job = release_job(&[])


### PR DESCRIPTION
This will make rerunning failing jobs easier, as this here is just a pager, not anything we need to rerun - there exists a second check that is blocking and should be rerun, this job however does not need to be.

Release Notes:

- N/A
