### PR TITLE
Add tabs.show_dirty_indicator setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1259,6 +1259,9 @@
     // 3. Mark files with errors and warnings:
     //    "all"
     "show_diagnostics": "off",
+    // Whether to show a dot when a tab or buffer has unsaved edits. When false, the dot is hidden
+    // for unsaved state only; merge conflicts still show a warning dot.
+    "show_dirty_indicator": true,
   },
   // Settings related to preview tabs.
   "preview_tabs": {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8256,7 +8256,9 @@ pub(crate) fn render_buffer_header(
         let buffer = buffer.read(cx);
         let indicator_color = match (buffer.has_conflict(), buffer.is_dirty()) {
             (true, _) => Some(Color::Warning),
-            (_, true) => Some(Color::Accent),
+            (_, true) => ItemSettings::get_global(cx)
+                .show_dirty_indicator
+                .then_some(Color::Accent),
             (false, false) => None,
         };
         indicator_color.map(|indicator_color| Indicator::dot().color(indicator_color))

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -734,6 +734,7 @@ impl VsCodeSettings {
                         ShowCloseButton::Hidden
                     }
                 }),
+            show_dirty_indicator: None,
         })
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -155,6 +155,11 @@ pub struct ItemSettingsContent {
     ///
     /// Default: false
     pub show_close_button: Option<ShowCloseButton>,
+    /// Whether to show a dot on tabs and buffer headers when a file has unsaved edits.
+    /// Merge conflicts still show a warning dot when this is disabled.
+    ///
+    /// Default: true
+    pub show_dirty_indicator: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -59,6 +59,7 @@ pub struct ItemSettings {
     pub file_icons: bool,
     pub show_diagnostics: ShowDiagnostics,
     pub show_close_button: ShowCloseButton,
+    pub show_dirty_indicator: bool,
 }
 
 #[derive(RegisterSetting)]
@@ -89,6 +90,7 @@ impl Settings for ItemSettings {
             file_icons: tabs.file_icons.unwrap(),
             show_diagnostics: tabs.show_diagnostics.unwrap(),
             show_close_button: tabs.show_close_button.unwrap(),
+            show_dirty_indicator: tabs.show_dirty_indicator.unwrap(),
         }
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4933,7 +4933,12 @@ pub fn render_item_indicator(item: Box<dyn ItemHandle>, cx: &App) -> Option<Indi
     maybe!({
         let indicator_color = match (item.has_conflict(cx), item.is_dirty(cx)) {
             (true, _) => Color::Warning,
-            (_, true) => Color::Accent,
+            (_, true) => {
+                if !ItemSettings::get_global(cx).show_dirty_indicator {
+                    return None;
+                }
+                Color::Accent
+            }
             (false, false) => return None,
         };
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1341,7 +1341,8 @@ or
     "git_status": false,
     "activate_on_close": "history",
     "show_close_button": "hover",
-    "show_diagnostics": "off"
+    "show_diagnostics": "off",
+    "show_dirty_indicator": true
   }
 }
 ```
@@ -1499,6 +1500,16 @@ or
   }
 }
 ```
+
+### Show dirty indicator
+
+- Description: Whether to show a dot on tabs and buffer headers when a file has unsaved edits. When disabled, merge conflicts still show a warning dot.
+- Setting: `show_dirty_indicator`
+- Default: `true`
+
+**Options**
+
+`boolean` values
 
 ### Show Inline Code Actions
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

### Summary
Adds a tabs.show_dirty_indicator setting (default true) so users can hide the accent dot that indicates unsaved edits on tabs and on the buffer header next to the file path. Merge conflicts still use the warning dot when present; only the “dirty” (unsaved) state is affected.

### Motivation
With fast autosave, the unsaved dot can flicker or feel redundant (similar to IDEs that save continuously). Turning it off is a small UX preference that doesn’t change save behavior.

Manually tested. Cursor Composer 2 wrote the code.

Release Notes:

- Added `tabs.show_dirty_indicator` to hide the unsaved-edit dot on tabs and buffer headers; merge conflicts still show a warning dot.
