### PR TITLE
Disable visual tests in CI

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -8,7 +8,7 @@ mod open_url_modal;
 mod quick_action_bar;
 pub mod remote_debug;
 pub mod telemetry_log;
-#[cfg(all(target_os = "macos", any(test, feature = "test-support")))]
+#[cfg(all(target_os = "macos", feature = "visual-tests"))]
 pub mod visual_tests;
 #[cfg(target_os = "windows")]
 pub(crate) mod windows_only_instance;


### PR DESCRIPTION
Gate the `visual_tests` module behind the `visual-tests` feature flag instead of `test`/`test-support`, so CI never compiles or runs visual tests.

To run them locally:

```
cargo test -p zed --features visual-tests visual_tests -- --ignored --test-threads=1
```

Release Notes:

- N/A