### PR TITLE
languages: Fix broken whitespace for C++

### DIFF
--- a/crates/grammars/src/cpp/indents.scm
+++ b/crates/grammars/src/cpp/indents.scm
@@ -13,6 +13,14 @@
   "{"
   "}" @end) @indent
 
+(field_declaration_list
+  (access_specifier) @start
+  "}" @end) @indent
+
+(field_declaration_list
+  (access_specifier)
+  (access_specifier) @outdent)
+
 (_
   "("
   ")" @end) @indent

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -67,6 +67,7 @@ util.workspace = true
 [dev-dependencies]
 fs = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
+settings = { workspace = true, features = ["test-support"] }
 theme = { workspace = true, features = ["test-support"] }
 tree-sitter-bash.workspace = true
 tree-sitter-c.workspace = true

--- a/crates/languages/src/cpp.rs
+++ b/crates/languages/src/cpp.rs
@@ -17,6 +17,332 @@ mod tests {
     use unindent::Unindent;
 
     #[gpui::test]
+    async fn test_cpp_autoindent_access_specifier(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            buffer.edit(
+                [(
+                    0..0,
+                    r#"
+                    class Foo {
+                    public:
+                    void bar();
+                    private:
+                    int x;
+                    };
+                    "#
+                    .unindent(),
+                )],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(
+                buffer.text(),
+                r#"
+                class Foo {
+                  public:
+                    void bar();
+                  private:
+                    int x;
+                };
+                "#
+                .unindent(),
+                "members after access specifiers should be indented one level deeper than the specifier"
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    async fn test_cpp_autoindent_access_specifier_next_line(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            buffer.edit(
+                [(
+                    0..0,
+                    r#"
+                    class Foo {
+                    public:
+                      void bar();
+                    void baz();
+                    private:
+                      int x;
+                    };
+                    "#
+                    .unindent(),
+                )],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(
+                buffer.text(),
+                r#"
+                class Foo {
+                  public:
+                    void bar();
+                    void baz();
+                  private:
+                    int x;
+                };
+                "#
+                .unindent(),
+                "members after access specifiers should be indented one level deeper than the specifier"
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    async fn test_cpp_autoindent_nested_class_access_specifiers(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            buffer.edit(
+                [(
+                    0..0,
+                    r#"
+                    class Outer {
+                    public:
+                    class Inner {
+                    public:
+                    void inner_pub();
+                    private:
+                    int inner_priv;
+                    };
+                    private:
+                    int outer_priv;
+                    };
+                    "#
+                    .unindent(),
+                )],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(
+                buffer.text(),
+                r#"
+                class Outer {
+                  public:
+                    class Inner {
+                      public:
+                        void inner_pub();
+                      private:
+                        int inner_priv;
+                    };
+                  private:
+                    int outer_priv;
+                };
+                "#
+                .unindent(),
+                "nested class access specifiers should indent independently at each nesting level"
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    async fn test_cpp_autoindent_consecutive_access_specifiers(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            buffer.edit(
+                [(
+                    0..0,
+                    r#"
+                    class Foo {
+                    public:
+                    protected:
+                    private:
+                    int x;
+                    };
+                    "#
+                    .unindent(),
+                )],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(
+                buffer.text(),
+                r#"
+                class Foo {
+                  public:
+                  protected:
+                  private:
+                    int x;
+                };
+                "#
+                .unindent(),
+                "consecutive access specifiers with no members between them should all align at class level"
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    async fn test_cpp_autoindent_indented_access_specifiers(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            buffer.edit(
+                [(
+                    0..0,
+                    r#"
+                    class Foo {
+                    int default_member;
+                    public:
+                    void pub_method();
+                    private:
+                    int priv_member;
+                    };
+                    "#
+                    .unindent(),
+                )],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(
+                buffer.text(),
+                r#"
+                class Foo {
+                  int default_member;
+                  public:
+                    void pub_method();
+                  private:
+                    int priv_member;
+                };
+                "#
+                .unindent(),
+                "access specifiers should be indented one level inside class braces"
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
+    async fn test_cpp_autoindent_access_specifier_with_method_bodies(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
+
+            buffer.edit(
+                [(
+                    0..0,
+                    r#"
+                    class Foo {
+                    public:
+                    void bar() {
+                    if (x)
+                    y++;
+                    }
+                    private:
+                    int get_x() {
+                    return x;
+                    }
+                    int x;
+                    };
+                    "#
+                    .unindent(),
+                )],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(
+                buffer.text(),
+                r#"
+                class Foo {
+                  public:
+                    void bar() {
+                      if (x)
+                        y++;
+                    }
+                  private:
+                    int get_x() {
+                      return x;
+                    }
+                    int x;
+                };
+                "#
+                .unindent(),
+                "method bodies inside access specifier sections should compose brace and specifier indent"
+            );
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
     async fn test_cpp_autoindent_basic(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let test_settings = SettingsStore::test(cx);


### PR DESCRIPTION
Uses tree-sitter indent queries to create a pseudo-scope, since access modifiers are single-node in thetree-sitter grammar.

The @outdent capture truncates the parent { } indent range at the access specifier, keeping it at the same level as the class keyword and the pseudo-scopes from stacking.

The @outdent range selects siblings so we don't outdent the access specifiers themselves, since screenshots from the reference issue seem to show that at least one interested party does not prefer outdented access modifiers, and also it seemed like less of a departure from existing design.

Also, there are probably more tests than needed because this is my first time writing treesitter queries and I wanted to triple-guess myself. Quite open too feedback on which ones are more valuable.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53175

Release Notes:

- Improves handling of indentation after C++ access modifiers
