### PR TITLE
Normalize Volar completion labels

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -576,6 +576,468 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
     fn process_prompt_response(&self, _context: &PromptResponseContext, _cx: &mut AsyncApp) {}
 }
 
+const VOLAR_IMPORT_FROM_MARKER: &str = "import from ";
+
+#[derive(Default)]
+struct VolarCompletionTextRewrite {
+    inline_text: Option<String>,
+    documentation_text: Option<String>,
+}
+
+pub fn should_normalize_volar_completion_item(completion_item: &lsp::CompletionItem) -> bool {
+    let mut has_signature = false;
+    let mut has_module_specifier = false;
+
+    for text in completion_item_texts(completion_item) {
+        if text.contains(" import from ")
+            || text.contains("(alias)")
+            || find_volar_label_signature_suffix(text).is_some()
+        {
+            return true;
+        }
+
+        has_signature |= looks_like_volar_signature(text);
+        has_module_specifier |= extract_volar_auto_import_module_specifier(text).is_some()
+            || looks_like_deep_module_specifier(text);
+    }
+
+    has_signature && has_module_specifier
+}
+
+pub fn normalize_volar_completion_item(completion_item: &mut lsp::CompletionItem) {
+    if !should_normalize_volar_completion_item(completion_item) {
+        return;
+    }
+
+    let label_rewrite = rewrite_volar_completion_label(&completion_item.label);
+    if let Some(inline_label) = label_rewrite.inline_text {
+        completion_item.label = inline_label;
+    }
+
+    let detail_rewrite = completion_item
+        .detail
+        .as_deref()
+        .map(rewrite_volar_completion_text);
+    let label_detail_rewrite = completion_item
+        .label_details
+        .as_ref()
+        .and_then(|label_details| label_details.detail.as_deref())
+        .map(rewrite_volar_completion_text);
+    let description_rewrite = completion_item
+        .label_details
+        .as_ref()
+        .and_then(|label_details| label_details.description.as_deref())
+        .map(rewrite_volar_completion_text);
+
+    let mut documentation_fragments = Vec::new();
+    if let Some(documentation_text) = label_rewrite.documentation_text.as_ref() {
+        push_unique_string(&mut documentation_fragments, documentation_text.clone());
+    }
+    if let Some(documentation_text) = detail_rewrite
+        .as_ref()
+        .and_then(|rewrite| rewrite.documentation_text.as_ref())
+    {
+        push_unique_string(&mut documentation_fragments, documentation_text.clone());
+    }
+    if let Some(documentation_text) = label_detail_rewrite
+        .as_ref()
+        .and_then(|rewrite| rewrite.documentation_text.as_ref())
+    {
+        push_unique_string(&mut documentation_fragments, documentation_text.clone());
+    }
+    if let Some(documentation_text) = description_rewrite
+        .as_ref()
+        .and_then(|rewrite| rewrite.documentation_text.as_ref())
+    {
+        push_unique_string(&mut documentation_fragments, documentation_text.clone());
+    }
+
+    let label_inline_detail = label_rewrite
+        .documentation_text
+        .as_deref()
+        .and_then(extract_volar_auto_import_module_specifier)
+        .map(str::to_string);
+
+    let inline_detail = detail_rewrite
+        .as_ref()
+        .and_then(|rewrite| rewrite.inline_text.clone())
+        .or_else(|| {
+            description_rewrite
+                .as_ref()
+                .and_then(|rewrite| rewrite.inline_text.clone())
+        })
+        .or(label_inline_detail);
+    completion_item.detail = inline_detail.clone();
+
+    if let Some(label_details) = completion_item.label_details.as_mut() {
+        label_details.detail = label_detail_rewrite
+            .and_then(|rewrite| rewrite.inline_text)
+            .filter(|detail| Some(detail.as_str()) != inline_detail.as_deref());
+        label_details.description = description_rewrite
+            .and_then(|rewrite| rewrite.inline_text)
+            .filter(|description| Some(description.as_str()) != inline_detail.as_deref());
+    }
+
+    if !documentation_fragments.is_empty() {
+        completion_item.documentation = merge_volar_completion_documentation(
+            completion_item.documentation.take(),
+            &documentation_fragments,
+        );
+    }
+}
+
+fn completion_item_texts(completion_item: &lsp::CompletionItem) -> Vec<&str> {
+    [
+        Some(completion_item.label.as_str()),
+        completion_item.detail.as_deref(),
+        completion_item
+            .label_details
+            .as_ref()
+            .and_then(|label_details| label_details.detail.as_deref()),
+        completion_item
+            .label_details
+            .as_ref()
+            .and_then(|label_details| label_details.description.as_deref()),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+fn rewrite_volar_completion_label(text: &str) -> VolarCompletionTextRewrite {
+    let trimmed_text = text.trim();
+    if trimmed_text.is_empty() {
+        return VolarCompletionTextRewrite::default();
+    }
+
+    let suffix_start = [
+        find_volar_label_import_suffix(trimmed_text),
+        find_volar_label_signature_suffix(trimmed_text),
+        trimmed_text.find(" (alias)"),
+        trimmed_text.find('\n'),
+    ]
+    .into_iter()
+    .flatten()
+    .min();
+    if let Some(suffix_start) = suffix_start {
+        let inline_text = trimmed_text[..suffix_start].trim_end();
+        let documentation_text = trimmed_text[suffix_start..].trim();
+        if !inline_text.is_empty() && !documentation_text.is_empty() {
+            return VolarCompletionTextRewrite {
+                inline_text: Some(inline_text.to_string()),
+                documentation_text: Some(documentation_text.to_string()),
+            };
+        }
+    }
+
+    VolarCompletionTextRewrite {
+        inline_text: Some(trimmed_text.to_string()),
+        documentation_text: None,
+    }
+}
+
+fn find_volar_label_import_suffix(text: &str) -> Option<usize> {
+    [" Add import from ", " Update import from ", " import from "]
+        .into_iter()
+        .filter_map(|marker| text.find(marker))
+        .min()
+}
+
+fn find_volar_label_signature_suffix(text: &str) -> Option<usize> {
+    let symbol_end = text.find(char::is_whitespace)?;
+    let suffix = &text[symbol_end..];
+
+    let signature_markers = [
+        " (alias)",
+        " interface ",
+        " var ",
+        " function ",
+        " class ",
+        " type ",
+    ];
+
+    signature_markers
+        .into_iter()
+        .any(|marker| suffix.starts_with(marker))
+        .then_some(symbol_end)
+}
+
+fn rewrite_volar_completion_text(text: &str) -> VolarCompletionTextRewrite {
+    let trimmed_text = text.trim();
+    if trimmed_text.is_empty() {
+        return VolarCompletionTextRewrite::default();
+    }
+
+    if let Some(module_specifier) = extract_volar_auto_import_module_specifier(trimmed_text) {
+        return VolarCompletionTextRewrite {
+            inline_text: Some(module_specifier.to_string()),
+            documentation_text: Some(trimmed_text.to_string()),
+        };
+    }
+
+    if looks_like_deep_module_specifier(trimmed_text) {
+        return VolarCompletionTextRewrite {
+            inline_text: Some(trimmed_text.to_string()),
+            documentation_text: Some(trimmed_text.to_string()),
+        };
+    }
+
+    if looks_like_volar_signature(trimmed_text) {
+        return VolarCompletionTextRewrite {
+            inline_text: None,
+            documentation_text: Some(trimmed_text.to_string()),
+        };
+    }
+
+    VolarCompletionTextRewrite {
+        inline_text: Some(trimmed_text.to_string()),
+        documentation_text: None,
+    }
+}
+
+fn extract_volar_auto_import_module_specifier(text: &str) -> Option<&str> {
+    let marker_start = text.find(VOLAR_IMPORT_FROM_MARKER)?;
+    let trimmed_rest = text[marker_start + VOLAR_IMPORT_FROM_MARKER.len()..].trim();
+    let quote = trimmed_rest.chars().next()?;
+    if !matches!(quote, '"' | '\'' | '`') {
+        return None;
+    }
+
+    let quoted_text = &trimmed_rest[quote.len_utf8()..];
+    let end = quoted_text.find(quote)?;
+    Some(&quoted_text[..end])
+}
+
+fn looks_like_deep_module_specifier(text: &str) -> bool {
+    let trimmed_text = text.trim_matches(|character| matches!(character, '"' | '\'' | '`'));
+    if trimmed_text.is_empty() || trimmed_text.chars().any(char::is_whitespace) {
+        return false;
+    }
+
+    let segment_count = trimmed_text
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .count();
+    if trimmed_text.starts_with('@') {
+        segment_count > 2
+    } else {
+        segment_count > 1
+    }
+}
+
+fn looks_like_volar_signature(text: &str) -> bool {
+    text.contains('\n')
+        || text.len() > 48
+        || text.starts_with('(')
+        || text.starts_with("interface ")
+        || text.starts_with("var ")
+        || text.starts_with("class ")
+        || text.starts_with("type ")
+        || text.contains("(alias)")
+        || text.contains("function ")
+        || text.contains("=>")
+        || text.contains("():")
+        || text.contains("):")
+}
+
+fn merge_volar_completion_documentation(
+    existing_documentation: Option<lsp::Documentation>,
+    documentation_fragments: &[String],
+) -> Option<lsp::Documentation> {
+    if documentation_fragments.is_empty() {
+        return existing_documentation;
+    }
+
+    let detail_markdown = documentation_fragments
+        .iter()
+        .map(|fragment| format!("```text\n{fragment}\n```"))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let value = match existing_documentation {
+        Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
+            kind: lsp::MarkupKind::Markdown,
+            value,
+        })) if !value.trim().is_empty() => format!("{detail_markdown}\n\n{value}"),
+        Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { value, .. }))
+            if !value.trim().is_empty() =>
+        {
+            format!("{detail_markdown}\n\n{}", value.trim())
+        }
+        Some(lsp::Documentation::String(value)) if !value.trim().is_empty() => {
+            format!("{detail_markdown}\n\n{}", value.trim())
+        }
+        _ => detail_markdown,
+    };
+
+    Some(lsp::Documentation::MarkupContent(lsp::MarkupContent {
+        kind: lsp::MarkupKind::Markdown,
+        value,
+    }))
+}
+
+fn push_unique_string(values: &mut Vec<String>, candidate: String) {
+    if values.iter().all(|value| value != &candidate) {
+        values.push(candidate);
+    }
+}
+
+#[cfg(test)]
+mod volar_completion_tests {
+    use super::{normalize_volar_completion_item, should_normalize_volar_completion_item};
+
+    #[test]
+    fn normalizes_auto_import_details_into_documentation() {
+        let mut completion_item = lsp::CompletionItem {
+            label: "useMessage".to_string(),
+            detail: Some(r#"Add import from "naive-ui/es/message/src/use-message""#.to_string()),
+            ..Default::default()
+        };
+
+        normalize_volar_completion_item(&mut completion_item);
+
+        assert_eq!(
+            completion_item.detail.as_deref(),
+            Some("naive-ui/es/message/src/use-message")
+        );
+        assert!(matches!(
+            completion_item.documentation,
+            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { kind: lsp::MarkupKind::Markdown, value }))
+                if value.contains(r#"Add import from "naive-ui/es/message/src/use-message""#)
+        ));
+    }
+
+    #[test]
+    fn normalizes_signature_with_module_path_descriptions() {
+        let mut completion_item = lsp::CompletionItem {
+            label: "useMessage".to_string(),
+            detail: Some("(alias) function useMessage(): MessageApiInjection".to_string()),
+            label_details: Some(lsp::CompletionItemLabelDetails {
+                detail: None,
+                description: Some("naive-ui/es/message/src/use-message".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        normalize_volar_completion_item(&mut completion_item);
+
+        assert_eq!(
+            completion_item.detail.as_deref(),
+            Some("naive-ui/es/message/src/use-message")
+        );
+        assert!(matches!(
+            completion_item.documentation,
+            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { kind: lsp::MarkupKind::Markdown, value }))
+                if value.contains("(alias) function useMessage(): MessageApiInjection")
+                    && value.contains("naive-ui/es/message/src/use-message")
+        ));
+    }
+
+    #[test]
+    fn strips_volar_suffixes_from_labels() {
+        let mut completion_item = lsp::CompletionItem {
+            label: r#"useMergedCheckStrategy Add import from "naive-ui/es/tree/src/utils""#
+                .to_string(),
+            ..Default::default()
+        };
+
+        normalize_volar_completion_item(&mut completion_item);
+
+        assert_eq!(completion_item.label, "useMergedCheckStrategy");
+        assert_eq!(
+            completion_item.detail.as_deref(),
+            Some("naive-ui/es/tree/src/utils")
+        );
+        assert!(matches!(
+            completion_item.documentation,
+            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { value, .. }))
+                if value.contains(r#"Add import from "naive-ui/es/tree/src/utils""#)
+        ));
+    }
+
+    #[test]
+    fn strips_update_import_and_signature_suffixes_from_labels() {
+        let mut completion_item = lsp::CompletionItem {
+            label:
+                r#"useModal Update import from "naive-ui" function useModal(): ModalApiInjection"#
+                    .to_string(),
+            ..Default::default()
+        };
+
+        normalize_volar_completion_item(&mut completion_item);
+
+        assert_eq!(completion_item.label, "useModal");
+        assert_eq!(completion_item.detail.as_deref(), Some("naive-ui"));
+        assert!(matches!(
+            completion_item.documentation,
+            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { value, .. }))
+                if value.contains(r#"Update import from "naive-ui" function useModal(): ModalApiInjection"#)
+        ));
+    }
+
+    #[test]
+    fn strips_global_type_signatures_from_labels() {
+        let mut completion_item = lsp::CompletionItem {
+            label: "URLSearchParams interface URLSearchParams var URLSearchParams: { prototype: URLSearchParams; new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams; }".to_string(),
+            ..Default::default()
+        };
+
+        normalize_volar_completion_item(&mut completion_item);
+
+        assert_eq!(completion_item.label, "URLSearchParams");
+        assert!(matches!(
+            completion_item.documentation,
+            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { value, .. }))
+                if value.contains("interface URLSearchParams")
+                    && value.contains("var URLSearchParams")
+        ));
+    }
+
+    #[test]
+    fn strips_global_variable_signatures_from_labels() {
+        let mut completion_item = lsp::CompletionItem {
+            label: "onmousemove var onmousemove: ((this: Window, ev: MouseEvent) => any) | null"
+                .to_string(),
+            ..Default::default()
+        };
+
+        normalize_volar_completion_item(&mut completion_item);
+
+        assert_eq!(completion_item.label, "onmousemove");
+        assert!(matches!(
+            completion_item.documentation,
+            Some(lsp::Documentation::MarkupContent(lsp::MarkupContent { value, .. }))
+                if value.contains("var onmousemove")
+                    && value.contains("MouseEvent")
+        ));
+    }
+
+    #[test]
+    fn detects_volar_shaped_completions() {
+        let completion_item = lsp::CompletionItem {
+            label: "useMessage".to_string(),
+            detail: Some("(alias) function useMessage(): MessageApiInjection".to_string()),
+            label_details: Some(lsp::CompletionItemLabelDetails {
+                detail: None,
+                description: Some("naive-ui/es/message/src/use-message".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        assert!(should_normalize_volar_completion_item(&completion_item));
+    }
+
+    #[test]
+    fn detects_global_signature_labels() {
+        let completion_item = lsp::CompletionItem {
+            label: "customElements var customElements: CustomElementRegistry".to_string(),
+            ..Default::default()
+        };
+
+        assert!(should_normalize_volar_completion_item(&completion_item));
+    }
+}
+
 pub trait LspInstaller {
     type BinaryVersion;
     fn check_if_user_installed(

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -11,6 +11,7 @@ use gpui::{App, AppContext, AsyncApp, Task};
 use language::{
     BinaryStatus, CodeLabel, DynLspInstaller, HighlightId, Language, LanguageName,
     LanguageServerBinaryLocations, LspAdapter, LspAdapterDelegate, Toolchain,
+    normalize_volar_completion_item, should_normalize_volar_completion_item,
 };
 use lsp::{
     CodeActionKind, LanguageServerBinary, LanguageServerBinaryOptions, LanguageServerName,
@@ -285,6 +286,16 @@ impl LspAdapter for ExtensionLspAdapter {
             CodeActionKind::REFACTOR_EXTRACT,
             CodeActionKind::SOURCE,
         ]))
+    }
+
+    async fn process_completions(&self, completion_items: &mut [lsp::CompletionItem]) {
+        for completion_item in completion_items {
+            if self.language_name.as_ref() == "Vue.js"
+                && should_normalize_volar_completion_item(completion_item)
+            {
+                normalize_volar_completion_item(completion_item);
+            }
+        }
     }
 
     fn language_ids(&self) -> HashMap<LanguageName, String> {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -7,7 +7,8 @@ use gpui::{App, AppContext, AsyncApp, Entity, Task};
 use itertools::Itertools as _;
 use language::{
     Buffer, ContextLocation, ContextProvider, File, LanguageName, LanguageToolchainStore,
-    LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain,
+    LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain, normalize_volar_completion_item,
+    should_normalize_volar_completion_item,
 };
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
@@ -770,6 +771,18 @@ impl LspAdapter for TypeScriptLspAdapter {
         item: &lsp::CompletionItem,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
+        let normalized_item;
+        let item = if language.name().as_ref() == "Vue.js" {
+            normalized_item = {
+                let mut item = item.clone();
+                normalize_volar_completion_item(&mut item);
+                item
+            };
+            &normalized_item
+        } else {
+            item
+        };
+
         use lsp::CompletionItemKind as Kind;
         let label_len = item.label.len();
         let grammar = language.grammar()?;
@@ -800,6 +813,14 @@ impl LspAdapter for TypeScriptLspAdapter {
             item.filter_text.as_deref(),
             vec![(0..label_len, highlight_id)],
         ))
+    }
+
+    async fn process_completions(&self, completion_items: &mut [lsp::CompletionItem]) {
+        for completion_item in completion_items {
+            if should_normalize_volar_completion_item(completion_item) {
+                normalize_volar_completion_item(completion_item);
+            }
+        }
     }
 
     async fn initialization_options(

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -4,6 +4,7 @@ use collections::HashMap;
 use gpui::AsyncApp;
 use language::{
     LanguageName, LspAdapter, LspAdapterDelegate, LspInstaller, PromptResponseContext, Toolchain,
+    normalize_volar_completion_item, should_normalize_volar_completion_item,
 };
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
@@ -197,11 +198,31 @@ impl LspAdapter for VtslsLspAdapter {
         ])
     }
 
+    async fn process_completions(&self, completion_items: &mut [lsp::CompletionItem]) {
+        for completion_item in completion_items {
+            if should_normalize_volar_completion_item(completion_item) {
+                normalize_volar_completion_item(completion_item);
+            }
+        }
+    }
+
     async fn label_for_completion(
         &self,
         item: &lsp::CompletionItem,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
+        let normalized_item;
+        let item = if language.name().as_ref() == "Vue.js" {
+            normalized_item = {
+                let mut item = item.clone();
+                normalize_volar_completion_item(&mut item);
+                item
+            };
+            &normalized_item
+        } else {
+            item
+        };
+
         use lsp::CompletionItemKind as Kind;
         let label_len = item.label.len();
         let grammar = language.grammar()?;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6542,10 +6542,15 @@ impl LspStore {
         completions: Rc<RefCell<Box<[Completion]>>>,
         completion_index: usize,
     ) -> Result<()> {
-        let completion_item = completions.borrow()[completion_index]
+        let mut completion_item = completions.borrow()[completion_index]
             .source
             .lsp_completion(true)
             .map(Cow::into_owned);
+        if let Some(completion_item) = completion_item.as_mut() {
+            adapter
+                .process_completions(std::slice::from_mut(completion_item))
+                .await;
+        }
         if let Some(lsp_documentation) = completion_item
             .as_ref()
             .and_then(|completion_item| completion_item.documentation.clone())
@@ -10214,13 +10219,13 @@ impl LspStore {
         mut cx: AsyncApp,
     ) -> Result<proto::ResolveCompletionDocumentationResponse> {
         let lsp_completion = serde_json::from_slice(&envelope.payload.lsp_completion)?;
+        let language_server_id = LanguageServerId(envelope.payload.language_server_id as usize);
 
-        let completion = this
+        let mut completion = this
             .read_with(&cx, |this, cx| {
-                let id = LanguageServerId(envelope.payload.language_server_id as usize);
                 let server = this
-                    .language_server_for_id(id)
-                    .with_context(|| format!("No language server {id}"))?;
+                    .language_server_for_id(language_server_id)
+                    .with_context(|| format!("No language server {language_server_id}"))?;
 
                 let request_timeout = ProjectSettings::get_global(cx)
                     .global_lsp_settings
@@ -10248,6 +10253,14 @@ impl LspStore {
                 }))
             })?
             .await?;
+
+        if let Some(adapter) = this.read_with(&cx, |this, _| {
+            this.language_server_adapter_for_id(language_server_id)
+        }) {
+            adapter
+                .process_completions(std::slice::from_mut(&mut completion))
+                .await;
+        }
 
         let mut documentation_is_markdown = false;
         let lsp_completion = serde_json::to_string(&completion)?.into_bytes();


### PR DESCRIPTION
## Context

Fixes #49883

Volar can return Vue completion items with auto-import text and function or interface signatures embedded directly in the completion label, detail, and label description fields. Zed was rendering that verbose text inline in the completion list, which made Vue suggestions hard to read and hid the useful part of the item.

This change normalizes Volar-shaped completion items before labels are rendered and when completion documentation is resolved. The main completion row keeps the symbol name, the inline detail keeps the relevant module path, and the verbose import or signature text is moved into the completion documentation popup instead of being shown inline.

This also handles fallback DOM and TypeScript globals when Volar returns their full interface or `var` signatures inside the label.

## How to Review

1. Start with `crates/language/src/language.rs`.
   This adds the shared Volar completion normalizer and the focused unit tests.

2. Review `crates/languages/src/vtsls.rs` and `crates/languages/src/typescript.rs`.
   These apply the normalizer before Vue completion labels are built.

3. Review `crates/language_extension/src/extension_lsp_adapter.rs` and `crates/project/src/lsp_store.rs`.
   These make sure normalized completion items stay consistent through the extension bridge and completion resolve flow.

4. If you want to test manually, reproduce with a Vue file using Volar auto-import suggestions such as `useModal`, `useModel`, or `useMergedCheckStrategy`.

## Test Plan

Added focused unit tests in `crates/language/src/language.rs` covering:

- auto-import detail normalization
- `Update import from ...` label normalization
- moving verbose signatures into completion documentation
- preserving full module paths inline
- stripping fallback DOM and TypeScript global signatures from labels

Verification run:

- `cargo check -p language -p language_extension -p languages -p project`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #49883

Release Notes:

- Fixed Vue/Volar completion items showing verbose import and signature text inline in the completion list