### PR TITLE
ci: Clean workspace members more eagerly

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -13,11 +13,8 @@ runs:
         node-version: "18"
 
     - name: Limit target directory size
-      env:
-        MAX_SIZE: ${{ runner.os == 'macOS' && 300 || 100 }}
       shell: bash -euxo pipefail {0}
-      # Use the variable in the run command
-      run: script/clear-target-dir-if-larger-than ${{ env.MAX_SIZE }}
+      run: script/clear-target-dir-if-larger-than 350 200
 
     - name: Run tests
       shell: bash -euxo pipefail {0}

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -68,7 +68,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 250
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: deploy_collab::tests::run_collab_tests
       run: cargo nextest run --package collab --no-fail-fast
     services:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:
@@ -83,7 +83,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 250
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:
@@ -126,7 +126,7 @@ jobs:
       with:
         node-version: '20'
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than.ps1 250
+      run: ./script/clear-target-dir-if-larger-than.ps1 350 200
       shell: pwsh
     - name: steps::setup_sccache
       run: ./script/setup-sccache.ps1
@@ -456,7 +456,7 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: run_bundling::bundle_mac::bundle_mac
       run: ./script/bundle-mac aarch64-apple-darwin
     - name: '@actions/upload-artifact Zed-aarch64.dmg'
@@ -501,7 +501,7 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: run_bundling::bundle_mac::bundle_mac
       run: ./script/bundle-mac x86_64-apple-darwin
     - name: '@actions/upload-artifact Zed-x86_64.dmg'

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         node-version: '20'
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than.ps1 250
+      run: ./script/clear-target-dir-if-larger-than.ps1 350 200
       shell: pwsh
     - name: steps::setup_sccache
       run: ./script/setup-sccache.ps1
@@ -220,7 +220,7 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: run_bundling::bundle_mac::bundle_mac
       run: ./script/bundle-mac aarch64-apple-darwin
     - name: '@actions/upload-artifact Zed-aarch64.dmg'
@@ -271,7 +271,7 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: run_bundling::bundle_mac::bundle_mac
       run: ./script/bundle-mac x86_64-apple-darwin
     - name: '@actions/upload-artifact Zed-x86_64.dmg'

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -116,7 +116,7 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: run_bundling::bundle_mac::bundle_mac
       run: ./script/bundle-mac aarch64-apple-darwin
     - name: '@actions/upload-artifact Zed-aarch64.dmg'
@@ -160,7 +160,7 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: run_bundling::bundle_mac::bundle_mac
       run: ./script/bundle-mac x86_64-apple-darwin
     - name: '@actions/upload-artifact Zed-x86_64.dmg'

--- a/.github/workflows/run_cron_unit_evals.yml
+++ b/.github/workflows/run_cron_unit_evals.yml
@@ -40,7 +40,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 250
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -324,7 +324,7 @@ jobs:
       with:
         node-version: '20'
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than.ps1 250
+      run: ./script/clear-target-dir-if-larger-than.ps1 350 200
       shell: pwsh
     - name: steps::setup_sccache
       run: ./script/setup-sccache.ps1
@@ -379,7 +379,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 250
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:
@@ -430,7 +430,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 300
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:

--- a/.github/workflows/run_unit_evals.yml
+++ b/.github/workflows/run_unit_evals.yml
@@ -43,7 +43,7 @@ jobs:
     - name: steps::cargo_install_nextest
       uses: taiki-e/install-action@921e2c9f7148d7ba14cd819f417db338f63e733c
     - name: steps::clear_target_dir_if_large
-      run: ./script/clear-target-dir-if-larger-than 250
+      run: ./script/clear-target-dir-if-larger-than 350 200
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:

--- a/script/clear-target-dir-if-larger-than
+++ b/script/clear-target-dir-if-larger-than
@@ -2,8 +2,8 @@
 
 set -euxo pipefail
 
-if [[ $# -ne 1 ]]; then
-    echo "usage: $0 <MAX_SIZE_IN_GB>"
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "usage: $0 <MAX_SIZE_IN_GB> [SMALL_CLEAN_SIZE_IN_GB]"
     exit 1
 fi
 
@@ -13,6 +13,12 @@ if ! [[ -d target ]]; then
 fi
 
 max_size_gb=$1
+small_clean_size_gb=${2:-}
+
+if [[ -n "${small_clean_size_gb}" && ${small_clean_size_gb} -ge ${max_size_gb} ]]; then
+    echo "error: small clean threshold (${small_clean_size_gb}gb) must be smaller than max size (${max_size_gb}gb)"
+    exit 1
+fi
 
 current_size=$(du -s target | cut -f1)
 current_size_gb=$(( ${current_size} / 1024 / 1024 ))
@@ -23,4 +29,7 @@ if [[ ${current_size_gb} -gt ${max_size_gb} ]]; then
     echo "clearing target directory"
     shopt -s dotglob
     rm -rf target/*
+elif [[ -n "${small_clean_size_gb}" && ${current_size_gb} -gt ${small_clean_size_gb} ]]; then
+    echo "running cargo clean --workspace (size above small clean threshold of ${small_clean_size_gb}gb)"
+    cargo clean --workspace
 fi

--- a/script/clear-target-dir-if-larger-than.ps1
+++ b/script/clear-target-dir-if-larger-than.ps1
@@ -1,6 +1,8 @@
 param (
     [Parameter(Mandatory = $true)]
-    [int]$MAX_SIZE_IN_GB
+    [int]$MAX_SIZE_IN_GB,
+    [Parameter(Mandatory = $false)]
+    [int]$SMALL_CLEAN_SIZE_IN_GB = -1
 )
 
 $ErrorActionPreference = "Stop"
@@ -12,6 +14,11 @@ if (-Not (Test-Path -Path "target")) {
     exit 0
 }
 
+if ($SMALL_CLEAN_SIZE_IN_GB -ge 0 -and $SMALL_CLEAN_SIZE_IN_GB -ge $MAX_SIZE_IN_GB) {
+    Write-Host "error: small clean threshold (${SMALL_CLEAN_SIZE_IN_GB}GB) must be smaller than max size (${MAX_SIZE_IN_GB}GB)"
+    exit 1
+}
+
 $current_size_gb = (Get-ChildItem -Recurse -Force -File -Path "target" | Measure-Object -Property Length -Sum).Sum / 1GB
 
 Write-Host "target directory size: ${current_size_gb}GB. max size: ${MAX_SIZE_IN_GB}GB"
@@ -19,4 +26,7 @@ Write-Host "target directory size: ${current_size_gb}GB. max size: ${MAX_SIZE_IN
 if ($current_size_gb -gt $MAX_SIZE_IN_GB) {
     Write-Host "clearing target directory"
     Remove-Item -Recurse -Force -Path "target\*" -ErrorAction SilentlyContinue
+} elseif ($SMALL_CLEAN_SIZE_IN_GB -ge 0 -and $current_size_gb -gt $SMALL_CLEAN_SIZE_IN_GB) {
+    Write-Host "running cargo clean --workspace (size above small clean threshold of ${SMALL_CLEAN_SIZE_IN_GB}GB)"
+    cargo clean --workspace
 }

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -213,9 +213,9 @@ pub fn cleanup_cargo_config(platform: Platform) -> Step<Run> {
 
 pub fn clear_target_dir_if_large(platform: Platform) -> Step<Run> {
     match platform {
-        Platform::Windows => named::pwsh("./script/clear-target-dir-if-larger-than.ps1 250"),
-        Platform::Linux => named::bash("./script/clear-target-dir-if-larger-than 250"),
-        Platform::Mac => named::bash("./script/clear-target-dir-if-larger-than 300"),
+        Platform::Windows => named::pwsh("./script/clear-target-dir-if-larger-than.ps1 350 200"),
+        Platform::Linux => named::bash("./script/clear-target-dir-if-larger-than 350 200"),
+        Platform::Mac => named::bash("./script/clear-target-dir-if-larger-than 350 200"),
     }
 }
 


### PR DESCRIPTION
This relies on 1.94s --workspace option we've added to cargo

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A
