### PR TITLE
docs: Remove contradictory statements in edit prediction docs

### DIFF
--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -146,8 +146,6 @@ If you configured edit prediction keybindings before Zed `v0.229.0`, your `keyma
 
 You can disable edit predictions at several levels, or turn them off entirely.
 
-Alternatively, if you have Zed set as your provider, consider [using Subtle Mode](#switching-modes).
-
 ### On Buffers
 
 To not have predictions appear automatically as you type, set this in your settings file ([how to edit](../configuring-zed.md#settings-files)):
@@ -158,7 +156,7 @@ To not have predictions appear automatically as you type, set this in your setti
 }
 ```
 
-This hides every indication that there is a prediction available, regardless of [the display mode](#switching-modes) you're in (valid only if you have Zed as your provider).
+This hides every indication that there is a prediction available, regardless of [the display mode](#switching-modes) you're in.
 Still, you can trigger edit predictions manually by executing {#action editor::ShowEditPrediction} or hitting {#kb editor::ShowEditPrediction}.
 
 ### For Specific Languages

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -8,7 +8,7 @@ description: Set up AI code completions in Zed with Zeta (built-in), GitHub Copi
 Edit Prediction is how Zed's AI code completions work: an LLM predicts the code you want to write.
 Each keystroke sends a new request to the edit prediction provider, which returns individual or multi-line suggestions you accept by pressing `tab`.
 
-The default provider is [Zeta, a proprietary open source and open dataset model](https://huggingface.co/zed-industries/zeta), but you can also use [other providers](#other-providers) like GitHub Copilot, Mercury Coder, and Codestral.
+The default provider is [Zeta, an open source model developed by Zed](https://zed.dev/blog/zeta2), but you can also use [other providers](#other-providers) like GitHub Copilot, Mercury Coder, and Codestral.
 
 ## Configuring Zeta
 
@@ -145,6 +145,8 @@ If you configured edit prediction keybindings before Zed `v0.229.0`, your `keyma
 ## Disabling Automatic Edit Prediction
 
 You can disable edit predictions at several levels, or turn them off entirely.
+
+Alternatively, consider [using Subtle Mode](#switching-modes).
 
 ### On Buffers
 


### PR DESCRIPTION
Remove statements that imply that `subtle` edit prediction mode can only be used if Zed is set as an edit provider, despite this not being the case.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53207 

Release Notes:

- N/A