### PR TITLE
Add automatic syntax highlighting for TopoJSON files

### DIFF
--- a/crates/grammars/src/json/config.toml
+++ b/crates/grammars/src/json/config.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 grammar = "json"
-path_suffixes = ["json", "flake.lock", "geojson", "prettierrc", "json.dist"]
+path_suffixes = ["json", "flake.lock", "geojson", "topojson", "prettierrc", "json.dist"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
TopoJSON is an extension of the geospatial data interchange format, GeoJSON. Although it is not as widely popular, it is frequently used in web maps, where its smaller file size is advantageous.

More information about TopoJSON can be found here: https://github.com/topojson/topojson-specification

This change adds `topojson` as a recognised path suffix, so TopoJSON files automatically open as JSON and get the standard JSON syntax highlighting.

This PR is similar to @flother’s PR for GeoJSON: https://github.com/zed-industries/zed/pull/49261

Closes (my own) discussion: https://github.com/zed-industries/zed/discussions/32963

PS: This is my first PR. I'd appreciate any feedback or suggestions for improvement

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release notes:

- Added automatic syntax highlighting for TopoJSON files
