### PR TITLE
diagnostics: Fall back to `multibuffer_context_lines` when syntactic expansion produces a single-line range

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -989,6 +989,7 @@ async fn context_range_for_entry(
         cx,
     )
     .await
+    .filter(|rows| rows.start() != rows.end())
     {
         Range {
             start: Point::new(*rows.start(), 0),


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A