### PR TITLE
Cherry-pick agent fixes to v0.232.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16092,6 +16092,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "telemetry",
  "theme",
  "theme_settings",
  "ui",

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -36,6 +36,18 @@ use util::path_list::PathList;
 use util::{ResultExt, get_default_system_shell_preferring_bash, paths::PathStyle};
 use uuid::Uuid;
 
+/// Returned when the model stops because it exhausted its output token budget.
+#[derive(Debug)]
+pub struct MaxOutputTokensError;
+
+impl std::fmt::Display for MaxOutputTokensError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "output token limit reached")
+    }
+}
+
+impl std::error::Error for MaxOutputTokensError {}
+
 /// Key used in ACP ToolCall meta to store the tool's programmatic name.
 /// This is a workaround since ACP's ToolCall doesn't have a dedicated name field.
 pub const TOOL_NAME_META_KEY: &str = "tool_name";
@@ -2262,17 +2274,15 @@ impl AcpThread {
                                         .is_some_and(|max| u.output_tokens >= max)
                                 });
 
-                            let message = if exceeded_max_output_tokens {
+                            if exceeded_max_output_tokens {
                                 log::error!(
                                     "Max output tokens reached. Usage: {:?}",
                                     this.token_usage
                                 );
-                                "Maximum output tokens reached"
                             } else {
                                 log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
-                                "Maximum tokens reached"
-                            };
-                            return Err(anyhow!(message));
+                            }
+                            return Err(anyhow!(MaxOutputTokensError));
                         }
 
                         let canceled = matches!(r.stop_reason, acp::StopReason::Cancelled);

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -64,6 +64,18 @@ const TOOL_CANCELED_MESSAGE: &str = "Tool canceled by user";
 pub const MAX_TOOL_NAME_LENGTH: usize = 64;
 pub const MAX_SUBAGENT_DEPTH: u8 = 1;
 
+/// Returned when a turn is attempted but no language model has been selected.
+#[derive(Debug)]
+pub struct NoModelConfiguredError;
+
+impl std::fmt::Display for NoModelConfiguredError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "no language model configured")
+    }
+}
+
+impl std::error::Error for NoModelConfiguredError {}
+
 /// Context passed to a subagent thread for lifecycle management
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubagentContext {
@@ -1768,7 +1780,9 @@ impl Thread {
         &mut self,
         cx: &mut Context<Self>,
     ) -> Result<mpsc::UnboundedReceiver<Result<ThreadEvent>>> {
-        let model = self.model().context("No language model configured")?;
+        let model = self
+            .model()
+            .ok_or_else(|| anyhow!(NoModelConfiguredError))?;
 
         log::info!("Thread::send called with model: {}", model.name().0);
         self.advance_prompt_id();
@@ -1892,7 +1906,10 @@ impl Thread {
             // mid-turn changes (e.g. the user switches model, toggles tools,
             // or changes profile) take effect between tool-call rounds.
             let (model, request) = this.update(cx, |this, cx| {
-                let model = this.model.clone().context("No language model configured")?;
+                let model = this
+                    .model
+                    .clone()
+                    .ok_or_else(|| anyhow!(NoModelConfiguredError))?;
                 this.refresh_turn_tools(cx);
                 let request = this.build_completion_request(intent, cx)?;
                 anyhow::Ok((model, request))
@@ -2738,7 +2755,9 @@ impl Thread {
                 completion_intent
             };
 
-        let model = self.model().context("No language model configured")?;
+        let model = self
+            .model()
+            .ok_or_else(|| anyhow!(NoModelConfiguredError))?;
         let tools = if let Some(turn) = self.running_turn.as_ref() {
             turn.tools
                 .iter()

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1304,6 +1304,34 @@ impl AgentPanel {
     }
 
     pub fn new_thread(&mut self, _action: &NewThread, window: &mut Window, cx: &mut Context<Self>) {
+        use settings::{NewThreadLocation, Settings};
+        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
+            NewThreadLocation::LocalProject => "current_worktree",
+            NewThreadLocation::NewWorktree => "new_worktree",
+        };
+        telemetry::event!(
+            "New Thread Clicked",
+            source = "agent_panel",
+            thread_location = thread_location
+        );
+        self.do_new_thread(window, cx);
+    }
+
+    pub fn new_thread_from_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        use settings::{NewThreadLocation, Settings};
+        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
+            NewThreadLocation::LocalProject => "current_worktree",
+            NewThreadLocation::NewWorktree => "new_worktree",
+        };
+        telemetry::event!(
+            "New Thread Clicked",
+            source = "sidebar",
+            thread_location = thread_location
+        );
+        self.do_new_thread(window, cx);
+    }
+
+    fn do_new_thread(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.reset_start_thread_in_to_default(cx);
         let initial_content = self.take_active_draft_initial_content(cx);
         self.external_thread(None, None, None, None, initial_content, true, window, cx);

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3768,7 +3768,16 @@ impl AgentPanel {
             let agent_server_store = agent_server_store;
 
             Rc::new(move |window, cx| {
-                telemetry::event!("New Thread Clicked");
+                use settings::{NewThreadLocation, Settings};
+                let thread_location = match AgentSettings::get_global(cx).new_thread_location {
+                    NewThreadLocation::LocalProject => "current_worktree",
+                    NewThreadLocation::NewWorktree => "new_worktree",
+                };
+                telemetry::event!(
+                    "New Thread Clicked",
+                    source = "agent_panel",
+                    thread_location = thread_location
+                );
 
                 let active_thread = active_thread.clone();
                 Some(ContextMenu::build(window, cx, |menu, _window, cx| {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2760,6 +2760,8 @@ impl AgentPanel {
     fn start_worktree_creations(
         git_repos: &[Entity<project::git_store::Repository>],
         worktree_name: Option<String>,
+        existing_worktree_names: &[String],
+        existing_worktree_paths: &HashSet<PathBuf>,
         branch_name: &str,
         use_existing_branch: bool,
         start_point: Option<String>,
@@ -2776,12 +2778,21 @@ impl AgentPanel {
         let mut creation_infos = Vec::new();
         let mut path_remapping = Vec::new();
 
-        let worktree_name = worktree_name.unwrap_or_else(|| branch_name.to_string());
+        let worktree_name = worktree_name.unwrap_or_else(|| {
+            let existing_refs: Vec<&str> =
+                existing_worktree_names.iter().map(|s| s.as_str()).collect();
+            let mut rng = rand::rng();
+            crate::branch_names::generate_branch_name(&existing_refs, &mut rng)
+                .unwrap_or_else(|| branch_name.to_string())
+        });
 
         for repo in git_repos {
             let (work_dir, new_path, receiver) = repo.update(cx, |repo, _cx| {
                 let new_path =
                     repo.path_for_new_linked_worktree(&worktree_name, worktree_directory_setting)?;
+                if existing_worktree_paths.contains(&new_path) {
+                    anyhow::bail!("A worktree already exists at {}", new_path.display());
+                }
                 let target = if use_existing_branch {
                     debug_assert!(
                         git_repos.len() == 1,
@@ -2846,7 +2857,8 @@ impl AgentPanel {
             return Ok(created_paths);
         };
 
-        // Rollback all successfully created worktrees
+        // Rollback all attempted worktrees (both successful and failed,
+        // since a failed creation may have left an orphan directory).
         let mut rollback_receivers = Vec::new();
         for (rollback_repo, rollback_path) in &repos_and_paths {
             if let Ok(receiver) = cx.update(|_, cx| {
@@ -2999,6 +3011,8 @@ impl AgentPanel {
                     }
 
                     let mut occupied_branches = HashSet::default();
+                    let mut existing_worktree_names = Vec::new();
+                    let mut existing_worktree_paths = HashSet::default();
                     for result in futures::future::join_all(worktree_receivers).await {
                         match result {
                             Ok(Ok(worktrees)) => {
@@ -3006,6 +3020,15 @@ impl AgentPanel {
                                     if let Some(branch_name) = worktree.branch_name() {
                                         occupied_branches.insert(branch_name.to_string());
                                     }
+                                    if let Some(name) = worktree
+                                        .path
+                                        .parent()
+                                        .and_then(|p| p.file_name())
+                                        .and_then(|n| n.to_str())
+                                    {
+                                        existing_worktree_names.push(name.to_string());
+                                    }
+                                    existing_worktree_paths.insert(worktree.path.clone());
                                 }
                             }
                             Ok(Err(err)) => {
@@ -3039,6 +3062,8 @@ impl AgentPanel {
                             Self::start_worktree_creations(
                                 &git_repos,
                                 worktree_name,
+                                &existing_worktree_names,
+                                &existing_worktree_paths,
                                 &branch_name,
                                 use_existing_branch,
                                 start_point,
@@ -6112,6 +6137,151 @@ mod tests {
         assert_ne!(resolved.0, "main");
         assert!(existing_branches.contains("main"));
         assert!(!existing_branches.contains(&resolved.0));
+    }
+
+    #[gpui::test]
+    async fn test_worktree_dir_name_is_random_when_using_existing_branch(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let app_state = cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+
+            let app_state = workspace::AppState::test(cx);
+            workspace::init(app_state.clone(), cx);
+            app_state
+        });
+
+        let fs = app_state.fs.as_fake();
+        fs.insert_tree(
+            "/project",
+            json!({
+                ".git": {},
+                "src": {
+                    "main.rs": "fn main() {}"
+                }
+            }),
+        )
+        .await;
+        // Put the main worktree on "develop" so that "main" is NOT
+        // occupied by any worktree.
+        fs.set_branch_name(Path::new("/project/.git"), Some("develop"));
+        fs.insert_branches(Path::new("/project/.git"), &["main", "develop"]);
+
+        let project = Project::test(app_state.fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        multi_workspace
+            .update(cx, |multi_workspace, _, cx| {
+                multi_workspace.open_sidebar(cx);
+            })
+            .unwrap();
+
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+
+        cx.update(|cx| {
+            cx.observe_new(
+                |workspace: &mut Workspace,
+                 window: Option<&mut Window>,
+                 cx: &mut Context<Workspace>| {
+                    if let Some(window) = window {
+                        let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+                        workspace.add_panel(panel, window, cx);
+                    }
+                },
+            )
+            .detach();
+        });
+
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+        cx.run_until_parked();
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        cx.run_until_parked();
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.open_external_thread_with_server(
+                Rc::new(StubAgentServer::default_response()),
+                window,
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        // Select "main" as an existing branch — this should NOT make the
+        // worktree directory named "main"; it should get a random name.
+        let content = vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "Hello from test",
+        ))];
+        panel.update_in(cx, |panel, window, cx| {
+            panel.handle_worktree_requested(
+                content,
+                WorktreeCreationArgs::New {
+                    worktree_name: None,
+                    branch_target: NewWorktreeBranchTarget::ExistingBranch {
+                        name: "main".to_string(),
+                    },
+                },
+                window,
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        // Find the new workspace and check its worktree path.
+        let new_worktree_path = multi_workspace
+            .read_with(cx, |multi_workspace, cx| {
+                let new_workspace = multi_workspace
+                    .workspaces()
+                    .find(|ws| ws.entity_id() != workspace.entity_id())
+                    .expect("a new workspace should have been created");
+
+                let new_project = new_workspace.read(cx).project().clone();
+                let worktree = new_project
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .next()
+                    .expect("new workspace should have a worktree");
+                worktree.read(cx).abs_path().to_path_buf()
+            })
+            .unwrap();
+
+        // The worktree directory path should contain a random adjective-noun
+        // name, NOT the branch name "main".
+        let path_str = new_worktree_path.to_string_lossy();
+        assert!(
+            !path_str.contains("/main/"),
+            "worktree directory should use a random name, not the branch name. \
+             Got path: {path_str}",
+        );
+        // Verify it looks like an adjective-noun pair (contains a hyphen in
+        // the directory component above the project name).
+        let parent = new_worktree_path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .expect("should have a parent directory name");
+        assert!(
+            parent.contains('-'),
+            "worktree parent directory should be an adjective-noun pair (e.g. 'swift-falcon'), \
+             got: {parent}",
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -214,6 +214,7 @@ pub fn init(cx: &mut App) {
                                 None,
                                 initial_content,
                                 true,
+                                "agent_panel",
                                 window,
                                 cx,
                             )
@@ -351,6 +352,7 @@ pub fn init(cx: &mut App) {
                                 auto_submit: true,
                             }),
                             true,
+                            "agent_panel",
                             window,
                             cx,
                         );
@@ -377,6 +379,7 @@ pub fn init(cx: &mut App) {
                                     auto_submit: true,
                                 }),
                                 true,
+                                "agent_panel",
                                 window,
                                 cx,
                             );
@@ -405,6 +408,7 @@ pub fn init(cx: &mut App) {
                                     auto_submit: true,
                                 }),
                                 true,
+                                "agent_panel",
                                 window,
                                 cx,
                             );
@@ -1269,6 +1273,7 @@ impl AgentPanel {
             title,
             None,
             true,
+            "agent_panel",
             window,
             cx,
         );
@@ -1304,27 +1309,27 @@ impl AgentPanel {
     }
 
     pub fn new_thread(&mut self, _action: &NewThread, window: &mut Window, cx: &mut Context<Self>) {
-        telemetry::event!(
-            "New Thread Clicked",
-            source = "agent_panel",
-            thread_location = thread_location_str(cx)
-        );
-        self.do_new_thread(window, cx);
+        self.do_new_thread("agent_panel", window, cx);
     }
 
     pub fn new_thread_from_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        telemetry::event!(
-            "New Thread Clicked",
-            source = "sidebar",
-            thread_location = thread_location_str(cx)
-        );
-        self.do_new_thread(window, cx);
+        self.do_new_thread("sidebar", window, cx);
     }
 
-    fn do_new_thread(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn do_new_thread(&mut self, source: &'static str, window: &mut Window, cx: &mut Context<Self>) {
         self.reset_start_thread_in_to_default(cx);
         let initial_content = self.take_active_draft_initial_content(cx);
-        self.external_thread(None, None, None, None, initial_content, true, window, cx);
+        self.external_thread(
+            None,
+            None,
+            None,
+            None,
+            initial_content,
+            true,
+            source,
+            window,
+            cx,
+        );
     }
 
     fn take_active_draft_initial_content(
@@ -1392,6 +1397,7 @@ impl AgentPanel {
                         title: thread.title,
                     }),
                     true,
+                    "agent_panel",
                     window,
                     cx,
                 );
@@ -1409,6 +1415,7 @@ impl AgentPanel {
         title: Option<SharedString>,
         initial_content: Option<AgentInitialContent>,
         focus: bool,
+        source: &'static str,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1436,6 +1443,7 @@ impl AgentPanel {
             project,
             agent,
             focus,
+            source,
             window,
             cx,
         );
@@ -2434,6 +2442,7 @@ impl AgentPanel {
             None,
             external_source_prompt.map(AgentInitialContent::from),
             true,
+            "agent_panel",
             window,
             cx,
         );
@@ -2459,6 +2468,7 @@ impl AgentPanel {
             None,
             initial_content,
             focus,
+            "agent_panel",
             window,
             cx,
         );
@@ -2520,6 +2530,7 @@ impl AgentPanel {
             title,
             None,
             focus,
+            "agent_panel",
             window,
             cx,
         );
@@ -2536,6 +2547,7 @@ impl AgentPanel {
         project: Entity<Project>,
         agent: Agent,
         focus: bool,
+        source: &'static str,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -2574,6 +2586,7 @@ impl AgentPanel {
                 project,
                 thread_store,
                 self.prompt_store.clone(),
+                source,
                 window,
                 cx,
             )
@@ -3266,6 +3279,7 @@ impl AgentPanel {
                             None,
                             Some(initial_content),
                             true,
+                            "agent_panel",
                             window,
                             cx,
                         );
@@ -3329,14 +3343,6 @@ fn agent_panel_side_str(cx: &App) -> &'static str {
     match agent_panel_dock_position(cx) {
         DockPosition::Left => "left",
         DockPosition::Right | DockPosition::Bottom => "right",
-    }
-}
-
-fn thread_location_str(cx: &App) -> &'static str {
-    use settings::{NewThreadLocation, Settings};
-    match AgentSettings::get_global(cx).new_thread_location {
-        NewThreadLocation::LocalProject => "current_worktree",
-        NewThreadLocation::NewWorktree => "new_worktree",
     }
 }
 
@@ -3801,12 +3807,6 @@ impl AgentPanel {
             let agent_server_store = agent_server_store;
 
             Rc::new(move |window, cx| {
-                telemetry::event!(
-                    "New Thread Clicked",
-                    source = "agent_panel",
-                    thread_location = thread_location_str(cx)
-                );
-
                 let active_thread = active_thread.clone();
                 Some(ContextMenu::build(window, cx, |menu, _window, cx| {
                     menu.context(focus_handle.clone())
@@ -4700,7 +4700,18 @@ impl AgentPanel {
         };
 
         self.create_agent_thread(
-            server, None, None, None, None, workspace, project, ext_agent, true, window, cx,
+            server,
+            None,
+            None,
+            None,
+            None,
+            workspace,
+            project,
+            ext_agent,
+            true,
+            "agent_panel",
+            window,
+            cx,
         );
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2247,6 +2247,16 @@ impl AgentPanel {
             }
         };
         self.start_thread_in = new_target;
+        let target = match &self.start_thread_in {
+            StartThreadIn::LocalProject => "current_worktree",
+            StartThreadIn::NewWorktree { .. } => "new_worktree",
+            StartThreadIn::LinkedWorktree { .. } => "linked_worktree",
+        };
+        telemetry::event!(
+            "Start Thread In Changed",
+            target = target,
+            side = agent_panel_side_str(cx)
+        );
         if let Some(thread) = self.active_thread_view(cx) {
             thread.update(cx, |thread, cx| thread.focus_handle(cx).focus(window, cx));
         }
@@ -3323,6 +3333,13 @@ impl Focusable for AgentPanel {
 
 fn agent_panel_dock_position(cx: &App) -> DockPosition {
     AgentSettings::get_global(cx).dock.into()
+}
+
+fn agent_panel_side_str(cx: &App) -> &'static str {
+    match agent_panel_dock_position(cx) {
+        DockPosition::Left => "left",
+        DockPosition::Right | DockPosition::Bottom => "right",
+    }
 }
 
 fn thread_location_str(cx: &App) -> &'static str {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2247,16 +2247,6 @@ impl AgentPanel {
             }
         };
         self.start_thread_in = new_target;
-        let target = match &self.start_thread_in {
-            StartThreadIn::LocalProject => "current_worktree",
-            StartThreadIn::NewWorktree { .. } => "new_worktree",
-            StartThreadIn::LinkedWorktree { .. } => "linked_worktree",
-        };
-        telemetry::event!(
-            "Start Thread In Changed",
-            target = target,
-            side = agent_panel_side_str(cx)
-        );
         if let Some(thread) = self.active_thread_view(cx) {
             thread.update(cx, |thread, cx| thread.focus_handle(cx).focus(window, cx));
         }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3335,6 +3335,11 @@ impl Panel for AgentPanel {
     }
 
     fn set_position(&mut self, position: DockPosition, _: &mut Window, cx: &mut Context<Self>) {
+        let side = match position {
+            DockPosition::Left => "left",
+            _ => "right",
+        };
+        telemetry::event!("Agent Panel Side Changed", side = side);
         settings::update_settings_file(self.fs.clone(), cx, move |settings, _| {
             settings
                 .agent

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1304,29 +1304,19 @@ impl AgentPanel {
     }
 
     pub fn new_thread(&mut self, _action: &NewThread, window: &mut Window, cx: &mut Context<Self>) {
-        use settings::{NewThreadLocation, Settings};
-        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
-            NewThreadLocation::LocalProject => "current_worktree",
-            NewThreadLocation::NewWorktree => "new_worktree",
-        };
         telemetry::event!(
             "New Thread Clicked",
             source = "agent_panel",
-            thread_location = thread_location
+            thread_location = thread_location_str(cx)
         );
         self.do_new_thread(window, cx);
     }
 
     pub fn new_thread_from_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        use settings::{NewThreadLocation, Settings};
-        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
-            NewThreadLocation::LocalProject => "current_worktree",
-            NewThreadLocation::NewWorktree => "new_worktree",
-        };
         telemetry::event!(
             "New Thread Clicked",
             source = "sidebar",
-            thread_location = thread_location
+            thread_location = thread_location_str(cx)
         );
         self.do_new_thread(window, cx);
     }
@@ -3335,6 +3325,14 @@ fn agent_panel_dock_position(cx: &App) -> DockPosition {
     AgentSettings::get_global(cx).dock.into()
 }
 
+fn thread_location_str(cx: &App) -> &'static str {
+    use settings::{NewThreadLocation, Settings};
+    match AgentSettings::get_global(cx).new_thread_location {
+        NewThreadLocation::LocalProject => "current_worktree",
+        NewThreadLocation::NewWorktree => "new_worktree",
+    }
+}
+
 pub enum AgentPanelEvent {
     ActiveViewChanged,
     ThreadFocused,
@@ -3365,7 +3363,7 @@ impl Panel for AgentPanel {
     fn set_position(&mut self, position: DockPosition, _: &mut Window, cx: &mut Context<Self>) {
         let side = match position {
             DockPosition::Left => "left",
-            _ => "right",
+            DockPosition::Right | DockPosition::Bottom => "right",
         };
         telemetry::event!("Agent Panel Side Changed", side = side);
         settings::update_settings_file(self.fs.clone(), cx, move |settings, _| {
@@ -3796,15 +3794,10 @@ impl AgentPanel {
             let agent_server_store = agent_server_store;
 
             Rc::new(move |window, cx| {
-                use settings::{NewThreadLocation, Settings};
-                let thread_location = match AgentSettings::get_global(cx).new_thread_location {
-                    NewThreadLocation::LocalProject => "current_worktree",
-                    NewThreadLocation::NewWorktree => "new_worktree",
-                };
                 telemetry::event!(
                     "New Thread Clicked",
                     source = "agent_panel",
-                    thread_location = thread_location
+                    thread_location = thread_location_str(cx)
                 );
 
                 let active_thread = active_thread.clone();

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3339,13 +3339,6 @@ fn agent_panel_dock_position(cx: &App) -> DockPosition {
     AgentSettings::get_global(cx).dock.into()
 }
 
-fn agent_panel_side_str(cx: &App) -> &'static str {
-    match agent_panel_dock_position(cx) {
-        DockPosition::Left => "left",
-        DockPosition::Right | DockPosition::Bottom => "right",
-    }
-}
-
 pub enum AgentPanelEvent {
     ActiveViewChanged,
     ThreadFocused,

--- a/crates/agent_ui/src/branch_names.rs
+++ b/crates/agent_ui/src/branch_names.rs
@@ -61,7 +61,7 @@ const NOUNS: &[&str] = &[
 pub fn generate_branch_name(existing_branches: &[&str], rng: &mut impl Rng) -> Option<String> {
     let existing: HashSet<&str> = existing_branches.iter().copied().collect();
 
-    for _ in 0..100 {
+    for _ in 0..10 {
         let adjective = ADJECTIVES[rng.random_range(0..ADJECTIVES.len())];
         let noun = NOUNS[rng.random_range(0..NOUNS.len())];
         let name = format!("{adjective}-{noun}");

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -659,6 +659,10 @@ impl ConversationView {
             settings::DockPosition::Left => "left",
             settings::DockPosition::Right | settings::DockPosition::Bottom => "right",
         };
+        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
+            settings::NewThreadLocation::LocalProject => "current_worktree",
+            settings::NewThreadLocation::NewWorktree => "new_worktree",
+        };
         let load_task = cx.spawn_in(window, async move |this, cx| {
             let (connection, history) = match connect_result.await {
                 Ok(AgentConnectedState {
@@ -678,7 +682,8 @@ impl ConversationView {
             telemetry::event!(
                 "Agent Thread Started",
                 agent = connection.telemetry_id(),
-                side = side
+                side = side,
+                thread_location = thread_location
             );
 
             let mut resumed_without_history = false;

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1,8 +1,9 @@
 use acp_thread::{
     AcpThread, AcpThreadEvent, AgentSessionInfo, AgentThreadEntry, AssistantMessage,
-    AssistantMessageChunk, AuthRequired, LoadError, MentionUri, PermissionOptionChoice,
-    PermissionOptions, PermissionPattern, RetryStatus, SelectedPermissionOutcome, ThreadStatus,
-    ToolCall, ToolCallContent, ToolCallStatus, UserMessageId,
+    AssistantMessageChunk, AuthRequired, LoadError, MaxOutputTokensError, MentionUri,
+    PermissionOptionChoice, PermissionOptions, PermissionPattern, RetryStatus,
+    SelectedPermissionOutcome, ThreadStatus, ToolCall, ToolCallContent, ToolCallStatus,
+    UserMessageId,
 };
 use acp_thread::{AgentConnection, Plan};
 use action_log::{ActionLog, ActionLogTelemetry, DiffStats};
@@ -126,6 +127,14 @@ pub(crate) enum ThreadError {
     StreamError {
         provider: SharedString,
     },
+    InvalidApiKey {
+        provider: SharedString,
+    },
+    PermissionDenied {
+        provider: SharedString,
+    },
+    RequestFailed,
+    MaxOutputTokens,
     Other {
         message: SharedString,
         acp_error_code: Option<SharedString>,
@@ -134,7 +143,9 @@ pub(crate) enum ThreadError {
 
 impl From<anyhow::Error> for ThreadError {
     fn from(error: anyhow::Error) -> Self {
-        if error.is::<language_model::PaymentRequiredError>() {
+        if error.is::<MaxOutputTokensError>() {
+            Self::MaxOutputTokens
+        } else if error.is::<language_model::PaymentRequiredError>() {
             Self::PaymentRequired
         } else if let Some(acp_error) = error.downcast_ref::<acp::Error>()
             && acp_error.code == acp::ErrorCode::AuthRequired
@@ -161,6 +172,13 @@ impl From<anyhow::Error> for ThreadError {
                 | HttpSend { provider, .. } => Self::StreamError {
                     provider: provider.to_string().into(),
                 },
+                AuthenticationError { provider, .. } => Self::InvalidApiKey {
+                    provider: provider.to_string().into(),
+                },
+                PermissionError { provider, .. } => Self::PermissionDenied {
+                    provider: provider.to_string().into(),
+                },
+                UpstreamProviderError { .. } => Self::RequestFailed,
                 _ => {
                     let message: SharedString = format!("{:#}", error).into();
                     Self::Other {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7,7 +7,9 @@ use acp_thread::{
 };
 use acp_thread::{AgentConnection, Plan};
 use action_log::{ActionLog, ActionLogTelemetry, DiffStats};
-use agent::{NativeAgentServer, NativeAgentSessionList, SharedThread, ThreadStore};
+use agent::{
+    NativeAgentServer, NativeAgentSessionList, NoModelConfiguredError, SharedThread, ThreadStore,
+};
 use agent_client_protocol as acp;
 #[cfg(test)]
 use agent_servers::AgentServerDelegate;
@@ -135,6 +137,10 @@ pub(crate) enum ThreadError {
     },
     RequestFailed,
     MaxOutputTokens,
+    NoModelSelected,
+    ApiError {
+        provider: SharedString,
+    },
     Other {
         message: SharedString,
         acp_error_code: Option<SharedString>,
@@ -145,6 +151,8 @@ impl From<anyhow::Error> for ThreadError {
     fn from(error: anyhow::Error) -> Self {
         if error.is::<MaxOutputTokensError>() {
             Self::MaxOutputTokens
+        } else if error.is::<NoModelConfiguredError>() {
+            Self::NoModelSelected
         } else if error.is::<language_model::PaymentRequiredError>() {
             Self::PaymentRequired
         } else if let Some(acp_error) = error.downcast_ref::<acp::Error>()
@@ -179,6 +187,11 @@ impl From<anyhow::Error> for ThreadError {
                     provider: provider.to_string().into(),
                 },
                 UpstreamProviderError { .. } => Self::RequestFailed,
+                BadRequestFormat { provider, .. }
+                | HttpResponseError { provider, .. }
+                | ApiEndpointNotFound { provider } => Self::ApiError {
+                    provider: provider.to_string().into(),
+                },
                 _ => {
                     let message: SharedString = format!("{:#}", error).into();
                     Self::Other {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -508,6 +508,7 @@ impl ConversationView {
         project: Entity<Project>,
         thread_store: Option<Entity<ThreadStore>>,
         prompt_store: Option<Entity<PromptStore>>,
+        source: &'static str,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -554,6 +555,7 @@ impl ConversationView {
                 title,
                 project,
                 initial_content,
+                source,
                 window,
                 cx,
             ),
@@ -597,6 +599,7 @@ impl ConversationView {
             title,
             self.project.clone(),
             None,
+            "agent_panel",
             window,
             cx,
         );
@@ -621,6 +624,7 @@ impl ConversationView {
         title: Option<SharedString>,
         project: Entity<Project>,
         initial_content: Option<AgentInitialContent>,
+        source: &'static str,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> ServerState {
@@ -682,6 +686,7 @@ impl ConversationView {
             telemetry::event!(
                 "Agent Thread Started",
                 agent = connection.telemetry_id(),
+                source = source,
                 side = side,
                 thread_location = thread_location
             );

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -34,7 +34,7 @@ use gpui::{
     list, point, pulsating_between,
 };
 use language::Buffer;
-use language_model::LanguageModelRegistry;
+use language_model::{LanguageModelCompletionError, LanguageModelRegistry};
 use markdown::{Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
 use parking_lot::RwLock;
 use project::{AgentId, AgentServerStore, Project, ProjectEntryId};
@@ -113,6 +113,19 @@ pub(crate) enum ThreadError {
     PaymentRequired,
     Refusal,
     AuthenticationRequired(SharedString),
+    RateLimitExceeded {
+        provider: SharedString,
+    },
+    ServerOverloaded {
+        provider: SharedString,
+    },
+    PromptTooLarge,
+    NoApiKey {
+        provider: SharedString,
+    },
+    StreamError {
+        provider: SharedString,
+    },
     Other {
         message: SharedString,
         acp_error_code: Option<SharedString>,
@@ -127,6 +140,35 @@ impl From<anyhow::Error> for ThreadError {
             && acp_error.code == acp::ErrorCode::AuthRequired
         {
             Self::AuthenticationRequired(acp_error.message.clone().into())
+        } else if let Some(lm_error) = error.downcast_ref::<LanguageModelCompletionError>() {
+            use LanguageModelCompletionError::*;
+            match lm_error {
+                RateLimitExceeded { provider, .. } => Self::RateLimitExceeded {
+                    provider: provider.to_string().into(),
+                },
+                ServerOverloaded { provider, .. } | ApiInternalServerError { provider, .. } => {
+                    Self::ServerOverloaded {
+                        provider: provider.to_string().into(),
+                    }
+                }
+                PromptTooLarge { .. } => Self::PromptTooLarge,
+                NoApiKey { provider } => Self::NoApiKey {
+                    provider: provider.to_string().into(),
+                },
+                StreamEndedUnexpectedly { provider }
+                | ApiReadResponseError { provider, .. }
+                | DeserializeResponse { provider, .. }
+                | HttpSend { provider, .. } => Self::StreamError {
+                    provider: provider.to_string().into(),
+                },
+                _ => {
+                    let message: SharedString = format!("{:#}", error).into();
+                    Self::Other {
+                        message,
+                        acp_error_code: None,
+                    }
+                }
+            }
         } else {
             let message: SharedString = format!("{:#}", error).into();
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -655,6 +655,10 @@ impl ConversationView {
         let connect_result = connection_entry.read(cx).wait_for_connection();
 
         let load_session_id = resume_session_id.clone();
+        let side = match AgentSettings::get_global(cx).dock {
+            settings::DockPosition::Left => "left",
+            settings::DockPosition::Right | settings::DockPosition::Bottom => "right",
+        };
         let load_task = cx.spawn_in(window, async move |this, cx| {
             let (connection, history) = match connect_result.await {
                 Ok(AgentConnectedState {
@@ -671,7 +675,11 @@ impl ConversationView {
                 }
             };
 
-            telemetry::event!("Agent Thread Started", agent = connection.telemetry_id());
+            telemetry::event!(
+                "Agent Thread Started",
+                agent = connection.telemetry_id(),
+                side = side
+            );
 
             let mut resumed_without_history = false;
             let result = if let Some(session_id) = load_session_id.clone() {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6711,19 +6711,11 @@ pub(crate) mod tests {
         conversation_view.read_with(cx, |conversation_view, cx| {
             let state = conversation_view.active_thread().unwrap();
             let error = &state.read(cx).thread_error;
-            match error {
-                Some(ThreadError::Other { message, .. }) => {
-                    assert!(
-                        message.contains("Maximum tokens reached"),
-                        "Expected 'Maximum tokens reached' error, got: {}",
-                        message
-                    );
-                }
-                other => panic!(
-                    "Expected ThreadError::Other with 'Maximum tokens reached', got: {:?}",
-                    other.is_some()
-                ),
-            }
+            assert!(
+                matches!(error, Some(ThreadError::MaxOutputTokens)),
+                "Expected ThreadError::MaxOutputTokens, got: {:?}",
+                error.is_some()
+            );
         });
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -13,7 +13,7 @@ use crate::message_editor::SharedSessionCapabilities;
 use gpui::{Corner, List};
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
-use settings::update_settings_file;
+use settings::{DockPosition, update_settings_file};
 use ui::{ButtonLike, SpinnerLabel, SpinnerVariant, SplitButton, SplitButtonStyle, Tab};
 use workspace::SERIALIZATION_THROTTLE_TIME;
 
@@ -1066,6 +1066,10 @@ impl ThreadView {
         })
         .detach();
 
+        let side = match AgentSettings::get_global(cx).dock {
+            DockPosition::Left => "left",
+            DockPosition::Right | DockPosition::Bottom => "right",
+        };
         let task = cx.spawn_in(window, async move |this, cx| {
             let Some((contents, tracked_buffers)) = contents_task.await? else {
                 return Ok(());
@@ -1134,7 +1138,8 @@ impl ThreadView {
                     session = session_id,
                     parent_session_id = parent_session_id.as_ref().map(|id| id.to_string()),
                     model = model_id,
-                    mode = mode_id
+                    mode = mode_id,
+                    side = side
                 );
 
                 thread.send(contents, cx)
@@ -1163,6 +1168,7 @@ impl ThreadView {
                 mode = mode_id,
                 status,
                 turn_time_ms,
+                side = side
             );
             res.map(|_| ())
         });

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1290,6 +1290,29 @@ impl ThreadView {
                     None,
                     format!("Connection to {provider}'s API was interrupted.").into(),
                 ),
+                ThreadError::InvalidApiKey { provider } => (
+                    "invalid_api_key",
+                    None,
+                    format!("Invalid or expired API key for {provider}.").into(),
+                ),
+                ThreadError::PermissionDenied { provider } => (
+                    "permission_denied",
+                    None,
+                    format!(
+                        "{provider}'s API rejected the request due to insufficient permissions."
+                    )
+                    .into(),
+                ),
+                ThreadError::RequestFailed => (
+                    "request_failed",
+                    None,
+                    "Request could not be completed after multiple attempts.".into(),
+                ),
+                ThreadError::MaxOutputTokens => (
+                    "max_output_tokens",
+                    None,
+                    "Model reached its maximum output length.".into(),
+                ),
                 ThreadError::Other {
                     acp_error_code,
                     message,
@@ -8118,6 +8141,14 @@ impl ThreadView {
                 self.render_no_api_key_error(provider.clone(), cx)
             }
             ThreadError::StreamError { provider } => self.render_stream_error(provider.clone(), cx),
+            ThreadError::InvalidApiKey { provider } => {
+                self.render_invalid_api_key_error(provider.clone(), cx)
+            }
+            ThreadError::PermissionDenied { provider } => {
+                self.render_permission_denied_error(provider.clone(), cx)
+            }
+            ThreadError::RequestFailed => self.render_request_failed_error(cx),
+            ThreadError::MaxOutputTokens => self.render_max_output_tokens_error(cx),
         };
 
         Some(div().child(content))
@@ -8274,6 +8305,73 @@ impl ThreadView {
                     .gap_0p5()
                     .when(can_resume, |this| this.child(self.retry_button(cx)))
                     .child(self.create_copy_button(&message)),
+            )
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_invalid_api_key_error(
+        &self,
+        provider: SharedString,
+        cx: &mut Context<Self>,
+    ) -> Callout {
+        let message = format!(
+            "The API key for {provider} is invalid or has expired. \
+            Update your key via the Agent Panel settings to continue."
+        );
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Invalid API Key")
+            .description(message)
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_permission_denied_error(
+        &self,
+        provider: SharedString,
+        cx: &mut Context<Self>,
+    ) -> Callout {
+        let message = format!(
+            "{provider}'s API rejected the request due to insufficient permissions. \
+            Check that your API key has access to this model."
+        );
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Permission Denied")
+            .description(message)
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_request_failed_error(&self, cx: &mut Context<Self>) -> Callout {
+        let can_resume = self.thread.read(cx).can_retry(cx);
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Request Failed")
+            .description(
+                "The request could not be completed after multiple attempts. \
+                Try again in a moment.",
+            )
+            .actions_slot(
+                h_flex()
+                    .gap_0p5()
+                    .when(can_resume, |this| this.child(self.retry_button(cx))),
+            )
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_max_output_tokens_error(&self, cx: &mut Context<Self>) -> Callout {
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Output Limit Reached")
+            .description(
+                "The model stopped because it reached its maximum output length. \
+                You can ask it to continue where it left off.",
             )
             .dismiss_action(self.dismiss_error_button(cx))
     }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1265,6 +1265,31 @@ impl ThreadView {
                 ThreadError::AuthenticationRequired(message) => {
                     ("authentication_required", None, message.clone())
                 }
+                ThreadError::RateLimitExceeded { provider } => (
+                    "rate_limit_exceeded",
+                    None,
+                    format!("{provider}'s rate limit was reached.").into(),
+                ),
+                ThreadError::ServerOverloaded { provider } => (
+                    "server_overloaded",
+                    None,
+                    format!("{provider}'s servers are temporarily unavailable.").into(),
+                ),
+                ThreadError::PromptTooLarge => (
+                    "prompt_too_large",
+                    None,
+                    "Context too large for the model's context window.".into(),
+                ),
+                ThreadError::NoApiKey { provider } => (
+                    "no_api_key",
+                    None,
+                    format!("No API key configured for {provider}.").into(),
+                ),
+                ThreadError::StreamError { provider } => (
+                    "stream_error",
+                    None,
+                    format!("Connection to {provider}'s API was interrupted.").into(),
+                ),
                 ThreadError::Other {
                     acp_error_code,
                     message,
@@ -8082,6 +8107,17 @@ impl ThreadView {
                 self.render_authentication_required_error(error.clone(), cx)
             }
             ThreadError::PaymentRequired => self.render_payment_required_error(cx),
+            ThreadError::RateLimitExceeded { provider } => {
+                self.render_rate_limit_error(provider.clone(), cx)
+            }
+            ThreadError::ServerOverloaded { provider } => {
+                self.render_server_overloaded_error(provider.clone(), cx)
+            }
+            ThreadError::PromptTooLarge => self.render_prompt_too_large_error(cx),
+            ThreadError::NoApiKey { provider } => {
+                self.render_no_api_key_error(provider.clone(), cx)
+            }
+            ThreadError::StreamError { provider } => self.render_stream_error(provider.clone(), cx),
         };
 
         Some(div().child(content))
@@ -8140,6 +8176,125 @@ impl ThreadView {
                     .child(self.create_copy_button(ERROR_MESSAGE)),
             )
             .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_rate_limit_error(&self, provider: SharedString, cx: &mut Context<Self>) -> Callout {
+        let can_resume = self.thread.read(cx).can_retry(cx);
+        let message = format!(
+            "{provider}'s rate limit was reached. Zed will retry automatically. \
+            You can also wait a moment and try again."
+        );
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Rate Limit Reached")
+            .description(message.clone())
+            .actions_slot(
+                h_flex()
+                    .gap_0p5()
+                    .when(can_resume, |this| this.child(self.retry_button(cx)))
+                    .child(self.create_copy_button(&message)),
+            )
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_server_overloaded_error(
+        &self,
+        provider: SharedString,
+        cx: &mut Context<Self>,
+    ) -> Callout {
+        let can_resume = self.thread.read(cx).can_retry(cx);
+        let message = format!(
+            "{provider}'s servers are temporarily unavailable. Zed will retry automatically. \
+            If the problem persists, check the provider's status page."
+        );
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Provider Unavailable")
+            .description(message.clone())
+            .actions_slot(
+                h_flex()
+                    .gap_0p5()
+                    .when(can_resume, |this| this.child(self.retry_button(cx)))
+                    .child(self.create_copy_button(&message)),
+            )
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_prompt_too_large_error(&self, cx: &mut Context<Self>) -> Callout {
+        const MESSAGE: &str = "This conversation is too long for the model's context window. \
+            Start a new thread or remove some attached files to continue.";
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Context Too Large")
+            .description(MESSAGE)
+            .actions_slot(
+                h_flex()
+                    .gap_0p5()
+                    .child(self.new_thread_button(cx))
+                    .child(self.create_copy_button(MESSAGE)),
+            )
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_no_api_key_error(&self, provider: SharedString, cx: &mut Context<Self>) -> Callout {
+        let message = format!(
+            "No API key is configured for {provider}. \
+            Add your key via the Agent Panel settings to continue."
+        );
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("API Key Missing")
+            .description(message.clone())
+            .actions_slot(self.create_copy_button(&message))
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_stream_error(&self, provider: SharedString, cx: &mut Context<Self>) -> Callout {
+        let can_resume = self.thread.read(cx).can_retry(cx);
+        let message = format!(
+            "The connection to {provider}'s API was interrupted. Zed will retry automatically. \
+            If the problem persists, check your network connection."
+        );
+
+        Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title("Connection Interrupted")
+            .description(message.clone())
+            .actions_slot(
+                h_flex()
+                    .gap_0p5()
+                    .when(can_resume, |this| this.child(self.retry_button(cx)))
+                    .child(self.create_copy_button(&message)),
+            )
+            .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn retry_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        Button::new("retry", "Retry")
+            .label_size(LabelSize::Small)
+            .style(ButtonStyle::Filled)
+            .on_click(cx.listener(|this, _, _, cx| {
+                this.retry_generation(cx);
+            }))
+    }
+
+    fn new_thread_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        Button::new("new_thread", "New Thread")
+            .label_size(LabelSize::Small)
+            .style(ButtonStyle::Filled)
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.clear_thread_error(cx);
+                window.dispatch_action(NewThread.boxed_clone(), cx);
+            }))
     }
 
     fn upgrade_button(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1313,6 +1313,14 @@ impl ThreadView {
                     None,
                     "Model reached its maximum output length.".into(),
                 ),
+                ThreadError::NoModelSelected => {
+                    ("no_model_selected", None, "No model selected.".into())
+                }
+                ThreadError::ApiError { provider } => (
+                    "api_error",
+                    None,
+                    format!("{provider}'s API returned an unexpected error.").into(),
+                ),
                 ThreadError::Other {
                     acp_error_code,
                     message,
@@ -8130,25 +8138,109 @@ impl ThreadView {
                 self.render_authentication_required_error(error.clone(), cx)
             }
             ThreadError::PaymentRequired => self.render_payment_required_error(cx),
-            ThreadError::RateLimitExceeded { provider } => {
-                self.render_rate_limit_error(provider.clone(), cx)
-            }
-            ThreadError::ServerOverloaded { provider } => {
-                self.render_server_overloaded_error(provider.clone(), cx)
-            }
+            ThreadError::RateLimitExceeded { provider } => self.render_error_callout(
+                "Rate Limit Reached",
+                format!(
+                    "{provider}'s rate limit was reached. Zed will retry automatically. \
+                    You can also wait a moment and try again."
+                )
+                .into(),
+                true,
+                true,
+                cx,
+            ),
+            ThreadError::ServerOverloaded { provider } => self.render_error_callout(
+                "Provider Unavailable",
+                format!(
+                    "{provider}'s servers are temporarily unavailable. Zed will retry \
+                    automatically. If the problem persists, check the provider's status page."
+                )
+                .into(),
+                true,
+                true,
+                cx,
+            ),
             ThreadError::PromptTooLarge => self.render_prompt_too_large_error(cx),
-            ThreadError::NoApiKey { provider } => {
-                self.render_no_api_key_error(provider.clone(), cx)
-            }
-            ThreadError::StreamError { provider } => self.render_stream_error(provider.clone(), cx),
-            ThreadError::InvalidApiKey { provider } => {
-                self.render_invalid_api_key_error(provider.clone(), cx)
-            }
-            ThreadError::PermissionDenied { provider } => {
-                self.render_permission_denied_error(provider.clone(), cx)
-            }
-            ThreadError::RequestFailed => self.render_request_failed_error(cx),
-            ThreadError::MaxOutputTokens => self.render_max_output_tokens_error(cx),
+            ThreadError::NoApiKey { provider } => self.render_error_callout(
+                "API Key Missing",
+                format!(
+                    "No API key is configured for {provider}. \
+                    Add your key via the Agent Panel settings to continue."
+                )
+                .into(),
+                false,
+                true,
+                cx,
+            ),
+            ThreadError::StreamError { provider } => self.render_error_callout(
+                "Connection Interrupted",
+                format!(
+                    "The connection to {provider}'s API was interrupted. Zed will retry \
+                    automatically. If the problem persists, check your network connection."
+                )
+                .into(),
+                true,
+                true,
+                cx,
+            ),
+            ThreadError::InvalidApiKey { provider } => self.render_error_callout(
+                "Invalid API Key",
+                format!(
+                    "The API key for {provider} is invalid or has expired. \
+                    Update your key via the Agent Panel settings to continue."
+                )
+                .into(),
+                false,
+                false,
+                cx,
+            ),
+            ThreadError::PermissionDenied { provider } => self.render_error_callout(
+                "Permission Denied",
+                format!(
+                    "{provider}'s API rejected the request due to insufficient permissions. \
+                    Check that your API key has access to this model."
+                )
+                .into(),
+                false,
+                false,
+                cx,
+            ),
+            ThreadError::RequestFailed => self.render_error_callout(
+                "Request Failed",
+                "The request could not be completed after multiple attempts. \
+                Try again in a moment."
+                    .into(),
+                true,
+                false,
+                cx,
+            ),
+            ThreadError::MaxOutputTokens => self.render_error_callout(
+                "Output Limit Reached",
+                "The model stopped because it reached its maximum output length. \
+                You can ask it to continue where it left off."
+                    .into(),
+                false,
+                false,
+                cx,
+            ),
+            ThreadError::NoModelSelected => self.render_error_callout(
+                "No Model Selected",
+                "Select a model from the model picker below to get started.".into(),
+                false,
+                false,
+                cx,
+            ),
+            ThreadError::ApiError { provider } => self.render_error_callout(
+                "API Error",
+                format!(
+                    "{provider}'s API returned an unexpected error. \
+                    If the problem persists, try switching models or restarting Zed."
+                )
+                .into(),
+                true,
+                true,
+                cx,
+            ),
         };
 
         Some(div().child(content))
@@ -8209,49 +8301,32 @@ impl ThreadView {
             .dismiss_action(self.dismiss_error_button(cx))
     }
 
-    fn render_rate_limit_error(&self, provider: SharedString, cx: &mut Context<Self>) -> Callout {
-        let can_resume = self.thread.read(cx).can_retry(cx);
-        let message = format!(
-            "{provider}'s rate limit was reached. Zed will retry automatically. \
-            You can also wait a moment and try again."
-        );
-
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("Rate Limit Reached")
-            .description(message.clone())
-            .actions_slot(
-                h_flex()
-                    .gap_0p5()
-                    .when(can_resume, |this| this.child(self.retry_button(cx)))
-                    .child(self.create_copy_button(&message)),
-            )
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_server_overloaded_error(
+    fn render_error_callout(
         &self,
-        provider: SharedString,
+        title: &'static str,
+        message: SharedString,
+        show_retry: bool,
+        show_copy: bool,
         cx: &mut Context<Self>,
     ) -> Callout {
-        let can_resume = self.thread.read(cx).can_retry(cx);
-        let message = format!(
-            "{provider}'s servers are temporarily unavailable. Zed will retry automatically. \
-            If the problem persists, check the provider's status page."
-        );
+        let can_resume = show_retry && self.thread.read(cx).can_retry(cx);
+        let show_actions = can_resume || show_copy;
 
         Callout::new()
             .severity(Severity::Error)
             .icon(IconName::XCircle)
-            .title("Provider Unavailable")
+            .title(title)
             .description(message.clone())
-            .actions_slot(
-                h_flex()
-                    .gap_0p5()
-                    .when(can_resume, |this| this.child(self.retry_button(cx)))
-                    .child(self.create_copy_button(&message)),
-            )
+            .when(show_actions, |callout| {
+                callout.actions_slot(
+                    h_flex()
+                        .gap_0p5()
+                        .when(can_resume, |this| this.child(self.retry_button(cx)))
+                        .when(show_copy, |this| {
+                            this.child(self.create_copy_button(message.clone()))
+                        }),
+                )
+            })
             .dismiss_action(self.dismiss_error_button(cx))
     }
 
@@ -8269,109 +8344,6 @@ impl ThreadView {
                     .gap_0p5()
                     .child(self.new_thread_button(cx))
                     .child(self.create_copy_button(MESSAGE)),
-            )
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_no_api_key_error(&self, provider: SharedString, cx: &mut Context<Self>) -> Callout {
-        let message = format!(
-            "No API key is configured for {provider}. \
-            Add your key via the Agent Panel settings to continue."
-        );
-
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("API Key Missing")
-            .description(message.clone())
-            .actions_slot(self.create_copy_button(&message))
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_stream_error(&self, provider: SharedString, cx: &mut Context<Self>) -> Callout {
-        let can_resume = self.thread.read(cx).can_retry(cx);
-        let message = format!(
-            "The connection to {provider}'s API was interrupted. Zed will retry automatically. \
-            If the problem persists, check your network connection."
-        );
-
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("Connection Interrupted")
-            .description(message.clone())
-            .actions_slot(
-                h_flex()
-                    .gap_0p5()
-                    .when(can_resume, |this| this.child(self.retry_button(cx)))
-                    .child(self.create_copy_button(&message)),
-            )
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_invalid_api_key_error(
-        &self,
-        provider: SharedString,
-        cx: &mut Context<Self>,
-    ) -> Callout {
-        let message = format!(
-            "The API key for {provider} is invalid or has expired. \
-            Update your key via the Agent Panel settings to continue."
-        );
-
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("Invalid API Key")
-            .description(message)
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_permission_denied_error(
-        &self,
-        provider: SharedString,
-        cx: &mut Context<Self>,
-    ) -> Callout {
-        let message = format!(
-            "{provider}'s API rejected the request due to insufficient permissions. \
-            Check that your API key has access to this model."
-        );
-
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("Permission Denied")
-            .description(message)
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_request_failed_error(&self, cx: &mut Context<Self>) -> Callout {
-        let can_resume = self.thread.read(cx).can_retry(cx);
-
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("Request Failed")
-            .description(
-                "The request could not be completed after multiple attempts. \
-                Try again in a moment.",
-            )
-            .actions_slot(
-                h_flex()
-                    .gap_0p5()
-                    .when(can_resume, |this| this.child(self.retry_button(cx))),
-            )
-            .dismiss_action(self.dismiss_error_button(cx))
-    }
-
-    fn render_max_output_tokens_error(&self, cx: &mut Context<Self>) -> Callout {
-        Callout::new()
-            .severity(Severity::Error)
-            .icon(IconName::XCircle)
-            .title("Output Limit Reached")
-            .description(
-                "The model stopped because it reached its maximum output length. \
-                You can ask it to continue where it left off.",
             )
             .dismiss_action(self.dismiss_error_button(cx))
     }

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -557,6 +557,11 @@ impl ThreadsArchiveView {
                     .on_click({
                         let thread = thread.clone();
                         cx.listener(move |this, _, window, cx| {
+                            let side = match AgentSettings::get_global(cx).sidebar_side() {
+                                settings::SidebarSide::Left => "left",
+                                settings::SidebarSide::Right => "right",
+                            };
+                            telemetry::event!("Archived Thread Opened", side = side);
                             this.unarchive_thread(thread.clone(), window, cx);
                         })
                     })

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -561,7 +561,11 @@ impl ThreadsArchiveView {
                                 settings::SidebarSide::Left => "left",
                                 settings::SidebarSide::Right => "right",
                             };
-                            telemetry::event!("Archived Thread Opened", side = side);
+                            telemetry::event!(
+                                "Archived Thread Opened",
+                                agent = thread.agent_id.as_ref(),
+                                side = side
+                            );
                             this.unarchive_thread(thread.clone(), window, cx);
                         })
                     })

--- a/crates/sidebar/Cargo.toml
+++ b/crates/sidebar/Cargo.toml
@@ -35,6 +35,7 @@ remote.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+telemetry.workspace = true
 theme.workspace = true
 theme_settings.workspace = true
 ui.workspace = true

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -30,7 +30,7 @@ use remote::RemoteConnectionOptions;
 use ui::utils::platform_title_bar_height;
 
 use serde::{Deserialize, Serialize};
-use settings::Settings as _;
+use settings::{NewThreadLocation, Settings as _};
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::rc::Rc;
@@ -3170,6 +3170,16 @@ impl Sidebar {
         let Some(multi_workspace) = self.multi_workspace.upgrade() else {
             return;
         };
+
+        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
+            NewThreadLocation::LocalProject => "current_worktree",
+            NewThreadLocation::NewWorktree => "new_worktree",
+        };
+        telemetry::event!(
+            "New Thread Clicked",
+            source = "sidebar",
+            thread_location = thread_location
+        );
 
         self.active_entry = Some(ActiveEntry::Draft(workspace.clone()));
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -3841,7 +3841,14 @@ impl Sidebar {
 
     fn toggle_archive(&mut self, _: &ToggleArchive, window: &mut Window, cx: &mut Context<Self>) {
         match &self.view {
-            SidebarView::ThreadList => self.show_archive(window, cx),
+            SidebarView::ThreadList => {
+                let side = match AgentSettings::get_global(cx).sidebar_side() {
+                    SidebarSide::Left => "left",
+                    SidebarSide::Right => "right",
+                };
+                telemetry::event!("Sidebar Archive Viewed", side = side);
+                self.show_archive(window, cx);
+            }
             SidebarView::Archive(_) => self.show_thread_list(window, cx),
         }
     }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -32,7 +32,6 @@ use settings::Settings as _;
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::rc::Rc;
-use telemetry;
 use theme::ActiveTheme;
 use ui::{
     AgentThreadStatus, CommonAnimationExt, ContextMenu, Divider, HighlightedLabel, KeyBinding,
@@ -2529,7 +2528,9 @@ impl Sidebar {
                                 panel.clear_active_thread(window, cx);
                             });
                         }
-                    });
+                    }
+                }
+            }
             return;
         }
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -3526,7 +3526,7 @@ impl Sidebar {
                             SidebarSide::Left => "left",
                             SidebarSide::Right => "right",
                         };
-                        telemetry::event!("Sidebar Open Project Clicked", side = side);
+                        telemetry::event!("Sidebar Add Project Clicked", side = side);
                         window.dispatch_action(
                             Open {
                                 create_new_window: false,

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -9,9 +9,7 @@ use agent_ui::threads_archive_view::{
     ThreadsArchiveView, ThreadsArchiveViewEvent, format_history_entry_timestamp,
 };
 use agent_ui::{AcpThreadImportOnboarding, ThreadImportModal};
-use agent_ui::{
-    Agent, AgentPanel, AgentPanelEvent, DEFAULT_THREAD_TITLE, NewThread, RemoveSelectedThread,
-};
+use agent_ui::{Agent, AgentPanel, AgentPanelEvent, DEFAULT_THREAD_TITLE, RemoveSelectedThread};
 use chrono::{DateTime, Utc};
 use editor::Editor;
 use gpui::{
@@ -30,7 +28,7 @@ use remote::RemoteConnectionOptions;
 use ui::utils::platform_title_bar_height;
 
 use serde::{Deserialize, Serialize};
-use settings::{NewThreadLocation, Settings as _};
+use settings::Settings as _;
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::rc::Rc;
@@ -2531,9 +2529,7 @@ impl Sidebar {
                                 panel.clear_active_thread(window, cx);
                             });
                         }
-                    }
-                }
-            }
+                    });
             return;
         }
 
@@ -2556,7 +2552,7 @@ impl Sidebar {
         if let Some(workspace) = self.active_entry_workspace().cloned() {
             if let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
                 panel.update(cx, |panel, cx| {
-                    panel.new_thread(&NewThread, window, cx);
+                    panel.new_thread_from_sidebar(window, cx);
                 });
             }
         }
@@ -3171,16 +3167,6 @@ impl Sidebar {
             return;
         };
 
-        let thread_location = match AgentSettings::get_global(cx).new_thread_location {
-            NewThreadLocation::LocalProject => "current_worktree",
-            NewThreadLocation::NewWorktree => "new_worktree",
-        };
-        telemetry::event!(
-            "New Thread Clicked",
-            source = "sidebar",
-            thread_location = thread_location
-        );
-
         self.active_entry = Some(ActiveEntry::Draft(workspace.clone()));
 
         multi_workspace.update(cx, |multi_workspace, cx| {
@@ -3190,7 +3176,7 @@ impl Sidebar {
         workspace.update(cx, |workspace, cx| {
             if let Some(agent_panel) = workspace.panel::<AgentPanel>(cx) {
                 agent_panel.update(cx, |panel, cx| {
-                    panel.new_thread(&NewThread, window, cx);
+                    panel.new_thread_from_sidebar(window, cx);
                 });
             }
             workspace.focus_panel::<AgentPanel>(window, cx);

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -34,6 +34,7 @@ use settings::Settings as _;
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::rc::Rc;
+use telemetry;
 use theme::ActiveTheme;
 use ui::{
     AgentThreadStatus, CommonAnimationExt, ContextMenu, Divider, HighlightedLabel, KeyBinding,
@@ -3521,6 +3522,11 @@ impl Sidebar {
                     .full_width()
                     .key_binding(KeyBinding::for_action(&workspace::Open::default(), cx))
                     .on_click(|_, window, cx| {
+                        let side = match AgentSettings::get_global(cx).sidebar_side() {
+                            SidebarSide::Left => "left",
+                            SidebarSide::Right => "right",
+                        };
+                        telemetry::event!("Sidebar Open Project Clicked", side = side);
                         window.dispatch_action(
                             Open {
                                 create_new_window: false,

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -473,6 +473,16 @@ impl MultiWorkspace {
             SidebarSide::Right => "right",
         };
         telemetry::event!("Sidebar Toggled", action = "open", side = side);
+        self.apply_open_sidebar(cx);
+    }
+
+    /// Restores the sidebar to open state from persisted session data without
+    /// firing a telemetry event, since this is not a user-initiated action.
+    pub(crate) fn restore_open_sidebar(&mut self, cx: &mut Context<Self>) {
+        self.apply_open_sidebar(cx);
+    }
+
+    fn apply_open_sidebar(&mut self, cx: &mut Context<Self>) {
         self.sidebar_open = true;
         if let ActiveWorkspace::Transient(workspace) = &self.active_workspace {
             let workspace = workspace.clone();

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -80,6 +80,11 @@ pub fn sidebar_side_context_menu(
                     IconPosition::Start,
                     None,
                     move |_window, cx| {
+                        let side = match position {
+                            SidebarDockPosition::Left => "left",
+                            SidebarDockPosition::Right => "right",
+                        };
+                        telemetry::event!("Sidebar Side Changed", side = side);
                         settings::update_settings_file(fs.clone(), cx, move |settings, _cx| {
                             settings
                                 .agent

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -468,6 +468,11 @@ impl MultiWorkspace {
     }
 
     pub fn open_sidebar(&mut self, cx: &mut Context<Self>) {
+        let side = match self.sidebar_side(cx) {
+            SidebarSide::Left => "left",
+            SidebarSide::Right => "right",
+        };
+        telemetry::event!("Sidebar Toggled", action = "open", side = side);
         self.sidebar_open = true;
         if let ActiveWorkspace::Transient(workspace) = &self.active_workspace {
             let workspace = workspace.clone();
@@ -485,6 +490,11 @@ impl MultiWorkspace {
     }
 
     pub fn close_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let side = match self.sidebar_side(cx) {
+            SidebarSide::Left => "left",
+            SidebarSide::Right => "right",
+        };
+        telemetry::event!("Sidebar Toggled", action = "close", side = side);
         self.sidebar_open = false;
         for workspace in self.workspaces.iter() {
             workspace.update(cx, |workspace, _cx| {
@@ -850,7 +860,11 @@ impl MultiWorkspace {
     /// persistent list regardless of sidebar state — it's used for system-
     /// initiated additions like deserialization and worktree discovery.
     pub fn add(&mut self, workspace: Entity<Workspace>, window: &Window, cx: &mut Context<Self>) {
+        let is_new = !self.workspaces.iter().any(|w| *w == workspace);
         self.insert_workspace(workspace, window, cx);
+        if is_new {
+            telemetry::event!("Workspace Added", workspace_count = self.workspaces.len());
+        }
     }
 
     /// Ensures the workspace is in the multiworkspace and makes it the active one.

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8782,7 +8782,7 @@ pub async fn restore_multiworkspace(
     if sidebar_open {
         window_handle
             .update(cx, |multi_workspace, _, cx| {
-                multi_workspace.open_sidebar(cx);
+                multi_workspace.restore_open_sidebar(cx);
             })
             .ok();
     }


### PR DESCRIPTION
Cherry-picks three PRs onto `v0.232.x`:

## #52919 — agent: Add telemetry for parallel agents

Adds telemetry events for sidebar toggles, agent panel interactions, and thread lifecycle.

## #53099 — agent_ui: Replace raw error messages with user-friendly copy

Replaces raw provider error strings in the agent panel with specific, user-friendly error callouts. Each error variant now has a clear title, actionable copy, and appropriate buttons instead of the generic "An Error Happened" fallback.

## #53631 — agent_ui: Fix worktree naming regression when using existing branches

When creating a new git worktree from an existing branch (e.g. `main`), the worktree directory was incorrectly named after the branch instead of getting a random adjective-noun name. Additionally, if a directory with that name already existed, the rollback logic could destructively delete the pre-existing worktree.

Changes:
- Generate a random adjective-noun name for worktree directories when no explicit name is provided
- Collect existing worktree directory names to avoid collisions
- Check generated paths against known worktree paths before creating
- Reduce random name retry count from 100 to 10
- Add regression test

Release Notes:

- Fixed a regression where creating a git worktree from an existing branch would name the worktree directory after the branch instead of generating a random name, potentially conflicting with or deleting existing worktrees.
- Improved error messages in the agent panel to show specific, actionable copy instead of raw provider error strings.