### PR TITLE
git: add cherry_pick, cherry_pick_continue, and cherry_pick_abort to GitRepository trait

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -854,6 +854,31 @@ pub trait GitRepository: Send + Sync {
         env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>>;
 
+    /// Applies the changes introduced by the given commit on top of the current HEAD.
+    ///
+    /// On conflict, the working tree is left in a cherry-pick-in-progress state, matching
+    /// the behavior of `git cherry-pick` on the command line. The caller is responsible
+    /// for resolving conflicts and calling `cherry_pick_continue` or `cherry_pick_abort`.
+    fn cherry_pick(
+        &self,
+        commit: String,
+        askpass: AskPassDelegate,
+        env: Arc<HashMap<String, String>>,
+    ) -> BoxFuture<'_, Result<()>>;
+
+    /// Continues an in-progress cherry-pick after conflicts have been resolved.
+    fn cherry_pick_continue(
+        &self,
+        askpass: AskPassDelegate,
+        env: Arc<HashMap<String, String>>,
+    ) -> BoxFuture<'_, Result<()>>;
+
+    /// Aborts an in-progress cherry-pick, restoring the pre-cherry-pick state.
+    fn cherry_pick_abort(
+        &self,
+        env: Arc<HashMap<String, String>>,
+    ) -> BoxFuture<'_, Result<()>>;
+
     fn push(
         &self,
         branch_name: String,


### PR DESCRIPTION
Adds three surgical, independently-cancellable methods to the `GitRepository` trait:

- `cherry_pick(commit, askpass, env)` — applies a commit's diff on top of HEAD
- `cherry_pick_continue(askpass, env)` — resumes after conflict resolution
- `cherry_pick_abort(env)` — restores pre-cherry-pick state

Each is a standalone `BoxFuture` with no internal sequencing, matching the shape of `stash_pop` and `reset`.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added `cherry_pick`, `cherry_pick_continue`, and `cherry_pick_abort` to `GitRepository`, enabling cherry-pick support in the Git Graph and agent workflows.