### PR TITLE
Always open agent panel when selecting a thread or draft

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1718,11 +1718,6 @@ impl Sidebar {
                                 // shown, so the user returns to whatever
                                 // thread/draft they were looking at.
                                 this.activate_workspace(&workspace, window, cx);
-                                if AgentPanel::is_visible(&workspace, cx) {
-                                    workspace.update(cx, |workspace, cx| {
-                                        workspace.focus_panel::<AgentPanel>(window, cx);
-                                    });
-                                }
                             } else {
                                 this.open_workspace_for_group(&key, window, cx);
                             }
@@ -2181,6 +2176,9 @@ impl Sidebar {
                     }
                 } else if let Some(workspace) = workspace {
                     self.activate_workspace(&workspace, window, cx);
+                    workspace.update(cx, |ws, cx| {
+                        ws.focus_panel::<AgentPanel>(window, cx);
+                    });
                 } else {
                     self.open_workspace_for_group(&key, window, cx);
                 }
@@ -4152,11 +4150,9 @@ impl Sidebar {
                     // Placeholder with an open workspace — just
                     // activate it. The panel remembers its last view.
                     this.activate_workspace(workspace, window, cx);
-                    if AgentPanel::is_visible(workspace, cx) {
-                        workspace.update(cx, |ws, cx| {
-                            ws.focus_panel::<AgentPanel>(window, cx);
-                        });
-                    }
+                    workspace.update(cx, |ws, cx| {
+                        ws.focus_panel::<AgentPanel>(window, cx);
+                    });
                 } else {
                     // No workspace at all — just open one. The
                     // panel's load fallback will create a draft.


### PR DESCRIPTION
When clicking a draft placeholder ("New Agent Thread" tab) or confirming one via keyboard, the agent panel now always opens. Previously it only focused the panel if it was already visible.

Regular threads and drafts with IDs already opened the panel through `activate_draft` and `load_agent_thread_in_workspace`. The project header click continues to activate the workspace without forcing the panel open.

cc @danilo-leal

Release Notes:

- N/A