### PR TITLE
edit_prediction_ui: Add configure providers menu item to Copilot and Codestral

### DIFF
--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -630,10 +630,7 @@ impl EditPredictionButton {
         menu
     }
 
-    fn add_configure_providers_item(
-        &self,
-        menu: ContextMenu,
-    ) -> ContextMenu {
+    fn add_configure_providers_item(&self, menu: ContextMenu) -> ContextMenu {
         menu.separator().item(
             ContextMenuEntry::new("Configure Providers")
                 .icon(IconName::Settings)
@@ -690,7 +687,8 @@ impl EditPredictionButton {
                     }
                 });
 
-            let menu = self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
+            let menu =
+                self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
             let menu = self.add_configure_providers_item(menu);
             menu
         })
@@ -1032,7 +1030,8 @@ impl EditPredictionButton {
                 self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
 
             let menu = self.add_configure_providers_item(menu);
-            let menu = menu.separator()
+            let menu = menu
+                .separator()
                 .item(
                     ContextMenuEntry::new("Copilot: Next Edit Suggestions")
                         .toggleable(IconPosition::Start, next_edit_suggestions)

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -630,6 +630,31 @@ impl EditPredictionButton {
         menu
     }
 
+    fn add_configure_providers_item(
+        &self,
+        menu: ContextMenu,
+    ) -> ContextMenu {
+        menu.separator().item(
+            ContextMenuEntry::new("Configure Providers")
+                .icon(IconName::Settings)
+                .icon_position(IconPosition::Start)
+                .icon_color(Color::Muted)
+                .handler(move |window, cx| {
+                    telemetry::event!(
+                        "Edit Prediction Menu Action",
+                        action = "configure_providers",
+                    );
+                    window.dispatch_action(
+                        OpenSettingsAt {
+                            path: "edit_predictions.providers".to_string(),
+                        }
+                        .boxed_clone(),
+                        cx,
+                    );
+                }),
+        )
+    }
+
     pub fn build_copilot_start_menu(
         &mut self,
         window: &mut Window,
@@ -637,39 +662,37 @@ impl EditPredictionButton {
     ) -> Entity<ContextMenu> {
         let fs = self.fs.clone();
         let project = self.project.clone();
-        ContextMenu::build(window, cx, |menu, _, _| {
-            menu.entry("Sign In to Copilot", None, move |window, cx| {
-                telemetry::event!(
-                    "Edit Prediction Menu Action",
-                    action = "sign_in",
-                    provider = "copilot",
-                );
-                if let Some(copilot) = EditPredictionStore::try_global(cx).and_then(|store| {
-                    store.update(cx, |this, cx| {
-                        this.start_copilot_for_project(&project.upgrade()?, cx)
-                    })
-                }) {
-                    copilot_ui::initiate_sign_in(copilot, window, cx);
-                }
-            })
-            .entry("Disable Copilot", None, {
-                let fs = fs.clone();
-                move |_window, cx| {
+        ContextMenu::build(window, cx, |menu, _, cx| {
+            let menu = menu
+                .entry("Sign In to Copilot", None, move |window, cx| {
                     telemetry::event!(
                         "Edit Prediction Menu Action",
-                        action = "disable_provider",
+                        action = "sign_in",
                         provider = "copilot",
                     );
-                    hide_copilot(fs.clone(), cx)
-                }
-            })
-            .separator()
-            .entry("Use Zed AI", None, {
-                let fs = fs.clone();
-                move |_window, cx| {
-                    set_completion_provider(fs.clone(), cx, EditPredictionProvider::Zed)
-                }
-            })
+                    if let Some(copilot) = EditPredictionStore::try_global(cx).and_then(|store| {
+                        store.update(cx, |this, cx| {
+                            this.start_copilot_for_project(&project.upgrade()?, cx)
+                        })
+                    }) {
+                        copilot_ui::initiate_sign_in(copilot, window, cx);
+                    }
+                })
+                .entry("Disable Copilot", None, {
+                    let fs = fs.clone();
+                    move |_window, cx| {
+                        telemetry::event!(
+                            "Edit Prediction Menu Action",
+                            action = "disable_provider",
+                            provider = "copilot",
+                        );
+                        hide_copilot(fs.clone(), cx)
+                    }
+                });
+
+            let menu = self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
+            let menu = self.add_configure_providers_item(menu);
+            menu
         })
     }
 
@@ -1008,7 +1031,8 @@ impl EditPredictionButton {
             let menu =
                 self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
 
-            menu.separator()
+            let menu = self.add_configure_providers_item(menu);
+            let menu = menu.separator()
                 .item(
                     ContextMenuEntry::new("Copilot: Next Edit Suggestions")
                         .toggleable(IconPosition::Start, next_edit_suggestions)
@@ -1034,7 +1058,8 @@ impl EditPredictionButton {
                     "Go to Copilot Settings",
                     OpenBrowser { url: settings_url }.boxed_clone(),
                 )
-                .action("Sign Out", copilot::SignOut.boxed_clone())
+                .action("Sign Out", copilot::SignOut.boxed_clone());
+            menu
         })
     }
 
@@ -1048,6 +1073,7 @@ impl EditPredictionButton {
             let menu =
                 self.add_provider_switching_section(menu, EditPredictionProvider::Codestral, cx);
 
+            let menu = self.add_configure_providers_item(menu);
             menu
         })
     }
@@ -1290,26 +1316,7 @@ impl EditPredictionButton {
                 }
             }
 
-            menu = menu.separator().item(
-                ContextMenuEntry::new("Configure Providers")
-                    .icon(IconName::Settings)
-                    .icon_position(IconPosition::Start)
-                    .icon_color(Color::Muted)
-                    .handler(move |window, cx| {
-                        telemetry::event!(
-                            "Edit Prediction Menu Action",
-                            action = "configure_providers",
-                        );
-                        window.dispatch_action(
-                            OpenSettingsAt {
-                                path: "edit_predictions.providers".to_string(),
-                            }
-                            .boxed_clone(),
-                            cx,
-                        );
-                    }),
-            );
-
+            let menu = self.add_configure_providers_item(menu);
             menu
         })
     }


### PR DESCRIPTION
Codestral and copilot has a custom menu being built out. While the common menu has the configure provider quick setting, the custom menu doesn't have them. however it is a neat feature to have and quickly switch it out. 

Furthermore, copilot has an option of "Use zed AI" when copilot isn't signed in. Instead add the complete list and configure provider when it is not signed in

Before
<img width="256" height="588" alt="Screenshot 2026-04-11 at 4 46 47 PM" src="https://github.com/user-attachments/assets/7de1c09c-a7a0-46d1-9572-fa5e970c77a8" />
<img width="230" height="480" alt="Screenshot 2026-04-11 at 4 47 00 PM" src="https://github.com/user-attachments/assets/7075538f-1966-4ece-985f-b5e0d1d50f4a" />

After
<img width="259" height="663" alt="Screenshot 2026-04-11 at 5 02 48 PM" src="https://github.com/user-attachments/assets/31094f7b-8efa-488a-87d8-1998e554ec74" />
<img width="242" height="580" alt="Screenshot 2026-04-11 at 5 03 21 PM" src="https://github.com/user-attachments/assets/aba8ba09-1fbd-4c43-ba1f-af7ed51551a4" />
<img width="224" height="253" alt="Screenshot 2026-04-11 at 5 03 44 PM" src="https://github.com/user-attachments/assets/108e7b6f-1216-4a2c-b0c0-7be3dc5438b0" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes NA

Release Notes:

- added configure provider menu item to copilot and codestral
