### PR TITLE
Simplify Thread ID by removing ID association management

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -641,14 +641,12 @@ fn build_conflicted_files_resolution_prompt(
 }
 
 pub(crate) struct AgentThread {
-    thread_id: ThreadId,
     conversation_view: Entity<ConversationView>,
 }
 
 enum BaseView {
     Uninitialized,
     AgentThread {
-        thread_id: ThreadId,
         conversation_view: Entity<ConversationView>,
     },
 }
@@ -656,7 +654,6 @@ enum BaseView {
 impl From<AgentThread> for BaseView {
     fn from(thread: AgentThread) -> Self {
         BaseView::AgentThread {
-            thread_id: thread.thread_id,
             conversation_view: thread.conversation_view,
         }
     }
@@ -1406,7 +1403,7 @@ impl AgentPanel {
             self.selected_agent.clone()
         };
         let thread = self.create_agent_thread(agent, None, None, None, None, window, cx);
-        let thread_id = thread.thread_id;
+        let thread_id = thread.conversation_view.read(cx).thread_id;
         self.retained_threads
             .insert(thread_id, thread.conversation_view);
         thread_id
@@ -1423,10 +1420,7 @@ impl AgentPanel {
             return;
         };
         self.set_base_view(
-            BaseView::AgentThread {
-                thread_id: id,
-                conversation_view,
-            },
+            BaseView::AgentThread { conversation_view },
             focus,
             window,
             cx,
@@ -1439,7 +1433,7 @@ impl AgentPanel {
             store.delete(id, cx);
         });
 
-        if self.active_thread_id() == Some(id) && self.active_thread_is_draft(cx) {
+        if self.active_thread_id(cx) == Some(id) && self.active_thread_is_draft(cx) {
             self.base_view = BaseView::Uninitialized;
             self.clear_overlay_state();
             self._thread_view_subscription = None;
@@ -1451,9 +1445,11 @@ impl AgentPanel {
         }
     }
 
-    pub fn active_thread_id(&self) -> Option<ThreadId> {
+    pub fn active_thread_id(&self, cx: &App) -> Option<ThreadId> {
         match &self.base_view {
-            BaseView::AgentThread { thread_id, .. } => Some(*thread_id),
+            BaseView::AgentThread { conversation_view } => {
+                Some(conversation_view.read(cx).thread_id)
+            }
             _ => None,
         }
     }
@@ -1474,13 +1470,10 @@ impl AgentPanel {
             .map(|(id, _)| *id)
             .collect();
 
-        if let BaseView::AgentThread {
-            thread_id,
-            conversation_view,
-        } = &self.base_view
-        {
-            if is_draft(conversation_view) && !ids.contains(thread_id) {
-                ids.push(*thread_id);
+        if let BaseView::AgentThread { conversation_view } = &self.base_view {
+            let thread_id = conversation_view.read(cx).thread_id;
+            if is_draft(conversation_view) && !ids.contains(&thread_id) {
+                ids.push(thread_id);
             }
         }
 
@@ -1500,10 +1493,11 @@ impl AgentPanel {
             .retained_threads
             .get(&id)
             .or_else(|| match &self.base_view {
-                BaseView::AgentThread {
-                    thread_id,
-                    conversation_view,
-                } if *thread_id == id => Some(conversation_view),
+                BaseView::AgentThread { conversation_view }
+                    if conversation_view.read(cx).thread_id == id =>
+                {
+                    Some(conversation_view)
+                }
                 _ => None,
             })?;
         let tv = cv.read(cx).active_thread()?;
@@ -1520,10 +1514,11 @@ impl AgentPanel {
             .retained_threads
             .get(&id)
             .or_else(|| match &self.base_view {
-                BaseView::AgentThread {
-                    thread_id,
-                    conversation_view,
-                } if *thread_id == id => Some(conversation_view),
+                BaseView::AgentThread { conversation_view }
+                    if conversation_view.read(cx).thread_id == id =>
+                {
+                    Some(conversation_view)
+                }
                 _ => None,
             });
         let Some(cv) = cv else { return };
@@ -2105,9 +2100,7 @@ impl AgentPanel {
 
     pub fn active_conversation_view(&self) -> Option<&Entity<ConversationView>> {
         match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => Some(conversation_view),
+            BaseView::AgentThread { conversation_view } => Some(conversation_view),
             _ => None,
         }
     }
@@ -2127,9 +2120,7 @@ impl AgentPanel {
 
     pub fn active_agent_thread(&self, cx: &App) -> Option<Entity<AcpThread>> {
         match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => conversation_view
+            BaseView::AgentThread { conversation_view } => conversation_view
                 .read(cx)
                 .active_thread()
                 .map(|r| r.read(cx).thread.clone()),
@@ -2148,9 +2139,11 @@ impl AgentPanel {
             .chain(self.retained_threads.values());
 
         for conversation_view in conversation_views {
-            if let Some(thread_view) = conversation_view.read(cx).thread_view(thread_id) {
-                thread_view.update(cx, |view, cx| view.cancel_generation(cx));
-                return true;
+            if *thread_id == conversation_view.read(cx).thread_id {
+                if let Some(thread_view) = conversation_view.read(cx).root_thread_view(cx) {
+                    thread_view.update(cx, |view, cx| view.cancel_generation(cx));
+                    return true;
+                }
             }
         }
         false
@@ -2197,7 +2190,7 @@ impl AgentPanel {
         // before a worktree was added would have stale paths and not
         // appear under the correct sidebar group.
         let mut thread_ids: Vec<ThreadId> = self.retained_threads.keys().copied().collect();
-        if let Some(active_id) = self.active_thread_id() {
+        if let Some(active_id) = self.active_thread_id(cx) {
             thread_ids.push(active_id);
         }
         if !thread_ids.is_empty() {
@@ -2208,13 +2201,11 @@ impl AgentPanel {
     }
 
     fn retain_running_thread(&mut self, old_view: BaseView, cx: &mut Context<Self>) {
-        let BaseView::AgentThread {
-            thread_id,
-            conversation_view,
-        } = old_view
-        else {
+        let BaseView::AgentThread { conversation_view } = old_view else {
             return;
         };
+
+        let thread_id = conversation_view.read(cx).thread_id;
 
         if self.retained_threads.contains_key(&thread_id) {
             return;
@@ -2307,9 +2298,9 @@ impl AgentPanel {
 
     pub(crate) fn active_native_agent_thread(&self, cx: &App) -> Option<Entity<agent::Thread>> {
         match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => conversation_view.read(cx).as_native_thread(cx),
+            BaseView::AgentThread { conversation_view } => {
+                conversation_view.read(cx).as_native_thread(cx)
+            }
             _ => None,
         }
     }
@@ -2326,10 +2317,7 @@ impl AgentPanel {
         let old_view = std::mem::replace(&mut self.base_view, new_view);
         self.retain_running_thread(old_view, cx);
 
-        if let BaseView::AgentThread {
-            conversation_view, ..
-        } = &self.base_view
-        {
+        if let BaseView::AgentThread { conversation_view } = &self.base_view {
             let thread_agent = conversation_view.read(cx).agent_key().clone();
             if self.selected_agent != thread_agent {
                 self.selected_agent = thread_agent;
@@ -2387,9 +2375,7 @@ impl AgentPanel {
 
     fn refresh_base_view_subscriptions(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self._base_view_observation = match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => {
+            BaseView::AgentThread { conversation_view } => {
                 self._thread_view_subscription =
                     Self::subscribe_to_active_thread_view(conversation_view, window, cx);
                 let focus_handle = conversation_view.focus_handle(cx);
@@ -2431,9 +2417,9 @@ impl AgentPanel {
 
         match &self.base_view {
             BaseView::Uninitialized => VisibleSurface::Uninitialized,
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => VisibleSurface::AgentThread(conversation_view),
+            BaseView::AgentThread { conversation_view } => {
+                VisibleSurface::AgentThread(conversation_view)
+            }
         }
     }
 
@@ -2523,15 +2509,10 @@ impl AgentPanel {
                         this.handle_first_send_requested(view.clone(), content.clone(), window, cx);
                     }
                     AcpThreadViewEvent::MessageSentOrQueued => {
-                        let Some(thread_id) = this.active_thread_id() else {
+                        let Some(thread_id) = this.active_thread_id(cx) else {
                             return;
                         };
-                        let session_id = view.read(cx).thread.read(cx).session_id().clone();
-                        if this.retained_threads.remove(&thread_id).is_some() {
-                            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
-                                store.assign_session(thread_id, session_id.clone(), cx);
-                            });
-                        }
+                        this.retained_threads.remove(&thread_id);
                         cx.emit(AgentPanelEvent::MessageSentOrQueued { thread_id });
                     }
                 },
@@ -2823,61 +2804,37 @@ impl AgentPanel {
             });
         }
 
-        let thread_id = ThreadMetadataStore::try_global(cx)
-            .and_then(|store| store.read(cx).thread_id_for_session(&session_id))
-            .or_else(|| {
-                // Fallback: scan active/background threads by ACP session_id
-                let find_thread_id = |cv: &Entity<ConversationView>| -> Option<ThreadId> {
-                    cv.read(cx).active_thread().and_then(|tv| {
-                        let tv = tv.read(cx);
-                        (tv.thread.read(cx).session_id() == &session_id).then_some(tv.id)
-                    })
-                };
-                if let BaseView::AgentThread {
-                    conversation_view, ..
-                } = &self.base_view
-                {
-                    if let Some(id) = find_thread_id(conversation_view) {
-                        return Some(id);
-                    }
-                }
-                for cv in self.retained_threads.values() {
-                    if let Some(id) = find_thread_id(cv) {
-                        return Some(id);
-                    }
-                }
-                None
-            });
+        let has_session = |cv: &Entity<ConversationView>| -> bool {
+            cv.read(cx)
+                .active_thread()
+                .is_some_and(|tv| tv.read(cx).thread.read(cx).session_id() == &session_id)
+        };
 
-        if let Some(thread_id) = thread_id {
+        // Check if the active view already has this session.
+        if let BaseView::AgentThread { conversation_view } = &self.base_view {
+            if has_session(conversation_view) {
+                self.clear_overlay_state();
+                cx.emit(AgentPanelEvent::ActiveViewChanged);
+                return;
+            }
+        }
+
+        // Check if a retained thread has this session — promote it.
+        let retained_key = self
+            .retained_threads
+            .iter()
+            .find(|(_, cv)| has_session(cv))
+            .map(|(id, _)| *id);
+        if let Some(thread_id) = retained_key {
             if let Some(conversation_view) = self.retained_threads.remove(&thread_id) {
                 self.set_base_view(
-                    BaseView::AgentThread {
-                        thread_id,
-                        conversation_view,
-                    },
+                    BaseView::AgentThread { conversation_view },
                     focus,
                     window,
                     cx,
                 );
                 self.remove_empty_draft(cx);
                 return;
-            }
-
-            if let BaseView::AgentThread {
-                conversation_view, ..
-            } = &self.base_view
-            {
-                if conversation_view
-                    .read(cx)
-                    .active_thread()
-                    .map(|t| t.read(cx).id)
-                    == Some(thread_id)
-                {
-                    self.clear_overlay_state();
-                    cx.emit(AgentPanelEvent::ActiveViewChanged);
-                    return;
-                }
             }
         }
 
@@ -2938,17 +2895,14 @@ impl AgentPanel {
         let project = self.project.clone();
         let worktree_paths = ThreadWorktreePaths::from_project(project.read(cx), cx);
         let remote_connection = project.read(cx).project_group_key(cx).host();
-        let metadata = ThreadMetadata {
+        let metadata = ThreadMetadata::new_draft(
             thread_id,
-            session_id: resume_session_id.clone(),
-            agent_id: agent.id(),
-            title: title.clone(),
-            updated_at: chrono::Utc::now(),
-            created_at: Some(chrono::Utc::now()),
+            resume_session_id.clone(),
+            agent.id(),
+            title.clone(),
             worktree_paths,
             remote_connection,
-            archived: false,
-        };
+        );
         ThreadMetadataStore::global(cx).update(cx, |store, cx| {
             store.save_all(vec![metadata], cx);
         });
@@ -3010,10 +2964,7 @@ impl AgentPanel {
         })
         .detach();
 
-        AgentThread {
-            thread_id,
-            conversation_view,
-        }
+        AgentThread { conversation_view }
     }
 
     fn active_thread_has_messages(&self, cx: &App) -> bool {
@@ -4007,21 +3958,19 @@ impl AgentPanel {
         let focus_handle = self.focus_handle(cx);
 
         let conversation_view = match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => Some(conversation_view.clone()),
+            BaseView::AgentThread { conversation_view } => Some(conversation_view.clone()),
             _ => None,
         };
         let thread_with_messages = match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => conversation_view.read(cx).has_user_submitted_prompt(cx),
+            BaseView::AgentThread { conversation_view } => {
+                conversation_view.read(cx).has_user_submitted_prompt(cx)
+            }
             _ => false,
         };
         let has_auth_methods = match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => conversation_view.read(cx).has_auth_methods(),
+            BaseView::AgentThread { conversation_view } => {
+                conversation_view.read(cx).has_auth_methods()
+            }
             _ => false,
         };
 
@@ -4242,9 +4191,9 @@ impl AgentPanel {
             };
 
         let active_thread = match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => conversation_view.read(cx).as_native_thread(cx),
+            BaseView::AgentThread { conversation_view } => {
+                conversation_view.read(cx).as_native_thread(cx)
+            }
             BaseView::Uninitialized => None,
         };
 
@@ -4814,12 +4763,12 @@ impl AgentPanel {
 
         match &self.base_view {
             BaseView::Uninitialized => false,
-            BaseView::AgentThread {
-                conversation_view, ..
-            } if conversation_view.read(cx).as_native_thread(cx).is_none() => false,
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => {
+            BaseView::AgentThread { conversation_view }
+                if conversation_view.read(cx).as_native_thread(cx).is_none() =>
+            {
+                false
+            }
+            BaseView::AgentThread { conversation_view } => {
                 let history_is_empty = conversation_view
                     .read(cx)
                     .history()
@@ -4941,9 +4890,7 @@ impl AgentPanel {
         cx: &mut Context<Self>,
     ) {
         match &self.base_view {
-            BaseView::AgentThread {
-                conversation_view, ..
-            } => {
+            BaseView::AgentThread { conversation_view } => {
                 conversation_view.update(cx, |conversation_view, cx| {
                     conversation_view.insert_dragged_files(paths, added_worktrees, window, cx);
                 });
@@ -5160,7 +5107,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let active_id = self.active_thread_id();
+        let active_id = self.active_thread_id(cx);
         let empty_draft_ids: Vec<ThreadId> = self
             .draft_thread_ids(cx)
             .into_iter()
@@ -6187,7 +6134,7 @@ mod tests {
         cx.run_until_parked();
 
         panel.read_with(&cx, |panel, cx| {
-            assert_eq!(panel.active_thread_id(), Some(retained_draft_id));
+            assert_eq!(panel.active_thread_id(cx), Some(retained_draft_id));
             assert!(panel.active_thread_is_draft(cx));
             assert_eq!(panel.draft_thread_ids(cx), vec![retained_draft_id]);
         });

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -238,89 +238,88 @@ impl ProfileProvider for Entity<agent::Thread> {
 
 #[derive(Default)]
 pub(crate) struct Conversation {
-    threads: HashMap<ThreadId, Entity<AcpThread>>,
-    permission_requests: IndexMap<ThreadId, Vec<acp::ToolCallId>>,
+    threads: HashMap<acp::SessionId, Entity<AcpThread>>,
+    permission_requests: IndexMap<acp::SessionId, Vec<acp::ToolCallId>>,
     subscriptions: Vec<Subscription>,
     updated_at: Option<Instant>,
 }
 
 impl Conversation {
-    pub fn register_thread(
-        &mut self,
-        thread_id: ThreadId,
-        thread: Entity<AcpThread>,
-        cx: &mut Context<Self>,
-    ) {
-        let subscription = cx.subscribe(&thread, move |this, _thread, event, _cx| {
-            this.updated_at = Some(Instant::now());
-            match event {
-                AcpThreadEvent::ToolAuthorizationRequested(id) => {
-                    this.permission_requests
-                        .entry(thread_id)
-                        .or_default()
-                        .push(id.clone());
-                }
-                AcpThreadEvent::ToolAuthorizationReceived(id) => {
-                    if let Some(tool_calls) = this.permission_requests.get_mut(&thread_id) {
-                        tool_calls.retain(|tool_call_id| tool_call_id != id);
-                        if tool_calls.is_empty() {
-                            this.permission_requests.shift_remove(&thread_id);
+    pub fn register_thread(&mut self, thread: Entity<AcpThread>, cx: &mut Context<Self>) {
+        let session_id = thread.read(cx).session_id().clone();
+        let subscription = cx.subscribe(&thread, {
+            let session_id = session_id.clone();
+            move |this, _thread, event, _cx| {
+                this.updated_at = Some(Instant::now());
+                match event {
+                    AcpThreadEvent::ToolAuthorizationRequested(id) => {
+                        this.permission_requests
+                            .entry(session_id.clone())
+                            .or_default()
+                            .push(id.clone());
+                    }
+                    AcpThreadEvent::ToolAuthorizationReceived(id) => {
+                        if let Some(tool_calls) = this.permission_requests.get_mut(&session_id) {
+                            tool_calls.retain(|tool_call_id| tool_call_id != id);
+                            if tool_calls.is_empty() {
+                                this.permission_requests.shift_remove(&session_id);
+                            }
                         }
                     }
+                    AcpThreadEvent::NewEntry
+                    | AcpThreadEvent::TitleUpdated
+                    | AcpThreadEvent::TokenUsageUpdated
+                    | AcpThreadEvent::EntryUpdated(_)
+                    | AcpThreadEvent::EntriesRemoved(_)
+                    | AcpThreadEvent::Retry(_)
+                    | AcpThreadEvent::SubagentSpawned(_)
+                    | AcpThreadEvent::Stopped(_)
+                    | AcpThreadEvent::Error
+                    | AcpThreadEvent::LoadError(_)
+                    | AcpThreadEvent::PromptCapabilitiesUpdated
+                    | AcpThreadEvent::Refusal
+                    | AcpThreadEvent::AvailableCommandsUpdated(_)
+                    | AcpThreadEvent::ModeUpdated(_)
+                    | AcpThreadEvent::ConfigOptionsUpdated(_)
+                    | AcpThreadEvent::WorkingDirectoriesUpdated => {}
                 }
-                AcpThreadEvent::NewEntry
-                | AcpThreadEvent::TitleUpdated
-                | AcpThreadEvent::TokenUsageUpdated
-                | AcpThreadEvent::EntryUpdated(_)
-                | AcpThreadEvent::EntriesRemoved(_)
-                | AcpThreadEvent::Retry(_)
-                | AcpThreadEvent::SubagentSpawned(_)
-                | AcpThreadEvent::Stopped(_)
-                | AcpThreadEvent::Error
-                | AcpThreadEvent::LoadError(_)
-                | AcpThreadEvent::PromptCapabilitiesUpdated
-                | AcpThreadEvent::Refusal
-                | AcpThreadEvent::AvailableCommandsUpdated(_)
-                | AcpThreadEvent::ModeUpdated(_)
-                | AcpThreadEvent::ConfigOptionsUpdated(_)
-                | AcpThreadEvent::WorkingDirectoriesUpdated => {}
             }
         });
         self.subscriptions.push(subscription);
-        self.threads.insert(thread_id, thread);
+        self.threads.insert(session_id, thread);
     }
 
     pub fn pending_tool_call<'a>(
         &'a self,
-        thread_id: &ThreadId,
+        session_id: &acp::SessionId,
         cx: &'a App,
-    ) -> Option<(ThreadId, acp::ToolCallId, &'a PermissionOptions)> {
-        let thread = self.threads.get(thread_id)?;
+    ) -> Option<(acp::SessionId, acp::ToolCallId, &'a PermissionOptions)> {
+        let thread = self.threads.get(session_id)?;
         let is_subagent = thread.read(cx).parent_session_id().is_some();
-        let (result_thread_id, thread, tool_id) = if is_subagent {
-            let id = self.permission_requests.get(thread_id)?.iter().next()?;
-            (*thread_id, thread, id)
+        let (result_session_id, thread, tool_id) = if is_subagent {
+            let id = self.permission_requests.get(session_id)?.iter().next()?;
+            (session_id.clone(), thread, id)
         } else {
             let (id, tool_calls) = self.permission_requests.first()?;
             let thread = self.threads.get(id)?;
             let tool_id = tool_calls.iter().next()?;
-            (*id, thread, tool_id)
+            (id.clone(), thread, tool_id)
         };
         let (_, tool_call) = thread.read(cx).tool_call(tool_id)?;
 
         let ToolCallStatus::WaitingForConfirmation { options, .. } = &tool_call.status else {
             return None;
         };
-        Some((result_thread_id, tool_id.clone(), options))
+        Some((result_session_id, tool_id.clone(), options))
     }
 
-    pub fn subagents_awaiting_permission(&self, cx: &App) -> Vec<(ThreadId, usize)> {
+    pub fn subagents_awaiting_permission(&self, cx: &App) -> Vec<(acp::SessionId, usize)> {
         self.permission_requests
             .iter()
-            .filter_map(|(thread_id, tool_call_ids)| {
-                let thread = self.threads.get(thread_id)?;
+            .filter_map(|(session_id, tool_call_ids)| {
+                let thread = self.threads.get(session_id)?;
                 if thread.read(cx).parent_session_id().is_some() && !tool_call_ids.is_empty() {
-                    Some((*thread_id, tool_call_ids.len()))
+                    Some((session_id.clone(), tool_call_ids.len()))
                 } else {
                     None
                 }
@@ -330,14 +329,15 @@ impl Conversation {
 
     pub fn authorize_pending_tool_call(
         &mut self,
-        thread_id: &ThreadId,
+        session_id: &acp::SessionId,
         kind: acp::PermissionOptionKind,
         cx: &mut Context<Self>,
     ) -> Option<()> {
-        let (authorize_thread_id, tool_call_id, options) = self.pending_tool_call(thread_id, cx)?;
+        let (authorize_session_id, tool_call_id, options) =
+            self.pending_tool_call(session_id, cx)?;
         let option = options.first_option_of_kind(kind)?;
         self.authorize_tool_call(
-            authorize_thread_id,
+            authorize_session_id,
             tool_call_id,
             SelectedPermissionOutcome::new(option.option_id.clone(), option.kind),
             cx,
@@ -347,12 +347,12 @@ impl Conversation {
 
     pub fn authorize_tool_call(
         &mut self,
-        thread_id: ThreadId,
+        session_id: acp::SessionId,
         tool_call_id: acp::ToolCallId,
         outcome: SelectedPermissionOutcome,
         cx: &mut Context<Self>,
     ) {
-        let Some(thread) = self.threads.get(&thread_id) else {
+        let Some(thread) = self.threads.get(&session_id) else {
             return;
         };
         let agent_telemetry_id = thread.read(cx).connection().telemetry_id();
@@ -380,6 +380,34 @@ impl Conversation {
     }
 }
 
+pub(crate) struct RootThreadUpdated;
+
+impl EventEmitter<RootThreadUpdated> for ConversationView {}
+
+fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
+    match event {
+        AcpThreadEvent::NewEntry
+        | AcpThreadEvent::TitleUpdated
+        | AcpThreadEvent::EntryUpdated(_)
+        | AcpThreadEvent::EntriesRemoved(_)
+        | AcpThreadEvent::ToolAuthorizationRequested(_)
+        | AcpThreadEvent::ToolAuthorizationReceived(_)
+        | AcpThreadEvent::Retry(_)
+        | AcpThreadEvent::Stopped(_)
+        | AcpThreadEvent::Error
+        | AcpThreadEvent::LoadError(_)
+        | AcpThreadEvent::Refusal
+        | AcpThreadEvent::WorkingDirectoriesUpdated => true,
+        // --
+        AcpThreadEvent::TokenUsageUpdated
+        | AcpThreadEvent::PromptCapabilitiesUpdated
+        | AcpThreadEvent::AvailableCommandsUpdated(_)
+        | AcpThreadEvent::ModeUpdated(_)
+        | AcpThreadEvent::ConfigOptionsUpdated(_)
+        | AcpThreadEvent::SubagentSpawned(_) => false,
+    }
+}
+
 pub enum AcpServerViewEvent {
     ActiveThreadChanged,
 }
@@ -395,6 +423,8 @@ pub struct ConversationView {
     project: Entity<Project>,
     thread_store: Option<Entity<ThreadStore>>,
     prompt_store: Option<Entity<PromptStore>>,
+    pub(crate) thread_id: ThreadId,
+    root_session_id: Option<acp::SessionId>,
     server_state: ServerState,
     focus_handle: FocusHandle,
     notifications: Vec<WindowHandle<AgentNotification>>,
@@ -427,24 +457,30 @@ impl ConversationView {
     pub fn pending_tool_call<'a>(
         &'a self,
         cx: &'a App,
-    ) -> Option<(ThreadId, acp::ToolCallId, &'a PermissionOptions)> {
-        let id = &self.active_thread()?.read(cx).id;
+    ) -> Option<(acp::SessionId, acp::ToolCallId, &'a PermissionOptions)> {
+        let session_id = self
+            .active_thread()?
+            .read(cx)
+            .thread
+            .read(cx)
+            .session_id()
+            .clone();
         self.as_connected()?
             .conversation
             .read(cx)
-            .pending_tool_call(id, cx)
+            .pending_tool_call(&session_id, cx)
     }
 
     pub fn root_thread_has_pending_tool_call(&self, cx: &App) -> bool {
         let Some(root_thread) = self.root_thread(cx) else {
             return false;
         };
-        let root_id = root_thread.read(cx).id;
+        let root_session_id = root_thread.read(cx).thread.read(cx).session_id().clone();
         self.as_connected().is_some_and(|connected| {
             connected
                 .conversation
                 .read(cx)
-                .pending_tool_call(&root_id, cx)
+                .pending_tool_call(&root_session_id, cx)
                 .is_some()
         })
     }
@@ -453,8 +489,10 @@ impl ConversationView {
         match &self.server_state {
             ServerState::Connected(connected) => {
                 let mut current = connected.active_view()?;
-                while let Some(parent_id) = current.read(cx).parent_id {
-                    if let Some(parent) = connected.threads.get(&parent_id) {
+                while let Some(parent_session_id) =
+                    current.read(cx).thread.read(cx).parent_session_id()
+                {
+                    if let Some(parent) = connected.threads.get(parent_session_id) {
                         current = parent;
                     } else {
                         break;
@@ -466,22 +504,30 @@ impl ConversationView {
         }
     }
 
-    pub fn thread_view(&self, thread_id: &ThreadId) -> Option<Entity<ThreadView>> {
+    pub(crate) fn root_acp_thread(&self, cx: &App) -> Option<Entity<AcpThread>> {
         let connected = self.as_connected()?;
-        connected.threads.get(thread_id).cloned()
+        let root_session_id = self.root_session_id.as_ref()?;
+        connected
+            .conversation
+            .read(cx)
+            .threads
+            .get(root_session_id)
+            .cloned()
     }
 
-    pub fn thread_view_for_session(
+    pub fn root_thread_view(&self, cx: &App) -> Option<Entity<ThreadView>> {
+        self.root_session_id
+            .as_ref()
+            .and_then(|sid| self.thread_view(sid, cx))
+    }
+
+    pub fn thread_view(
         &self,
         session_id: &acp::SessionId,
-        cx: &App,
+        _cx: &App,
     ) -> Option<Entity<ThreadView>> {
         let connected = self.as_connected()?;
-        connected
-            .threads
-            .values()
-            .find(|view| view.read(cx).thread.read(cx).session_id() == session_id)
-            .cloned()
+        connected.threads.get(session_id).cloned()
     }
 
     pub fn as_connected(&self) -> Option<&ConnectedServerState> {
@@ -505,7 +551,7 @@ impl ConversationView {
 
     pub fn navigate_to_thread(
         &mut self,
-        thread_id: ThreadId,
+        session_id: acp::SessionId,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -513,7 +559,7 @@ impl ConversationView {
             return;
         };
 
-        connected.navigate_to_thread(thread_id);
+        connected.navigate_to_thread(session_id);
         if let Some(view) = self.active_thread() {
             view.focus_handle(cx).focus(window, cx);
         }
@@ -531,11 +577,8 @@ impl ConversationView {
 }
 
 enum ServerState {
-    Loading(Entity<LoadingView>),
-    LoadError {
-        error: LoadError,
-        thread_id: Option<ThreadId>,
-    },
+    Loading { _loading: Entity<LoadingView> },
+    LoadError { error: LoadError },
     Connected(ConnectedServerState),
 }
 
@@ -543,8 +586,8 @@ enum ServerState {
 // hashmap of threads, current becomes session_id
 pub struct ConnectedServerState {
     auth_state: AuthState,
-    active_id: Option<ThreadId>,
-    pub(crate) threads: HashMap<ThreadId, Entity<ThreadView>>,
+    active_id: Option<acp::SessionId>,
+    pub(crate) threads: HashMap<acp::SessionId, Entity<ThreadView>>,
     connection: Rc<dyn AgentConnection>,
     history: Option<Entity<ThreadHistory>>,
     conversation: Entity<Conversation>,
@@ -568,7 +611,6 @@ impl AuthState {
 }
 
 struct LoadingView {
-    thread_id: Option<ThreadId>,
     _load_task: Task<()>,
 }
 
@@ -582,9 +624,9 @@ impl ConnectedServerState {
             .map_or(false, |view| view.read(cx).thread_error.is_some())
     }
 
-    pub fn navigate_to_thread(&mut self, thread_id: ThreadId) {
-        if self.threads.contains_key(&thread_id) {
-            self.active_id = Some(thread_id);
+    pub fn navigate_to_thread(&mut self, session_id: acp::SessionId) {
+        if self.threads.contains_key(&session_id) {
+            self.active_id = Some(session_id);
         }
     }
 
@@ -647,6 +689,7 @@ impl ConversationView {
         .detach();
 
         let is_new_draft = resume_session_id.is_none();
+        let thread_id = thread_id.unwrap_or_else(ThreadId::new);
 
         Self {
             agent: agent.clone(),
@@ -657,12 +700,13 @@ impl ConversationView {
             project: project.clone(),
             thread_store,
             prompt_store,
+            thread_id,
+            root_session_id: None,
             server_state: Self::initial_state(
                 agent.clone(),
                 connection_store,
                 connection_key,
                 resume_session_id,
-                thread_id,
                 work_dirs,
                 title,
                 project,
@@ -690,7 +734,7 @@ impl ConversationView {
     }
 
     fn reset(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let (resume_session_id, cwd, title, thread_id) = self
+        let (resume_session_id, cwd, title) = self
             .active_thread()
             .map(|thread_view| {
                 let tv = thread_view.read(cx);
@@ -699,17 +743,15 @@ impl ConversationView {
                     Some(thread.session_id().clone()),
                     thread.work_dirs().cloned(),
                     thread.title(),
-                    Some(tv.id),
                 )
             })
-            .unwrap_or((None, None, None, None));
+            .unwrap_or((None, None, None));
 
         let state = Self::initial_state(
             self.agent.clone(),
             self.connection_store.clone(),
             self.connection_key.clone(),
             resume_session_id,
-            thread_id,
             cwd,
             title,
             self.project.clone(),
@@ -734,7 +776,6 @@ impl ConversationView {
         connection_store: Entity<AgentConnectionStore>,
         connection_key: Agent,
         resume_session_id: Option<acp::SessionId>,
-        thread_id: Option<ThreadId>,
         work_dirs: Option<PathList>,
         title: Option<SharedString>,
         project: Entity<Project>,
@@ -749,7 +790,6 @@ impl ConversationView {
                 error: LoadError::Other(
                     "External agents are not yet supported in shared projects.".into(),
                 ),
-                thread_id,
             };
         }
         let session_work_dirs = work_dirs.unwrap_or_else(|| project.read(cx).default_path_list(cx));
@@ -854,33 +894,15 @@ impl ConversationView {
             this.update_in(cx, |this, window, cx| {
                 match result {
                     Ok(thread) => {
-                        let thread_id = thread_id.unwrap_or_else(ThreadId::new);
-
-                        // Register the session → thread_id mapping so the
-                        // metadata store reuses this ThreadId when it later
-                        // handles thread events.
-                        if let Some(store) =
-                            crate::thread_metadata_store::ThreadMetadataStore::try_global(cx)
-                        {
-                            let session_id = thread.read(cx).session_id().clone();
-                            store.update(
-                                cx,
-                                |store: &mut crate::thread_metadata_store::ThreadMetadataStore,
-                                 _cx| {
-                                    store.associate_session(session_id, thread_id);
-                                },
-                            );
-                        }
+                        let root_session_id = thread.read(cx).session_id().clone();
 
                         let conversation = cx.new(|cx| {
                             let mut conversation = Conversation::default();
-                            conversation.register_thread(thread_id, thread.clone(), cx);
+                            conversation.register_thread(thread.clone(), cx);
                             conversation
                         });
 
                         let current = this.new_thread_view(
-                            None,
-                            thread_id,
                             thread,
                             conversation.clone(),
                             resumed_without_history,
@@ -898,12 +920,13 @@ impl ConversationView {
                                 .focus(window, cx);
                         }
 
+                        this.root_session_id = Some(root_session_id.clone());
                         this.set_server_state(
                             ServerState::Connected(ConnectedServerState {
                                 connection,
                                 auth_state: AuthState::Ok,
-                                active_id: Some(thread_id),
-                                threads: HashMap::from_iter([(thread_id, current)]),
+                                active_id: Some(root_session_id.clone()),
+                                threads: HashMap::from_iter([(root_session_id, current)]),
                                 conversation,
                                 history,
                                 _connection_entry_subscription: connection_entry_subscription,
@@ -924,17 +947,16 @@ impl ConversationView {
         });
 
         let loading_view = cx.new(|_cx| LoadingView {
-            thread_id,
             _load_task: load_task,
         });
 
-        ServerState::Loading(loading_view)
+        ServerState::Loading {
+            _loading: loading_view,
+        }
     }
 
     fn new_thread_view(
         &self,
-        parent_id: Option<ThreadId>,
-        thread_id: ThreadId,
         thread: Entity<AcpThread>,
         conversation: Entity<Conversation>,
         resumed_without_history: bool,
@@ -1052,10 +1074,16 @@ impl ConversationView {
             .collect::<Vec<_>>();
 
         if !subagent_sessions.is_empty() {
+            let parent_session_id = thread.read(cx).session_id().clone();
             cx.spawn_in(window, async move |this, cx| {
                 this.update_in(cx, |this, window, cx| {
                     for subagent_id in subagent_sessions {
-                        this.load_subagent_session(subagent_id, thread_id, window, cx);
+                        this.load_subagent_session(
+                            subagent_id,
+                            parent_session_id.clone(),
+                            window,
+                            cx,
+                        );
                     }
                 })
             })
@@ -1100,8 +1128,6 @@ impl ConversationView {
         let weak = cx.weak_entity();
         cx.new(|cx| {
             ThreadView::new(
-                parent_id,
-                thread_id,
                 thread,
                 conversation,
                 weak,
@@ -1225,13 +1251,7 @@ impl ConversationView {
             }
         }
         self.emit_load_error_telemetry(&err);
-        self.set_server_state(
-            ServerState::LoadError {
-                error: err,
-                thread_id: None,
-            },
-            cx,
-        );
+        self.set_server_state(ServerState::LoadError { error: err }, cx);
     }
 
     fn handle_agent_servers_updated(
@@ -1245,7 +1265,7 @@ impl ConversationView {
         // when agent.connect() fails during loading), retry loading the thread.
         // This handles the case where a thread is restored before authentication completes.
         let should_retry = match &self.server_state {
-            ServerState::Loading(_) => false,
+            ServerState::Loading { .. } => false,
             ServerState::LoadError { .. } => true,
             ServerState::Connected(connected) => {
                 connected.auth_state.is_ok() && connected.has_thread_error(cx)
@@ -1276,7 +1296,7 @@ impl ConversationView {
                 .active_view()
                 .and_then(|v| v.read(cx).thread.read(cx).title())
                 .unwrap_or_else(|| DEFAULT_THREAD_TITLE.into()),
-            ServerState::Loading(_) => "Loading…".into(),
+            ServerState::Loading { .. } => "Loading…".into(),
             ServerState::LoadError { error, .. } => match error {
                 LoadError::Unsupported { .. } => {
                     format!("Upgrade {}", self.agent.agent_id()).into()
@@ -1298,13 +1318,8 @@ impl ConversationView {
         }
     }
 
-    // The parent ID is None if we haven't created a thread yet
-    pub fn parent_id(&self, cx: &App) -> Option<ThreadId> {
-        match &self.server_state {
-            ServerState::Connected(_) => self.root_thread(cx).map(|thread| thread.read(cx).id),
-            ServerState::Loading(loading) => loading.read(cx).thread_id,
-            ServerState::LoadError { thread_id, .. } => *thread_id,
-        }
+    pub fn parent_id(&self) -> ThreadId {
+        self.thread_id
     }
 
     pub fn is_loading(&self) -> bool {
@@ -1361,23 +1376,22 @@ impl ConversationView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let thread_entity_id = thread.entity_id();
-        let thread_id = self.as_connected().and_then(|connected| {
-            connected
-                .threads
-                .iter()
-                .find(|(_, tv)| tv.read(cx).thread.entity_id() == thread_entity_id)
-                .map(|(id, _)| *id)
-        });
-        let Some(thread_id) = thread_id else {
+        let session_id = thread.read(cx).session_id().clone();
+        let has_thread = self
+            .as_connected()
+            .is_some_and(|connected| connected.threads.contains_key(&session_id));
+        if !has_thread {
             return;
         };
         let is_subagent = thread.read(cx).parent_session_id().is_some();
+        if !is_subagent && affects_thread_metadata(event) {
+            cx.emit(RootThreadUpdated);
+        }
         match event {
             AcpThreadEvent::NewEntry => {
                 let len = thread.read(cx).entries().len();
                 let index = len - 1;
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     let entry_view_state = active.read(cx).entry_view_state.clone();
                     let list_state = active.read(cx).list_state.clone();
                     entry_view_state.update(cx, |view_state, cx| {
@@ -1395,7 +1409,7 @@ impl ConversationView {
                 }
             }
             AcpThreadEvent::EntryUpdated(index) => {
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     let entry_view_state = active.read(cx).entry_view_state.clone();
                     let list_state = active.read(cx).list_state.clone();
                     entry_view_state.update(cx, |view_state, cx| {
@@ -1408,7 +1422,7 @@ impl ConversationView {
                 }
             }
             AcpThreadEvent::EntriesRemoved(range) => {
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     let entry_view_state = active.read(cx).entry_view_state.clone();
                     let list_state = active.read(cx).list_state.clone();
                     entry_view_state.update(cx, |view_state, _cx| view_state.remove(range.clone()));
@@ -1418,22 +1432,22 @@ impl ConversationView {
                     });
                 }
             }
-            AcpThreadEvent::SubagentSpawned(session_id) => {
-                self.load_subagent_session(session_id.clone(), thread_id, window, cx)
+            AcpThreadEvent::SubagentSpawned(subagent_session_id) => {
+                self.load_subagent_session(subagent_session_id.clone(), session_id, window, cx)
             }
             AcpThreadEvent::ToolAuthorizationRequested(_) => {
                 self.notify_with_sound("Waiting for tool confirmation", IconName::Info, window, cx);
             }
             AcpThreadEvent::ToolAuthorizationReceived(_) => {}
             AcpThreadEvent::Retry(retry) => {
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     active.update(cx, |active, _cx| {
                         active.thread_retry_status = Some(retry.clone());
                     });
                 }
             }
             AcpThreadEvent::Stopped(stop_reason) => {
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     let is_generating =
                         matches!(thread.read(cx).status(), ThreadStatus::Generating);
                     active.update(cx, |active, cx| {
@@ -1497,7 +1511,7 @@ impl ConversationView {
             }
             AcpThreadEvent::Refusal => {
                 let error = ThreadError::Refusal;
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     active.update(cx, |active, cx| {
                         active.handle_thread_error(error, cx);
                         active.thread_retry_status.take();
@@ -1511,7 +1525,7 @@ impl ConversationView {
                 }
             }
             AcpThreadEvent::Error => {
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     let is_generating =
                         matches!(thread.read(cx).status(), ThreadStatus::Generating);
                     active.update(cx, |active, cx| {
@@ -1547,14 +1561,13 @@ impl ConversationView {
                 self.set_server_state(
                     ServerState::LoadError {
                         error: error.clone(),
-                        thread_id: Some(thread_id),
                     },
                     cx,
                 );
             }
             AcpThreadEvent::TitleUpdated => {
                 if let Some(title) = thread.read(cx).title()
-                    && let Some(active_thread) = self.thread_view(&thread_id)
+                    && let Some(active_thread) = self.thread_view(&session_id, cx)
                 {
                     let title_editor = active_thread.read(cx).title_editor.clone();
                     title_editor.update(cx, |editor, cx| {
@@ -1566,7 +1579,7 @@ impl ConversationView {
                 cx.notify();
             }
             AcpThreadEvent::PromptCapabilitiesUpdated => {
-                if let Some(active) = self.thread_view(&thread_id) {
+                if let Some(active) = self.thread_view(&session_id, cx) {
                     active.update(cx, |active, _cx| {
                         active
                             .session_capabilities
@@ -1580,7 +1593,7 @@ impl ConversationView {
                 self.emit_token_limit_telemetry_if_needed(thread, cx);
             }
             AcpThreadEvent::AvailableCommandsUpdated(available_commands) => {
-                if let Some(thread_view) = self.thread_view(&thread_id) {
+                if let Some(thread_view) = self.thread_view(&session_id, cx) {
                     let has_commands = !available_commands.is_empty();
 
                     let agent_display_name = self
@@ -1758,22 +1771,19 @@ impl ConversationView {
     fn load_subagent_session(
         &mut self,
         subagent_id: acp::SessionId,
-        parent_thread_id: ThreadId,
+        parent_session_id: acp::SessionId,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let Some(connected) = self.as_connected() else {
             return;
         };
-        if connected
-            .threads
-            .values()
-            .any(|tv| tv.read(cx).thread.read(cx).session_id() == &subagent_id)
+        if connected.threads.contains_key(&subagent_id)
             || !connected.connection.supports_load_session()
         {
             return;
         }
-        let Some(parent_thread) = connected.threads.get(&parent_thread_id) else {
+        let Some(parent_thread) = connected.threads.get(&parent_session_id) else {
             return;
         };
         let work_dirs = parent_thread
@@ -1801,13 +1811,11 @@ impl ConversationView {
                 else {
                     return;
                 };
-                let subagent_thread_id = ThreadId::new();
+                let subagent_session_id = subagent_thread.read(cx).session_id().clone();
                 conversation.update(cx, |conversation, cx| {
-                    conversation.register_thread(subagent_thread_id, subagent_thread.clone(), cx);
+                    conversation.register_thread(subagent_thread.clone(), cx);
                 });
                 let view = this.new_thread_view(
-                    Some(parent_thread_id),
-                    subagent_thread_id,
                     subagent_thread,
                     conversation,
                     false,
@@ -1819,7 +1827,7 @@ impl ConversationView {
                 let Some(connected) = this.as_connected_mut() else {
                     return;
                 };
-                connected.threads.insert(subagent_thread_id, view);
+                connected.threads.insert(subagent_session_id, view);
             })
         })
         .detach();
@@ -2941,7 +2949,7 @@ pub(crate) mod tests {
     use workspace::{Item, MultiWorkspace};
 
     use crate::agent_panel;
-    use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore};
+    use crate::thread_metadata_store::ThreadMetadataStore;
 
     use super::*;
 
@@ -3432,7 +3440,7 @@ pub(crate) mod tests {
                 other => panic!(
                     "Expected LoadError::Other, got: {}",
                     match other {
-                        ServerState::Loading(_) => "Loading (stuck!)",
+                        ServerState::Loading { .. } => "Loading (stuck!)",
                         ServerState::LoadError { .. } => "LoadError (wrong variant)",
                         ServerState::Connected(_) => "Connected",
                     }
@@ -6823,13 +6831,13 @@ pub(crate) mod tests {
         let project = Project::test(fs, [], cx).await;
         let connection: Rc<dyn AgentConnection> = Rc::new(StubAgentConnection::new());
 
-        let thread_id = ThreadId::new();
+        let session_id = acp::SessionId::new("session-1");
         let (thread, conversation) = cx.update(|cx| {
             let thread =
                 create_test_acp_thread(None, "session-1", connection.clone(), project.clone(), cx);
             let conversation = cx.new(|cx| {
                 let mut conversation = Conversation::default();
-                conversation.register_thread(thread_id, thread.clone(), cx);
+                conversation.register_thread(thread.clone(), cx);
                 conversation
             });
             (thread, conversation)
@@ -6841,7 +6849,7 @@ pub(crate) mod tests {
         cx.read(|cx| {
             let (_, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&thread_id, cx)
+                .pending_tool_call(&session_id, cx)
                 .expect("Expected a pending tool call");
             assert_eq!(tool_call_id, acp::ToolCallId::new("tc-1"));
         });
@@ -6849,7 +6857,7 @@ pub(crate) mod tests {
         cx.update(|cx| {
             conversation.update(cx, |conversation, cx| {
                 conversation.authorize_tool_call(
-                    thread_id,
+                    session_id.clone(),
                     acp::ToolCallId::new("tc-1"),
                     SelectedPermissionOutcome::new(
                         acp::PermissionOptionId::new("allow-1"),
@@ -6865,7 +6873,7 @@ pub(crate) mod tests {
         cx.read(|cx| {
             let (_, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&thread_id, cx)
+                .pending_tool_call(&session_id, cx)
                 .expect("Expected tc-2 to be pending after tc-1 was authorized");
             assert_eq!(tool_call_id, acp::ToolCallId::new("tc-2"));
         });
@@ -6873,7 +6881,7 @@ pub(crate) mod tests {
         cx.update(|cx| {
             conversation.update(cx, |conversation, cx| {
                 conversation.authorize_tool_call(
-                    thread_id,
+                    session_id.clone(),
                     acp::ToolCallId::new("tc-2"),
                     SelectedPermissionOutcome::new(
                         acp::PermissionOptionId::new("allow-2"),
@@ -6890,7 +6898,7 @@ pub(crate) mod tests {
             assert!(
                 conversation
                     .read(cx)
-                    .pending_tool_call(&thread_id, cx)
+                    .pending_tool_call(&session_id, cx)
                     .is_none(),
                 "Expected no pending tool calls after both were authorized"
             );
@@ -6905,8 +6913,8 @@ pub(crate) mod tests {
         let project = Project::test(fs, [], cx).await;
         let connection: Rc<dyn AgentConnection> = Rc::new(StubAgentConnection::new());
 
-        let parent_thread_id = ThreadId::new();
-        let subagent_thread_id = ThreadId::new();
+        let parent_session_id = acp::SessionId::new("parent");
+        let subagent_session_id = acp::SessionId::new("subagent");
         let (parent_thread, subagent_thread, conversation) = cx.update(|cx| {
             let parent_thread =
                 create_test_acp_thread(None, "parent", connection.clone(), project.clone(), cx);
@@ -6919,8 +6927,8 @@ pub(crate) mod tests {
             );
             let conversation = cx.new(|cx| {
                 let mut conversation = Conversation::default();
-                conversation.register_thread(parent_thread_id, parent_thread.clone(), cx);
-                conversation.register_thread(subagent_thread_id, subagent_thread.clone(), cx);
+                conversation.register_thread(parent_thread.clone(), cx);
+                conversation.register_thread(subagent_thread.clone(), cx);
                 conversation
             });
             (parent_thread, subagent_thread, conversation)
@@ -6931,25 +6939,25 @@ pub(crate) mod tests {
         let _subagent_task =
             request_test_tool_authorization(&subagent_thread, "subagent-tc", "allow-subagent", cx);
 
-        // Querying with the subagent's thread ID returns only the
+        // Querying with the subagent's session ID returns only the
         // subagent's own tool call (subagent path is scoped to its session)
         cx.read(|cx| {
-            let (returned_thread_id, tool_call_id, _) = conversation
+            let (returned_session_id, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&subagent_thread_id, cx)
+                .pending_tool_call(&subagent_session_id, cx)
                 .expect("Expected subagent's pending tool call");
-            assert_eq!(returned_thread_id, subagent_thread_id);
+            assert_eq!(returned_session_id, subagent_session_id);
             assert_eq!(tool_call_id, acp::ToolCallId::new("subagent-tc"));
         });
 
-        // Querying with the parent's thread ID returns the first pending
+        // Querying with the parent's session ID returns the first pending
         // request in FIFO order across all sessions
         cx.read(|cx| {
-            let (returned_thread_id, tool_call_id, _) = conversation
+            let (returned_session_id, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&parent_thread_id, cx)
+                .pending_tool_call(&parent_session_id, cx)
                 .expect("Expected a pending tool call from parent query");
-            assert_eq!(returned_thread_id, parent_thread_id);
+            assert_eq!(returned_session_id, parent_session_id);
             assert_eq!(tool_call_id, acp::ToolCallId::new("parent-tc"));
         });
     }
@@ -6964,8 +6972,8 @@ pub(crate) mod tests {
         let project = Project::test(fs, [], cx).await;
         let connection: Rc<dyn AgentConnection> = Rc::new(StubAgentConnection::new());
 
-        let thread_id_a = ThreadId::new();
-        let thread_id_b = ThreadId::new();
+        let session_id_a = acp::SessionId::new("thread-a");
+        let session_id_b = acp::SessionId::new("thread-b");
         let (thread_a, thread_b, conversation) = cx.update(|cx| {
             let thread_a =
                 create_test_acp_thread(None, "thread-a", connection.clone(), project.clone(), cx);
@@ -6973,8 +6981,8 @@ pub(crate) mod tests {
                 create_test_acp_thread(None, "thread-b", connection.clone(), project.clone(), cx);
             let conversation = cx.new(|cx| {
                 let mut conversation = Conversation::default();
-                conversation.register_thread(thread_id_a, thread_a.clone(), cx);
-                conversation.register_thread(thread_id_b, thread_b.clone(), cx);
+                conversation.register_thread(thread_a.clone(), cx);
+                conversation.register_thread(thread_b.clone(), cx);
                 conversation
             });
             (thread_a, thread_b, conversation)
@@ -6986,23 +6994,23 @@ pub(crate) mod tests {
         // Both threads are non-subagent, so pending_tool_call always returns
         // the first entry from permission_requests (FIFO across all sessions)
         cx.read(|cx| {
-            let (returned_thread_id, tool_call_id, _) = conversation
+            let (returned_session_id, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&thread_id_a, cx)
+                .pending_tool_call(&session_id_a, cx)
                 .expect("Expected a pending tool call");
-            assert_eq!(returned_thread_id, thread_id_a);
+            assert_eq!(returned_session_id, session_id_a);
             assert_eq!(tool_call_id, acp::ToolCallId::new("tc-a"));
         });
 
         // Querying with thread-b also returns thread-a's tool call,
         // because non-subagent queries always use permission_requests.first()
         cx.read(|cx| {
-            let (returned_thread_id, tool_call_id, _) = conversation
+            let (returned_session_id, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&thread_id_b, cx)
+                .pending_tool_call(&session_id_b, cx)
                 .expect("Expected a pending tool call from thread-b query");
             assert_eq!(
-                returned_thread_id, thread_id_a,
+                returned_session_id, session_id_a,
                 "Non-subagent queries always return the first pending request in FIFO order"
             );
             assert_eq!(tool_call_id, acp::ToolCallId::new("tc-a"));
@@ -7012,7 +7020,7 @@ pub(crate) mod tests {
         cx.update(|cx| {
             conversation.update(cx, |conversation, cx| {
                 conversation.authorize_tool_call(
-                    thread_id_a,
+                    session_id_a.clone(),
                     acp::ToolCallId::new("tc-a"),
                     SelectedPermissionOutcome::new(
                         acp::PermissionOptionId::new("allow-a"),
@@ -7026,11 +7034,11 @@ pub(crate) mod tests {
         cx.run_until_parked();
 
         cx.read(|cx| {
-            let (returned_thread_id, tool_call_id, _) = conversation
+            let (returned_session_id, tool_call_id, _) = conversation
                 .read(cx)
-                .pending_tool_call(&thread_id_b, cx)
+                .pending_tool_call(&session_id_b, cx)
                 .expect("Expected thread-b's tool call after thread-a's was authorized");
-            assert_eq!(returned_thread_id, thread_id_b);
+            assert_eq!(returned_session_id, session_id_b);
             assert_eq!(tool_call_id, acp::ToolCallId::new("tc-b"));
         });
     }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10,7 +10,7 @@ use editor::actions::OpenExcerpts;
 
 use crate::StartThreadIn;
 use crate::message_editor::SharedSessionCapabilities;
-use crate::thread_metadata_store::ThreadId;
+
 use gpui::{Corner, List};
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
@@ -263,8 +263,8 @@ impl PermissionSelection {
 }
 
 pub struct ThreadView {
-    pub id: ThreadId,
-    pub parent_id: Option<ThreadId>,
+    pub session_id: acp::SessionId,
+    pub parent_session_id: Option<acp::SessionId>,
     pub thread: Entity<AcpThread>,
     pub(crate) conversation: Entity<super::Conversation>,
     pub server_view: WeakEntity<ConversationView>,
@@ -295,7 +295,7 @@ pub struct ThreadView {
     pub expanded_thinking_blocks: HashSet<(usize, usize)>,
     auto_expanded_thinking_block: Option<(usize, usize)>,
     user_toggled_thinking_blocks: HashSet<(usize, usize)>,
-    pub subagent_scroll_handles: RefCell<HashMap<ThreadId, ScrollHandle>>,
+    pub subagent_scroll_handles: RefCell<HashMap<acp::SessionId, ScrollHandle>>,
     pub edits_expanded: bool,
     pub plan_expanded: bool,
     pub queue_expanded: bool,
@@ -338,7 +338,7 @@ pub struct ThreadView {
 }
 impl Focusable for ThreadView {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
-        if self.parent_id.is_some() {
+        if self.parent_session_id.is_some() {
             self.focus_handle.clone()
         } else {
             self.active_editor(cx).focus_handle(cx)
@@ -358,8 +358,6 @@ pub struct TurnFields {
 
 impl ThreadView {
     pub(crate) fn new(
-        parent_id: Option<ThreadId>,
-        thread_id: ThreadId,
         thread: Entity<AcpThread>,
         conversation: Entity<super::Conversation>,
         server_view: WeakEntity<ConversationView>,
@@ -385,7 +383,8 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let id = thread_id;
+        let session_id = thread.read(cx).session_id().clone();
+        let parent_session_id = thread.read(cx).parent_session_id().cloned();
 
         let has_commands = !session_capabilities.read().available_commands().is_empty();
         let placeholder = placeholder_text(agent_display_name.as_ref(), has_commands);
@@ -509,8 +508,8 @@ impl ThreadView {
             .unwrap_or_default();
 
         let mut this = Self {
-            id,
-            parent_id,
+            session_id,
+            parent_session_id,
             focus_handle: cx.focus_handle(),
             thread,
             conversation,
@@ -698,7 +697,7 @@ impl ThreadView {
     }
 
     fn is_subagent(&self) -> bool {
-        self.parent_id.is_some()
+        self.parent_session_id.is_some()
     }
 
     /// Returns the currently active editor, either for a message that is being
@@ -1708,14 +1707,14 @@ impl ThreadView {
 
     pub fn authorize_tool_call(
         &mut self,
-        thread_id: ThreadId,
+        session_id: acp::SessionId,
         tool_call_id: acp::ToolCallId,
         outcome: SelectedPermissionOutcome,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.conversation.update(cx, |conversation, cx| {
-            conversation.authorize_tool_call(thread_id, tool_call_id, outcome, cx);
+            conversation.authorize_tool_call(session_id, tool_call_id, outcome, cx);
         });
         if self.should_be_following {
             self.workspace
@@ -1745,8 +1744,9 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<()> {
+        let session_id = self.thread.read(cx).session_id().clone();
         self.conversation.update(cx, |conversation, cx| {
-            conversation.authorize_pending_tool_call(&self.id, kind, cx)
+            conversation.authorize_pending_tool_call(&session_id, kind, cx)
         })?;
         if self.should_be_following {
             self.workspace
@@ -1786,8 +1786,9 @@ impl ThreadView {
             _ => acp::PermissionOptionKind::AllowOnce,
         };
 
+        let session_id = self.thread.read(cx).session_id().clone();
         self.authorize_tool_call(
-            self.id,
+            session_id,
             tool_call_id,
             SelectedPermissionOutcome::new(option_id, option_kind),
             window,
@@ -1865,15 +1866,25 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<()> {
-        let (thread_id, tool_call_id, options) =
-            self.conversation.read(cx).pending_tool_call(&self.id, cx)?;
+        let session_id = self.thread.read(cx).session_id().clone();
+        let (returned_session_id, tool_call_id, options) = self
+            .conversation
+            .read(cx)
+            .pending_tool_call(&session_id, cx)?;
         let options = options.clone();
-        self.authorize_with_granularity(thread_id, tool_call_id, &options, is_allow, window, cx)
+        self.authorize_with_granularity(
+            returned_session_id,
+            tool_call_id,
+            &options,
+            is_allow,
+            window,
+            cx,
+        )
     }
 
     fn authorize_with_granularity(
         &mut self,
-        thread_id: ThreadId,
+        session_id: acp::SessionId,
         tool_call_id: acp::ToolCallId,
         options: &PermissionOptions,
         is_allow: bool,
@@ -1898,7 +1909,7 @@ impl ThreadView {
         // When in per-command pattern mode, use the checked patterns.
         if let Some(PermissionSelection::SelectedPatterns(checked)) = selection {
             if let Some(outcome) = options.build_outcome_for_checked_patterns(checked, is_allow) {
-                self.authorize_tool_call(thread_id, tool_call_id, outcome, window, cx);
+                self.authorize_tool_call(session_id, tool_call_id, outcome, window, cx);
                 return Some(());
             }
         }
@@ -1911,7 +1922,7 @@ impl ThreadView {
         let selected_choice = choices.get(selected_index).or(choices.last())?;
         let outcome = selected_choice.build_outcome(is_allow);
 
-        self.authorize_tool_call(thread_id, tool_call_id, outcome, window, cx);
+        self.authorize_tool_call(session_id, tool_call_id, outcome, window, cx);
 
         Some(())
     }
@@ -2592,17 +2603,7 @@ impl ThreadView {
 
         let awaiting_session_ids: Vec<_> = awaiting
             .iter()
-            .filter_map(|(thread_id, _)| {
-                self.server_view.upgrade().and_then(|server_view| {
-                    server_view
-                        .read(cx)
-                        .as_connected()
-                        .and_then(|connected| connected.threads.get(thread_id))
-                        .map(|thread_view| {
-                            thread_view.read(cx).thread.read(cx).session_id().clone()
-                        })
-                })
-            })
+            .map(|(session_id, _)| session_id.clone())
             .collect();
 
         let thread = self.thread.read(cx);
@@ -3122,7 +3123,7 @@ impl ThreadView {
     }
 
     fn is_subagent_canceled_or_failed(&self, cx: &App) -> bool {
-        let Some(parent_session_id) = self.parent_id.as_ref() else {
+        let Some(parent_session_id) = self.parent_session_id.as_ref() else {
             return false;
         };
 
@@ -3130,7 +3131,7 @@ impl ThreadView {
 
         self.server_view
             .upgrade()
-            .and_then(|sv| sv.read(cx).thread_view(parent_session_id))
+            .and_then(|sv| sv.read(cx).thread_view(parent_session_id, cx))
             .is_some_and(|parent_view| {
                 parent_view
                     .read(cx)
@@ -3149,9 +3150,10 @@ impl ThreadView {
     }
 
     pub(crate) fn render_subagent_titlebar(&mut self, cx: &mut Context<Self>) -> Option<Div> {
-        let Some(parent_session_id) = self.parent_id else {
+        if self.parent_session_id.is_none() {
             return None;
-        };
+        }
+        let parent_session_id = self.thread.read(cx).parent_session_id()?.clone();
 
         let server_view = self.server_view.clone();
         let thread = self.thread.clone();
@@ -3220,7 +3222,7 @@ impl ThreadView {
                                         .on_click(move |_, window, cx| {
                                             let _ = server_view.update(cx, |server_view, cx| {
                                                 server_view.navigate_to_thread(
-                                                    parent_session_id,
+                                                    parent_session_id.clone(),
                                                     window,
                                                     cx,
                                                 );
@@ -4720,7 +4722,7 @@ impl ThreadView {
             }
             AgentThreadEntry::ToolCall(tool_call) => self
                 .render_any_tool_call(
-                    &self.id,
+                    self.thread.read(cx).session_id(),
                     entry_ix,
                     tool_call,
                     &self.focus_handle(cx),
@@ -5875,7 +5877,7 @@ impl ThreadView {
 
     fn render_terminal_tool_call(
         &self,
-        active_thread_id: &ThreadId,
+        active_session_id: &acp::SessionId,
         entry_ix: usize,
         terminal: &Entity<acp_thread::Terminal>,
         tool_call: &ToolCall,
@@ -6152,9 +6154,9 @@ impl ThreadView {
                 )
             })
             .when_some(confirmation_options, |this, options| {
-                let is_first = self.is_first_tool_call(active_thread_id, &tool_call.id, cx);
+                let is_first = self.is_first_tool_call(active_session_id, &tool_call.id, cx);
                 this.child(self.render_permission_buttons(
-                    self.id,
+                    self.thread.read(cx).session_id().clone(),
                     is_first,
                     options,
                     entry_ix,
@@ -6168,21 +6170,22 @@ impl ThreadView {
 
     fn is_first_tool_call(
         &self,
-        active_thread_id: &ThreadId,
+        active_session_id: &acp::SessionId,
         tool_call_id: &acp::ToolCallId,
         cx: &App,
     ) -> bool {
         self.conversation
             .read(cx)
-            .pending_tool_call(active_thread_id, cx)
-            .map_or(false, |(pending_thread_id, pending_tool_call_id, _)| {
-                self.id == pending_thread_id && tool_call_id == &pending_tool_call_id
+            .pending_tool_call(active_session_id, cx)
+            .map_or(false, |(pending_session_id, pending_tool_call_id, _)| {
+                self.thread.read(cx).session_id() == &pending_session_id
+                    && tool_call_id == &pending_tool_call_id
             })
     }
 
     fn render_any_tool_call(
         &self,
-        active_thread_id: &ThreadId,
+        active_session_id: &acp::SessionId,
         entry_ix: usize,
         tool_call: &ToolCall,
         focus_handle: &FocusHandle,
@@ -6196,7 +6199,7 @@ impl ThreadView {
             if tool_call.is_subagent() {
                 this.child(
                     self.render_subagent_tool_call(
-                        active_thread_id,
+                        active_session_id,
                         entry_ix,
                         tool_call,
                         tool_call
@@ -6211,7 +6214,7 @@ impl ThreadView {
             } else if has_terminals {
                 this.children(tool_call.terminals().map(|terminal| {
                     self.render_terminal_tool_call(
-                        active_thread_id,
+                        active_session_id,
                         entry_ix,
                         terminal,
                         tool_call,
@@ -6223,7 +6226,7 @@ impl ThreadView {
                 }))
             } else {
                 this.child(self.render_tool_call(
-                    active_thread_id,
+                    active_session_id,
                     entry_ix,
                     tool_call,
                     focus_handle,
@@ -6237,7 +6240,7 @@ impl ThreadView {
 
     fn render_tool_call(
         &self,
-        active_thread_id: &ThreadId,
+        active_session_id: &acp::SessionId,
         entry_ix: usize,
         tool_call: &ToolCall,
         focus_handle: &FocusHandle,
@@ -6308,7 +6311,7 @@ impl ThreadView {
                             .map(|(content_ix, content)| {
                                 div()
                                     .child(self.render_tool_call_content(
-                                        active_thread_id,
+                                        active_session_id,
                                         entry_ix,
                                         content,
                                         content_ix,
@@ -6388,8 +6391,8 @@ impl ThreadView {
                         )
                     })
                     .child(self.render_permission_buttons(
-                        self.id,
-                        self.is_first_tool_call(active_thread_id, &tool_call.id, cx),
+                        self.thread.read(cx).session_id().clone(),
+                        self.is_first_tool_call(active_session_id, &tool_call.id, cx),
                         options,
                         entry_ix,
                         tool_call.id.clone(),
@@ -6438,7 +6441,7 @@ impl ThreadView {
                             .map(|(content_ix, content)| {
                                 div().id(("tool-call-output", entry_ix)).child(
                                     self.render_tool_call_content(
-                                        active_thread_id,
+                                        active_session_id,
                                         entry_ix,
                                         content,
                                         content_ix,
@@ -6663,7 +6666,7 @@ impl ThreadView {
 
     fn render_permission_buttons(
         &self,
-        thread_id: ThreadId,
+        session_id: acp::SessionId,
         is_first: bool,
         options: &PermissionOptions,
         entry_ix: usize,
@@ -6673,7 +6676,7 @@ impl ThreadView {
     ) -> Div {
         match options {
             PermissionOptions::Flat(options) => self.render_permission_buttons_flat(
-                thread_id,
+                session_id,
                 is_first,
                 options,
                 entry_ix,
@@ -7080,7 +7083,7 @@ impl ThreadView {
 
     fn render_permission_buttons_flat(
         &self,
-        thread_id: ThreadId,
+        session_id: acp::SessionId,
         is_first: bool,
         options: &[acp::PermissionOption],
         entry_ix: usize,
@@ -7150,9 +7153,10 @@ impl ThreadView {
                         let tool_call_id = tool_call_id.clone();
                         let option_id = option.option_id.clone();
                         let option_kind = option.kind;
+                        let session_id = session_id.clone();
                         move |this, _, window, cx| {
                             this.authorize_tool_call(
-                                thread_id,
+                                session_id.clone(),
                                 tool_call_id.clone(),
                                 SelectedPermissionOutcome::new(option_id.clone(), option_kind),
                                 window,
@@ -7410,7 +7414,7 @@ impl ThreadView {
 
     fn render_tool_call_content(
         &self,
-        thread_id: &ThreadId,
+        session_id: &acp::SessionId,
         entry_ix: usize,
         content: &ToolCallContent,
         context_ix: usize,
@@ -7453,7 +7457,7 @@ impl ThreadView {
                 self.render_diff_editor(entry_ix, diff, tool_call, has_failed, cx)
             }
             ToolCallContent::Terminal(terminal) => self.render_terminal_tool_call(
-                thread_id,
+                session_id,
                 entry_ix,
                 terminal,
                 tool_call,
@@ -7694,7 +7698,7 @@ impl ThreadView {
 
     fn render_subagent_tool_call(
         &self,
-        active_thread_id: &ThreadId,
+        active_session_id: &acp::SessionId,
         entry_ix: usize,
         tool_call: &ToolCall,
         subagent_session_id: Option<acp::SessionId>,
@@ -7706,16 +7710,11 @@ impl ThreadView {
             self.server_view
                 .upgrade()
                 .and_then(|server_view| server_view.read(cx).as_connected())
-                .and_then(|connected| {
-                    connected
-                        .threads
-                        .values()
-                        .find(|tv| tv.read(cx).thread.read(cx).session_id() == &session_id)
-                })
+                .and_then(|connected| connected.threads.get(&session_id))
         });
 
         let content = self.render_subagent_card(
-            active_thread_id,
+            active_session_id,
             entry_ix,
             subagent_thread_view,
             tool_call,
@@ -7729,7 +7728,7 @@ impl ThreadView {
 
     fn render_subagent_card(
         &self,
-        active_thread_id: &ThreadId,
+        active_session_id: &acp::SessionId,
         entry_ix: usize,
         thread_view: Option<&Entity<ThreadView>>,
         tool_call: &ToolCall,
@@ -7751,9 +7750,8 @@ impl ThreadView {
         let is_pending_tool_call = thread_view
             .as_ref()
             .and_then(|tv| {
-                self.conversation
-                    .read(cx)
-                    .pending_tool_call(&tv.read(cx).id, cx)
+                let sid = tv.read(cx).thread.read(cx).session_id();
+                self.conversation.read(cx).pending_tool_call(sid, cx)
             })
             .is_some();
 
@@ -7979,12 +7977,13 @@ impl ThreadView {
             )
             .when_some(thread_view, |this, thread_view| {
                 let thread = &thread_view.read(cx).thread;
+                let tv_session_id = thread.read(cx).session_id();
                 let pending_tool_call = self
                     .conversation
                     .read(cx)
-                    .pending_tool_call(&thread_view.read(cx).id, cx);
+                    .pending_tool_call(tv_session_id, cx);
 
-                let nav_thread_id = thread_view.read(cx).id;
+                let nav_session_id = tv_session_id.clone();
 
                 let fullscreen_toggle = h_flex()
                     .id(entry_ix)
@@ -8006,7 +8005,7 @@ impl ThreadView {
                         telemetry::event!("Subagent Maximized");
                         this.server_view
                             .update(cx, |this, cx| {
-                                this.navigate_to_thread(nav_thread_id, window, cx);
+                                this.navigate_to_thread(nav_session_id.clone(), window, cx);
                             })
                             .ok();
                     }));
@@ -8017,7 +8016,7 @@ impl ThreadView {
                     {
                         this.child(Divider::horizontal().color(DividerColor::Border))
                             .child(thread_view.read(cx).render_any_tool_call(
-                                active_thread_id,
+                                active_session_id,
                                 entry_ix,
                                 tool_call,
                                 focus_handle,
@@ -8103,7 +8102,7 @@ impl ThreadView {
         let scroll_handle = self
             .subagent_scroll_handles
             .borrow_mut()
-            .entry(subagent_view.id)
+            .entry(subagent_view.session_id.clone())
             .or_default()
             .clone();
 
@@ -8903,15 +8902,15 @@ impl Render for ThreadView {
             .key_context("AcpThread")
             .track_focus(&self.focus_handle)
             .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
-                if this.parent_id.is_none() {
+                if this.parent_session_id.is_none() {
                     this.cancel_generation(cx);
                 }
             }))
             .on_action(cx.listener(|this, _: &workspace::GoBack, window, cx| {
-                if let Some(parent_thread_id) = this.parent_id {
+                if let Some(parent_session_id) = this.thread.read(cx).parent_session_id().cloned() {
                     this.server_view
                         .update(cx, |view, cx| {
-                            view.navigate_to_thread(parent_thread_id, window, cx);
+                            view.navigate_to_thread(parent_session_id, window, cx);
                         })
                         .ok();
                 }

--- a/crates/agent_ui/src/test_support.rs
+++ b/crates/agent_ui/src/test_support.rs
@@ -133,7 +133,5 @@ pub fn active_thread_id(
     panel: &Entity<AgentPanel>,
     cx: &VisualTestContext,
 ) -> crate::thread_metadata_store::ThreadId {
-    panel.read_with(cx, |panel, cx| {
-        panel.active_thread_view(cx).unwrap().read(cx).id
-    })
+    panel.read_with(cx, |panel, cx| panel.active_thread_id(cx).unwrap())
 }

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -3,7 +3,6 @@ use std::{
     sync::Arc,
 };
 
-use acp_thread::AcpThreadEvent;
 use agent::{ThreadStore, ZED_AGENT_ID};
 use agent_client_protocol as acp;
 use anyhow::Context as _;
@@ -416,6 +415,28 @@ pub struct ThreadMetadata {
 }
 
 impl ThreadMetadata {
+    pub fn new_draft(
+        thread_id: ThreadId,
+        session_id: Option<acp::SessionId>,
+        agent_id: AgentId,
+        title: Option<SharedString>,
+        worktree_paths: ThreadWorktreePaths,
+        remote_connection: Option<RemoteConnectionOptions>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            thread_id,
+            session_id,
+            agent_id,
+            title,
+            updated_at: now,
+            created_at: Some(now),
+            worktree_paths: worktree_paths.clone(),
+            remote_connection,
+            archived: worktree_paths.is_empty(),
+        }
+    }
+
     pub fn is_draft(&self) -> bool {
         self.session_id.is_none()
     }
@@ -495,7 +516,7 @@ pub struct ArchivedGitWorktree {
 
 /// The store holds all metadata needed to show threads in the sidebar/the archive.
 ///
-/// Automatically listens to AcpThread events and updates metadata if it has changed.
+/// Listens to ConversationView events and updates metadata when the root thread changes.
 pub struct ThreadMetadataStore {
     db: ThreadMetadataDb,
     threads: HashMap<ThreadId, ThreadMetadata>,
@@ -503,7 +524,7 @@ pub struct ThreadMetadataStore {
     threads_by_main_paths: HashMap<PathList, HashSet<ThreadId>>,
     sessions: HashMap<acp::SessionId, ThreadId>,
     reload_task: Option<Shared<Task<()>>>,
-    session_subscriptions: HashMap<acp::SessionId, Subscription>,
+    conversation_subscriptions: HashMap<gpui::EntityId, Subscription>,
     pending_thread_ops_tx: smol::channel::Sender<DbOperation>,
     in_flight_archives: HashMap<ThreadId, (Task<()>, smol::channel::Sender<()>)>,
     _db_operations_task: Task<()>,
@@ -569,15 +590,7 @@ impl ThreadMetadataStore {
         self.threads.get(&thread_id)
     }
 
-    /// Associates a session with a thread_id so that when
-    /// `handle_thread_event` fires later, it reuses this ThreadId instead
-    /// of generating a new one.
-    pub fn associate_session(&mut self, session_id: acp::SessionId, thread_id: ThreadId) {
-        self.sessions.insert(session_id, thread_id);
-    }
-
-    /// Returns the `ThreadId` associated with an ACP session, including
-    /// associations made via `associate_session` that haven't been saved yet.
+    /// Returns the `ThreadId` associated with an ACP session.
     pub fn thread_id_for_session(&self, session_id: &acp::SessionId) -> Option<ThreadId> {
         self.sessions.get(session_id).copied()
     }
@@ -770,21 +783,6 @@ impl ThreadMetadataStore {
             changed = true;
         }
         if changed {
-            cx.notify();
-        }
-    }
-
-    pub fn assign_session(
-        &mut self,
-        thread_id: ThreadId,
-        session_id: acp::SessionId,
-        cx: &mut Context<Self>,
-    ) {
-        if let Some(thread) = self.threads.get(&thread_id) {
-            self.save_internal(ThreadMetadata {
-                session_id: Some(session_id),
-                ..thread.clone()
-            });
             cx.notify();
         }
     }
@@ -1034,21 +1032,16 @@ impl ThreadMetadataStore {
     fn new(db: ThreadMetadataDb, cx: &mut Context<Self>) -> Self {
         let weak_store = cx.weak_entity();
 
-        cx.observe_new::<acp_thread::AcpThread>(move |thread, _window, cx| {
-            // Don't track subagent threads in the sidebar.
-            if thread.parent_session_id().is_some() {
-                return;
-            }
-
-            let thread_entity = cx.entity();
+        cx.observe_new::<crate::ConversationView>(move |_view, _window, cx| {
+            let view_entity = cx.entity();
+            let entity_id = view_entity.entity_id();
 
             cx.on_release({
                 let weak_store = weak_store.clone();
-                move |thread, cx| {
+                move |_view, cx| {
                     weak_store
                         .update(cx, |store, _cx| {
-                            let session_id = thread.session_id().clone();
-                            store.session_subscriptions.remove(&session_id);
+                            store.conversation_subscriptions.remove(&entity_id);
                         })
                         .ok();
                 }
@@ -1057,9 +1050,9 @@ impl ThreadMetadataStore {
 
             weak_store
                 .update(cx, |this, cx| {
-                    let subscription = cx.subscribe(&thread_entity, Self::handle_thread_event);
-                    this.session_subscriptions
-                        .insert(thread.session_id().clone(), subscription);
+                    let subscription = cx.subscribe(&view_entity, Self::handle_conversation_event);
+                    this.conversation_subscriptions
+                        .insert(entity_id, subscription);
                 })
                 .ok();
         })
@@ -1096,7 +1089,7 @@ impl ThreadMetadataStore {
             threads_by_main_paths: HashMap::default(),
             sessions: HashMap::default(),
             reload_task: None,
-            session_subscriptions: HashMap::default(),
+            conversation_subscriptions: HashMap::default(),
             pending_thread_ops_tx: tx,
             in_flight_archives: HashMap::default(),
             _db_operations_task,
@@ -1116,91 +1109,62 @@ impl ThreadMetadataStore {
         ops.into_values().collect()
     }
 
-    fn handle_thread_event(
+    fn handle_conversation_event(
         &mut self,
-        thread: Entity<acp_thread::AcpThread>,
-        event: &AcpThreadEvent,
+        conversation_view: Entity<crate::ConversationView>,
+        _event: &crate::conversation_view::RootThreadUpdated,
         cx: &mut Context<Self>,
     ) {
-        // Don't track subagent threads in the sidebar.
-        if thread.read(cx).parent_session_id().is_some() {
+        let view = conversation_view.read(cx);
+        let thread_id = view.thread_id;
+        let Some(thread) = view.root_acp_thread(cx) else {
+            return;
+        };
+
+        let thread_ref = thread.read(cx);
+        if thread_ref.entries().is_empty() {
             return;
         }
 
-        match event {
-            AcpThreadEvent::NewEntry
-            | AcpThreadEvent::TitleUpdated
-            | AcpThreadEvent::EntryUpdated(_)
-            | AcpThreadEvent::EntriesRemoved(_)
-            | AcpThreadEvent::ToolAuthorizationRequested(_)
-            | AcpThreadEvent::ToolAuthorizationReceived(_)
-            | AcpThreadEvent::Retry(_)
-            | AcpThreadEvent::Stopped(_)
-            | AcpThreadEvent::Error
-            | AcpThreadEvent::LoadError(_)
-            | AcpThreadEvent::Refusal
-            | AcpThreadEvent::WorkingDirectoriesUpdated => {
-                let thread_ref = thread.read(cx);
-                if thread_ref.entries().is_empty() {
-                    return;
-                }
+        let existing_thread = self.entry(thread_id);
+        let session_id = Some(thread_ref.session_id().clone());
+        let title = thread_ref.title();
 
-                let existing_thread = self.entry_by_session(thread_ref.session_id());
-                let session_id = Some(thread_ref.session_id().clone());
-                let title = thread_ref.title();
+        let updated_at = Utc::now();
 
-                let updated_at = Utc::now();
+        let created_at = existing_thread
+            .and_then(|t| t.created_at)
+            .unwrap_or_else(|| updated_at);
 
-                let created_at = existing_thread
-                    .and_then(|t| t.created_at)
-                    .unwrap_or_else(|| updated_at);
+        let agent_id = thread_ref.connection().agent_id();
 
-                let agent_id = thread_ref.connection().agent_id();
+        let project = thread_ref.project().read(cx);
+        let worktree_paths = ThreadWorktreePaths::from_project(project, cx);
 
-                let project = thread_ref.project().read(cx);
-                let worktree_paths = ThreadWorktreePaths::from_project(project, cx);
+        let project_group_key = project.project_group_key(cx);
+        let remote_connection = project_group_key.host();
 
-                let project_group_key = project.project_group_key(cx);
-                let remote_connection = project_group_key.host();
+        // Threads without a folder path (e.g. started in an empty
+        // window) are archived by default so they don't get lost,
+        // because they won't show up in the sidebar. Users can reload
+        // them from the archive.
+        let archived = existing_thread
+            .map(|t| t.archived)
+            .unwrap_or(worktree_paths.is_empty());
 
-                // Threads without a folder path (e.g. started in an empty
-                // window) are archived by default so they don't get lost,
-                // because they won't show up in the sidebar. Users can reload
-                // them from the archive.
-                let archived = existing_thread
-                    .map(|t| t.archived)
-                    .unwrap_or(worktree_paths.is_empty());
+        let metadata = ThreadMetadata {
+            thread_id,
+            session_id,
+            agent_id,
+            title,
+            created_at: Some(created_at),
+            updated_at,
+            worktree_paths,
+            remote_connection,
+            archived,
+        };
 
-                let thread_id = existing_thread
-                    .map(|t| t.thread_id)
-                    .or_else(|| {
-                        session_id
-                            .as_ref()
-                            .and_then(|sid| self.sessions.get(sid).copied())
-                    })
-                    .unwrap_or_else(ThreadId::new);
-
-                let metadata = ThreadMetadata {
-                    thread_id,
-                    session_id,
-                    agent_id,
-                    title,
-                    created_at: Some(created_at),
-                    updated_at,
-                    worktree_paths,
-                    remote_connection,
-                    archived,
-                };
-
-                self.save(metadata, cx);
-            }
-            AcpThreadEvent::TokenUsageUpdated
-            | AcpThreadEvent::SubagentSpawned(_)
-            | AcpThreadEvent::PromptCapabilitiesUpdated
-            | AcpThreadEvent::AvailableCommandsUpdated(_)
-            | AcpThreadEvent::ModeUpdated(_)
-            | AcpThreadEvent::ConfigOptionsUpdated(_) => {}
-        }
+        self.save(metadata, cx);
     }
 }
 
@@ -1597,17 +1561,18 @@ impl Column for ArchivedGitWorktree {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use acp_thread::{AgentConnection, StubAgentConnection};
+    use acp_thread::StubAgentConnection;
     use action_log::ActionLog;
     use agent::DbThread;
     use agent_client_protocol as acp;
 
-    use gpui::TestAppContext;
+    use gpui::{TestAppContext, VisualTestContext};
     use project::FakeFs;
     use project::Project;
     use remote::WslConnectionOptions;
     use std::path::Path;
     use std::rc::Rc;
+    use workspace::MultiWorkspace;
 
     fn make_db_thread(title: &str, updated_at: DateTime<Utc>) -> DbThread {
         DbThread {
@@ -1658,11 +1623,32 @@ mod tests {
         cx.update(|cx| {
             let settings_store = settings::SettingsStore::test(cx);
             cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+            release_channel::init("0.0.0".parse().unwrap(), cx);
+            prompt_store::init(cx);
             <dyn Fs>::set_global(fs, cx);
             ThreadMetadataStore::init_global(cx);
             ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
         });
         cx.run_until_parked();
+    }
+
+    fn setup_panel_with_project(
+        project: Entity<Project>,
+        cx: &mut TestAppContext,
+    ) -> (Entity<crate::AgentPanel>, VisualTestContext) {
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace_entity = multi_workspace
+            .read_with(cx, |mw, _cx| mw.workspace().clone())
+            .unwrap();
+        let mut vcx = VisualTestContext::from_window(multi_workspace.into(), cx);
+        let panel = workspace_entity.update_in(&mut vcx, |workspace, window, cx| {
+            cx.new(|cx| crate::AgentPanel::new(workspace, None, window, cx))
+        });
+        (panel, vcx)
     }
 
     fn clear_thread_metadata_remote_connection_backfill(cx: &mut TestAppContext) {
@@ -2226,48 +2212,54 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, None::<&Path>, cx).await;
-        let connection = Rc::new(StubAgentConnection::new());
+        let connection = StubAgentConnection::new();
 
-        let thread = cx
-            .update(|cx| {
-                connection
-                    .clone()
-                    .new_session(project.clone(), PathList::default(), cx)
-            })
-            .await
-            .unwrap();
-        let session_id = cx.read(|cx| thread.read(cx).session_id().clone());
+        let (panel, mut vcx) = setup_panel_with_project(project, cx);
+        crate::test_support::open_thread_with_connection(&panel, connection, &mut vcx);
 
-        cx.update(|cx| {
-            thread.update(cx, |thread, cx| {
-                thread.set_title("Draft Thread".into(), cx).detach();
-            });
-        });
-        cx.run_until_parked();
+        let thread = panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
+        let session_id = thread.read_with(&vcx, |t, _| t.session_id().clone());
+        let thread_id = crate::test_support::active_thread_id(&panel, &vcx);
 
-        let metadata_ids = cx.update(|cx| {
-            ThreadMetadataStore::global(cx)
-                .read(cx)
-                .entry_ids()
-                .collect::<Vec<_>>()
-        });
-        assert!(
-            metadata_ids.is_empty(),
-            "expected empty draft thread title updates to be ignored"
-        );
-
-        cx.update(|cx| {
-            thread.update(cx, |thread, cx| {
-                thread.push_user_content_block(None, "Hello".into(), cx);
-            });
-        });
-        cx.run_until_parked();
-
-        cx.update(|cx| {
-            let store = ThreadMetadataStore::global(cx);
-            let store = store.read(cx);
+        // Initial metadata was created by the panel with session_id: None.
+        cx.read(|cx| {
+            let store = ThreadMetadataStore::global(cx).read(cx);
             assert_eq!(store.entry_ids().count(), 1);
-            assert!(store.entry_by_session(&session_id).is_some());
+            assert!(
+                store.entry(thread_id).unwrap().session_id.is_none(),
+                "expected initial panel metadata to have no session_id"
+            );
+        });
+
+        // Setting a title on an empty thread should be ignored by the
+        // event handler (entries are empty), leaving session_id as None.
+        thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.set_title("Draft Thread".into(), cx).detach();
+        });
+        vcx.run_until_parked();
+
+        cx.read(|cx| {
+            let store = ThreadMetadataStore::global(cx).read(cx);
+            assert!(
+                store.entry(thread_id).unwrap().session_id.is_none(),
+                "expected title updates on empty thread to be ignored by event handler"
+            );
+        });
+
+        // Pushing content makes entries non-empty, so the event handler
+        // should now update metadata with the real session_id.
+        thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.push_user_content_block(None, "Hello".into(), cx);
+        });
+        vcx.run_until_parked();
+
+        cx.read(|cx| {
+            let store = ThreadMetadataStore::global(cx).read(cx);
+            assert_eq!(store.entry_ids().count(), 1);
+            assert_eq!(
+                store.entry(thread_id).unwrap().session_id.as_ref(),
+                Some(&session_id),
+            );
         });
     }
 
@@ -2277,39 +2269,32 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, None::<&Path>, cx).await;
-        let connection = Rc::new(StubAgentConnection::new());
+        let connection = StubAgentConnection::new();
 
-        let thread = cx
-            .update(|cx| {
-                connection
-                    .clone()
-                    .new_session(project.clone(), PathList::default(), cx)
-            })
-            .await
-            .unwrap();
-        let session_id = cx.read(|cx| thread.read(cx).session_id().clone());
+        let (panel, mut vcx) = setup_panel_with_project(project, cx);
+        crate::test_support::open_thread_with_connection(&panel, connection, &mut vcx);
 
-        cx.update(|cx| {
-            thread.update(cx, |thread, cx| {
-                thread.push_user_content_block(None, "Hello".into(), cx);
-            });
+        let session_id = crate::test_support::active_session_id(&panel, &vcx);
+        let thread = panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
+
+        thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.push_user_content_block(None, "Hello".into(), cx);
         });
-        cx.run_until_parked();
+        vcx.run_until_parked();
 
-        cx.update(|cx| {
-            let store = ThreadMetadataStore::global(cx);
-            let store = store.read(cx);
+        cx.read(|cx| {
+            let store = ThreadMetadataStore::global(cx).read(cx);
             assert_eq!(store.entry_ids().count(), 1);
             assert!(store.entry_by_session(&session_id).is_some());
         });
 
-        drop(thread);
+        // Dropping the panel releases the ConversationView and its thread.
+        drop(panel);
         cx.update(|_| {});
         cx.run_until_parked();
 
-        cx.update(|cx| {
-            let store = ThreadMetadataStore::global(cx);
-            let store = store.read(cx);
+        cx.read(|cx| {
+            let store = ThreadMetadataStore::global(cx).read(cx);
             assert_eq!(store.entry_ids().count(), 1);
             assert!(store.entry_by_session(&session_id).is_some());
         });
@@ -2324,49 +2309,40 @@ mod tests {
         let fs = FakeFs::new(cx.executor());
         let project_without_worktree = Project::test(fs.clone(), None::<&Path>, cx).await;
         let project_with_worktree = Project::test(fs, [Path::new("/project-a")], cx).await;
-        let connection = Rc::new(StubAgentConnection::new());
 
-        let thread_without_worktree = cx
-            .update(|cx| {
-                connection.clone().new_session(
-                    project_without_worktree.clone(),
-                    PathList::default(),
-                    cx,
-                )
-            })
-            .await
-            .unwrap();
+        // Thread in project without worktree
+        let (panel_no_wt, mut vcx_no_wt) = setup_panel_with_project(project_without_worktree, cx);
+        crate::test_support::open_thread_with_connection(
+            &panel_no_wt,
+            StubAgentConnection::new(),
+            &mut vcx_no_wt,
+        );
+        let thread_no_wt = panel_no_wt.read_with(&vcx_no_wt, |panel, cx| {
+            panel.active_agent_thread(cx).unwrap()
+        });
+        thread_no_wt.update_in(&mut vcx_no_wt, |thread, _window, cx| {
+            thread.push_user_content_block(None, "content".into(), cx);
+            thread.set_title("No Project Thread".into(), cx).detach();
+        });
+        vcx_no_wt.run_until_parked();
         let session_without_worktree =
-            cx.read(|cx| thread_without_worktree.read(cx).session_id().clone());
+            crate::test_support::active_session_id(&panel_no_wt, &vcx_no_wt);
 
-        cx.update(|cx| {
-            thread_without_worktree.update(cx, |thread, cx| {
-                thread.push_user_content_block(None, "content".into(), cx);
-                thread.set_title("No Project Thread".into(), cx).detach();
-            });
+        // Thread in project with worktree
+        let (panel_wt, mut vcx_wt) = setup_panel_with_project(project_with_worktree, cx);
+        crate::test_support::open_thread_with_connection(
+            &panel_wt,
+            StubAgentConnection::new(),
+            &mut vcx_wt,
+        );
+        let thread_wt =
+            panel_wt.read_with(&vcx_wt, |panel, cx| panel.active_agent_thread(cx).unwrap());
+        thread_wt.update_in(&mut vcx_wt, |thread, _window, cx| {
+            thread.push_user_content_block(None, "content".into(), cx);
+            thread.set_title("Project Thread".into(), cx).detach();
         });
-        cx.run_until_parked();
-
-        let thread_with_worktree = cx
-            .update(|cx| {
-                connection.clone().new_session(
-                    project_with_worktree.clone(),
-                    PathList::default(),
-                    cx,
-                )
-            })
-            .await
-            .unwrap();
-        let session_with_worktree =
-            cx.read(|cx| thread_with_worktree.read(cx).session_id().clone());
-
-        cx.update(|cx| {
-            thread_with_worktree.update(cx, |thread, cx| {
-                thread.push_user_content_block(None, "content".into(), cx);
-                thread.set_title("Project Thread".into(), cx).detach();
-            });
-        });
-        cx.run_until_parked();
+        vcx_wt.run_until_parked();
+        let session_with_worktree = crate::test_support::active_session_id(&panel_wt, &vcx_wt);
 
         cx.update(|cx| {
             let store = ThreadMetadataStore::global(cx);
@@ -2403,28 +2379,24 @@ mod tests {
         let project = Project::test(fs, None::<&Path>, cx).await;
         let connection = Rc::new(StubAgentConnection::new());
 
-        // Create a regular (non-subagent) AcpThread.
-        let regular_thread = cx
-            .update(|cx| {
-                connection
-                    .clone()
-                    .new_session(project.clone(), PathList::default(), cx)
-            })
-            .await
-            .unwrap();
+        // Create a regular (non-subagent) thread through the panel.
+        let (panel, mut vcx) = setup_panel_with_project(project.clone(), cx);
+        crate::test_support::open_thread_with_connection(&panel, (*connection).clone(), &mut vcx);
 
-        let regular_session_id = cx.read(|cx| regular_thread.read(cx).session_id().clone());
+        let regular_thread =
+            panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
+        let regular_session_id = regular_thread.read_with(&vcx, |t, _| t.session_id().clone());
 
-        // Set a title on the regular thread to trigger a save via handle_thread_update.
-        cx.update(|cx| {
-            regular_thread.update(cx, |thread, cx| {
-                thread.push_user_content_block(None, "content".into(), cx);
-                thread.set_title("Regular Thread".into(), cx).detach();
-            });
+        regular_thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.push_user_content_block(None, "content".into(), cx);
+            thread.set_title("Regular Thread".into(), cx).detach();
         });
-        cx.run_until_parked();
+        vcx.run_until_parked();
 
-        // Create a subagent AcpThread
+        // Create a standalone subagent AcpThread (not wrapped in a
+        // ConversationView). The ThreadMetadataStore only observes
+        // ConversationView events, so this thread's events should
+        // have no effect on sidebar metadata.
         let subagent_session_id = acp::SessionId::new("subagent-session");
         let subagent_thread = cx.update(|cx| {
             let action_log = cx.new(|_| ActionLog::new(project.clone()));
@@ -2443,7 +2415,6 @@ mod tests {
             })
         });
 
-        // Set a title on the subagent thread to trigger handle_thread_update.
         cx.update(|cx| {
             subagent_thread.update(cx, |thread, cx| {
                 thread
@@ -2453,14 +2424,14 @@ mod tests {
         });
         cx.run_until_parked();
 
-        // List all metadata from the store cache.
+        // Only the regular thread should appear in sidebar metadata.
+        // The subagent thread is excluded because the metadata store
+        // only observes ConversationView events.
         let list = cx.update(|cx| {
             let store = ThreadMetadataStore::global(cx);
             store.read(cx).entries().cloned().collect::<Vec<_>>()
         });
 
-        // The subagent thread should NOT appear in the sidebar metadata.
-        // Only the regular thread should be listed.
         assert_eq!(
             list.len(),
             1,

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -841,7 +841,7 @@ impl Sidebar {
         if let Some(pending_thread_id) = self.pending_thread_activation {
             let panel_thread_id = panel
                 .active_conversation_view()
-                .and_then(|cv| cv.read(cx).parent_id(cx));
+                .map(|cv| cv.read(cx).parent_id());
 
             if panel_thread_id == Some(pending_thread_id) {
                 let session_id = panel
@@ -859,7 +859,7 @@ impl Sidebar {
             return false;
         }
 
-        if let Some(thread_id) = panel.active_thread_id() {
+        if let Some(thread_id) = panel.active_thread_id(cx) {
             let session_id = panel
                 .active_agent_thread(cx)
                 .map(|thread| thread.read(cx).session_id().clone());
@@ -2415,13 +2415,11 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let load_thread = |
-            agent_panel: Entity<AgentPanel>,
-            metadata: &ThreadMetadata,
-            focus: bool,
-            window: &mut Window,
-            cx: &mut App,
-        | {
+        let load_thread = |agent_panel: Entity<AgentPanel>,
+                           metadata: &ThreadMetadata,
+                           focus: bool,
+                           window: &mut Window,
+                           cx: &mut App| {
             let Some(session_id) = metadata.session_id.clone() else {
                 return;
             };
@@ -2475,11 +2473,7 @@ impl Sidebar {
         .detach_and_log_err(cx);
     }
 
-    fn clear_empty_group_drafts(
-        &mut self,
-        workspace: &Entity<Workspace>,
-        cx: &mut Context<Self>,
-    ) {
+    fn clear_empty_group_drafts(&mut self, workspace: &Entity<Workspace>, cx: &mut Context<Self>) {
         let Some(multi_workspace) = self.multi_workspace.upgrade() else {
             return;
         };
@@ -3268,7 +3262,7 @@ impl Sidebar {
                         let panel_shows_archived = panel
                             .read(cx)
                             .active_conversation_view()
-                            .and_then(|cv| cv.read(cx).parent_id(cx))
+                            .map(|cv| cv.read(cx).parent_id())
                             .is_some_and(|live_thread_id| {
                                 thread_id.is_some_and(|id| id == live_thread_id)
                             });
@@ -4079,7 +4073,7 @@ impl Sidebar {
             let panel = workspace.panel::<AgentPanel>(cx)?;
             let draft_id = panel.update(cx, |panel, cx| {
                 if let Some(id) = panel.draft_thread_ids(cx).first().copied() {
-                    if panel.active_thread_id() != Some(id) {
+                    if panel.active_thread_id(cx) != Some(id) {
                         panel.activate_retained_thread(id, true, window, cx);
                     }
                     id
@@ -5004,6 +4998,7 @@ fn all_thread_infos_for_workspace(
             let has_pending_tool_call = conversation_view
                 .read(cx)
                 .root_thread_has_pending_tool_call(cx);
+            let conversation_thread_id = conversation_view.read(cx).parent_id();
             let thread_view = conversation_view.read(cx).root_thread(cx)?;
             let thread_view_ref = thread_view.read(cx);
             let thread = thread_view_ref.thread.read(cx);
@@ -5016,7 +5011,7 @@ fn all_thread_infos_for_workspace(
             let is_native = thread_view_ref.as_native_thread(cx).is_some();
             let is_title_generating = is_native && thread.has_provisional_title();
             let session_id = thread.session_id().clone();
-            let is_background = agent_panel.is_retained_thread(&thread_view_ref.id);
+            let is_background = agent_panel.is_retained_thread(&conversation_thread_id);
 
             let status = if has_pending_tool_call {
                 AgentThreadStatus::WaitingForConfirmation

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1580,11 +1580,7 @@ async fn test_subagent_permission_request_marks_parent_sidebar_thread_waiting(
     let subagent_thread = panel.read_with(cx, |panel, cx| {
         panel
             .active_conversation_view()
-            .and_then(|conversation| {
-                conversation
-                    .read(cx)
-                    .thread_view_for_session(&subagent_session_id, cx)
-            })
+            .and_then(|conversation| conversation.read(cx).thread_view(&subagent_session_id, cx))
             .map(|thread_view| thread_view.read(cx).thread.clone())
             .expect("Expected subagent thread to be loaded into the conversation")
     });
@@ -2346,7 +2342,10 @@ async fn test_confirm_on_historical_thread_in_new_project_group_opens_real_threa
 
     let workspace_b = multi_workspace.read_with(cx, |mw, cx| {
         mw.workspaces()
-            .find(|workspace| PathList::new(&workspace.read(cx).root_paths(cx)) == project_b_key.path_list().clone())
+            .find(|workspace| {
+                PathList::new(&workspace.read(cx).root_paths(cx))
+                    == project_b_key.path_list().clone()
+            })
             .cloned()
             .expect("expected workspace for project-b after opening the historical thread")
     });
@@ -2371,7 +2370,7 @@ async fn test_confirm_on_historical_thread_in_new_project_group_opens_real_threa
     });
 
     assert_eq!(
-        panel.read_with(cx, |panel, _| panel.active_thread_id()),
+        panel.read_with(cx, |panel, cx| panel.active_thread_id(cx)),
         Some(expected_thread_id),
         "expected the agent panel to activate the real historical thread rather than a draft"
     );
@@ -3119,7 +3118,7 @@ async fn test_draft_title_survives_folder_addition(cx: &mut TestAppContext) {
     editor.update_in(cx, |editor, window, cx| {
         editor.set_text("Initial text", window, cx);
     });
-    let thread_id = panel.read_with(cx, |panel, _| panel.active_thread_id().unwrap());
+    let thread_id = panel.read_with(cx, |panel, cx| panel.active_thread_id(cx).unwrap());
     cx.run_until_parked();
 
     // The thread without a title should show the editor text via
@@ -3327,7 +3326,7 @@ async fn test_sending_message_from_draft_removes_draft(cx: &mut TestAppContext) 
     // the NativeAgentServer in tests, so replicate the key steps:
     // remove the draft, open a real thread with a stub connection,
     // and send.
-    let thread_id = panel.read_with(cx, |panel, _| panel.active_thread_id().unwrap());
+    let thread_id = panel.read_with(cx, |panel, cx| panel.active_thread_id(cx).unwrap());
     panel.update_in(cx, |panel, _window, cx| {
         panel.remove_thread(thread_id, cx);
     });
@@ -6099,7 +6098,7 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
             .expect("expected unarchive to install an agent panel in the new workspace")
     });
 
-    let restored_thread_id = restored_panel.read_with(cx, |panel, _| panel.active_thread_id());
+    let restored_thread_id = restored_panel.read_with(cx, |panel, cx| panel.active_thread_id(cx));
     assert_eq!(
         restored_thread_id,
         Some(original_thread_id),
@@ -6120,8 +6119,7 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
         "expected exactly one metadata row for restored session after opening a new workspace, got: {session_entries:?}"
     );
     assert_eq!(
-        session_entries[0].thread_id,
-        original_thread_id,
+        session_entries[0].thread_id, original_thread_id,
         "expected restore into a new workspace to reuse the original thread id"
     );
     assert!(
@@ -6152,7 +6150,9 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
         "expected exactly one visible real thread row after restore into a new workspace, got entries: {entries:?}"
     );
     assert!(
-        entries.iter().any(|entry| entry.contains("Unarchived Thread")),
+        entries
+            .iter()
+            .any(|entry| entry.contains("Unarchived Thread")),
         "expected restored thread row to be visible, got entries: {entries:?}"
     );
 }
@@ -6391,12 +6391,14 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
     });
 
     let panel_b_before_settle = workspace_b.read_with(cx, |workspace, cx| {
-        workspace
-            .panel::<AgentPanel>(cx)
-            .expect("target workspace should still have an agent panel immediately after activation")
+        workspace.panel::<AgentPanel>(cx).expect(
+            "target workspace should still have an agent panel immediately after activation",
+        )
     });
-    let immediate_active_thread_id = panel_b_before_settle.read_with(cx, |panel, _| panel.active_thread_id());
-    let immediate_draft_ids = panel_b_before_settle.read_with(cx, |panel, cx| panel.draft_thread_ids(cx));
+    let immediate_active_thread_id =
+        panel_b_before_settle.read_with(cx, |panel, cx| panel.active_thread_id(cx));
+    let immediate_draft_ids =
+        panel_b_before_settle.read_with(cx, |panel, cx| panel.draft_thread_ids(cx));
 
     cx.run_until_parked();
     cx.run_until_parked();
@@ -6416,7 +6418,7 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
             .expect("target workspace should still have an agent panel")
     });
     assert_eq!(
-        panel_b.read_with(cx, |panel, _| panel.active_thread_id()),
+        panel_b.read_with(cx, |panel, cx| panel.active_thread_id(cx)),
         Some(thread_id),
         "expected target panel to activate the restored thread id"
     );
@@ -6428,9 +6430,7 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
     let entries = visible_entries_as_strings(&sidebar, cx);
     let target_rows: Vec<_> = entries
         .iter()
-        .filter(|entry| {
-            entry.contains("Restored In Inactive Workspace") || entry.contains("Draft")
-        })
+        .filter(|entry| entry.contains("Restored In Inactive Workspace") || entry.contains("Draft"))
         .cloned()
         .collect();
     assert_eq!(
@@ -6507,7 +6507,10 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
             .entry(thread_id)
             .cloned()
             .expect("archived metadata should still exist after archive");
-        assert!(metadata.archived, "thread should be archived before project removal");
+        assert!(
+            metadata.archived,
+            "thread should be archived before project removal"
+        );
         metadata
     });
 
@@ -6515,7 +6518,9 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
     let remove_task = multi_workspace.update_in(cx, |mw, window, cx| {
         mw.remove_project_group(&group_key_b, window, cx)
     });
-    remove_task.await.expect("remove project group task should complete");
+    remove_task
+        .await
+        .expect("remove project group task should complete");
     cx.run_until_parked();
     cx.run_until_parked();
 
@@ -6534,7 +6539,10 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
 
     let restored_workspace = multi_workspace.read_with(cx, |mw, cx| {
         mw.workspaces()
-            .find(|workspace| PathList::new(&workspace.read(cx).root_paths(cx)) == PathList::new(&[PathBuf::from("/project-b")]))
+            .find(|workspace| {
+                PathList::new(&workspace.read(cx).root_paths(cx))
+                    == PathList::new(&[PathBuf::from("/project-b")])
+            })
             .cloned()
             .expect("expected unarchive to recreate the removed project workspace")
     });
@@ -6551,7 +6559,7 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
             .expect("session should still map to restored thread id")
     });
     assert_eq!(
-        restored_panel.read_with(cx, |panel, _| panel.active_thread_id()),
+        restored_panel.read_with(cx, |panel, cx| panel.active_thread_id(cx)),
         Some(restored_thread_id),
         "expected unarchive after project removal to activate the restored real thread"
     );
@@ -6583,9 +6591,7 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
 }
 
 #[gpui::test]
-async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(
-    cx: &mut TestAppContext,
-) {
+async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(cx: &mut TestAppContext) {
     agent_ui::test_support::init_test(cx);
     cx.update(|cx| {
         ThreadStore::init_global(cx);
@@ -6654,8 +6660,7 @@ async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(
         "expected exactly one metadata row for the restored session, got: {session_entries:?}"
     );
     assert_eq!(
-        session_entries[0].thread_id,
-        original_thread_id,
+        session_entries[0].thread_id, original_thread_id,
         "expected unarchive to reuse the original thread id instead of creating a duplicate row"
     );
     assert!(
@@ -7252,8 +7257,7 @@ async fn test_unarchive_linked_worktree_thread_into_project_group_shows_only_res
         "expected exactly one metadata row for restored linked worktree session, got: {session_entries:?}"
     );
     assert_eq!(
-        session_entries[0].thread_id,
-        original_thread_id,
+        session_entries[0].thread_id, original_thread_id,
         "expected unarchive to reuse the original linked worktree thread id"
     );
     assert!(
@@ -8182,12 +8186,20 @@ async fn test_delete_last_draft_in_empty_group_shows_placeholder(cx: &mut TestAp
     let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
     let entries = visible_entries_as_strings(&sidebar, cx);
     let draft_count = entries.iter().filter(|e| e.contains("Draft")).count();
-    assert_eq!(draft_count, 1, "should start with 1 draft from reconciliation");
+    assert_eq!(
+        draft_count, 1,
+        "should start with 1 draft from reconciliation"
+    );
 
     // Find and delete the draft.
     let draft_thread_id = sidebar.read_with(cx, |_sidebar, cx| {
         let panel = workspace.read(cx).panel::<AgentPanel>(cx).unwrap();
-        panel.read(cx).draft_thread_ids(cx).into_iter().next().unwrap()
+        panel
+            .read(cx)
+            .draft_thread_ids(cx)
+            .into_iter()
+            .next()
+            .unwrap()
     });
     sidebar.update_in(cx, |sidebar, window, cx| {
         sidebar.remove_draft(draft_thread_id, &workspace, window, cx);
@@ -9321,7 +9333,7 @@ mod property_test {
         //    when the workspace just changed and the new panel has no
         //    content yet.
         let panel = active_workspace.read(cx).panel::<AgentPanel>(cx).unwrap();
-        let panel_has_content = panel.read(cx).active_thread_id().is_some()
+        let panel_has_content = panel.read(cx).active_thread_id(cx).is_some()
             || panel.read(cx).active_conversation_view().is_some();
 
         let Some(entry) = sidebar.active_entry.as_ref() else {
@@ -9348,7 +9360,7 @@ mod property_test {
         );
 
         // 3. The entry must match the agent panel's current state.
-        if panel.read(cx).active_thread_id().is_some() {
+        if panel.read(cx).active_thread_id(cx).is_some() {
             anyhow::ensure!(
                 matches!(entry, ActiveEntry { .. }),
                 "panel shows a tracked draft but active_entry is {:?}",
@@ -9357,7 +9369,7 @@ mod property_test {
         } else if let Some(thread_id) = panel
             .read(cx)
             .active_conversation_view()
-            .and_then(|cv| cv.read(cx).parent_id(cx))
+            .map(|cv| cv.read(cx).parent_id())
         {
             anyhow::ensure!(
                 matches!(entry, ActiveEntry { thread_id: tid, .. } if *tid == thread_id),


### PR DESCRIPTION
The ThreadID refactor revealed that the ThreadMetadataStore was operating at the wrong layer of the abstraction. Fixed it to be explicitly about Conversations

Self-Review Checklist:

- [x] Manually run this code
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A
