### PR TITLE
markdown: Improve table cell alignment

### DIFF
--- a/crates/markdown/src/html/html_rendering.rs
+++ b/crates/markdown/src/html/html_rendering.rs
@@ -1,6 +1,8 @@
 use std::ops::Range;
 
-use gpui::{App, FontStyle, FontWeight, StrikethroughStyle, TextStyleRefinement, UnderlineStyle};
+use gpui::{
+    App, FontStyle, FontWeight, StrikethroughStyle, TextAlign, TextStyleRefinement, UnderlineStyle,
+};
 use pulldown_cmark::Alignment;
 use ui::prelude::*;
 
@@ -245,6 +247,13 @@ impl MarkdownElement {
                 }
 
                 let max_span = max_column_count.saturating_sub(column_index);
+                let text_align = match cell.alignment {
+                    Alignment::Left => TextAlign::Left,
+                    Alignment::Center => TextAlign::Center,
+                    Alignment::Right => TextAlign::Right,
+                    _ => self.style.base_text_style.text_align,
+                };
+
                 let mut cell_div = div()
                     .col_span(cell.col_span.min(max_span) as u16)
                     .row_span(cell.row_span.min(total_rows - row_index) as u16)
@@ -269,9 +278,19 @@ impl MarkdownElement {
                     _ => cell_div,
                 };
 
+                builder.push_text_style(TextStyleRefinement {
+                    text_align: Some(text_align),
+                    ..Default::default()
+                });
                 builder.push_div(cell_div, &table.source_range, markdown_end);
                 builder.push_div(
-                    div().flex().flex_col().flex_1().justify_center(),
+                    div()
+                        .flex()
+                        .flex_col()
+                        .flex_1()
+                        .w_full()
+                        .justify_center()
+                        .text_align(text_align),
                     &table.source_range,
                     markdown_end,
                 );
@@ -284,6 +303,7 @@ impl MarkdownElement {
                 );
                 builder.pop_div();
                 builder.pop_div();
+                builder.pop_text_style();
 
                 for row_offset in 0..cell.row_span {
                     for column_offset in 0..cell.col_span {

--- a/crates/markdown/src/html/html_rendering.rs
+++ b/crates/markdown/src/html/html_rendering.rs
@@ -248,11 +248,14 @@ impl MarkdownElement {
                 let mut cell_div = div()
                     .col_span(cell.col_span.min(max_span) as u16)
                     .row_span(cell.row_span.min(total_rows - row_index) as u16)
+                    .flex()
+                    .flex_col()
                     .when(column_index > 0, |this| this.border_l_1())
                     .when(row_index > 0, |this| this.border_t_1())
                     .border_color(cx.theme().colors().border)
                     .px_2()
                     .py_1()
+                    .h_full()
                     .when(cell.is_header, |this| {
                         this.bg(cx.theme().colors().title_bar_background)
                     })
@@ -267,6 +270,11 @@ impl MarkdownElement {
                 };
 
                 builder.push_div(cell_div, &table.source_range, markdown_end);
+                builder.push_div(
+                    div().flex().flex_col().flex_1().justify_center(),
+                    &table.source_range,
+                    markdown_end,
+                );
                 self.render_html_paragraph(
                     &cell.children,
                     source_allocator,
@@ -274,6 +282,7 @@ impl MarkdownElement {
                     cx,
                     markdown_end,
                 );
+                builder.pop_div();
                 builder.pop_div();
 
                 for row_offset in 0..cell.row_span {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2000,20 +2000,33 @@ impl Element for MarkdownElement {
                             let is_header = builder.table.in_head;
                             let row_index = builder.table.row_index;
                             let col_index = builder.table.col_index;
+                            let alignment = builder.table.alignments.get(col_index).copied();
 
+                            let mut cell_div = div()
+                                .flex()
+                                .flex_col()
+                                .h_full()
+                                .when(col_index > 0, |this| this.border_l_1())
+                                .when(row_index > 0, |this| this.border_t_1())
+                                .border_color(cx.theme().colors().border)
+                                .px_1()
+                                .py_0p5()
+                                .when(is_header, |this| {
+                                    this.bg(cx.theme().colors().title_bar_background)
+                                })
+                                .when(!is_header && row_index % 2 == 1, |this| {
+                                    this.bg(cx.theme().colors().panel_background)
+                                });
+
+                            cell_div = match alignment {
+                                Some(Alignment::Center) => cell_div.items_center(),
+                                Some(Alignment::Right) => cell_div.items_end(),
+                                _ => cell_div,
+                            };
+
+                            builder.push_div(cell_div, range, markdown_end);
                             builder.push_div(
-                                div()
-                                    .when(col_index > 0, |this| this.border_l_1())
-                                    .when(row_index > 0, |this| this.border_t_1())
-                                    .border_color(cx.theme().colors().border)
-                                    .px_1()
-                                    .py_0p5()
-                                    .when(is_header, |this| {
-                                        this.bg(cx.theme().colors().title_bar_background)
-                                    })
-                                    .when(!is_header && row_index % 2 == 1, |this| {
-                                        this.bg(cx.theme().colors().panel_background)
-                                    }),
+                                div().flex().flex_col().flex_1().justify_center(),
                                 range,
                                 markdown_end,
                             );
@@ -2112,6 +2125,7 @@ impl Element for MarkdownElement {
                     }
                     MarkdownTagEnd::TableCell => {
                         builder.replace_pending_checkbox(self.on_checkbox_toggle.clone());
+                        builder.pop_div();
                         builder.pop_div();
                         builder.table.end_cell();
                     }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2001,6 +2001,12 @@ impl Element for MarkdownElement {
                             let row_index = builder.table.row_index;
                             let col_index = builder.table.col_index;
                             let alignment = builder.table.alignments.get(col_index).copied();
+                            let text_align = match alignment {
+                                Some(Alignment::Left) => TextAlign::Left,
+                                Some(Alignment::Center) => TextAlign::Center,
+                                Some(Alignment::Right) => TextAlign::Right,
+                                _ => self.style.base_text_style.text_align,
+                            };
 
                             let mut cell_div = div()
                                 .flex()
@@ -2024,9 +2030,19 @@ impl Element for MarkdownElement {
                                 _ => cell_div,
                             };
 
+                            builder.push_text_style(TextStyleRefinement {
+                                text_align: Some(text_align),
+                                ..Default::default()
+                            });
                             builder.push_div(cell_div, range, markdown_end);
                             builder.push_div(
-                                div().flex().flex_col().flex_1().justify_center(),
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
+                                    .w_full()
+                                    .justify_center()
+                                    .text_align(text_align),
                                 range,
                                 markdown_end,
                             );
@@ -2127,6 +2143,7 @@ impl Element for MarkdownElement {
                         builder.replace_pending_checkbox(self.on_checkbox_toggle.clone());
                         builder.pop_div();
                         builder.pop_div();
+                        builder.pop_text_style();
                         builder.table.end_cell();
                     }
                     MarkdownTagEnd::FootnoteDefinition => {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2140,7 +2140,7 @@ impl Element for MarkdownElement {
                         builder.table.end_row();
                     }
                     MarkdownTagEnd::TableCell => {
-                        builder.replace_pending_checkbox(range, self.on_checkbox_toggle.clone());
+                        builder.replace_pending_checkbox(self.on_checkbox_toggle.clone());
                         builder.pop_div();
                         builder.pop_div();
                         builder.pop_text_style();
@@ -2700,11 +2700,7 @@ impl MarkdownElementBuilder {
         }
     }
 
-    fn replace_pending_checkbox(
-        &mut self,
-        source_range: &Range<usize>,
-        on_toggle: Option<CheckboxToggleCallback>,
-    ) {
+    fn replace_pending_checkbox(&mut self, on_toggle: Option<CheckboxToggleCallback>) {
         let text = &self.pending_line.text;
         let trimmed = text.trim();
         if trimmed != "[x]" && trimmed != "[X]" && trimmed != "[ ]" {
@@ -2714,10 +2710,9 @@ impl MarkdownElementBuilder {
 
         let leading_ws = text.len() - text.trim_start().len();
         let marker_rendered = leading_ws..leading_ws + trimmed.len();
-        let marker_source = self.source_range_for_rendered(&marker_rendered);
-        let checkbox_source = marker_source
-            .clone()
-            .unwrap_or_else(|| source_range.clone());
+        let marker_source = self
+            .source_range_for_rendered(&marker_rendered)
+            .expect("pending checkbox text must have source mappings");
 
         self.pending_line = PendingLine::default();
 
@@ -2730,7 +2725,7 @@ impl MarkdownElementBuilder {
             ElementId::Name(
                 format!(
                     "table_checkbox_{}_{}",
-                    checkbox_source.start, checkbox_source.end
+                    marker_source.start, marker_source.end
                 )
                 .into(),
             ),
@@ -2738,7 +2733,7 @@ impl MarkdownElementBuilder {
         )
         .fill();
 
-        let checkbox = if let (Some(on_toggle), Some(marker_source)) = (on_toggle, marker_source) {
+        let checkbox = if let Some(on_toggle) = on_toggle {
             checkbox
                 .on_click(move |_state, window, cx| {
                     on_toggle(marker_source.clone(), !checked, window, cx);

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2140,7 +2140,7 @@ impl Element for MarkdownElement {
                         builder.table.end_row();
                     }
                     MarkdownTagEnd::TableCell => {
-                        builder.replace_pending_checkbox(self.on_checkbox_toggle.clone());
+                        builder.replace_pending_checkbox(range, self.on_checkbox_toggle.clone());
                         builder.pop_div();
                         builder.pop_div();
                         builder.pop_text_style();
@@ -2700,7 +2700,11 @@ impl MarkdownElementBuilder {
         }
     }
 
-    fn replace_pending_checkbox(&mut self, on_toggle: Option<CheckboxToggleCallback>) {
+    fn replace_pending_checkbox(
+        &mut self,
+        source_range: &Range<usize>,
+        on_toggle: Option<CheckboxToggleCallback>,
+    ) {
         let text = &self.pending_line.text;
         let trimmed = text.trim();
         if trimmed != "[x]" && trimmed != "[X]" && trimmed != "[ ]" {
@@ -2710,9 +2714,10 @@ impl MarkdownElementBuilder {
 
         let leading_ws = text.len() - text.trim_start().len();
         let marker_rendered = leading_ws..leading_ws + trimmed.len();
-        let marker_source = self
-            .source_range_for_rendered(&marker_rendered)
-            .expect("pending checkbox text must have source mappings");
+        let marker_source = self.source_range_for_rendered(&marker_rendered);
+        let checkbox_source = marker_source
+            .clone()
+            .unwrap_or_else(|| source_range.clone());
 
         self.pending_line = PendingLine::default();
 
@@ -2725,7 +2730,7 @@ impl MarkdownElementBuilder {
             ElementId::Name(
                 format!(
                     "table_checkbox_{}_{}",
-                    marker_source.start, marker_source.end
+                    checkbox_source.start, checkbox_source.end
                 )
                 .into(),
             ),
@@ -2733,7 +2738,7 @@ impl MarkdownElementBuilder {
         )
         .fill();
 
-        let element = if let Some(on_toggle) = on_toggle {
+        let checkbox = if let (Some(on_toggle), Some(marker_source)) = (on_toggle, marker_source) {
             checkbox
                 .on_click(move |_state, window, cx| {
                     on_toggle(marker_source.clone(), !checked, window, cx);
@@ -2742,7 +2747,18 @@ impl MarkdownElementBuilder {
         } else {
             checkbox.visualization_only(true).into_any_element()
         };
-        self.div_stack.last_mut().unwrap().extend([element]);
+
+        let mut checkbox_container = h_flex().w_full();
+        checkbox_container = match self.text_style().text_align {
+            TextAlign::Left => checkbox_container.justify_start(),
+            TextAlign::Center => checkbox_container.justify_center(),
+            TextAlign::Right => checkbox_container.justify_end(),
+        };
+
+        self.div_stack
+            .last_mut()
+            .unwrap()
+            .extend([checkbox_container.child(checkbox).into_any_element()]);
     }
 
     fn source_range_for_rendered(&self, rendered: &Range<usize>) -> Option<Range<usize>> {


### PR DESCRIPTION
## Summary

Markdown preview tables kept text pinned to the top of a row when a neighboring cell contained a taller image. This made mixed text-and-image tables look unbalanced and inconsistent with common editor behavior. This change makes table text stay visually centered within taller rows so Markdown tables are easier to scan and match expected rendering more closely.

## Before / After

| Before | After |
| --- | --- |
| <img width="849" height="869" alt="Screenshot 2026-04-08 at 19 55 50" src="https://github.com/user-attachments/assets/b3751bff-3750-4ca1-8997-6f5265e4d291" /> | <img width="898" height="734" alt="Screenshot 2026-04-08 at 21 47 31" src="https://github.com/user-attachments/assets/d853c0a1-800c-4a2a-aec9-e0ef08453fa7" /> |

## References
Inspired by comparing this with VS Code preview
<img width="1286" height="878" alt="Screenshot 2026-04-08 at 21 54 06" src="https://github.com/user-attachments/assets/8dbbfe28-9980-4012-94f1-1b5b3503065b" />

Release Notes:

- Improved Markdown preview table cells to vertically center content in tall rows and respect column alignment from the table header.
