### PR TITLE
compliance: Use tag instead of branch name by default

### DIFF
--- a/tooling/compliance/src/git.rs
+++ b/tooling/compliance/src/git.rs
@@ -303,12 +303,12 @@ impl FromStr for VersionTagList {
     }
 }
 
-pub struct CommitsFromVersionToHead {
+pub struct CommitsFromVersionToVersion {
     version_tag: VersionTag,
     branch: String,
 }
 
-impl CommitsFromVersionToHead {
+impl CommitsFromVersionToVersion {
     pub fn new(version_tag: VersionTag, branch: String) -> Self {
         Self {
             version_tag,
@@ -317,7 +317,7 @@ impl CommitsFromVersionToHead {
     }
 }
 
-impl Subcommand for CommitsFromVersionToHead {
+impl Subcommand for CommitsFromVersionToVersion {
     type ParsedOutput = CommitList;
 
     fn args(&self) -> impl IntoIterator<Item = String> {

--- a/tooling/xtask/src/tasks/compliance.rs
+++ b/tooling/xtask/src/tasks/compliance.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 
 use compliance::{
     checks::Reporter,
-    git::{CommitsFromVersionToHead, GetVersionTags, GitCommand, VersionTag},
+    git::{CommitsFromVersionToVersion, GetVersionTags, GitCommand, VersionTag},
     github::GitHubClient,
     report::ReportReviewSummary,
 };
@@ -28,14 +28,10 @@ impl ComplianceArgs {
         &self.version_tag
     }
 
-    fn version_branch(&self) -> String {
-        self.branch.clone().unwrap_or_else(|| {
-            format!(
-                "v{major}.{minor}.x",
-                major = self.version_tag().version().major,
-                minor = self.version_tag().version().minor
-            )
-        })
+    fn version_head(&self) -> String {
+        self.branch
+            .clone()
+            .unwrap_or_else(|| self.version_tag().to_string())
     }
 }
 
@@ -62,9 +58,9 @@ async fn check_compliance_impl(args: ComplianceArgs) -> Result<()> {
         previous_version.version()
     );
 
-    let commits = GitCommand::run(CommitsFromVersionToHead::new(
+    let commits = GitCommand::run(CommitsFromVersionToVersion::new(
         previous_version,
-        args.version_branch(),
+        args.version_head(),
     ))?;
 
     let Some(range) = commits.range() else {


### PR DESCRIPTION
Applies the changes from https://github.com/zed-industries/zed/pull/53409 to the main branch

Release Notes:

- N/A
