### PR TITLE
Add MCP task-augmented tool calls with model continuation

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2357,6 +2357,24 @@ impl AcpThread {
         .boxed()
     }
 
+    pub fn cancel_tool_call(&mut self, tool_call_id: &acp::ToolCallId, cx: &mut Context<Self>) {
+        self.connection
+            .cancel_tool_call(&self.session_id, tool_call_id, cx);
+
+        if let Some((ix, call)) = self.tool_call_mut(tool_call_id) {
+            if matches!(
+                call.status,
+                ToolCallStatus::Pending
+                    | ToolCallStatus::WaitingForConfirmation { .. }
+                    | ToolCallStatus::InProgress
+            ) {
+                call.status = ToolCallStatus::Canceled;
+                cx.emit(AcpThreadEvent::EntryUpdated(ix));
+                cx.notify();
+            }
+        }
+    }
+
     pub fn cancel(&mut self, cx: &mut Context<Self>) -> Task<()> {
         let Some(turn) = self.running_turn.take() else {
             return Task::ready(());

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -136,6 +136,16 @@ pub trait AgentConnection {
 
     fn cancel(&self, session_id: &acp::SessionId, cx: &mut App);
 
+    /// Cancel a single tool call without stopping the entire turn.
+    /// Default implementation is a no-op for connections that don't support it.
+    fn cancel_tool_call(
+        &self,
+        _session_id: &acp::SessionId,
+        _tool_call_id: &acp::ToolCallId,
+        _cx: &mut App,
+    ) {
+    }
+
     fn truncate(
         &self,
         _session_id: &acp::SessionId,

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1249,6 +1249,19 @@ impl NativeAgentConnection {
                             }
                             ThreadEvent::Stop(stop_reason) => {
                                 log::debug!("Assistant message complete: {:?}", stop_reason);
+
+                                // Background tasks (terminal with background:true,
+                                // MCP task background pollers) may still send
+                                // ToolCallUpdate events after the turn ends.
+                                // Spawn a detached task that continues draining
+                                // the event channel so those updates reach the
+                                // AcpThread and the tool cards update correctly.
+                                let bg_acp_thread = acp_thread.clone();
+                                let mut bg_cx = cx.clone();
+                                cx.foreground_executor().spawn(async move {
+                                    Self::drain_background_events(events, bg_acp_thread, &mut bg_cx).await;
+                                }).detach();
+
                                 return Ok(acp::PromptResponse::new(stop_reason));
                             }
                         }
@@ -1263,6 +1276,44 @@ impl NativeAgentConnection {
             log::debug!("Response stream completed");
             anyhow::Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
         })
+    }
+
+    /// Drains remaining events from a turn's event channel after the turn
+    /// has completed. Background tasks (terminal `background: true`, MCP
+    /// task background pollers) may send `ToolCallUpdate` events after the
+    /// `Stop` event. This function processes those updates so tool cards
+    /// transition to Completed/Failed correctly.
+    ///
+    /// Only `ToolCallUpdate` events are processed — all other event types
+    /// are logged and discarded since the turn is already over.
+    async fn drain_background_events(
+        mut events: mpsc::UnboundedReceiver<Result<ThreadEvent>>,
+        acp_thread: WeakEntity<AcpThread>,
+        cx: &mut AsyncApp,
+    ) {
+        while let Some(result) = events.next().await {
+            match result {
+                Ok(ThreadEvent::ToolCallUpdate(update)) => {
+                    if let Err(e) = acp_thread.update(cx, |thread, cx| {
+                        thread.update_tool_call(update, cx)
+                    }) {
+                        log::debug!(
+                            "Background event drain: failed to update tool call: {e:#}"
+                        );
+                        return;
+                    }
+                }
+                Ok(event) => {
+                    log::debug!(
+                        "Background event drain: ignoring non-update event: {event:?}"
+                    );
+                }
+                Err(e) => {
+                    log::debug!("Background event drain: channel error: {e:#}");
+                    return;
+                }
+            }
+        }
     }
 }
 
@@ -1577,6 +1628,22 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
                     .thread
                     .update(cx, |thread, cx| thread.cancel(cx))
                     .detach();
+            }
+        });
+    }
+
+    fn cancel_tool_call(
+        &self,
+        session_id: &acp::SessionId,
+        tool_call_id: &acp::ToolCallId,
+        cx: &mut App,
+    ) {
+        let tool_use_id = language_model::LanguageModelToolUseId::from(tool_call_id.to_string());
+        self.0.update(cx, |agent, cx| {
+            if let Some(session) = agent.sessions.get(session_id) {
+                session
+                    .thread
+                    .update(cx, |thread, cx| thread.cancel_tool_call(tool_use_id, cx));
             }
         });
     }

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -261,6 +261,7 @@ impl DbThread {
                                 tool_use_id: tool_result.tool_use_id,
                                 tool_name: name.into(),
                                 is_error: tool_result.is_error,
+                                is_provisional: false,
                                 content: tool_result.content,
                                 output: tool_result.output,
                             },

--- a/crates/agent/src/edit_agent/evals.rs
+++ b/crates/agent/src/edit_agent/evals.rs
@@ -1156,6 +1156,7 @@ fn tool_result(
         tool_use_id: LanguageModelToolUseId::from(id.into()),
         tool_name: name.into(),
         is_error: false,
+        is_provisional: false,
         content: LanguageModelToolResultContent::Text(result.into()),
         output: None,
     })

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -55,6 +55,7 @@ use util::path;
 
 mod edit_file_thread_test;
 mod test_mcp_audience;
+mod test_mcp_tasks;
 mod test_tools;
 use test_tools::*;
 
@@ -321,6 +322,7 @@ async fn test_terminal_tool_timeout_kills_handle(cx: &mut TestAppContext) {
                 command: "sleep 1000".to_string(),
                 cd: ".".to_string(),
                 timeout_ms: Some(5),
+                background: false,
             }),
             event_stream,
             cx,
@@ -388,6 +390,7 @@ async fn test_terminal_tool_without_timeout_does_not_kill_handle(cx: &mut TestAp
                 command: "sleep 1000".to_string(),
                 cd: ".".to_string(),
                 timeout_ms: None,
+                background: false,
             }),
             event_stream,
             cx,
@@ -638,6 +641,7 @@ async fn test_prompt_caching(cx: &mut TestAppContext) {
         tool_use_id: "tool_1".into(),
         tool_name: EchoTool::NAME.into(),
         is_error: false,
+        is_provisional: false,
         content: "test".into(),
         output: Some("test".into()),
     };
@@ -867,6 +871,7 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
                 tool_use_id: tool_call_auth_1.tool_call.tool_call_id.0.to_string().into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: false,
+                is_provisional: false,
                 content: "Allowed".into(),
                 output: Some("Allowed".into())
             }),
@@ -874,6 +879,7 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
                 tool_use_id: tool_call_auth_2.tool_call.tool_call_id.0.to_string().into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: true,
+                is_provisional: false,
                 content: "Permission to run tool denied by user".into(),
                 output: Some("Permission to run tool denied by user".into())
             })
@@ -913,6 +919,7 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
                 tool_use_id: tool_call_auth_3.tool_call.tool_call_id.0.to_string().into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: false,
+                is_provisional: false,
                 content: "Allowed".into(),
                 output: Some("Allowed".into())
             }
@@ -941,6 +948,7 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
                 tool_use_id: "tool_id_4".into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: false,
+                is_provisional: false,
                 content: "Allowed".into(),
                 output: Some("Allowed".into())
             }
@@ -1461,6 +1469,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
             .unwrap(),
             output_schema: None,
             annotations: None,
+            execution: None,
         }],
         &context_server_store,
         cx,
@@ -1564,6 +1573,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
                 tool_use_id: "tool_3".into(),
                 tool_name: "echo".into(),
                 is_error: false,
+                is_provisional: false,
                 content: "native".into(),
                 output: Some("native".into()),
             },),
@@ -1571,6 +1581,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
                 tool_use_id: "tool_2".into(),
                 tool_name: "test_server_echo".into(),
                 is_error: false,
+                is_provisional: false,
                 content: "mcp".into(),
                 output: Some("mcp".into()),
             },),
@@ -1581,6 +1592,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
 }
 
 // Audience annotation tests are in test_mcp_audience.rs
+
 
 #[gpui::test]
 async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAppContext) {
@@ -1631,6 +1643,7 @@ async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAp
             }),
             output_schema: None,
             annotations: None,
+            execution: None,
         }],
         &context_server_store,
         cx,
@@ -1824,6 +1837,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 .unwrap(),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
             context_server::types::Tool {
                 name: "unique_tool_1".into(),
@@ -1831,6 +1845,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
         ],
         &context_server_store,
@@ -1849,6 +1864,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 .unwrap(),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
             context_server::types::Tool {
                 name: "unique_tool_2".into(),
@@ -1856,6 +1872,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
             context_server::types::Tool {
                 name: "a".repeat(MAX_TOOL_NAME_LENGTH - 2),
@@ -1863,6 +1880,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
             context_server::types::Tool {
                 name: "b".repeat(MAX_TOOL_NAME_LENGTH - 1),
@@ -1870,6 +1888,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
         ],
         &context_server_store,
@@ -1884,6 +1903,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
             context_server::types::Tool {
                 name: "b".repeat(MAX_TOOL_NAME_LENGTH - 1),
@@ -1891,6 +1911,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
             context_server::types::Tool {
                 name: "c".repeat(MAX_TOOL_NAME_LENGTH + 1),
@@ -1898,6 +1919,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
                 input_schema: json!({"type": "object", "properties": {}}),
                 output_schema: None,
                 annotations: None,
+                execution: None,
             },
         ],
         &context_server_store,
@@ -1916,6 +1938,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
             .unwrap(),
             output_schema: None,
             annotations: None,
+            execution: None,
         }],
         &context_server_store,
         cx,
@@ -3235,6 +3258,7 @@ async fn test_building_request_with_pending_tools(cx: &mut TestAppContext) {
                     tool_use_id: echo_tool_use.id.clone(),
                     tool_name: echo_tool_use.name,
                     is_error: false,
+                    is_provisional: false,
                     content: "test".into(),
                     output: Some("test".into())
                 })],
@@ -3721,6 +3745,7 @@ async fn test_send_retry_finishes_tool_calls_on_error(cx: &mut TestAppContext) {
                         tool_use_id: tool_use_1.id.clone(),
                         tool_name: tool_use_1.name.clone(),
                         is_error: false,
+                        is_provisional: false,
                         content: "test".into(),
                         output: Some("test".into())
                     }
@@ -3881,6 +3906,7 @@ async fn test_streaming_tool_completes_when_llm_stream_ends_without_final_input(
                         tool_use_id: tool_use.id.clone(),
                         tool_name: tool_use.name,
                         is_error: true,
+                        is_provisional: false,
                         content: "Failed to receive tool input: tool input was not fully received"
                             .into(),
                         output: Some(
@@ -4075,7 +4101,6 @@ async fn setup(cx: &mut TestAppContext, model: TestModel) -> ThreadTest {
                             InfiniteTool::NAME: true,
                             CancellationAwareTool::NAME: true,
                             StreamingEchoTool::NAME: true,
-                            StreamingJsonErrorContextTool::NAME: true,
                             StreamingFailingEchoTool::NAME: true,
                             TerminalTool::NAME: true,
                             UpdatePlanTool::NAME: true,
@@ -4499,6 +4524,7 @@ async fn test_terminal_tool_permission_rules(cx: &mut TestAppContext) {
                     command: "rm -rf /".to_string(),
                     cd: ".".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -4551,6 +4577,7 @@ async fn test_terminal_tool_permission_rules(cx: &mut TestAppContext) {
                     command: "echo hello".to_string(),
                     cd: ".".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -4609,6 +4636,7 @@ async fn test_terminal_tool_permission_rules(cx: &mut TestAppContext) {
                     command: "sudo rm file".to_string(),
                     cd: ".".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -4656,6 +4684,7 @@ async fn test_terminal_tool_permission_rules(cx: &mut TestAppContext) {
                     command: "echo hello".to_string(),
                     cd: ".".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -6325,9 +6354,9 @@ async fn test_edit_file_tool_allow_rule_skips_confirmation(cx: &mut TestAppConte
 
     cx.run_until_parked();
 
-    let event = rx.try_recv();
+    let event = rx.try_next();
     assert!(
-        !matches!(event, Ok(Ok(ThreadEvent::ToolCallAuthorization(_)))),
+        !matches!(event, Ok(Some(Ok(ThreadEvent::ToolCallAuthorization(_))))),
         "expected no authorization request for allowed .md file"
     );
 }
@@ -6469,9 +6498,9 @@ async fn test_fetch_tool_allow_rule_skips_confirmation(cx: &mut TestAppContext) 
 
     cx.run_until_parked();
 
-    let event = rx.try_recv();
+    let event = rx.try_next();
     assert!(
-        !matches!(event, Ok(Ok(ThreadEvent::ToolCallAuthorization(_)))),
+        !matches!(event, Ok(Some(Ok(ThreadEvent::ToolCallAuthorization(_))))),
         "expected no authorization request for allowed docs.rs URL"
     );
 }
@@ -6625,6 +6654,7 @@ async fn test_streaming_tool_error_breaks_stream_loop_immediately(cx: &mut TestA
                         tool_use_id: tool_use.id.clone(),
                         tool_name: tool_use.name,
                         is_error: true,
+                        is_provisional: false,
                         content: "failed".into(),
                         output: Some("failed".into()),
                     }
@@ -6736,6 +6766,7 @@ async fn test_streaming_tool_error_waits_for_prior_tools_to_complete(cx: &mut Te
                         tool_use_id: second_tool_use.id.clone(),
                         tool_name: second_tool_use.name,
                         is_error: true,
+                        is_provisional: false,
                         content: "failed".into(),
                         output: Some("failed".into()),
                     }),
@@ -6743,6 +6774,7 @@ async fn test_streaming_tool_error_waits_for_prior_tools_to_complete(cx: &mut Te
                         tool_use_id: first_tool_use.id.clone(),
                         tool_name: first_tool_use.name,
                         is_error: false,
+                        is_provisional: false,
                         content: "hello world".into(),
                         output: Some("hello world".into()),
                     }),

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -54,6 +54,7 @@ use std::{
 use util::path;
 
 mod edit_file_thread_test;
+mod test_mcp_audience;
 mod test_tools;
 use test_tools::*;
 
@@ -1493,6 +1494,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
         .send(context_server::types::CallToolResponse {
             content: vec![context_server::types::ToolResponseContent::Text {
                 text: "test".into(),
+                annotations: None,
             }],
             is_error: None,
             meta: None,
@@ -1545,7 +1547,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
     assert_eq!(tool_call_params.arguments, Some(json!({"text": "mcp"})));
     tool_call_response
         .send(context_server::types::CallToolResponse {
-            content: vec![context_server::types::ToolResponseContent::Text { text: "mcp".into() }],
+            content: vec![context_server::types::ToolResponseContent::Text { text: "mcp".into(), annotations: None }],
             is_error: None,
             meta: None,
             structured_content: None,
@@ -1577,6 +1579,8 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
     fake_model.end_last_completion_stream();
     events.collect::<Vec<_>>().await;
 }
+
+// Audience annotation tests are in test_mcp_audience.rs
 
 #[gpui::test]
 async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAppContext) {
@@ -1671,6 +1675,7 @@ async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAp
         .send(context_server::types::CallToolResponse {
             content: vec![context_server::types::ToolResponseContent::Text {
                 text: expected_tool_output.into(),
+                annotations: None,
             }],
             is_error: None,
             meta: None,

--- a/crates/agent/src/tests/test_mcp_audience.rs
+++ b/crates/agent/src/tests/test_mcp_audience.rs
@@ -169,6 +169,7 @@ async fn run_audience_test(
             input_schema: json!({"type": "object", "properties": {}}),
             output_schema: None,
             annotations: None,
+            execution: None,
         }],
         &context_server_store,
         cx,
@@ -220,6 +221,7 @@ fn expected_tool_result(tool_name: &str, text: &str) -> Vec<MessageContent> {
         tool_use_id: "tool_1".into(),
         tool_name: tool_name.into(),
         is_error: false,
+        is_provisional: false,
         content: text.into(),
         output: Some(text.into()),
     })]

--- a/crates/agent/src/tests/test_mcp_audience.rs
+++ b/crates/agent/src/tests/test_mcp_audience.rs
@@ -1,0 +1,332 @@
+//! Tests for MCP tool response audience annotations (`annotations.audience`).
+//!
+//! # MCP spec reference
+//!
+//! The `Annotations` type is defined in the MCP JSON Schema (all versions
+//! since 2024-11-05).  Each content block in a `tools/call` response may
+//! carry an `annotations` object whose `audience` field is an array of
+//! `Role` values (`"user"` and/or `"assistant"`).
+//!
+//! Spec: <https://modelcontextprotocol.io/specification/2025-03-26/server/tools>
+//! Schema: <https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.json>
+//!
+//! # ACP mapping
+//!
+//! Zed maps MCP audience annotations to ACP (`agent-client-protocol`)
+//! ToolCallContent updates.  User-only blocks are pushed to the event
+//! stream as `ToolCallContent::Content` display updates (shown in the
+//! tool call card) but excluded from the `AgentToolOutput` sent to the
+//! model.  See `ContextServerTool::run()` in
+//! `crates/agent/src/tools/context_server_registry.rs`.
+//!
+//! # Routing rules tested here
+//!
+//! | `annotations.audience`      | Sent to model? | User display update? |
+//! |-----------------------------|----------------|----------------------|
+//! | absent / `null`             | yes            | no                   |
+//! | `["user"]`                  | **no**         | **yes**              |
+//! | `["assistant"]`             | yes            | no                   |
+//! | `["user", "assistant"]`     | yes            | no                   |
+//!
+//! When *all* blocks are user-only the model receives the placeholder
+//! `"[output displayed to user]"`.
+
+use super::*;
+use pretty_assertions::assert_eq;
+use acp_thread::UserMessageId;
+use agent_client_protocol as acp;
+use agent_settings::AgentProfileId;
+use context_server::types::{
+    CallToolResponse, MessageAnnotations, Role as McpRole, ToolResponseContent,
+};
+use futures::StreamExt;
+use language_model::{
+    LanguageModelCompletionEvent, LanguageModelToolResult, LanguageModelToolUse, MessageContent,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn user_ann() -> Option<MessageAnnotations> {
+    Some(MessageAnnotations {
+        audience: Some(vec![McpRole::User]),
+        priority: None,
+    })
+}
+
+fn assistant_ann() -> Option<MessageAnnotations> {
+    Some(MessageAnnotations {
+        audience: Some(vec![McpRole::Assistant]),
+        priority: None,
+    })
+}
+
+fn both_ann() -> Option<MessageAnnotations> {
+    Some(MessageAnnotations {
+        audience: Some(vec![McpRole::User, McpRole::Assistant]),
+        priority: None,
+    })
+}
+
+fn text_block(text: &str, annotations: Option<MessageAnnotations>) -> ToolResponseContent {
+    ToolResponseContent::Text {
+        text: text.into(),
+        annotations,
+    }
+}
+
+fn tool_response(content: Vec<ToolResponseContent>) -> CallToolResponse {
+    CallToolResponse {
+        content,
+        is_error: None,
+        meta: None,
+        structured_content: None,
+    }
+}
+
+/// Collects any text pushed as user-only display content via ToolCallUpdate.
+fn collect_display_texts(
+    events: &mut (impl futures::Stream<Item = Result<ThreadEvent>> + Unpin),
+) -> Vec<String> {
+    let mut texts = Vec::new();
+    while let Some(event) = events.next().now_or_never().flatten() {
+        if let Ok(ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update))) =
+            &event
+        {
+            if let Some(content) = &update.fields.content {
+                for item in content {
+                    if let acp::ToolCallContent::Content(c) = item {
+                        if let acp::ContentBlock::Text(t) = &c.content {
+                            texts.push(t.text.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    texts
+}
+
+/// Result of [`run_audience_test`] — the bits each test needs to assert on.
+struct AudienceResult {
+    /// The tool result content the model received.
+    model_content: Vec<MessageContent>,
+    /// Any text emitted as user-only display updates.
+    display_texts: Vec<String>,
+}
+
+/// Sets up a fake MCP server with one tool, sends a user message, has the
+/// model invoke the tool, delivers `response_blocks` as the tool output,
+/// and returns what the model received plus any display-only content.
+///
+/// Every audience test follows this exact sequence — only the response
+/// blocks and assertions differ.
+async fn run_audience_test(
+    server_name: &'static str,
+    tool_name: &'static str,
+    response_blocks: Vec<ToolResponseContent>,
+    cx: &mut TestAppContext,
+) -> AudienceResult {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "always_allow_tool_actions": true,
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {}
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    let mut mcp_tool_calls = setup_context_server(
+        server_name,
+        vec![context_server::types::Tool {
+            name: tool_name.into(),
+            description: Some("test".into()),
+            input_schema: json!({"type": "object", "properties": {}}),
+            output_schema: None,
+            annotations: None,
+        }],
+        &context_server_store,
+        cx,
+    );
+
+    let mut events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let _initial = fake_model.pending_completions().pop().unwrap();
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: tool_name.into(),
+            raw_input: json!({}).to_string(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let (_params, responder) = mcp_tool_calls.next().await.unwrap();
+    responder.send(tool_response(response_blocks)).unwrap();
+    cx.run_until_parked();
+
+    let completion = fake_model
+        .pending_completions()
+        .pop()
+        .expect("no pending completion after tool response");
+    let model_content = completion.messages.last().unwrap().content.clone();
+    let display_texts = collect_display_texts(&mut events);
+
+    fake_model.send_last_completion_stream_text_chunk("ok");
+    fake_model.end_last_completion_stream();
+
+    AudienceResult {
+        model_content,
+        display_texts,
+    }
+}
+
+fn expected_tool_result(tool_name: &str, text: &str) -> Vec<MessageContent> {
+    vec![MessageContent::ToolResult(LanguageModelToolResult {
+        tool_use_id: "tool_1".into(),
+        tool_name: tool_name.into(),
+        is_error: false,
+        content: text.into(),
+        output: Some(text.into()),
+    })]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Mixed response: one user-only block (displayed but hidden from model)
+/// and one unannotated block (sent to model).
+#[gpui::test]
+async fn test_mixed_audience(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_mixed",
+        "preview",
+        vec![
+            text_block("rich preview for the human", user_ann()),
+            text_block("dimensions: 800x600", None),
+        ],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("preview", "dimensions: 800x600"));
+    assert!(
+        result.display_texts.contains(&"rich preview for the human".into()),
+        "user-only block should appear as display update, got: {:?}",
+        result.display_texts
+    );
+}
+
+/// Every block is user-only → model gets the placeholder.
+#[gpui::test]
+async fn test_all_user_only(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_user_only",
+        "render",
+        vec![
+            text_block("image data", user_ann()),
+            text_block("more display content", user_ann()),
+        ],
+        cx,
+    )
+    .await;
+
+    assert_eq!(
+        result.model_content,
+        expected_tool_result("render", "[output displayed to user]")
+    );
+}
+
+/// No annotations at all — baseline. Everything goes to both user and model,
+/// no separate display update is emitted.
+#[gpui::test]
+async fn test_no_annotations(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_none",
+        "plain",
+        vec![text_block("plain output", None)],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("plain", "plain output"));
+    assert!(
+        result.display_texts.is_empty(),
+        "no annotation should not produce display update, got: {:?}",
+        result.display_texts
+    );
+}
+
+/// audience: ["assistant"] — content goes to the model, no user display update.
+#[gpui::test]
+async fn test_model_only(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_model",
+        "compute",
+        vec![text_block("the answer is 4", assistant_ann())],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("compute", "the answer is 4"));
+    assert!(
+        result.display_texts.is_empty(),
+        "model-only block should not produce display update, got: {:?}",
+        result.display_texts
+    );
+}
+
+/// audience: ["user","assistant"] — same as no annotation. Content goes to
+/// the model and no separate display update is emitted.
+#[gpui::test]
+async fn test_both_audiences(cx: &mut TestAppContext) {
+    let result = run_audience_test(
+        "aud_both",
+        "lookup",
+        vec![text_block("shared content", both_ann())],
+        cx,
+    )
+    .await;
+
+    assert_eq!(result.model_content, expected_tool_result("lookup", "shared content"));
+    assert!(
+        result.display_texts.is_empty(),
+        "both-audience block should not produce display update, got: {:?}",
+        result.display_texts
+    );
+}

--- a/crates/agent/src/tests/test_mcp_tasks.rs
+++ b/crates/agent/src/tests/test_mcp_tasks.rs
@@ -1,0 +1,971 @@
+use super::*;
+use context_server::types::{
+    self, CallToolParams, CallToolResponse, CreateTaskResult, ServerCapabilities,
+    ServerTaskRequestsCapabilities, ServerTaskToolsCapabilities, ServerTasksCapabilities, Task,
+    TaskStatus, TaskSupport, TasksGetParams, TasksResultParams, Tool, ToolExecution,
+    ToolResponseContent, MODEL_IMMEDIATE_RESPONSE_KEY,
+};
+use pretty_assertions::assert_eq;
+use std::collections::VecDeque;
+use std::sync::Mutex as StdMutex;
+
+/// Shared state that tests use to control what the fake task server returns.
+struct TaskServerState {
+    /// Sequence of Task states that TasksGet will return, popped from front.
+    task_get_responses: VecDeque<Task>,
+    /// The value that TasksResult will return.
+    task_result: Option<serde_json::Value>,
+}
+
+/// Sets up a fake MCP context server that advertises task capabilities.
+///
+/// Returns:
+/// - A receiver for CallToolAsTask invocations (like `setup_context_server`'s CallTool receiver)
+/// - An `Arc<StdMutex<TaskServerState>>` for controlling TasksGet / TasksResult responses
+/// - An `Arc<FakeTransport>` for injecting notifications from the test body
+fn setup_task_context_server(
+    name: &'static str,
+    tools: Vec<Tool>,
+    context_server_store: &Entity<ContextServerStore>,
+    cx: &mut TestAppContext,
+) -> (
+    mpsc::UnboundedReceiver<(CallToolParams, oneshot::Sender<CreateTaskResult>)>,
+    Arc<StdMutex<TaskServerState>>,
+    Arc<context_server::test::FakeTransport>,
+) {
+    cx.update(|cx| {
+        let mut settings = ProjectSettings::get_global(cx).clone();
+        settings.context_servers.insert(
+            name.into(),
+            project::project_settings::ContextServerSettings::Stdio {
+                enabled: true,
+                remote: false,
+                command: ContextServerCommand {
+                    path: "somebinary".into(),
+                    args: Vec::new(),
+                    env: None,
+                    timeout: None,
+                },
+            },
+        );
+        ProjectSettings::override_global(settings, cx);
+    });
+
+    let state = Arc::new(StdMutex::new(TaskServerState {
+        task_get_responses: VecDeque::new(),
+        task_result: None,
+    }));
+
+    let (tool_calls_tx, tool_calls_rx) = mpsc::unbounded();
+
+    let tasks_get_state = state.clone();
+    let tasks_result_state = state.clone();
+
+    let fake_transport = context_server::test::create_fake_transport(name, cx.executor())
+        .on_request::<types::requests::Initialize, _>(move |_params| async move {
+            types::InitializeResponse {
+                protocol_version: types::ProtocolVersion(
+                    types::LATEST_PROTOCOL_VERSION.to_string(),
+                ),
+                server_info: types::Implementation {
+                    name: name.into(),
+                    version: "1.0.0".to_string(),
+                },
+                capabilities: ServerCapabilities {
+                    tools: Some(types::ToolsCapabilities {
+                        list_changed: Some(true),
+                    }),
+                    tasks: Some(ServerTasksCapabilities {
+                        list: None,
+                        cancel: None,
+                        requests: Some(ServerTaskRequestsCapabilities {
+                            tools: Some(ServerTaskToolsCapabilities {
+                                call: Some(serde_json::json!({})),
+                            }),
+                        }),
+                    }),
+                    ..Default::default()
+                },
+                meta: None,
+            }
+        })
+        .on_request::<types::requests::ListTools, _>(move |_params| {
+            let tools = tools.clone();
+            async move {
+                types::ListToolsResponse {
+                    tools,
+                    next_cursor: None,
+                    meta: None,
+                }
+            }
+        })
+        .on_request::<types::requests::CallToolAsTask, _>(move |params| {
+            let tool_calls_tx = tool_calls_tx.clone();
+            async move {
+                let (response_tx, response_rx) = oneshot::channel();
+                tool_calls_tx
+                    .unbounded_send((params, response_tx))
+                    .unwrap();
+                response_rx.await.unwrap()
+            }
+        })
+        .on_request::<types::requests::TasksGet, _>(move |params: TasksGetParams| {
+            let state = tasks_get_state.clone();
+            async move {
+                let mut guard = state.lock().unwrap();
+                guard.task_get_responses.pop_front().unwrap_or_else(|| {
+                    panic!(
+                        "TasksGet called for task '{}' but no responses were queued",
+                        params.task_id
+                    )
+                })
+            }
+        })
+        .on_request::<types::requests::TasksResult, _>(move |params: TasksResultParams| {
+            let state = tasks_result_state.clone();
+            async move {
+                let guard = state.lock().unwrap();
+                guard.task_result.clone().unwrap_or_else(|| {
+                    panic!(
+                        "TasksResult called for task '{}' but no result was set",
+                        params.task_id
+                    )
+                })
+            }
+        });
+
+    let transport_arc = Arc::new(fake_transport);
+
+    context_server_store.update(cx, |store, cx| {
+        store.start_server(
+            Arc::new(ContextServer::new(
+                ContextServerId(name.into()),
+                transport_arc.clone() as Arc<dyn context_server::transport::Transport>,
+            )),
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    (tool_calls_rx, state, transport_arc)
+}
+
+/// Sets up a fake MCP context server that advertises task capabilities but
+/// whose tool has `task_support: Forbidden`. This should cause the agent to
+/// use the normal `CallTool` path instead of `CallToolAsTask`.
+fn setup_non_task_context_server(
+    name: &'static str,
+    tools: Vec<Tool>,
+    context_server_store: &Entity<ContextServerStore>,
+    cx: &mut TestAppContext,
+) -> mpsc::UnboundedReceiver<(CallToolParams, oneshot::Sender<CallToolResponse>)> {
+    cx.update(|cx| {
+        let mut settings = ProjectSettings::get_global(cx).clone();
+        settings.context_servers.insert(
+            name.into(),
+            project::project_settings::ContextServerSettings::Stdio {
+                enabled: true,
+                remote: false,
+                command: ContextServerCommand {
+                    path: "somebinary".into(),
+                    args: Vec::new(),
+                    env: None,
+                    timeout: None,
+                },
+            },
+        );
+        ProjectSettings::override_global(settings, cx);
+    });
+
+    let (tool_calls_tx, tool_calls_rx) = mpsc::unbounded();
+
+    let fake_transport = context_server::test::create_fake_transport(name, cx.executor())
+        .on_request::<types::requests::Initialize, _>(move |_params| async move {
+            types::InitializeResponse {
+                protocol_version: types::ProtocolVersion(
+                    types::LATEST_PROTOCOL_VERSION.to_string(),
+                ),
+                server_info: types::Implementation {
+                    name: name.into(),
+                    version: "1.0.0".to_string(),
+                },
+                capabilities: ServerCapabilities {
+                    tools: Some(types::ToolsCapabilities {
+                        list_changed: Some(true),
+                    }),
+                    tasks: Some(ServerTasksCapabilities {
+                        list: None,
+                        cancel: None,
+                        requests: Some(ServerTaskRequestsCapabilities {
+                            tools: Some(ServerTaskToolsCapabilities {
+                                call: Some(serde_json::json!({})),
+                            }),
+                        }),
+                    }),
+                    ..Default::default()
+                },
+                meta: None,
+            }
+        })
+        .on_request::<types::requests::ListTools, _>(move |_params| {
+            let tools = tools.clone();
+            async move {
+                types::ListToolsResponse {
+                    tools,
+                    next_cursor: None,
+                    meta: None,
+                }
+            }
+        })
+        .on_request::<types::requests::CallTool, _>(move |params| {
+            let tool_calls_tx = tool_calls_tx.clone();
+            async move {
+                let (response_tx, response_rx) = oneshot::channel();
+                tool_calls_tx
+                    .unbounded_send((params, response_tx))
+                    .unwrap();
+                response_rx.await.unwrap()
+            }
+        });
+
+    context_server_store.update(cx, |store, cx| {
+        store.start_server(
+            Arc::new(ContextServer::new(
+                ContextServerId(name.into()),
+                Arc::new(fake_transport),
+            )),
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    tool_calls_rx
+}
+
+fn make_task(
+    task_id: &str,
+    status: TaskStatus,
+    message: Option<&str>,
+    poll_interval: Option<u64>,
+) -> Task {
+    Task {
+        task_id: task_id.to_string(),
+        status,
+        status_message: message.map(|s| s.to_string()),
+        created_at: "2025-01-01T00:00:00Z".to_string(),
+        last_updated_at: "2025-01-01T00:00:01Z".to_string(),
+        ttl: Some(300_000),
+        poll_interval,
+    }
+}
+
+fn make_tool(name: &str, task_support: TaskSupport) -> Tool {
+    Tool {
+        name: name.into(),
+        description: Some(format!("A tool named {name}")),
+        input_schema: json!({"type": "object", "properties": {"text": {"type": "string"}}}),
+        output_schema: None,
+        annotations: None,
+        execution: Some(ToolExecution {
+            task_support: Some(task_support),
+        }),
+    }
+}
+
+/// Extract the text from a `LanguageModelToolResultContent`.
+fn tool_result_text(content: &language_model::LanguageModelToolResultContent) -> &str {
+    match content {
+        language_model::LanguageModelToolResultContent::Text(text) => text.as_ref(),
+        other => panic!("expected Text tool result content, got: {other:?}"),
+    }
+}
+
+/// Configures settings so MCP tools are auto-allowed and the test profile
+/// enables all context servers.
+async fn configure_test_profile(
+    fs: &Arc<FakeFs>,
+    thread: &Entity<Thread>,
+    cx: &mut TestAppContext,
+) {
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "tool_permissions": { "default": "allow" },
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {}
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+}
+
+/// Simulate the model issuing a tool call, end the stream, and park.
+fn model_call_tool(fake_model: &FakeLanguageModel, tool_name: &str, cx: &mut TestAppContext) {
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: tool_name.into(),
+            raw_input: json!({"text": "hello"}).to_string(),
+            input: json!({"text": "hello"}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+}
+
+/// Wait for the model to receive a new pending completion request.
+///
+/// The MCP task polling loop uses `smol::Timer::after` which requires
+/// real wall-clock time to fire. The test executor's `run_until_parked()`
+/// is synchronous and does not park for real time, so we cannot drive
+/// smol timers with it. Instead, we await a short smol timer in the
+/// test itself — the `block()` method in the test scheduler parks the
+/// thread for real time, during which the tool's smol timers fire and
+/// the polling loop progresses.
+async fn wait_for_model_completion(
+    fake_model: &FakeLanguageModel,
+    cx: &mut TestAppContext,
+) {
+    for _ in 0..50 {
+        // Yield real wall-clock time so smol timers in spawned tasks can fire.
+        smol::Timer::after(Duration::from_millis(50)).await;
+        cx.run_until_parked();
+        if !fake_model.pending_completions().is_empty() {
+            return;
+        }
+    }
+    panic!("Timed out waiting for model to receive a new completion request");
+}
+
+#[gpui::test]
+async fn test_mcp_task_basic_lifecycle(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    configure_test_profile(&fs, &thread, cx).await;
+
+    let (mut tool_calls, state, _transport) = setup_task_context_server(
+        "task_server",
+        vec![make_tool("slow_echo", TaskSupport::Required)],
+        &context_server_store,
+        cx,
+    );
+
+    // Queue up TasksGet responses: first "working", then "completed".
+    {
+        let mut guard = state.lock().unwrap();
+        guard.task_get_responses.push_back(make_task(
+            "task-1",
+            TaskStatus::Working,
+            Some("Still processing..."),
+            Some(10),
+        ));
+        guard.task_get_responses.push_back(make_task(
+            "task-1",
+            TaskStatus::Completed,
+            Some("Done!"),
+            Some(10),
+        ));
+        guard.task_result = Some(
+            serde_json::to_value(CallToolResponse {
+                content: vec![ToolResponseContent::Text {
+                    text: "echoed: hello".into(),
+                    annotations: None,
+                }],
+                is_error: None,
+                meta: None,
+                structured_content: None,
+            })
+            .unwrap(),
+        );
+    }
+
+    // Send a user message so the model gets a completion request.
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    // Verify the tool is available.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    assert!(
+        tool_names_for_completion(&completion).contains(&"slow_echo".to_string()),
+        "slow_echo tool should be available"
+    );
+
+    // Simulate the model calling the tool.
+    model_call_tool(&fake_model, "slow_echo", cx);
+
+    // The server receives the CallToolAsTask request — respond with CreateTaskResult.
+    let (call_params, response_tx) = tool_calls.next().await.unwrap();
+    assert_eq!(call_params.name, "slow_echo");
+    assert_eq!(call_params.arguments, Some(json!({"text": "hello"})));
+    assert!(
+        call_params.task.is_some(),
+        "task params should be set for task-augmented calls"
+    );
+
+    response_tx
+        .send(CreateTaskResult {
+            task: make_task("task-1", TaskStatus::Working, Some("Starting..."), Some(10)),
+            meta: None,
+        })
+        .unwrap();
+
+    // Wait for the polling loop to complete and the model to get a new
+    // completion request with the tool result. The polling loop uses
+    // smol::Timer::after which needs real wall-clock time.
+    wait_for_model_completion(&fake_model, cx).await;
+
+    // The model should now have a new completion request with the tool result.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r),
+            _ => None,
+        })
+        .expect("expected a tool result in the completion");
+
+    assert_eq!(tool_result.tool_use_id.to_string(), "tool_1");
+    assert!(!tool_result.is_error, "tool result should not be an error");
+    let result_text = tool_result_text(&tool_result.content);
+    assert!(
+        result_text.contains("echoed: hello"),
+        "tool result content should contain the echoed text, got: {result_text}",
+    );
+
+    // Finish the model turn.
+    fake_model.send_last_completion_stream_text_chunk("All done!");
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
+async fn test_mcp_task_failure(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    configure_test_profile(&fs, &thread, cx).await;
+
+    let (mut tool_calls, state, _transport) = setup_task_context_server(
+        "fail_server",
+        vec![make_tool("failing_tool", TaskSupport::Required)],
+        &context_server_store,
+        cx,
+    );
+
+    // Queue up TasksGet to return "failed" immediately.
+    {
+        let mut guard = state.lock().unwrap();
+        guard.task_get_responses.push_back(make_task(
+            "task-fail",
+            TaskStatus::Failed,
+            Some("Something went wrong on the server"),
+            Some(10),
+        ));
+        guard.task_result = Some(
+            serde_json::to_value(CallToolResponse {
+                content: vec![ToolResponseContent::Text {
+                    text: "Error: Something went wrong on the server".into(),
+                    annotations: None,
+                }],
+                is_error: Some(true),
+                meta: None,
+                structured_content: None,
+            })
+            .unwrap(),
+        );
+    }
+
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the failing tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    model_call_tool(&fake_model, "failing_tool", cx);
+
+    let (_call_params, response_tx) = tool_calls.next().await.unwrap();
+    response_tx
+        .send(CreateTaskResult {
+            task: make_task(
+                "task-fail",
+                TaskStatus::Working,
+                Some("Starting..."),
+                Some(10),
+            ),
+            meta: None,
+        })
+        .unwrap();
+
+    // Wait for the polling loop to detect the failure and return a result.
+    wait_for_model_completion(&fake_model, cx).await;
+
+    // The model should receive a tool result indicating failure.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r),
+            _ => None,
+        })
+        .expect("expected a tool result in the completion");
+
+    assert_eq!(tool_result.tool_use_id.to_string(), "tool_1");
+    assert!(
+        tool_result.is_error,
+        "tool result should be marked as an error"
+    );
+    let result_text = tool_result_text(&tool_result.content);
+    assert!(
+        result_text.contains("Something went wrong"),
+        "tool result should contain the error message, got: {result_text}",
+    );
+
+    // Finish the model turn.
+    fake_model.send_last_completion_stream_text_chunk("The tool failed.");
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
+async fn test_mcp_task_progress_notifications(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    configure_test_profile(&fs, &thread, cx).await;
+
+    let (mut tool_calls, state, transport) = setup_task_context_server(
+        "progress_server",
+        vec![make_tool("progress_tool", TaskSupport::Required)],
+        &context_server_store,
+        cx,
+    );
+
+    // Queue up TasksGet responses. The task completes on first poll.
+    {
+        let mut guard = state.lock().unwrap();
+        guard.task_get_responses.push_back(make_task(
+            "task-progress",
+            TaskStatus::Completed,
+            Some("Finished processing"),
+            Some(10),
+        ));
+        guard.task_result = Some(
+            serde_json::to_value(CallToolResponse {
+                content: vec![ToolResponseContent::Text {
+                    text: "progress result".into(),
+                    annotations: None,
+                }],
+                is_error: None,
+                meta: None,
+                structured_content: None,
+            })
+            .unwrap(),
+        );
+    }
+
+    let mut events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the progress tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    model_call_tool(&fake_model, "progress_tool", cx);
+
+    // The server receives the CallToolAsTask request. Before responding,
+    // extract the progress token from the params so we can send a matching
+    // notifications/progress notification.
+    let (call_params, response_tx) = tool_calls.next().await.unwrap();
+    assert_eq!(call_params.name, "progress_tool");
+
+    // Extract the progress token from _meta.progressToken.
+    let progress_token = call_params
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("progressToken"))
+        .cloned()
+        .expect("CallToolParams should contain a progressToken in _meta");
+
+    // Send a progress notification via the transport before returning
+    // the CreateTaskResult.
+    transport
+        .send_notification(
+            "notifications/progress",
+            json!({
+                "progressToken": progress_token,
+                "progress": 0.5,
+                "message": "Halfway there"
+            }),
+        )
+        .expect("sending progress notification should succeed");
+    cx.run_until_parked();
+
+    // Now respond with the CreateTaskResult.
+    response_tx
+        .send(CreateTaskResult {
+            task: make_task(
+                "task-progress",
+                TaskStatus::Working,
+                Some("Processing..."),
+                Some(10),
+            ),
+            meta: None,
+        })
+        .unwrap();
+
+    // Wait for the polling loop to complete.
+    wait_for_model_completion(&fake_model, cx).await;
+
+    // Verify the model received the tool result.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r),
+            _ => None,
+        })
+        .expect("expected a tool result in the completion");
+
+    let result_text = tool_result_text(&tool_result.content);
+    assert!(
+        result_text.contains("progress result"),
+        "tool result should contain the expected output, got: {result_text}",
+    );
+
+    // Drain events and look for a ToolCallUpdate that contains one of
+    // our progress/status messages (either "Halfway there" from the
+    // notifications/progress notification, "Processing..." from the
+    // CreateTaskResult, or "Finished processing" from the final TasksGet).
+    let mut found_status_update = false;
+    while let Some(Some(event)) = events.next().now_or_never() {
+        if let Ok(ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update))) =
+            &event
+        {
+            if let Some(title) = &update.fields.title {
+                if title == "Halfway there"
+                    || title == "Processing..."
+                    || title == "Finished processing"
+                {
+                    found_status_update = true;
+                }
+            }
+        }
+    }
+    assert!(
+        found_status_update,
+        "Should have received a ToolCallUpdate with a progress or status message as the title"
+    );
+
+    fake_model.send_last_completion_stream_text_chunk("Done with progress!");
+    fake_model.end_last_completion_stream();
+}
+
+#[gpui::test]
+async fn test_mcp_task_non_task_tool_uses_normal_path(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    configure_test_profile(&fs, &thread, cx).await;
+
+    // The server has task capabilities, but this specific tool has Forbidden.
+    let mut mcp_tool_calls = setup_non_task_context_server(
+        "non_task_server",
+        vec![make_tool("normal_tool", TaskSupport::Forbidden)],
+        &context_server_store,
+        cx,
+    );
+
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the normal tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    assert!(
+        tool_names_for_completion(&completion).contains(&"normal_tool".to_string()),
+        "normal_tool should be available"
+    );
+
+    model_call_tool(&fake_model, "normal_tool", cx);
+
+    // The server should receive a regular CallTool (not CallToolAsTask).
+    let (call_params, response_tx) = mcp_tool_calls.next().await.unwrap();
+    assert_eq!(call_params.name, "normal_tool");
+    assert_eq!(call_params.arguments, Some(json!({"text": "hello"})));
+    // The task field should NOT be set for non-task calls.
+    assert!(
+        call_params.task.is_none(),
+        "task params should not be set for Forbidden task_support tools"
+    );
+
+    response_tx
+        .send(CallToolResponse {
+            content: vec![ToolResponseContent::Text {
+                text: "normal result".into(),
+                annotations: None,
+            }],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // The model should receive the tool result directly.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r),
+            _ => None,
+        })
+        .expect("expected a tool result in the completion");
+
+    assert_eq!(tool_result.tool_use_id.to_string(), "tool_1");
+    assert!(!tool_result.is_error);
+    let result_text = tool_result_text(&tool_result.content);
+    assert!(
+        result_text.contains("normal result"),
+        "tool result should contain the normal output, got: {result_text}",
+    );
+
+    // Finish the model turn.
+    fake_model.send_last_completion_stream_text_chunk("Got it!");
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
+async fn test_mcp_task_model_immediate_response(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    configure_test_profile(&fs, &thread, cx).await;
+
+    let (mut tool_calls, state, _transport) = setup_task_context_server(
+        "immediate_server",
+        vec![make_tool("background_tool", TaskSupport::Required)],
+        &context_server_store,
+        cx,
+    );
+
+    // Queue up TasksGet responses: the task stays "working" for one poll,
+    // then completes. The model should NOT wait for these — it should
+    // continue immediately with the provisional response.
+    {
+        let mut guard = state.lock().unwrap();
+        guard.task_get_responses.push_back(make_task(
+            "task-imm-1",
+            TaskStatus::Working,
+            Some("Still crunching..."),
+            Some(10),
+        ));
+        guard.task_get_responses.push_back(make_task(
+            "task-imm-1",
+            TaskStatus::Completed,
+            Some("All done in background"),
+            Some(10),
+        ));
+        guard.task_result = Some(
+            serde_json::to_value(CallToolResponse {
+                content: vec![ToolResponseContent::Text {
+                    text: "final background result".into(),
+                    annotations: None,
+                }],
+                is_error: None,
+                meta: None,
+                structured_content: None,
+            })
+            .unwrap(),
+        );
+    }
+
+    // Send a user message.
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["call the background tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    assert!(
+        tool_names_for_completion(&completion).contains(&"background_tool".to_string()),
+        "background_tool should be available"
+    );
+
+    // Simulate the model calling the tool.
+    model_call_tool(&fake_model, "background_tool", cx);
+
+    // The server receives CallToolAsTask — respond with a CreateTaskResult
+    // that includes a model-immediate-response in _meta.
+    let (call_params, response_tx) = tool_calls.next().await.unwrap();
+    assert_eq!(call_params.name, "background_tool");
+    assert!(call_params.task.is_some());
+
+    let provisional_response = CallToolResponse {
+        content: vec![ToolResponseContent::Text {
+            text: "provisional: task started, check back later".into(),
+            annotations: None,
+        }],
+        is_error: None,
+        meta: None,
+        structured_content: None,
+    };
+
+    let mut meta_map = collections::HashMap::default();
+    meta_map.insert(
+        MODEL_IMMEDIATE_RESPONSE_KEY.to_string(),
+        serde_json::to_value(&provisional_response).unwrap(),
+    );
+
+    response_tx
+        .send(CreateTaskResult {
+            task: make_task(
+                "task-imm-1",
+                TaskStatus::Working,
+                Some("Starting background work..."),
+                Some(10),
+            ),
+            meta: Some(meta_map),
+        })
+        .unwrap();
+
+    // The model should receive the provisional result WITHOUT waiting for
+    // the background task to complete. Because the provisional response is
+    // returned immediately (no polling needed), run_until_parked is enough.
+    cx.run_until_parked();
+
+    // The model should now have a new completion request with the provisional
+    // tool result.
+    assert!(
+        !fake_model.pending_completions().is_empty(),
+        "model should have a pending completion with the provisional tool result"
+    );
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r),
+            _ => None,
+        })
+        .expect("expected a tool result in the completion");
+
+    assert_eq!(tool_result.tool_use_id.to_string(), "tool_1");
+    assert!(
+        !tool_result.is_error,
+        "provisional tool result should not be an error"
+    );
+    assert!(
+        tool_result.is_provisional,
+        "provisional tool result should have is_provisional=true"
+    );
+    let result_text = tool_result_text(&tool_result.content);
+    assert!(
+        result_text.contains("provisional: task started"),
+        "model should receive the provisional response, got: {result_text}",
+    );
+
+    // Finish the model turn — the model continues immediately.
+    fake_model.send_last_completion_stream_text_chunk("Got provisional result, moving on!");
+    fake_model.end_last_completion_stream();
+    // Don't use events.collect() here — the background poller holds a clone
+    // of the ThreadEventStream sender, so the receiver never sees the stream
+    // close. Instead, drop the receiver and let run_until_parked() drive the
+    // turn task to completion.
+    drop(events);
+    cx.run_until_parked();
+
+    // The background poller is still running (detached). Give it real
+    // wall-clock time so its smol timers fire and it polls to completion.
+    for _i in 0..50 {
+        smol::Timer::after(Duration::from_millis(50)).await;
+        cx.run_until_parked();
+        // Check if the background poller has drained all TasksGet responses.
+        let remaining = state.lock().unwrap().task_get_responses.len();
+        if remaining == 0 {
+            break;
+        }
+    }
+
+    // All queued TasksGet responses should have been consumed by the
+    // background poller.
+    let remaining = state.lock().unwrap().task_get_responses.len();
+    assert_eq!(
+        remaining, 0,
+        "background poller should have consumed all TasksGet responses, {} remain",
+        remaining,
+    );
+}

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -53,7 +53,10 @@ use std::{
     ops::RangeInclusive,
     path::Path,
     rc::Rc,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 use std::{fmt::Write, path::PathBuf};
@@ -1233,6 +1236,7 @@ impl Thread {
                 stream.clone(),
                 Some(self.project.read(cx).fs().clone()),
                 cancellation_rx,
+                None,
             );
             tool.replay(tool_use.input.clone(), output, tool_event_stream, cx)
                 .log_err();
@@ -1612,6 +1616,16 @@ impl Thread {
         }
     }
 
+    pub fn cancel_tool_call(&mut self, tool_use_id: LanguageModelToolUseId, cx: &mut Context<Self>) {
+        if let Some(running_turn) = self.running_turn.as_mut() {
+            if let Some(mut sender) = running_turn.tool_cancellation_senders.remove(&tool_use_id) {
+                log::debug!("Cancelling individual tool call: {}", tool_use_id);
+                sender.send(true).ok();
+            }
+        }
+        cx.notify();
+    }
+
     pub fn cancel(&mut self, cx: &mut Context<Self>) -> Task<()> {
         for subagent in self.running_subagents.drain(..) {
             if let Some(subagent) = subagent.upgrade() {
@@ -1852,6 +1866,7 @@ impl Thread {
             tools: self.enabled_tools(cx),
             cancellation_tx,
             streaming_tool_inputs: HashMap::default(),
+            tool_cancellation_senders: HashMap::default(),
             _task: cx.spawn(async move |this, cx| {
                 log::debug!("Starting agent turn execution");
 
@@ -2115,17 +2130,19 @@ impl Thread {
     ) -> Result<(), anyhow::Error> {
         log::debug!("Tool finished {:?}", tool_result);
 
-        event_stream.update_tool_call_fields(
-            &tool_result.tool_use_id,
-            acp::ToolCallUpdateFields::new()
-                .status(if tool_result.is_error {
-                    acp::ToolCallStatus::Failed
-                } else {
-                    acp::ToolCallStatus::Completed
-                })
-                .raw_output(tool_result.output.clone()),
-            None,
-        );
+        if !tool_result.is_provisional {
+            event_stream.update_tool_call_fields(
+                &tool_result.tool_use_id,
+                acp::ToolCallUpdateFields::new()
+                    .status(if tool_result.is_error {
+                        acp::ToolCallStatus::Failed
+                    } else {
+                        acp::ToolCallStatus::Completed
+                    })
+                    .raw_output(tool_result.output.clone()),
+                None,
+            );
+        }
         this.update(cx, |this, _cx| {
             this.pending_message()
                 .tool_results
@@ -2331,6 +2348,7 @@ impl Thread {
                 tool_use_id: tool_use.id,
                 tool_name: tool_use.name,
                 is_error: true,
+                is_provisional: false,
                 output: None,
             }));
         };
@@ -2389,7 +2407,7 @@ impl Thread {
     }
 
     fn run_tool(
-        &self,
+        &mut self,
         tool: Arc<dyn AnyAgentTool>,
         tool_input: ToolInput<serde_json::Value>,
         tool_use_id: LanguageModelToolUseId,
@@ -2398,12 +2416,17 @@ impl Thread {
         cancellation_rx: watch::Receiver<bool>,
         cx: &mut Context<Self>,
     ) -> Task<LanguageModelToolResult> {
+        let (tool_cancel_tx, tool_cancel_rx) = watch::channel(false);
+        if let Some(running_turn) = self.running_turn.as_mut() {
+            running_turn.tool_cancellation_senders.insert(tool_use_id.clone(), tool_cancel_tx);
+        }
         let fs = self.project.read(cx).fs().clone();
         let tool_event_stream = ToolCallEventStream::new(
             tool_use_id.clone(),
             event_stream.clone(),
             Some(fs),
             cancellation_rx,
+            Some(tool_cancel_rx),
         );
         tool_event_stream.update_fields(
             acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::InProgress),
@@ -2431,6 +2454,7 @@ impl Thread {
                 tool_use_id,
                 tool_name,
                 is_error,
+                is_provisional: output.is_provisional,
                 content: output.llm_output,
                 output: Some(output.raw_output),
             }
@@ -2471,6 +2495,7 @@ impl Thread {
                 tool_use_id: tool_use.id,
                 tool_name: tool_use.name,
                 is_error: true,
+                is_provisional: false,
                 output: None,
             }));
         };
@@ -2734,6 +2759,7 @@ impl Thread {
                         tool_use_id: tool_use.id.clone(),
                         tool_name: tool_use.name.clone(),
                         is_error: true,
+                        is_provisional: false,
                         content: LanguageModelToolResultContent::Text(TOOL_CANCELED_MESSAGE.into()),
                         output: None,
                     },
@@ -3156,6 +3182,7 @@ struct RunningTurn {
     /// Senders for tools that support input streaming and have already been
     /// started but are still receiving input from the LLM.
     streaming_tool_inputs: HashMap<LanguageModelToolUseId, ToolInputSender>,
+    tool_cancellation_senders: HashMap<LanguageModelToolUseId, watch::Sender<bool>>,
 }
 
 impl RunningTurn {
@@ -3385,6 +3412,7 @@ pub struct Erased<T>(T);
 pub struct AgentToolOutput {
     pub llm_output: LanguageModelToolResultContent,
     pub raw_output: serde_json::Value,
+    pub is_provisional: bool,
 }
 
 impl AgentToolOutput {
@@ -3394,6 +3422,7 @@ impl AgentToolOutput {
         Self {
             raw_output: serde_json::Value::String(message),
             llm_output,
+            is_provisional: false,
         }
     }
 }
@@ -3468,6 +3497,7 @@ where
         cx: &mut App,
     ) -> Task<Result<AgentToolOutput, AgentToolOutput>> {
         let tool_input: ToolInput<T::Input> = input.cast();
+        let event_stream_ref = event_stream.clone();
         let task = self.0.clone().run(tool_input, event_stream, cx);
         cx.spawn(async move |_cx| match task.await {
             Ok(output) => {
@@ -3477,6 +3507,7 @@ where
                 Ok(AgentToolOutput {
                     llm_output: output.into(),
                     raw_output,
+                    is_provisional: event_stream_ref.is_provisional(),
                 })
             }
             Err(error_output) => {
@@ -3487,6 +3518,7 @@ where
                 Err(AgentToolOutput {
                     llm_output: error_output.into(),
                     raw_output,
+                    is_provisional: false,
                 })
             }
         })
@@ -3603,6 +3635,8 @@ pub struct ToolCallEventStream {
     stream: ThreadEventStream,
     fs: Option<Arc<dyn Fs>>,
     cancellation_rx: watch::Receiver<bool>,
+    provisional: Arc<AtomicBool>,
+    tool_cancellation_rx: Option<watch::Receiver<bool>>,
 }
 
 impl ToolCallEventStream {
@@ -3622,6 +3656,7 @@ impl ToolCallEventStream {
             ThreadEventStream(events_tx),
             None,
             cancellation_rx,
+            None,
         );
 
         (
@@ -3642,27 +3677,51 @@ impl ToolCallEventStream {
         stream: ThreadEventStream,
         fs: Option<Arc<dyn Fs>>,
         cancellation_rx: watch::Receiver<bool>,
+        tool_cancellation_rx: Option<watch::Receiver<bool>>,
     ) -> Self {
         Self {
             tool_use_id,
             stream,
             fs,
             cancellation_rx,
+            provisional: Arc::new(AtomicBool::new(false)),
+            tool_cancellation_rx,
         }
     }
 
     /// Returns a future that resolves when the user cancels the tool call.
     /// Tools should select on this alongside their main work to detect user cancellation.
     pub fn cancelled_by_user(&self) -> impl std::future::Future<Output = ()> + '_ {
-        let mut rx = self.cancellation_rx.clone();
+        let mut turn_rx = self.cancellation_rx.clone();
+        let mut tool_rx = self.tool_cancellation_rx.clone();
         async move {
             loop {
-                if *rx.borrow() {
+                if *turn_rx.borrow() {
                     return;
                 }
-                if rx.changed().await.is_err() {
-                    // Sender dropped, will never be cancelled
-                    std::future::pending::<()>().await;
+                if let Some(ref mut rx) = tool_rx {
+                    if *rx.borrow() {
+                        return;
+                    }
+                }
+
+                let turn_changed = turn_rx.changed();
+                if let Some(ref mut rx) = tool_rx {
+                    let tool_changed = rx.changed();
+                    futures::pin_mut!(turn_changed);
+                    futures::pin_mut!(tool_changed);
+                    match futures::future::select(turn_changed, tool_changed).await {
+                        futures::future::Either::Left((Ok(()), _)) => {}
+                        futures::future::Either::Right((Ok(()), _)) => {}
+                        futures::future::Either::Left((Err(_), _))
+                        | futures::future::Either::Right((Err(_), _)) => {
+                            std::future::pending::<()>().await;
+                        }
+                    }
+                } else {
+                    if turn_changed.await.is_err() {
+                        std::future::pending::<()>().await;
+                    }
                 }
             }
         }
@@ -3672,7 +3731,23 @@ impl ToolCallEventStream {
     /// This is useful for checking cancellation state after an operation completes,
     /// to determine if the completion was due to user cancellation.
     pub fn was_cancelled_by_user(&self) -> bool {
-        *self.cancellation_rx.clone().borrow()
+        if *self.cancellation_rx.clone().borrow() {
+            return true;
+        }
+        if let Some(mut rx) = self.tool_cancellation_rx.clone() {
+            if *rx.borrow() {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn set_provisional(&self) {
+        self.provisional.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_provisional(&self) -> bool {
+        self.provisional.load(Ordering::SeqCst)
     }
 
     pub fn tool_use_id(&self) -> &LanguageModelToolUseId {

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -1,5 +1,5 @@
 use crate::{AgentToolOutput, AnyAgentTool, ToolCallEventStream, ToolInput};
-use agent_client_protocol::ToolKind;
+use agent_client_protocol as acp;
 use anyhow::Result;
 use collections::{BTreeMap, HashMap};
 use context_server::{ContextServerId, client::NotificationSubscription};
@@ -304,8 +304,8 @@ impl AnyAgentTool for ContextServerTool {
         self.tool.description.clone().unwrap_or_default().into()
     }
 
-    fn kind(&self) -> ToolKind {
-        ToolKind::Other
+    fn kind(&self) -> acp::ToolKind {
+        acp::ToolKind::Other
     }
 
     fn initial_title(&self, _input: serde_json::Value, _cx: &mut App) -> SharedString {
@@ -370,7 +370,7 @@ impl AnyAgentTool for ContextServerTool {
 
             let request = protocol.request::<context_server::types::requests::CallTool>(
                 context_server::types::CallToolParams {
-                    name: tool_name,
+                    name: tool_name.clone(),
                     arguments,
                     meta: None,
                 },
@@ -389,10 +389,25 @@ impl AnyAgentTool for ContextServerTool {
                 return Err(AgentToolOutput::from_error(error_message));
             }
 
+            // Partition content blocks by MCP audience annotation.
+            //
+            // MCP spec (2025-03-26) defines `annotations.audience` on tool
+            // response content blocks as an array of Role ("user" / "assistant").
+            // Blocks with audience: ["user"] are displayed to the human but
+            // excluded from model context.  When all blocks are user-only the
+            // model receives "[output displayed to user]" as a placeholder.
+            //
+            // Spec: https://modelcontextprotocol.io/specification/2025-03-26/server/tools
+            // Tests: crates/agent/src/tests/test_mcp_audience.rs
+            let (user_only, model_facing): (Vec<_>, Vec<_>) =
+                response.content.into_iter().partition(|c| c.is_user_only());
+
+            let user_only_count = user_only.len();
+
             let mut result = String::new();
-            for content in response.content {
+            for content in model_facing {
                 match content {
-                    context_server::types::ToolResponseContent::Text { text } => {
+                    context_server::types::ToolResponseContent::Text { text, .. } => {
                         result.push_str(&text);
                     }
                     context_server::types::ToolResponseContent::Image { .. } => {
@@ -406,6 +421,36 @@ impl AnyAgentTool for ContextServerTool {
                     }
                 }
             }
+
+            if !user_only.is_empty() {
+                let user_content: Vec<acp::ToolCallContent> = user_only
+                    .into_iter()
+                    .filter_map(|c| {
+                        if let context_server::types::ToolResponseContent::Text { text, .. } = c {
+                            Some(acp::ToolCallContent::Content(acp::Content::new(text)))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                if !user_content.is_empty() {
+                    event_stream.update_fields(
+                        acp::ToolCallUpdateFields::new().content(user_content),
+                    );
+                }
+
+                log::debug!(
+                    "MCP tool {}: audience filtering excluded {} user-only content block(s) from model context",
+                    tool_name,
+                    user_only_count
+                );
+
+                if result.is_empty() {
+                    result = "[output displayed to user]".to_string();
+                }
+            }
+
             Ok(AgentToolOutput {
                 raw_output: result.clone().into(),
                 llm_output: result.into(),

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -2,7 +2,7 @@ use crate::{AgentToolOutput, AnyAgentTool, ToolCallEventStream, ToolInput};
 use agent_client_protocol as acp;
 use anyhow::Result;
 use collections::{BTreeMap, HashMap};
-use context_server::{ContextServerId, client::NotificationSubscription};
+use context_server::{ContextServerId, client::NotificationSubscription, types::Notification as _};
 use futures::FutureExt as _;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task};
 use project::context_server_store::{ContextServerStatus, ContextServerStore};
@@ -345,7 +345,7 @@ impl AnyAgentTool for ContextServerTool {
         let authorize =
             event_stream.authorize_third_party_tool(initial_title, tool_id, display_name, cx);
 
-        cx.spawn(async move |_cx| {
+        cx.spawn(async move |cx| {
             let input = input.recv().await.map_err(|e| {
                 AgentToolOutput::from_error(format!("Failed to receive tool input: {e}"))
             })?;
@@ -368,93 +368,344 @@ impl AnyAgentTool for ContextServerTool {
                 arguments
             );
 
-            let request = protocol.request::<context_server::types::requests::CallTool>(
-                context_server::types::CallToolParams {
-                    name: tool_name.clone(),
-                    arguments,
-                    meta: None,
-                },
+            let progress_token = context_server::types::ProgressToken::String(
+                uuid::Uuid::new_v4().to_string(),
             );
-
-            let response = futures::select! {
-                response = request.fuse() => response.map_err(|e| AgentToolOutput::from_error(e.to_string()))?,
-                _ = event_stream.cancelled_by_user().fuse() => {
-                    return Err(AgentToolOutput::from_error("MCP tool cancelled by user"));
-                }
+            let meta = {
+                let mut map = collections::HashMap::default();
+                map.insert(
+                    "progressToken".to_string(),
+                    serde_json::to_value(&progress_token)
+                        .unwrap_or(serde_json::Value::Null),
+                );
+                Some(map)
             };
 
-            if response.is_error == Some(true) {
-                let error_message: String =
-                    response.content.iter().filter_map(|c| c.text()).collect();
-                return Err(AgentToolOutput::from_error(error_message));
-            }
+            let mut params = context_server::types::CallToolParams {
+                name: tool_name.clone(),
+                arguments,
+                meta,
+                task: None,
+            };
 
-            // Partition content blocks by MCP audience annotation.
-            //
-            // MCP spec (2025-03-26) defines `annotations.audience` on tool
-            // response content blocks as an array of Role ("user" / "assistant").
-            // Blocks with audience: ["user"] are displayed to the human but
-            // excluded from model context.  When all blocks are user-only the
-            // model receives "[output displayed to user]" as a placeholder.
-            //
-            // Spec: https://modelcontextprotocol.io/specification/2025-03-26/server/tools
-            // Tests: crates/agent/src/tests/test_mcp_audience.rs
-            let (user_only, model_facing): (Vec<_>, Vec<_>) =
-                response.content.into_iter().partition(|c| c.is_user_only());
+            // Subscribe to notifications/progress so the server can push live
+            // status updates for this tool call. We use an mpsc channel so
+            // that messages arriving between poll iterations are queued
+            // instead of overwriting each other.
+            let (progress_tx, mut progress_rx) =
+                futures::channel::mpsc::unbounded::<String>();
+            let _progress_subscription = {
+                let progress_tx = progress_tx.clone();
+                let expected_token =
+                    serde_json::to_value(&progress_token).ok();
+                protocol.on_notification(
+                    context_server::types::notifications::Progress::METHOD,
+                    Box::new(move |notification_value, _cx| {
+                        if let Ok(progress) =
+                            serde_json::from_value::<
+                                context_server::types::ProgressParams,
+                            >(notification_value)
+                        {
+                            let token_json =
+                                serde_json::to_value(&progress.progress_token)
+                                    .ok();
+                            if token_json == expected_token {
+                                if let Some(message) = progress.message {
+                                    let _ = progress_tx.unbounded_send(message);
+                                }
+                            }
+                        }
+                    }),
+                )
+            };
 
-            let user_only_count = user_only.len();
+            // Determine whether to use the task-augmented protocol.
+            let server_supports_tasks = protocol
+                .initialize
+                .capabilities
+                .tasks
+                .as_ref()
+                .and_then(|t| t.requests.as_ref())
+                .and_then(|r| r.tools.as_ref())
+                .and_then(|t| t.call.as_ref())
+                .is_some();
 
-            let mut result = String::new();
-            for content in model_facing {
-                match content {
-                    context_server::types::ToolResponseContent::Text { text, .. } => {
-                        result.push_str(&text);
-                    }
-                    context_server::types::ToolResponseContent::Image { .. } => {
-                        log::warn!("Ignoring image content from tool response");
-                    }
-                    context_server::types::ToolResponseContent::Audio { .. } => {
-                        log::warn!("Ignoring audio content from tool response");
-                    }
-                    context_server::types::ToolResponseContent::Resource { .. } => {
-                        log::warn!("Ignoring resource content from tool response");
-                    }
+            let tool_task_support = self
+                .tool
+                .execution
+                .as_ref()
+                .and_then(|e| e.task_support.as_ref());
+
+            let use_task = server_supports_tasks
+                && matches!(
+                    tool_task_support,
+                    Some(context_server::types::TaskSupport::Required)
+                        | Some(context_server::types::TaskSupport::Optional)
+                );
+
+            let response = if use_task {
+                params.task =
+                    Some(context_server::types::TaskParams { ttl: Some(300_000) });
+
+                let create_result = protocol
+                    .request::<context_server::types::requests::CallToolAsTask>(params)
+                    .await
+                    .map_err(|e| AgentToolOutput::from_error(e.to_string()))?;
+
+                if let Some(msg) = &create_result.task.status_message {
+                    event_stream
+                        .update_fields(acp::ToolCallUpdateFields::new().title(msg.clone()));
                 }
-            }
 
-            if !user_only.is_empty() {
-                let user_content: Vec<acp::ToolCallContent> = user_only
-                    .into_iter()
-                    .filter_map(|c| {
-                        if let context_server::types::ToolResponseContent::Text { text, .. } = c {
-                            Some(acp::ToolCallContent::Content(acp::Content::new(text)))
+                let task_id = create_result.task.task_id.clone();
+                let poll_interval_ms =
+                    create_result.task.poll_interval.unwrap_or(2000);
+
+                // Model continuation: if the server provided a provisional
+                // result via model-immediate-response, return it to the model
+                // immediately and continue polling in the background.
+                //
+                // Per the spec (2025-11-25), the value "should be a string
+                // intended to be passed as an immediate tool result to the
+                // model." In practice servers may also send a structured
+                // CallToolResponse object (with audience annotations, etc.).
+                // We handle both forms.
+                if let Some(provisional_response) = create_result
+                    .meta
+                    .as_ref()
+                    .and_then(|m| {
+                        m.get(context_server::types::MODEL_IMMEDIATE_RESPONSE_KEY)
+                    })
+                    .and_then(|v| {
+                        // Try structured CallToolResponse first, then fall
+                        // back to a plain string wrapped in a text content
+                        // block.
+                        if let Ok(response) = serde_json::from_value::<
+                            context_server::types::CallToolResponse,
+                        >(v.clone()) {
+                            Some(response)
+                        } else if let Some(text) = v.as_str() {
+                            Some(context_server::types::CallToolResponse {
+                                content: vec![
+                                    context_server::types::ToolResponseContent::Text {
+                                        text: text.to_string(),
+                                        annotations: None,
+                                    },
+                                ],
+                                is_error: None,
+                                meta: None,
+                                structured_content: None,
+                            })
                         } else {
+                            log::warn!(
+                                "MCP tool {}: model-immediate-response is neither \
+                                 a string nor a CallToolResponse: {:?}",
+                                tool_name,
+                                v,
+                            );
                             None
                         }
                     })
-                    .collect();
-
-                if !user_content.is_empty() {
-                    event_stream.update_fields(
-                        acp::ToolCallUpdateFields::new().content(user_content),
+                {
+                    log::debug!(
+                        "MCP tool {}: using model-immediate-response for task {}",
+                        tool_name,
+                        task_id,
                     );
+
+                    let provisional_output = process_tool_response(
+                        provisional_response,
+                        &tool_name,
+                        &event_stream,
+                    );
+
+                    match provisional_output {
+                        Ok(mut output) => {
+                            output.is_provisional = true;
+
+                            // Subscribe to task status notifications for
+                            // the background poller.
+                            let status_subscription = {
+                                let task_id_for_status = task_id.clone();
+                                let status_tx = progress_tx.clone();
+                                protocol.on_notification(
+                                    context_server::types::notifications::TaskStatus::METHOD,
+                                    Box::new(move |params, _cx| {
+                                        if let Ok(task) =
+                                            serde_json::from_value::<
+                                                context_server::types::Task,
+                                            >(params)
+                                        {
+                                            if task.task_id == task_id_for_status {
+                                                if let Some(msg) =
+                                                    task.status_message
+                                                {
+                                                    let _ = status_tx
+                                                        .unbounded_send(msg);
+                                                }
+                                            }
+                                        }
+                                    }),
+                                )
+                            };
+
+                            // Spawn a background task that continues polling
+                            // the MCP task and forwards progress/status
+                            // updates to the tool card.
+                            let background_event_stream = event_stream.clone();
+                            let background_tool_name = tool_name.clone();
+                            cx.foreground_executor()
+                                .spawn(mcp_task_background_poller(
+                                    protocol,
+                                    task_id,
+                                    poll_interval_ms,
+                                    background_event_stream,
+                                    progress_rx,
+                                    background_tool_name,
+                                    _progress_subscription,
+                                    status_subscription,
+                                ))
+                                .detach();
+
+                            return Ok(output);
+                        }
+                        Err(error_output) => {
+                            // Cancel the orphaned MCP task so it doesn't
+                            // run until TTL expiry with nobody polling it.
+                            let _ = protocol
+                                .request::<context_server::types::requests::TasksCancel>(
+                                    context_server::types::TasksCancelParams {
+                                        task_id: task_id.clone(),
+                                    },
+                                )
+                                .await;
+                            return Err(error_output);
+                        }
+                    }
                 }
 
+                // No model-immediate-response: blocking poll loop.
+                let _status_subscription = {
+                    let task_id_for_status = task_id.clone();
+                    let status_tx = progress_tx.clone();
+                    protocol.on_notification(
+                        context_server::types::notifications::TaskStatus::METHOD,
+                        Box::new(move |params, _cx| {
+                            if let Ok(task) =
+                                serde_json::from_value::<context_server::types::Task>(params)
+                            {
+                                if task.task_id == task_id_for_status {
+                                    if let Some(msg) = task.status_message {
+                                        let _ = status_tx.unbounded_send(msg);
+                                    }
+                                }
+                            }
+                        }),
+                    )
+                };
+
+                let mut blocking_poll_interval_ms = poll_interval_ms;
+                loop {
+                    let sleep_duration =
+                        std::time::Duration::from_millis(blocking_poll_interval_ms);
+                    futures::select! {
+                        _ = smol::Timer::after(sleep_duration).fuse() => {},
+                        _ = event_stream.cancelled_by_user().fuse() => {
+                            let _ = protocol
+                                .request::<context_server::types::requests::TasksCancel>(
+                                    context_server::types::TasksCancelParams {
+                                        task_id: task_id.clone(),
+                                    },
+                                )
+                                .await;
+                            return Err(AgentToolOutput::from_error(
+                                "MCP task cancelled by user",
+                            ));
+                        }
+                    }
+
+                    while let Ok(msg) = progress_rx.try_recv() {
+                        event_stream.update_fields(
+                            acp::ToolCallUpdateFields::new().title(msg),
+                        );
+                    }
+
+                    let task_state = protocol
+                        .request::<context_server::types::requests::TasksGet>(
+                            context_server::types::TasksGetParams {
+                                task_id: task_id.clone(),
+                            },
+                        )
+                        .await
+                        .map_err(|e| {
+                            AgentToolOutput::from_error(format!(
+                                "Failed to poll task: {e}"
+                            ))
+                        })?;
+
+                    if let Some(msg) = &task_state.status_message {
+                        event_stream.update_fields(
+                            acp::ToolCallUpdateFields::new().title(msg.clone()),
+                        );
+                    }
+
+                    if let Some(interval) = task_state.poll_interval {
+                        blocking_poll_interval_ms = interval;
+                    }
+
+                    match task_state.status {
+                        context_server::types::TaskStatus::Completed
+                        | context_server::types::TaskStatus::Failed
+                        | context_server::types::TaskStatus::Cancelled => break,
+                        context_server::types::TaskStatus::Working
+                        | context_server::types::TaskStatus::InputRequired => continue,
+                    }
+                }
+
+                let result_value = protocol
+                    .request::<context_server::types::requests::TasksResult>(
+                        context_server::types::TasksResultParams {
+                            task_id: task_id.clone(),
+                        },
+                    )
+                    .await
+                    .map_err(|e| {
+                        AgentToolOutput::from_error(format!(
+                            "Failed to get task result: {e}"
+                        ))
+                    })?;
+
+                serde_json::from_value::<context_server::types::CallToolResponse>(
+                    result_value,
+                )
+                .map_err(|e| {
+                    AgentToolOutput::from_error(format!(
+                        "Failed to parse task result: {e}"
+                    ))
+                })?
+            } else {
+                let request =
+                    protocol.request::<context_server::types::requests::CallTool>(params);
+
+                futures::select! {
+                    response = request.fuse() => {
+                        response.map_err(|e| AgentToolOutput::from_error(e.to_string()))?
+                    }
+                    _ = event_stream.cancelled_by_user().fuse() => {
+                        return Err(AgentToolOutput::from_error("MCP tool cancelled by user"));
+                    }
+                }
+            };
+
+            while let Ok(msg) = progress_rx.try_recv() {
                 log::debug!(
-                    "MCP tool {}: audience filtering excluded {} user-only content block(s) from model context",
+                    "MCP tool {}: received progress message: {}",
                     tool_name,
-                    user_only_count
+                    msg
                 );
-
-                if result.is_empty() {
-                    result = "[output displayed to user]".to_string();
-                }
             }
 
-            Ok(AgentToolOutput {
-                raw_output: result.clone().into(),
-                llm_output: result.into(),
-            })
+            process_tool_response(response, &tool_name, &event_stream)
         })
     }
 
@@ -467,6 +718,198 @@ impl AnyAgentTool for ContextServerTool {
     ) -> Result<()> {
         Ok(())
     }
+}
+
+/// Background poller for MCP tasks when model-immediate-response is used.
+///
+/// Continues polling the task for status and forwards progress/status
+/// updates to the tool card. When the task reaches a terminal state,
+/// fetches the final result and updates the tool card status.
+///
+/// This poller intentionally does NOT use `cancelled_by_user()` because it
+/// outlives the turn that spawned it. The turn's cancellation sender is
+/// dropped when the turn ends normally, and `cancelled_by_user()` would
+/// spin in an infinite loop polling the dropped sender. Instead, the poller
+/// simply runs until the MCP task reaches a terminal state or the protocol
+/// connection fails.
+///
+/// The notification subscriptions are kept alive by moving them into this
+/// function — they are dropped when the poller exits.
+async fn mcp_task_background_poller(
+    protocol: Arc<context_server::protocol::InitializedContextServerProtocol>,
+    task_id: String,
+    initial_poll_interval_ms: u64,
+    event_stream: ToolCallEventStream,
+    mut progress_rx: futures::channel::mpsc::UnboundedReceiver<String>,
+    tool_name: String,
+    _progress_subscription: NotificationSubscription,
+    _status_subscription: NotificationSubscription,
+) {
+    let mut poll_interval_ms = initial_poll_interval_ms;
+
+    loop {
+        let sleep_duration = std::time::Duration::from_millis(poll_interval_ms);
+        smol::Timer::after(sleep_duration).await;
+
+        // Drain queued progress/status messages.
+        while let Ok(msg) = progress_rx.try_recv() {
+            event_stream
+                .update_fields(acp::ToolCallUpdateFields::new().title(msg));
+        }
+
+        let task_state = match protocol
+            .request::<context_server::types::requests::TasksGet>(
+                context_server::types::TasksGetParams {
+                    task_id: task_id.clone(),
+                },
+            )
+            .await
+        {
+            Ok(state) => state,
+            Err(e) => {
+                log::error!(
+                    "MCP tool {}: background poller failed to poll task: {e}",
+                    tool_name,
+                );
+                event_stream.update_fields(
+                    acp::ToolCallUpdateFields::new()
+                        .status(acp::ToolCallStatus::Failed),
+                );
+                return;
+            }
+        };
+
+        if let Some(msg) = &task_state.status_message {
+            event_stream.update_fields(
+                acp::ToolCallUpdateFields::new().title(msg.clone()),
+            );
+        }
+
+        if let Some(interval) = task_state.poll_interval {
+            poll_interval_ms = interval;
+        }
+
+        match task_state.status {
+            context_server::types::TaskStatus::Completed => {
+                // Fetch the final result to display in the tool card.
+                match protocol
+                    .request::<context_server::types::requests::TasksResult>(
+                        context_server::types::TasksResultParams {
+                            task_id: task_id.clone(),
+                        },
+                    )
+                    .await
+                {
+                    Ok(result_value) => {
+                        event_stream.update_fields(
+                            acp::ToolCallUpdateFields::new()
+                                .status(acp::ToolCallStatus::Completed)
+                                .raw_output(Some(result_value)),
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "MCP tool {}: background poller failed to fetch final result: {e}",
+                            tool_name,
+                        );
+                        event_stream.update_fields(
+                            acp::ToolCallUpdateFields::new()
+                                .status(acp::ToolCallStatus::Completed),
+                        );
+                    }
+                }
+                return;
+            }
+            context_server::types::TaskStatus::Failed
+            | context_server::types::TaskStatus::Cancelled => {
+                event_stream.update_fields(
+                    acp::ToolCallUpdateFields::new()
+                        .status(acp::ToolCallStatus::Failed),
+                );
+                return;
+            }
+            context_server::types::TaskStatus::Working
+            | context_server::types::TaskStatus::InputRequired => continue,
+        }
+    }
+}
+
+fn process_tool_response(
+    response: context_server::types::CallToolResponse,
+    tool_name: &str,
+    event_stream: &ToolCallEventStream,
+) -> Result<AgentToolOutput, AgentToolOutput> {
+    if response.is_error == Some(true) {
+        let error_message: String = response.content.iter().filter_map(|c| c.text()).collect();
+        return Err(AgentToolOutput::from_error(error_message));
+    }
+
+    // Partition content blocks by MCP audience annotation.
+    //
+    // MCP spec (2025-03-26) defines `annotations.audience` on tool
+    // response content blocks as an array of Role ("user" / "assistant").
+    // Blocks with audience: ["user"] are displayed to the human but
+    // excluded from model context.  When all blocks are user-only the
+    // model receives "[output displayed to user]" as a placeholder.
+    //
+    // Spec: https://modelcontextprotocol.io/specification/2025-03-26/server/tools
+    // Tests: crates/agent/src/tests/test_mcp_audience.rs
+    let (user_only, model_facing): (Vec<_>, Vec<_>) =
+        response.content.into_iter().partition(|c| c.is_user_only());
+
+    let user_only_count = user_only.len();
+
+    let mut result = String::new();
+    for content in model_facing {
+        match content {
+            context_server::types::ToolResponseContent::Text { text, .. } => {
+                result.push_str(&text);
+            }
+            context_server::types::ToolResponseContent::Image { .. } => {
+                log::warn!("Ignoring image content from tool response");
+            }
+            context_server::types::ToolResponseContent::Audio { .. } => {
+                log::warn!("Ignoring audio content from tool response");
+            }
+            context_server::types::ToolResponseContent::Resource { .. } => {
+                log::warn!("Ignoring resource content from tool response");
+            }
+        }
+    }
+
+    if !user_only.is_empty() {
+        let user_content: Vec<acp::ToolCallContent> = user_only
+            .into_iter()
+            .filter_map(|c| {
+                if let context_server::types::ToolResponseContent::Text { text, .. } = c {
+                    Some(acp::ToolCallContent::Content(acp::Content::new(text)))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if !user_content.is_empty() {
+            event_stream
+                .update_fields(acp::ToolCallUpdateFields::new().content(user_content));
+        }
+
+        log::debug!(
+            "MCP tool {}: audience filtering excluded {} user-only content block(s) from model context",
+            tool_name,
+            user_only_count
+        );
+
+        if result.is_empty() {
+            result = "[output displayed to user]".to_string();
+        }
+    }
+
+    Ok(AgentToolOutput {
+        raw_output: result.clone().into(),
+        llm_output: result.into(),
+        is_provisional: false,
+    })
 }
 
 pub fn get_prompt(

--- a/crates/agent/src/tools/evals/streaming_edit_file.rs
+++ b/crates/agent/src/tools/evals/streaming_edit_file.rs
@@ -666,6 +666,7 @@ fn tool_result(
         tool_use_id: LanguageModelToolUseId::from(id.into()),
         tool_name: name.into(),
         is_error: false,
+        is_provisional: false,
         content: LanguageModelToolResultContent::Text(result.into()),
         output: None,
     })

--- a/crates/agent/src/tools/terminal_tool.rs
+++ b/crates/agent/src/tools/terminal_tool.rs
@@ -34,6 +34,8 @@ const COMMAND_OUTPUT_LIMIT: u64 = 16 * 1024;
 /// Do not use this tool for commands that run indefinitely, such as servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers that don't terminate on their own.
 ///
 /// For potentially long-running commands, prefer specifying `timeout_ms` to bound runtime and prevent indefinite hangs.
+/// When you don't need the output to continue (e.g. builds, test suites, deployments), set `background: true` to return immediately while the command runs.
+/// WARNING: with `background: true` you will NOT receive the command output — only a confirmation that it started. Do not use background mode if you need to read, parse, or act on the command's output.
 ///
 /// Remember that each invocation of this tool will spawn a new shell process, so you can't rely on any state from previous invocations.
 ///
@@ -47,6 +49,20 @@ pub struct TerminalToolInput {
     pub cd: String,
     /// Optional maximum runtime (in milliseconds). If exceeded, the running terminal task is killed.
     pub timeout_ms: Option<u64>,
+    /// When true, the command runs in the background: the model receives a
+    /// provisional result immediately ("Running `command`...") and continues
+    /// its turn while the command executes. The user sees live output in the
+    /// tool card. When the command finishes, the tool card updates to
+    /// Completed/Failed.
+    ///
+    /// Use this for long-running commands where you don't need the output
+    /// to continue (e.g. builds, deployments, test suites you'll check later).
+    /// You will NOT receive the command output in background mode — only a
+    /// confirmation that the command started. The user can see the live
+    /// output in the tool card. Default is false — the model blocks until
+    /// the command finishes and receives the full output.
+    #[serde(default)]
+    pub background: bool,
 }
 
 pub struct TerminalTool {
@@ -91,6 +107,7 @@ impl AgentTool for TerminalTool {
         event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<Self::Output, Self::Output>> {
+        let foreground = cx.foreground_executor().clone();
         cx.spawn(async move |cx| {
             let input = input
                 .recv()
@@ -146,6 +163,36 @@ impl AgentTool for TerminalTool {
                 acp::ToolCallContent::Terminal(acp::Terminal::new(terminal_id)),
             ]));
 
+            // Background mode: return a provisional result immediately and
+            // let the command run in a detached task. The user sees live
+            // output in the tool card; when the command finishes the tool
+            // card updates to Completed/Failed.
+            if input.background {
+                event_stream.set_provisional();
+
+                let background_event_stream = event_stream.clone();
+                let command = input.command.clone();
+                let timeout = input.timeout_ms.map(Duration::from_millis);
+
+                foreground
+                    .spawn(terminal_background_waiter(
+                        terminal,
+                        command,
+                        timeout,
+                        background_event_stream,
+                        cx.clone(),
+                    ))
+                    .detach();
+
+                return Ok(format!(
+                    "Running `{}` in the background. \
+                     Output is visible in the tool card.",
+                    input.command,
+                ));
+            }
+
+            // Foreground (default): block until the command finishes and
+            // return the full output to the model.
             let timeout = input.timeout_ms.map(Duration::from_millis);
 
             let mut timed_out = false;
@@ -202,6 +249,70 @@ impl AgentTool for TerminalTool {
             ))
         })
     }
+}
+
+/// Background waiter for terminal commands with `background: true`.
+///
+/// Waits for the command to finish (with optional timeout), then updates the
+/// tool card status. Does NOT use `cancelled_by_user()` because it outlives
+/// the turn — same rationale as `mcp_task_background_poller`.
+async fn terminal_background_waiter(
+    terminal: Rc<dyn crate::TerminalHandle>,
+    command: String,
+    timeout: Option<Duration>,
+    event_stream: ToolCallEventStream,
+    cx: gpui::AsyncApp,
+) {
+    let wait_for_exit = match terminal.wait_for_exit(&cx) {
+        Ok(future) => future,
+        Err(e) => {
+            log::error!("Background terminal `{command}`: failed to wait for exit: {e}");
+            event_stream.update_fields(
+                acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::Failed),
+            );
+            return;
+        }
+    };
+
+    let timed_out = if let Some(timeout) = timeout {
+        futures::select! {
+            _ = wait_for_exit.clone().fuse() => false,
+            _ = smol::Timer::after(timeout).fuse() => {
+                if let Err(e) = terminal.kill(&cx) {
+                    log::error!("Background terminal `{command}`: failed to kill after timeout: {e}");
+                }
+                wait_for_exit.await;
+                true
+            }
+        }
+    } else {
+        wait_for_exit.await;
+        false
+    };
+
+    let output = match terminal.current_output(&cx) {
+        Ok(output) => output,
+        Err(e) => {
+            log::error!("Background terminal `{command}`: failed to read output: {e}");
+            event_stream.update_fields(
+                acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::Failed),
+            );
+            return;
+        }
+    };
+    let summary = process_content(output, &command, timed_out, false);
+
+    let status = if timed_out || summary.starts_with("Command failed") {
+        acp::ToolCallStatus::Failed
+    } else {
+        acp::ToolCallStatus::Completed
+    };
+
+    event_stream.update_fields(
+        acp::ToolCallUpdateFields::new()
+            .status(status)
+            .raw_output(Some(serde_json::Value::String(summary))),
+    );
 }
 
 fn process_content(
@@ -332,6 +443,7 @@ mod tests {
                 .to_string(),
             cd: ".".to_string(),
             timeout_ms: None,
+            background: false,
         };
 
         let title = format_initial_title(Ok(input));
@@ -391,6 +503,7 @@ mod tests {
                 command: cmd.to_string(),
                 cd: ".".to_string(),
                 timeout_ms: None,
+                background: false,
             };
 
             let title = format_initial_title(Ok(input));
@@ -428,6 +541,7 @@ mod tests {
             command: "echo 'hello world'".to_string(),
             cd: ".".to_string(),
             timeout_ms: None,
+            background: false,
         };
 
         let title = format_initial_title(Ok(input));
@@ -457,6 +571,7 @@ mod tests {
             command: long_command,
             cd: ".".to_string(),
             timeout_ms: None,
+            background: false,
         };
 
         let title = format_initial_title(Ok(input));
@@ -663,6 +778,7 @@ mod tests {
                     command: "echo $HOME".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -730,6 +846,7 @@ mod tests {
                     command: "echo $HOME".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -791,6 +908,7 @@ mod tests {
                     command: "echo $(rm -rf /)".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -860,6 +978,7 @@ mod tests {
                     command: "PAGER=blah git log --oneline".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -933,6 +1052,7 @@ mod tests {
                     command: "PAGER=blah git log".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -1040,6 +1160,7 @@ mod tests {
                     command: command.to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -1207,6 +1328,7 @@ mod tests {
                     command: "echo $(whoami)".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -1279,6 +1401,7 @@ mod tests {
                     command: "PAGER=other git log".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -1345,6 +1468,7 @@ mod tests {
                     command: "A=1 B=2 git log".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,
@@ -1422,6 +1546,7 @@ mod tests {
                     command: "PAGER=\"less -R\" git log".to_string(),
                     cd: "root".to_string(),
                     timeout_ms: None,
+                    background: false,
                 }),
                 event_stream,
                 cx,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2239,10 +2239,14 @@ impl ThreadView {
         let subagents_awaiting_permission = self.render_subagents_awaiting_permission(cx);
         let has_subagents_awaiting = subagents_awaiting_permission.is_some();
 
+        let running_tasks = self.render_running_tasks(cx);
+        let has_running_tasks = running_tasks.is_some();
+
         if changed_buffers.is_empty()
             && plan.is_empty()
             && queue_is_empty
             && !has_subagents_awaiting
+            && !has_running_tasks
         {
             return None;
         }
@@ -2283,8 +2287,14 @@ impl ThreadView {
                     .when_some(subagents_awaiting_permission, |this, element| {
                         this.child(element)
                     })
+                    .when(has_subagents_awaiting && has_running_tasks, |this| {
+                        this.child(Divider::horizontal().color(DividerColor::Border))
+                    })
+                    .when_some(running_tasks, |this, element| {
+                        this.child(element)
+                    })
                     .when(
-                        has_subagents_awaiting
+                        (has_subagents_awaiting || has_running_tasks)
                             && (!plan.is_empty() || !changed_buffers.is_empty() || !queue_is_empty),
                         |this| this.child(Divider::horizontal().color(DividerColor::Border)),
                     )
@@ -2646,6 +2656,135 @@ impl ThreadView {
                                             .color(Color::Muted)
                                             .truncate(),
                                     ),
+                                )
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.list_state.scroll_to(ListOffset {
+                                        item_ix: entry_ix,
+                                        offset_in_item: px(0.0),
+                                    });
+                                    cx.notify();
+                                }))
+                        },
+                    )),
+                )
+                .into_any(),
+        )
+    }
+
+    fn render_running_tasks(&self, cx: &Context<Self>) -> Option<AnyElement> {
+        let thread = self.thread.read(cx);
+        let entries = thread.entries();
+        let mut task_items: Vec<(SharedString, acp::ToolCallId, usize)> = Vec::new();
+
+        for (entry_ix, entry) in entries.iter().enumerate() {
+            if let AgentThreadEntry::ToolCall(tool_call) = entry {
+                if matches!(tool_call.status, ToolCallStatus::InProgress)
+                    && !tool_call.is_subagent()
+                {
+                    let title: SharedString = {
+                        let source = tool_call.label.read(cx).source().to_string();
+                        if source.is_empty() {
+                            "Background Task".into()
+                        } else {
+                            source.into()
+                        }
+                    };
+                    task_items.push((title, tool_call.id.clone(), entry_ix));
+                }
+            }
+        }
+
+        if task_items.is_empty() {
+            return None;
+        }
+
+        let item_count = task_items.len();
+
+        Some(
+            v_flex()
+                .child(
+                    h_flex()
+                        .py_1()
+                        .px_2()
+                        .w_full()
+                        .gap_1()
+                        .border_b_1()
+                        .border_color(cx.theme().colors().border)
+                        .child(
+                            Label::new("Running Tasks:")
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .child(Label::new(item_count.to_string()).size(LabelSize::Small)),
+                )
+                .child(
+                    v_flex().children(task_items.into_iter().enumerate().map(
+                        |(ix, (label, tool_call_id, entry_ix))| {
+                            let is_last = ix == item_count - 1;
+                            let group = format!("mcp-task-group-{}", entry_ix);
+                            let thread = self.thread.clone();
+
+                            h_flex()
+                                .cursor_pointer()
+                                .id(format!("mcp-task-{}", entry_ix))
+                                .group(&group)
+                                .p_1()
+                                .pl_2()
+                                .min_w_0()
+                                .w_full()
+                                .gap_1()
+                                .justify_between()
+                                .bg(cx.theme().colors().editor_background)
+                                .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                .when(!is_last, |this| {
+                                    this.border_b_1().border_color(cx.theme().colors().border)
+                                })
+                                .child(
+                                    h_flex()
+                                        .gap_1p5()
+                                        .min_w_0()
+                                        .child(
+                                            Icon::new(IconName::ArrowCircle)
+                                                .size(IconSize::XSmall)
+                                                .color(Color::Accent),
+                                        )
+                                        .child(
+                                            Label::new(label)
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted)
+                                                .truncate(),
+                                        ),
+                                )
+                                .child(
+                                    h_flex()
+                                        .gap_1()
+                                        .child(
+                                            div().visible_on_hover(&group).child(
+                                                Label::new("Scroll to Task")
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted)
+                                                    .truncate(),
+                                            ),
+                                        )
+                                        .child(
+                                            IconButton::new(
+                                                SharedString::from(format!(
+                                                    "cancel-mcp-task-{}",
+                                                    entry_ix
+                                                )),
+                                                IconName::Stop,
+                                            )
+                                            .icon_size(IconSize::XSmall)
+                                            .icon_color(Color::Error)
+                                            .shape(ui::IconButtonShape::Square)
+                                            .tooltip(Tooltip::text("Cancel Task"))
+                                            .on_click(move |_, _, cx| {
+                                                thread.update(cx, |thread, cx| {
+                                                    thread
+                                                        .cancel_tool_call(&tool_call_id, cx);
+                                                });
+                                            }),
+                                        ),
                                 )
                                 .on_click(cx.listener(move |this, _, _, cx| {
                                     this.list_state.scroll_to(ListOffset {

--- a/crates/context_server/src/listener.rs
+++ b/crates/context_server/src/listener.rs
@@ -296,6 +296,7 @@ impl McpServer {
                             Err(err) => CallToolResponse {
                                 content: vec![ToolResponseContent::Text {
                                     text: err.to_string(),
+                                    annotations: None,
                                 }],
                                 is_error: Some(true),
                                 meta: None,

--- a/crates/context_server/src/listener.rs
+++ b/crates/context_server/src/listener.rs
@@ -110,6 +110,7 @@ impl McpServer {
                     Some(generator.root_schema_for::<T::Output>().into())
                 },
                 annotations: Some(tool.annotations()),
+                execution: None,
             },
             handler: Box::new({
                 move |input_value, cx| {

--- a/crates/context_server/src/protocol.rs
+++ b/crates/context_server/src/protocol.rs
@@ -27,6 +27,7 @@ impl ModelContextProtocol {
     fn supported_protocols() -> Vec<types::ProtocolVersion> {
         vec![
             types::ProtocolVersion(types::LATEST_PROTOCOL_VERSION.to_string()),
+            types::ProtocolVersion(types::VERSION_2025_03_26.to_string()),
             types::ProtocolVersion(types::VERSION_2024_11_05.to_string()),
         ]
     }
@@ -41,6 +42,7 @@ impl ModelContextProtocol {
                 experimental: None,
                 sampling: None,
                 roots: None,
+                tasks: None,
             },
             meta: None,
             client_info,
@@ -82,6 +84,7 @@ pub enum ServerCapability {
     Prompts,
     Resources,
     Tools,
+    Tasks,
 }
 
 impl InitializedContextServerProtocol {
@@ -93,6 +96,7 @@ impl InitializedContextServerProtocol {
             ServerCapability::Prompts => self.initialize.capabilities.prompts.is_some(),
             ServerCapability::Resources => self.initialize.capabilities.resources.is_some(),
             ServerCapability::Tools => self.initialize.capabilities.tools.is_some(),
+            ServerCapability::Tasks => self.initialize.capabilities.tasks.is_some(),
         }
     }
 

--- a/crates/context_server/src/test.rs
+++ b/crates/context_server/src/test.rs
@@ -78,6 +78,29 @@ impl FakeTransport {
         );
         self
     }
+
+    pub fn send_notification(&self, method: &str, params: serde_json::Value) -> anyhow::Result<()> {
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        self.tx
+            .unbounded_send(notification.to_string())
+            .context("sending notification")?;
+        Ok(())
+    }
+
+    pub fn send_typed_notification<T: crate::types::Notification>(
+        &self,
+        params: T::Params,
+    ) -> anyhow::Result<()>
+    where
+        T::Params: serde::Serialize,
+    {
+        let params = serde_json::to_value(params)?;
+        self.send_notification(T::METHOD, params)
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -5,7 +5,8 @@ use url::Url;
 
 use crate::client::RequestId;
 
-pub const LATEST_PROTOCOL_VERSION: &str = "2025-03-26";
+pub const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
+pub const VERSION_2025_03_26: &str = "2025-03-26";
 pub const VERSION_2024_11_05: &str = "2024-11-05";
 
 pub mod requests {
@@ -77,6 +78,25 @@ pub mod requests {
         ListResourceTemplatesResponse
     );
     request!("roots/list", ListRoots, (), ListRootsResponse);
+
+    // Task-augmented tool call: same JSON-RPC method as CallTool, but the
+    // response is a CreateTaskResult instead of CallToolResponse. The caller
+    // chooses which request type to use based on task support negotiation.
+    request!(
+        "tools/call",
+        CallToolAsTask,
+        CallToolParams,
+        CreateTaskResult
+    );
+    request!("tasks/get", TasksGet, TasksGetParams, Task);
+    request!(
+        "tasks/result",
+        TasksResult,
+        TasksResultParams,
+        serde_json::Value
+    );
+    request!("tasks/list", TasksList, TasksListParams, TasksListResponse);
+    request!("tasks/cancel", TasksCancel, TasksCancelParams, Task);
 }
 
 pub trait Request {
@@ -116,6 +136,11 @@ pub mod notifications {
     notification!("notifications/tools/list_changed", ToolsListChanged, ());
     notification!("notifications/prompts/list_changed", PromptsListChanged, ());
     notification!("notifications/roots/list_changed", RootsListChanged, ());
+    notification!(
+        "notifications/tasks/status",
+        TaskStatus,
+        TaskStatusNotificationParams
+    );
 }
 
 pub trait Notification {
@@ -159,6 +184,8 @@ pub struct CallToolParams {
     pub arguments: Option<serde_json::Value>,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
     pub meta: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<TaskParams>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -446,6 +473,8 @@ pub struct ClientCapabilities {
     pub sampling: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub roots: Option<RootsCapabilities>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<ClientTasksCapabilities>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -463,6 +492,8 @@ pub struct ServerCapabilities {
     pub resources: Option<ResourcesCapabilities>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<ToolsCapabilities>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<ServerTasksCapabilities>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -506,6 +537,8 @@ pub struct Tool {
     pub output_schema: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ToolAnnotations>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ToolExecution>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -638,6 +671,16 @@ pub struct CancelledParams {
 pub enum ProgressToken {
     String(String),
     Number(f64),
+}
+
+impl PartialEq for ProgressToken {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ProgressToken::String(a), ProgressToken::String(b)) => a == b,
+            (ProgressToken::Number(a), ProgressToken::Number(b)) => a.to_bits() == b.to_bits(),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -812,6 +855,190 @@ pub struct Root {
     pub name: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// MCP Task types (spec version 2025-11-25, experimental)
+// ---------------------------------------------------------------------------
+
+/// Parameters for task augmentation, included in the request params.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u64>,
+}
+
+/// A task represents the execution state of a request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Task {
+    pub task_id: String,
+    pub status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_message: Option<String>,
+    pub created_at: String,
+    pub last_updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poll_interval: Option<u64>,
+}
+
+/// Task status values per the MCP spec state machine.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Working,
+    InputRequired,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// `_meta` key for model-immediate-response per MCP Tasks spec (2025-11-25).
+/// When present in a `CreateTaskResult`, the value is a provisional
+/// `CallToolResponse` that can be returned to the model immediately while
+/// the task continues running in the background.
+pub const MODEL_IMMEDIATE_RESPONSE_KEY: &str = "io.modelcontextprotocol/model-immediate-response";
+
+/// Response to a task-augmented request. Contains task metadata and optional
+/// `_meta` (which may include `io.modelcontextprotocol/model-immediate-response`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTaskResult {
+    pub task: Task,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Parameters for `tasks/get`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksGetParams {
+    pub task_id: String,
+}
+
+/// Parameters for `tasks/result`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksResultParams {
+    pub task_id: String,
+}
+
+/// Parameters for `tasks/list`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksListParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+/// Response for `tasks/list`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksListResponse {
+    pub tasks: Vec<Task>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+/// Parameters for `tasks/cancel`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksCancelParams {
+    pub task_id: String,
+}
+
+/// Parameters for `notifications/tasks/status`. The notification carries the
+/// full Task state inline.
+pub type TaskStatusNotificationParams = Task;
+
+// ---------------------------------------------------------------------------
+// MCP Task capability types
+// ---------------------------------------------------------------------------
+
+/// Server-side tasks capabilities declared during initialization.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTasksCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests: Option<ServerTaskRequestsCapabilities>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTaskRequestsCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<ServerTaskToolsCapabilities>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTaskToolsCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call: Option<serde_json::Value>,
+}
+
+/// Client-side tasks capabilities declared during initialization.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientTasksCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests: Option<ClientTaskRequestsCapabilities>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientTaskRequestsCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampling: Option<ClientTaskSamplingCapabilities>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elicitation: Option<ClientTaskElicitationCapabilities>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientTaskSamplingCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_message: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientTaskElicitationCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create: Option<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Tool execution metadata
+// ---------------------------------------------------------------------------
+
+/// Execution metadata on a Tool, controlling task support negotiation.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolExecution {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_support: Option<TaskSupport>,
+}
+
+/// Per-tool task support level.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskSupport {
+    Required,
+    Optional,
+    Forbidden,
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -967,6 +1194,56 @@ mod tests {
     }
 
     #[test]
+    fn test_create_task_result_with_model_immediate_response() {
+        // Exact JSON the Python MCP server sends over the wire when
+        // model-immediate-response is injected into _meta.
+        let json = r#"{"_meta":{"io.modelcontextprotocol/model-immediate-response":{"content":[{"type":"text","text":"Task started — the full result will arrive in about 5 seconds. You can continue working."}],"isError":false}},"task":{"taskId":"t1","status":"working","createdAt":"2026-04-12T04:44:45.818973Z","lastUpdatedAt":"2026-04-12T04:44:45.819731Z","ttl":300000,"pollInterval":2000}}"#;
+        let result: CreateTaskResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.task.task_id, "t1");
+        assert_eq!(result.task.status, TaskStatus::Working);
+        assert!(result.meta.is_some());
+        let meta = result.meta.as_ref().unwrap();
+        assert!(meta.contains_key(MODEL_IMMEDIATE_RESPONSE_KEY));
+
+        // The provisional response should parse as CallToolResponse.
+        let provisional_value = &meta[MODEL_IMMEDIATE_RESPONSE_KEY];
+        let provisional: CallToolResponse =
+            serde_json::from_value(provisional_value.clone()).unwrap();
+        assert_eq!(provisional.content.len(), 1);
+        assert_eq!(
+            provisional.content[0].text(),
+            Some("Task started — the full result will arrive in about 5 seconds. You can continue working.")
+        );
+    }
+
+    #[test]
+    fn test_create_task_result_with_model_immediate_response_string() {
+        // Per the spec (2025-11-25), the value "should be a string intended
+        // to be passed as an immediate tool result to the model."
+        let json = r#"{"_meta":{"io.modelcontextprotocol/model-immediate-response":"Task accepted, running in background."},"task":{"taskId":"t2","status":"working","createdAt":"2026-01-01T00:00:00Z","lastUpdatedAt":"2026-01-01T00:00:01Z","ttl":300000,"pollInterval":2000}}"#;
+        let result: CreateTaskResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.task.task_id, "t2");
+        let meta = result.meta.as_ref().unwrap();
+        let value = &meta[MODEL_IMMEDIATE_RESPONSE_KEY];
+
+        // The value is a plain JSON string, not a CallToolResponse object.
+        assert!(value.is_string());
+        assert_eq!(
+            value.as_str().unwrap(),
+            "Task accepted, running in background."
+        );
+
+        // Our Zed-side code wraps this into a CallToolResponse with a single
+        // text content block. Verify the string can't accidentally parse as
+        // a CallToolResponse (it shouldn't — it's just a string).
+        assert!(
+            serde_json::from_value::<CallToolResponse>(value.clone()).is_err(),
+            "a plain string should not parse as CallToolResponse"
+        );
+    }
+
+    #[test]
+
     fn test_deserialize_from_mcp_wire_format() {
         let json = r#"{"type":"text","text":"preview data","annotations":{"audience":["user"]}}"#;
         let block: ToolResponseContent = serde_json::from_str(json).unwrap();
@@ -981,4 +1258,199 @@ mod tests {
         assert!(!block.is_user_only());
         assert!(block.audience().is_none());
     }
+
+    // -----------------------------------------------------------------------
+    // MCP Task type tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_task_status_serde_round_trip() {
+        let statuses = vec![
+            (TaskStatus::Working, "\"working\""),
+            (TaskStatus::InputRequired, "\"input_required\""),
+            (TaskStatus::Completed, "\"completed\""),
+            (TaskStatus::Failed, "\"failed\""),
+            (TaskStatus::Cancelled, "\"cancelled\""),
+        ];
+        for (status, expected_json) in statuses {
+            let json = serde_json::to_string(&status).unwrap();
+            assert_eq!(json, expected_json);
+            let deserialized: TaskStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, status);
+        }
+    }
+
+    #[test]
+    fn test_task_serde_round_trip() {
+        let task = Task {
+            task_id: "abc-123".to_string(),
+            status: TaskStatus::Working,
+            status_message: Some("Processing...".to_string()),
+            created_at: "2025-11-25T10:30:00Z".to_string(),
+            last_updated_at: "2025-11-25T10:40:00Z".to_string(),
+            ttl: Some(60000),
+            poll_interval: Some(5000),
+        };
+        let json = serde_json::to_string(&task).unwrap();
+        let deserialized: Task = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.task_id, "abc-123");
+        assert_eq!(deserialized.status, TaskStatus::Working);
+        assert_eq!(deserialized.status_message.as_deref(), Some("Processing..."));
+        assert_eq!(deserialized.ttl, Some(60000));
+        assert_eq!(deserialized.poll_interval, Some(5000));
+    }
+
+    #[test]
+    fn test_task_deserialize_from_wire_format() {
+        let json = r#"{
+            "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+            "status": "completed",
+            "createdAt": "2025-11-25T10:30:00Z",
+            "lastUpdatedAt": "2025-11-25T10:50:00Z",
+            "ttl": 60000,
+            "pollInterval": 5000
+        }"#;
+        let task: Task = serde_json::from_str(json).unwrap();
+        assert_eq!(task.task_id, "786512e2-9e0d-44bd-8f29-789f320fe840");
+        assert_eq!(task.status, TaskStatus::Completed);
+        assert!(task.status_message.is_none());
+        assert_eq!(task.ttl, Some(60000));
+    }
+
+    #[test]
+    fn test_create_task_result_serde() {
+        let json = r#"{
+            "task": {
+                "taskId": "test-task-1",
+                "status": "working",
+                "statusMessage": "Starting...",
+                "createdAt": "2025-01-01T00:00:00Z",
+                "lastUpdatedAt": "2025-01-01T00:00:00Z",
+                "ttl": 30000,
+                "pollInterval": 1000
+            },
+            "_meta": {
+                "io.modelcontextprotocol/model-immediate-response": "Task started, result will be available shortly."
+            }
+        }"#;
+        let result: CreateTaskResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.task.task_id, "test-task-1");
+        assert_eq!(result.task.status, TaskStatus::Working);
+        assert!(result.meta.is_some());
+        let meta = result.meta.unwrap();
+        assert!(meta.contains_key("io.modelcontextprotocol/model-immediate-response"));
+    }
+
+    #[test]
+    fn test_task_support_serde() {
+        assert_eq!(
+            serde_json::to_string(&TaskSupport::Required).unwrap(),
+            r#""required""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TaskSupport::Optional).unwrap(),
+            r#""optional""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TaskSupport::Forbidden).unwrap(),
+            r#""forbidden""#
+        );
+        let deserialized: TaskSupport = serde_json::from_str(r#""optional""#).unwrap();
+        assert_eq!(deserialized, TaskSupport::Optional);
+    }
+
+    #[test]
+    fn test_tool_with_execution_field() {
+        let json = r#"{
+            "name": "long_running_tool",
+            "description": "A tool that takes a while",
+            "inputSchema": {"type": "object"},
+            "execution": {
+                "taskSupport": "required"
+            }
+        }"#;
+        let tool: Tool = serde_json::from_str(json).unwrap();
+        assert_eq!(tool.name, "long_running_tool");
+        let execution = tool.execution.unwrap();
+        assert_eq!(execution.task_support, Some(TaskSupport::Required));
+    }
+
+    #[test]
+    fn test_tool_without_execution_field_backwards_compat() {
+        let json = r#"{
+            "name": "simple_tool",
+            "inputSchema": {"type": "object"}
+        }"#;
+        let tool: Tool = serde_json::from_str(json).unwrap();
+        assert!(tool.execution.is_none());
+    }
+
+    #[test]
+    fn test_server_capabilities_with_tasks() {
+        let json = r#"{
+            "tools": {"listChanged": true},
+            "tasks": {
+                "list": {},
+                "cancel": {},
+                "requests": {
+                    "tools": {
+                        "call": {}
+                    }
+                }
+            }
+        }"#;
+        let caps: ServerCapabilities = serde_json::from_str(json).unwrap();
+        assert!(caps.tools.is_some());
+        let tasks = caps.tasks.unwrap();
+        assert!(tasks.list.is_some());
+        assert!(tasks.cancel.is_some());
+        let requests = tasks.requests.unwrap();
+        assert!(requests.tools.unwrap().call.is_some());
+    }
+
+    #[test]
+    fn test_server_capabilities_without_tasks_backwards_compat() {
+        let json = r#"{"tools": {"listChanged": true}}"#;
+        let caps: ServerCapabilities = serde_json::from_str(json).unwrap();
+        assert!(caps.tasks.is_none());
+    }
+
+    #[test]
+    fn test_call_tool_params_with_task_augmentation() {
+        let json = r#"{
+            "name": "get_weather",
+            "arguments": {"city": "New York"},
+            "task": {"ttl": 60000}
+        }"#;
+        let params: CallToolParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.name, "get_weather");
+        let task = params.task.unwrap();
+        assert_eq!(task.ttl, Some(60000));
+    }
+
+    #[test]
+    fn test_call_tool_params_without_task_backwards_compat() {
+        let json = r#"{"name": "echo", "arguments": {"text": "hi"}}"#;
+        let params: CallToolParams = serde_json::from_str(json).unwrap();
+        assert!(params.task.is_none());
+    }
+
+    #[test]
+    fn test_progress_token_partial_eq() {
+        assert_eq!(
+            ProgressToken::String("abc".to_string()),
+            ProgressToken::String("abc".to_string())
+        );
+        assert_ne!(
+            ProgressToken::String("abc".to_string()),
+            ProgressToken::String("def".to_string())
+        );
+        assert_eq!(ProgressToken::Number(42.0), ProgressToken::Number(42.0));
+        assert_ne!(ProgressToken::Number(1.0), ProgressToken::Number(2.0));
+        assert_ne!(
+            ProgressToken::String("42".to_string()),
+            ProgressToken::Number(42.0)
+        );
+    }
+
 }

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -690,7 +690,7 @@ impl CallToolResponse {
     pub fn text_contents(&self) -> String {
         let mut text = String::new();
         for chunk in &self.content {
-            if let ToolResponseContent::Text { text: chunk } = chunk {
+            if let ToolResponseContent::Text { text: chunk, .. } = chunk {
                 text.push_str(chunk)
             };
         }
@@ -702,21 +702,76 @@ impl CallToolResponse {
 #[serde(tag = "type")]
 pub enum ToolResponseContent {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
     #[serde(rename = "image", rename_all = "camelCase")]
-    Image { data: String, mime_type: String },
+    Image {
+        data: String,
+        mime_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
     #[serde(rename = "audio", rename_all = "camelCase")]
-    Audio { data: String, mime_type: String },
+    Audio {
+        data: String,
+        mime_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
     #[serde(rename = "resource")]
-    Resource { resource: ResourceContents },
+    Resource {
+        resource: ResourceContents,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        annotations: Option<MessageAnnotations>,
+    },
 }
 
 impl ToolResponseContent {
     pub fn text(&self) -> Option<&str> {
-        if let ToolResponseContent::Text { text } = self {
+        if let ToolResponseContent::Text { text, .. } = self {
             Some(text)
         } else {
             None
+        }
+    }
+
+    /// Returns the audience annotation for this content block, if present.
+    ///
+    /// MCP spec (2025-03-26) `Annotations.audience`: an array of `Role`
+    /// values indicating the intended recipients of this content block.
+    /// <https://modelcontextprotocol.io/specification/2025-03-26/server/tools>
+    pub fn audience(&self) -> Option<&Vec<Role>> {
+        let annotations = match self {
+            Self::Text { annotations, .. }
+            | Self::Image { annotations, .. }
+            | Self::Audio { annotations, .. }
+            | Self::Resource { annotations, .. } => annotations,
+        };
+        annotations.as_ref().and_then(|a| a.audience.as_ref())
+    }
+
+    /// Returns `true` if this content block is intended only for the user —
+    /// i.e. the audience contains `User` but not `Assistant`.
+    ///
+    /// Per the MCP spec, absent or empty `audience` means the content is
+    /// for both user and model (returns `false`).  `["user"]` means
+    /// display-only (returns `true`).  `["user", "assistant"]` means both
+    /// (returns `false`).
+    ///
+    /// Used by `ContextServerTool::run()` to partition tool response blocks.
+    /// See `crates/agent/src/tests/test_mcp_audience.rs` for the full
+    /// routing table and integration tests.
+    pub fn is_user_only(&self) -> bool {
+        match self.audience() {
+            None => false,
+            Some(roles) => {
+                let has_user = roles.iter().any(|r| matches!(r, Role::User));
+                let has_assistant = roles.iter().any(|r| matches!(r, Role::Assistant));
+                has_user && !has_assistant
+            }
         }
     }
 }
@@ -755,4 +810,175 @@ pub struct Root {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_block(text: &str) -> ToolResponseContent {
+        ToolResponseContent::Text {
+            text: text.to_string(),
+            annotations: None,
+        }
+    }
+
+    fn text_block_with_audience(text: &str, audience: Vec<Role>) -> ToolResponseContent {
+        ToolResponseContent::Text {
+            text: text.to_string(),
+            annotations: Some(MessageAnnotations {
+                audience: Some(audience),
+                priority: None,
+            }),
+        }
+    }
+
+    fn image_block_with_audience(audience: Vec<Role>) -> ToolResponseContent {
+        ToolResponseContent::Image {
+            data: "fake".to_string(),
+            mime_type: "image/png".to_string(),
+            annotations: Some(MessageAnnotations {
+                audience: Some(audience),
+                priority: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_no_annotations_is_not_user_only() {
+        let block = text_block("hello");
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
+
+    #[test]
+    fn test_empty_audience_is_not_user_only() {
+        let block = ToolResponseContent::Text {
+            text: "hello".into(),
+            annotations: Some(MessageAnnotations {
+                audience: Some(vec![]),
+                priority: None,
+            }),
+        };
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_user_only_audience() {
+        let block = text_block_with_audience("secret", vec![Role::User]);
+        assert!(block.is_user_only());
+        assert_eq!(block.audience().unwrap(), &vec![Role::User]);
+    }
+
+    #[test]
+    fn test_assistant_only_is_not_user_only() {
+        let block = text_block_with_audience("model-only", vec![Role::Assistant]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_both_roles_is_not_user_only() {
+        let block = text_block_with_audience("shared", vec![Role::User, Role::Assistant]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_both_roles_reversed_is_not_user_only() {
+        let block = text_block_with_audience("shared", vec![Role::Assistant, Role::User]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_image_block_user_only() {
+        let block = image_block_with_audience(vec![Role::User]);
+        assert!(block.is_user_only());
+    }
+
+    #[test]
+    fn test_image_block_both_is_not_user_only() {
+        let block = image_block_with_audience(vec![Role::User, Role::Assistant]);
+        assert!(!block.is_user_only());
+    }
+
+    #[test]
+    fn test_resource_block_audience() {
+        let block = ToolResponseContent::Resource {
+            resource: ResourceContents {
+                uri: Url::parse("file:///test").unwrap(),
+                mime_type: None,
+            },
+            annotations: Some(MessageAnnotations {
+                audience: Some(vec![Role::User]),
+                priority: None,
+            }),
+        };
+        assert!(block.is_user_only());
+    }
+
+    #[test]
+    fn test_audio_block_no_annotations() {
+        let block = ToolResponseContent::Audio {
+            data: "audio-data".to_string(),
+            mime_type: "audio/wav".to_string(),
+            annotations: None,
+        };
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
+
+    #[test]
+    fn test_annotations_with_only_priority_is_not_user_only() {
+        let block = ToolResponseContent::Text {
+            text: "hello".into(),
+            annotations: Some(MessageAnnotations {
+                audience: None,
+                priority: Some(0.5),
+            }),
+        };
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
+
+    #[test]
+    fn test_tool_response_content_text_accessor() {
+        let block = text_block_with_audience("hello", vec![Role::User]);
+        assert_eq!(block.text(), Some("hello"));
+
+        let image = image_block_with_audience(vec![Role::User]);
+        assert_eq!(image.text(), None);
+    }
+
+    #[test]
+    fn test_serde_round_trip_with_annotations() {
+        let block = text_block_with_audience("test", vec![Role::User]);
+        let json = serde_json::to_string(&block).unwrap();
+        let deserialized: ToolResponseContent = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_user_only());
+        assert_eq!(deserialized.text(), Some("test"));
+    }
+
+    #[test]
+    fn test_serde_round_trip_without_annotations() {
+        let block = text_block("plain");
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(!json.contains("annotations"));
+        let deserialized: ToolResponseContent = serde_json::from_str(&json).unwrap();
+        assert!(!deserialized.is_user_only());
+    }
+
+    #[test]
+    fn test_deserialize_from_mcp_wire_format() {
+        let json = r#"{"type":"text","text":"preview data","annotations":{"audience":["user"]}}"#;
+        let block: ToolResponseContent = serde_json::from_str(json).unwrap();
+        assert!(block.is_user_only());
+        assert_eq!(block.text(), Some("preview data"));
+    }
+
+    #[test]
+    fn test_deserialize_without_annotations_field() {
+        let json = r#"{"type":"text","text":"plain"}"#;
+        let block: ToolResponseContent = serde_json::from_str(json).unwrap();
+        assert!(!block.is_user_only());
+        assert!(block.audience().is_none());
+    }
 }

--- a/crates/language_model_core/src/request.rs
+++ b/crates/language_model_core/src/request.rs
@@ -102,6 +102,11 @@ pub struct LanguageModelToolResult {
     pub tool_use_id: LanguageModelToolUseId,
     pub tool_name: Arc<str>,
     pub is_error: bool,
+    /// When true, the tool result is a provisional/immediate response and the
+    /// tool is still running in the background. The UI should NOT mark this
+    /// tool call as Completed — the background task will send the final status.
+    #[serde(default)]
+    pub is_provisional: bool,
     /// The tool output formatted for presenting to the model
     pub content: LanguageModelToolResultContent,
     /// The raw tool output, if available, often for debugging or extra state for replay

--- a/script/test-audience-mcp.py
+++ b/script/test-audience-mcp.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uvx --from fastmcp fastmcp run --no-banner -t stdio
+"""
+Test MCP server for audience annotations.
+
+Exposes tools that return content blocks with different annotations.audience
+values so you can verify Zed's filtering behaviour:
+
+  - user-only blocks appear in the tool call card but are excluded from model context
+  - model-facing blocks go to both
+  - mixed responses are partitioned correctly
+
+Configure in Zed settings under context_servers:
+
+  "context_servers": {
+    "test-audience": {
+      "command": "uvx",
+      "args": ["--from", "fastmcp", "fastmcp", "run", "<path-to-zed>/script/test-audience-mcp.py:mcp", "-t", "stdio"]
+    }
+  }
+
+Or run directly:  uvx --from fastmcp fastmcp run script/test-audience-mcp.py:mcp -t stdio
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from mcp.types import Annotations, TextContent
+
+mcp = FastMCP("test-audience")
+
+
+@mcp.tool()
+def mixed_audience(query: str = "hello") -> list[TextContent]:
+    """Return a mix of user-only and model-facing content blocks.
+
+    The first block is user-only (detailed explanation). The second block
+    has no audience annotation, so it goes to both user and model.
+    """
+    return [
+        TextContent(
+            type="text",
+            text=(
+                f"## Detailed results for '{query}'\n\n"
+                "This block is annotated with `audience: [\"user\"]` so it "
+                "should appear in the tool call card but **not** be sent to "
+                "the model.\n\n"
+                "- Item A: 42\n"
+                "- Item B: 97\n"
+                "- Item C: 13\n"
+            ),
+            annotations=Annotations(audience=["user"]),
+        ),
+        TextContent(
+            type="text",
+            text=f"Summary for '{query}': found 3 items totalling 152.",
+        ),
+    ]
+
+
+@mcp.tool()
+def user_only() -> list[TextContent]:
+    """Return content that is entirely user-only.
+
+    Every block has audience: ["user"]. The model should receive the
+    placeholder text "[output displayed to user]" instead.
+    """
+    return [
+        TextContent(
+            type="text",
+            text=(
+                "This is a rich, formatted explanation meant only for the "
+                "human reading the tool call card.\n\n"
+                "The model should NOT see this text. Instead it should "
+                "receive a short placeholder."
+            ),
+            annotations=Annotations(audience=["user"]),
+        ),
+    ]
+
+
+@mcp.tool()
+def model_only(question: str = "What is 2+2?") -> list[TextContent]:
+    """Return content annotated for the model only.
+
+    The block has audience: ["assistant"]. It should go to the model but
+    not appear in the tool call card displayed to the user.
+    """
+    return [
+        TextContent(
+            type="text",
+            text=f"The answer to '{question}' is 4.",
+            annotations=Annotations(audience=["assistant"]),
+        ),
+    ]
+
+
+@mcp.tool()
+def no_annotations() -> list[TextContent]:
+    """Return content with no audience annotations at all.
+
+    This is the baseline -- content goes to both user and model, same as
+    any normal MCP tool.
+    """
+    return [
+        TextContent(
+            type="text",
+            text="This content has no annotations. It should appear everywhere.",
+        ),
+    ]


### PR DESCRIPTION
Depends on #53044.

Implements the [MCP Tasks protocol](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) (spec 2025-11-25, experimental). MCP servers can now run long-lived tool calls. Zed polls for status, shows live progress in the tool card, and optionally lets the model keep working while a task runs in the background.

Also adds a `background` mode to the built-in terminal tool using the same infrastructure.

## What changed

**Wire types** (`context_server/src/types.rs`): `Task`, `TaskStatus`, `CreateTaskResult`, capability structs, per-tool `execution.taskSupport` negotiation (`required`/`optional`/`forbidden`), and all the `tasks/*` RPC request types. 16 serde tests.

**Protocol** (`context_server/src/protocol.rs`, `test.rs`): `CallToolAsTask` shares the `tools/call` method but expects `CreateTaskResult` back. `FakeTransport` gained `send_notification()` for injecting progress/status notifications in tests.

**Tool call flow** (`tools/context_server_registry.rs`): When a server advertises task support and the tool isn't `forbidden`, Zed sends `CallToolAsTask` with a progress token and TTL. It subscribes to `notifications/progress` and `notifications/tasks/status`, then either:

- **Blocks**: polls `tasks/get` in a select loop (timer vs cancellation), forwarding status messages to the tool card, and fetches `tasks/result` when done.
- **Continues**: if the server sends `model-immediate-response` in `_meta`, the model gets that provisional result immediately. A detached background poller keeps polling and updates the tool card when the task finishes. Handles both the string form (per spec) and structured `CallToolResponse` (with audience annotations).

**Provisional results** (`thread.rs`, `language_model_core/request.rs`): `is_provisional` flag on `LanguageModelToolResult` and `AgentToolOutput`. When set, `process_tool_result` feeds the result to the model but doesn't flip the tool card to Completed. The background poller does that later. `ToolCallEventStream::set_provisional()` exposes this to built-in tools too (used by the terminal).

**Background event drain** (`agent.rs`): `handle_thread_events` normally returns on the `Stop` event. Background tasks that outlive the turn still need to push tool card updates. A detached `drain_background_events` task keeps consuming the event channel after Stop so those late updates reach the AcpThread.

**Per-tool cancellation** (`thread.rs`, `acp_thread.rs`, `connection.rs`): Each tool call gets its own `watch::channel`. `cancel_tool_call()` fires the individual channel without stopping the turn. `cancelled_by_user()` races both the turn-level and per-tool channels.

**Running tasks bar** (`agent_ui/thread_view.rs`): Shows all in-progress tool calls (not just MCP) with per-task stop buttons. Ticks down as each completes.

**Background terminal** (`tools/terminal_tool.rs`): `background: bool` parameter (default false). When true, starts the command, shows live output in the tool card, returns "Running \`cmd\`..." to the model immediately, and spawns a detached waiter that updates the card on exit. The model doesn't get the command output; the tool description says so explicitly.

## Tests

5 integration tests in `tests/test_mcp_tasks.rs` using FakeTransport: basic lifecycle, failure, progress notifications, forbidden-tool fallback, and model-immediate-response with background poller verification.

Not committed: `script/test-tasks-mcp.py` (12-tool FastMCP test server) and `script/test-immediate-response-wire.py` (stdio wire format validator). Both useful for manual testing but not part of the PR.

## Not done

- **`tasks/list`**: wire types exist but nothing calls them. Could be used for reconnection (picking up tasks from a previous session).
- **`input_required` + elicitation**: spec allows tasks to pause and ask the client for input. Zed doesn't have elicitation yet. The test server has a placeholder tool for when it lands.
- **Client capabilities advertisement**: `ClientCapabilities.tasks` is left as `None`. Should be set once we're confident.
- **Feature flag**: the spec is experimental and could change. No flag gates it currently.
- **Final result delivery to model**: with model continuation, the model only sees the provisional response. A "deferred result" mechanism to inject the final output into a later turn would be useful but doesn't exist.

Release Notes:

- Added experimental support for the MCP Tasks protocol, enabling long-running MCP tool calls with live progress updates, per-task cancellation, and model continuation via `model-immediate-response`.
- Added `background` mode to the terminal tool for commands that don't need to block the model.
