### PR TITLE
Fix empty path being shown as an item in the recent projects picker

### DIFF
--- a/crates/sidebar/src/sidebar_tests.proptest-regressions
+++ b/crates/sidebar/src/sidebar_tests.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 36183b5df9e5e2521c5366af3f6b295559b5c72b9477169e394f2c640d1d54f5 # shrinks to TestSidebarInvariantsArgs = TestSidebarInvariantsArgs { __seed: 18181010490781345706, raw_operations: [16, 69, 72] }

--- a/crates/sidebar/src/sidebar_tests.proptest-regressions
+++ b/crates/sidebar/src/sidebar_tests.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 36183b5df9e5e2521c5366af3f6b295559b5c72b9477169e394f2c640d1d54f5 # shrinks to TestSidebarInvariantsArgs = TestSidebarInvariantsArgs { __seed: 18181010490781345706, raw_operations: [16, 69, 72] }

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -578,6 +578,9 @@ impl MultiWorkspace {
     pub fn restore_project_group_keys(&mut self, keys: Vec<ProjectGroupKey>) {
         let mut restored: Vec<ProjectGroupKey> = Vec::with_capacity(keys.len());
         for key in keys {
+            if key.path_list().paths().is_empty() {
+                continue;
+            }
             if !restored.contains(&key) {
                 restored.push(key);
             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8778,6 +8778,9 @@ pub async fn restore_multiworkspace(
         // stale keys from previous sessions get normalized and deduped.
         let mut resolved_keys: Vec<ProjectGroupKey> = Vec::new();
         for key in project_group_keys.into_iter().map(ProjectGroupKey::from) {
+            if key.path_list().paths().is_empty() {
+                continue;
+            }
             let mut resolved_paths = Vec::new();
             for path in key.path_list().paths() {
                 if let Some(common_dir) =


### PR DESCRIPTION
A couple of restore project group/workspaces functions weren't filtering out project groups with empty paths, leading to an empty being shown in the recent projects picker. This is the problem this PR solves:

<img width="400" height="1042" alt="Screenshot 2026-04-08 at 11  06@2x" src="https://github.com/user-attachments/assets/4d96cc53-5b03-445c-968b-8a8edec559da" />

Release Notes:

- N/A
