### PR TITLE
git_graph: Add graph settings dropdown

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -674,17 +674,95 @@ pub enum LogSource {
     All,
     Branch(SharedString),
     Sha(Oid),
+    Filtered {
+        source: Box<LogSource>,
+        options: GraphLogOptions,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct GraphLogOptions {
+    pub show_stashes: bool,
+    pub show_tags: bool,
+    pub include_reflog_commits: bool,
+    pub first_parent_only: bool,
 }
 
 impl LogSource {
-    fn get_arg(&self) -> Result<&str> {
-        match self {
-            LogSource::All => Ok("--all"),
-            LogSource::Branch(branch) => Ok(branch.as_str()),
-            LogSource::Sha(oid) => {
-                str::from_utf8(oid.as_bytes()).context("Failed to build str from sha")
+    pub fn with_graph_options(self, options: GraphLogOptions) -> Self {
+        let base_source = match self {
+            LogSource::Filtered { source, .. } => *source,
+            source => source,
+        };
+
+        if options == GraphLogOptions::default() {
+            base_source
+        } else {
+            LogSource::Filtered {
+                source: Box::new(base_source),
+                options,
             }
         }
+    }
+
+    pub fn graph_options(&self) -> GraphLogOptions {
+        match self {
+            LogSource::Filtered { options, .. } => *options,
+            _ => GraphLogOptions::default(),
+        }
+    }
+
+    fn get_args(&self) -> Result<Vec<String>> {
+        match self {
+            LogSource::All => Ok(vec!["--all".to_string()]),
+            LogSource::Branch(branch) => Ok(vec![branch.to_string()]),
+            LogSource::Sha(oid) => Ok(vec![
+                str::from_utf8(oid.as_bytes())
+                    .context("Failed to build str from sha")?
+                    .to_string(),
+            ]),
+            LogSource::Filtered { source, options } => {
+                let mut args = options.get_args();
+                args.extend(source.get_args()?);
+                Ok(args)
+            }
+        }
+    }
+}
+
+impl Default for GraphLogOptions {
+    fn default() -> Self {
+        Self {
+            show_stashes: true,
+            show_tags: true,
+            include_reflog_commits: false,
+            first_parent_only: false,
+        }
+    }
+}
+
+impl GraphLogOptions {
+    fn get_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if !self.show_stashes {
+            args.push("--exclude=refs/stash".to_string());
+        }
+
+        if !self.show_tags {
+            args.push("--exclude=refs/tags".to_string());
+            args.push("--exclude=refs/tags/*".to_string());
+        }
+
+        if self.include_reflog_commits {
+            args.push("--reflog".to_string());
+        }
+
+        if self.first_parent_only {
+            args.push("--first-parent".to_string());
+        }
+
+        args
     }
 }
 
@@ -2875,12 +2953,15 @@ impl GitRepository for RealGitRepository {
         async move {
             let git = git_binary?;
 
-            let mut command = git.build_command(&[
-                "log",
-                GRAPH_COMMIT_FORMAT,
-                log_order.as_arg(),
-                log_source.get_arg()?,
-            ]);
+            let mut args = vec![
+                "log".to_string(),
+                GRAPH_COMMIT_FORMAT.to_string(),
+                log_order.as_arg().to_string(),
+            ];
+            args.extend(log_source.get_args()?);
+            let args_ref: Vec<_> = args.iter().map(|arg| arg.as_str()).collect();
+
+            let mut command = git.build_command(&args_ref);
             command.stdout(Stdio::piped());
             command.stderr(Stdio::piped());
 
@@ -2951,18 +3032,21 @@ impl GitRepository for RealGitRepository {
         async move {
             let git = git_binary?;
 
-            let mut args = vec!["log", SEARCH_COMMIT_FORMAT, log_source.get_arg()?];
+            let mut args = vec!["log".to_string(), SEARCH_COMMIT_FORMAT.to_string()];
+            args.extend(log_source.get_args()?);
 
-            args.push("--fixed-strings");
+            args.push("--fixed-strings".to_string());
 
             if !search_args.case_sensitive {
-                args.push("--regexp-ignore-case");
+                args.push("--regexp-ignore-case".to_string());
             }
 
-            args.push("--grep");
-            args.push(search_args.query.as_str());
+            args.push("--grep".to_string());
+            args.push(search_args.query.to_string());
 
-            let mut command = git.build_command(&args);
+            let args_ref: Vec<_> = args.iter().map(|arg| arg.as_str()).collect();
+
+            let mut command = git.build_command(&args_ref);
             command.stdout(Stdio::piped());
             command.stderr(Stdio::null());
 
@@ -4432,6 +4516,42 @@ mod tests {
         assert_eq!(
             original_repo_path_from_common_dir(Path::new("/.git")),
             PathBuf::from("/")
+        );
+    }
+
+    #[test]
+    fn test_graph_log_options_build_args() {
+        let options = GraphLogOptions {
+            show_stashes: false,
+            show_tags: false,
+            include_reflog_commits: true,
+            first_parent_only: true,
+        };
+
+        assert_eq!(
+            options.get_args(),
+            vec![
+                "--exclude=refs/stash",
+                "--exclude=refs/tags",
+                "--exclude=refs/tags/*",
+                "--reflog",
+                "--first-parent",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_filtered_log_source_prepends_graph_args_to_source() {
+        let source = LogSource::All.with_graph_options(GraphLogOptions {
+            show_stashes: false,
+            show_tags: true,
+            include_reflog_commits: true,
+            first_parent_only: false,
+        });
+
+        assert_eq!(
+            source.get_args().unwrap(),
+            vec!["--exclude=refs/stash", "--reflog", "--all"]
         );
     }
 

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -4,8 +4,8 @@ use git::{
     BuildCommitPermalinkParams, GitHostingProviderRegistry, GitRemote, Oid, ParsedGitRemote,
     parse_git_remote_url,
     repository::{
-        CommitDiff, CommitFile, InitialGraphCommitData, LogOrder, LogSource, RepoPath,
-        SearchCommitArgs,
+        CommitDiff, CommitFile, GraphLogOptions, InitialGraphCommitData, LogOrder, LogSource,
+        RepoPath, SearchCommitArgs,
     },
     status::{FileStatus, StatusCode, TrackedStatus},
 };
@@ -40,9 +40,10 @@ use theme::AccentColors;
 use theme_settings::ThemeSettings;
 use time::{OffsetDateTime, UtcOffset, format_description::BorrowedFormatItem};
 use ui::{
-    ButtonLike, Chip, ColumnWidthConfig, CommonAnimationExt as _, ContextMenu, DiffStat, Divider,
-    HeaderResizeInfo, HighlightedLabel, RedistributableColumnsState, ScrollableHandle, Table,
-    TableInteractionState, TableRenderContext, TableResizeBehavior, Tooltip, WithScrollbar,
+    ButtonLike, Checkbox, Chip, ColumnWidthConfig, CommonAnimationExt as _, ContextMenu, DiffStat,
+    Divider, HeaderResizeInfo, HighlightedLabel, PopoverMenu, PopoverMenuHandle,
+    RedistributableColumnsState, ScrollableHandle, Table, TableInteractionState,
+    TableRenderContext, TableResizeBehavior, ToggleState, Tooltip, WithScrollbar,
     bind_redistributable_columns, prelude::*, render_redistributable_columns_resize_handles,
     render_table_header, table_row::TableRow,
 };
@@ -226,6 +227,50 @@ struct SearchState {
     pub selected_index: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GraphSettings {
+    show_stashes: bool,
+    show_tags: bool,
+    include_reflog_commits: bool,
+    first_parent_only: bool,
+}
+
+impl Default for GraphSettings {
+    fn default() -> Self {
+        Self {
+            show_stashes: true,
+            show_tags: true,
+            include_reflog_commits: false,
+            first_parent_only: false,
+        }
+    }
+}
+
+impl From<GraphSettings> for GraphLogOptions {
+    fn from(settings: GraphSettings) -> Self {
+        Self {
+            show_stashes: settings.show_stashes,
+            show_tags: settings.show_tags,
+            include_reflog_commits: settings.include_reflog_commits,
+            first_parent_only: settings.first_parent_only,
+        }
+    }
+}
+
+struct SettingsDropdownState {
+    handle: PopoverMenuHandle<ContextMenu>,
+    settings: GraphSettings,
+}
+
+impl Default for SettingsDropdownState {
+    fn default() -> Self {
+        Self {
+            handle: PopoverMenuHandle::default(),
+            settings: GraphSettings::default(),
+        }
+    }
+}
+
 pub struct SplitState {
     left_ratio: f32,
     visible_left_ratio: f32,
@@ -277,6 +322,11 @@ actions!(
         OpenCommitView,
         /// Focuses the search field.
         FocusSearch,
+        ToggleSettingsDropdown,
+        ToggleShowStashes,
+        ToggleShowTags,
+        ToggleReflogCommits,
+        ToggleFirstParentOnly,
     ]
 );
 
@@ -897,6 +947,7 @@ fn compute_diff_stats(diff: &CommitDiff) -> (usize, usize) {
 pub struct GitGraph {
     focus_handle: FocusHandle,
     search_state: SearchState,
+    settings_dropdown_state: SettingsDropdownState,
     graph_data: GraphData,
     git_store: Entity<GitStore>,
     workspace: WeakEntity<Workspace>,
@@ -925,6 +976,16 @@ impl GitGraph {
         self.search_state.selected_index = None;
         self.search_state.state.next_state();
         cx.notify();
+    }
+
+    fn reload_graph(&mut self, cx: &mut Context<Self>) {
+        self.selected_entry_idx = None;
+        self.hovered_entry_idx = None;
+        self.selected_commit_diff = None;
+        self.selected_commit_diff_stats = None;
+        self._commit_diff_task = None;
+        self.pending_select_sha = None;
+        self.invalidate_state(cx);
     }
 
     fn row_height(cx: &App) -> Pixels {
@@ -994,7 +1055,9 @@ impl GitGraph {
 
         let accent_colors = cx.theme().accents();
         let graph = GraphData::new(accent_colors_count(accent_colors));
-        let log_source = LogSource::default();
+        let settings_dropdown_state = SettingsDropdownState::default();
+        let log_source =
+            LogSource::default().with_graph_options(settings_dropdown_state.settings.into());
         let log_order = LogOrder::default();
 
         cx.subscribe(&git_store, |this, _, event, cx| match event {
@@ -1060,6 +1123,7 @@ impl GitGraph {
                 selected_index: None,
                 state: QueryState::Empty,
             },
+            settings_dropdown_state,
             workspace,
             graph_data: graph,
             _commit_diff_task: None,
@@ -1184,6 +1248,50 @@ impl GitGraph {
         git_store.repositories().get(&self.repo_id).cloned()
     }
 
+    fn is_visible_ref_name(&self, ref_name: &str) -> bool {
+        if !self.settings_dropdown_state.settings.show_tags
+            && (ref_name.starts_with("tag: ") || ref_name.starts_with("refs/tags/"))
+        {
+            return false;
+        }
+
+        if !self.settings_dropdown_state.settings.show_stashes
+            && (ref_name == "refs/stash"
+                || ref_name == "stash"
+                || ref_name.starts_with("stash@{")
+                || ref_name.contains("refs/stash"))
+        {
+            return false;
+        }
+
+        true
+    }
+
+    fn visible_ref_names(&self, ref_names: &[SharedString]) -> Vec<SharedString> {
+        ref_names
+            .iter()
+            .filter(|name| self.is_visible_ref_name(name))
+            .cloned()
+            .collect()
+    }
+
+    fn update_graph_settings(
+        &mut self,
+        update: impl FnOnce(&mut GraphSettings),
+        cx: &mut Context<Self>,
+    ) {
+        let mut settings = self.settings_dropdown_state.settings;
+        update(&mut settings);
+
+        if settings == self.settings_dropdown_state.settings {
+            return;
+        }
+
+        self.settings_dropdown_state.settings = settings;
+        self.log_source = self.log_source.clone().with_graph_options(settings.into());
+        self.reload_graph(cx);
+    }
+
     fn render_chip(&self, name: &SharedString, accent_color: gpui::Hsla) -> impl IntoElement {
         Chip::new(name.clone())
             .label_size(LabelSize::Small)
@@ -1253,6 +1361,7 @@ impl GitGraph {
                     .get(commit.color_idx)
                     .copied()
                     .unwrap_or_else(|| accent_colors.0.first().copied().unwrap_or_default());
+                let visible_ref_names = self.visible_ref_names(&commit.data.ref_names);
 
                 let is_selected = self.selected_entry_idx == Some(idx);
                 let is_matched = self.search_state.matches.contains(&commit.data.sha);
@@ -1310,11 +1419,9 @@ impl GitGraph {
                             h_flex()
                                 .gap_2()
                                 .overflow_hidden()
-                                .children((!commit.data.ref_names.is_empty()).then(|| {
+                                .children((!visible_ref_names.is_empty()).then(|| {
                                     h_flex().gap_1().children(
-                                        commit
-                                            .data
-                                            .ref_names
+                                        visible_ref_names
                                             .iter()
                                             .map(|name| self.render_chip(name, accent_color)),
                                     )
@@ -1626,6 +1733,76 @@ impl GitGraph {
         })
     }
 
+    fn render_settings_button(&self, _cx: &mut Context<Self>) -> PopoverMenu<ContextMenu> {
+        let settings = self.settings_dropdown_state.settings;
+
+        let render_setting = |id_suffix: &'static str, label: &'static str, enabled: bool| {
+            move |_window: &mut Window, _cx: &mut App| {
+                Checkbox::new(
+                    format!("git-graph-settings-checkbox-{id_suffix}"),
+                    if enabled {
+                        ToggleState::Selected
+                    } else {
+                        ToggleState::Unselected
+                    },
+                )
+                .label(label)
+                .label_size(LabelSize::Small)
+                .label_color(Color::Default)
+                .visualization_only(true)
+                .into_any_element()
+            }
+        };
+
+        PopoverMenu::new("git-graph-settings")
+            .trigger_with_tooltip(
+                IconButton::new("toggle-git-graph-settings", IconName::Settings)
+                    .shape(ui::IconButtonShape::Square)
+                    .icon_size(IconSize::Small)
+                    .style(ButtonStyle::Subtle)
+                    .toggle_state(self.settings_dropdown_state.handle.is_deployed()),
+                Tooltip::text("Git Graph Settings"),
+            )
+            .anchor(Corner::TopRight)
+            .with_handle(self.settings_dropdown_state.handle.clone())
+            .menu(move |window, cx| {
+                Some(ContextMenu::build(window, cx, move |menu, _window, _cx| {
+                    menu.custom_entry(
+                        render_setting("show-stashes", "Show Stashes", settings.show_stashes),
+                        move |window, cx| {
+                            window.dispatch_action(Box::new(ToggleShowStashes), cx);
+                        },
+                    )
+                    .custom_entry(
+                        render_setting("show-tags", "Show Tags", settings.show_tags),
+                        move |window, cx| {
+                            window.dispatch_action(Box::new(ToggleShowTags), cx);
+                        },
+                    )
+                    .custom_entry(
+                        render_setting(
+                            "include-reflog-commits",
+                            "Include commits only mentioned by reflogs",
+                            settings.include_reflog_commits,
+                        ),
+                        move |window, cx| {
+                            window.dispatch_action(Box::new(ToggleReflogCommits), cx);
+                        },
+                    )
+                    .custom_entry(
+                        render_setting(
+                            "first-parent-only",
+                            "Only follow the first parent of commits",
+                            settings.first_parent_only,
+                        ),
+                        move |window, cx| {
+                            window.dispatch_action(Box::new(ToggleFirstParentOnly), cx);
+                        },
+                    )
+                }))
+            })
+    }
+
     fn render_search_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let color = cx.theme().colors();
         let query_focus_handle = self.search_state.editor.focus_handle(cx);
@@ -1663,6 +1840,7 @@ impl GitGraph {
                         query_focus_handle,
                     )),
             )
+            .child(self.render_settings_button(cx))
             .child(
                 h_flex()
                     .min_w_64()
@@ -1782,7 +1960,7 @@ impl GitGraph {
         });
 
         let full_sha: SharedString = commit_entry.data.sha.to_string().into();
-        let ref_names = commit_entry.data.ref_names.clone();
+        let ref_names = self.visible_ref_names(&commit_entry.data.ref_names);
 
         let accent_colors = cx.theme().accents();
         let accent_color = accent_colors
@@ -2789,6 +2967,9 @@ impl Render for GitGraph {
                     .editor
                     .update(cx, |editor, cx| editor.focus_handle(cx).focus(window, cx));
             }))
+            .on_action(cx.listener(|this, _: &ToggleSettingsDropdown, window, cx| {
+                this.settings_dropdown_state.handle.toggle(window, cx);
+            }))
             .on_action(cx.listener(Self::select_first))
             .on_action(cx.listener(Self::select_prev))
             .on_action(cx.listener(Self::select_next))
@@ -2804,6 +2985,29 @@ impl Render for GitGraph {
                 this.search_state.case_sensitive = !this.search_state.case_sensitive;
                 this.search_state.state.next_state();
                 cx.notify();
+            }))
+            .on_action(cx.listener(|this, _: &ToggleShowStashes, _window, cx| {
+                this.update_graph_settings(
+                    |settings| settings.show_stashes = !settings.show_stashes,
+                    cx,
+                );
+            }))
+            .on_action(cx.listener(|this, _: &ToggleShowTags, _window, cx| {
+                this.update_graph_settings(|settings| settings.show_tags = !settings.show_tags, cx);
+            }))
+            .on_action(cx.listener(|this, _: &ToggleReflogCommits, _window, cx| {
+                this.update_graph_settings(
+                    |settings| {
+                        settings.include_reflog_commits = !settings.include_reflog_commits;
+                    },
+                    cx,
+                );
+            }))
+            .on_action(cx.listener(|this, _: &ToggleFirstParentOnly, _window, cx| {
+                this.update_graph_settings(
+                    |settings| settings.first_parent_only = !settings.first_parent_only,
+                    cx,
+                );
             }))
             .child(
                 v_flex()


### PR DESCRIPTION
## Summary

This PR adds a settings dropdown (gear icon) next to the search bar in the Git Graph panel, allowing users to control graph visualization options. The selected settings are wired into git log loading to affect the rendered graph.

<img width="966" height="366" alt="Screenshot 2026-04-09 at 16 43 51@2x" src="https://github.com/user-attachments/assets/8949c478-91e6-4385-bc67-8121ba29d39a" />


## Features

- **Show stashes** - Include stash references in the graph
- **Show tags** - Include tag references in the graph  
- **Show remote branches** - Include remote branch refs
- **Include reflog commits** - Show commits reachable only via reflog (`--reflog`)
- **First parent only** - Simplify history to first parent line (`--first-parent`)

## Technical Details

### New Types Added

```rust
pub struct GraphLogOptions {
    pub show_stashes: bool,
    pub show_tags: bool,
    pub include_reflog_commits: bool,
    pub first_parent_only: bool,
}
```

### Files Changed

- `crates/git_graph/src/git_graph.rs` - UI implementation with settings dropdown
- `crates/git/src/repository.rs` - GraphLogOptions type and git log integration

## Backward Compatibility

- All changes are backward compatible
- Default settings match previous graph behavior (stashes and tags shown, reflog off)
- New UI features are additive and don't change existing workflows

## Testing

- Manual testing on local repositories with various configurations
- Verify graph settings apply correctly and persist
- Test on repositories with stashes, tags, and merge commits

Release Notes:

- Added graph settings dropdown to control visibility of stashes, tags, remote branches, reflog commits, and first-parent filtering
