### PR TITLE
Strip think tags from text stream

### DIFF
--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -248,6 +248,124 @@ pub trait LanguageModel: Send + Sync {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fake_provider::FakeLanguageModel;
+    use futures::StreamExt;
+    use gpui::TestAppContext;
+    use std::sync::Arc;
+
+    async fn collect_text_stream(
+        model: &Arc<FakeLanguageModel>,
+        chunks: &[&str],
+        cx: &AsyncApp,
+    ) -> String {
+        let stream_future =
+            model.stream_completion_text(LanguageModelRequest::default(), cx);
+
+        for chunk in chunks {
+            model.send_last_completion_stream_text_chunk(*chunk);
+        }
+        model.end_last_completion_stream();
+
+        let mut text_stream = stream_future.await.unwrap();
+        let mut result = String::new();
+        while let Some(chunk) = text_stream.stream.next().await {
+            result.push_str(&chunk.unwrap());
+        }
+        result
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_text_strips_think_tags(cx: &mut TestAppContext) {
+        let model = Arc::new(FakeLanguageModel::default());
+        let cx = cx.to_async();
+
+        let result = collect_text_stream(
+            &model,
+            &["<think>internal reasoning</think>Fix the bug"],
+            &cx,
+        )
+        .await;
+
+        assert_eq!(result, "Fix the bug");
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_text_strips_think_tags_split_across_chunks(
+        cx: &mut TestAppContext,
+    ) {
+        let model = Arc::new(FakeLanguageModel::default());
+        let cx = cx.to_async();
+
+        let result = collect_text_stream(
+            &model,
+            &["<think>", "internal reasoning", "</think>", "Fix the bug"],
+            &cx,
+        )
+        .await;
+
+        assert_eq!(result, "Fix the bug");
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_text_passes_through_non_think_text(
+        cx: &mut TestAppContext,
+    ) {
+        let model = Arc::new(FakeLanguageModel::default());
+        let cx = cx.to_async();
+
+        let result = collect_text_stream(&model, &["Fix the bug"], &cx).await;
+
+        assert_eq!(result, "Fix the bug");
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_text_unclosed_think_tag_discards_rest(
+        cx: &mut TestAppContext,
+    ) {
+        let model = Arc::new(FakeLanguageModel::default());
+        let cx = cx.to_async();
+
+        let result =
+            collect_text_stream(&model, &["<think>reasoning with no end tag"], &cx).await;
+
+        assert_eq!(result, "");
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_text_strips_multiple_think_blocks(
+        cx: &mut TestAppContext,
+    ) {
+        let model = Arc::new(FakeLanguageModel::default());
+        let cx = cx.to_async();
+
+        let result = collect_text_stream(
+            &model,
+            &["<think>first</think>Fix<think>second</think> the bug"],
+            &cx,
+        )
+        .await;
+
+        assert_eq!(result, "Fix the bug");
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_text_lone_close_tag_passes_through(
+        cx: &mut TestAppContext,
+    ) {
+        let model = Arc::new(FakeLanguageModel::default());
+        let cx = cx.to_async();
+
+        let result =
+            collect_text_stream(&model, &["before</think>after"], &cx).await;
+
+        assert_eq!(result, "before</think>after");
+    }
+}
+
 impl std::fmt::Debug for dyn LanguageModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("<dyn LanguageModel>")

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -152,6 +152,7 @@ pub trait LanguageModel: Send + Sync {
             let mut message_id = None;
             let mut first_item_text = None;
             let last_token_usage = Arc::new(Mutex::new(TokenUsage::default()));
+            let stripper = Arc::new(Mutex::new(ThinkTagStripper::new()));
 
             if let Some(first_event) = events.next().await {
                 match first_event {
@@ -159,7 +160,10 @@ pub trait LanguageModel: Send + Sync {
                         message_id = Some(id);
                     }
                     Ok(LanguageModelCompletionEvent::Text(text)) => {
-                        first_item_text = Some(text);
+                        let stripped = stripper.lock().process(&text);
+                        if !stripped.is_empty() {
+                            first_item_text = Some(stripped);
+                        }
                     }
                     _ => (),
                 }
@@ -170,12 +174,16 @@ pub trait LanguageModel: Send + Sync {
                     let last_token_usage = last_token_usage.clone();
                     move |result| {
                         let last_token_usage = last_token_usage.clone();
+                        let stripper = stripper.clone();
                         async move {
                             match result {
                                 Ok(LanguageModelCompletionEvent::Queued { .. }) => None,
                                 Ok(LanguageModelCompletionEvent::Started) => None,
                                 Ok(LanguageModelCompletionEvent::StartMessage { .. }) => None,
-                                Ok(LanguageModelCompletionEvent::Text(text)) => Some(Ok(text)),
+                                Ok(LanguageModelCompletionEvent::Text(text)) => {
+                                    let stripped = stripper.lock().process(&text);
+                                    if stripped.is_empty() { None } else { Some(Ok(stripped)) }
+                                }
                                 Ok(LanguageModelCompletionEvent::Thinking { .. }) => None,
                                 Ok(LanguageModelCompletionEvent::RedactedThinking { .. }) => None,
                                 Ok(LanguageModelCompletionEvent::ReasoningDetails(_)) => None,
@@ -248,6 +256,57 @@ pub trait LanguageModel: Send + Sync {
     }
 }
 
+const OPEN_THINK_TAG: &str = "<think>";
+const CLOSE_THINK_TAG: &str = "</think>";
+
+struct ThinkTagStripper {
+    buffer: String,
+    in_think: bool,
+}
+
+impl ThinkTagStripper {
+    fn new() -> Self {
+        Self {
+            buffer: String::new(),
+            in_think: false,
+        }
+    }
+
+    fn process(&mut self, input: &str) -> String {
+        self.buffer.push_str(input);
+        let mut output = String::new();
+        loop {
+            if self.in_think {
+                if let Some(end) = self.buffer.find(CLOSE_THINK_TAG) {
+                    self.buffer.drain(..end + CLOSE_THINK_TAG.len());
+                    self.in_think = false;
+                } else {
+                    let keep = partial_tag_suffix_len(&self.buffer, CLOSE_THINK_TAG);
+                    self.buffer.drain(..self.buffer.len() - keep);
+                    break;
+                }
+            } else if let Some(start) = self.buffer.find(OPEN_THINK_TAG) {
+                output.push_str(&self.buffer[..start]);
+                self.buffer.drain(..start + OPEN_THINK_TAG.len());
+                self.in_think = true;
+            } else {
+                let keep = partial_tag_suffix_len(&self.buffer, OPEN_THINK_TAG);
+                let emit = self.buffer.len() - keep;
+                output.push_str(&self.buffer[..emit]);
+                self.buffer.drain(..emit);
+                break;
+            }
+        }
+        output
+    }
+}
+
+fn partial_tag_suffix_len(s: &str, tag: &str) -> usize {
+    (1..tag.len())
+        .rev()
+        .find(|&i| s.ends_with(&tag[..i]))
+        .unwrap_or(0)
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #50989
Also related to #22373

Release Notes:

- Fixed models that emit `<think>` reasoning tags (e.g. DeepSeek, Qwen) leaking internal chain-of-thought into user-facing responses
