### PR TITLE
Fix auto update status not being shown in the title bar

### DIFF
--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -84,11 +84,11 @@ impl Render for UpdateVersion {
             AutoUpdateStatus::Checking if self.update_check_type.is_manual() => {
                 UpdateButton::checking().into_any_element()
             }
-            AutoUpdateStatus::Downloading { version } if self.update_check_type.is_manual() => {
+            AutoUpdateStatus::Downloading { version } => {
                 let tooltip = Self::version_tooltip_message(&version);
                 UpdateButton::downloading(tooltip).into_any_element()
             }
-            AutoUpdateStatus::Installing { version } if self.update_check_type.is_manual() => {
+            AutoUpdateStatus::Installing { version } => {
                 let tooltip = Self::version_tooltip_message(&version);
                 UpdateButton::installing(tooltip).into_any_element()
             }
@@ -116,10 +116,7 @@ impl Render for UpdateVersion {
                     }))
                     .into_any_element()
             }
-            AutoUpdateStatus::Idle
-            | AutoUpdateStatus::Checking { .. }
-            | AutoUpdateStatus::Downloading { .. }
-            | AutoUpdateStatus::Installing { .. } => Empty.into_any_element(),
+            AutoUpdateStatus::Idle | AutoUpdateStatus::Checking { .. } => Empty.into_any_element(),
         }
     }
 }


### PR DESCRIPTION
Fixes a UI regression introduced in https://github.com/zed-industries/zed/pull/48467, which prevented automatic update statuses from being shown in the title bar unless the update was checked for manually by the user, causing some users to unknowingly cancel updates in progress by closing the application, since there was no indication.

https://github.com/user-attachments/assets/ea16a600-3db4-49dc-bca5-11c8fcfff619

Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes https://github.com/zed-industries/zed/issues/50162

Release Notes:

- Fixed missing indication that an update was currently being downloaded or installed in the title bar
