### PR TITLE
mistral: Fix tools calls

### DIFF
--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -652,6 +652,7 @@ impl MistralEventMapper {
 
                 if let Some(tool_id) = tool_call.id.clone()
                     && !tool_id.is_empty()
+                    && tool_id != "null"
                 {
                     entry.id = tool_id;
                 }


### PR DESCRIPTION
When using streaming tool calls, Mistral sometimes provides a "null" tool id in some chunks (that is the string "null", not the null value). This would override the real tool id and Mistral would error on subsequent messages with "Tool call id has to be defined in serving mode".

Example response from Mistral:

    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"WcG8xhSs1","function":{"name":"read_file","arguments":""},"index":0}]},"finish_reason":null}],"p":"abcdefghijklmno"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"","arguments":"{\""},"index":0}]},"finish_reason":null}],"p":"abcdefghijklmnopqrstuvwxyz01234567"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"name":"","arguments":"path"},"index":0}]},"finish_reason":null}],"p":"abcdefghijkl"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"null","function":{"name":"","arguments":"\": \"cr"},"index":0}]},"finish_reason":null}],"p":"abcdef"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"null","function":{"name":"","arguments":"ates/language_models"},"index":0}]},"finish_reason":null}],"p":"abc"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"null","function":{"name":"","arguments":"/src/provider/mist"},"index":0}]},"finish_reason":null}],"p":"abcdefghijklmnopqrstuvwxyz012345678"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"tool_calls":[{"id":"null","function":{"name":"","arguments":"ral.rs\"}"},"index":0}]},"finish_reason":null}],"p":"abcdefghijklmnopqrstuvwxyz012"}
    data: {"id":"a7c258430bcb18fdacd3bbd773efb9f1","object":"chat.completion.chunk","created":1775811362,"model":"devstral-medium-latest","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":7530,"total_tokens":7551,"completion_tokens":21,"prompt_tokens_details":{"cached_tokens":0}},"p":"abcdefghijklmnopqrstuvwxyz01234"}
    data: [DONE]

This patch fixes the issue by ignoring any "null" tool id.

Closes #53034

Release Notes:

- Fix tool calls for Mistral AI