### PR TITLE
Fix/vim respect autoindent

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4097,6 +4097,21 @@ impl Editor {
         });
     }
 
+    pub fn edit_bottom_up_with_autoindent<I, S, T>(&mut self, edits: I, cx: &mut Context<Self>)
+    where
+        I: IntoIterator<Item = (Range<S>, T)>,
+        S: ToOffset,
+        T: Into<Arc<str>>,
+    {
+        if self.read_only(cx) {
+            return;
+        }
+
+        self.buffer.update(cx, |buffer, cx| {
+            buffer.edit_bottom_up(edits, self.autoindent_mode.clone(), cx)
+        });
+    }
+
     pub fn edit_with_block_indent<I, S, T>(
         &mut self,
         edits: I,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -920,6 +920,12 @@ impl<T> BracketMatch<T> {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EditDirection {
+    TopDown,
+    BottomUp,
+}
+
 impl Buffer {
     /// Create a new buffer with the given base text.
     pub fn local<T: Into<String>>(base_text: T, cx: &Context<Self>) -> Self {
@@ -2635,7 +2641,35 @@ impl Buffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits_iter, autoindent_mode, true, cx)
+        self.edit_internal(
+            edits_iter,
+            autoindent_mode,
+            true,
+            EditDirection::TopDown,
+            cx,
+        )
+    }
+
+    /// Like [`edit`](Self::edit), but for edits made before the cursor. Used for Vim actions like
+    /// `InsertLineAbove`
+    pub fn edit_bottom_up<I, S, T>(
+        &mut self,
+        edits_iter: I,
+        autoindent_mode: Option<AutoindentMode>,
+        cx: &mut Context<Self>,
+    ) -> Option<clock::Lamport>
+    where
+        I: IntoIterator<Item = (Range<S>, T)>,
+        S: ToOffset,
+        T: Into<Arc<str>>,
+    {
+        self.edit_internal(
+            edits_iter,
+            autoindent_mode,
+            true,
+            EditDirection::BottomUp,
+            cx,
+        )
     }
 
     /// Like [`edit`](Self::edit), but does not coalesce adjacent edits.
@@ -2650,7 +2684,13 @@ impl Buffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits_iter, autoindent_mode, false, cx)
+        self.edit_internal(
+            edits_iter,
+            autoindent_mode,
+            false,
+            EditDirection::TopDown,
+            cx,
+        )
     }
 
     fn edit_internal<I, S, T>(
@@ -2658,6 +2698,7 @@ impl Buffer {
         edits_iter: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
+        edit_direction: EditDirection,
         cx: &mut Context<Self>,
     ) -> Option<clock::Lamport>
     where
@@ -2764,8 +2805,12 @@ impl Buffer {
 
                     // When inserting text starting with a newline, avoid auto-indenting the
                     // previous line.
-                    if new_text.starts_with('\n') {
+                    if edit_direction == EditDirection::TopDown && new_text.starts_with('\n') {
                         range_of_insertion_to_indent.start += 1;
+                        first_line_is_new = true;
+                    } else if edit_direction == EditDirection::BottomUp && new_text.ends_with('\n')
+                    {
+                        range_of_insertion_to_indent.end -= 1;
                         first_line_is_new = true;
                     }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -19,10 +19,10 @@ use gpui::{App, Context, Entity, EntityId, EventEmitter};
 use itertools::Itertools;
 use language::{
     AutoindentMode, BracketMatch, Buffer, BufferChunks, BufferRow, BufferSnapshot, Capability,
-    CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape, DiagnosticEntryRef, File,
-    IndentGuideSettings, IndentSize, Language, LanguageScope, OffsetRangeExt, OffsetUtf16, Outline,
-    OutlineItem, Point, PointUtf16, Selection, TextDimension, TextObject, ToOffset as _,
-    ToPoint as _, TransactionId, TreeSitterOptions, Unclipped,
+    CharClassifier, CharKind, CharScopeContext, Chunk, CursorShape, DiagnosticEntryRef,
+    EditDirection, File, IndentGuideSettings, IndentSize, Language, LanguageScope, OffsetRangeExt,
+    OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection, TextDimension, TextObject,
+    ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions, Unclipped,
     language_settings::{AllLanguageSettings, LanguageSettings},
 };
 
@@ -1311,7 +1311,20 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, true, cx);
+        self.edit_internal(edits, autoindent_mode, true, EditDirection::TopDown, cx);
+    }
+
+    pub fn edit_bottom_up<I, S, T>(
+        &mut self,
+        edits: I,
+        autoindent_mode: Option<AutoindentMode>,
+        cx: &mut Context<Self>,
+    ) where
+        I: IntoIterator<Item = (Range<S>, T)>,
+        S: ToOffset,
+        T: Into<Arc<str>>,
+    {
+        self.edit_internal(edits, autoindent_mode, true, EditDirection::BottomUp, cx);
     }
 
     pub fn edit_non_coalesce<I, S, T>(
@@ -1324,7 +1337,7 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
-        self.edit_internal(edits, autoindent_mode, false, cx);
+        self.edit_internal(edits, autoindent_mode, false, EditDirection::TopDown, cx);
     }
 
     fn edit_internal<I, S, T>(
@@ -1332,6 +1345,7 @@ impl MultiBuffer {
         edits: I,
         autoindent_mode: Option<AutoindentMode>,
         coalesce_adjacent: bool,
+        edit_direction: EditDirection,
         cx: &mut Context<Self>,
     ) where
         I: IntoIterator<Item = (Range<S>, T)>,
@@ -1354,7 +1368,14 @@ impl MultiBuffer {
             })
             .collect::<Vec<_>>();
 
-        return edit_internal(self, edits, autoindent_mode, coalesce_adjacent, cx);
+        return edit_internal(
+            self,
+            edits,
+            autoindent_mode,
+            coalesce_adjacent,
+            edit_direction,
+            cx,
+        );
 
         // Non-generic part of edit, hoisted out to avoid blowing up LLVM IR.
         fn edit_internal(
@@ -1362,6 +1383,7 @@ impl MultiBuffer {
             edits: Vec<(Range<MultiBufferOffset>, Arc<str>)>,
             mut autoindent_mode: Option<AutoindentMode>,
             coalesce_adjacent: bool,
+            edit_direction: EditDirection,
             cx: &mut Context<MultiBuffer>,
         ) {
             let original_indent_columns = match &mut autoindent_mode {
@@ -1453,8 +1475,13 @@ impl MultiBuffer {
                         };
 
                     if coalesce_adjacent {
-                        buffer.edit(deletions, deletion_autoindent_mode, cx);
-                        buffer.edit(insertions, insertion_autoindent_mode, cx);
+                        if edit_direction == EditDirection::TopDown {
+                            buffer.edit(deletions, deletion_autoindent_mode, cx);
+                            buffer.edit(insertions, insertion_autoindent_mode, cx);
+                        } else {
+                            buffer.edit_bottom_up(deletions, deletion_autoindent_mode, cx);
+                            buffer.edit_bottom_up(insertions, insertion_autoindent_mode, cx);
+                        }
                     } else {
                         buffer.edit_non_coalesce(deletions, deletion_autoindent_mode, cx);
                         buffer.edit_non_coalesce(insertions, insertion_autoindent_mode, cx);

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -729,7 +729,7 @@ impl Vim {
                         (start_of_line..start_of_line, indent + "\n")
                     })
                     .collect::<Vec<_>>();
-                editor.edit_with_autoindent(edits, cx);
+                editor.edit_bottom_up_with_autoindent(edits, cx);
                 editor.change_selections(Default::default(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
                         let previous_line = map.start_of_relative_buffer_row(selection.start, -1);

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -29,7 +29,7 @@ use editor::{Anchor, SelectionEffects};
 use editor::{Bias, ToPoint};
 use editor::{display_map::ToDisplayPoint, movement};
 use gpui::{Context, Window, actions};
-use language::{Point, SelectionGoal};
+use language::{AutoIndentMode, Point, SelectionGoal};
 use log::error;
 use multi_buffer::MultiBufferRow;
 
@@ -717,19 +717,38 @@ impl Vim {
                     .into_iter()
                     .map(|selection| selection.start.row)
                     .collect();
-                let edits = selection_start_rows
-                    .into_iter()
-                    .map(|row| {
-                        let indent = snapshot
-                            .indent_and_comment_for_line(MultiBufferRow(row), cx)
-                            .chars()
-                            .collect::<String>();
 
-                        let start_of_line = Point::new(row, 0);
-                        (start_of_line..start_of_line, indent + "\n")
-                    })
-                    .collect::<Vec<_>>();
-                editor.edit_bottom_up_with_autoindent(edits, cx);
+                let mut plain_edits = Vec::new();
+                let mut autoindent_edits = Vec::new();
+                for row in selection_start_rows {
+                    let start_of_line = Point::new(row, 0);
+                    let auto_indent = snapshot
+                        .language_settings_at(start_of_line, cx)
+                        .auto_indent;
+                    let new_text = match auto_indent {
+                        AutoIndentMode::None => "\n".to_string(),
+                        AutoIndentMode::PreserveIndent | AutoIndentMode::SyntaxAware => {
+                            let indent = snapshot
+                                .indent_and_comment_for_line(MultiBufferRow(row), cx)
+                                .chars()
+                                .collect::<String>();
+                            indent + "\n"
+                        }
+                    };
+                    let edit = (start_of_line..start_of_line, new_text);
+                    if auto_indent == AutoIndentMode::SyntaxAware {
+                        autoindent_edits.push(edit);
+                    } else {
+                        plain_edits.push(edit);
+                    }
+                }
+                if !plain_edits.is_empty() {
+                    editor.edit(plain_edits, cx);
+                }
+                if !autoindent_edits.is_empty() {
+                    editor.edit_bottom_up_with_autoindent(autoindent_edits, cx);
+                }
+
                 editor.change_selections(Default::default(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
                         let previous_line = map.start_of_relative_buffer_row(selection.start, -1);
@@ -764,18 +783,32 @@ impl Vim {
                         }
                     })
                     .collect();
-                let edits = selection_end_rows
-                    .into_iter()
-                    .map(|row| {
-                        let indent = snapshot
-                            .indent_and_comment_for_line(MultiBufferRow(row), cx)
-                            .chars()
-                            .collect::<String>();
 
-                        let end_of_line = Point::new(row, snapshot.line_len(MultiBufferRow(row)));
-                        (end_of_line..end_of_line, "\n".to_string() + &indent)
-                    })
-                    .collect::<Vec<_>>();
+                let mut plain_edits = Vec::new();
+                let mut autoindent_edits = Vec::new();
+                for row in selection_end_rows {
+                    let end_of_line = Point::new(row, snapshot.line_len(MultiBufferRow(row)));
+                    let auto_indent = snapshot
+                        .language_settings_at(end_of_line, cx)
+                        .auto_indent;
+                    let new_text = match auto_indent {
+                        AutoIndentMode::None => "\n".to_string(),
+                        AutoIndentMode::PreserveIndent | AutoIndentMode::SyntaxAware => {
+                            let indent = snapshot
+                                .indent_and_comment_for_line(MultiBufferRow(row), cx)
+                                .chars()
+                                .collect::<String>();
+                            "\n".to_string() + &indent
+                        }
+                    };
+                    let edit = (end_of_line..end_of_line, new_text);
+                    if auto_indent == AutoIndentMode::SyntaxAware {
+                        autoindent_edits.push(edit);
+                    } else {
+                        plain_edits.push(edit);
+                    }
+                }
+
                 editor.change_selections(Default::default(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
                         let current_line = if !selection.is_empty() && selection.end.column() == 0 {
@@ -790,7 +823,13 @@ impl Vim {
                         selection.collapse_to(insert_point, SelectionGoal::None)
                     });
                 });
-                editor.edit_with_autoindent(edits, cx);
+
+                if !plain_edits.is_empty() {
+                    editor.edit(plain_edits, cx);
+                }
+                if !autoindent_edits.is_empty() {
+                    editor.edit_with_autoindent(autoindent_edits, cx);
+                }
             });
         });
     }
@@ -2053,6 +2092,137 @@ mod test {
         cx.shared_state().await.assert_eq("// hello\n// ˇ\n");
         cx.simulate_shared_keystrokes("x escape shift-o").await;
         cx.shared_state().await.assert_eq("// hello\n// ˇ\n// x\n");
+    }
+
+    #[gpui::test]
+    async fn test_insert_line_below_respects_auto_indent_none(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |content| {
+                    content.project.all_languages.defaults.auto_indent =
+                        Some(settings::AutoIndentMode::None);
+                });
+            })
+        });
+
+        cx.set_state(
+            indoc! {"
+                fn test() {
+                    println!(ˇ);
+                }"},
+            Mode::Normal,
+        );
+        cx.simulate_keystrokes("o");
+        cx.assert_state(
+            indoc! {"
+                fn test() {
+                    println!();
+                ˇ
+                }"},
+            Mode::Insert,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_insert_line_above_respects_auto_indent_none(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |content| {
+                    content.project.all_languages.defaults.auto_indent =
+                        Some(settings::AutoIndentMode::None);
+                });
+            })
+        });
+
+        cx.set_state(
+            indoc! {"
+                fn test() {
+                    println!(ˇ);
+                }"},
+            Mode::Normal,
+        );
+        cx.simulate_keystrokes("shift-o");
+        cx.assert_state(
+            indoc! {"
+                fn test() {
+                ˇ
+                    println!();
+                }"},
+            Mode::Insert,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_insert_line_respects_auto_indent_preserve_indent(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |content| {
+                    content.project.all_languages.defaults.auto_indent =
+                        Some(settings::AutoIndentMode::PreserveIndent);
+                });
+            })
+        });
+
+        cx.set_state(
+            indoc! {"
+                fn test() {
+                    println!(ˇ);
+                }"},
+            Mode::Normal,
+        );
+        cx.simulate_keystrokes("o");
+        cx.assert_state(
+            indoc! {"
+                fn test() {
+                    println!();
+                    ˇ
+                }"},
+            Mode::Insert,
+        );
+
+        cx.set_state(
+            indoc! {"
+                fn test() {
+                    println!(ˇ);
+                }"},
+            Mode::Normal,
+        );
+        cx.simulate_keystrokes("shift-o");
+        cx.assert_state(
+            indoc! {"
+                fn test() {
+                    ˇ
+                    println!();
+                }"},
+            Mode::Insert,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_insert_line_below_respects_auto_indent_syntax_aware(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state(
+            indoc! {"
+                fn test() {ˇ
+                    println!();
+                }"},
+            Mode::Normal,
+        );
+        cx.simulate_keystrokes("o");
+        cx.assert_state(
+            indoc! {"
+                fn test() {
+                    ˇ
+                    println!();
+                }"},
+            Mode::Insert,
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #53570

Release Notes:

- Pressing 'o/O' in vim normal mode now respects `auto-indent: "none"`
