### PR TITLE
language_models: Add API key helper for OpenAI-compatible providers

### DIFF
--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -277,6 +277,7 @@ fn save_provider_to_settings(
                         OpenAiCompatibleSettingsContent {
                             api_url,
                             available_models: models,
+                            api_key_helper: None,
                         },
                     );
             });

--- a/crates/language_model/src/api_key.rs
+++ b/crates/language_model/src/api_key.rs
@@ -11,8 +11,8 @@ use util::ResultExt as _;
 
 use crate::AuthenticateError;
 
-/// Manages a single API key for a language model provider. API keys either come from environment
-/// variables or the system keychain.
+/// Manages a single API key for a language model provider. API keys come from environment
+/// variables, the system keychain, or an external helper command.
 ///
 /// Keys from the system keychain are associated with a provider URL, and this ensures that they are
 /// only used with that URL.
@@ -202,6 +202,32 @@ impl ApiKeyState {
         })
     }
 
+    /// Clears the cached API key if it was provided by a helper command.
+    /// Keys from environment variables or the system keychain are left untouched.
+    pub fn clear_helper_key(&mut self) {
+        if matches!(
+            &self.load_status,
+            LoadStatus::Loaded(ApiKey {
+                source: ApiKeySource::Helper,
+                ..
+            })
+        ) {
+            self.load_status = LoadStatus::NotPresent;
+        }
+    }
+
+    /// Recorded as `Helper` rather than `EnvVar` so that `store()` and
+    /// `handle_url_change()` still work — env-var keys block keychain writes
+    /// and URL-change reloads.
+    pub fn set_key_from_helper(&mut self, url: SharedString, key: Arc<str>) {
+        self.url = url;
+        self.load_status = LoadStatus::Loaded(ApiKey {
+            source: ApiKeySource::Helper,
+            key,
+        });
+        self.load_task = None;
+    }
+
     fn load<Ent: 'static>(
         url: SharedString,
         get_this: impl Fn(&mut Ent) -> &mut Self + 'static,
@@ -286,6 +312,7 @@ impl LoadStatus {
 enum ApiKeySource {
     EnvVar(SharedString),
     SystemKeychain,
+    Helper,
 }
 
 impl Display for ApiKeySource {
@@ -293,6 +320,7 @@ impl Display for ApiKeySource {
         match self {
             ApiKeySource::EnvVar(var) => write!(f, "environment variable {}", var),
             ApiKeySource::SystemKeychain => write!(f, "system keychain"),
+            ApiKeySource::Helper => write!(f, "api_key_helper"),
         }
     }
 }

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -66,5 +66,6 @@ vercel = { workspace = true, features = ["schemars"] }
 x_ai = { workspace = true, features = ["schemars"] }
 
 [dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use convert_case::{Case, Casing};
 use credentials_provider::CredentialsProvider;
-use futures::{FutureExt, StreamExt, future::BoxFuture};
+use futures::{FutureExt, StreamExt, future::BoxFuture, future::Shared};
 use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, Window};
 use http_client::HttpClient;
 use language_model::{
@@ -18,9 +18,11 @@ use open_ai::{
 };
 use settings::{Settings, SettingsStore};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use ui::{ElevationIndex, Tooltip, prelude::*};
 use ui_input::InputField;
 use util::ResultExt;
+use util::shell::ShellKind;
 
 use crate::provider::open_ai::{
     OpenAiEventMapper, OpenAiResponseEventMapper, into_open_ai, into_open_ai_response,
@@ -32,6 +34,24 @@ pub use settings::OpenAiCompatibleModelCapabilities as ModelCapabilities;
 pub struct OpenAiCompatibleSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
+    pub api_key_helper: Option<ApiKeyHelperConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApiKeyHelperConfig {
+    pub command: String,
+    pub ttl_seconds: Option<u64>,
+}
+
+const MAX_TTL_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+impl From<settings::ApiKeyHelperConfig> for ApiKeyHelperConfig {
+    fn from(config: settings::ApiKeyHelperConfig) -> Self {
+        Self {
+            command: config.command,
+            ttl_seconds: config.ttl_seconds.map(|s| s.min(MAX_TTL_SECONDS)),
+        }
+    }
 }
 
 pub struct OpenAiCompatibleLanguageModelProvider {
@@ -46,11 +66,24 @@ pub struct State {
     api_key_state: ApiKeyState,
     settings: OpenAiCompatibleSettings,
     credentials_provider: Arc<dyn CredentialsProvider>,
+    helper_key_status: HelperKeyStatus,
+}
+
+enum HelperKeyStatus {
+    NeverRun,
+    Running {
+        task: Shared<Task<Result<(), String>>>,
+    },
+    Succeeded { expires_at: Option<Instant> },
+    Failed { error: String },
 }
 
 impl State {
     fn is_authenticated(&self) -> bool {
-        self.api_key_state.has_key()
+        if self.api_key_state.is_from_env_var() {
+            return true;
+        }
+        self.api_key_state.has_key() && !self.needs_helper_refresh()
     }
 
     fn set_api_key(&mut self, api_key: Option<String>, cx: &mut Context<Self>) -> Task<Result<()>> {
@@ -65,15 +98,227 @@ impl State {
         )
     }
 
+    fn reset_helper_status(&mut self) {
+        self.helper_key_status = HelperKeyStatus::NeverRun;
+    }
+
+    fn needs_helper_refresh(&self) -> bool {
+        if self.settings.api_key_helper.is_none() {
+            return false;
+        }
+        match &self.helper_key_status {
+            HelperKeyStatus::NeverRun | HelperKeyStatus::Failed { .. } => true,
+            HelperKeyStatus::Running { .. } => false,
+            HelperKeyStatus::Succeeded { expires_at } => {
+                expires_at.is_some_and(|expires_at| Instant::now() >= expires_at)
+            }
+        }
+    }
+
+    fn run_api_key_helper(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
+        let Some(helper) = self.settings.api_key_helper.clone() else {
+            return Task::ready(Err(AuthenticateError::CredentialsNotFound));
+        };
+
+        if helper.command.trim().is_empty() {
+            let error = "api_key_helper command is empty".to_string();
+            self.helper_key_status = HelperKeyStatus::Failed {
+                error: error.clone(),
+            };
+            cx.notify();
+            return Task::ready(Err(AuthenticateError::Other(anyhow::anyhow!(error))));
+        }
+
+        if let HelperKeyStatus::Running { task } = &self.helper_key_status {
+            let task = task.clone();
+            return cx.spawn(
+                async move |_state, _cx| {
+                    task.await
+                        .map_err(|e| AuthenticateError::Other(anyhow::anyhow!(e)))
+                },
+            );
+        }
+
+        let launched_for_url = self.settings.api_url.clone();
+        let launched_for_helper = self.settings.api_key_helper.clone();
+
+        let credentials_provider = self.credentials_provider.clone();
+        let api_url = SharedString::new(launched_for_url.as_str());
+        let ttl_seconds = helper.ttl_seconds;
+
+        log::debug!("Running api_key_helper command");
+
+        let inner_task = cx
+            .spawn(async move |state, cx| {
+                let result: Result<String, String> = async {
+                    let command_str = helper.command;
+                    let command_task = cx.background_spawn(async move {
+                        let shell =
+                            util::get_default_system_shell_preferring_bash();
+                        let shell_kind =
+                            ShellKind::new(&shell, cfg!(windows));
+                        let args =
+                            shell_kind.args_for_shell(false, command_str);
+                        util::command::new_command(&shell)
+                            .args(&args)
+                            .kill_on_drop(true)
+                            .output()
+                            .await
+                    });
+
+                    let timeout = cx.background_executor().timer(Duration::from_secs(30));
+
+                    let output = match futures::future::select(
+                        std::pin::pin!(command_task),
+                        std::pin::pin!(timeout),
+                    )
+                    .await
+                    {
+                        futures::future::Either::Left((result, _)) => result,
+                        futures::future::Either::Right((_, _)) => {
+                            return Err(
+                                "api_key_helper timed out after 30 seconds".to_string()
+                            );
+                        }
+                    };
+
+                    let output = output
+                        .context("Failed to execute api_key_helper")
+                        .map_err(|e| e.to_string())?;
+
+                    if !output.status.success() {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        let truncated = truncate_for_display(stderr.trim(), 200);
+                        return Err(format!(
+                            "api_key_helper exited with {}: {}",
+                            output.status, truncated,
+                        ));
+                    }
+
+                    let api_key = String::from_utf8(output.stdout)
+                        .context("api_key_helper output is not valid UTF-8")
+                        .map_err(|e| e.to_string())?
+                        .trim()
+                        .to_string();
+
+                    if api_key.is_empty() {
+                        return Err("api_key_helper produced empty output".to_string());
+                    }
+
+                    Ok(api_key)
+                }
+                .await;
+
+                match result {
+                    Ok(api_key) => {
+                        if let Err(err) = credentials_provider
+                            .write_credentials(&api_url, "Bearer", api_key.as_bytes(), cx)
+                            .await
+                        {
+                            log::warn!(
+                                "Failed to persist API key from helper to keychain: {err}. \
+                                 The key will only be available for this session."
+                            );
+                        }
+
+                        state
+                            .update(cx, |state, cx| {
+                                // Guard against stale results: if the URL or helper
+                                // config changed while this task was running, discard
+                                // the result so the new config takes effect.
+                                if state.settings.api_url != launched_for_url
+                                    || state.settings.api_key_helper != launched_for_helper
+                                {
+                                    state.helper_key_status = HelperKeyStatus::NeverRun;
+                                    cx.notify();
+                                    return;
+                                }
+                                state.helper_key_status = HelperKeyStatus::Succeeded {
+                                    expires_at: ttl_seconds
+                                        .map(|secs| Instant::now() + Duration::from_secs(secs)),
+                                };
+                                state
+                                    .api_key_state
+                                    .set_key_from_helper(api_url, api_key.into());
+                                cx.notify();
+                            })
+                            .map_err(|e| e.to_string())?;
+
+                        Ok(())
+                    }
+                    Err(error_msg) => {
+                        state
+                            .update(cx, |state, cx| {
+                                if state.settings.api_url != launched_for_url
+                                    || state.settings.api_key_helper != launched_for_helper
+                                {
+                                    state.helper_key_status = HelperKeyStatus::NeverRun;
+                                    cx.notify();
+                                    return;
+                                }
+                                state.helper_key_status =
+                                    HelperKeyStatus::Failed {
+                                        error: error_msg.clone(),
+                                    };
+                                state.api_key_state.clear_helper_key();
+                                cx.notify();
+                            })
+                            .log_err();
+                        Err(error_msg)
+                    }
+                }
+            })
+            .shared();
+
+        self.helper_key_status = HelperKeyStatus::Running {
+            task: inner_task.clone(),
+        };
+
+        cx.spawn(async move |_state, _cx| {
+            inner_task
+                .await
+                .map_err(|e| AuthenticateError::Other(anyhow::anyhow!(e)))
+        })
+    }
+
     fn authenticate(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
         let credentials_provider = self.credentials_provider.clone();
         let api_url = SharedString::new(self.settings.api_url.clone());
-        self.api_key_state.load_if_needed(
+        let has_helper = self.settings.api_key_helper.is_some();
+
+        let load_task = self.api_key_state.load_if_needed(
             api_url,
             |this| &mut this.api_key_state,
             credentials_provider,
             cx,
-        )
+        );
+
+        if !has_helper {
+            return load_task;
+        }
+
+        cx.spawn(async move |state, cx| {
+            // load_if_needed always returns Ok(()) — errors are stored in load_status,
+            // not propagated through the task. Check state afterwards instead.
+            let _ = load_task.await;
+
+            let should_run_helper = state
+                .read_with(cx, |state, _| {
+                    if state.api_key_state.is_from_env_var() {
+                        return false;
+                    }
+                    !state.api_key_state.has_key() || state.needs_helper_refresh()
+                })
+                .unwrap_or(false);
+
+            if !should_run_helper {
+                return Ok(());
+            }
+
+            let helper_task = state
+                .update(cx, |state, cx| state.run_api_key_helper(cx))?;
+            helper_task.await
+        })
     }
 }
 
@@ -96,7 +341,7 @@ impl OpenAiCompatibleLanguageModelProvider {
                 let Some(settings) = resolve_settings(&this.id, cx).cloned() else {
                     return;
                 };
-                if &this.settings != &settings {
+                if this.settings != settings {
                     let credentials_provider = this.credentials_provider.clone();
                     let api_url = SharedString::new(settings.api_url.as_str());
                     this.api_key_state.handle_url_change(
@@ -105,6 +350,11 @@ impl OpenAiCompatibleLanguageModelProvider {
                         credentials_provider,
                         cx,
                     );
+                    if this.settings.api_key_helper != settings.api_key_helper
+                        || this.settings.api_url != settings.api_url
+                    {
+                        this.reset_helper_status();
+                    }
                     this.settings = settings;
                     cx.notify();
                 }
@@ -119,6 +369,7 @@ impl OpenAiCompatibleLanguageModelProvider {
                 ),
                 settings,
                 credentials_provider,
+                helper_key_status: HelperKeyStatus::NeverRun,
             }
         });
 
@@ -206,8 +457,10 @@ impl LanguageModelProvider for OpenAiCompatibleLanguageModelProvider {
     }
 
     fn reset_credentials(&self, cx: &mut App) -> Task<Result<()>> {
-        self.state
-            .update(cx, |state, cx| state.set_api_key(None, cx))
+        self.state.update(cx, |state, cx| {
+            state.reset_helper_status();
+            state.set_api_key(None, cx)
+        })
     }
 }
 
@@ -450,20 +703,11 @@ impl ConfigurationView {
         })
         .detach();
 
-        let load_credentials_task = Some(cx.spawn_in(window, {
-            let state = state.clone();
-            async move |this, cx| {
-                if let Some(task) = Some(state.update(cx, |state, cx| state.authenticate(cx))) {
-                    // We don't log an error, because "not signed in" is also an error.
-                    let _ = task.await;
-                }
-                this.update(cx, |this, cx| {
-                    this.load_credentials_task = None;
-                    cx.notify();
-                })
-                .log_err();
-            }
-        }));
+        let load_credentials_task = Some(Self::spawn_authenticate(
+            state.clone(),
+            window,
+            cx,
+        ));
 
         Self {
             api_key_editor,
@@ -496,16 +740,61 @@ impl ConfigurationView {
             .update(cx, |input, cx| input.set_text("", window, cx));
 
         let state = self.state.clone();
-        cx.spawn_in(window, async move |_, cx| {
+        self.load_credentials_task = Some(cx.spawn_in(window, async move |this, cx| {
             state
-                .update(cx, |state, cx| state.set_api_key(None, cx))
+                .update(cx, |state, cx| {
+                    state.reset_helper_status();
+                    state.set_api_key(None, cx)
+                })
                 .await
+                .log_err();
+
+            Self::run_authenticate_and_clear_task(state, this, cx).await;
+        }));
+    }
+
+    fn retry_helper(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let state = self.state.clone();
+        self.load_credentials_task = Some(cx.spawn_in(window, async move |this, cx| {
+            state.update(cx, |state, cx| {
+                state.reset_helper_status();
+                cx.notify();
+            });
+
+            Self::run_authenticate_and_clear_task(state, this, cx).await;
+        }));
+    }
+
+    fn spawn_authenticate(
+        state: Entity<State>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
+        cx.spawn_in(window, async move |this, cx| {
+            Self::run_authenticate_and_clear_task(state, this, cx).await;
         })
-        .detach_and_log_err(cx);
+    }
+
+    async fn run_authenticate_and_clear_task(
+        state: Entity<State>,
+        this: gpui::WeakEntity<Self>,
+        cx: &mut AsyncApp,
+    ) {
+        let task = state.update(cx, |state, cx| state.authenticate(cx));
+        match task.await {
+            Ok(()) | Err(AuthenticateError::CredentialsNotFound) => {}
+            Err(err) => log::error!("Authentication failed: {err}"),
+        }
+        this.update(cx, |this, cx| {
+            this.load_credentials_task = None;
+            cx.notify();
+        })
+        .log_err();
     }
 
     fn should_render_editor(&self, cx: &Context<Self>) -> bool {
-        !self.state.read(cx).is_authenticated()
+        let state = self.state.read(cx);
+        !state.is_authenticated() && state.settings.api_key_helper.is_none()
     }
 }
 
@@ -514,6 +803,12 @@ impl Render for ConfigurationView {
         let state = self.state.read(cx);
         let env_var_set = state.api_key_state.is_from_env_var();
         let env_var_name = state.api_key_state.env_var_name();
+        let has_helper = state.settings.api_key_helper.is_some();
+        let is_authenticated = state.is_authenticated();
+        let helper_error = match &state.helper_key_status {
+            HelperKeyStatus::Failed { error } => Some(error.clone()),
+            _ => None,
+        };
 
         let api_key_section = if self.should_render_editor(cx) {
             v_flex()
@@ -531,7 +826,34 @@ impl Render for ConfigurationView {
                     .size(LabelSize::Small).color(Color::Muted),
                 )
                 .into_any()
+        } else if let Some(error) = helper_error {
+            v_flex()
+                .gap_2()
+                .child(
+                    Label::new(format!("api_key_helper failed: {error}"))
+                        .color(Color::Error),
+                )
+                .child(
+                    Button::new("retry-helper", "Retry")
+                        .label_size(LabelSize::Small)
+                        .layer(ElevationIndex::ModalSurface)
+                        .on_click(
+                            cx.listener(|this, _, window, cx| this.retry_helper(window, cx)),
+                        ),
+                )
+                .into_any()
+        } else if has_helper && !is_authenticated {
+            v_flex()
+                .child(Label::new("Waiting for api_key_helper to provide credentials…"))
+                .into_any()
         } else {
+            let status_label = if env_var_set {
+                format!("API key set in {env_var_name} environment variable")
+            } else if has_helper {
+                "API key provided by api_key_helper".to_string()
+            } else {
+                format!("API key configured for {}", &state.settings.api_url)
+            };
             h_flex()
                 .mt_1()
                 .p_1()
@@ -551,13 +873,7 @@ impl Render for ConfigurationView {
                                 .w_full()
                                 .overflow_x_hidden()
                                 .text_ellipsis()
-                                .child(Label::new(
-                                    if env_var_set {
-                                        format!("API key set in {env_var_name} environment variable")
-                                    } else {
-                                        format!("API key configured for {}", &state.settings.api_url)
-                                    }
-                                ))
+                                .child(Label::new(status_label))
                         ),
                 )
                 .child(
@@ -569,7 +885,10 @@ impl Render for ConfigurationView {
                                 .start_icon(Icon::new(IconName::Undo).size(IconSize::Small))
                                 .layer(ElevationIndex::ModalSurface)
                                 .when(env_var_set, |this| {
-                                    this.tooltip(Tooltip::text(format!("To reset your API key, unset the {env_var_name} environment variable.")))
+                                    this.disabled(true)
+                                        .tooltip(Tooltip::text(
+                                            format!("To reset your API key, unset the {env_var_name} environment variable.")
+                                        ))
                                 })
                                 .on_click(cx.listener(|this, _, window, cx| this.reset_api_key(window, cx))),
                         ),
@@ -582,5 +901,221 @@ impl Render for ConfigurationView {
         } else {
             v_flex().size_full().child(api_key_section).into_any()
         }
+    }
+}
+
+fn truncate_for_display(text: &str, max_len: usize) -> &str {
+    match text.char_indices().nth(max_len) {
+        Some((idx, _)) => &text[..idx],
+        None => text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future;
+    use language_model::EnvVar;
+    use std::pin::Pin;
+
+    struct NoopCredentialsProvider;
+
+    impl CredentialsProvider for NoopCredentialsProvider {
+        fn read_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _cx: &'a AsyncApp,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<(String, Vec<u8>)>>> + 'a>> {
+            Box::pin(future::ready(Ok(None)))
+        }
+
+        fn write_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _username: &'a str,
+            _password: &'a [u8],
+            _cx: &'a AsyncApp,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
+            Box::pin(future::ready(Ok(())))
+        }
+
+        fn delete_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _cx: &'a AsyncApp,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
+            Box::pin(future::ready(Ok(())))
+        }
+    }
+
+    fn test_state(helper: Option<ApiKeyHelperConfig>, status: HelperKeyStatus) -> State {
+        State {
+            id: Arc::from("test"),
+            api_key_state: ApiKeyState::new(
+                SharedString::from("http://test"),
+                EnvVar::new("TEST_API_KEY".into()),
+            ),
+            settings: OpenAiCompatibleSettings {
+                api_url: "http://test".to_string(),
+                available_models: vec![],
+                api_key_helper: helper,
+            },
+            credentials_provider: Arc::new(NoopCredentialsProvider),
+            helper_key_status: status,
+        }
+    }
+
+    fn helper_config() -> ApiKeyHelperConfig {
+        ApiKeyHelperConfig {
+            command: "echo test-key".to_string(),
+            ttl_seconds: Some(60),
+        }
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_no_helper() {
+        let state = test_state(None, HelperKeyStatus::NeverRun);
+        assert!(!state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_never_run() {
+        let state = test_state(Some(helper_config()), HelperKeyStatus::NeverRun);
+        assert!(state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_failed() {
+        let state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Failed {
+                error: "command failed".to_string(),
+            },
+        );
+        assert!(state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_running() {
+        let state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Running {
+                task: Task::ready(Ok(())).shared(),
+            },
+        );
+        assert!(!state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_succeeded_no_ttl() {
+        let state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Succeeded { expires_at: None },
+        );
+        assert!(!state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_succeeded_not_expired() {
+        let state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Succeeded {
+                expires_at: Some(Instant::now() + Duration::from_secs(3600)),
+            },
+        );
+        assert!(!state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_needs_helper_refresh_succeeded_expired() {
+        let state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Succeeded {
+                expires_at: Some(Instant::now() - Duration::from_secs(1)),
+            },
+        );
+        assert!(state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_is_authenticated_no_key() {
+        let state = test_state(None, HelperKeyStatus::NeverRun);
+        assert!(!state.is_authenticated());
+    }
+
+    #[test]
+    fn test_is_authenticated_with_key_no_helper() {
+        let mut state = test_state(None, HelperKeyStatus::NeverRun);
+        state
+            .api_key_state
+            .set_key_from_helper("http://test".into(), "test-key".into());
+        assert!(state.is_authenticated());
+    }
+
+    #[test]
+    fn test_is_authenticated_with_key_helper_expired() {
+        let mut state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Succeeded {
+                expires_at: Some(Instant::now() - Duration::from_secs(1)),
+            },
+        );
+        state
+            .api_key_state
+            .set_key_from_helper("http://test".into(), "test-key".into());
+        assert!(!state.is_authenticated());
+    }
+
+    #[test]
+    fn test_is_authenticated_with_key_helper_valid() {
+        let mut state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Succeeded {
+                expires_at: Some(Instant::now() + Duration::from_secs(3600)),
+            },
+        );
+        state
+            .api_key_state
+            .set_key_from_helper("http://test".into(), "test-key".into());
+        assert!(state.is_authenticated());
+    }
+
+    #[test]
+    fn test_running_guard_prevents_duplicate_launch() {
+        let state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Running {
+                task: Task::ready(Ok(())).shared(),
+            },
+        );
+        assert!(matches!(
+            state.helper_key_status,
+            HelperKeyStatus::Running { .. }
+        ));
+        // When status is Running, needs_helper_refresh returns false,
+        // and run_api_key_helper returns Ok(()) without spawning.
+        assert!(!state.needs_helper_refresh());
+    }
+
+    #[test]
+    fn test_reset_helper_status() {
+        let mut state = test_state(
+            Some(helper_config()),
+            HelperKeyStatus::Succeeded {
+                expires_at: Some(Instant::now() + Duration::from_secs(3600)),
+            },
+        );
+        state.reset_helper_status();
+        assert!(matches!(
+            state.helper_key_status,
+            HelperKeyStatus::NeverRun
+        ));
+    }
+
+    #[test]
+    fn test_truncate_for_display() {
+        assert_eq!(truncate_for_display("hello", 10), "hello");
+        assert_eq!(truncate_for_display("hello world", 5), "hello");
+        assert_eq!(truncate_for_display("", 5), "");
     }
 }

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -7,7 +7,8 @@ use crate::provider::{
     anthropic::AnthropicSettings, bedrock::AmazonBedrockSettings, cloud::ZedDotDevSettings,
     deepseek::DeepSeekSettings, google::GoogleSettings, lmstudio::LmStudioSettings,
     mistral::MistralSettings, ollama::OllamaSettings, open_ai::OpenAiSettings,
-    open_ai_compatible::OpenAiCompatibleSettings, open_router::OpenRouterSettings,
+    open_ai_compatible::OpenAiCompatibleSettings,
+    open_router::OpenRouterSettings,
     opencode::OpenCodeSettings, vercel::VercelSettings, vercel_ai_gateway::VercelAiGatewaySettings,
     x_ai::XAiSettings,
 };
@@ -108,6 +109,7 @@ impl settings::Settings for AllLanguageModelSettings {
                         OpenAiCompatibleSettings {
                             api_url: value.api_url,
                             available_models: value.available_models,
+                            api_key_helper: value.api_key_helper.map(Into::into),
                         },
                     )
                 })

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -250,6 +250,20 @@ impl MergeFrom for OpenAiReasoningEffort {
 pub struct OpenAiCompatibleSettingsContent {
     pub api_url: String,
     pub available_models: Vec<OpenAiCompatibleAvailableModel>,
+    /// Configuration for an external command that provides the API key.
+    pub api_key_helper: Option<ApiKeyHelperConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct ApiKeyHelperConfig {
+    /// The shell command to execute via `sh -c`. Should output the API key on stdout.
+    pub command: String,
+    /// Cache lifetime in seconds for the key returned by the command.
+    /// Values above 604800 (one week) are clamped to that maximum.
+    /// When omitted, the key is fetched once per Zed session and only refreshed
+    /// when the helper settings change or Zed is restarted.
+    #[schemars(range(min = 0, max = 604800))]
+    pub ttl_seconds: Option<u64>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added support for api_key_helper on OpenAI-compatible providers, allowing API keys to be fetched from external commands like secret managers
