### PR TITLE
settings: Add buffer letter spacing support

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -39,6 +39,10 @@
   "buffer_font_size": 15,
   // The weight of the editor font in standard CSS units from 100 to 900.
   "buffer_font_weight": 400,
+  // The letter spacing (or tracking) of the editor font in ems (relative to buffer_font_size).
+  // For example, 0.05 will insert a space between each grapheme cluster, with a width of 5% of the font size.
+  // This value can be positive or negative.
+  "buffer_letter_spacing": 0.0,
   // Set the buffer's line height.
   // May take 3 values:
   //  1. Use a line height that's comfortable for reading (1.618)

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1705,6 +1705,7 @@ impl CodeActionsMenu {
         let mut line_wrapper = text_system.line_wrapper(
             window.text_style().font(),
             window.text_style().font_size.to_pixels(window.rem_size()),
+            window.text_style().letter_spacing,
         );
         let is_truncated = line_wrapper.should_truncate_line(
             &label,

--- a/crates/editor/src/config.rs
+++ b/crates/editor/src/config.rs
@@ -37,13 +37,14 @@ impl Editor {
         if !self.mode.is_minimap() {
             let font = style.text.font();
             let font_size = style.text.font_size.to_pixels(window.rem_size());
+            let letter_spacing = style.text.letter_spacing;
             let display_map = self
                 .placeholder_display_map
                 .as_ref()
                 .filter(|_| self.is_empty(cx))
                 .unwrap_or(&self.display_map);
 
-            display_map.update(cx, |map, cx| map.set_font(font, font_size, cx));
+            display_map.update(cx, |map, cx| map.set_font(font, font_size, letter_spacing, cx));
         }
         self.style = Some(style);
     }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -94,8 +94,8 @@ pub use wrap_map::{WrapPoint, WrapRow, WrapSnapshot};
 
 use collections::{HashMap, HashSet, IndexSet};
 use gpui::{
-    App, Context, Entity, EntityId, Font, HighlightStyle, Hsla, LineLayout, Pixels, UnderlineStyle,
-    WeakEntity,
+    App, Context, Entity, EntityId, Font, HighlightStyle, Hsla, LetterSpacing, LineLayout, Pixels,
+    UnderlineStyle, WeakEntity,
 };
 use language::{
     LanguageAwareStyling, Point, Subscription as BufferSubscription,
@@ -366,6 +366,7 @@ impl DisplayMap {
         buffer: Entity<MultiBuffer>,
         font: Font,
         font_size: Pixels,
+        letter_spacing: LetterSpacing,
         wrap_width: Option<Pixels>,
         buffer_header_height: u32,
         excerpt_header_height: u32,
@@ -384,7 +385,8 @@ impl DisplayMap {
         let (inlay_map, snapshot) = InlayMap::new(buffer_snapshot);
         let (fold_map, snapshot) = FoldMap::new(snapshot);
         let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
-        let (wrap_map, snapshot) = WrapMap::new(snapshot, font, font_size, wrap_width, cx);
+        let (wrap_map, snapshot) =
+            WrapMap::new(snapshot, font, font_size, letter_spacing, wrap_width, cx);
         let block_map = BlockMap::new(snapshot, buffer_header_height, excerpt_header_height);
 
         cx.observe(&wrap_map, |_, _, cx| cx.notify()).detach();
@@ -1228,9 +1230,16 @@ impl DisplayMap {
         cleared
     }
 
-    pub fn set_font(&self, font: Font, font_size: Pixels, cx: &mut Context<Self>) -> bool {
-        self.wrap_map
-            .update(cx, |map, cx| map.set_font_with_size(font, font_size, cx))
+    pub fn set_font(
+        &self,
+        font: Font,
+        font_size: Pixels,
+        letter_spacing: LetterSpacing,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.wrap_map.update(cx, |map, cx| {
+            map.set_font_with_size(font, font_size, letter_spacing, cx)
+        })
     }
 
     pub fn set_wrap_width(&self, width: Option<Pixels>, cx: &mut Context<Self>) -> bool {
@@ -2650,6 +2659,7 @@ pub mod tests {
                 buffer.clone(),
                 font,
                 font_size,
+                LetterSpacing::default(),
                 wrap_width,
                 buffer_start_excerpt_header_height,
                 excerpt_header_height,
@@ -2903,6 +2913,7 @@ pub mod tests {
                     buffer.clone(),
                     font("Helvetica"),
                     font_size,
+                    LetterSpacing::default(),
                     wrap_width,
                     1,
                     1,
@@ -2989,7 +3000,12 @@ pub mod tests {
 
             // Re-wrap on font size changes
             map.update(cx, |map, cx| {
-                map.set_font(font("Helvetica"), font_size + Pixels::from(3.), cx)
+                map.set_font(
+                    font("Helvetica"),
+                    font_size + px(3.),
+                    LetterSpacing::default(),
+                    cx,
+                )
             });
 
             let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
@@ -3013,6 +3029,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3075,6 +3092,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3176,6 +3194,7 @@ pub mod tests {
                 buffer,
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3277,6 +3296,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 px(16.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3381,6 +3401,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 px(16.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3479,6 +3500,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Courier"),
                 px(16.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3620,6 +3642,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 font_size,
+                LetterSpacing::default(),
                 Some(px(40.0)),
                 1,
                 1,
@@ -3708,6 +3731,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3834,6 +3858,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3872,6 +3897,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -3948,6 +3974,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -4031,6 +4058,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -4165,6 +4193,7 @@ pub mod tests {
                 multibuffer.clone(),
                 font("Helvetica"),
                 px(14.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -2873,7 +2873,7 @@ mod tests {
         test::test_font,
     };
     use buffer_diff::BufferDiff;
-    use gpui::{App, AppContext as _, Element, div, font, px};
+    use gpui::{App, AppContext as _, Element, LetterSpacing, div, font, px};
     use itertools::Itertools;
     use language::{Buffer, Capability, Point};
     use multi_buffer::{MultiBuffer, PathKey};
@@ -2920,8 +2920,16 @@ mod tests {
         let (mut inlay_map, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default(), None);
@@ -3135,7 +3143,14 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(multi_buffer_snapshot);
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wraps_snapshot) = WrapMap::new(tab_snapshot, font, font_size, Some(wrap_width), cx);
+        let (_, wraps_snapshot) = WrapMap::new(
+            tab_snapshot,
+            font,
+            font_size,
+            LetterSpacing::default(),
+            Some(wrap_width),
+            cx,
+        );
 
         let block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
         let snapshot = block_map.read(wraps_snapshot, Default::default(), None);
@@ -3169,8 +3184,16 @@ mod tests {
         let (_inlay_map, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
-        let (_wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default(), None);
@@ -3274,7 +3297,14 @@ mod tests {
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let (_, wraps_snapshot) = cx.update(|cx| {
-            WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), Some(px(90.)), cx)
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                Some(px(90.)),
+                cx,
+            )
         });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
@@ -3318,8 +3348,16 @@ mod tests {
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let tab_size = 1.try_into().unwrap();
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, tab_size);
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default(), None);
@@ -3485,8 +3523,16 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_, wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wrap_snapshot.clone(), 2, 1);
         let blocks_snapshot = block_map.read(wrap_snapshot.clone(), Patch::default(), None);
 
@@ -3830,8 +3876,16 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_, wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wrap_snapshot.clone(), 2, 1);
         let blocks_snapshot = block_map.read(wrap_snapshot.clone(), Patch::default(), None);
 
@@ -3906,8 +3960,16 @@ mod tests {
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let font = test_font();
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font, font_size, wrap_width, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font,
+                font_size,
+                LetterSpacing::default(),
+                wrap_width,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(
             wraps_snapshot,
             buffer_start_header_height,
@@ -4500,8 +4562,16 @@ mod tests {
         let (_inlay_map, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default(), None);
@@ -4550,8 +4620,16 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_, wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wrap_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wrap_snapshot.clone(), Patch::default(), None);
@@ -4595,8 +4673,16 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_, wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wrap_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wrap_snapshot.clone(), Patch::default(), None);
@@ -4631,7 +4717,7 @@ mod tests {
         let diff = cx.new(|cx| {
             BufferDiff::new_with_base_text(base_text, &rhs_buffer.read(cx).text_snapshot(), cx)
         });
-        let lhs_buffer = diff.read_with(cx, |diff, _| diff.base_text_buffer().clone());
+        let lhs_buffer = diff.read_with(cx, |diff: &BufferDiff, _| diff.base_text_buffer().clone());
 
         let lhs_multibuffer = cx.new(|cx| {
             let mut mb = MultiBuffer::new(Capability::ReadWrite);
@@ -4663,8 +4749,16 @@ mod tests {
         let (mut _lhs_fold_map, lhs_fold_snapshot) = FoldMap::new(lhs_inlay_snapshot);
         let (mut _lhs_tab_map, lhs_tab_snapshot) =
             TabMap::new(lhs_fold_snapshot, 4.try_into().unwrap());
-        let (_lhs_wrap_map, lhs_wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(lhs_tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_lhs_wrap_map, lhs_wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                lhs_tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let lhs_block_map = BlockMap::new(lhs_wrap_snapshot.clone(), 0, 0);
 
         let rhs_buffer_snapshot = cx.update(|cx| rhs_multibuffer.read(cx).snapshot(cx));
@@ -4672,8 +4766,16 @@ mod tests {
         let (mut rhs_fold_map, rhs_fold_snapshot) = FoldMap::new(rhs_inlay_snapshot);
         let (mut rhs_tab_map, rhs_tab_snapshot) =
             TabMap::new(rhs_fold_snapshot, 4.try_into().unwrap());
-        let (_rhs_wrap_map, rhs_wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(rhs_tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_rhs_wrap_map, rhs_wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                rhs_tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let rhs_block_map = BlockMap::new(rhs_wrap_snapshot.clone(), 0, 0);
 
         let rhs_entity_id = rhs_multibuffer.entity_id();

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -4,9 +4,8 @@ use super::{
     fold_map::{Chunk, FoldRows},
     tab_map::{self, TabEdit, TabPoint, TabSnapshot},
 };
-
 use futures_lite::future::yield_now;
-use gpui::{App, AppContext as _, Context, Entity, Font, LineWrapper, Pixels, Task};
+use gpui::{App, AppContext as _, Context, Entity, Font, LetterSpacing, LineWrapper, Pixels, Task};
 use language::{LanguageAwareStyling, Point};
 use multi_buffer::{MultiBufferSnapshot, RowInfo};
 use std::{cmp, collections::VecDeque, mem, ops::Range, sync::LazyLock, time::Duration};
@@ -36,7 +35,7 @@ pub struct WrapMap {
     edits_since_sync: WrapPatch,
     wrap_width: Option<Pixels>,
     background_task: Option<Task<()>>,
-    font_with_size: (Font, Pixels),
+    font_with_size: (Font, Pixels, LetterSpacing),
 }
 
 #[derive(Clone)]
@@ -110,12 +109,13 @@ impl WrapMap {
         tab_snapshot: TabSnapshot,
         font: Font,
         font_size: Pixels,
+        letter_spacing: LetterSpacing,
         wrap_width: Option<Pixels>,
         cx: &mut App,
     ) -> (Entity<Self>, WrapSnapshot) {
         let handle = cx.new(|cx| {
             let mut this = Self {
-                font_with_size: (font, font_size),
+                font_with_size: (font, font_size, letter_spacing),
                 wrap_width: None,
                 pending_edits: Default::default(),
                 interpolated_edits: Default::default(),
@@ -161,9 +161,10 @@ impl WrapMap {
         &mut self,
         font: Font,
         font_size: Pixels,
+        letter_spacing: LetterSpacing,
         cx: &mut Context<Self>,
     ) -> bool {
-        let font_with_size = (font, font_size);
+        let font_with_size = (font, font_size, letter_spacing);
 
         if font_with_size == self.font_with_size {
             false
@@ -195,8 +196,8 @@ impl WrapMap {
             let mut new_snapshot = self.snapshot.clone();
 
             let text_system = cx.text_system();
-            let (font, font_size) = self.font_with_size.clone();
-            let mut line_wrapper = text_system.line_wrapper(font, font_size);
+            let (font, font_size, letter_spacing) = self.font_with_size.clone();
+            let mut line_wrapper = text_system.line_wrapper(font, font_size, letter_spacing);
             let tab_snapshot = new_snapshot.tab_snapshot.clone();
             let total_rows = tab_snapshot.max_point().row() as usize + 1;
             let range = TabPoint::zero()..tab_snapshot.max_point();
@@ -290,8 +291,8 @@ impl WrapMap {
             let mut pending_edits = self.pending_edits.clone();
             let mut snapshot = self.snapshot.clone();
             let text_system = cx.text_system().clone();
-            let (font, font_size) = self.font_with_size.clone();
-            let mut line_wrapper = text_system.line_wrapper(font, font_size);
+            let (font, font_size, letter_spacing) = self.font_with_size.clone();
+            let mut line_wrapper = text_system.line_wrapper(font, font_size, letter_spacing);
 
             if pending_edits.len() == 1
                 && let Some((_, tab_edits)) = pending_edits.back()
@@ -1391,8 +1392,16 @@ mod tests {
             let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
             let (mut tab_map, _) = TabMap::new(fold_snapshot, tab_size);
             let tabs_snapshot = tab_map.set_max_expansion_column(32);
-            let (_wrap_map, wrap_snapshot) =
-                cx.update(|cx| WrapMap::new(tabs_snapshot, font, font_size, soft_wrapping, cx));
+            let (_wrap_map, wrap_snapshot) = cx.update(|cx| {
+                WrapMap::new(
+                    tabs_snapshot,
+                    font,
+                    font_size,
+                    LetterSpacing::default(),
+                    soft_wrapping,
+                    cx,
+                )
+            });
 
             wrap_snapshot
         }
@@ -1452,6 +1461,7 @@ mod tests {
         let font = test_font();
         let _font_id = text_system.resolve_font(&font);
         let font_size = px(14.0);
+        let letter_spacing = LetterSpacing::default();
 
         log::info!("Tab size: {}", tab_size);
         log::info!("Wrap width: {:?}", wrap_width);
@@ -1477,11 +1487,20 @@ mod tests {
         let tabs_snapshot = tab_map.set_max_expansion_column(32);
         log::info!("TabMap text: {:?}", tabs_snapshot.text());
 
-        let mut line_wrapper = text_system.line_wrapper(font.clone(), font_size);
+        let mut line_wrapper =
+            text_system.line_wrapper(font.clone(), font_size, LetterSpacing::default());
         let expected_text = wrap_text(&tabs_snapshot, wrap_width, &mut line_wrapper);
 
-        let (wrap_map, _) =
-            cx.update(|cx| WrapMap::new(tabs_snapshot.clone(), font, font_size, wrap_width, cx));
+        let (wrap_map, _) = cx.update(|cx| {
+            WrapMap::new(
+                tabs_snapshot.clone(),
+                font,
+                font_size,
+                letter_spacing,
+                wrap_width,
+                cx,
+            )
+        });
         let mut notifications = observe(&wrap_map, cx);
 
         if wrap_map.read_with(cx, |map, _| map.is_rewrapping()) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -138,11 +138,11 @@ use gpui::{
     AvailableSpace, Background, Bounds, ClickEvent, ClipboardEntry, ClipboardItem, Context,
     DispatchPhase, Edges, Entity, EntityId, EntityInputHandler, EventEmitter, FocusHandle,
     FocusOutEvent, Focusable, FontId, FontStyle, FontWeight, Global, HighlightStyle, Hsla,
-    KeyContext, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad, ParentElement,
-    Pixels, PressureStage, Render, ScrollHandle, SharedString, SharedUri, Size, Stateful, Styled,
-    Subscription, Task, TextRun, TextStyle, TextStyleRefinement, UTF16Selection, UnderlineStyle,
-    UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, div, point, prelude::*,
-    pulsating_between, px, relative, size,
+    KeyContext, LetterSpacing, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad,
+    ParentElement, Pixels, PressureStage, Render, ScrollHandle, SharedString, SharedUri, Size,
+    Stateful, Styled, Subscription, Task, TextRun, TextStyle, TextStyleRefinement, UTF16Selection,
+    UnderlineStyle, UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, div, point,
+    prelude::*, pulsating_between, px, relative, size,
 };
 use hover_links::{HoverLink, HoveredLinkState, find_file};
 use hover_popover::{HoverState, hide_hover};
@@ -2104,20 +2104,19 @@ impl Editor {
             merge_adjacent: true,
             ..FoldPlaceholder::default()
         };
-        let display_map = display_map.unwrap_or_else(|| {
-            cx.new(|cx| {
-                DisplayMap::new(
-                    multi_buffer.clone(),
-                    style.font(),
-                    font_size,
-                    None,
-                    FILE_HEADER_HEIGHT,
-                    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
-                    fold_placeholder,
-                    diagnostics_max_severity,
-                    cx,
-                )
-            })
+        let display_map = cx.new(|cx| {
+            DisplayMap::new(
+                multi_buffer.clone(),
+                style.font(),
+                font_size,
+                LetterSpacing::default(),
+                None,
+                FILE_HEADER_HEIGHT,
+                MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+                fold_placeholder,
+                diagnostics_max_severity,
+                cx,
+            )
         });
 
         let selections = SelectionsCollection::new();
@@ -3391,6 +3390,7 @@ impl Editor {
                 multibuffer,
                 style.font(),
                 style.font_size.to_pixels(window.rem_size()),
+                LetterSpacing::default(),
                 None,
                 FILE_HEADER_HEIGHT,
                 MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
@@ -17265,7 +17265,13 @@ impl Editor {
                         .unwrap_or((true, HashMap::default(), None, None));
                     (comments, expanded, editors, avatar_uri, line_ranges)
                 })
-                .unwrap_or((Vec::new(), true, HashMap::default(), None, None));
+                .unwrap_or((
+                    Vec::new(),
+                    true,
+                    HashMap::default(),
+                    None::<SharedUri>,
+                    None::<Vec<(u32, u32)>>,
+                ));
 
         let comment_count = comments.len();
         let avatar_size = px(20.);
@@ -20961,7 +20967,57 @@ impl Focusable for Editor {
 
 impl Render for Editor {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        EditorElement::new(&cx.entity(), self.create_style(cx))
+        let settings = ThemeSettings::get_global(cx);
+
+        let mut text_style = match self.mode {
+            EditorMode::SingleLine { .. } | EditorMode::AutoHeight { .. } => TextStyle {
+                color: cx.theme().colors().editor_foreground,
+                font_family: settings.ui_font.family.clone(),
+                font_features: settings.ui_font.features.clone(),
+                font_fallbacks: settings.ui_font.fallbacks.clone(),
+                font_size: rems(0.875).into(),
+                font_weight: settings.ui_font.weight,
+                line_height: relative(settings.buffer_line_height.value()),
+                ..Default::default()
+            },
+            EditorMode::Full { .. } | EditorMode::Minimap { .. } => TextStyle {
+                color: cx.theme().colors().editor_foreground,
+                font_family: settings.buffer_font.family.clone(),
+                font_features: settings.buffer_font.features.clone(),
+                font_fallbacks: settings.buffer_font.fallbacks.clone(),
+                font_size: settings.buffer_font_size(cx).into(),
+                font_weight: settings.buffer_font.weight,
+                letter_spacing: settings.buffer_letter_spacing,
+                line_height: relative(settings.buffer_line_height.value()),
+                ..Default::default()
+            },
+        };
+        if let Some(text_style_refinement) = &self.text_style_refinement {
+            text_style.refine(text_style_refinement)
+        }
+
+        let background = match self.mode {
+            EditorMode::SingleLine { .. } => cx.theme().system().transparent,
+            EditorMode::AutoHeight { .. } => cx.theme().system().transparent,
+            EditorMode::Full { .. } => cx.theme().colors().editor_background,
+            EditorMode::Minimap { .. } => cx.theme().colors().editor_background.opacity(0.7),
+        };
+
+        EditorElement::new(
+            &cx.entity(),
+            EditorStyle {
+                background,
+                local_player: cx.theme().players().local(),
+                text: text_style,
+                scrollbar_width: EditorElement::SCROLLBAR_WIDTH,
+                syntax: cx.theme().syntax().clone(),
+                status: cx.theme().status().clone(),
+                inlay_hints_style: make_inlay_hints_style(cx),
+                edit_prediction_styles: make_suggestion_styles(cx),
+                unnecessary_code_fade: ThemeSettings::get_global(cx).unnecessary_code_fade,
+                ..Default::default()
+            },
+        )
     }
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1884,6 +1884,7 @@ impl EditorElement {
                                 &[TextRun {
                                     len,
                                     font,
+                                    letter_spacing: self.style.text.letter_spacing,
                                     color,
                                     ..Default::default()
                                 }],
@@ -3866,6 +3867,7 @@ impl EditorElement {
                     let run = TextRun {
                         len: line.len(),
                         font: style.text.font(),
+                        letter_spacing: style.text.letter_spacing,
                         color: placeholder_color,
                         ..Default::default()
                     };
@@ -7977,6 +7979,7 @@ impl EditorElement {
         let run = TextRun {
             len: text.len(),
             font: self.style.text.font(),
+            letter_spacing: self.style.text.letter_spacing,
             color,
             ..Default::default()
         };
@@ -9071,6 +9074,7 @@ impl LineWithInvisibles {
                         let run = TextRun {
                             len: x.len(),
                             font: text_style.font(),
+                            letter_spacing: text_style.letter_spacing,
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -9143,6 +9147,7 @@ impl LineWithInvisibles {
                         styles.push(TextRun {
                             len: line_chunk.len(),
                             font: text_style.font(),
+                            letter_spacing: text_style.letter_spacing,
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -9226,6 +9231,7 @@ impl LineWithInvisibles {
                     output_runs.push(TextRun {
                         len: span_len,
                         font: text_run.font.clone(),
+                        letter_spacing: text_run.letter_spacing,
                         color: text_run.color,
                         background_color: text_run.background_color,
                         underline: text_run.underline,
@@ -9240,6 +9246,7 @@ impl LineWithInvisibles {
                     output_runs.push(TextRun {
                         len: segment_slice_end_col - cursor_col,
                         font: text_run.font.clone(),
+                        letter_spacing: text_run.letter_spacing,
                         color: new_text_color,
                         background_color: text_run.background_color,
                         underline: text_run.underline,
@@ -9256,6 +9263,7 @@ impl LineWithInvisibles {
                 output_runs.push(TextRun {
                     len: run_end_col - cursor_col,
                     font: text_run.font.clone(),
+                    letter_spacing: text_run.letter_spacing,
                     color: text_run.color,
                     background_color: text_run.background_color,
                     underline: text_run.underline,
@@ -11339,6 +11347,7 @@ impl Element for EditorElement {
 
         let text_style = TextStyleRefinement {
             font_size: Some(self.style.text.font_size),
+            letter_spacing: Some(self.style.text.letter_spacing),
             line_height: Some(self.style.text.line_height),
             ..Default::default()
         };

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -937,7 +937,7 @@ mod tests {
         inlays::Inlay,
         test::{editor_test_context::EditorTestContext, marked_display_snapshot},
     };
-    use gpui::{AppContext as _, font, px};
+    use gpui::{AppContext as _, LetterSpacing, font, px};
     use language::Capability;
     use multi_buffer::PathKey;
     use project::project_settings::DiagnosticSeverity;
@@ -1070,6 +1070,7 @@ mod tests {
                 buffer,
                 font,
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -1272,6 +1273,7 @@ mod tests {
                     multibuffer,
                     font,
                     px(14.0),
+                    LetterSpacing::default(),
                     None,
                     0,
                     1,
@@ -1427,6 +1429,7 @@ mod tests {
                 buffer,
                 font,
                 px(14.0),
+                LetterSpacing::default(),
                 None,
                 0,
                 1,

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use collections::HashMap;
 use gpui::{
-    AppContext as _, Context, Entity, EntityId, Font, FontFeatures, FontStyle, FontWeight, Pixels,
-    VisualTestContext, Window, font, size,
+    AppContext as _, Context, Entity, EntityId, Font, FontFeatures, FontStyle, FontWeight,
+    LetterSpacing, Pixels, VisualTestContext, Window, font, size,
 };
 use multi_buffer::{MultiBufferOffset, ToPoint};
 use pretty_assertions::assert_eq;
@@ -67,6 +67,7 @@ pub fn marked_display_snapshot(
             buffer,
             font,
             font_size,
+            LetterSpacing::default(),
             None,
             1,
             1,

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -5,10 +5,10 @@ use std::ops::Range;
 use gpui::{
     App, Bounds, ClipboardItem, Context, CursorStyle, ElementId, ElementInputHandler, Entity,
     EntityInputHandler, FocusHandle, Focusable, GlobalElementId, KeyBinding, Keystroke, LayoutId,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
-    ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, Window, WindowBounds,
-    WindowOptions, actions, black, div, fill, hsla, opaque_grey, point, prelude::*, px, relative,
-    rgb, rgba, size, white, yellow,
+    LetterSpacing, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels,
+    Point, ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, Window,
+    WindowBounds, WindowOptions, actions, black, div, fill, hsla, opaque_grey, point, prelude::*,
+    px, relative, rgb, rgba, size, white, yellow,
 };
 use gpui_platform::application;
 use unicode_segmentation::*;
@@ -465,6 +465,7 @@ impl Element for TextElement {
         let run = TextRun {
             len: display_text.len(),
             font: style.font(),
+            letter_spacing: LetterSpacing::default(),
             color: text_color,
             background_color: None,
             underline: None,

--- a/crates/gpui/examples/text_layout.rs
+++ b/crates/gpui/examples/text_layout.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(target_family = "wasm", no_main)]
 
-use gpui::{
-    App, Bounds, Context, FontStyle, FontWeight, StyledText, Window, WindowBounds, WindowOptions,
-    div, prelude::*, px, size,
-};
+use gpui::{App, Bounds, Context, Window, WindowBounds, WindowOptions, div, prelude::*, px, size};
 use gpui_platform::application;
 
 struct HelloWorld {}
@@ -74,12 +71,21 @@ impl Render for HelloWorld {
                             .child("100%"),
                     ),
             )
-            .child(div().flex().gap_2().justify_between().child(
-                StyledText::new("ABCD").with_highlights([
-                    (0..1, FontWeight::EXTRA_BOLD.into()),
-                    (2..3, FontStyle::Italic.into()),
-                ]),
-            ))
+            .child(
+                div()
+                    .letter_spacing(0.00)
+                    .child("I have default letter_spacing"),
+            )
+            .child(
+                div()
+                    .letter_spacing(0.05)
+                    .child("I have positive letter_spacing"),
+            )
+            .child(
+                div()
+                    .letter_spacing(-0.05)
+                    .child("I have negative letter_spacing"),
+            )
     }
 }
 

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -399,6 +399,7 @@ impl TextLayout {
     ) -> LayoutId {
         let text_style = window.text_style();
         let font_size = text_style.font_size.to_pixels(window.rem_size());
+        let letter_spacing = text_style.letter_spacing;
         let line_height = window.pixel_snap(
             text_style
                 .line_height
@@ -454,12 +455,14 @@ impl TextLayout {
                     return size;
                 }
 
-                let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
-                let (text, runs) = if let Some(truncate_width) = truncate_width {
+                let mut line_wrapper =
+                    cx.text_system()
+                        .line_wrapper(text_style.font(), font_size, letter_spacing);
+                let (text, shaped_runs) = if let Some(truncate_width) = truncate_width {
                     line_wrapper.truncate_line(
                         text.clone(),
                         truncate_width,
-                        &truncation_affix,
+                        truncation_affix.as_ref(),
                         &runs,
                         truncate_from,
                     )
@@ -473,7 +476,7 @@ impl TextLayout {
                     .shape_text(
                         text,
                         font_size,
-                        &runs,
+                        &shaped_runs,
                         wrap_width,            // Wrap if we know the width.
                         text_style.line_clamp, // Limit the number of lines if line_clamp is set.
                     )

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -7,9 +7,9 @@ use std::{
 use crate::{
     AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
-    point, quad, rems, size,
+    FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, LetterSpacing,
+    Pixels, Point, PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun,
+    Window, black, phi, point, quad, rems, size,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -437,6 +437,9 @@ pub struct TextStyle {
 
     /// The number of lines to display before truncating the text
     pub line_clamp: Option<usize>,
+
+    /// The letter spacing of the text
+    pub letter_spacing: LetterSpacing,
 }
 
 impl Default for TextStyle {
@@ -458,6 +461,7 @@ impl Default for TextStyle {
             text_overflow: None,
             text_align: TextAlign::default(),
             line_clamp: None,
+            letter_spacing: LetterSpacing::default(),
         }
     }
 }
@@ -527,6 +531,7 @@ impl TextStyle {
             background_color: self.background_color,
             underline: self.underline,
             strikethrough: self.strikethrough,
+            letter_spacing: self.letter_spacing,
         }
     }
 }

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,9 +1,9 @@
 use crate::{
     self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CursorStyle,
     DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
-    FontWeight, GridPlacement, GridTemplate, Hsla, JustifyContent, Length, SharedString,
-    StrikethroughStyle, StyleRefinement, TemplateColumnMinSize, TextAlign, TextOverflow,
-    TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
+    FontWeight, GridPlacement, GridTemplate, Hsla, JustifyContent, Length, LetterSpacing,
+    SharedString, StrikethroughStyle, StyleRefinement, TemplateColumnMinSize, TextAlign,
+    TextOverflow, TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
 };
 pub use gpui_macros::{
     border_style_methods, box_shadow_style_methods, cursor_style_methods, margin_style_methods,
@@ -138,6 +138,12 @@ pub trait Styled: Sized {
         let mut text_style = self.text_style();
         text_style.line_clamp = Some(lines);
         self.overflow_hidden()
+    }
+
+    /// Sets the letter spacing of the text.
+    fn letter_spacing(mut self, spacing: f32) -> Self {
+        self.text_style().letter_spacing = Some(LetterSpacing(spacing));
+        self
     }
 
     /// Sets the flex direction of the element to `column`.

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -215,6 +215,7 @@ impl TextSystem {
                 &[FontRun {
                     len: buffer.len(),
                     font_id,
+                    letter_spacing: LetterSpacing::default(),
                 }],
             )
             .width
@@ -310,15 +311,29 @@ impl TextSystem {
     }
 
     /// Returns a handle to a line wrapper, for the given font and font size.
-    pub fn line_wrapper(self: &Arc<Self>, font: Font, font_size: Pixels) -> LineWrapperHandle {
+    pub fn line_wrapper(
+        self: &Arc<Self>,
+        font: Font,
+        font_size: Pixels,
+        letter_spacing: LetterSpacing,
+    ) -> LineWrapperHandle {
         let lock = &mut self.wrapper_pool.lock();
         let font_id = self.resolve_font(&font);
         let wrappers = lock
-            .entry(FontIdWithSize { font_id, font_size })
+            .entry(FontIdWithSize {
+                font_id,
+                font_size,
+                letter_spacing,
+            })
             .or_default();
-        let wrapper = wrappers
-            .pop()
-            .unwrap_or_else(|| LineWrapper::new(font_id, font_size, self.clone()));
+        let wrapper = wrappers.pop().unwrap_or_else(|| {
+            LineWrapper::new(
+                font_id,
+                font_size,
+                letter_spacing,
+                self.platform_text_system.clone(),
+            )
+        });
 
         LineWrapperHandle {
             wrapper: Some(wrapper),
@@ -530,7 +545,8 @@ impl WindowTextSystem {
         let mut process_line = |line_text: SharedString, line_start, line_end| {
             font_runs.clear();
 
-            let mut decoration_runs = <Vec<DecorationRun>>::with_capacity(32);
+            let mut last_font: Option<(Font, LetterSpacing)> = None;
+            let mut decoration_runs = SmallVec::<[DecorationRun; 32]>::new();
             let mut run_start = line_start;
             while run_start < line_end {
                 let Some(run) = runs.peek_mut() else {
@@ -540,14 +556,24 @@ impl WindowTextSystem {
 
                 let run_len_within_line = cmp::min(line_end - run_start, run.len);
 
-                let decoration_changed = if let Some(last_run) = decoration_runs.last_mut()
-                    && last_run.color == run.color
-                    && last_run.underline == run.underline
-                    && last_run.strikethrough == run.strikethrough
-                    && last_run.background_color == run.background_color
-                {
-                    last_run.len += run_len_within_line as u32;
-                    false
+                if last_font == Some((run.font.clone(), run.letter_spacing)) {
+                    font_runs.last_mut().unwrap().len += run_len_within_line;
+                } else {
+                    last_font = Some((run.font.clone(), run.letter_spacing));
+                    font_runs.push(FontRun {
+                        len: run_len_within_line,
+                        font_id: self.resolve_font(&run.font),
+                        letter_spacing: run.letter_spacing,
+                    });
+                }
+
+                if decoration_runs.last().map_or(false, |last_run| {
+                    last_run.color == run.color
+                        && last_run.underline == run.underline
+                        && last_run.strikethrough == run.strikethrough
+                        && last_run.background_color == run.background_color
+                }) {
+                    decoration_runs.last_mut().unwrap().len += run_len_within_line as u32;
                 } else {
                     decoration_runs.push(DecorationRun {
                         len: run_len_within_line as u32,
@@ -555,20 +581,6 @@ impl WindowTextSystem {
                         background_color: run.background_color,
                         underline: run.underline,
                         strikethrough: run.strikethrough,
-                    });
-                    true
-                };
-
-                let font_id = self.resolve_font(&run.font);
-                if let Some(font_run) = font_runs.last_mut()
-                    && font_id == font_run.font_id
-                    && !decoration_changed
-                {
-                    font_run.len += run_len_within_line;
-                } else {
-                    font_runs.push(FontRun {
-                        len: run_len_within_line,
-                        font_id,
                     });
                 }
 
@@ -591,7 +603,7 @@ impl WindowTextSystem {
 
             lines.push(WrappedLine {
                 layout,
-                decoration_runs,
+                decoration_runs: decoration_runs.into_vec(),
                 text: line_text,
             });
 
@@ -655,36 +667,22 @@ impl WindowTextSystem {
         runs: &[TextRun],
         force_width: Option<Pixels>,
     ) -> Arc<LineLayout> {
-        let mut last_run = None::<&TextRun>;
         let mut font_runs = self.font_runs_pool.lock().pop().unwrap_or_default();
         font_runs.clear();
 
         for run in runs.iter() {
-            let decoration_changed = if let Some(last_run) = last_run
-                && last_run.color == run.color
-                && last_run.underline == run.underline
-                && last_run.strikethrough == run.strikethrough
-            // we do not consider differing background color relevant, as it does not affect glyphs
-            // && last_run.background_color == run.background_color
-            {
-                false
-            } else {
-                last_run = Some(run);
-                true
-            };
-
             let font_id = self.resolve_font(&run.font);
-            if let Some(font_run) = font_runs.last_mut()
-                && font_id == font_run.font_id
-                && !decoration_changed
-            {
-                font_run.len += run.len;
-            } else {
-                font_runs.push(FontRun {
-                    len: run.len,
-                    font_id,
-                });
+            if let Some(last_run) = font_runs.last_mut() {
+                if last_run.font_id == font_id && last_run.letter_spacing == run.letter_spacing {
+                    last_run.len += run.len;
+                    continue;
+                }
             }
+            font_runs.push(FontRun {
+                len: run.len,
+                font_id,
+                letter_spacing: run.letter_spacing,
+            });
         }
 
         let layout = self.line_layout_cache.layout_line(
@@ -715,36 +713,22 @@ impl WindowTextSystem {
         runs: &[TextRun],
         force_width: Option<Pixels>,
     ) -> Option<Arc<LineLayout>> {
-        let mut last_run = None::<&TextRun>;
         let mut font_runs = self.font_runs_pool.lock().pop().unwrap_or_default();
         font_runs.clear();
 
         for run in runs.iter() {
-            let decoration_changed = if let Some(last_run) = last_run
-                && last_run.color == run.color
-                && last_run.underline == run.underline
-                && last_run.strikethrough == run.strikethrough
-            // we do not consider differing background color relevant, as it does not affect glyphs
-            // && last_run.background_color == run.background_color
-            {
-                false
-            } else {
-                last_run = Some(run);
-                true
-            };
-
             let font_id = self.resolve_font(&run.font);
-            if let Some(font_run) = font_runs.last_mut()
-                && font_id == font_run.font_id
-                && !decoration_changed
-            {
-                font_run.len += run.len;
-            } else {
-                font_runs.push(FontRun {
-                    len: run.len,
-                    font_id,
-                });
+            if let Some(last_run) = font_runs.last_mut() {
+                if last_run.font_id == font_id && last_run.letter_spacing == run.letter_spacing {
+                    last_run.len += run.len;
+                    continue;
+                }
             }
+            font_runs.push(FontRun {
+                len: run.len,
+                font_id,
+                letter_spacing: run.letter_spacing,
+            });
         }
 
         let layout = self.line_layout_cache.try_layout_line_by_hash(
@@ -777,36 +761,22 @@ impl WindowTextSystem {
         force_width: Option<Pixels>,
         materialize_text: impl FnOnce() -> SharedString,
     ) -> Arc<LineLayout> {
-        let mut last_run = None::<&TextRun>;
         let mut font_runs = self.font_runs_pool.lock().pop().unwrap_or_default();
         font_runs.clear();
 
         for run in runs.iter() {
-            let decoration_changed = if let Some(last_run) = last_run
-                && last_run.color == run.color
-                && last_run.underline == run.underline
-                && last_run.strikethrough == run.strikethrough
-            // we do not consider differing background color relevant, as it does not affect glyphs
-            // && last_run.background_color == run.background_color
-            {
-                false
-            } else {
-                last_run = Some(run);
-                true
-            };
-
             let font_id = self.resolve_font(&run.font);
-            if let Some(font_run) = font_runs.last_mut()
-                && font_id == font_run.font_id
-                && !decoration_changed
-            {
-                font_run.len += run.len;
-            } else {
-                font_runs.push(FontRun {
-                    len: run.len,
-                    font_id,
-                });
+            if let Some(last_run) = font_runs.last_mut() {
+                if last_run.font_id == font_id && last_run.letter_spacing == run.letter_spacing {
+                    last_run.len += run.len;
+                    continue;
+                }
             }
+            font_runs.push(FontRun {
+                len: run.len,
+                font_id,
+                letter_spacing: run.letter_spacing,
+            });
         }
 
         let layout = self.line_layout_cache.layout_line_by_hash(
@@ -828,6 +798,7 @@ impl WindowTextSystem {
 struct FontIdWithSize {
     font_id: FontId,
     font_size: Pixels,
+    letter_spacing: LetterSpacing,
 }
 
 /// A handle into the text system, which can be used to compute the wrapped layout of text
@@ -844,6 +815,7 @@ impl Drop for LineWrapperHandle {
             .get_mut(&FontIdWithSize {
                 font_id: wrapper.font_id,
                 font_size: wrapper.font_size,
+                letter_spacing: wrapper.letter_spacing,
             })
             .unwrap()
             .push(wrapper);
@@ -966,13 +938,42 @@ impl Display for FontStyle {
     }
 }
 
-/// A styled run of text, for use in [`crate::TextLayout`].
+/// Letter spacing (in ems).
+#[derive(
+    Clone, Copy, Default, Debug, PartialEq, PartialOrd, Deserialize, Serialize, JsonSchema,
+)]
+pub struct LetterSpacing(pub f32);
+
+impl Hash for LetterSpacing {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u32(u32::from_be_bytes(self.0.to_be_bytes()));
+    }
+}
+
+impl Eq for LetterSpacing {}
+
+impl Display for LetterSpacing {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl LetterSpacing {
+    /// Converts the letter spacing (in ems) to pixels.
+    pub fn to_px(&self, font_size: Pixels) -> Pixels {
+        self.0 * font_size
+    }
+}
+
+/// A styled run of text, for use in [`TextLayout`].
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct TextRun {
     /// A number of utf8 bytes
     pub len: usize,
     /// The font to use for this run.
     pub font: Font,
+    /// The letter spacing to use for this run.
+    pub letter_spacing: LetterSpacing,
     /// The color
     pub color: Hsla,
     /// The background color (if any)

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -1,4 +1,7 @@
-use crate::{FontId, GlyphId, Pixels, PlatformTextSystem, Point, SharedString, Size, point, px};
+use crate::{
+    FontId, GlyphId, LetterSpacing, Pixels, PlatformTextSystem, Point, SharedString, Size, point,
+    px,
+};
 use collections::FxHashMap;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use smallvec::SmallVec;
@@ -815,6 +818,7 @@ fn apply_force_width_to_layout(layout: &mut LineLayout, force_width: Pixels) {
 pub struct FontRun {
     pub len: usize,
     pub font_id: FontId,
+    pub letter_spacing: LetterSpacing,
 }
 
 trait AsCacheKeyRef {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -1,4 +1,6 @@
-use crate::{FontId, Pixels, SharedString, TextRun, TextSystem, px};
+use crate::{
+    FontId, FontRun, LetterSpacing, Pixels, PlatformTextSystem, SharedString, TextRun, px,
+};
 use collections::HashMap;
 use std::{borrow::Cow, iter, sync::Arc};
 
@@ -13,9 +15,10 @@ pub enum TruncateFrom {
 
 /// The GPUI line wrapper, used to wrap lines of text to a given width.
 pub struct LineWrapper {
-    text_system: Arc<TextSystem>,
+    platform_text_system: Arc<dyn PlatformTextSystem>,
     pub(crate) font_id: FontId,
     pub(crate) font_size: Pixels,
+    pub(crate) letter_spacing: LetterSpacing,
     cached_ascii_char_widths: [Option<Pixels>; 128],
     cached_other_char_widths: HashMap<char, Pixels>,
 }
@@ -24,11 +27,17 @@ impl LineWrapper {
     /// The maximum indent that can be applied to a line.
     pub const MAX_INDENT: u32 = 256;
 
-    pub(crate) fn new(font_id: FontId, font_size: Pixels, text_system: Arc<TextSystem>) -> Self {
+    pub(crate) fn new(
+        font_id: FontId,
+        font_size: Pixels,
+        letter_spacing: LetterSpacing,
+        platform_text_system: Arc<dyn PlatformTextSystem>,
+    ) -> Self {
         Self {
-            text_system,
+            platform_text_system,
             font_id,
             font_size,
+            letter_spacing,
             cached_ascii_char_widths: [None; 128],
             cached_other_char_widths: HashMap::default(),
         }
@@ -254,21 +263,33 @@ impl LineWrapper {
             if let Some(cached_width) = self.cached_ascii_char_widths[c as usize] {
                 cached_width
             } else {
-                let width = self
-                    .text_system
-                    .layout_width(self.font_id, self.font_size, c);
+                let width = self.compute_width_for_char(c);
                 self.cached_ascii_char_widths[c as usize] = Some(width);
                 width
             }
         } else if let Some(cached_width) = self.cached_other_char_widths.get(&c) {
             *cached_width
         } else {
-            let width = self
-                .text_system
-                .layout_width(self.font_id, self.font_size, c);
+            let width = self.compute_width_for_char(c);
             self.cached_other_char_widths.insert(c, width);
             width
         }
+    }
+
+    fn compute_width_for_char(&self, c: char) -> Pixels {
+        let mut buffer = [0; 4];
+        let buffer = c.encode_utf8(&mut buffer);
+        self.platform_text_system
+            .layout_line(
+                buffer,
+                self.font_size,
+                &[FontRun {
+                    len: buffer.len(),
+                    font_id: self.font_id,
+                    letter_spacing: self.letter_spacing,
+                }],
+            )
+            .width
     }
 }
 
@@ -389,8 +410,14 @@ mod tests {
     fn build_wrapper() -> LineWrapper {
         let dispatcher = TestDispatcher::new(0);
         let cx = TestAppContext::build(dispatcher, None);
-        let id = cx.text_system().resolve_font(&font(".ZedMono"));
-        LineWrapper::new(id, px(16.), cx.text_system().clone())
+        let text_system = cx.text_system();
+        let id = text_system.font_id(&font("Zed Plex Mono")).unwrap();
+        LineWrapper::new(
+            id,
+            px(16.),
+            LetterSpacing::default(),
+            text_system.platform_text_system.clone(),
+        )
     }
 
     fn generate_test_runs(input_run_len: &[usize]) -> Vec<TextRun> {
@@ -405,7 +432,11 @@ mod tests {
                     weight: FontWeight::default(),
                     style: FontStyle::Normal,
                 },
-                ..Default::default()
+                letter_spacing: LetterSpacing::default(),
+                color: crate::Hsla::default(),
+                background_color: None,
+                underline: None,
+                strikethrough: None,
             })
             .collect()
     }
@@ -890,6 +921,7 @@ mod tests {
             let normal = TextRun {
                 len: 0,
                 font: font("Helvetica"),
+                letter_spacing: LetterSpacing::default(),
                 color: Default::default(),
                 underline: Default::default(),
                 ..Default::default()
@@ -897,7 +929,11 @@ mod tests {
             let bold = TextRun {
                 len: 0,
                 font: font("Helvetica").bold(),
-                ..Default::default()
+                letter_spacing: LetterSpacing::default(),
+                color: Default::default(),
+                underline: Default::default(),
+                strikethrough: None,
+                background_color: None,
             };
 
             let text = "aa bbb cccc ddddd eeee".into();

--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -6,7 +6,7 @@ use core_foundation::{
     attributed_string::CFMutableAttributedString,
     base::{CFRange, TCFType},
     number::CFNumber,
-    string::CFString,
+    string::{CFString, CFStringRef},
 };
 use core_graphics::{
     base::{CGGlyph, kCGImageAlphaPremultipliedLast},
@@ -52,6 +52,10 @@ use crate::open_type::apply_features_and_fallbacks;
 
 #[allow(non_upper_case_globals)]
 const kCGImageAlphaOnly: u32 = 7;
+
+unsafe extern "C" {
+    pub static kCTTrackingAttributeName: CFStringRef;
+}
 
 /// macOS text system using CoreText for font shaping.
 pub struct MacTextSystem(RwLock<MacTextSystemState>);
@@ -523,6 +527,7 @@ impl MacTextSystemState {
                 let length = utf16_end - utf16_start;
                 let cf_range = CFRange::init(utf16_start, length);
                 let font = &self.fonts[run.font_id.0];
+                let letter_spacing = CFNumber::from(f32::from(run.letter_spacing.to_px(font_size)));
 
                 let font_metrics = font.metrics();
                 let font_scale = f32::from(font_size) / font_metrics.units_per_em as f32;
@@ -540,6 +545,7 @@ impl MacTextSystemState {
                         kCTFontAttributeName,
                         &font.native_font().clone_with_font_size(font_size.into()),
                     );
+                    string.set_attribute(cf_range, kCTTrackingAttributeName, &letter_spacing);
                 }
                 break_ligature = !break_ligature;
             }
@@ -740,7 +746,7 @@ mod lenient_font_attributes {
 #[cfg(test)]
 mod tests {
     use crate::MacTextSystem;
-    use gpui::{FontRun, GlyphId, PlatformTextSystem, font, px};
+    use gpui::{FontRun, GlyphId, LetterSpacing, PlatformTextSystem, font, px};
 
     #[test]
     fn test_layout_line_bom_char() {
@@ -750,6 +756,7 @@ mod tests {
         let mut style = FontRun {
             font_id,
             len: line.len(),
+            letter_spacing: LetterSpacing::default(),
         };
 
         let layout = fonts.layout_line(line, px(16.), &[style]);
@@ -771,10 +778,12 @@ mod tests {
             FontRun {
                 len: "\u{feff}".len(),
                 font_id,
+                letter_spacing: LetterSpacing::default(),
             },
             FontRun {
                 len: "ab".len(),
                 font_id,
+                letter_spacing: LetterSpacing::default(),
             },
         ];
         let layout = fonts.layout_line(line, px(16.), font_runs);
@@ -793,8 +802,16 @@ mod tests {
 
         let text = "hello world";
         let font_runs = &[
-            FontRun { font_id, len: 5 }, // "hello"
-            FontRun { font_id, len: 6 }, // " world"
+            FontRun {
+                font_id,
+                len: 5,
+                letter_spacing: LetterSpacing::default(),
+            }, // "hello"
+            FontRun {
+                font_id,
+                len: 6,
+                letter_spacing: LetterSpacing::default(),
+            }, // " world"
         ];
 
         let layout = fonts.layout_line(text, px(16.), font_runs);
@@ -814,11 +831,16 @@ mod tests {
         // Test with different font runs - should not insert ZWNJ
         let font_id2 = fonts.font_id(&font("Times")).unwrap_or(font_id);
         let font_runs_different = &[
-            FontRun { font_id, len: 5 }, // "hello"
+            FontRun {
+                font_id,
+                len: 5,
+                letter_spacing: LetterSpacing::default(),
+            }, // "hello"
             // " world"
             FontRun {
                 font_id: font_id2,
                 len: 6,
+                letter_spacing: LetterSpacing::default(),
             },
         ];
 
@@ -843,15 +865,31 @@ mod tests {
         let font_id = fonts.font_id(&font("Helvetica")).unwrap();
 
         let text = "hello";
-        let font_runs = &[FontRun { font_id, len: 5 }];
+        let font_runs = &[FontRun {
+            font_id,
+            len: 5,
+            letter_spacing: LetterSpacing::default(),
+        }];
         let layout = fonts.layout_line(text, px(16.), font_runs);
         assert_eq!(layout.len, text.len());
 
         let text = "abc";
         let font_runs = &[
-            FontRun { font_id, len: 1 }, // "a"
-            FontRun { font_id, len: 1 }, // "b"
-            FontRun { font_id, len: 1 }, // "c"
+            FontRun {
+                font_id,
+                len: 1,
+                letter_spacing: LetterSpacing::default(),
+            }, // "a"
+            FontRun {
+                font_id,
+                len: 1,
+                letter_spacing: LetterSpacing::default(),
+            }, // "b"
+            FontRun {
+                font_id,
+                len: 1,
+                letter_spacing: LetterSpacing::default(),
+            }, // "c"
         ];
         let layout = fonts.layout_line(text, px(16.), font_runs);
         assert_eq!(layout.len, text.len());

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -428,6 +428,7 @@ impl CosmicTextSystemState {
                     .stretch(face.stretch)
                     .style(face.style)
                     .weight(face.weight)
+                    .letter_spacing(run.letter_spacing.0)
                     .font_features(loaded_font.features.clone()),
             );
             offs += run.len;

--- a/crates/repl/src/outputs/table.rs
+++ b/crates/repl/src/outputs/table.rs
@@ -100,6 +100,7 @@ impl TableView {
         let mut runs = [TextRun {
             len: 0,
             font: text_font,
+            letter_spacing: text_style.letter_spacing,
             color: text_style.color,
             ..Default::default()
         }];

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -973,6 +973,7 @@ impl VsCodeSettings {
             buffer_font_size: self.read_f32("editor.fontSize").map(FontSize::from),
             buffer_font_weight: self.read_f32("editor.fontWeight").map(FontWeightContent),
             buffer_line_height: None,
+            buffer_letter_spacing: None,
             buffer_font_features: None,
             agent_ui_font_size: None,
             agent_buffer_font_size: None,

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -142,6 +142,9 @@ pub struct ThemeSettingsContent {
     pub buffer_font_weight: Option<FontWeightContent>,
     /// The buffer's line height.
     pub buffer_line_height: Option<BufferLineHeight>,
+    /// The buffer's letter spacing, in ems.
+    #[schemars(default = "default_buffer_letter_spacing")]
+    pub buffer_letter_spacing: Option<f32>,
     /// The OpenType features to enable for rendering in text buffers.
     #[schemars(default = "default_font_features")]
     pub buffer_font_features: Option<FontFeaturesContent>,
@@ -248,6 +251,10 @@ fn default_font_fallbacks() -> Option<Vec<FontFamilyName>> {
 
 fn default_buffer_font_weight() -> Option<FontWeightContent> {
     Some(FontWeightContent::NORMAL)
+}
+
+fn default_buffer_letter_spacing() -> Option<f32> {
+    Some(0.0)
 }
 
 /// Represents the selection of a theme, which can be either static or dynamic.

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -3,10 +3,10 @@ use gpui::{
     AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, ContentMask, Context, DispatchPhase,
     Element, ElementId, Entity, FocusHandle, Font, FontFeatures, FontStyle, FontWeight,
     GlobalElementId, HighlightStyle, Hitbox, Hsla, InputHandler, InteractiveElement, Interactivity,
-    IntoElement, LayoutId, Length, ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels,
-    Point, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun, TextStyle,
-    UTF16Selection, UnderlineStyle, WeakEntity, WhiteSpace, Window, div, fill, point, px, relative,
-    size,
+    IntoElement, LayoutId, Length, LetterSpacing, ModifiersChangedEvent, MouseButton,
+    MouseMoveEvent, Pixels, Point, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun,
+    TextStyle, UTF16Selection, UnderlineStyle, WeakEntity, WhiteSpace, Window, div, fill, point,
+    px, relative, size,
 };
 use itertools::Itertools;
 use language::CursorShape;
@@ -615,6 +615,7 @@ impl TerminalElement {
             },
             underline,
             strikethrough,
+            letter_spacing: LetterSpacing::default(),
         };
 
         if let Some((style, range)) = hyperlink
@@ -1207,6 +1208,25 @@ impl Element for TerminalElement {
                 let cursor = if let AlacCursorShape::Hidden = cursor.shape {
                     None
                 } else {
+                    let cursor_text = {
+                        let str_trxt = cursor_char.to_string();
+                        let len = str_trxt.len();
+                        window.text_system().shape_line(
+                            str_trxt.into(),
+                            text_style.font_size.to_pixels(window.rem_size()),
+                            &[TextRun {
+                                len,
+                                font: text_style.font(),
+                                letter_spacing: text_style.letter_spacing,
+                                color: theme.colors().terminal_ansi_background,
+                                background_color: None,
+                                underline: Default::default(),
+                                strikethrough: None,
+                            }],
+                            None,
+                        )
+                    };
+
                     let focused = self.focused;
                     ime_cursor_bounds.map(move |bounds| {
                         let (shape, text) = match cursor.shape {

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -4,8 +4,8 @@ use crate::schema::{status_colors_refinement, syntax_overrides, theme_colors_ref
 use crate::{merge_accent_colors, merge_player_colors};
 use collections::HashMap;
 use gpui::{
-    App, Context, Font, FontFallbacks, FontStyle, Global, Pixels, SharedString, Subscription,
-    Window, px,
+    App, Context, Font, FontFallbacks, FontStyle, Global, LetterSpacing, Pixels, SharedString,
+    Subscription, Window, px,
 };
 use refineable::Refineable;
 use schemars::JsonSchema;
@@ -68,6 +68,8 @@ pub struct ThemeSettings {
     ///
     /// The terminal font family can be overridden using it's own setting.
     pub buffer_line_height: BufferLineHeight,
+    /// The letter spacing for buffers, in ems.
+    pub buffer_letter_spacing: LetterSpacing,
     /// The current theme selection.
     pub theme: ThemeSelection,
     /// Manual overrides for the active theme.
@@ -645,6 +647,7 @@ impl settings::Settings for ThemeSettings {
             },
             buffer_font_size: clamp_font_size(content.buffer_font_size.unwrap().into_gpui()),
             buffer_line_height: content.buffer_line_height.unwrap().into(),
+            buffer_letter_spacing: LetterSpacing(content.buffer_letter_spacing.unwrap_or(0.0)),
             agent_ui_font_size: content.agent_ui_font_size.map(|s| s.into_gpui()),
             agent_buffer_font_size: content.agent_buffer_font_size.map(|s| s.into_gpui()),
             markdown_preview_font_family: content

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1131,6 +1131,7 @@ impl Vim {
                 background_color: None,
                 underline: None,
                 strikethrough: None,
+                letter_spacing: gpui::LetterSpacing::default(),
             };
 
             text_system.layout_line(text, font_size, &[run], None).width


### PR DESCRIPTION
Adds configurable letter spacing for editor buffers via a new `buffer_letter_spacing` setting, bringing Zed closer to parity with other editors (for example VS Code’s `editor.letterSpacing`).

<img width="1358" height="974" alt="image" src="https://github.com/user-attachments/assets/7404537c-efa4-4440-bc7d-bf9f87b3fc99" />

This builds on the earlier work by @rjeli in #29105. That PR was approved but ultimately closed after going stale without a rebase; this PR revives and extends the effort on current code.

- New setting `buffer_letter_spacing` (f32, in ems relative to `buffer_font_size`). Positive and negative values are both supported. Default `0.0`.
- New `LetterSpacing` type in GPUI threaded through the text layout, shaping, and platform backends.

Then the line wrapper in crates/gpui/src/text_system/line_wrapper.rs. This is the part most worth scrutinizing - it's where wrap decisions are made, so any drift between "width used to wrap" and "width used to render" would show up as misaligned cursors or wrong soft-wraps. 
The change adds letter_spacing to the wrapper's state and folds it into per-grapheme advance. Worth checking: that the same advance calculation is used both for wrap-point detection and for the layout that ends up on screen.

In wrap_map.rs, the font_with_size tuple now carries letter_spacing alongside font and size, and set_font_with_size triggers a full rewrap when it changes - same code path as a font-size change.

Settings surface is the smallest piece: a new optional f32 in ThemeSettingsContent, a default of 0.0, and a VS Code import mapping.

Things I'd specifically like a second pair of eyes on:

1. The LineWrapper advance accounting - easy to be off by one grapheme.
2. Whether LetterSpacing belongs in TextStyle or should live on Font (I went with TextStyle because it's a layout concern, not a font identity concern, but I could be talked out of it).
3. MacOS and Windows behavior - I haven't been able to test it.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #10348 #16686 #7621 

Release Notes:

- Added `buffer_letter_spacing` setting to control character spacing in the editor buffer