### PR TITLE
git_graph: Use ui_font_size to determine the row height

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -930,7 +930,7 @@ impl GitGraph {
     fn row_height(cx: &App) -> Pixels {
         let settings = ThemeSettings::get_global(cx);
         let font_size = settings.ui_font_size(cx);
-        font_size + px(12.0)
+        font_size * (1.0 + 0.75)
     }
 
     fn graph_canvas_content_width(&self) -> Pixels {

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -929,7 +929,7 @@ impl GitGraph {
 
     fn row_height(cx: &App) -> Pixels {
         let settings = ThemeSettings::get_global(cx);
-        let font_size = settings.buffer_font_size(cx);
+        let font_size = settings.ui_font_size(cx);
         font_size + px(12.0)
     }
 

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -58,6 +58,7 @@ const LEFT_PADDING: Pixels = px(12.0);
 const LINE_WIDTH: Pixels = px(1.5);
 const RESIZE_HANDLE_WIDTH: f32 = 8.0;
 const COPIED_STATE_DURATION: Duration = Duration::from_secs(2);
+const ROW_HEIGHT_FONT_SIZE_MULTIPLIER: f32 = 1.75;
 
 struct CopiedState {
     copied_at: Option<Instant>,
@@ -930,7 +931,7 @@ impl GitGraph {
     fn row_height(cx: &App) -> Pixels {
         let settings = ThemeSettings::get_global(cx);
         let font_size = settings.ui_font_size(cx);
-        font_size * (1.0 + 0.75)
+        font_size * ROW_HEIGHT_FONT_SIZE_MULTIPLIER
     }
 
     fn graph_canvas_content_width(&self) -> Pixels {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53492

After fix:
ui_font_size: 16
<img width="1614" height="854" alt="image" src="https://github.com/user-attachments/assets/8158f5be-c761-4981-8908-e4d2d85f3b22" />

ui_font_size: 20
<img width="1614" height="854" alt="image" src="https://github.com/user-attachments/assets/4bb6834c-44e6-4b4b-a09a-79aff35152ca" />

ui_font_size: 24
<img width="1614" height="854" alt="image" src="https://github.com/user-attachments/assets/ca8de245-a3d9-44bc-91bb-d8fec0aef219" />


Release Notes:

- Fixed git graph row height not scaling with ui_font_size setting
