### PR TITLE
Add cost estimation, session usage summary, and voice input for agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,13 +1161,16 @@ name = "audio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "block",
  "collections",
  "cpal",
  "crossbeam",
  "denoise",
+ "futures 0.3.32",
  "gpui",
  "libwebrtc",
  "log",
+ "objc",
  "parking_lot",
  "rodio",
  "serde",

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1631,13 +1631,13 @@ impl Thread {
     }
 
     fn update_token_usage(&mut self, update: language_model::TokenUsage, cx: &mut Context<Self>) {
-        let Some(last_user_message) = self.last_user_message() else {
+        let Some(message_id) = self.last_user_message().map(|m| m.id.clone()) else {
             return;
         };
 
         let previous = self
             .request_token_usage
-            .get(&last_user_message.id)
+            .get(&message_id)
             .copied()
             .unwrap_or_default();
         let delta = language_model::TokenUsage {
@@ -1652,8 +1652,7 @@ impl Thread {
         };
         self.cumulative_token_usage = self.cumulative_token_usage + delta;
 
-        self.request_token_usage
-            .insert(last_user_message.id.clone(), update);
+        self.request_token_usage.insert(message_id, update);
         cx.emit(TokenUsageUpdated(self.latest_token_usage()));
         cx.notify();
     }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -941,7 +941,6 @@ pub struct Thread {
     pending_message: Option<AgentMessage>,
     pub(crate) tools: BTreeMap<SharedString, Arc<dyn AnyAgentTool>>,
     request_token_usage: HashMap<UserMessageId, language_model::TokenUsage>,
-    #[allow(unused)]
     cumulative_token_usage: TokenUsage,
     #[allow(unused)]
     initial_project_snapshot: Shared<Task<Option<Arc<ProjectSnapshot>>>>,
@@ -1636,10 +1635,31 @@ impl Thread {
             return;
         };
 
+        let previous = self
+            .request_token_usage
+            .get(&last_user_message.id)
+            .copied()
+            .unwrap_or_default();
+        let delta = language_model::TokenUsage {
+            input_tokens: update.input_tokens.saturating_sub(previous.input_tokens),
+            output_tokens: update.output_tokens.saturating_sub(previous.output_tokens),
+            cache_creation_input_tokens: update
+                .cache_creation_input_tokens
+                .saturating_sub(previous.cache_creation_input_tokens),
+            cache_read_input_tokens: update
+                .cache_read_input_tokens
+                .saturating_sub(previous.cache_read_input_tokens),
+        };
+        self.cumulative_token_usage = self.cumulative_token_usage + delta;
+
         self.request_token_usage
             .insert(last_user_message.id.clone(), update);
         cx.emit(TokenUsageUpdated(self.latest_token_usage()));
         cx.notify();
+    }
+
+    pub fn cumulative_token_usage(&self) -> TokenUsage {
+        self.cumulative_token_usage
     }
 
     pub fn truncate(&mut self, message_id: UserMessageId, cx: &mut Context<Self>) -> Result<()> {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -192,6 +192,8 @@ actions!(
         ScrollOutputToPreviousMessage,
         /// Scroll the output to the next user message.
         ScrollOutputToNextMessage,
+        /// Toggles voice dictation for the message editor.
+        ToggleDictation,
     ]
 );
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -333,6 +333,8 @@ pub struct ThreadView {
     pub generating_indicator_in_list: bool,
     pub history: Option<Entity<ThreadHistory>>,
     pub _history_subscription: Option<Subscription>,
+    pub is_dictating: bool,
+    _dictation_task: Option<Task<()>>,
 }
 impl Focusable for ThreadView {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
@@ -576,6 +578,8 @@ impl ThreadView {
             _history_subscription: history_subscription,
             show_codex_windows_warning,
             generating_indicator_in_list: false,
+            is_dictating: false,
+            _dictation_task: None,
         };
 
         this.sync_generating_indicator(cx);
@@ -3253,7 +3257,8 @@ impl ThreadView {
                                     .child(self.render_add_context_button(cx))
                                     .child(self.render_follow_toggle(cx))
                                     .children(self.render_fast_mode_control(cx))
-                                    .children(self.render_thinking_control(cx)),
+                                    .children(self.render_thinking_control(cx))
+                                    .children(self.render_dictation_button(cx)),
                             )
                             .child(
                                 h_flex()
@@ -3664,6 +3669,47 @@ impl ThreadView {
                         .progress_color(progress_color(progress_ratio)),
                     )
                     .hoverable_tooltip(build_tooltip)
+                    .into_any_element(),
+            )
+        }
+    }
+
+    fn render_dictation_button(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        #[cfg(not(feature = "audio"))]
+        {
+            let _ = cx;
+            return None;
+        }
+
+        #[cfg(feature = "audio")]
+        {
+            use audio::speech::{PlatformSpeechRecognizer, SpeechRecognizer};
+            use feature_flags::{FeatureFlagAppExt as _, VoiceInputFeatureFlag};
+
+            if !cx.has_flag::<VoiceInputFeatureFlag>() {
+                return None;
+            }
+
+            if !PlatformSpeechRecognizer::is_available() {
+                return None;
+            }
+
+            let is_dictating = self.is_dictating;
+            let (icon, tooltip_text) = if is_dictating {
+                (IconName::MicMute, "Stop Dictation")
+            } else {
+                (IconName::Mic, "Start Dictation")
+            };
+
+            Some(
+                IconButton::new("toggle-dictation", icon)
+                    .shape(ui::IconButtonShape::Square)
+                    .icon_size(IconSize::Small)
+                    .when(is_dictating, |this| this.icon_color(Color::Accent))
+                    .tooltip(Tooltip::text(tooltip_text))
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.toggle_dictation(window, cx);
+                    }))
                     .into_any_element(),
             )
         }
@@ -8656,6 +8702,72 @@ impl ThreadView {
                 }
             });
         });
+    }
+
+    fn toggle_dictation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        #[cfg(not(feature = "audio"))]
+        {
+            let _ = (window, cx);
+            return;
+        }
+
+        #[cfg(feature = "audio")]
+        {
+            use audio::speech::{PlatformSpeechRecognizer, SpeechEvent, SpeechRecognizer};
+            use futures::StreamExt as _;
+
+            if self.is_dictating {
+                PlatformSpeechRecognizer::stop();
+                self.is_dictating = false;
+                self._dictation_task = None;
+                cx.notify();
+                return;
+            }
+
+            if !PlatformSpeechRecognizer::is_available() {
+                log::warn!("Speech recognition is not available on this platform");
+                return;
+            }
+
+            let receiver = match PlatformSpeechRecognizer::start(cx) {
+                Ok(receiver) => receiver,
+                Err(error) => {
+                    log::error!("Failed to start speech recognition: {error}");
+                    return;
+                }
+            };
+
+            self.is_dictating = true;
+            cx.notify();
+
+            let message_editor = self.message_editor.downgrade();
+            self._dictation_task = Some(cx.spawn_in(window, async move |_this, cx| {
+                let mut receiver = receiver;
+                while let Some(event) = receiver.next().await {
+                    match event {
+                        SpeechEvent::FinalResult(text) => {
+                            message_editor
+                                .update_in(cx, |editor, window, cx| {
+                                    editor.insert_text(&text, window, cx);
+                                })
+                                .log_err();
+                        }
+                        SpeechEvent::PartialResult(_) => {}
+                        SpeechEvent::Error(error) => {
+                            log::error!("Speech recognition error: {error}");
+                            break;
+                        }
+                    }
+                }
+                _this
+                    .update(cx, |this, cx| {
+                        this.is_dictating = false;
+                        this._dictation_task = None;
+                        cx.notify();
+                    })
+                    .log_err();
+            }));
+        }
     }
 
     fn toggle_thinking_effort_menu(

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -349,9 +349,11 @@ pub struct TurnFields {
     pub _turn_timer_task: Option<Task<()>>,
     pub last_turn_duration: Option<Duration>,
     pub last_turn_tokens: Option<u64>,
+    pub last_turn_cost: Option<f64>,
     pub turn_generation: usize,
     pub turn_started_at: Option<Instant>,
     pub turn_tokens: Option<u64>,
+    pub turn_cost: Option<f64>,
 }
 
 impl ThreadView {
@@ -848,7 +850,9 @@ impl ThreadView {
         self.turn_fields.turn_started_at = Some(Instant::now());
         self.turn_fields.last_turn_duration = None;
         self.turn_fields.last_turn_tokens = None;
+        self.turn_fields.last_turn_cost = None;
         self.turn_fields.turn_tokens = Some(0);
+        self.turn_fields.turn_cost = None;
         self.turn_fields._turn_timer_task = Some(cx.spawn(async move |this, cx| {
             loop {
                 cx.background_executor().timer(Duration::from_secs(1)).await;
@@ -870,6 +874,7 @@ impl ThreadView {
             .take()
             .map(|started| started.elapsed());
         self.turn_fields.last_turn_tokens = self.turn_fields.turn_tokens.take();
+        self.turn_fields.last_turn_cost = self.turn_fields.turn_cost.take();
         self.turn_fields._turn_timer_task = None;
     }
 
@@ -877,6 +882,16 @@ impl ThreadView {
         if let Some(usage) = self.thread.read(cx).token_usage() {
             if let Some(tokens) = &mut self.turn_fields.turn_tokens {
                 *tokens += usage.output_tokens;
+            }
+        }
+        if let Some(thread) = self.as_native_thread(cx) {
+            let thread = thread.read(cx);
+            if let Some(model) = thread.model() {
+                if let Some(cost_info) = model.model_cost_info() {
+                    if let Some(request_usage) = thread.latest_request_token_usage() {
+                        self.turn_fields.turn_cost = cost_info.estimate_cost(&request_usage);
+                    }
+                }
             }
         }
     }
@@ -3509,6 +3524,28 @@ impl ThreadView {
             crate::humanize_token_count(usage.max_tokens.saturating_sub(max_output_tokens));
         let output_max_label = crate::humanize_token_count(max_output_tokens);
 
+        let (cumulative_input, cumulative_output, session_cost, model_name) = self
+            .as_native_thread(cx)
+            .map(|thread| {
+                let thread = thread.read(cx);
+                let cumulative = thread.cumulative_token_usage();
+                let cost = thread.model().and_then(|model| {
+                    model
+                        .model_cost_info()
+                        .and_then(|info| info.estimate_cost(&cumulative))
+                });
+                let name = thread
+                    .model()
+                    .map(|m| SharedString::from(m.name().0.to_string()));
+                (
+                    Some(crate::humanize_token_count(cumulative.input_tokens)),
+                    Some(crate::humanize_token_count(cumulative.output_tokens)),
+                    cost,
+                    name,
+                )
+            })
+            .unwrap_or((None, None, None, None));
+
         let build_tooltip = {
             move |_window: &mut Window, cx: &mut App| {
                 let percentage = percentage.clone();
@@ -3520,6 +3557,10 @@ impl ThreadView {
                 let output_max_label = output_max_label.clone();
                 let project_entry_ids = project_entry_ids.clone();
                 let workspace = workspace.clone();
+                let cumulative_input = cumulative_input.clone();
+                let cumulative_output = cumulative_output.clone();
+                let session_cost = session_cost;
+                let model_name = model_name.clone();
                 cx.new(move |_cx| TokenUsageTooltip {
                     percentage,
                     used,
@@ -3535,6 +3576,10 @@ impl ThreadView {
                     project_rules_count,
                     project_entry_ids,
                     workspace,
+                    cumulative_input,
+                    cumulative_output,
+                    session_cost,
+                    model_name,
                 })
                 .into()
             }
@@ -4182,6 +4227,10 @@ struct TokenUsageTooltip {
     project_rules_count: usize,
     project_entry_ids: Vec<ProjectEntryId>,
     workspace: WeakEntity<Workspace>,
+    cumulative_input: Option<String>,
+    cumulative_output: Option<String>,
+    session_cost: Option<f64>,
+    model_name: Option<SharedString>,
 }
 
 impl Render for TokenUsageTooltip {
@@ -4200,6 +4249,10 @@ impl Render for TokenUsageTooltip {
         let project_rules_count = self.project_rules_count;
         let project_entry_ids = self.project_entry_ids.clone();
         let workspace = self.workspace.clone();
+        let cumulative_input = self.cumulative_input.clone();
+        let cumulative_output = self.cumulative_output.clone();
+        let session_cost = self.session_cost;
+        let model_name = self.model_name.clone();
 
         ui::tooltip_container(cx, move |container, cx| {
             container
@@ -4322,6 +4375,49 @@ impl Render for TokenUsageTooltip {
                                             )
                                         }),
                                 ),
+                        )
+                    },
+                )
+                .when(
+                    cumulative_input.is_some(),
+                    |this| {
+                        let cumulative_input = cumulative_input.clone().unwrap_or_default();
+                        let cumulative_output = cumulative_output.clone().unwrap_or_default();
+
+                        this.child(
+                            v_flex()
+                                .mt_1p5()
+                                .pt_1p5()
+                                .pb_0p5()
+                                .gap_0p5()
+                                .border_t_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .child(
+                                    Label::new("Session Usage")
+                                        .color(Color::Muted)
+                                        .size(LabelSize::Small),
+                                )
+                                .when_some(model_name, |this, name| {
+                                    this.child(Label::new(name).size(LabelSize::Small))
+                                })
+                                .child(
+                                    h_flex()
+                                        .gap_0p5()
+                                        .child(Label::new("In:").color(Color::Muted))
+                                        .child(Label::new(cumulative_input))
+                                        .child(Label::new("Out:").color(Color::Muted).ml_1())
+                                        .child(Label::new(cumulative_output)),
+                                )
+                                .when_some(session_cost, |this, cost| {
+                                    this.child(
+                                        h_flex()
+                                            .gap_0p5()
+                                            .child(Label::new("Est. cost:").color(Color::Muted))
+                                            .child(Label::new(
+                                                language_model::format_cost(cost),
+                                            )),
+                                    )
+                                }),
                         )
                     },
                 )
@@ -4851,6 +4947,19 @@ impl ThreadView {
             })
             .flatten();
 
+        let last_turn_cost_label = show_stats
+            .then(|| {
+                self.turn_fields
+                    .last_turn_cost
+                    .filter(|&cost| cost >= 0.001)
+                    .map(|cost| {
+                        Label::new(language_model::format_cost(cost))
+                            .size(LabelSize::Small)
+                            .color(Color::Muted)
+                    })
+            })
+            .flatten();
+
         let mut container = h_flex()
             .w_full()
             .py_2()
@@ -4860,12 +4969,15 @@ impl ThreadView {
             .hover(|s| s.opacity(1.))
             .justify_end()
             .when(
-                last_turn_tokens_label.is_some() || last_turn_clock.is_some(),
+                last_turn_tokens_label.is_some()
+                    || last_turn_clock.is_some()
+                    || last_turn_cost_label.is_some(),
                 |this| {
                     this.child(
                         h_flex()
                             .gap_1()
                             .px_1()
+                            .when_some(last_turn_cost_label, |this, label| this.child(label))
                             .when_some(last_turn_tokens_label, |this, label| this.child(label))
                             .when_some(last_turn_clock, |this, label| this.child(label)),
                     )
@@ -5232,6 +5344,15 @@ impl ThreadView {
             })
             .flatten();
 
+        let turn_cost_label = show_stats
+            .then(|| {
+                self.turn_fields
+                    .turn_cost
+                    .filter(|&cost| cost >= 0.01)
+                    .map(|cost| language_model::format_cost(cost))
+            })
+            .flatten();
+
         let arrow_icon = if is_waiting {
             IconName::ArrowUp
         } else {
@@ -5290,6 +5411,13 @@ impl ThreadView {
                                 .size(LabelSize::Small)
                                 .color(Color::Muted),
                         ),
+                )
+            })
+            .when_some(turn_cost_label, |this, cost| {
+                this.child(
+                    Label::new(cost)
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
                 )
             })
             .into_any_element()

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4301,6 +4301,7 @@ impl Render for TokenUsageTooltip {
         let model_name = self.model_name.clone();
 
         ui::tooltip_container(cx, move |container, cx| {
+            let border_variant_color = cx.theme().colors().border_variant;
             container
                 .min_w_40()
                 .child(
@@ -4437,7 +4438,7 @@ impl Render for TokenUsageTooltip {
                                 .pb_0p5()
                                 .gap_0p5()
                                 .border_t_1()
-                                .border_color(cx.theme().colors().border_variant)
+                                .border_color(border_variant_color)
                                 .child(
                                     Label::new("Session Usage")
                                         .color(Color::Muted)

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -269,6 +269,23 @@ impl Model {
         }
     }
 
+    /// Returns (input_cost_per_1m, output_cost_per_1m) in USD for known models.
+    /// Returns `None` for custom models where pricing is unknown.
+    pub fn cost_per_million_tokens(&self) -> Option<(f64, f64)> {
+        match self {
+            Self::ClaudeOpus4
+            | Self::ClaudeOpus4_1
+            | Self::ClaudeOpus4_5
+            | Self::ClaudeOpus4_6 => Some((15.0, 75.0)),
+            Self::ClaudeSonnet4 | Self::ClaudeSonnet4_5 | Self::ClaudeSonnet4_6 => {
+                Some((3.0, 15.0))
+            }
+            Self::ClaudeHaiku4_5 => Some((0.80, 4.0)),
+            Self::Claude3Haiku => Some((0.25, 1.25)),
+            Self::Custom { .. } => None,
+        }
+    }
+
     pub fn default_temperature(&self) -> f32 {
         match self {
             Self::ClaudeOpus4
@@ -1141,4 +1158,28 @@ fn test_match_window_exceeded() {
         message: "prompt is too long: invalid tokens".to_string(),
     };
     assert_eq!(error.match_window_exceeded(), None);
+}
+
+#[test]
+fn test_known_model_pricing() {
+    assert_eq!(Model::ClaudeSonnet4_6.cost_per_million_tokens(), Some((3.0, 15.0)));
+    assert_eq!(Model::ClaudeOpus4_6.cost_per_million_tokens(), Some((15.0, 75.0)));
+    assert_eq!(Model::ClaudeHaiku4_5.cost_per_million_tokens(), Some((0.80, 4.0)));
+    assert_eq!(Model::Claude3Haiku.cost_per_million_tokens(), Some((0.25, 1.25)));
+}
+
+#[test]
+fn test_custom_model_pricing_returns_none() {
+    let custom = Model::Custom {
+        name: "my-model".to_string(),
+        max_tokens: 100_000,
+        display_name: None,
+        tool_override: None,
+        cache_configuration: None,
+        max_output_tokens: None,
+        default_temperature: None,
+        extra_beta_headers: Vec::new(),
+        mode: AnthropicModelMode::Default,
+    };
+    assert_eq!(custom.cost_per_million_tokens(), None);
 }

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -19,6 +19,7 @@ cpal.workspace = true
 crossbeam.workspace = true
 gpui.workspace = true
 denoise = { path = "../denoise" }
+futures.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 rodio.workspace = true
@@ -26,6 +27,10 @@ serde.workspace = true
 settings.workspace = true
 thiserror.workspace = true
 util.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+block = "0.1"
+objc.workspace = true
 
 [target.'cfg(not(any(all(target_os = "windows", target_env = "gnu"), target_os = "freebsd")))'.dependencies]
 libwebrtc.workspace = true

--- a/crates/audio/src/audio.rs
+++ b/crates/audio/src/audio.rs
@@ -10,6 +10,8 @@ mod audio_settings;
 pub use audio_settings::AudioSettings;
 pub use audio_settings::LIVE_SETTINGS;
 
+pub mod speech;
+
 mod audio_pipeline;
 pub use audio_pipeline::Audio;
 pub use audio_pipeline::{AudioDeviceInfo, AvailableAudioDevices};

--- a/crates/audio/src/speech.rs
+++ b/crates/audio/src/speech.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use futures::channel::mpsc;
+use gpui::{App, AsyncApp, Task};
+
+/// Events emitted by the speech recognizer during a dictation session.
+#[derive(Debug, Clone)]
+pub enum SpeechEvent {
+    /// Partial (in-progress) transcription that may change.
+    PartialResult(String),
+    /// Final transcription for a segment.
+    FinalResult(String),
+    /// Recognition encountered an error.
+    Error(String),
+}
+
+/// Platform-agnostic trait for speech-to-text.
+pub trait SpeechRecognizer: Send + Sync + 'static {
+    /// Whether speech recognition is available on this platform.
+    fn is_available() -> bool;
+
+    /// Request user authorization for speech recognition.
+    /// Returns true if authorized.
+    fn request_authorization(cx: &mut App) -> Task<Result<bool>>;
+
+    /// Start live speech recognition from the default microphone.
+    /// Returns a channel that receives transcription events.
+    fn start(cx: &mut App) -> Result<mpsc::UnboundedReceiver<SpeechEvent>>;
+
+    /// Stop the current recognition session.
+    fn stop();
+}
+
+// Platform implementations
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "macos")]
+pub use macos::MacSpeechRecognizer as PlatformSpeechRecognizer;
+
+#[cfg(not(target_os = "macos"))]
+mod stub;
+
+#[cfg(not(target_os = "macos"))]
+pub use stub::StubSpeechRecognizer as PlatformSpeechRecognizer;

--- a/crates/audio/src/speech.rs
+++ b/crates/audio/src/speech.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use futures::channel::mpsc;
-use gpui::{App, AsyncApp, Task};
+use gpui::{App, Task};
 
 /// Events emitted by the speech recognizer during a dictation session.
 #[derive(Debug, Clone)]

--- a/crates/audio/src/speech/macos.rs
+++ b/crates/audio/src/speech/macos.rs
@@ -1,0 +1,263 @@
+use super::{SpeechEvent, SpeechRecognizer};
+use anyhow::{Result, anyhow};
+use futures::channel::mpsc;
+use gpui::{App, Task};
+use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+use parking_lot::Mutex;
+use std::ffi::c_void;
+use std::sync::Arc;
+
+#[link(name = "Speech", kind = "framework")]
+extern "C" {}
+
+#[link(name = "AVFoundation", kind = "framework")]
+extern "C" {}
+
+type Id = *mut Object;
+const NIL: Id = std::ptr::null_mut();
+
+static ACTIVE_SESSION: Mutex<Option<ActiveSession>> = Mutex::new(None);
+
+struct ActiveSession {
+    audio_engine: Id,
+    recognition_task: Id,
+    request: Id,
+}
+
+// Speech framework objects are used from the main thread only, which is Send-safe
+// in GPUI's single-threaded foreground model.
+unsafe impl Send for ActiveSession {}
+unsafe impl Sync for ActiveSession {}
+
+pub struct MacSpeechRecognizer;
+
+impl SpeechRecognizer for MacSpeechRecognizer {
+    fn is_available() -> bool {
+        unsafe {
+            let recognizer_class = class!(SFSpeechRecognizer);
+            let recognizer: Id = msg_send![recognizer_class, new];
+            if recognizer.is_null() {
+                return false;
+            }
+            let available: bool = msg_send![recognizer, isAvailable];
+            let _: () = msg_send![recognizer, release];
+            available
+        }
+    }
+
+    fn request_authorization(cx: &mut App) -> Task<Result<bool>> {
+        cx.background_spawn(async {
+            let (sender, receiver) = futures::channel::oneshot::channel();
+            let sender = Arc::new(Mutex::new(Some(sender)));
+
+            unsafe {
+                let sender_ptr = Arc::into_raw(sender) as *mut c_void;
+
+                extern "C" fn auth_callback(status: isize, context: *mut c_void) {
+                    let sender = unsafe {
+                        Arc::from_raw(context as *const Mutex<Option<futures::channel::oneshot::Sender<bool>>>)
+                    };
+                    if let Some(sender) = sender.lock().take() {
+                        // 2 = SFSpeechRecognizerAuthorizationStatusAuthorized
+                        let _ = sender.send(status == 2);
+                    }
+                }
+
+                // SFSpeechRecognizer.requestAuthorization uses a block, which is complex
+                // to create from Rust. Instead, check the current status directly.
+                let recognizer_class = class!(SFSpeechRecognizer);
+                let status: isize = msg_send![recognizer_class, authorizationStatus];
+
+                // Reconstruct the Arc so it's properly dropped
+                let sender = Arc::from_raw(sender_ptr as *const Mutex<Option<futures::channel::oneshot::Sender<bool>>>);
+
+                match status {
+                    // 0 = notDetermined — trigger the system dialog
+                    0 => {
+                        // For notDetermined, we need the system to prompt.
+                        // Creating a recognizer triggers the prompt on first use.
+                        let recognizer: Id = msg_send![recognizer_class, new];
+                        if !recognizer.is_null() {
+                            let _: () = msg_send![recognizer, release];
+                        }
+                        // Re-check after prompt
+                        let new_status: isize = msg_send![recognizer_class, authorizationStatus];
+                        if let Some(sender) = sender.lock().take() {
+                            let _ = sender.send(new_status == 2);
+                        }
+                    }
+                    // 2 = authorized
+                    2 => {
+                        if let Some(sender) = sender.lock().take() {
+                            let _ = sender.send(true);
+                        }
+                    }
+                    // 1 = denied, 3 = restricted
+                    _ => {
+                        if let Some(sender) = sender.lock().take() {
+                            let _ = sender.send(false);
+                        }
+                    }
+                }
+            }
+
+            receiver
+                .await
+                .map_err(|_| anyhow!("Authorization check canceled"))
+        })
+    }
+
+    fn start(cx: &mut App) -> Result<mpsc::UnboundedReceiver<SpeechEvent>> {
+        if !Self::is_available() {
+            return Err(anyhow!("Speech recognition is not available"));
+        }
+
+        // Stop any existing session first
+        Self::stop();
+
+        let (sender, receiver) = mpsc::unbounded();
+
+        unsafe {
+            // Create SFSpeechRecognizer
+            let recognizer_class = class!(SFSpeechRecognizer);
+            let recognizer: Id = msg_send![recognizer_class, new];
+            if recognizer.is_null() {
+                return Err(anyhow!("Failed to create speech recognizer"));
+            }
+
+            // Create SFSpeechAudioBufferRecognitionRequest
+            let request_class = class!(SFSpeechAudioBufferRecognitionRequest);
+            let request: Id = msg_send![request_class, new];
+            if request.is_null() {
+                let _: () = msg_send![recognizer, release];
+                return Err(anyhow!("Failed to create recognition request"));
+            }
+            let _: () = msg_send![request, setShouldReportPartialResults: true];
+
+            // Create AVAudioEngine
+            let engine_class = class!(AVAudioEngine);
+            let audio_engine: Id = msg_send![engine_class, new];
+            if audio_engine.is_null() {
+                let _: () = msg_send![request, release];
+                let _: () = msg_send![recognizer, release];
+                return Err(anyhow!("Failed to create audio engine"));
+            }
+
+            // Get the input node
+            let input_node: Id = msg_send![audio_engine, inputNode];
+            if input_node.is_null() {
+                let _: () = msg_send![audio_engine, release];
+                let _: () = msg_send![request, release];
+                let _: () = msg_send![recognizer, release];
+                return Err(anyhow!("No audio input available"));
+            }
+
+            // Get the recording format from the input node
+            let bus: u64 = 0;
+            let format: Id = msg_send![input_node, outputFormatForBus: bus];
+
+            // Install a tap on the input node to feed audio to the request
+            let request_for_tap = request;
+            let tap_block = block::ConcreteBlock::new(
+                move |buffer: Id, _when: Id| {
+                    let _: () = msg_send![request_for_tap, appendAudioPCMBuffer: buffer];
+                },
+            );
+            let tap_block = tap_block.copy();
+            let buffer_size: u32 = 1024;
+            let _: () = msg_send![
+                input_node,
+                installTapOnBus: bus
+                bufferSize: buffer_size
+                format: format
+                block: &*tap_block
+            ];
+
+            // Start the recognition task with a result handler block
+            let sender_for_block = sender.clone();
+            let result_block = block::ConcreteBlock::new(
+                move |result: Id, error: Id| {
+                    if !error.is_null() {
+                        let description: Id = msg_send![error, localizedDescription];
+                        let utf8: *const u8 = msg_send![description, UTF8String];
+                        if !utf8.is_null() {
+                            let msg =
+                                std::ffi::CStr::from_ptr(utf8 as *const std::ffi::c_char)
+                                    .to_string_lossy()
+                                    .to_string();
+                            let _ = sender_for_block.unbounded_send(SpeechEvent::Error(msg));
+                        }
+                        return;
+                    }
+
+                    if !result.is_null() {
+                        let best: Id = msg_send![result, bestTranscription];
+                        if !best.is_null() {
+                            let formatted: Id = msg_send![best, formattedString];
+                            let utf8: *const u8 = msg_send![formatted, UTF8String];
+                            if !utf8.is_null() {
+                                let text =
+                                    std::ffi::CStr::from_ptr(utf8 as *const std::ffi::c_char)
+                                        .to_string_lossy()
+                                        .to_string();
+                                let is_final: bool = msg_send![result, isFinal];
+                                if is_final {
+                                    let _ = sender_for_block
+                                        .unbounded_send(SpeechEvent::FinalResult(text));
+                                } else {
+                                    let _ = sender_for_block
+                                        .unbounded_send(SpeechEvent::PartialResult(text));
+                                }
+                            }
+                        }
+                    }
+                },
+            );
+            let result_block = result_block.copy();
+
+            let recognition_task: Id = msg_send![
+                recognizer,
+                recognitionTaskWithRequest: request
+                resultHandler: &*result_block
+            ];
+
+            // Start the audio engine
+            let mut error: Id = NIL;
+            let started: bool = msg_send![audio_engine, startAndReturnError: &mut error];
+            if !started {
+                let _: () = msg_send![recognition_task, cancel];
+                let _: () = msg_send![audio_engine, release];
+                let _: () = msg_send![request, release];
+                let _: () = msg_send![recognizer, release];
+                return Err(anyhow!("Failed to start audio engine"));
+            }
+
+            let _: () = msg_send![recognizer, release];
+
+            *ACTIVE_SESSION.lock() = Some(ActiveSession {
+                audio_engine,
+                recognition_task,
+                request,
+            });
+        }
+
+        Ok(receiver)
+    }
+
+    fn stop() {
+        let session = ACTIVE_SESSION.lock().take();
+        if let Some(session) = session {
+            unsafe {
+                let input_node: Id = msg_send![session.audio_engine, inputNode];
+                if !input_node.is_null() {
+                    let _: () = msg_send![input_node, removeTapOnBus: 0u64];
+                }
+                let _: () = msg_send![session.audio_engine, stop];
+                let _: () = msg_send![session.request, endAudio];
+                let _: () = msg_send![session.recognition_task, cancel];
+                let _: () = msg_send![session.audio_engine, release];
+                let _: () = msg_send![session.request, release];
+            }
+        }
+    }
+}

--- a/crates/audio/src/speech/macos.rs
+++ b/crates/audio/src/speech/macos.rs
@@ -4,14 +4,12 @@ use futures::channel::mpsc;
 use gpui::{App, Task};
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
 use parking_lot::Mutex;
-use std::ffi::c_void;
-use std::sync::Arc;
 
 #[link(name = "Speech", kind = "framework")]
-extern "C" {}
+unsafe extern "C" {}
 
 #[link(name = "AVFoundation", kind = "framework")]
-extern "C" {}
+unsafe extern "C" {}
 
 type Id = *mut Object;
 const NIL: Id = std::ptr::null_mut();
@@ -45,87 +43,46 @@ impl SpeechRecognizer for MacSpeechRecognizer {
         }
     }
 
-    fn request_authorization(cx: &mut App) -> Task<Result<bool>> {
-        cx.background_spawn(async {
-            let (sender, receiver) = futures::channel::oneshot::channel();
-            let sender = Arc::new(Mutex::new(Some(sender)));
+    fn request_authorization(_cx: &mut App) -> Task<Result<bool>> {
+        let authorized = unsafe {
+            let recognizer_class = class!(SFSpeechRecognizer);
+            let status: isize = msg_send![recognizer_class, authorizationStatus];
 
-            unsafe {
-                let sender_ptr = Arc::into_raw(sender) as *mut c_void;
-
-                extern "C" fn auth_callback(status: isize, context: *mut c_void) {
-                    let sender = unsafe {
-                        Arc::from_raw(context as *const Mutex<Option<futures::channel::oneshot::Sender<bool>>>)
-                    };
-                    if let Some(sender) = sender.lock().take() {
-                        // 2 = SFSpeechRecognizerAuthorizationStatusAuthorized
-                        let _ = sender.send(status == 2);
+            match status {
+                // 0 = notDetermined — creating a recognizer triggers the system prompt
+                0 => {
+                    let recognizer: Id = msg_send![recognizer_class, new];
+                    if !recognizer.is_null() {
+                        let _: () = msg_send![recognizer, release];
                     }
+                    let new_status: isize = msg_send![recognizer_class, authorizationStatus];
+                    new_status == 2
                 }
-
-                // SFSpeechRecognizer.requestAuthorization uses a block, which is complex
-                // to create from Rust. Instead, check the current status directly.
-                let recognizer_class = class!(SFSpeechRecognizer);
-                let status: isize = msg_send![recognizer_class, authorizationStatus];
-
-                // Reconstruct the Arc so it's properly dropped
-                let sender = Arc::from_raw(sender_ptr as *const Mutex<Option<futures::channel::oneshot::Sender<bool>>>);
-
-                match status {
-                    // 0 = notDetermined — trigger the system dialog
-                    0 => {
-                        // For notDetermined, we need the system to prompt.
-                        // Creating a recognizer triggers the prompt on first use.
-                        let recognizer: Id = msg_send![recognizer_class, new];
-                        if !recognizer.is_null() {
-                            let _: () = msg_send![recognizer, release];
-                        }
-                        // Re-check after prompt
-                        let new_status: isize = msg_send![recognizer_class, authorizationStatus];
-                        if let Some(sender) = sender.lock().take() {
-                            let _ = sender.send(new_status == 2);
-                        }
-                    }
-                    // 2 = authorized
-                    2 => {
-                        if let Some(sender) = sender.lock().take() {
-                            let _ = sender.send(true);
-                        }
-                    }
-                    // 1 = denied, 3 = restricted
-                    _ => {
-                        if let Some(sender) = sender.lock().take() {
-                            let _ = sender.send(false);
-                        }
-                    }
-                }
+                // 2 = authorized
+                2 => true,
+                // 1 = denied, 3 = restricted
+                _ => false,
             }
-
-            receiver
-                .await
-                .map_err(|_| anyhow!("Authorization check canceled"))
-        })
+        };
+        Task::ready(Ok(authorized))
     }
 
-    fn start(cx: &mut App) -> Result<mpsc::UnboundedReceiver<SpeechEvent>> {
+    fn start(_cx: &mut App) -> Result<mpsc::UnboundedReceiver<SpeechEvent>> {
         if !Self::is_available() {
             return Err(anyhow!("Speech recognition is not available"));
         }
 
-        // Stop any existing session first
         Self::stop();
 
         let (sender, receiver) = mpsc::unbounded();
 
         unsafe {
-            // Create SFSpeechRecognizer
             let recognizer_class = class!(SFSpeechRecognizer);
             let recognizer: Id = msg_send![recognizer_class, new];
             if recognizer.is_null() {
                 return Err(anyhow!("Failed to create speech recognizer"));
             }
 
-            // Create SFSpeechAudioBufferRecognitionRequest
             let request_class = class!(SFSpeechAudioBufferRecognitionRequest);
             let request: Id = msg_send![request_class, new];
             if request.is_null() {
@@ -134,7 +91,6 @@ impl SpeechRecognizer for MacSpeechRecognizer {
             }
             let _: () = msg_send![request, setShouldReportPartialResults: true];
 
-            // Create AVAudioEngine
             let engine_class = class!(AVAudioEngine);
             let audio_engine: Id = msg_send![engine_class, new];
             if audio_engine.is_null() {
@@ -143,7 +99,6 @@ impl SpeechRecognizer for MacSpeechRecognizer {
                 return Err(anyhow!("Failed to create audio engine"));
             }
 
-            // Get the input node
             let input_node: Id = msg_send![audio_engine, inputNode];
             if input_node.is_null() {
                 let _: () = msg_send![audio_engine, release];
@@ -152,11 +107,9 @@ impl SpeechRecognizer for MacSpeechRecognizer {
                 return Err(anyhow!("No audio input available"));
             }
 
-            // Get the recording format from the input node
             let bus: u64 = 0;
             let format: Id = msg_send![input_node, outputFormatForBus: bus];
 
-            // Install a tap on the input node to feed audio to the request
             let request_for_tap = request;
             let tap_block = block::ConcreteBlock::new(
                 move |buffer: Id, _when: Id| {
@@ -173,7 +126,6 @@ impl SpeechRecognizer for MacSpeechRecognizer {
                 block: &*tap_block
             ];
 
-            // Start the recognition task with a result handler block
             let sender_for_block = sender.clone();
             let result_block = block::ConcreteBlock::new(
                 move |result: Id, error: Id| {
@@ -221,7 +173,6 @@ impl SpeechRecognizer for MacSpeechRecognizer {
                 resultHandler: &*result_block
             ];
 
-            // Start the audio engine
             let mut error: Id = NIL;
             let started: bool = msg_send![audio_engine, startAndReturnError: &mut error];
             if !started {

--- a/crates/audio/src/speech/stub.rs
+++ b/crates/audio/src/speech/stub.rs
@@ -1,0 +1,22 @@
+use super::{SpeechEvent, SpeechRecognizer};
+use anyhow::{Result, anyhow};
+use futures::channel::mpsc;
+use gpui::{App, Task};
+
+pub struct StubSpeechRecognizer;
+
+impl SpeechRecognizer for StubSpeechRecognizer {
+    fn is_available() -> bool {
+        false
+    }
+
+    fn request_authorization(_cx: &mut App) -> Task<Result<bool>> {
+        Task::ready(Ok(false))
+    }
+
+    fn start(_cx: &mut App) -> Result<mpsc::UnboundedReceiver<SpeechEvent>> {
+        Err(anyhow!("Speech recognition is not available on this platform"))
+    }
+
+    fn stop() {}
+}

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -57,6 +57,16 @@ impl FeatureFlag for UpdatePlanToolFeatureFlag {
     }
 }
 
+pub struct VoiceInputFeatureFlag;
+
+impl FeatureFlag for VoiceInputFeatureFlag {
+    const NAME: &'static str = "voice-input";
+
+    fn enabled_for_staff() -> bool {
+        true
+    }
+}
+
 pub struct ProjectPanelUndoRedoFeatureFlag;
 
 impl FeatureFlag for ProjectPanelUndoRedoFeatureFlag {

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -354,11 +354,118 @@ impl LanguageModelCostInfo {
         }
     }
 
+    /// Estimate the dollar cost for the given token usage.
+    ///
+    /// Returns `None` for `RequestCost` (no per-token pricing available).
+    ///
+    /// Note: cache tokens (creation and read) are currently billed at the
+    /// standard input rate. Actual provider pricing may differ (e.g., Anthropic
+    /// charges 1.25x for cache writes, 0.1x for cache reads). This is an
+    /// approximation.
+    pub fn estimate_cost(&self, usage: &TokenUsage) -> Option<f64> {
+        match self {
+            LanguageModelCostInfo::TokenCost {
+                input_token_cost_per_1m,
+                output_token_cost_per_1m,
+            } => {
+                let total_input = usage.input_tokens
+                    + usage.cache_creation_input_tokens
+                    + usage.cache_read_input_tokens;
+                let input_cost = total_input as f64 * input_token_cost_per_1m / 1_000_000.0;
+                let output_cost =
+                    usage.output_tokens as f64 * output_token_cost_per_1m / 1_000_000.0;
+                Some(input_cost + output_cost)
+            }
+            LanguageModelCostInfo::RequestCost { .. } => None,
+        }
+    }
+
     fn cost_value_to_string(cost: &f64) -> SharedString {
         if (cost.fract() - 0.0).abs() < std::f64::EPSILON {
             SharedString::from(format!("{:.0}", cost))
         } else {
             SharedString::from(format!("{:.2}", cost))
         }
+    }
+}
+
+/// Format a dollar cost for display.
+pub fn format_cost(cost: f64) -> String {
+    if cost < 0.01 {
+        "<$0.01".to_string()
+    } else {
+        format!("${:.2}", cost)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_cost_token_based() {
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 3.0,
+            output_token_cost_per_1m: 15.0,
+        };
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 100_000,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        };
+        let cost = cost_info.estimate_cost(&usage).expect("should return cost");
+        assert!((cost - 4.5).abs() < 0.001); // $3 input + $1.5 output
+    }
+
+    #[test]
+    fn test_estimate_cost_with_cache_tokens() {
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 3.0,
+            output_token_cost_per_1m: 15.0,
+        };
+        let usage = TokenUsage {
+            input_tokens: 500_000,
+            output_tokens: 50_000,
+            cache_creation_input_tokens: 200_000,
+            cache_read_input_tokens: 300_000,
+        };
+        let cost = cost_info.estimate_cost(&usage).expect("should return cost");
+        // Total input: 1M tokens -> $3, output: 50k -> $0.75
+        assert!((cost - 3.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_estimate_cost_request_based_returns_none() {
+        let cost_info = LanguageModelCostInfo::RequestCost {
+            cost_per_request: 0.01,
+        };
+        let usage = TokenUsage {
+            input_tokens: 1_000,
+            output_tokens: 500,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        };
+        assert!(cost_info.estimate_cost(&usage).is_none());
+    }
+
+    #[test]
+    fn test_estimate_cost_zero_usage() {
+        let cost_info = LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: 15.0,
+            output_token_cost_per_1m: 75.0,
+        };
+        let usage = TokenUsage::default();
+        let cost = cost_info.estimate_cost(&usage).expect("should return cost");
+        assert!((cost - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_format_cost() {
+        assert_eq!(format_cost(0.001), "<$0.01");
+        assert_eq!(format_cost(0.005), "<$0.01");
+        assert_eq!(format_cost(0.05), "$0.05");
+        assert_eq!(format_cost(1.234), "$1.23");
+        assert_eq!(format_cost(10.0), "$10.00");
     }
 }

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -11,9 +11,9 @@ use language_model::{
     ANTHROPIC_PROVIDER_ID, ANTHROPIC_PROVIDER_NAME, ApiKeyState, AuthenticateError,
     ConfigurationViewTargetAgent, EnvVar, IconOrSvg, LanguageModel,
     LanguageModelCacheConfiguration, LanguageModelCompletionError, LanguageModelCompletionEvent,
-    LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
-    LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
-    LanguageModelToolChoice, RateLimiter, env_var,
+    LanguageModelCostInfo, LanguageModelId, LanguageModelName, LanguageModelProvider,
+    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
+    LanguageModelRequest, LanguageModelToolChoice, RateLimiter, env_var,
 };
 use settings::{Settings, SettingsStore};
 use std::sync::{Arc, LazyLock};
@@ -353,6 +353,14 @@ impl LanguageModel for AnthropicModel {
         } else {
             Vec::new()
         }
+    }
+
+    fn model_cost_info(&self) -> Option<LanguageModelCostInfo> {
+        let (input, output) = self.model.cost_per_million_tokens()?;
+        Some(LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: input,
+            output_token_cost_per_1m: output,
+        })
     }
 
     fn telemetry_id(&self) -> String {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -6,10 +6,10 @@ use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, Window};
 use http_client::HttpClient;
 use language_model::{
     ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel, LanguageModelCompletionError,
-    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
-    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
-    LanguageModelRequest, LanguageModelToolChoice, OPEN_AI_PROVIDER_ID, OPEN_AI_PROVIDER_NAME,
-    RateLimiter, env_var,
+    LanguageModelCompletionEvent, LanguageModelCostInfo, LanguageModelId, LanguageModelName,
+    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
+    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice,
+    OPEN_AI_PROVIDER_ID, OPEN_AI_PROVIDER_NAME, RateLimiter, env_var,
 };
 use menu;
 use open_ai::{
@@ -355,6 +355,14 @@ impl LanguageModel for OpenAiLanguageModel {
 
     fn supports_split_token_display(&self) -> bool {
         true
+    }
+
+    fn model_cost_info(&self) -> Option<LanguageModelCostInfo> {
+        let (input, output) = self.model.cost_per_million_tokens()?;
+        Some(LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: input,
+            output_token_cost_per_1m: output,
+        })
     }
 
     fn telemetry_id(&self) -> String {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -240,6 +240,24 @@ impl Model {
         }
     }
 
+    /// Returns (input_cost_per_1m, output_cost_per_1m) in USD for known models.
+    /// Returns `None` for custom models or models with unknown pricing.
+    pub fn cost_per_million_tokens(&self) -> Option<(f64, f64)> {
+        match self {
+            Self::ThreePointFiveTurbo => Some((0.50, 1.50)),
+            Self::Four => Some((30.0, 60.0)),
+            Self::FourTurbo => Some((10.0, 30.0)),
+            Self::FourOmniMini => Some((0.15, 0.60)),
+            Self::FourPointOneNano => Some((0.10, 0.40)),
+            Self::O1 => Some((15.0, 60.0)),
+            Self::O3Mini => Some((1.10, 4.40)),
+            Self::O3 => Some((2.0, 8.0)),
+            Self::Custom { .. } => None,
+            // GPT-5+ models: pricing not yet confirmed, return None
+            _ => None,
+        }
+    }
+
     pub fn reasoning_effort(&self) -> Option<ReasoningEffort> {
         match self {
             Self::Custom {


### PR DESCRIPTION
Two features that bring the agent panel closer to full-featured agent parity:

## 1. Cost Estimation + Session Usage Summary

When using Anthropic or OpenAI providers with direct API keys, the agent now displays estimated dollar costs alongside token counts.

- Adds `estimate_cost()` method to `LanguageModelCostInfo`, computing dollar cost from token usage and per-million pricing
- Implements `model_cost_info()` on `AnthropicModel` and `OpenAiLanguageModel` with hardcoded pricing tables for current models
- Wires up the existing (previously unused) `cumulative_token_usage` field on Thread with delta-based accumulation
- Shows per-turn estimated cost in the turn stats bar (when `show_turn_stats` is enabled)
- Adds a "Session Usage" section to the token usage tooltip showing cumulative input/output tokens, model name, and total estimated session cost
- Gracefully degrades: when cost data is unavailable (Zed Cloud, custom models), cost fields are hidden

**Pricing note:** Cache tokens are currently billed at standard input rate. Actual Anthropic pricing differs (1.25x cache writes, 0.1x cache reads). Documented in code.

## 2. Voice Input (Speech-to-Text) for Agent Chat

Adds dictation support behind the `voice-input` feature flag (staff-only). A microphone button appears in the message editor toolbar.

- On macOS: uses Apple's Speech framework (`SFSpeechRecognizer` + `AVAudioEngine`) via `objc` FFI for on-device speech recognition
- On other platforms: button hidden (stub implementation)
- New `speech` module in the `audio` crate with platform-abstracted `SpeechRecognizer` trait
- `ToggleDictation` action toggles recording on/off
- Transcribed text is inserted directly into the message editor
- All speech code gated behind `#[cfg(feature = "audio")]` and the feature flag

**Files changed:**

Cost estimation:
- `crates/language_model/src/language_model.rs` — `estimate_cost()` + `format_cost()` + tests
- `crates/anthropic/src/anthropic.rs` — pricing table + tests
- `crates/open_ai/src/open_ai.rs` — pricing table
- `crates/language_models/src/provider/anthropic.rs` — implement `model_cost_info()`
- `crates/language_models/src/provider/open_ai.rs` — implement `model_cost_info()`
- `crates/agent/src/thread.rs` — cumulative usage accumulation + getter
- `crates/agent_ui/src/conversation_view/thread_view.rs` — per-turn cost + session summary tooltip

Voice input:
- `crates/feature_flags/src/flags.rs` — `VoiceInputFeatureFlag`
- `crates/audio/src/speech.rs` — `SpeechRecognizer` trait + platform dispatch
- `crates/audio/src/speech/macos.rs` — macOS implementation via Speech.framework
- `crates/audio/src/speech/stub.rs` — no-op for unsupported platforms
- `crates/audio/Cargo.toml` — add `objc`, `block`, `futures` deps for macOS
- `crates/agent_ui/src/agent_ui.rs` — `ToggleDictation` action
- `crates/agent_ui/src/conversation_view/thread_view.rs` — mic button + dictation wiring

## Test plan

- [x] Unit tests for `estimate_cost()` (token-based, cache tokens, request-based returns None, zero usage)
- [x] Unit tests for `format_cost()` formatting
- [x] Unit tests for Anthropic model pricing table
- [ ] Manual: use Anthropic direct provider, verify cost in turn stats and tooltip
- [ ] Manual: use Zed Cloud provider, verify no cost shown (graceful degradation)
- [ ] Manual: verify "Session Usage" tooltip section across multiple turns
- [ ] Manual: enable `voice-input` flag, verify mic button appears (macOS)
- [ ] Manual: click mic button, speak, verify text appears in editor
- [ ] Manual: verify mic button hidden on Linux/Windows
- [ ] Manual: verify no crash when speech permission denied

## Follow-ups

- Differentiated cache token pricing (1.25x write, 0.1x read for Anthropic)
- Pricing for Google, DeepSeek, Bedrock, etc.
- Cloud provider cost data (requires server-side API changes)
- Voice input for Linux (PipeWire + Vosk) and Windows (SAPI)
- Push-to-talk keybinding for voice input
- Partial transcription preview in editor

Release Notes:

- Added estimated dollar cost display in agent turn stats and token usage tooltip for Anthropic and OpenAI direct providers
- Added voice dictation for agent chat (macOS, behind `voice-input` feature flag)