### PR TITLE
editor: Exclude newlines and indentation from soft wrap when highlighting word diff ranges

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1678,34 +1678,40 @@ impl DisplaySnapshot {
     }
 
     /// Converts a buffer offset range into one or more `DisplayPoint` ranges
-    /// that cover only actual buffer text, excluding any inlay hint text that
-    /// falls within the range.
+    /// that cover only actual buffer text, excluding any non-isomorphic content
+    /// added or removed by display map layers (inlays, folds, soft wraps, blocks).
     pub fn isomorphic_display_point_ranges_for_buffer_range(
         &self,
         range: Range<MultiBufferOffset>,
     ) -> SmallVec<[Range<DisplayPoint>; 1]> {
         let inlay_snapshot = self.inlay_snapshot();
-        inlay_snapshot
-            .buffer_offset_to_inlay_ranges(range)
-            .map(|inlay_range| {
-                let inlay_point_to_display_point = |inlay_point: InlayPoint, bias: Bias| {
-                    let fold_point = self.fold_snapshot().to_fold_point(inlay_point, bias);
-                    let tab_point = self.tab_snapshot().fold_point_to_tab_point(fold_point);
-                    let wrap_point = self.wrap_snapshot().tab_point_to_wrap_point(tab_point);
-                    let block_point = self.block_snapshot.to_block_point(wrap_point);
-                    DisplayPoint(block_point)
-                };
+        let fold_snapshot = self.fold_snapshot();
+        let tab_snapshot = self.tab_snapshot();
+        let wrap_snapshot = self.wrap_snapshot();
 
-                let start = inlay_point_to_display_point(
-                    inlay_snapshot.to_point(inlay_range.start),
-                    Bias::Left,
-                );
-                let end = inlay_point_to_display_point(
-                    inlay_snapshot.to_point(inlay_range.end),
-                    Bias::Left,
-                );
-                start..end
-            })
+        let inlay_ranges: SmallVec<[_; 1]> = inlay_snapshot
+            .buffer_offset_to_inlay_ranges(range)
+            .collect();
+
+        let fold_ranges: SmallVec<[_; 1]> = inlay_ranges
+            .into_iter()
+            .flat_map(|r| fold_snapshot.isomorphic_ranges(r))
+            .collect();
+
+        let tab_ranges: SmallVec<[_; 1]> = fold_ranges
+            .into_iter()
+            .flat_map(|r| tab_snapshot.isomorphic_ranges(r))
+            .collect();
+
+        let wrap_ranges: SmallVec<[_; 1]> = tab_ranges
+            .into_iter()
+            .flat_map(|r| wrap_snapshot.isomorphic_ranges(r))
+            .collect();
+
+        wrap_ranges
+            .into_iter()
+            .flat_map(|r| self.block_snapshot.isomorphic_ranges(r))
+            .map(|r| DisplayPoint(r.start)..DisplayPoint(r.end))
             .collect()
     }
 
@@ -4080,6 +4086,146 @@ pub mod tests {
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 10));
         assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 14));
+    }
+
+    #[gpui::test]
+    async fn test_isomorphic_ranges_with_soft_wraps(cx: &mut gpui::TestAppContext) {
+        cx.background_executor
+            .set_block_on_ticks(usize::MAX..=usize::MAX);
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let mut cx = crate::test::editor_test_context::EditorTestContext::new(cx).await;
+        let window = cx.window;
+
+        _ = cx.update_window(window, |_, _window, cx| {
+            let font_size = px(12.0);
+            let wrap_width = Some(px(96.));
+
+            let text = "one two three four five\nsix seven eight";
+            let buffer = MultiBuffer::build_simple(text, cx);
+            let map = cx.new(|cx| {
+                DisplayMap::new(
+                    buffer.clone(),
+                    font("Helvetica"),
+                    font_size,
+                    wrap_width,
+                    1,
+                    1,
+                    FoldPlaceholder::test(),
+                    DiagnosticSeverity::Warning,
+                    cx,
+                )
+            });
+
+            let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+            assert_eq!(
+                snapshot.text_chunks(DisplayRow(0)).collect::<String>(),
+                "one two \nthree four \nfive\nsix seven \neight"
+            );
+
+            let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+                MultiBufferOffset(4)..MultiBufferOffset(15),
+            );
+            assert_eq!(
+                ranges.len(),
+                2,
+                "expected split at soft wrap, got: {:?}",
+                ranges,
+            );
+            assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 4));
+            assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 8));
+            assert_eq!(ranges[1].start, DisplayPoint::new(DisplayRow(1), 0));
+            assert_eq!(ranges[1].end, DisplayPoint::new(DisplayRow(1), 7));
+
+            let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+                MultiBufferOffset(0)..MultiBufferOffset(7),
+            );
+            assert_eq!(ranges.len(), 1);
+            assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 0));
+            assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 7));
+
+            let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+                MultiBufferOffset(4)..MultiBufferOffset(22),
+            );
+            assert_eq!(
+                ranges.len(),
+                3,
+                "expected split at two soft wraps, got: {:?}",
+                ranges,
+            );
+            assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 4));
+            assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 8));
+            assert_eq!(ranges[1].start, DisplayPoint::new(DisplayRow(1), 0));
+            assert_eq!(ranges[1].end, DisplayPoint::new(DisplayRow(1), 11));
+            assert_eq!(ranges[2].start, DisplayPoint::new(DisplayRow(2), 0));
+            assert_eq!(ranges[2].end, DisplayPoint::new(DisplayRow(2), 3));
+        });
+    }
+
+    #[gpui::test]
+    fn test_isomorphic_ranges_with_folds(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let text = "fn outer() {\n    fn inner() {}\n}";
+        let buffer = cx.new(|cx| Buffer::local(text, cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+
+        let font_size = px(14.0);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer.clone(),
+                font("Helvetica"),
+                font_size,
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+
+        map.update(cx, |map, cx| {
+            map.fold(
+                vec![Crease::simple(
+                    MultiBufferPoint::new(0, 12)..MultiBufferPoint::new(2, 0),
+                    FoldPlaceholder::test(),
+                )],
+                cx,
+            )
+        });
+
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+        assert_eq!(snapshot.text(), "fn outer() {⋯}");
+
+        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+            MultiBufferOffset(3)..MultiBufferOffset(10),
+        );
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, DisplayPoint::new(DisplayRow(0), 3));
+        assert_eq!(ranges[0].end, DisplayPoint::new(DisplayRow(0), 10));
+
+        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+            MultiBufferOffset(3)..MultiBufferOffset(32),
+        );
+        assert_eq!(
+            ranges.len(),
+            2,
+            "expected split around fold, got: {:?}",
+            ranges,
+        );
+        assert_eq!(
+            ranges.as_slice(),
+            &[
+                DisplayPoint::new(DisplayRow(0), 3)..DisplayPoint::new(DisplayRow(0), 12),
+                DisplayPoint::new(DisplayRow(0), 15)..DisplayPoint::new(DisplayRow(0), 16),
+            ],
+        );
+
+        let ranges = snapshot.isomorphic_display_point_ranges_for_buffer_range(
+            MultiBufferOffset(13)..MultiBufferOffset(30),
+        );
+        assert_eq!(ranges.len(), 0);
     }
 
     #[test]

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -15,6 +15,7 @@ use multi_buffer::{
     MultiBufferSnapshot, RowInfo, ToOffset, ToPoint as _,
 };
 use parking_lot::Mutex;
+use smallvec::SmallVec;
 use std::{
     cell::{Cell, RefCell},
     cmp::{self, Ordering},
@@ -2513,6 +2514,63 @@ impl BlockSnapshot {
         } else {
             self.max_point()
         }
+    }
+
+    pub(super) fn isomorphic_ranges(
+        &self,
+        range: Range<WrapPoint>,
+    ) -> SmallVec<[Range<BlockPoint>; 1]> {
+        let mut result = SmallVec::new();
+        let mut cursor = self.transforms.cursor::<Dimensions<WrapRow, BlockRow>>(());
+        cursor.seek(&range.start.row(), Bias::Right);
+
+        loop {
+            match cursor.item() {
+                None => break,
+                Some(transform) => {
+                    if transform.block.is_none() {
+                        let seg_wrap_start = cursor.start().0;
+                        let seg_wrap_end = cursor.end().0;
+                        let seg_block_start = cursor.start().1;
+
+                        let overlap_start = if range.start.row() >= seg_wrap_start {
+                            range.start
+                        } else {
+                            WrapPoint::new(seg_wrap_start, 0)
+                        };
+
+                        let seg_last_row = WrapRow(seg_wrap_end.0.saturating_sub(1));
+                        let overlap_end = if range.end.row() <= seg_last_row {
+                            range.end
+                        } else {
+                            WrapPoint::new(seg_last_row, self.wrap_snapshot.line_len(seg_last_row))
+                        };
+
+                        let past_end = range.end.row() < seg_wrap_end;
+                        cursor.next();
+
+                        if overlap_start < overlap_end {
+                            let input_start = Point::new(seg_wrap_start.0, 0);
+                            let output_start = Point::new(seg_block_start.0, 0);
+
+                            let block_start =
+                                BlockPoint(output_start + (overlap_start.0 - input_start));
+                            let block_end =
+                                BlockPoint(output_start + (overlap_end.0 - input_start));
+                            result.push(block_start..block_end);
+                        }
+
+                        if past_end {
+                            break;
+                        }
+                    } else {
+                        cursor.next();
+                    }
+                }
+            }
+        }
+
+        result
     }
 
     #[ztracing::instrument(skip_all)]

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -794,6 +794,50 @@ impl FoldSnapshot {
         }
     }
 
+    pub fn isomorphic_ranges(
+        &self,
+        range: Range<InlayOffset>,
+    ) -> impl Iterator<Item = Range<FoldPoint>> + '_ {
+        let mut cursor = self
+            .transforms
+            .cursor::<Dimensions<InlayOffset, FoldPoint>>(());
+        cursor.seek(&range.start, Bias::Right);
+
+        std::iter::from_fn(move || {
+            loop {
+                let transform = cursor.item()?;
+                if transform.placeholder.is_some() {
+                    cursor.next();
+                } else {
+                    let seg_inlay_start = cursor.start().0;
+                    let seg_inlay_end = cursor.end().0;
+                    let seg_fold_start = cursor.start().1;
+
+                    let overlap_start = cmp::max(range.start, seg_inlay_start);
+                    let overlap_end = cmp::min(range.end, seg_inlay_end);
+
+                    let past_end = seg_inlay_end >= range.end;
+                    cursor.next();
+
+                    if overlap_start < overlap_end {
+                        let start_inlay_point = self.inlay_snapshot.to_point(overlap_start);
+                        let end_inlay_point = self.inlay_snapshot.to_point(overlap_end);
+                        let seg_inlay_point = self.inlay_snapshot.to_point(seg_inlay_start);
+                        let fold_start =
+                            FoldPoint(seg_fold_start.0 + (start_inlay_point.0 - seg_inlay_point.0));
+                        let fold_end =
+                            FoldPoint(seg_fold_start.0 + (end_inlay_point.0 - seg_inlay_point.0));
+                        return Some(fold_start..fold_end);
+                    }
+
+                    if past_end {
+                        return None;
+                    }
+                }
+            }
+        })
+    }
+
     #[ztracing::instrument(skip_all)]
     pub fn fold_point_cursor(&self) -> FoldPointCursor<'_> {
         let cursor = self

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -5,6 +5,7 @@ use super::{
 
 use language::{LanguageAwareStyling, Point};
 use multi_buffer::MultiBufferSnapshot;
+use smallvec::{SmallVec, smallvec};
 use std::{cmp, num::NonZeroU32, ops::Range};
 use sum_tree::Bias;
 
@@ -358,6 +359,12 @@ impl TabSnapshot {
             self.fold_snapshot
                 .clip_point(self.tab_point_to_fold_point(point, bias).0, bias),
         )
+    }
+
+    pub fn isomorphic_ranges(&self, range: Range<FoldPoint>) -> SmallVec<[Range<TabPoint>; 1]> {
+        smallvec![
+            self.fold_point_to_tab_point(range.start)..self.fold_point_to_tab_point(range.end)
+        ]
     }
 
     #[ztracing::instrument(skip_all)]

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -7,6 +7,7 @@ use super::{
 use gpui::{App, AppContext as _, Context, Entity, Font, LineWrapper, Pixels, Task};
 use language::{LanguageAwareStyling, Point};
 use multi_buffer::{MultiBufferSnapshot, RowInfo};
+use smallvec::SmallVec;
 use smol::future::yield_now;
 use std::{cmp, collections::VecDeque, mem, ops::Range, sync::LazyLock, time::Duration};
 use sum_tree::{Bias, Cursor, Dimensions, SumTree};
@@ -851,6 +852,49 @@ impl WrapSnapshot {
             self.transforms
                 .find::<Dimensions<TabPoint, WrapPoint>, _>((), &point, Bias::Right);
         WrapPoint(start.1.0 + (point.0 - start.0.0))
+    }
+
+    pub fn isomorphic_ranges(&self, range: Range<TabPoint>) -> SmallVec<[Range<WrapPoint>; 1]> {
+        let mut result = SmallVec::new();
+        let mut cursor = self
+            .transforms
+            .cursor::<Dimensions<TabPoint, WrapPoint>>(());
+        cursor.seek(&range.start, Bias::Right);
+
+        loop {
+            match cursor.item() {
+                None => break,
+                Some(transform) => {
+                    if transform.is_isomorphic() {
+                        let seg_tab_start = cursor.start().0;
+                        let seg_tab_end = cursor.end().0;
+                        let seg_wrap_start = cursor.start().1;
+
+                        let overlap_start = cmp::max(range.start, seg_tab_start);
+                        let overlap_end = cmp::min(range.end, seg_tab_end);
+
+                        let past_end = seg_tab_end >= range.end;
+                        cursor.next();
+
+                        if overlap_start < overlap_end {
+                            let wrap_start =
+                                WrapPoint(seg_wrap_start.0 + (overlap_start.0 - seg_tab_start.0));
+                            let wrap_end =
+                                WrapPoint(seg_wrap_start.0 + (overlap_end.0 - seg_tab_start.0));
+                            result.push(wrap_start..wrap_end);
+                        }
+
+                        if past_end {
+                            break;
+                        }
+                    } else {
+                        cursor.next();
+                    }
+                }
+            }
+        }
+
+        result
     }
 
     #[ztracing::instrument(skip_all)]


### PR DESCRIPTION
We have some existing logic for excluding inlay hints from word diff highlighting. This PR extends that to cover the newlines and indentation added by soft wrap as well, improving the appearance of word diffs when soft wrap is enabled. The approach is to add a new `isomorphic_ranges` method to each layer of the display map, which splits a range in the layer's output coordinates into its intersections with isomorphic transforms. Then we determine the ranges to highlight by passing the original buffer range up through the map, splitting at each layer. 

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Improved the appearance of word diffs in combination with soft wrap.
