### PR TITLE
Scope search filters to specific directories with glob patterns

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -3839,8 +3839,8 @@ pub mod tests {
                     search_view.included_files_editor.update(cx, |editor, cx| {
                         assert_eq!(
                             editor.display_text(cx),
-                            a_dir_entry.path.display(PathStyle::local()),
-                            "New search in directory should have included dir entry path"
+                            format!("{}/**", a_dir_entry.path.display(PathStyle::local())),
+                            "New search in directory should have included dir entry path with /** suffix"
                         );
                     });
                 });
@@ -3866,6 +3866,106 @@ pub mod tests {
                     .update(cx, |editor, cx| editor.display_text(cx)),
                 "\n\nconst ONE: usize = 1;\n\n\nconst TWO: usize = one::ONE + one::ONE;",
                 "New search in directory should have a filter that matches a certain directory"
+            );
+                })
+            })
+            .unwrap();
+    }
+
+    #[perf]
+    #[gpui::test]
+    async fn test_new_project_search_in_directory_with_duplicate_folder_names(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                "src": {
+                    "main.rs": "const NEEDLE: usize = 1;",
+                },
+                "node_modules": {
+                    "some-pkg": {
+                        "src": {
+                            "index.js": "const NEEDLE = 1;",
+                        },
+                    },
+                },
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = window
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window.into(), cx);
+        let search_bar = window.build_entity(cx, |_, _| ProjectSearchBar::new());
+
+        workspace.update_in(cx, move |workspace, window, cx| {
+            workspace.panes()[0].update(cx, move |pane, cx| {
+                pane.toolbar()
+                    .update(cx, |toolbar, cx| toolbar.add_item(search_bar, window, cx))
+            });
+        });
+
+        let src_dir_entry = cx.update(|_, cx| {
+            workspace
+                .read(cx)
+                .project()
+                .read(cx)
+                .entry_for_path(&(worktree_id, rel_path("src")).into(), cx)
+                .expect("no entry for /src/ directory")
+                .clone()
+        });
+        assert!(src_dir_entry.is_dir());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            ProjectSearchView::new_search_in_directory(workspace, &src_dir_entry.path, window, cx)
+        });
+
+        let Some(search_view) = cx.read(|cx| {
+            workspace
+                .read(cx)
+                .active_pane()
+                .read(cx)
+                .active_item()
+                .and_then(|item| item.downcast::<ProjectSearchView>())
+        }) else {
+            panic!("Search view expected to appear after new search in directory event trigger")
+        };
+
+        cx.background_executor.run_until_parked();
+        window
+            .update(cx, |_, window, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    search_view.query_editor.update(cx, |query_editor, cx| {
+                        query_editor.set_text("NEEDLE", window, cx)
+                    });
+                    search_view.search(cx);
+                });
+            })
+            .unwrap();
+
+        cx.background_executor.run_until_parked();
+        window
+            .update(cx, |_, _, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    let results = search_view
+                        .results_editor
+                        .update(cx, |editor, cx| editor.display_text(cx));
+                    assert!(
+                        results.contains("const NEEDLE: usize = 1;"),
+                        "Should find match in top-level src/"
+                    );
+                    assert!(
+                        !results.contains("const NEEDLE = 1;"),
+                        "Should NOT find match in node_modules/.../src/ — only the selected src/ folder should be searched"
                     );
                 })
             })

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1077,7 +1077,13 @@ impl ProjectSearchView {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
-        let filter_str = dir_path.display(workspace.path_style(cx));
+        let filter_str = if dir_path.is_empty() {
+            dir_path.display(workspace.path_style(cx))
+        } else {
+            // Append /** so the filter is anchored to this exact directory and doesn't
+            // match same-named directories elsewhere in the tree (e.g. node_modules/.../src).
+            format!("{}/**", dir_path.display(workspace.path_style(cx))).into()
+        };
 
         let weak_workspace = cx.entity().downgrade();
 
@@ -3860,7 +3866,7 @@ pub mod tests {
                     .update(cx, |editor, cx| editor.display_text(cx)),
                 "\n\nconst ONE: usize = 1;\n\n\nconst TWO: usize = one::ONE + one::ONE;",
                 "New search in directory should have a filter that matches a certain directory"
-            );
+                    );
                 })
             })
             .unwrap();


### PR DESCRIPTION
**context:**
When using "Find in Folder" in a single-worktree workspace, the include filter was set to a bare folder name (e.g. src). This caused the search to match any directory with that name anywhere in the project tree(eg node_modules/.../src/) because the path matcher's ends_with check would match ancestor directories with the same name when walking up the file tree.
<img width="888" height="524" alt="Image" src="https://github.com/user-attachments/assets/20bd078e-d678-4086-a6b9-308199a134ad" />

**the fix**
Appending  /** to the filter path, anchors it to the exact selected directory so only files under that specific folder are included.
and also added the tests.
<img width="941" height="448" alt="image" src="https://github.com/user-attachments/assets/24876887-4019-4df8-a3f0-be2cd1a473af" />




Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #53495.

Release Notes:

- Fixed "Find in Folder" incorrectly including results from directories with the same name elsewhere in the project (e.g. node_modules/.../src when searching src/)