### PR TITLE
gpui: Add letter spacing and text transform

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8872,6 +8872,7 @@ impl LineWithInvisibles {
                             background_color: text_style.background_color,
                             underline: text_style.underline,
                             strikethrough: text_style.strikethrough,
+                            letter_spacing: text_style.letter_spacing,
                         };
                         let line_layout = window
                             .text_system()
@@ -8942,6 +8943,7 @@ impl LineWithInvisibles {
                             background_color: text_style.background_color,
                             underline: text_style.underline,
                             strikethrough: text_style.strikethrough,
+                            letter_spacing: text_style.letter_spacing,
                         });
 
                         if editor_mode.is_full() && !highlighted_chunk.is_inlay {
@@ -9021,6 +9023,7 @@ impl LineWithInvisibles {
                         background_color: text_run.background_color,
                         underline: text_run.underline,
                         strikethrough: text_run.strikethrough,
+                        letter_spacing: text_run.letter_spacing,
                     });
                     cursor_col = segment_start_col;
                 }
@@ -9035,6 +9038,7 @@ impl LineWithInvisibles {
                         background_color: text_run.background_color,
                         underline: text_run.underline,
                         strikethrough: text_run.strikethrough,
+                        letter_spacing: text_run.letter_spacing,
                     });
                     cursor_col = segment_slice_end_col;
                 }
@@ -9051,6 +9055,7 @@ impl LineWithInvisibles {
                     background_color: text_run.background_color,
                     underline: text_run.underline,
                     strikethrough: text_run.strikethrough,
+                    letter_spacing: text_run.letter_spacing,
                 });
             }
             line_col = run_end_col;

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -95,6 +95,7 @@ strum.workspace = true
 sum_tree.workspace = true
 taffy = "=0.9.0"
 thiserror.workspace = true
+unicode-segmentation.workspace = true
 gpui_util.workspace = true
 waker-fn = "1.2.0"
 lyon = "1.0"
@@ -153,7 +154,6 @@ lyon = { version = "1.0", features = ["extra"] }
 proptest = { workspace = true }
 rand.workspace = true
 scheduler = { workspace = true, features = ["test-support"] }
-unicode-segmentation = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 http_client = { workspace = true, features = ["test-support"] }

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -469,6 +469,7 @@ impl Element for TextElement {
             background_color: None,
             underline: None,
             strikethrough: None,
+            letter_spacing: style.letter_spacing,
         };
         let runs = if let Some(marked_range) = input.marked_range.as_ref() {
             vec![

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -17,6 +17,7 @@ use std::{
     rc::Rc,
     sync::Arc,
 };
+use unicode_segmentation::UnicodeSegmentation;
 
 impl Element for &'static str {
     type RequestLayoutState = TextLayout;
@@ -673,41 +674,20 @@ fn apply_text_transform_preserving_byte_len(
             }
         }
         TextTransform::Capitalize => {
-            let mut word = Vec::<char>::new();
-            let flush = |out: &mut String, w: &[char]| {
-                if w.is_empty() {
-                    return;
-                }
-                let word_starts_with_letter = w[0].is_alphabetic();
-                let mut seen_first_alpha = false;
-                for &ch in w {
-                    if ch.is_alphabetic() {
-                        if word_starts_with_letter {
-                            if !seen_first_alpha {
-                                push_case_mapped_char(out, ch, CaseMapKind::Upper);
-                                seen_first_alpha = true;
-                            } else {
-                                push_case_mapped_char(out, ch, CaseMapKind::Lower);
-                            }
-                        } else {
-                            out.push(ch);
-                        }
+            // Match CSS / Tailwind `capitalize` (UAX #29 word boundaries): uppercase only the first
+            // alphabetic character in each word; leave every other character unchanged. GPUI does not
+            // model `em` or other CSS units here — only this Unicode algorithm.
+            for piece in text.as_ref().split_word_bounds() {
+                let mut seen_first_letter = false;
+                for ch in piece.chars() {
+                    if !seen_first_letter && ch.is_alphabetic() {
+                        push_case_mapped_char(&mut output, ch, CaseMapKind::Upper);
+                        seen_first_letter = true;
                     } else {
-                        out.push(ch);
+                        output.push(ch);
                     }
                 }
-            };
-
-            for ch in text.as_ref().chars() {
-                if ch.is_alphanumeric() {
-                    word.push(ch);
-                } else {
-                    flush(&mut output, &word);
-                    word.clear();
-                    output.push(ch);
-                }
             }
-            flush(&mut output, &word);
         }
         TextTransform::None => unreachable!(),
     }
@@ -753,7 +733,7 @@ mod text_transform_tests {
 
         assert_eq!(uppercase.as_ref(), "HELLO   WORLD\tFOO-BAR 123BAZ DÉJÀ VU");
         assert_eq!(lowercase.as_ref(), "hello   world\tfoo-bar 123baz déjà vu");
-        assert_eq!(capitalize.as_ref(), "Hello   World\tFoo-Bar 123baz Déjà Vu");
+        assert_eq!(capitalize.as_ref(), "Hello   WORLD\tFoo-Bar 123Baz Déjà Vu");
         assert_eq!(input.len(), uppercase.len());
         assert_eq!(input.len(), lowercase.len());
         assert_eq!(input.len(), capitalize.len());
@@ -777,19 +757,23 @@ mod text_transform_tests {
     #[test]
     fn capitalize_leaves_letters_after_digit_prefix_unchanged() {
         let input = SharedString::from("123BAZ");
-        let out = apply_text_transform_preserving_byte_len(
-            input.clone(),
-            Some(TextTransform::Capitalize),
-        );
+        let out = apply_text_transform_preserving_byte_len(input.clone(), Some(TextTransform::Capitalize));
         assert_eq!(out.as_ref(), "123BAZ");
         assert_eq!(input.len(), out.len());
     }
 
     #[test]
-    fn capitalize_lowercases_after_first_letter_in_letter_led_word() {
+    fn capitalize_does_not_fold_remaining_letters() {
         let input = SharedString::from("foo2BAR");
         let out = apply_text_transform_preserving_byte_len(input, Some(TextTransform::Capitalize));
-        assert_eq!(out.as_ref(), "Foo2bar");
+        assert_eq!(out.as_ref(), "Foo2BAR");
+    }
+
+    #[test]
+    fn capitalize_handles_apostrophe_contractions_like_css() {
+        let input = SharedString::from("don't panic");
+        let out = apply_text_transform_preserving_byte_len(input, Some(TextTransform::Capitalize));
+        assert_eq!(out.as_ref(), "Don't Panic");
     }
 }
 

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -2,7 +2,7 @@ use crate::{
     ActiveTooltip, AnyView, App, Bounds, DispatchPhase, Element, ElementId, GlobalElementId,
     HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, Size, TextOverflow,
-    TextRun, TextStyle, TooltipId, TruncateFrom, WhiteSpace, Window, WrappedLine,
+    TextRun, TextStyle, TextTransform, TooltipId, TruncateFrom, WhiteSpace, Window, WrappedLine,
     WrappedLineLayout, register_tooltip_mouse_handlers, set_tooltip_on_window,
 };
 use anyhow::Context as _;
@@ -344,6 +344,7 @@ impl TextLayout {
         _: &mut App,
     ) -> LayoutId {
         let text_style = window.text_style();
+        let text = apply_text_transform_preserving_byte_len(text, text_style.text_transform);
         let font_size = text_style.font_size.to_pixels(window.rem_size());
         let line_height = text_style
             .line_height
@@ -644,6 +645,151 @@ impl TextLayout {
         // Remove trailing newline
         accumulator.pop();
         accumulator
+    }
+}
+
+/// Applies [`TextTransform`] for display while preserving UTF-8 byte length (see [`TextTransform`]).
+fn apply_text_transform_preserving_byte_len(
+    text: SharedString,
+    transform: Option<TextTransform>,
+) -> SharedString {
+    let Some(transform) = transform else {
+        return text;
+    };
+    if matches!(transform, TextTransform::None) {
+        return text;
+    }
+
+    let mut output = String::with_capacity(text.len());
+    match transform {
+        TextTransform::Uppercase => {
+            for ch in text.as_ref().chars() {
+                push_case_mapped_char(&mut output, ch, CaseMapKind::Upper);
+            }
+        }
+        TextTransform::Lowercase => {
+            for ch in text.as_ref().chars() {
+                push_case_mapped_char(&mut output, ch, CaseMapKind::Lower);
+            }
+        }
+        TextTransform::Capitalize => {
+            let mut word = Vec::<char>::new();
+            let flush = |out: &mut String, w: &[char]| {
+                if w.is_empty() {
+                    return;
+                }
+                let word_starts_with_letter = w[0].is_alphabetic();
+                let mut seen_first_alpha = false;
+                for &ch in w {
+                    if ch.is_alphabetic() {
+                        if word_starts_with_letter {
+                            if !seen_first_alpha {
+                                push_case_mapped_char(out, ch, CaseMapKind::Upper);
+                                seen_first_alpha = true;
+                            } else {
+                                push_case_mapped_char(out, ch, CaseMapKind::Lower);
+                            }
+                        } else {
+                            out.push(ch);
+                        }
+                    } else {
+                        out.push(ch);
+                    }
+                }
+            };
+
+            for ch in text.as_ref().chars() {
+                if ch.is_alphanumeric() {
+                    word.push(ch);
+                } else {
+                    flush(&mut output, &word);
+                    word.clear();
+                    output.push(ch);
+                }
+            }
+            flush(&mut output, &word);
+        }
+        TextTransform::None => unreachable!(),
+    }
+
+    SharedString::from(output)
+}
+
+#[derive(Copy, Clone)]
+enum CaseMapKind {
+    Upper,
+    Lower,
+}
+
+fn push_case_mapped_char(output: &mut String, ch: char, kind: CaseMapKind) {
+    let mapped = match kind {
+        CaseMapKind::Upper => ch.to_uppercase().collect::<String>(),
+        CaseMapKind::Lower => ch.to_lowercase().collect::<String>(),
+    };
+
+    if mapped.len() == ch.len_utf8() && mapped.chars().count() == 1 {
+        output.push_str(&mapped);
+    } else {
+        output.push(ch);
+    }
+}
+
+#[cfg(test)]
+mod text_transform_tests {
+    use super::apply_text_transform_preserving_byte_len;
+    use crate::{SharedString, TextTransform};
+
+    #[test]
+    fn text_transforms_preserve_bytes_and_spacing() {
+        let input = SharedString::from("hello   WORLD\tfoo-bar 123baz déjà vu");
+        let uppercase =
+            apply_text_transform_preserving_byte_len(input.clone(), Some(TextTransform::Uppercase));
+        let lowercase =
+            apply_text_transform_preserving_byte_len(input.clone(), Some(TextTransform::Lowercase));
+        let capitalize = apply_text_transform_preserving_byte_len(
+            input.clone(),
+            Some(TextTransform::Capitalize),
+        );
+
+        assert_eq!(uppercase.as_ref(), "HELLO   WORLD\tFOO-BAR 123BAZ DÉJÀ VU");
+        assert_eq!(lowercase.as_ref(), "hello   world\tfoo-bar 123baz déjà vu");
+        assert_eq!(capitalize.as_ref(), "Hello   World\tFoo-Bar 123baz Déjà Vu");
+        assert_eq!(input.len(), uppercase.len());
+        assert_eq!(input.len(), lowercase.len());
+        assert_eq!(input.len(), capitalize.len());
+    }
+
+    #[test]
+    fn text_transforms_skip_expanding_unicode_mappings() {
+        let input = SharedString::from("straße İSTANBUL");
+        let uppercase =
+            apply_text_transform_preserving_byte_len(input.clone(), Some(TextTransform::Uppercase));
+        let lowercase =
+            apply_text_transform_preserving_byte_len(input.clone(), Some(TextTransform::Lowercase));
+
+        assert_eq!(uppercase.as_ref(), "STRAßE İSTANBUL");
+        // `İ` lowercases to ASCII `i` in Turkish, which would shrink UTF-8 length; preserve `İ`.
+        assert_eq!(lowercase.as_ref(), "straße İstanbul");
+        assert_eq!(input.len(), uppercase.len());
+        assert_eq!(input.len(), lowercase.len());
+    }
+
+    #[test]
+    fn capitalize_leaves_letters_after_digit_prefix_unchanged() {
+        let input = SharedString::from("123BAZ");
+        let out = apply_text_transform_preserving_byte_len(
+            input.clone(),
+            Some(TextTransform::Capitalize),
+        );
+        assert_eq!(out.as_ref(), "123BAZ");
+        assert_eq!(input.len(), out.len());
+    }
+
+    #[test]
+    fn capitalize_lowercases_after_first_letter_in_letter_led_word() {
+        let input = SharedString::from("foo2BAR");
+        let out = apply_text_transform_preserving_byte_len(input, Some(TextTransform::Capitalize));
+        assert_eq!(out.as_ref(), "Foo2bar");
     }
 }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -858,7 +858,7 @@ impl PlatformTextSystem for NoopTextSystem {
         Ok((raster_bounds.size, Vec::new()))
     }
 
-    fn layout_line(&self, text: &str, font_size: Pixels, _runs: &[FontRun]) -> LineLayout {
+    fn layout_line(&self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
         let mut position = px(0.);
         let metrics = self.font_metrics(FontId(0));
         let em_width = font_size
@@ -885,9 +885,9 @@ impl PlatformTextSystem for NoopTextSystem {
                 position += em_width
             }
         }
-        let mut runs = Vec::default();
+        let mut shaped_runs = Vec::default();
         if !glyphs.is_empty() {
-            runs.push(ShapedRun {
+            shaped_runs.push(ShapedRun {
                 font_id: FontId(0),
                 glyphs,
             });
@@ -895,12 +895,26 @@ impl PlatformTextSystem for NoopTextSystem {
             position = px(0.);
         }
 
+        let mut tracking = px(0.);
+        let mut byte_offset = 0usize;
+        for run in font_runs {
+            let end = byte_offset.saturating_add(run.len).min(text.len());
+            let slice = text.get(byte_offset..end).unwrap_or("");
+            let n = slice.chars().count();
+            if n > 1 {
+                if let Some(spacing) = run.letter_spacing {
+                    tracking += spacing * (n - 1) as f32;
+                }
+            }
+            byte_offset = byte_offset.saturating_add(run.len);
+        }
+
         LineLayout {
             font_size,
-            width: position,
+            width: position + tracking,
             ascent: font_size * (metrics.ascent / metrics.units_per_em as f32),
             descent: font_size * (metrics.descent / metrics.units_per_em as f32),
-            runs,
+            runs: shaped_runs,
             len: text.len(),
         }
     }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -397,9 +397,11 @@ pub enum TextAlign {
 /// character is kept. That keeps indices into the underlying buffer aligned with hit-testing and
 /// editor-style caret positions that use raw byte offsets.
 ///
-/// [`TextTransform::Capitalize`] follows CSS-like word boundaries (see variant docs) with an extra
-/// rule for digit- or symbol-led words so those segments do not change following letters (stable
-/// offsets and predictable treatment of tokens like `"123abc"`).
+/// [`TextTransform::Capitalize`] matches CSS / Tailwind [`capitalize`][tw-cap] using Unicode word
+/// boundaries: only the first alphabetic code point in each word is uppercased; other characters
+/// are unchanged.
+///
+/// [tw-cap]: https://tailwindcss.com/docs/text-transform
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum TextTransform {
     /// Do not transform text.
@@ -409,12 +411,8 @@ pub enum TextTransform {
     Uppercase,
     /// Lowercase text (Unicode, byte-length preserving — see [`TextTransform`]).
     Lowercase,
-    /// CSS-like capitalization for words that **start with a letter**: uppercase the first
-    /// letter, lowercase the rest. Words are maximal [`char::is_alphanumeric`] runs; other
-    /// characters act as separators (including `-`, so `foo-bar` → `Foo-Bar`).
-    ///
-    /// If the first character of a word is not alphabetic (digits, `_`, etc.), alphabetic
-    /// characters in that word are **unchanged** so numeric or symbol prefixes are not altered.
+    /// `text-transform: capitalize` semantics (Tailwind class `capitalize`): per Unicode word, only
+    /// the first alphabetic character is mapped to uppercase; the rest of the string is unchanged.
     Capitalize,
 }
 

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -389,6 +389,35 @@ pub enum TextAlign {
     Right,
 }
 
+/// Case mapping applied at layout time while keeping **UTF-8 byte lengths** unchanged.
+///
+/// [`TextTransform::Uppercase`] and [`TextTransform::Lowercase`] use Unicode full case folding via
+/// [`char::to_uppercase`] / [`char::to_lowercase`]. If mapping a code point would change its UTF-8
+/// length, or would replace one scalar value with more than one character, the **original**
+/// character is kept. That keeps indices into the underlying buffer aligned with hit-testing and
+/// editor-style caret positions that use raw byte offsets.
+///
+/// [`TextTransform::Capitalize`] follows CSS-like word boundaries (see variant docs) with an extra
+/// rule for digit- or symbol-led words so those segments do not change following letters (stable
+/// offsets and predictable treatment of tokens like `"123abc"`).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum TextTransform {
+    /// Do not transform text.
+    #[default]
+    None,
+    /// Uppercase text (Unicode, byte-length preserving — see [`TextTransform`]).
+    Uppercase,
+    /// Lowercase text (Unicode, byte-length preserving — see [`TextTransform`]).
+    Lowercase,
+    /// CSS-like capitalization for words that **start with a letter**: uppercase the first
+    /// letter, lowercase the rest. Words are maximal [`char::is_alphanumeric`] runs; other
+    /// characters act as separators (including `-`, so `foo-bar` → `Foo-Bar`).
+    ///
+    /// If the first character of a word is not alphabetic (digits, `_`, etc.), alphabetic
+    /// characters in that word are **unchanged** so numeric or symbol prefixes are not altered.
+    Capitalize,
+}
+
 /// The properties that can be used to style text in GPUI
 #[derive(Refineable, Clone, Debug, PartialEq)]
 #[refineable(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -437,6 +466,14 @@ pub struct TextStyle {
 
     /// The number of lines to display before truncating the text
     pub line_clamp: Option<usize>,
+
+    /// Letter spacing added between characters, in pixels (positive widens, negative tightens).
+    ///
+    /// The platform text stack may clamp values outside the range it supports.
+    pub letter_spacing: Option<Pixels>,
+
+    /// Case transformation applied at layout time.
+    pub text_transform: Option<TextTransform>,
 }
 
 impl Default for TextStyle {
@@ -458,6 +495,8 @@ impl Default for TextStyle {
             text_overflow: None,
             text_align: TextAlign::default(),
             line_clamp: None,
+            letter_spacing: None,
+            text_transform: None,
         }
     }
 }
@@ -527,12 +566,18 @@ impl TextStyle {
             background_color: self.background_color,
             underline: self.underline,
             strikethrough: self.strikethrough,
+            letter_spacing: self.letter_spacing,
         }
     }
 }
 
 /// A highlight style to apply, similar to a `TextStyle` except
 /// for a single font, uniformly sized and spaced text.
+///
+/// Layout extras on the base [`TextStyle`] — such as [`TextStyle::letter_spacing`] and
+/// [`TextStyle::text_transform`] — are not stored here; highlighted segments inherit them
+/// from the surrounding style (see [`TextStyle::highlight`] and
+/// [`crate::StyledText::with_default_highlights`]).
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct HighlightStyle {
     /// The color of the text

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,7 +1,7 @@
 use crate::{
     self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CursorStyle,
     DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
-    FontWeight, GridPlacement, GridTemplate, Hsla, JustifyContent, Length, SharedString,
+    FontWeight, GridPlacement, GridTemplate, Hsla, JustifyContent, Length, Pixels, SharedString,
     StrikethroughStyle, StyleRefinement, TemplateColumnMinSize, TextAlign, TextOverflow,
     TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
 };
@@ -99,6 +99,18 @@ pub trait Styled: Sized {
     /// Set the text alignment of the element.
     fn text_align(mut self, align: TextAlign) -> Self {
         self.text_style().text_align = Some(align);
+        self
+    }
+
+    /// Sets the letter spacing (tracking) for text in this element and its children.
+    fn letter_spacing(mut self, spacing: impl Into<Pixels>) -> Self {
+        self.text_style().letter_spacing = Some(spacing.into());
+        self
+    }
+
+    /// Sets the case transform for text in this element and its children.
+    fn text_transform(mut self, transform: crate::TextTransform) -> Self {
+        self.text_style().text_transform = Some(transform);
         self
     }
 

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -219,6 +219,7 @@ impl TextSystem {
                 &[FontRun {
                     len: buffer.len(),
                     font_id,
+                    letter_spacing: None,
                 }],
             )
             .width
@@ -361,6 +362,14 @@ impl TextSystem {
     ) -> TextRenderingMode {
         self.platform_text_system
             .recommended_rendering_mode(font_id, font_size)
+    }
+}
+
+#[cfg(test)]
+impl TextSystem {
+    /// Reach the platform shaper from crate tests (e.g. `line_wrapper`) without a [`WindowTextSystem`].
+    pub(crate) fn platform_text_system_for_tests(&self) -> Arc<dyn PlatformTextSystem> {
+        self.platform_text_system.clone()
     }
 }
 
@@ -559,8 +568,10 @@ impl WindowTextSystem {
                 };
 
                 let font_id = self.resolve_font(&run.font);
+                let letter_spacing = run.letter_spacing;
                 if let Some(font_run) = font_runs.last_mut()
                     && font_id == font_run.font_id
+                    && font_run.letter_spacing == letter_spacing
                     && !decoration_changed
                 {
                     font_run.len += run_len_within_line;
@@ -568,6 +579,7 @@ impl WindowTextSystem {
                     font_runs.push(FontRun {
                         len: run_len_within_line,
                         font_id,
+                        letter_spacing,
                     });
                 }
 
@@ -673,8 +685,10 @@ impl WindowTextSystem {
             };
 
             let font_id = self.resolve_font(&run.font);
+            let letter_spacing = run.letter_spacing;
             if let Some(font_run) = font_runs.last_mut()
                 && font_id == font_run.font_id
+                && font_run.letter_spacing == letter_spacing
                 && !decoration_changed
             {
                 font_run.len += run.len;
@@ -682,6 +696,7 @@ impl WindowTextSystem {
                 font_runs.push(FontRun {
                     len: run.len,
                     font_id,
+                    letter_spacing,
                 });
             }
         }
@@ -733,8 +748,10 @@ impl WindowTextSystem {
             };
 
             let font_id = self.resolve_font(&run.font);
+            let letter_spacing = run.letter_spacing;
             if let Some(font_run) = font_runs.last_mut()
                 && font_id == font_run.font_id
+                && font_run.letter_spacing == letter_spacing
                 && !decoration_changed
             {
                 font_run.len += run.len;
@@ -742,6 +759,7 @@ impl WindowTextSystem {
                 font_runs.push(FontRun {
                     len: run.len,
                     font_id,
+                    letter_spacing,
                 });
             }
         }
@@ -795,8 +813,10 @@ impl WindowTextSystem {
             };
 
             let font_id = self.resolve_font(&run.font);
+            let letter_spacing = run.letter_spacing;
             if let Some(font_run) = font_runs.last_mut()
                 && font_id == font_run.font_id
+                && font_run.letter_spacing == letter_spacing
                 && !decoration_changed
             {
                 font_run.len += run.len;
@@ -804,6 +824,7 @@ impl WindowTextSystem {
                 font_runs.push(FontRun {
                     len: run.len,
                     font_id,
+                    letter_spacing,
                 });
             }
         }
@@ -980,6 +1001,8 @@ pub struct TextRun {
     pub underline: Option<UnderlineStyle>,
     /// The strikethrough style (if any)
     pub strikethrough: Option<StrikethroughStyle>,
+    /// Letter spacing applied between glyphs, in pixels.
+    pub letter_spacing: Option<Pixels>,
 }
 
 #[cfg(all(target_os = "macos", test))]

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -796,11 +796,23 @@ impl LineLayoutCache {
 }
 
 /// A run of text with a single font.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[expect(missing_docs)]
 pub struct FontRun {
     pub len: usize,
     pub font_id: FontId,
+    pub letter_spacing: Option<Pixels>,
+}
+
+impl Hash for FontRun {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len.hash(state);
+        self.font_id.hash(state);
+        self.letter_spacing
+            .map(Pixels::as_f32)
+            .map(f32::to_bits)
+            .hash(state);
+    }
 }
 
 trait AsCacheKeyRef {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -382,8 +382,8 @@ impl Boundary {
 mod tests {
     use super::*;
     use crate::{
-        Font, FontFeatures, FontRun, FontStyle, FontWeight, Hsla, PlatformTextSystem,
-        TestAppContext, TestDispatcher, TextRun, font,
+        Font, FontFeatures, FontRun, FontStyle, FontWeight, Hsla, TestAppContext,
+        TestDispatcher, TextRun, font,
     };
     #[cfg(target_os = "macos")]
     use crate::{WindowTextSystem, WrapBoundary};

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -381,9 +381,12 @@ impl Boundary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Font, FontFeatures, FontStyle, FontWeight, TestAppContext, TestDispatcher, font};
+    use crate::{
+        Font, FontFeatures, FontRun, FontStyle, FontWeight, Hsla, PlatformTextSystem,
+        TestAppContext, TestDispatcher, TextRun, font,
+    };
     #[cfg(target_os = "macos")]
-    use crate::{TextRun, WindowTextSystem, WrapBoundary};
+    use crate::{WindowTextSystem, WrapBoundary};
 
     fn build_wrapper() -> LineWrapper {
         let dispatcher = TestDispatcher::new(0);
@@ -407,6 +410,53 @@ mod tests {
                 ..Default::default()
             })
             .collect()
+    }
+
+    #[test]
+    fn test_tracking_changes_measured_width() {
+        let dispatcher = TestDispatcher::new(1);
+        let cx = TestAppContext::build(dispatcher, None);
+        let base = TextRun {
+            len: 4,
+            font: font(".ZedMono"),
+            color: Hsla::default(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+            ..Default::default()
+        };
+        let font_id = cx.text_system().resolve_font(&base.font);
+        let platform = cx.text_system().platform_text_system_for_tests();
+        let no_tracking = platform.layout_line(
+            "TEST",
+            px(16.),
+            &[FontRun {
+                len: 4,
+                font_id,
+                letter_spacing: None,
+            }],
+        );
+        let wide = platform.layout_line(
+            "TEST",
+            px(16.),
+            &[FontRun {
+                len: 4,
+                font_id,
+                letter_spacing: Some(px(2.0)),
+            }],
+        );
+        let tight = platform.layout_line(
+            "TEST",
+            px(16.),
+            &[FontRun {
+                len: 4,
+                font_id,
+                letter_spacing: Some(px(-0.5)),
+            }],
+        );
+
+        assert!(wide.width > no_tracking.width);
+        assert!(tight.width <= no_tracking.width);
     }
 
     #[test]

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -489,7 +489,7 @@ impl Platform for MacPlatform {
             pool.drain();
 
             (*app).set_ivar(MAC_PLATFORM_IVAR, null_mut::<c_void>());
-            (*NSWindow::delegate(app)).set_ivar(MAC_PLATFORM_IVAR, null_mut::<c_void>());
+            (*app_delegate).set_ivar(MAC_PLATFORM_IVAR, null_mut::<c_void>());
         }
     }
 

--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -22,7 +22,7 @@ use core_text::{
         kCTFontWidthTrait,
     },
     line::CTLine,
-    string_attributes::kCTFontAttributeName,
+    string_attributes::{kCTFontAttributeName, kCTKernAttributeName},
 };
 use font_kit::{
     font::Font as FontKitFont,
@@ -506,6 +506,13 @@ impl MacTextSystemState {
                         kCTFontAttributeName,
                         &font.native_font().clone_with_font_size(font_size.into()),
                     );
+                    if let Some(spacing) = run.letter_spacing {
+                        string.set_attribute(
+                            cf_range,
+                            kCTKernAttributeName,
+                            &CFNumber::from(f64::from(spacing.as_f32())),
+                        );
+                    }
                 }
                 break_ligature = !break_ligature;
             }
@@ -716,6 +723,7 @@ mod tests {
         let mut style = FontRun {
             font_id,
             len: line.len(),
+            letter_spacing: None,
         };
 
         let layout = fonts.layout_line(line, px(16.), &[style]);
@@ -737,10 +745,12 @@ mod tests {
             FontRun {
                 len: "\u{feff}".len(),
                 font_id,
+                letter_spacing: None,
             },
             FontRun {
                 len: "ab".len(),
                 font_id,
+                letter_spacing: None,
             },
         ];
         let layout = fonts.layout_line(line, px(16.), font_runs);
@@ -759,8 +769,16 @@ mod tests {
 
         let text = "hello world";
         let font_runs = &[
-            FontRun { font_id, len: 5 }, // "hello"
-            FontRun { font_id, len: 6 }, // " world"
+            FontRun {
+                font_id,
+                len: 5,
+                letter_spacing: None,
+            }, // "hello"
+            FontRun {
+                font_id,
+                len: 6,
+                letter_spacing: None,
+            }, // " world"
         ];
 
         let layout = fonts.layout_line(text, px(16.), font_runs);
@@ -780,11 +798,16 @@ mod tests {
         // Test with different font runs - should not insert ZWNJ
         let font_id2 = fonts.font_id(&font("Times")).unwrap_or(font_id);
         let font_runs_different = &[
-            FontRun { font_id, len: 5 }, // "hello"
+            FontRun {
+                font_id,
+                len: 5,
+                letter_spacing: None,
+            }, // "hello"
             // " world"
             FontRun {
                 font_id: font_id2,
                 len: 6,
+                letter_spacing: None,
             },
         ];
 
@@ -809,15 +832,31 @@ mod tests {
         let font_id = fonts.font_id(&font("Helvetica")).unwrap();
 
         let text = "hello";
-        let font_runs = &[FontRun { font_id, len: 5 }];
+        let font_runs = &[FontRun {
+            font_id,
+            len: 5,
+            letter_spacing: None,
+        }];
         let layout = fonts.layout_line(text, px(16.), font_runs);
         assert_eq!(layout.len, text.len());
 
         let text = "abc";
         let font_runs = &[
-            FontRun { font_id, len: 1 }, // "a"
-            FontRun { font_id, len: 1 }, // "b"
-            FontRun { font_id, len: 1 }, // "c"
+            FontRun {
+                font_id,
+                len: 1,
+                letter_spacing: None,
+            }, // "a"
+            FontRun {
+                font_id,
+                len: 1,
+                letter_spacing: None,
+            }, // "b"
+            FontRun {
+                font_id,
+                len: 1,
+                letter_spacing: None,
+            }, // "c"
         ];
         let layout = fonts.layout_line(text, px(16.), font_runs);
         assert_eq!(layout.len, text.len());

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -412,16 +412,17 @@ impl CosmicTextSystemState {
                 continue;
             };
 
-            attrs_list.add_span(
-                offs..(offs + run.len),
-                &Attrs::new()
-                    .metadata(run.font_id.0)
-                    .family(Family::Name(&first_family.0))
-                    .stretch(face.stretch)
-                    .style(face.style)
-                    .weight(face.weight)
-                    .font_features(loaded_font.features.clone()),
-            );
+            let mut attrs = Attrs::new()
+                .metadata(run.font_id.0)
+                .family(Family::Name(&first_family.0))
+                .stretch(face.stretch)
+                .style(face.style)
+                .weight(face.weight)
+                .font_features(loaded_font.features.clone());
+            if let Some(spacing) = run.letter_spacing {
+                attrs = attrs.letter_spacing(spacing.as_f32());
+            }
+            attrs_list.add_span(offs..(offs + run.len), &attrs);
             offs += run.len;
         }
 

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -551,12 +551,10 @@ impl DirectWriteState {
                     format.SetFontFallback(fallbacks)?;
                 }
 
-                let layout = components.factory.CreateTextLayout(
-                    text_wide,
-                    &format,
-                    f32::INFINITY,
-                    f32::INFINITY,
-                )?;
+                let layout: IDWriteTextLayout1 = components
+                    .factory
+                    .CreateTextLayout(text_wide, &format, f32::INFINITY, f32::INFINITY)?
+                    .cast()?;
                 let current_text = &text[utf8_offset..(utf8_offset + first_run.len)];
                 utf8_offset += first_run.len;
                 let current_text_utf16_length = current_text.encode_utf16().count() as u32;
@@ -565,6 +563,9 @@ impl DirectWriteState {
                     length: current_text_utf16_length,
                 };
                 layout.SetTypography(&font_info.features, text_range)?;
+                if let Some(spacing) = first_run.letter_spacing {
+                    layout.SetCharacterSpacing(0.0, spacing.as_f32(), 0.0, text_range)?;
+                }
                 utf16_offset += current_text_utf16_length;
 
                 layout
@@ -603,6 +604,9 @@ impl DirectWriteState {
                 text_layout.SetFontStyle(font_info.font_face.GetStyle(), text_range)?;
                 text_layout.SetFontWeight(font_info.font_face.GetWeight(), text_range)?;
                 text_layout.SetTypography(&font_info.features, text_range)?;
+                if let Some(spacing) = run.letter_spacing {
+                    text_layout.SetCharacterSpacing(0.0, spacing.as_f32(), 0.0, text_range)?;
+                }
 
                 break_ligatures = !break_ligatures;
             }

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -602,6 +602,7 @@ impl TerminalElement {
             },
             underline,
             strikethrough,
+            letter_spacing: text_style.letter_spacing,
         };
 
         if let Some((style, range)) = hyperlink


### PR DESCRIPTION
Adds `letter_spacing` and `text_transform` support to GPUI's text rendering stack, from the high-level `TextStyle` API down to each platform renderer.

## What's included

**API layer (`TextStyle`, `FontRun`, `TextRun`)**
- New `letter_spacing: Option<Pixels>` and `text_transform: Option<TextTransform>` fields on `TextStyle`
- Convenience `Styled` trait methods: `.letter_spacing()`, `.text_transform()`
- `TextTransform` enum: `None`, `Uppercase`, `Lowercase`, `Capitalize`
- `letter_spacing` propagated through `FontRun` → `TextRun` → shaping path
- Run merging respects `letter_spacing` (runs with different spacing are not merged)

**Text transform**
- Applied pre-shaping in `TextLayout` via `apply_text_transform_preserving_byte_len`
- Case mapping only applied when the result has the same UTF-8 byte length as the original (avoids shifting glyph offsets)
- `Capitalize` uses `unicode_segmentation` UAX #29 word boundaries, matching CSS `text-transform: capitalize` semantics

**Platform implementations**
- macOS: `kCTKernAttributeName` via Core Text
- Windows: `IDWriteTextLayout1::SetCharacterSpacing`
- Linux/WGPU: `cosmic-text` `Attrs::letter_spacing`

**Also included**
- `fix(gpui_macos)`: Fix NSApplication delegate teardown — was clearing the wrong object's ivar (`NSWindow::delegate(app)` instead of `app_delegate`)

## Testing
- Unit tests for `text_transform` edge cases (Turkish characters, digit-prefixed words, apostrophe contractions, multi-byte Unicode)
- Unit test verifying `letter_spacing` affects measured glyph widths
- All existing text layout tests pass

Release Notes:

- Added `letter_spacing` and `text_transform` properties to GPUI's `TextStyle`, with platform implementations on macOS, Windows, and Linux