### PR TITLE
git: Fix spurious file creation when staging

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1462,7 +1462,7 @@ impl GitRepository for RealGitRepository {
                     log::debug!("indexing SHA: {sha}, path {path:?}");
 
                     let output = git
-                        .build_command(&["update-index", "--add", "--cacheinfo", mode, sha, "--"])
+                        .build_command(&["update-index", "--add", "--cacheinfo", mode, sha])
                         .envs(env.iter())
                         .arg(path.as_unix_str())
                         .output()


### PR DESCRIPTION
Related to https://github.com/zed-industries/zed/pull/53484. 

This PR fixes a `--` file being created when staging a hunk.

Release Notes:

- N/A
