### PR TITLE
git_graph: Refresh graph when git refs change

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -7,7 +7,7 @@ use git::{
     blame::Blame,
     repository::{
         AskPassDelegate, Branch, CommitDataReader, CommitDetails, CommitOptions,
-        CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRepository,
+        CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRef, GitRepository,
         GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource, PushOptions, Remote,
         RepoPath, ResetMode, SearchCommitArgs, Worktree,
     },
@@ -466,12 +466,17 @@ impl GitRepository for FakeGitRepository {
         })
     }
 
-    fn refs(&self) -> BoxFuture<'_, Result<Arc<[gpui::SharedString]>>> {
+    fn refs(&self) -> BoxFuture<'_, Result<Vec<GitRef>>> {
         self.with_state_async(false, |state| {
-            let mut refs: Vec<gpui::SharedString> =
-                state.refs.keys().map(|r| r.clone().into()).collect();
-            refs.sort();
-            Ok(refs.into())
+            let mut refs: Vec<GitRef> = state
+                .refs
+                .keys()
+                .map(|r| GitRef {
+                    name: r.clone().into(),
+                })
+                .collect();
+            refs.sort_by(|a, b| a.name.cmp(&b.name));
+            Ok(refs)
         })
     }
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -466,6 +466,15 @@ impl GitRepository for FakeGitRepository {
         })
     }
 
+    fn refs(&self) -> BoxFuture<'_, Result<Arc<[gpui::SharedString]>>> {
+        self.with_state_async(false, |state| {
+            let mut refs: Vec<gpui::SharedString> =
+                state.refs.keys().map(|r| r.clone().into()).collect();
+            refs.sort();
+            Ok(refs.into())
+        })
+    }
+
     fn worktrees(&self) -> BoxFuture<'_, Result<Vec<Worktree>>> {
         let fs = self.fs.clone();
         let common_dir_path = self.common_dir_path.clone();

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -189,6 +189,11 @@ fn parse_cat_file_commit(sha: Oid, content: &str) -> Option<GraphCommitData> {
     })
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct GitRef {
+    pub name: SharedString,
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Branch {
     pub is_head: bool,
@@ -742,7 +747,7 @@ pub trait GitRepository: Send + Sync {
 
     fn branches(&self) -> BoxFuture<'_, Result<Vec<Branch>>>;
 
-    fn refs(&self) -> BoxFuture<'_, Result<Arc<[SharedString]>>>;
+    fn refs(&self) -> BoxFuture<'_, Result<Vec<GitRef>>>;
 
     fn change_branch(&self, name: String) -> BoxFuture<'_, Result<()>>;
     fn create_branch(&self, name: String, base_branch: Option<String>)
@@ -1638,7 +1643,7 @@ impl GitRepository for RealGitRepository {
             .boxed()
     }
 
-    fn refs(&self) -> BoxFuture<'_, Result<Arc<[SharedString]>>> {
+    fn refs(&self) -> BoxFuture<'_, Result<Vec<GitRef>>> {
         let git_binary = self.git_binary();
         self.executor
             .spawn(async move {
@@ -1646,17 +1651,20 @@ impl GitRepository for RealGitRepository {
                 let output = git.build_command(&["show-ref"]).output().await?;
 
                 if !output.status.success() {
-                    return Ok(Arc::from([]));
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    anyhow::bail!("git show-ref failed: {stderr}");
                 }
 
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let refs = stdout
                     .lines()
                     .filter(|line| !line.is_empty())
-                    .map(|line| SharedString::from(line.to_string()))
+                    .map(|line| GitRef {
+                        name: SharedString::from(line.to_string()),
+                    })
                     .collect::<Vec<_>>();
 
-                Ok(refs.into())
+                Ok(refs)
             })
             .boxed()
     }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -742,6 +742,8 @@ pub trait GitRepository: Send + Sync {
 
     fn branches(&self) -> BoxFuture<'_, Result<Vec<Branch>>>;
 
+    fn refs(&self) -> BoxFuture<'_, Result<Arc<[SharedString]>>>;
+
     fn change_branch(&self, name: String) -> BoxFuture<'_, Result<()>>;
     fn create_branch(&self, name: String, base_branch: Option<String>)
     -> BoxFuture<'_, Result<()>>;
@@ -1632,6 +1634,29 @@ impl GitRepository for RealGitRepository {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     anyhow::bail!("git status failed: {stderr}");
                 }
+            })
+            .boxed()
+    }
+
+    fn refs(&self) -> BoxFuture<'_, Result<Arc<[SharedString]>>> {
+        let git_binary = self.git_binary();
+        self.executor
+            .spawn(async move {
+                let git = git_binary?;
+                let output = git.build_command(&["show-ref"]).output().await?;
+
+                if !output.status.success() {
+                    return Ok(Arc::from([]));
+                }
+
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let refs = stdout
+                    .lines()
+                    .filter(|line| !line.is_empty())
+                    .map(|line| SharedString::from(line.to_string()))
+                    .collect::<Vec<_>>();
+
+                Ok(refs.into())
             })
             .boxed()
     }

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1148,7 +1148,9 @@ impl GitGraph {
                     }
                 }
             }
-            RepositoryEvent::HeadChanged | RepositoryEvent::BranchListChanged => {
+            RepositoryEvent::HeadChanged
+            | RepositoryEvent::BranchListChanged
+            | RepositoryEvent::RefsChanged => {
                 self.pending_select_sha = None;
                 // Only invalidate if we scanned atleast once,
                 // meaning we are not inside the initial repo loading state
@@ -3933,6 +3935,122 @@ mod tests {
             commits.len(),
             "graph data should be reloaded after switching back"
         );
+    }
+
+    #[gpui::test]
+    async fn test_graph_data_reloaded_after_refs_change(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {},
+                "file.txt": "content",
+            }),
+        )
+        .await;
+
+        let initial_head = Oid::from_bytes(&[1; 20]).unwrap();
+        let updated_head = Oid::from_bytes(&[3; 20]).unwrap();
+
+        fs.set_graph_commits(
+            Path::new("/project/.git"),
+            vec![Arc::new(InitialGraphCommitData {
+                sha: initial_head,
+                parents: smallvec![],
+                ref_names: vec!["HEAD".into(), "refs/heads/main".into()],
+            })],
+        );
+        fs.with_git_state(Path::new("/project/.git"), true, |state| {
+            state.refs = [
+                ("HEAD".to_string(), "1".repeat(40)),
+                ("refs/heads/main".to_string(), "1".repeat(40)),
+            ]
+            .into_iter()
+            .collect();
+        })
+        .unwrap();
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        cx.run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("should have a repository")
+        });
+
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace_weak =
+            multi_workspace.read_with(&*cx, |multi, _| multi.workspace().downgrade());
+        let git_graph = cx.new_window_entity(|window, cx| {
+            GitGraph::new(
+                repository.read(cx).id,
+                project.read(cx).git_store().clone(),
+                workspace_weak,
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        let initial_shas = git_graph.read_with(&*cx, |graph, _| {
+            graph
+                .graph_data
+                .commits
+                .iter()
+                .map(|commit| commit.data.sha)
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(initial_shas, vec![initial_head]);
+
+        fs.set_graph_commits(
+            Path::new("/project/.git"),
+            vec![Arc::new(InitialGraphCommitData {
+                sha: updated_head,
+                parents: smallvec![],
+                ref_names: vec![
+                    "HEAD".into(),
+                    "refs/heads/main".into(),
+                    "refs/tags/v1.0.0".into(),
+                ],
+            })],
+        );
+        fs.with_git_state(Path::new("/project/.git"), true, |state| {
+            state.refs = [
+                ("HEAD".to_string(), "3".repeat(40)),
+                ("refs/heads/main".to_string(), "3".repeat(40)),
+                ("refs/tags/v1.0.0".to_string(), "3".repeat(40)),
+            ]
+            .into_iter()
+            .collect();
+        })
+        .unwrap();
+
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.run_until_parked();
+
+        cx.draw(
+            point(px(0.), px(0.)),
+            gpui::size(px(1200.), px(800.)),
+            |_, _| git_graph.clone().into_any_element(),
+        );
+        cx.run_until_parked();
+
+        let reloaded_shas = git_graph.read_with(&*cx, |graph, _| {
+            graph
+                .graph_data
+                .commits
+                .iter()
+                .map(|commit| commit.data.sha)
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(reloaded_shas, vec![updated_head]);
     }
 
     #[gpui::test]

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -3952,7 +3952,8 @@ mod tests {
         .await;
 
         let initial_head = Oid::from_bytes(&[1; 20]).unwrap();
-        let updated_head = Oid::from_bytes(&[3; 20]).unwrap();
+        let branch_head = Oid::from_bytes(&[2; 20]).unwrap();
+        let tag_head = Oid::from_bytes(&[3; 20]).unwrap();
 
         fs.set_graph_commits(
             Path::new("/project/.git"),
@@ -4007,23 +4008,27 @@ mod tests {
         });
         assert_eq!(initial_shas, vec![initial_head]);
 
+        // Step 1: Add a new local branch
         fs.set_graph_commits(
             Path::new("/project/.git"),
-            vec![Arc::new(InitialGraphCommitData {
-                sha: updated_head,
-                parents: smallvec![],
-                ref_names: vec![
-                    "HEAD".into(),
-                    "refs/heads/main".into(),
-                    "refs/tags/v1.0.0".into(),
-                ],
-            })],
+            vec![
+                Arc::new(InitialGraphCommitData {
+                    sha: branch_head,
+                    parents: smallvec![initial_head],
+                    ref_names: vec!["refs/heads/feature".into()],
+                }),
+                Arc::new(InitialGraphCommitData {
+                    sha: initial_head,
+                    parents: smallvec![],
+                    ref_names: vec!["HEAD".into(), "refs/heads/main".into()],
+                }),
+            ],
         );
         fs.with_git_state(Path::new("/project/.git"), true, |state| {
             state.refs = [
-                ("HEAD".to_string(), "3".repeat(40)),
-                ("refs/heads/main".to_string(), "3".repeat(40)),
-                ("refs/tags/v1.0.0".to_string(), "3".repeat(40)),
+                ("HEAD".to_string(), "1".repeat(40)),
+                ("refs/heads/main".to_string(), "1".repeat(40)),
+                ("refs/heads/feature".to_string(), "2".repeat(40)),
             ]
             .into_iter()
             .collect();
@@ -4042,7 +4047,7 @@ mod tests {
         );
         cx.run_until_parked();
 
-        let reloaded_shas = git_graph.read_with(&*cx, |graph, _| {
+        let branch_shas = git_graph.read_with(&*cx, |graph, _| {
             graph
                 .graph_data
                 .commits
@@ -4050,7 +4055,63 @@ mod tests {
                 .map(|commit| commit.data.sha)
                 .collect::<Vec<_>>()
         });
-        assert_eq!(reloaded_shas, vec![updated_head]);
+        assert_eq!(branch_shas, vec![branch_head, initial_head]);
+
+        // Step 2: Add a tag and remote branch
+        fs.set_graph_commits(
+            Path::new("/project/.git"),
+            vec![
+                Arc::new(InitialGraphCommitData {
+                    sha: tag_head,
+                    parents: smallvec![branch_head],
+                    ref_names: vec!["refs/tags/v1.0.0".into(), "refs/remotes/origin/main".into()],
+                }),
+                Arc::new(InitialGraphCommitData {
+                    sha: branch_head,
+                    parents: smallvec![initial_head],
+                    ref_names: vec!["refs/heads/feature".into()],
+                }),
+                Arc::new(InitialGraphCommitData {
+                    sha: initial_head,
+                    parents: smallvec![],
+                    ref_names: vec!["HEAD".into(), "refs/heads/main".into()],
+                }),
+            ],
+        );
+        fs.with_git_state(Path::new("/project/.git"), true, |state| {
+            state.refs = [
+                ("HEAD".to_string(), "1".repeat(40)),
+                ("refs/heads/main".to_string(), "1".repeat(40)),
+                ("refs/heads/feature".to_string(), "2".repeat(40)),
+                ("refs/tags/v1.0.0".to_string(), "3".repeat(40)),
+                ("refs/remotes/origin/main".to_string(), "3".repeat(40)),
+            ]
+            .into_iter()
+            .collect();
+        })
+        .unwrap();
+
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.run_until_parked();
+
+        cx.draw(
+            point(px(0.), px(0.)),
+            gpui::size(px(1200.), px(800.)),
+            |_, _| git_graph.clone().into_any_element(),
+        );
+        cx.run_until_parked();
+
+        let tag_shas = git_graph.read_with(&*cx, |graph, _| {
+            graph
+                .graph_data
+                .commits
+                .iter()
+                .map(|commit| commit.data.sha)
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(tag_shas, vec![tag_head, branch_head, initial_head]);
     }
 
     #[gpui::test]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -33,7 +33,7 @@ use git::{
     parse_git_remote_url,
     repository::{
         Branch, CommitDetails, CommitDiff, CommitFile, CommitOptions, CreateWorktreeTarget,
-        DiffType, FetchOptions, GitRepository, GitRepositoryCheckpoint, GraphCommitData,
+        DiffType, FetchOptions, GitRef, GitRepository, GitRepositoryCheckpoint, GraphCommitData,
         InitialGraphCommitData, LogOrder, LogSource, PushOptions, Remote, RemoteCommandOutput,
         RepoPath, ResetMode, SearchCommitArgs, UpstreamTrackingStatus, Worktree as GitWorktree,
     },
@@ -295,7 +295,7 @@ pub struct RepositorySnapshot {
     pub remote_upstream_url: Option<String>,
     pub stash_entries: GitStash,
     pub linked_worktrees: Arc<[GitWorktree]>,
-    pub refs: Arc<[SharedString]>,
+    pub refs: Arc<[GitRef]>,
 }
 
 type JobId = u64;
@@ -7559,7 +7559,7 @@ async fn compute_snapshot(
             remote_origin_url,
             remote_upstream_url,
             linked_worktrees,
-            refs,
+            refs: refs.into(),
             scan_id: prev_snapshot.scan_id + 1,
             ..prev_snapshot
         };

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -295,6 +295,7 @@ pub struct RepositorySnapshot {
     pub remote_upstream_url: Option<String>,
     pub stash_entries: GitStash,
     pub linked_worktrees: Arc<[GitWorktree]>,
+    pub refs: Arc<[SharedString]>,
 }
 
 type JobId = u64;
@@ -435,6 +436,7 @@ pub enum RepositoryEvent {
     GitWorktreeListChanged,
     PendingOpsChanged { pending_ops: SumTree<PendingOps> },
     GraphEvent((LogSource, LogOrder), GitGraphEvent),
+    RefsChanged,
 }
 
 #[derive(Clone, Debug)]
@@ -3757,6 +3759,7 @@ impl RepositorySnapshot {
             remote_upstream_url: None,
             stash_entries: Default::default(),
             linked_worktrees: Arc::from([]),
+            refs: Arc::from([]),
             path_style,
         }
     }
@@ -4112,7 +4115,9 @@ impl Repository {
             .shared();
 
         cx.subscribe_self(move |this, event: &RepositoryEvent, _| match event {
-            RepositoryEvent::HeadChanged | RepositoryEvent::BranchListChanged => {
+            RepositoryEvent::HeadChanged
+            | RepositoryEvent::BranchListChanged
+            | RepositoryEvent::RefsChanged => {
                 if this.scan_id > 1 {
                     this.initial_graph_data.clear();
                 }
@@ -7501,14 +7506,15 @@ async fn compute_snapshot(
             })
         }
     };
-    let (branches, head_commit, all_worktrees) = cx
+    let (branches, head_commit, all_worktrees, refs) = cx
         .background_spawn({
             let backend = backend.clone();
             async move {
-                futures::future::try_join3(
+                futures::future::try_join4(
                     backend.branches(),
                     head_commit_future,
                     backend.worktrees(),
+                    backend.refs(),
                 )
                 .await
             }
@@ -7542,6 +7548,7 @@ async fn compute_snapshot(
             branch != this.snapshot.branch || head_commit != this.snapshot.head_commit;
         let branch_list_changed = *branch_list != *this.snapshot.branch_list;
         let worktrees_changed = *linked_worktrees != *this.snapshot.linked_worktrees;
+        let refs_changed = *refs != *this.snapshot.refs;
 
         this.snapshot = RepositorySnapshot {
             id,
@@ -7552,12 +7559,17 @@ async fn compute_snapshot(
             remote_origin_url,
             remote_upstream_url,
             linked_worktrees,
+            refs,
             scan_id: prev_snapshot.scan_id + 1,
             ..prev_snapshot
         };
 
         if head_changed {
             cx.emit(RepositoryEvent::HeadChanged);
+        }
+
+        if refs_changed {
+            cx.emit(RepositoryEvent::RefsChanged);
         }
 
         if branch_list_changed {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53594

Previously, the Git Graph UI only automatically refreshed when `HEAD` or branches (local/remote) were modified. This meant that creating or deleting tags, or updating other non-branch refs, did not trigger a UI update until another action forced a refresh.

This PR adds a comprehensive `refs()` scan to the repository snapshot (via `git show-ref`), allowing the system to track the exact state of all refs. By emitting a new `RefsChanged` event, the Git Graph now immediately reflects new tag decorations when they are created, deleted, or fetched.

Release Notes:

- Fixed an issue where the Git Graph UI would not automatically refresh when Git tags were created, deleted, or updated.
