### PR TITLE
Add support for background colors on fenced code blocks in Markdown

### DIFF
--- a/.rules
+++ b/.rules
@@ -1,190 +1,60 @@
-# Rust coding guidelines
+# CLAUDE.md
 
-* Prioritize code correctness and clarity. Speed and efficiency are secondary priorities unless otherwise specified.
-* Do not write organizational or comments that summarize the code. Comments should only be written in order to explain "why" the code is written in some way in the case there is a reason that is tricky / non-obvious.
-* Prefer implementing functionality in existing files unless it is a new logical component. Avoid creating many small files.
-* Avoid using functions that panic like `unwrap()`, instead use mechanisms like `?` to propagate errors.
-* Be careful with operations like indexing which may panic if the indexes are out of bounds.
-* Never silently discard errors with `let _ =` on fallible operations. Always handle errors appropriately:
-  - Propagate errors with `?` when the calling function should handle them
-  - Use `.log_err()` or similar when you need to ignore errors but want visibility
-  - Use explicit error handling with `match` or `if let Err(...)` when you need custom logic
-  - Example: avoid `let _ = client.request(...).await?;` - use `client.request(...).await?;` instead
-* When implementing async operations that may fail, ensure errors propagate to the UI layer so users get meaningful feedback.
-* Never create files with `mod.rs` paths - prefer `src/some_module.rs` instead of `src/some_module/mod.rs`.
-* When creating new crates, prefer specifying the library root path in `Cargo.toml` using `[lib] path = "...rs"` instead of the default `lib.rs`, to maintain consistent and descriptive naming (e.g., `gpui.rs` or `main.rs`).
-* Avoid creative additions unless explicitly requested
-* Use full words for variable names (no abbreviations like "q" for "queue")
-* Use variable shadowing to scope clones in async contexts for clarity, minimizing the lifetime of borrowed references.
-  Example:
-  ```rust
-  executor.spawn({
-      let task_ran = task_ran.clone();
-      async move {
-          *task_ran.borrow_mut() = true;
+## Fenced Code Block Background Highlighting
+
+This documents the implementation of full-width background color support for markdown fenced code blocks in Zed, replicating Sublime Text's `markup.raw` background behavior.
+
+### How it works
+
+Zed's tree-sitter highlight system uses a stack of nested captures per chunk, but only the deepest (most specific) capture determines a chunk's foreground style. To add block-level backgrounds without losing language-injected foreground colors, this implementation:
+
+1. **Propagates parent highlight IDs** through the chunk pipeline via a `parent_syntax_highlight_ids` field on `Chunk` structs
+2. **Merges only `background_color`** from parent captures, leaving foreground colors to the deepest (child) capture
+3. **Paints full-width row backgrounds** via the `highlighted_rows` system in `element.rs`
+
+### Key design decisions
+
+- **`HighlightId::TRANSPARENT` sentinel**: Captures whose names don't match any theme key (e.g., `(paragraph) @text` when the theme has no `text` entry) are pushed onto the highlight stack as `TRANSPARENT`. This preserves correct nesting depth so inline code (`code_span`) always has >=2 stack entries, distinguishing it from block-level single-entry captures.
+
+- **Single-entry stack special case**: When the highlight stack has exactly 1 entry (e.g., `code_fence_content` on empty lines or in blocks without language injection), the entry is included in both `syntax_highlight_id` and `parent_syntax_highlight_ids`. This is safe because inline captures always have >=2 entries thanks to TRANSPARENT parent pushes.
+
+- **Separate capture name**: Fenced code block content uses `@text.literal.block.markup` (distinct from inline code's `@text.literal.markup` in markdown-inline) so users can set different background colors for block vs inline code.
+
+- **Per-row iteration in `syntax_background_rows()`**: Instead of tracking rows by counting newlines (which drifted at capture boundaries), each display row independently checks its own chunks for parent backgrounds.
+
+### Files modified
+
+| File | Change |
+|------|--------|
+| `crates/language_core/src/highlight_map.rs` | Added `HighlightId::TRANSPARENT` sentinel |
+| `crates/language/src/buffer.rs` | Always push captures onto stack (TRANSPARENT for unmapped); single-entry stack populates parents; filter TRANSPARENT from output |
+| `crates/editor/src/display_map/fold_map.rs` | Added `parent_syntax_highlight_ids` field to fold `Chunk`, passed through from buffer |
+| `crates/editor/src/display_map.rs` | Extract only `background_color` from parent highlights in `highlighted_chunks()` and `combined_highlights()`; added `syntax_background_rows()` |
+| `crates/editor/src/element.rs` | Insert `syntax_background_rows` results into `highlighted_rows` for full-width painting |
+| `crates/grammars/src/markdown/highlights.scm` | Added `(fenced_code_block (code_fence_content) @text.literal.block.markup)` |
+
+### User configuration
+
+```json
+{
+  "experimental.theme_overrides": {
+    "syntax": {
+      "text.literal.block.markup": {
+        "background_color": "#3b82f626"
+      },
+      "text.literal.markup": {
+        "background_color": "#3b82f620"
       }
-  });
-  ```
-
-# Timers in tests
-
-* In GPUI tests, prefer GPUI executor timers over `smol::Timer::after(...)` when you need timeouts, delays, or to drive `run_until_parked()`:
-  - Use `cx.background_executor().timer(duration).await` (or `cx.background_executor.timer(duration).await` in `TestAppContext`) so the work is scheduled on GPUI's dispatcher.
-  - Avoid `smol::Timer::after(...)` for test timeouts when you rely on `run_until_parked()`, because it may not be tracked by GPUI's scheduler and can lead to "nothing left to run" when pumping.
-
-# GPUI
-
-GPUI is a UI framework which also provides primitives for state and concurrency management.
-
-## Context
-
-Context types allow interaction with global state, windows, entities, and system services. They are typically passed to functions as the argument named `cx`. When a function takes callbacks they come after the `cx` parameter.
-
-* `App` is the root context type, providing access to global state and read and update of entities.
-* `Context<T>` is provided when updating an `Entity<T>`. This context dereferences into `App`, so functions which take `&App` can also take `&Context<T>`.
-* `AsyncApp` and `AsyncWindowContext` are provided by `cx.spawn` and `cx.spawn_in`. These can be held across await points.
-
-## `Window`
-
-`Window` provides access to the state of an application window. It is passed to functions as an argument named `window` and comes before `cx` when present. It is used for managing focus, dispatching actions, directly drawing, getting user input state, etc.
-
-## Entities
-
-An `Entity<T>` is a handle to state of type `T`. With `thing: Entity<T>`:
-
-* `thing.entity_id()` returns `EntityId`
-* `thing.downgrade()` returns `WeakEntity<T>`
-* `thing.read(cx: &App)` returns `&T`.
-* `thing.read_with(cx, |thing: &T, cx: &App| ...)` returns the closure's return value.
-* `thing.update(cx, |thing: &mut T, cx: &mut Context<T>| ...)` allows the closure to mutate the state, and provides a `Context<T>` for interacting with the entity. It returns the closure's return value.
-* `thing.update_in(cx, |thing: &mut T, window: &mut Window, cx: &mut Context<T>| ...)` takes a `AsyncWindowContext` or `VisualTestContext`. It's the same as `update` while also providing the `Window`.
-
-Within the closures, the inner `cx` provided to the closure must be used instead of the outer `cx` to avoid issues with multiple borrows.
-
-Trying to update an entity while it's already being updated must be avoided as this will cause a panic.
-
-When  `read_with`, `update`, or `update_in` are used with an async context, the closure's return value is wrapped in an `anyhow::Result`.
-
-`WeakEntity<T>` is a weak handle. It has `read_with`, `update`, and `update_in` methods that work the same, but always return an `anyhow::Result` so that they can fail if the entity no longer exists. This can be useful to avoid memory leaks - if entities have mutually recursive handles to each other they will never be dropped.
-
-## Concurrency
-
-All use of entities and UI rendering occurs on a single foreground thread.
-
-`cx.spawn(async move |cx| ...)` runs an async closure on the foreground thread. Within the closure, `cx` is `&mut AsyncApp`.
-
-When the outer cx is a `Context<T>`, the use of `spawn` instead looks like `cx.spawn(async move |this, cx| ...)`, where `this: WeakEntity<T>` and `cx: &mut AsyncApp`.
-
-To do work on other threads, `cx.background_spawn(async move { ... })` is used. Often this background task is awaited on by a foreground task which uses the results to update state.
-
-Both `cx.spawn` and `cx.background_spawn` return a `Task<R>`, which is a future that can be awaited upon. If this task is dropped, then its work is cancelled. To prevent this one of the following must be done:
-
-* Awaiting the task in some other async context.
-* Detaching the task via `task.detach()` or `task.detach_and_log_err(cx)`, allowing it to run indefinitely.
-* Storing the task in a field, if the work should be halted when the struct is dropped.
-
-A task which doesn't do anything but provide a value can be created with `Task::ready(value)`.
-
-## Elements
-
-The `Render` trait is used to render some state into an element tree that is laid out using flexbox layout. An `Entity<T>` where `T` implements `Render` is sometimes called a "view".
-
-Example:
-
-```
-struct TextWithBorder(SharedString);
-
-impl Render for TextWithBorder {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().border_1().child(self.0.clone())
     }
+  }
 }
 ```
 
-Since `impl IntoElement for SharedString` exists, it can be used as an argument to `child`. `SharedString` is used to avoid copying strings, and is either an `&'static str` or `Arc<str>`.
+- `text.literal.block.markup` — full-width background for fenced code block content (between ``` delimiters, excluding the delimiter lines themselves)
+- `text.literal.markup` — per-glyph background for inline backtick code
 
-UI components that are constructed just to be turned into elements can instead implement the `RenderOnce` trait, which is similar to `Render`, but its `render` method takes ownership of `self` and receives `&mut App` instead of `&mut Context<Self>`. Types that implement this trait can use `#[derive(IntoElement)]` to use them directly as children.
+### Known limitations
 
-The style methods on elements are similar to those used by Tailwind CSS.
-
-If some attributes or children of an element tree are conditional, `.when(condition, |this| ...)` can be used to run the closure only when `condition` is true. Similarly, `.when_some(option, |this, value| ...)` runs the closure when the `Option` has a value.
-
-## Input events
-
-Input event handlers can be registered on an element via methods like `.on_click(|event, window, cx: &mut App| ...)`.
-
-Often event handlers will want to update the entity that's in the current `Context<T>`. The `cx.listener` method provides this - its use looks like `.on_click(cx.listener(|this: &mut T, event, window, cx: &mut Context<T>| ...)`.
-
-## Actions
-
-Actions are dispatched via user keyboard interaction or in code via `window.dispatch_action(SomeAction.boxed_clone(), cx)` or `focus_handle.dispatch_action(&SomeAction, window, cx)`.
-
-Actions with no data defined with the `actions!(some_namespace, [SomeAction, AnotherAction])` macro call. Otherwise the `Action` derive macro is used. Doc comments on actions are displayed to the user.
-
-Action handlers can be registered on an element via the event handler `.on_action(|action, window, cx| ...)`. Like other event handlers, this is often used with `cx.listener`.
-
-## Notify
-
-When a view's state has changed in a way that may affect its rendering, it should call `cx.notify()`. This will cause the view to be rerendered. It will also cause any observe callbacks registered for the entity with `cx.observe` to be called.
-
-## Entity events
-
-While updating an entity (`cx: Context<T>`), it can emit an event using `cx.emit(event)`. Entities register which events they can emit by declaring `impl EventEmitter<EventType> for EntityType {}`.
-
-Other entities can then register a callback to handle these events by doing `cx.subscribe(other_entity, |this, other_entity, event, cx| ...)`. This will return a `Subscription` which deregisters the callback when dropped.  Typically `cx.subscribe` happens when creating a new entity and the subscriptions are stored in a `_subscriptions: Vec<Subscription>` field.
-
-## Build guidelines
-
-- Use `./script/clippy` instead of `cargo clippy`
-
-# Pull request hygiene
-
-When an agent opens or updates a pull request, it must:
-
-- Use a clear, correctly capitalized, imperative PR title (for example, `Fix crash in project panel`).
-- Avoid conventional commit prefixes in PR titles (`fix:`, `feat:`, `docs:`, etc.).
-- Avoid trailing punctuation in PR titles.
-- Optionally prefix the title with a crate name when one crate is the clear scope (for example, `git_ui: Add history view`).
-- Include a `Release Notes:` section as the final section in the PR body.
-- Use one bullet under `Release Notes:`:
-  - `- Added ...`, `- Fixed ...`, or `- Improved ...` for user-facing changes, or
-  - `- N/A` for docs-only and other non-user-facing changes.
-- Format release notes exactly with a blank line after the heading, for example:
-
-```
-Release Notes:
-
-- N/A
-```
-
-# Crash Investigation
-
-## Sentry Integration
-- Crash investigation prompts: `.factory/prompts/crash/investigate.md`
-- Crash fix prompts: `.factory/prompts/crash/fix.md`
-- Fetch crash reports: `script/sentry-fetch <issue-id>`
-- Generate investigation prompt from crash: `script/crash-to-prompt <issue-id>`
-
-# Rules Hygiene
-
-These `.rules` files are read by every agent session. Keep them high-signal.
-
-## After any agentic session
-If you discover a non-obvious pattern that would help future sessions, include a **"Suggested .rules additions"** heading in your PR description with the proposed text. Do **not** edit `.rules` inline during normal feature/fix work. Reviewers decide what gets merged.
-
-## High bar for new rules
-Editing or clarifying existing rules is always welcome. New rules must meet **all three** criteria:
-1. **Non-obvious** — someone familiar with the codebase would still get it wrong without the rule.
-2. **Repeatedly encountered** — it came up more than once (multiple hits in one session counts).
-3. **Specific enough to act on** — a concrete instruction, not a vague principle.
-
-Rules that apply to a single crate belong in that crate's own `.rules` file, not the repo root.
-
-## What NOT to put in `.rules`
-Avoid architectural descriptions of a crate (module layout, data flow, key types). These go stale fast and the agent can gather them by reading the code. Rules should be **traps to avoid**, not **maps to follow**.
-
-## No drive-by additions
-Rules emerge from validated patterns, not one-off observations. The workflow is:
-1. Agent notes a pattern during a session.
-2. Team validates the pattern in code review.
-3. A dedicated commit adds the rule with context on *why* it exists.
+- Selection highlight may become invisible on background-colored regions (pre-existing issue #25014)
+- Per-language theme overrides (`languages.Markdown`) don't work (#20166)
+- The `syntax_background_rows()` per-row iteration creates a chunk iterator per visible row; this is correct but could be optimized if profiling shows it as a bottleneck

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -94,8 +94,8 @@ pub use wrap_map::{WrapPoint, WrapRow, WrapSnapshot};
 
 use collections::{HashMap, HashSet, IndexSet};
 use gpui::{
-    App, Context, Entity, EntityId, Font, HighlightStyle, LineLayout, Pixels, UnderlineStyle,
-    WeakEntity,
+    App, Context, Entity, EntityId, Font, HighlightStyle, Hsla, LineLayout, Pixels,
+    UnderlineStyle, WeakEntity,
 };
 use language::{
     LanguageAwareStyling, Point, Subscription as BufferSubscription,
@@ -119,6 +119,7 @@ use ztracing::instrument;
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
+use std::collections::BTreeMap;
 use std::{
     any::TypeId,
     borrow::Cow,
@@ -1836,6 +1837,16 @@ impl DisplaySnapshot {
             },
         )
         .flat_map(|chunk| {
+            let parent_highlight_style = chunk
+                .parent_syntax_highlight_ids
+                .iter()
+                .filter_map(|id| editor_style.syntax.get(*id))
+                .find_map(|style| style.background_color)
+                .map(|bg| HighlightStyle {
+                    background_color: Some(bg),
+                    ..Default::default()
+                });
+
             let syntax_highlight_style = chunk
                 .syntax_highlight_id
                 .and_then(|id| editor_style.syntax.get(id).cloned());
@@ -1885,6 +1896,7 @@ impl DisplaySnapshot {
                 });
 
             let style = [
+                parent_highlight_style,
                 syntax_highlight_style,
                 chunk_highlight,
                 diagnostic_highlight,
@@ -1933,17 +1945,26 @@ impl DisplaySnapshot {
                 continue;
             }
 
+            let parent_style = chunk
+                .parent_syntax_highlight_ids
+                .iter()
+                .filter_map(|id| syntax_theme.get(*id))
+                .find_map(|style| style.background_color)
+                .map(|bg| HighlightStyle {
+                    background_color: Some(bg),
+                    ..Default::default()
+                });
+
             let syntax_style = chunk
                 .syntax_highlight_id
                 .and_then(|id| syntax_theme.get(id).cloned());
 
             let overlay_style = chunk.highlight_style;
 
-            let combined = match (syntax_style, overlay_style) {
-                (Some(syntax), Some(overlay)) => Some(syntax.highlight(overlay)),
-                (some @ Some(_), None) | (None, some @ Some(_)) => some,
-                (None, None) => None,
-            };
+            let combined = [parent_style, syntax_style, overlay_style]
+                .into_iter()
+                .flatten()
+                .reduce(|acc, style| acc.highlight(style));
 
             if let Some(style) = combined {
                 highlights.push((offset..offset + chunk_len, style));
@@ -1951,6 +1972,34 @@ impl DisplaySnapshot {
             offset += chunk_len;
         }
         highlights
+    }
+
+    /// Returns display rows that should have a full-width background color
+    /// from parent syntax captures (e.g., fenced code blocks in markdown).
+    pub fn syntax_background_rows(
+        &self,
+        display_rows: Range<DisplayRow>,
+        syntax_theme: &theme::SyntaxTheme,
+    ) -> BTreeMap<DisplayRow, Hsla> {
+        let mut result = BTreeMap::new();
+
+        for row_idx in display_rows.start.0..display_rows.end.0 {
+            let row = DisplayRow(row_idx);
+            for chunk in self.chunks(row..row.next_row(), LanguageAwareStyling { tree_sitter: true, diagnostics: false }, HighlightStyles::default()) {
+                let background = chunk
+                    .parent_syntax_highlight_ids
+                    .iter()
+                    .filter_map(|id| syntax_theme.get(*id))
+                    .find_map(|style| style.background_color);
+
+                if let Some(bg_color) = background {
+                    result.insert(row, bg_color);
+                    break;
+                }
+            }
+        }
+
+        result
     }
 
     #[instrument(skip_all)]

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use gpui::{AnyElement, App, ElementId, HighlightStyle, Pixels, SharedString, Stateful, Window};
 use language::{Edit, HighlightId, LanguageAwareStyling, Point};
+use smallvec::SmallVec;
 use multi_buffer::{
     Anchor, AnchorRangeExt, MBTextSummary, MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot,
     RowInfo, ToOffset,
@@ -1393,6 +1394,8 @@ pub struct Chunk<'a> {
     pub text: &'a str,
     /// The syntax highlighting style of the chunk.
     pub syntax_highlight_id: Option<HighlightId>,
+    /// Syntax highlight IDs from parent captures in the highlight stack.
+    pub parent_syntax_highlight_ids: SmallVec<[HighlightId; 1]>,
     /// The highlight style that has been applied to this chunk in
     /// the editor.
     pub highlight_style: Option<HighlightStyle>,
@@ -1594,6 +1597,7 @@ impl<'a> Iterator for FoldChunks<'a> {
                 chars: chunk.chars,
                 newlines: chunk.newlines,
                 syntax_highlight_id: chunk.syntax_highlight_id,
+                parent_syntax_highlight_ids: chunk.parent_syntax_highlight_ids.clone(),
                 highlight_style: chunk.highlight_style,
                 diagnostic_severity: chunk.diagnostic_severity,
                 is_unnecessary: chunk.is_unnecessary,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9879,6 +9879,20 @@ impl Element for EditorElement {
                         .editor
                         .update(cx, |editor, cx| editor.highlighted_display_rows(window, cx));
 
+                    // Add full-width backgrounds for parent syntax highlights
+                    // (e.g., fenced code blocks in markdown).
+                    for (row, bg_color) in snapshot.display_snapshot.syntax_background_rows(
+                        start_row..end_row,
+                        &self.style.syntax,
+                    ) {
+                        highlighted_rows.entry(row).or_insert(LineHighlight {
+                            background: solid_background(bg_color),
+                            border: None,
+                            include_gutter: false,
+                            type_id: None,
+                        });
+                    }
+
                     let is_light = cx.theme().appearance().is_light();
 
                     let mut highlighted_ranges = self

--- a/crates/grammars/src/markdown/highlights.scm
+++ b/crates/grammars/src/markdown/highlights.scm
@@ -43,6 +43,9 @@
   (info_string)
 ] @punctuation.embedded.markup
 
+(fenced_code_block
+  (code_fence_content) @text.literal.block.markup)
+
 (link_reference_definition) @link_text.markup
 
 (link_destination) @link_uri.markup

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -525,6 +525,10 @@ pub struct Chunk<'a> {
     pub text: &'a str,
     /// The syntax highlighting style of the chunk.
     pub syntax_highlight_id: Option<HighlightId>,
+    /// Syntax highlight IDs from parent captures in the highlight stack,
+    /// ordered from outermost to innermost (excluding the deepest capture
+    /// which is stored in `syntax_highlight_id`).
+    pub parent_syntax_highlight_ids: SmallVec<[HighlightId; 1]>,
     /// The highlight style that has been applied to this chunk in
     /// the editor.
     pub highlight_style: Option<HighlightStyle>,
@@ -5586,10 +5590,10 @@ impl<'a> BufferChunks<'a> {
                     && range.start >= capture.node.start_byte()
                 {
                     let next_capture_end = capture.node.end_byte();
-                    if range.start < next_capture_end
-                        && let Some(capture_id) =
-                            highlights.highlight_maps[capture.grammar_index].get(capture.index)
-                    {
+                    if range.start < next_capture_end {
+                        let capture_id = highlights.highlight_maps[capture.grammar_index]
+                            .get(capture.index)
+                            .unwrap_or(HighlightId::TRANSPARENT);
                         highlights.stack.push((next_capture_end, capture_id));
                     }
                     highlights.next_capture.take();
@@ -5723,13 +5727,12 @@ impl<'a> Iterator for BufferChunks<'a> {
                     next_capture_start = capture.node.start_byte();
                     break;
                 } else {
-                    let highlight_id =
-                        highlights.highlight_maps[capture.grammar_index].get(capture.index);
-                    if let Some(highlight_id) = highlight_id {
-                        highlights
-                            .stack
-                            .push((capture.node.end_byte(), highlight_id));
-                    }
+                    let highlight_id = highlights.highlight_maps[capture.grammar_index]
+                        .get(capture.index)
+                        .unwrap_or(HighlightId::TRANSPARENT);
+                    highlights
+                        .stack
+                        .push((capture.node.end_byte(), highlight_id));
                     highlights.next_capture = highlights.captures.next();
                 }
             }
@@ -5762,11 +5765,33 @@ impl<'a> Iterator for BufferChunks<'a> {
                 .min(next_capture_start)
                 .min(next_diagnostic_endpoint);
             let mut highlight_id = None;
-            if let Some(highlights) = self.highlights.as_ref()
-                && let Some((parent_capture_end, parent_highlight_id)) = highlights.stack.last()
-            {
-                chunk_end = chunk_end.min(*parent_capture_end);
-                highlight_id = Some(*parent_highlight_id);
+            let mut parent_syntax_highlight_ids = SmallVec::new();
+            if let Some(highlights) = self.highlights.as_ref() {
+                if let Some((parent_capture_end, parent_highlight_id)) = highlights.stack.last() {
+                    chunk_end = chunk_end.min(*parent_capture_end);
+                    if *parent_highlight_id != HighlightId::TRANSPARENT {
+                        highlight_id = Some(*parent_highlight_id);
+                    }
+                }
+                if highlights.stack.len() > 1 {
+                    for &(_, id) in &highlights.stack[..highlights.stack.len() - 1] {
+                        if id != HighlightId::TRANSPARENT {
+                            parent_syntax_highlight_ids.push(id);
+                        }
+                    }
+                } else if highlights.stack.len() == 1 {
+                    // Single-entry stack: the capture is both deepest and parent.
+                    // Include it in parents so syntax_background_rows can paint
+                    // full-width backgrounds (e.g., code_fence_content on empty
+                    // lines). This is safe because inline captures (code_span)
+                    // always have >=2 stack entries thanks to TRANSPARENT pushes
+                    // for their container captures (paragraph, heading, etc.).
+                    if let Some(&(_, id)) = highlights.stack.first() {
+                        if id != HighlightId::TRANSPARENT {
+                            parent_syntax_highlight_ids.push(id);
+                        }
+                    }
+                }
             }
             let bit_start = chunk_start - self.chunks.offset();
             let bit_end = chunk_end - self.chunks.offset();
@@ -5786,6 +5811,7 @@ impl<'a> Iterator for BufferChunks<'a> {
             Some(Chunk {
                 text: slice,
                 syntax_highlight_id: highlight_id,
+                parent_syntax_highlight_ids,
                 underline: self.underline,
                 diagnostic_severity: self.current_diagnostic_severity(),
                 is_unnecessary: self.current_code_is_unnecessary(),

--- a/crates/language_core/src/highlight_map.rs
+++ b/crates/language_core/src/highlight_map.rs
@@ -9,6 +9,9 @@ pub struct HighlightId(NonZeroU32);
 impl HighlightId {
     pub const TABSTOP_INSERT_ID: HighlightId = HighlightId(NonZeroU32::new(u32::MAX - 1).unwrap());
     pub const TABSTOP_REPLACE_ID: HighlightId = HighlightId(NonZeroU32::new(u32::MAX - 2).unwrap());
+    /// Sentinel for captures that have no theme style. Used to preserve stack
+    /// depth so parent-vs-child nesting is tracked correctly.
+    pub const TRANSPARENT: HighlightId = HighlightId(NonZeroU32::new(u32::MAX - 3).unwrap());
 
     pub fn new(capture_id: u32) -> Self {
         Self(NonZeroU32::new(capture_id + 1).unwrap_or(NonZeroU32::MAX))


### PR DESCRIPTION
https://github.com/zed-industries/zed/issues/7336

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-
  industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #7336 (Technically it was already closed, but this solves the issue which was punted before closing)

Replaces #53180 (which was opened from my fork's `main` branch and included unrelated commits).

Release Notes:

- Added full-width background color support for markdown fenced code blocks,
  configurable via `text.literal.block.markup` in theme syntax overrides
- On the left is the current Zed build, on the right is the new build after incorporating code changes
  
  
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/07666bdd-7d62-437f-ac3d-30e1c35cd525" />