### PR TITLE
extensions_ui: Make extension tab appearance consistent with other tabs

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1872,6 +1872,21 @@ impl Focusable for ExtensionsPage {
 impl Item for ExtensionsPage {
     type Event = ItemEvent;
 
+    fn tab_content(
+        &self,
+        params: workspace::item::TabContentParams,
+        _window: &Window,
+        cx: &App,
+    ) -> gpui::AnyElement {
+        h_flex()
+            .gap_2()
+            .child(
+                Label::new(self.tab_content_text(params.detail.unwrap_or_default(), cx))
+                    .color(params.text_color()),
+            )
+            .into_any_element()
+    }
+
     fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
         "Extensions".into()
     }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- make extension tab appearance consistent with other tabs


### before extensions tab appearance
<img width="173" height="45" alt="1f62b630-a414-468c-8450-a4e899d4b699" src="https://github.com/user-attachments/assets/5c6fdc13-6284-40d4-b683-a96d4cafd1f4" />

### after extensions tab appearance
<img width="136" height="35" alt="QQ_1775666191571" src="https://github.com/user-attachments/assets/5abb02bb-3368-49d0-9022-0a79f1f572a0" />

