### PR TITLE
Fix Agent Panel font size incrementing by 2px instead of 1px

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -53,7 +53,7 @@ use std::time::Instant;
 use std::{collections::BTreeMap, rc::Rc, time::Duration};
 use terminal_view::terminal_panel::TerminalPanel;
 use text::Anchor;
-use theme_settings::AgentFontSize;
+use theme_settings::{AgentBufferFontSize, AgentUiFontSize};
 use ui::{
     Callout, CircularProgress, CommonAnimationExt, ContextMenu, ContextMenuEntry, CopyButton,
     DecoratedIcon, DiffStat, Disclosure, Divider, DividerColor, IconDecoration, IconDecorationKind,
@@ -601,7 +601,8 @@ impl ConversationView {
         let agent_server_store = project.read(cx).agent_server_store().clone();
         let subscriptions = vec![
             cx.observe_global_in::<SettingsStore>(window, Self::agent_ui_font_size_changed),
-            cx.observe_global_in::<AgentFontSize>(window, Self::agent_ui_font_size_changed),
+            cx.observe_global_in::<AgentUiFontSize>(window, Self::agent_ui_font_size_changed),
+            cx.observe_global_in::<AgentBufferFontSize>(window, Self::agent_ui_font_size_changed),
             cx.subscribe_in(
                 &agent_server_store,
                 window,

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -96,11 +96,17 @@ pub(crate) struct UiFontSize(Pixels);
 
 impl Global for UiFontSize {}
 
-/// In-memory override for the font size in the agent panel.
+/// In-memory override for the UI font size in the agent panel.
 #[derive(Default)]
-pub struct AgentFontSize(Pixels);
+pub struct AgentUiFontSize(Pixels);
 
-impl Global for AgentFontSize {}
+impl Global for AgentUiFontSize {}
+
+/// In-memory override for the buffer font size in the agent panel.
+#[derive(Default)]
+pub struct AgentBufferFontSize(Pixels);
+
+impl Global for AgentBufferFontSize {}
 
 /// Represents the selection of a theme, which can be either static or dynamic.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -378,7 +384,7 @@ impl ThemeSettings {
 
     /// Returns the agent panel font size. Falls back to the UI font size if unset.
     pub fn agent_ui_font_size(&self, cx: &App) -> Pixels {
-        cx.try_global::<AgentFontSize>()
+        cx.try_global::<AgentUiFontSize>()
             .map(|size| size.0)
             .or(self.agent_ui_font_size)
             .map(clamp_font_size)
@@ -387,7 +393,7 @@ impl ThemeSettings {
 
     /// Returns the agent panel buffer font size.
     pub fn agent_buffer_font_size(&self, cx: &App) -> Pixels {
-        cx.try_global::<AgentFontSize>()
+        cx.try_global::<AgentBufferFontSize>()
             .map(|size| size.0)
             .or(self.agent_buffer_font_size)
             .map(clamp_font_size)
@@ -543,16 +549,16 @@ pub fn reset_ui_font_size(cx: &mut App) {
 pub fn adjust_agent_ui_font_size(cx: &mut App, f: impl FnOnce(Pixels) -> Pixels) {
     let agent_ui_font_size = ThemeSettings::get_global(cx).agent_ui_font_size(cx);
     let adjusted_size = cx
-        .try_global::<AgentFontSize>()
+        .try_global::<AgentUiFontSize>()
         .map_or(agent_ui_font_size, |adjusted_size| adjusted_size.0);
-    cx.set_global(AgentFontSize(clamp_font_size(f(adjusted_size))));
+    cx.set_global(AgentUiFontSize(clamp_font_size(f(adjusted_size))));
     cx.refresh_windows();
 }
 
 /// Resets the agent response font size in the agent panel to the default value.
 pub fn reset_agent_ui_font_size(cx: &mut App) {
-    if cx.has_global::<AgentFontSize>() {
-        cx.remove_global::<AgentFontSize>();
+    if cx.has_global::<AgentUiFontSize>() {
+        cx.remove_global::<AgentUiFontSize>();
         cx.refresh_windows();
     }
 }
@@ -561,16 +567,16 @@ pub fn reset_agent_ui_font_size(cx: &mut App) {
 pub fn adjust_agent_buffer_font_size(cx: &mut App, f: impl FnOnce(Pixels) -> Pixels) {
     let agent_buffer_font_size = ThemeSettings::get_global(cx).agent_buffer_font_size(cx);
     let adjusted_size = cx
-        .try_global::<AgentFontSize>()
+        .try_global::<AgentBufferFontSize>()
         .map_or(agent_buffer_font_size, |adjusted_size| adjusted_size.0);
-    cx.set_global(AgentFontSize(clamp_font_size(f(adjusted_size))));
+    cx.set_global(AgentBufferFontSize(clamp_font_size(f(adjusted_size))));
     cx.refresh_windows();
 }
 
 /// Resets the user message font size in the agent panel to the default value.
 pub fn reset_agent_buffer_font_size(cx: &mut App) {
-    if cx.has_global::<AgentFontSize>() {
-        cx.remove_global::<AgentFontSize>();
+    if cx.has_global::<AgentBufferFontSize>() {
+        cx.remove_global::<AgentBufferFontSize>();
         cx.refresh_windows();
     }
 }

--- a/crates/theme_settings/src/theme_settings.rs
+++ b/crates/theme_settings/src/theme_settings.rs
@@ -28,12 +28,12 @@ pub use crate::schema::{
 };
 use crate::settings::adjust_buffer_font_size;
 pub use crate::settings::{
-    AgentFontSize, BufferLineHeight, FontFamilyName, IconThemeName, IconThemeSelection,
-    ThemeAppearanceMode, ThemeName, ThemeSelection, ThemeSettings, adjust_agent_buffer_font_size,
-    adjust_agent_ui_font_size, adjust_ui_font_size, adjusted_font_size, appearance_to_mode,
-    clamp_font_size, default_theme, observe_buffer_font_size_adjustment,
-    reset_agent_buffer_font_size, reset_agent_ui_font_size, reset_buffer_font_size,
-    reset_ui_font_size, set_icon_theme, set_mode, set_theme, setup_ui_font,
+    AgentBufferFontSize, AgentUiFontSize, BufferLineHeight, FontFamilyName, IconThemeName,
+    IconThemeSelection, ThemeAppearanceMode, ThemeName, ThemeSelection, ThemeSettings,
+    adjust_agent_buffer_font_size, adjust_agent_ui_font_size, adjust_ui_font_size,
+    adjusted_font_size, appearance_to_mode, clamp_font_size, default_theme,
+    observe_buffer_font_size_adjustment, reset_agent_buffer_font_size, reset_agent_ui_font_size,
+    reset_buffer_font_size, reset_ui_font_size, set_icon_theme, set_mode, set_theme, setup_ui_font,
 };
 pub use theme::UiDensity;
 


### PR DESCRIPTION
Split the shared `AgentFontSize` in-memory global into separate `AgentBufferFontSize` and `AgentUiFontSize` globals. Previously, both `adjust_agent_ui_font_size` and `adjust_agent_buffer_font_size` read from and wrote to the same global, so calling them back-to-back in `handle_font_size_action` applied the delta twice.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53368.

Release Notes:

- Fixed Agent Panel font size incrementing by 2px instead of 1px
