### PR TITLE
Fix Rename Symbol in Vue SFC script blocks

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5158,6 +5158,81 @@ impl LspStore {
             .collect()
     }
 
+    pub fn prepare_rename_across_servers<T: language::ToPointUtf16>(
+        &mut self,
+        buffer: Entity<Buffer>,
+        position: T,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<(crate::PrepareRenameResponse, Option<LanguageServerId>)>> {
+        use crate::PrepareRenameResponse;
+
+        let position = position.to_point_utf16(buffer.read(cx));
+        let request = PrepareRename { position };
+
+        let capable_server_ids: Vec<LanguageServerId> = buffer.update(cx, |buffer, cx| {
+            let Some(local) = self.as_local() else {
+                return Vec::new();
+            };
+            local
+                .language_servers_for_buffer(buffer, cx)
+                .filter(|(_, server)| {
+                    request.check_capabilities(server.adapter_server_capabilities())
+                })
+                .map(|(_, server)| server.server_id())
+                .collect()
+        });
+
+        if capable_server_ids.len() <= 1 {
+            let task = self.request_lsp(buffer, LanguageServerToQuery::FirstCapable, request, cx);
+            return cx.background_spawn(async move { Ok((task.await?, None)) });
+        }
+
+        let tasks: Vec<(LanguageServerId, Task<Result<PrepareRenameResponse>>)> =
+            capable_server_ids
+                .into_iter()
+                .map(|server_id| {
+                    let task = self.request_lsp(
+                        buffer.clone(),
+                        LanguageServerToQuery::Other(server_id),
+                        PrepareRename { position },
+                        cx,
+                    );
+                    (server_id, task)
+                })
+                .collect();
+
+        cx.background_spawn(async move {
+            for (server_id, task) in tasks {
+                match task.await {
+                    Ok(response @ PrepareRenameResponse::Success(_))
+                    | Ok(response @ PrepareRenameResponse::OnlyUnpreparedRenameSupported) => {
+                        log::debug!(
+                            "[rename-fallback] Server {server_id:?} succeeded for prepare rename",
+                        );
+                        return Ok((response, Some(server_id)));
+                    }
+                    Ok(PrepareRenameResponse::InvalidPosition) => {
+                        log::info!(
+                            "[rename-fallback] Server {server_id:?} returned InvalidPosition, \
+                             trying next server",
+                        );
+                        continue;
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "[rename-fallback] Server {server_id:?} errored: {err}, \
+                             trying next server",
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            log::debug!("[rename-fallback] All servers exhausted, returning InvalidPosition");
+            Ok((PrepareRenameResponse::InvalidPosition, None))
+        })
+    }
+
     pub fn request_lsp<R>(
         &mut self,
         buffer: Entity<Buffer>,
@@ -5182,12 +5257,18 @@ impl LspStore {
 
         let Some(language_server) = buffer.update(cx, |buffer, cx| match server {
             LanguageServerToQuery::FirstCapable => self.as_local().and_then(|local| {
-                local
+                let result = local
                     .language_servers_for_buffer(buffer, cx)
                     .find(|(_, server)| {
                         request.check_capabilities(server.adapter_server_capabilities())
                     })
-                    .map(|(_, server)| server.clone())
+                    .map(|(_, server)| server.clone());
+                log::debug!(
+                    "FirstCapable for '{}': selected {:?}",
+                    request.display_name(),
+                    result.as_ref().map(|s| s.name())
+                );
+                result
             }),
             LanguageServerToQuery::Other(id) => self
                 .language_server_for_local_buffer(buffer, id, cx)
@@ -5275,6 +5356,12 @@ impl LspStore {
             };
 
             let result = lsp_request.await.into_response();
+            log::debug!(
+                "'{}' via {} result: ok={}",
+                request.display_name(),
+                language_server.name(),
+                result.is_ok()
+            );
 
             let response = result.map_err(|err| {
                 let message = format!(

--- a/crates/project/src/lsp_store/vue_language_server_ext.rs
+++ b/crates/project/src/lsp_store/vue_language_server_ext.rs
@@ -1,8 +1,13 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
 use anyhow::Context as _;
 use gpui::{AppContext, WeakEntity};
 use lsp::{LanguageServer, LanguageServerName};
 use serde_json::Value;
 
+use super::LspStoreEvent;
 use crate::{LspStore, ProjectSettings};
 use settings::Settings;
 
@@ -25,6 +30,276 @@ const VUE_SERVER_NAME: LanguageServerName = LanguageServerName::new_static("vue-
 const VTSLS: LanguageServerName = LanguageServerName::new_static("vtsls");
 const TS_LS: LanguageServerName = LanguageServerName::new_static("typescript-language-server");
 
+const TS_SERVER_READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct PendingBridgeQueue {
+    requests: Vec<(u64, String, serde_json::Value)>,
+    vue_server: Arc<LanguageServer>,
+}
+
+fn find_ts_server_id(
+    lsp_store: &WeakEntity<LspStore>,
+    cx: &impl AppContext,
+) -> Option<lsp::LanguageServerId> {
+    lsp_store
+        .read_with(cx, |this, _| {
+            this.as_local().and_then(|local| {
+                local
+                    .language_server_ids
+                    .iter()
+                    .find_map(|(seed, v)| [VTSLS, TS_LS].contains(&seed.name).then_some(v.id))
+            })
+        })
+        .ok()
+        .flatten()
+}
+
+fn find_running_ts_server(
+    lsp_store: &WeakEntity<LspStore>,
+    cx: &impl AppContext,
+) -> anyhow::Result<Arc<LanguageServer>> {
+    let server_id = find_ts_server_id(lsp_store, cx)
+        .context("Could not find vtsls or typescript-language-server in language_server_ids")?;
+
+    lsp_store.read_with(cx, |this, _| {
+        this.language_server_for_id(server_id)
+            .context("TS server exists in language_server_ids but is not Running")
+    })?
+}
+
+fn forward_requests(
+    requests: Vec<(u64, String, serde_json::Value)>,
+    target_server: Arc<LanguageServer>,
+    vue_server: Arc<LanguageServer>,
+    request_timeout: Duration,
+    cx: &gpui::AsyncApp,
+) {
+    for (request_id, command, payload) in requests {
+        let target_server = target_server.clone();
+        let vue_server = vue_server.clone();
+        let command_name = command.clone();
+        cx.background_spawn(async move {
+            let response = target_server
+                .request::<lsp::request::ExecuteCommand>(
+                    lsp::ExecuteCommandParams {
+                        command: "typescript.tsserverRequest".to_owned(),
+                        arguments: vec![Value::String(command), payload],
+                        ..Default::default()
+                    },
+                    request_timeout,
+                )
+                .await;
+
+            let response_body = match response {
+                util::ConnectionResult::Result(Ok(result)) => match result {
+                    Some(Value::Object(mut map)) => {
+                        map.remove("body").unwrap_or(Value::Object(map))
+                    }
+                    Some(other) => {
+                        log::debug!(
+                            "[vue-bridge] tsserver/request id={request_id} cmd={command_name} \
+                            returned non-object: {}",
+                            other
+                        );
+                        other
+                    }
+                    None => {
+                        log::warn!(
+                            "[vue-bridge] tsserver/request id={request_id} cmd={command_name} \
+                            returned None"
+                        );
+                        Value::Null
+                    }
+                },
+                util::ConnectionResult::Result(Err(error)) => {
+                    log::warn!(
+                        "[vue-bridge] tsserver/request id={request_id} cmd={command_name} \
+                        failed: {error:?}"
+                    );
+                    Value::Null
+                }
+                other => {
+                    log::warn!(
+                        "[vue-bridge] tsserver/request id={request_id} cmd={command_name} \
+                        no response: {other:?}"
+                    );
+                    Value::Null
+                }
+            };
+
+            if let Err(error) =
+                vue_server.notify::<TypescriptServerResponse>(vec![(request_id, response_body)])
+            {
+                log::warn!(
+                    "[vue-bridge] Failed to send tsserver/response id={request_id}: {error:?}"
+                );
+            }
+        })
+        .detach();
+    }
+}
+
+fn send_null_responses(
+    requests: Vec<(u64, String, serde_json::Value)>,
+    vue_server: &Arc<LanguageServer>,
+) {
+    if requests.is_empty() {
+        return;
+    }
+    let null_responses = requests
+        .into_iter()
+        .map(|(id, _, _)| (id, Value::Null))
+        .collect::<Vec<_>>();
+    if let Err(error) = vue_server.notify::<TypescriptServerResponse>(null_responses) {
+        log::warn!("Failed to send null tsserver responses: {error:?}");
+    }
+}
+
+/// Flush queued requests if vtsls is now Running. Returns true if flushed.
+fn try_flush_queue(
+    pending_queue: &Arc<Mutex<Option<PendingBridgeQueue>>>,
+    target_server: Arc<LanguageServer>,
+    request_timeout: Duration,
+    cx: &gpui::AsyncApp,
+) -> bool {
+    let Ok(mut guard) = pending_queue.lock() else {
+        return false;
+    };
+
+    let Some(queue) = guard.take() else {
+        return false;
+    };
+
+    log::info!(
+        "[vue-bridge] Flushing {} queued request(s) to TS server",
+        queue.requests.len()
+    );
+    forward_requests(
+        queue.requests,
+        target_server,
+        queue.vue_server,
+        request_timeout,
+        cx,
+    );
+    true
+}
+
+/// vtsls is Running: flush any pending queue and forward requests directly.
+fn handle_requests_with_running_ts_server(
+    requests: Vec<(u64, String, serde_json::Value)>,
+    target_server: Arc<LanguageServer>,
+    vue_server: Arc<LanguageServer>,
+    pending_queue: &Arc<Mutex<Option<PendingBridgeQueue>>>,
+    cx: &gpui::AsyncApp,
+) {
+    let request_timeout = cx.update(|app| {
+        ProjectSettings::get_global(app)
+            .global_lsp_settings
+            .get_request_timeout()
+    });
+
+    try_flush_queue(pending_queue, target_server.clone(), request_timeout, cx);
+    forward_requests(requests, target_server, vue_server, request_timeout, cx);
+}
+
+/// vtsls is not Running: buffer requests and set up a subscription + timeout
+/// to flush or discard them once vtsls starts (or doesn't).
+#[allow(clippy::redundant_clone)]
+fn buffer_requests_until_ts_server_ready(
+    requests: Vec<(u64, String, serde_json::Value)>,
+    vue_server: Arc<LanguageServer>,
+    lsp_store: &WeakEntity<LspStore>,
+    pending_queue: &Arc<Mutex<Option<PendingBridgeQueue>>>,
+    subscription_registered: &Arc<AtomicBool>,
+    cx: &mut gpui::AsyncApp,
+) {
+    let mut guard = match pending_queue.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    if let Some(queue) = guard.as_mut() {
+        queue.requests.extend(requests);
+        return;
+    }
+
+    log::debug!(
+        "[vue-bridge] vtsls not Running, buffering {} request(s)",
+        requests.len(),
+    );
+
+    *guard = Some(PendingBridgeQueue {
+        requests,
+        vue_server: vue_server.clone(),
+    });
+
+    drop(guard);
+
+    if subscription_registered.load(Ordering::Relaxed) {
+        return;
+    }
+
+    if let Some(lsp_store_entity) = lsp_store.upgrade() {
+        cx.subscribe(&lsp_store_entity, {
+            let pending_queue = pending_queue.clone();
+            let lsp_store = lsp_store.clone();
+            move |_entity, event, cx| {
+                let LspStoreEvent::LanguageServerAdded(_, name, _) = event else {
+                    return;
+                };
+
+                if *name != VTSLS && *name != TS_LS {
+                    return;
+                }
+
+                let Ok(target_server) = find_running_ts_server(&lsp_store, cx) else {
+                    return;
+                };
+
+                log::info!(
+                    "[vue-bridge] {} reached Running (event-driven flush)",
+                    name
+                );
+
+                let request_timeout = ProjectSettings::get_global(cx)
+                    .global_lsp_settings
+                    .get_request_timeout();
+
+                let async_cx = cx.to_async();
+                try_flush_queue(&pending_queue, target_server, request_timeout, &async_cx);
+            }
+        })
+        .detach();
+
+        subscription_registered.store(true, Ordering::Relaxed);
+    }
+
+    let pending_queue = pending_queue.clone();
+    let vue_server = vue_server.clone();
+    let background_executor = cx.background_executor().clone();
+    cx.background_spawn(async move {
+        background_executor.timer(TS_SERVER_READY_TIMEOUT).await;
+
+        let Ok(mut guard) = pending_queue.lock() else {
+            return;
+        };
+
+        let Some(queue) = guard.take() else {
+            return;
+        };
+
+        log::warn!(
+            "[vue-bridge] Timed out waiting {}s for vtsls to reach Running. \
+                Sending null responses for {} queued request(s).",
+            TS_SERVER_READY_TIMEOUT.as_secs(),
+            queue.requests.len()
+        );
+
+        send_null_responses(queue.requests, &vue_server);
+    })
+    .detach();
+}
+
 pub fn register_requests(lsp_store: WeakEntity<LspStore>, language_server: &LanguageServer) {
     let language_server_name = language_server.name();
     if language_server_name != VUE_SERVER_NAME {
@@ -32,100 +307,41 @@ pub fn register_requests(lsp_store: WeakEntity<LspStore>, language_server: &Lang
     }
 
     let vue_server_id = language_server.server_id();
+
+    // Shared queue state:
+    // - Some(queue) = Queuing phase (vtsls not yet Running, requests are buffered)
+    // - None = Direct phase (vtsls is Running, or queue was drained by timeout)
+    let pending_queue: Arc<Mutex<Option<PendingBridgeQueue>>> = Arc::new(Mutex::new(None));
+
+    let subscription_registered: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
     language_server
         .on_notification::<VueServerRequest, _>({
             move |params, cx| {
                 let lsp_store = lsp_store.clone();
-                let Ok(Some(vue_server)) = lsp_store.read_with(cx, |this, _| {
-                    this.language_server_for_id(vue_server_id)
-                }) else {
+                let Ok(Some(vue_server)) =
+                    lsp_store.read_with(cx, |this, _| this.language_server_for_id(vue_server_id))
+                else {
                     return;
                 };
 
-                let requests = params;
-                let target_server = match lsp_store.read_with(cx, |this, _| {
-                    let language_server_id = this
-                        .as_local()
-                        .and_then(|local| {
-                            local.language_server_ids.iter().find_map(|(seed, v)| {
-                                [VTSLS, TS_LS].contains(&seed.name).then_some(v.id)
-                            })
-                        })
-                        .context("Could not find language server")?;
-
-                    this.language_server_for_id(language_server_id)
-                        .context("language server not found")
-                }) {
-                    Ok(Ok(server)) => server,
-                    other => {
-                        log::warn!(
-                            "vue-language-server forwarding skipped: {other:?}. \
-                                Returning null tsserver responses"
-                        );
-                        if !requests.is_empty() {
-                            let null_responses = requests
-                                .into_iter()
-                                .map(|(id, _, _)| (id, Value::Null))
-                                .collect::<Vec<_>>();
-                            let _ = vue_server
-                                .notify::<TypescriptServerResponse>(null_responses);
-                        }
-                        return;
-                    }
-                };
-
-                let cx = cx.clone();
-                let request_timeout = cx.update(|app|
-                    ProjectSettings::get_global(app)
-                    .global_lsp_settings
-                    .get_request_timeout()
-                );
-
-                for (request_id, command, payload) in requests.into_iter() {
-                    let target_server = target_server.clone();
-                    let vue_server = vue_server.clone();
-                    cx.background_spawn(async move {
-                        let response = target_server
-                            .request::<lsp::request::ExecuteCommand>(
-                                lsp::ExecuteCommandParams {
-                                    command: "typescript.tsserverRequest".to_owned(),
-                                    arguments: vec![Value::String(command), payload],
-                                    ..Default::default()
-                                }, request_timeout
-                            )
-                            .await;
-
-                        let response_body = match response {
-                            util::ConnectionResult::Result(Ok(result)) => match result {
-                                Some(Value::Object(mut map)) => map
-                                    .remove("body")
-                                    .unwrap_or(Value::Object(map)),
-                                Some(other) => other,
-                                None => Value::Null,
-                            },
-                            util::ConnectionResult::Result(Err(error)) => {
-                                log::warn!(
-                                    "typescript.tsserverRequest failed: {error:?} for request {request_id}"
-                                );
-                                Value::Null
-                            }
-                            other => {
-                                log::warn!(
-                                    "typescript.tsserverRequest did not return a response: {other:?} for request {request_id}"
-                                );
-                                Value::Null
-                            }
-                        };
-
-                        if let Err(err) = vue_server
-                            .notify::<TypescriptServerResponse>(vec![(request_id, response_body)])
-                        {
-                            log::warn!(
-                                "Failed to notify vue-language-server of tsserver response: {err:?}"
-                            );
-                        }
-                    })
-                    .detach();
+                if let Ok(target_server) = find_running_ts_server(&lsp_store, cx) {
+                    handle_requests_with_running_ts_server(
+                        params,
+                        target_server,
+                        vue_server,
+                        &pending_queue,
+                        cx,
+                    );
+                } else {
+                    buffer_requests_until_ts_server_ready(
+                        params,
+                        vue_server,
+                        &lsp_store,
+                        &pending_queue,
+                        &subscription_registered,
+                        cx,
+                    );
                 }
             }
         })

--- a/crates/project/src/lsp_store/vue_language_server_ext.rs
+++ b/crates/project/src/lsp_store/vue_language_server_ext.rs
@@ -155,7 +155,6 @@ fn send_null_responses(
     }
 }
 
-/// Flush queued requests if vtsls is now Running. Returns true if flushed.
 fn try_flush_queue(
     pending_queue: &Arc<Mutex<Option<PendingBridgeQueue>>>,
     target_server: Arc<LanguageServer>,
@@ -184,7 +183,6 @@ fn try_flush_queue(
     true
 }
 
-/// vtsls is Running: flush any pending queue and forward requests directly.
 fn handle_requests_with_running_ts_server(
     requests: Vec<(u64, String, serde_json::Value)>,
     target_server: Arc<LanguageServer>,
@@ -202,8 +200,6 @@ fn handle_requests_with_running_ts_server(
     forward_requests(requests, target_server, vue_server, request_timeout, cx);
 }
 
-/// vtsls is not Running: buffer requests and set up a subscription + timeout
-/// to flush or discard them once vtsls starts (or doesn't).
 #[allow(clippy::redundant_clone)]
 fn buffer_requests_until_ts_server_ready(
     requests: Vec<(u64, String, serde_json::Value)>,
@@ -256,10 +252,7 @@ fn buffer_requests_until_ts_server_ready(
                     return;
                 };
 
-                log::info!(
-                    "[vue-bridge] {} reached Running (event-driven flush)",
-                    name
-                );
+                log::info!("[vue-bridge] {} reached Running (event-driven flush)", name);
 
                 let request_timeout = ProjectSettings::get_global(cx)
                     .global_lsp_settings
@@ -309,8 +302,8 @@ pub fn register_requests(lsp_store: WeakEntity<LspStore>, language_server: &Lang
     let vue_server_id = language_server.server_id();
 
     // Shared queue state:
-    // - Some(queue) = Queuing phase (vtsls not yet Running, requests are buffered)
-    // - None = Direct phase (vtsls is Running, or queue was drained by timeout)
+    // - Some(queue) = Queuing phase (TS LSP not yet Running, requests are buffered)
+    // - None = Direct phase (TS LSP is Running, or queue was drained by timeout)
     let pending_queue: Arc<Mutex<Option<PendingBridgeQueue>>> = Arc::new(Mutex::new(None));
 
     let subscription_registered: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -251,6 +251,7 @@ pub struct Project {
     agent_location: Option<AgentLocation>,
     downloading_files: Arc<Mutex<HashMap<(WorktreeId, String), DownloadingFile>>>,
     last_worktree_paths: WorktreePaths,
+    last_prepare_rename_server_id: Option<LanguageServerId>,
 }
 
 struct DownloadingFile {
@@ -1352,6 +1353,7 @@ impl Project {
                 agent_location: None,
                 downloading_files: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
+                last_prepare_rename_server_id: None,
             }
         })
     }
@@ -1594,6 +1596,7 @@ impl Project {
                 agent_location: None,
                 downloading_files: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
+                last_prepare_rename_server_id: None,
             };
 
             // remote server -> local machine handlers
@@ -1881,6 +1884,7 @@ impl Project {
                 agent_location: None,
                 downloading_files: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
+                last_prepare_rename_server_id: None,
             };
             project.set_role(role, cx);
             for worktree in worktrees {
@@ -4454,13 +4458,19 @@ impl Project {
         position: T,
         cx: &mut Context<Self>,
     ) -> Task<Result<PrepareRenameResponse>> {
-        let position = position.to_point_utf16(buffer.read(cx));
-        self.request_lsp(
-            buffer,
-            LanguageServerToQuery::FirstCapable,
-            PrepareRename { position },
-            cx,
-        )
+        self.last_prepare_rename_server_id = None;
+        let task = self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.prepare_rename_across_servers(buffer, position, cx)
+        });
+        cx.spawn(async move |this, cx| {
+            let (response, server_id) = task.await?;
+            cx.update(|cx| {
+                this.update(cx, |this, _| {
+                    this.last_prepare_rename_server_id = server_id;
+                })
+            })?;
+            Ok(response)
+        })
     }
 
     pub fn perform_rename<T: ToPointUtf16>(
@@ -4472,9 +4482,13 @@ impl Project {
     ) -> Task<Result<ProjectTransaction>> {
         let push_to_history = true;
         let position = position.to_point_utf16(buffer.read(cx));
+        let server = self
+            .last_prepare_rename_server_id
+            .map(LanguageServerToQuery::Other)
+            .unwrap_or(LanguageServerToQuery::FirstCapable);
         self.request_lsp(
             buffer,
-            LanguageServerToQuery::FirstCapable,
+            server,
             PerformRename {
                 position,
                 new_name,

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -6943,6 +6943,331 @@ async fn test_rename(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_rename_fallback_to_second_server(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let rename_capabilities = lsp::ServerCapabilities {
+        rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: Default::default(),
+        })),
+        ..Default::default()
+    };
+
+    let settings_json = json!({
+        "languages": {
+            "Vue.js": {
+                "language_servers": ["vue-language-server", "vtsls"]
+            }
+        },
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            ".zed": {
+                "settings.json": settings_json.to_string(),
+            },
+            "App.vue": "const appTitle = ref(1)",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(vue_lang());
+
+    let mut vue_servers = language_registry.register_fake_lsp(
+        "Vue.js",
+        FakeLspAdapter {
+            name: "vue-language-server",
+            capabilities: rename_capabilities.clone(),
+            ..Default::default()
+        },
+    );
+    let mut ts_servers = language_registry.register_fake_lsp(
+        "Vue.js",
+        FakeLspAdapter {
+            name: "vtsls",
+            capabilities: rename_capabilities.clone(),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/project/App.vue"), cx)
+        })
+        .await
+        .unwrap();
+
+    let vue_server = vue_servers.next().await.unwrap();
+    let ts_server = ts_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    // vue-language-server can't rename TS symbols in <script> (returns None -> InvalidPosition).
+    // Set handlers BEFORE initiating the request so both are ready when requests arrive.
+    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
+        |_, _| async move { Ok(None) },
+    );
+    ts_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
+        |params, _| async move {
+            assert_eq!(params.position, lsp::Position::new(0, 7));
+            Ok(Some(lsp::PrepareRenameResponse::Range(lsp::Range::new(
+                lsp::Position::new(0, 6),
+                lsp::Position::new(0, 14),
+            ))))
+        },
+    );
+
+    let response = project
+        .update(cx, |project, cx| {
+            project.prepare_rename(buffer.clone(), 7, cx)
+        })
+        .await
+        .unwrap();
+    let PrepareRenameResponse::Success(range) = response else {
+        panic!("Expected Success, got {:?}", response);
+    };
+    let range = buffer.update(cx, |buffer, _| range.to_offset(buffer));
+    assert_eq!(range, 6..14); // "appTitle"
+
+    // perform_rename should go to vtsls (the server that prepared successfully).
+    ts_server.set_request_handler::<lsp::request::Rename, _, _>(|params, _| async move {
+        assert_eq!(params.new_name, "pageTitle");
+        Ok(Some(lsp::WorkspaceEdit {
+            changes: Some(
+                [(
+                    lsp::Uri::from_file_path(path!("/project/App.vue")).unwrap(),
+                    vec![lsp::TextEdit::new(
+                        lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 14)),
+                        "pageTitle".to_string(),
+                    )],
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        }))
+    });
+
+    let response = project
+        .update(cx, |project, cx| {
+            project.perform_rename(buffer.clone(), 7, "pageTitle".to_string(), cx)
+        })
+        .await
+        .unwrap()
+        .0;
+    assert_eq!(response.len(), 1);
+    assert_eq!(
+        buffer.update(cx, |buffer, _| buffer.text()),
+        "const pageTitle = ref(1)"
+    );
+}
+
+#[gpui::test]
+async fn test_rename_no_fallback_when_first_server_succeeds(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let rename_capabilities = lsp::ServerCapabilities {
+        rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: Default::default(),
+        })),
+        ..Default::default()
+    };
+
+    let settings_json = json!({
+        "languages": {
+            "Vue.js": {
+                "language_servers": ["vue-language-server", "vtsls"]
+            }
+        },
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            ".zed": {
+                "settings.json": settings_json.to_string(),
+            },
+            "App.vue": "const appTitle = ref(1)",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(vue_lang());
+
+    let mut vue_servers = language_registry.register_fake_lsp(
+        "Vue.js",
+        FakeLspAdapter {
+            name: "vue-language-server",
+            capabilities: rename_capabilities.clone(),
+            ..Default::default()
+        },
+    );
+    let mut ts_servers = language_registry.register_fake_lsp(
+        "Vue.js",
+        FakeLspAdapter {
+            name: "vtsls",
+            capabilities: rename_capabilities.clone(),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/project/App.vue"), cx)
+        })
+        .await
+        .unwrap();
+
+    let vue_server = vue_servers.next().await.unwrap();
+    let _ts_server = ts_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    // vue-language-server succeeds (e.g., renaming a template component).
+    // vtsls should never be queried.
+    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
+        |_, _| async move {
+            Ok(Some(lsp::PrepareRenameResponse::Range(lsp::Range::new(
+                lsp::Position::new(0, 6),
+                lsp::Position::new(0, 14),
+            ))))
+        },
+    );
+
+    let response = project
+        .update(cx, |project, cx| {
+            project.prepare_rename(buffer.clone(), 7, cx)
+        })
+        .await
+        .unwrap();
+    let PrepareRenameResponse::Success(range) = response else {
+        panic!("Expected Success, got {:?}", response);
+    };
+    let range = buffer.update(cx, |buffer, _| range.to_offset(buffer));
+    assert_eq!(range, 6..14);
+
+    // perform_rename should go to vue-language-server.
+    vue_server.set_request_handler::<lsp::request::Rename, _, _>(|params, _| async move {
+        assert_eq!(params.new_name, "pageTitle");
+        Ok(Some(lsp::WorkspaceEdit {
+            changes: Some(
+                [(
+                    lsp::Uri::from_file_path(path!("/project/App.vue")).unwrap(),
+                    vec![lsp::TextEdit::new(
+                        lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 14)),
+                        "pageTitle".to_string(),
+                    )],
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        }))
+    });
+
+    let response = project
+        .update(cx, |project, cx| {
+            project.perform_rename(buffer.clone(), 7, "pageTitle".to_string(), cx)
+        })
+        .await
+        .unwrap()
+        .0;
+    assert_eq!(response.len(), 1);
+    assert_eq!(
+        buffer.update(cx, |buffer, _| buffer.text()),
+        "const pageTitle = ref(1)"
+    );
+}
+
+#[gpui::test]
+async fn test_rename_fallback_all_servers_fail(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let rename_capabilities = lsp::ServerCapabilities {
+        rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: Default::default(),
+        })),
+        ..Default::default()
+    };
+
+    let settings_json = json!({
+        "languages": {
+            "Vue.js": {
+                "language_servers": ["vue-language-server", "vtsls"]
+            }
+        },
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            ".zed": {
+                "settings.json": settings_json.to_string(),
+            },
+            "App.vue": "const appTitle = ref(1)",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(vue_lang());
+
+    let mut vue_servers = language_registry.register_fake_lsp(
+        "Vue.js",
+        FakeLspAdapter {
+            name: "vue-language-server",
+            capabilities: rename_capabilities.clone(),
+            ..Default::default()
+        },
+    );
+    let mut ts_servers = language_registry.register_fake_lsp(
+        "Vue.js",
+        FakeLspAdapter {
+            name: "vtsls",
+            capabilities: rename_capabilities.clone(),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/project/App.vue"), cx)
+        })
+        .await
+        .unwrap();
+
+    let vue_server = vue_servers.next().await.unwrap();
+    let ts_server = ts_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    // Both servers return None (InvalidPosition).
+    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
+        |_, _| async move { Ok(None) },
+    );
+    ts_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
+        |_, _| async move { Ok(None) },
+    );
+
+    let response = project
+        .update(cx, |project, cx| {
+            project.prepare_rename(buffer.clone(), 7, cx)
+        })
+        .await
+        .unwrap();
+    assert_matches!(response, PrepareRenameResponse::InvalidPosition);
+}
+
+#[gpui::test]
 async fn test_search(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
@@ -12166,6 +12491,20 @@ fn js_lang() -> Arc<Language> {
             name: "JavaScript".into(),
             matcher: LanguageMatcher {
                 path_suffixes: vec!["js".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        None,
+    ))
+}
+
+fn vue_lang() -> Arc<Language> {
+    Arc::new(Language::new(
+        LanguageConfig {
+            name: "Vue.js".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["vue".to_string()],
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -7008,9 +7008,9 @@ async fn test_rename_fallback_to_second_server(cx: &mut gpui::TestAppContext) {
 
     // vue-language-server can't rename TS symbols in <script> (returns None -> InvalidPosition).
     // Set handlers BEFORE initiating the request so both are ready when requests arrive.
-    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
-        |_, _| async move { Ok(None) },
-    );
+    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(|_, _| async move {
+        Ok(None)
+    });
     ts_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
         |params, _| async move {
             assert_eq!(params.position, lsp::Position::new(0, 7));
@@ -7132,14 +7132,12 @@ async fn test_rename_no_fallback_when_first_server_succeeds(cx: &mut gpui::TestA
 
     // vue-language-server succeeds (e.g., renaming a template component).
     // vtsls should never be queried.
-    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
-        |_, _| async move {
-            Ok(Some(lsp::PrepareRenameResponse::Range(lsp::Range::new(
-                lsp::Position::new(0, 6),
-                lsp::Position::new(0, 14),
-            ))))
-        },
-    );
+    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(|_, _| async move {
+        Ok(Some(lsp::PrepareRenameResponse::Range(lsp::Range::new(
+            lsp::Position::new(0, 6),
+            lsp::Position::new(0, 14),
+        ))))
+    });
 
     let response = project
         .update(cx, |project, cx| {
@@ -7251,12 +7249,12 @@ async fn test_rename_fallback_all_servers_fail(cx: &mut gpui::TestAppContext) {
     cx.executor().run_until_parked();
 
     // Both servers return None (InvalidPosition).
-    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
-        |_, _| async move { Ok(None) },
-    );
-    ts_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(
-        |_, _| async move { Ok(None) },
-    );
+    vue_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(|_, _| async move {
+        Ok(None)
+    });
+    ts_server.set_request_handler::<lsp::request::PrepareRenameRequest, _, _>(|_, _| async move {
+        Ok(None)
+    });
 
     let response = project
         .update(cx, |project, cx| {


### PR DESCRIPTION
Closes #52961

## Summary

Rename Symbol silently fails in `<script>` blocks of `.vue` files. This PR fixes two independent root causes:

1. **Volar's TS bridge gets poisoned on startup** -- vue-language-server sends `tsserver/request` before vtsls is Running, gets null responses, and permanently loses TS integration for the session.

2. **Rename always goes to the wrong server** -- `FirstCapable` picks vue-language-server (first in settings order) for rename, but vue-language-server in hybrid mode cannot rename TypeScript symbols alone -- it advertises `renameProvider` yet returns `InvalidPosition` for `<script>` TS symbols, expecting the TS server to handle rename directly via standard LSP. vtsls can handle it but Zed never tries it.

## How other editors handle this

This is not a Zed-specific problem. Every editor that integrates Volar in hybrid mode faces the same two challenges: the tsserver bridge startup race and rename routing across overlapping servers.

**VS Code** avoids both problems by architecture. In hybrid mode, vue-language-server still runs as a separate process, but `@vue/typescript-plugin` runs *inside* VS Code's built-in TypeScript server. The bridge (`tsserver/request` forwarding) targets the built-in TS server, which is already running before Volar starts. Rename of TypeScript symbols in `.vue` files is handled by the TS server (with Vue awareness from the plugin), not by vue-language-server -- so there is no multi-server fallback needed.

**Neovim** faces both problems and solves them independently:
- *Bridge race*: `nvim-lspconfig`'s `vue_ls` config retries the bridge up to 10 times with 100ms delays (1 second window) if the TS client is not found. This is the equivalent of our queue strategy.
- *Rename fallback*: Neovim's built-in `vim.lsp.buf.rename()` uses sequential fallback -- it tries `prepareRename` on each attached server and falls back to the next if the response is null or an error. This is why rename works in all Neovim distros (LazyVim, NvChad, AstroNvim) without any special rename configuration.

Our fix follows the same patterns that work in production across the Neovim ecosystem: buffer bridge requests during startup, and try the next server when rename fails.

## Changes

### Fix 1: Queue strategy for tsserver bridge (`vue_language_server_ext.rs`)

When vue-language-server sends `tsserver/request` and the TS LSP is not yet Running, requests are now buffered instead of immediately returning null:

- Requests queue in an `Arc<Mutex<Option<PendingBridgeQueue>>>`
- An `LspStoreEvent::LanguageServerAdded` subscription flushes the queue when the TS LSP reaches Running
- A 5-second timeout sends null responses if the TS LSP never starts (prevents indefinite hangs)
- Once Running, all subsequent requests go directly (zero overhead)

### Fix 2: Rename fallback across language servers (`lsp_store.rs`, `project.rs`)

`prepare_rename` now tries each capable server sequentially (in settings priority order) instead of only the first:

- If vue-language-server returns `InvalidPosition`, fall back to vtsls
- The server that succeeds for `prepareRename` is stored on `Project` and used for `performRename`
- When only one server is capable, the fast path is unchanged (delegates to `request_lsp` directly)
- No public API changes -- server ID is stored as internal `Project` state

## Why this fix was chosen

### Rename fallback (Neovim-style sequential try)

Neovim's `vim.lsp.buf.rename()` solves the same problem with sequential fallback: try `prepareRename` on each server, use the first one that succeeds. This works in all Neovim distros (LazyVim, NvChad, AstroNvim) without special rename configuration.

### Queue strategy (buffer + event-driven flush)

The queue prevents the one-shot bridge poisoning that occurs during startup. Volar has no retry logic -- if the first `tsserver/request` gets a null response, the TS plugin never initializes. Buffering requests until the TS LSP is Running closes this race window.

## Alternatives considered

### Swap server order to vtsls-first

Changing the default from `["vue-language-server", "vtsls"]` to `["vtsls", "vue-language-server"]` fixes rename because vtsls would be selected by `FirstCapable`. However:

- `FirstCapable` applies to ALL LSP requests, not just rename
- Putting vtsls first would cause completions, diagnostics, hover, and all other overlapping features to be handled by vtsls instead of vue-language-server
- vue-language-server owns Vue-specific behavior (`<template>` intellisense, component props, slot types, CSS scoped modules) and should remain the primary server
- This is a workaround, not a fix -- it trades rename for degraded Vue-specific features

### Concurrent requests to all servers (race for first non-null)

Send `prepareRename` to all capable servers concurrently and return the first non-null response. However:

- Wastes resources on servers that will never be used
- Makes it harder to respect server priority order
- If vue-language-server returns a non-null but empty/useless response quickly, it wins the race and the fallback never triggers
- Adds complexity for handling cancellation of in-flight requests
- Sequential fallback is fast enough in practice: `prepareRename` is a lightweight operation

### Generic fallback in `request_lsp`

Add a `FirstCapableWithFallback` variant to `LanguageServerToQuery`. However:

- `request_lsp` would need to understand "empty response" for every response type
- The concept of "empty" varies per LSP command
- Overly generic for a problem that currently only affects rename
- Can be added later if more commands need fallback

## Test plan

- [x] Open a `.vue` file, rename a variable in `<script>` -- works via vtsls fallback
- [x] Open a `.vue` file, rename a component in `<template>` -- works via vue-language-server directly
- [x] Open a `.ts` file, rename a variable -- works as before (single server, no fallback triggered)
- [x] Cold start: open a Vue project, immediately try rename -- queue strategy buffers bridge requests until TS LSP is ready
- [x] Check `Zed.log` for `[vue-bridge]` and `[rename-fallback]` log lines confirming the flow


## Testing Video
https://github.com/user-attachments/assets/1ef75c39-29ff-41b7-a1b0-4e73b3cadc25

Release Notes:

- Fixed Rename Symbol failing silently in `<script>` blocks of `.vue` files ([#52961](https://github.com/zed-industries/zed/issues/52961))