### PR TITLE
Fix up state management across the multiworkspace and sidebar

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -24,7 +24,7 @@ use zed_actions::agent::{
     ResolveConflictsWithAgent, ReviewBranchDiff,
 };
 
-use crate::thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore, WorktreePaths};
+use crate::thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore};
 use crate::{
     AddContextServer, AgentDiffPane, ConversationView, CopyThreadToClipboard, CycleStartThreadIn,
     Follow, InlineAssistant, LoadThreadFromClipboard, NewThread, NewWorktreeBranchTarget,

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -24,9 +24,7 @@ use zed_actions::agent::{
     ResolveConflictsWithAgent, ReviewBranchDiff,
 };
 
-use crate::thread_metadata_store::{
-    ThreadId, ThreadMetadata, ThreadMetadataStore, ThreadWorktreePaths,
-};
+use crate::thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore, WorktreePaths};
 use crate::{
     AddContextServer, AgentDiffPane, ConversationView, CopyThreadToClipboard, CycleStartThreadIn,
     Follow, InlineAssistant, LoadThreadFromClipboard, NewThread, NewWorktreeBranchTarget,
@@ -113,7 +111,7 @@ impl WorkspaceSidebarDelegate for AgentPanelSidebarDelegate {
     fn reconcile_group(
         &self,
         workspace: &mut Workspace,
-        group_key: &project::ProjectGroupKey,
+        group_key: &workspace::ProjectGroupKey,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> bool {
@@ -2178,7 +2176,7 @@ impl AgentPanel {
 
     fn update_thread_work_dirs(&self, cx: &mut Context<Self>) {
         let new_work_dirs = self.project.read(cx).default_path_list(cx);
-        let new_worktree_paths = ThreadWorktreePaths::from_project(self.project.read(cx), cx);
+        let new_worktree_paths = self.project.read(cx).worktree_paths(cx);
 
         if let Some(conversation_view) = self.active_conversation_view() {
             conversation_view.update(cx, |conversation_view, cx| {
@@ -2256,7 +2254,8 @@ impl AgentPanel {
         // panel's worktree paths (e.g. from a previously removed workspace).
         let path_list = {
             let project = self.project.read(cx);
-            project.project_group_key(cx).path_list().clone()
+            let worktree_paths = project.worktree_paths(cx);
+            worktree_paths.main_worktree_path_list().clone()
         };
         if let Some(store) = ThreadMetadataStore::try_global(cx) {
             let orphaned: Vec<ThreadId> = {
@@ -2936,8 +2935,8 @@ impl AgentPanel {
             .unwrap_or_else(ThreadId::new);
         let workspace = self.workspace.clone();
         let project = self.project.clone();
-        let worktree_paths = ThreadWorktreePaths::from_project(project.read(cx), cx);
-        let remote_connection = project.read(cx).project_group_key(cx).host();
+        let worktree_paths = project.read(cx).worktree_paths(cx);
+        let remote_connection = project.read(cx).remote_connection_options(cx);
         let metadata = ThreadMetadata {
             thread_id,
             session_id: resume_session_id.clone(),

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -23,7 +23,7 @@ use workspace::{ModalView, MultiWorkspace, Workspace};
 use crate::{
     Agent, AgentPanel,
     agent_connection_store::AgentConnectionStore,
-    thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore, ThreadWorktreePaths},
+    thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore, WorktreePaths},
 };
 
 pub struct AcpThreadImportOnboarding;
@@ -527,7 +527,7 @@ fn collect_importable_threads(
                 title: session.title,
                 updated_at: session.updated_at.unwrap_or_else(|| Utc::now()),
                 created_at: session.created_at,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&folder_paths),
+                worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
                 remote_connection: remote_connection.clone(),
                 archived: true,
             });

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 
 use acp_thread::AcpThreadEvent;
 use agent::{ThreadStore, ZED_AGENT_ID};
@@ -23,6 +20,7 @@ use fs::Fs;
 use futures::{FutureExt, future::Shared};
 use gpui::{AppContext as _, Entity, Global, Subscription, Task};
 use project::AgentId;
+pub use project::WorktreePaths;
 use remote::RemoteConnectionOptions;
 use ui::{App, Context, SharedString};
 use util::ResultExt as _;
@@ -100,7 +98,7 @@ fn migrate_thread_metadata(cx: &mut App) -> Task<anyhow::Result<()>> {
                         },
                         updated_at: entry.updated_at,
                         created_at: entry.created_at,
-                        worktree_paths: ThreadWorktreePaths::from_folder_paths(&entry.folder_paths),
+                        worktree_paths: WorktreePaths::from_folder_paths(&entry.folder_paths),
                         remote_connection: None,
                         archived: true,
                     })
@@ -259,147 +257,6 @@ fn migrate_thread_ids(cx: &mut App) {
 struct GlobalThreadMetadataStore(Entity<ThreadMetadataStore>);
 impl Global for GlobalThreadMetadataStore {}
 
-/// Paired worktree paths for a thread. Each folder path has a corresponding
-/// main worktree path at the same position. The two lists are always the
-/// same length and are modified together via `add_path` / `remove_main_path`.
-///
-/// For non-linked worktrees, the main path and folder path are identical.
-/// For linked worktrees, the main path is the original repo and the folder
-/// path is the linked worktree location.
-///
-/// Internally stores two `PathList`s with matching insertion order so that
-/// `ordered_paths()` on both yields positionally-paired results.
-#[derive(Default, Debug, Clone)]
-pub struct ThreadWorktreePaths {
-    folder_paths: PathList,
-    main_worktree_paths: PathList,
-}
-
-impl PartialEq for ThreadWorktreePaths {
-    fn eq(&self, other: &Self) -> bool {
-        self.folder_paths == other.folder_paths
-            && self.main_worktree_paths == other.main_worktree_paths
-    }
-}
-
-impl ThreadWorktreePaths {
-    /// Build from a project's current state. Each visible worktree is paired
-    /// with its main repo path (resolved via git), falling back to the
-    /// worktree's own path if no git repo is found.
-    pub fn from_project(project: &project::Project, cx: &App) -> Self {
-        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = project
-            .visible_worktrees(cx)
-            .map(|worktree| {
-                let snapshot = worktree.read(cx).snapshot();
-                let folder_path = snapshot.abs_path().to_path_buf();
-                let main_path = snapshot
-                    .root_repo_common_dir()
-                    .and_then(|dir| Some(dir.parent()?.to_path_buf()))
-                    .unwrap_or_else(|| folder_path.clone());
-                (main_path, folder_path)
-            })
-            .unzip();
-        Self {
-            folder_paths: PathList::new(&folders),
-            main_worktree_paths: PathList::new(&mains),
-        }
-    }
-
-    /// Build from two parallel `PathList`s that already share the same
-    /// insertion order. Used for deserialization from DB.
-    ///
-    /// Returns an error if the two lists have different lengths, which
-    /// indicates corrupted data from a prior migration bug.
-    pub fn from_path_lists(
-        main_worktree_paths: PathList,
-        folder_paths: PathList,
-    ) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            main_worktree_paths.paths().len() == folder_paths.paths().len(),
-            "main_worktree_paths has {} entries but folder_paths has {}",
-            main_worktree_paths.paths().len(),
-            folder_paths.paths().len(),
-        );
-        Ok(Self {
-            folder_paths,
-            main_worktree_paths,
-        })
-    }
-
-    /// Build for non-linked worktrees where main == folder for every path.
-    pub fn from_folder_paths(folder_paths: &PathList) -> Self {
-        Self {
-            folder_paths: folder_paths.clone(),
-            main_worktree_paths: folder_paths.clone(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.folder_paths.is_empty()
-    }
-
-    /// The folder paths (for workspace matching / `threads_by_paths` index).
-    pub fn folder_path_list(&self) -> &PathList {
-        &self.folder_paths
-    }
-
-    /// The main worktree paths (for group key / `threads_by_main_paths` index).
-    pub fn main_worktree_path_list(&self) -> &PathList {
-        &self.main_worktree_paths
-    }
-
-    /// Iterate the (main_worktree_path, folder_path) pairs in insertion order.
-    pub fn ordered_pairs(&self) -> impl Iterator<Item = (&PathBuf, &PathBuf)> {
-        self.main_worktree_paths
-            .ordered_paths()
-            .zip(self.folder_paths.ordered_paths())
-    }
-
-    /// Add a new path pair. If the exact (main, folder) pair already exists,
-    /// this is a no-op. Rebuilds both internal `PathList`s to maintain
-    /// consistent ordering.
-    pub fn add_path(&mut self, main_path: &Path, folder_path: &Path) {
-        let already_exists = self
-            .ordered_pairs()
-            .any(|(m, f)| m.as_path() == main_path && f.as_path() == folder_path);
-        if already_exists {
-            return;
-        }
-        let (mut mains, mut folders): (Vec<PathBuf>, Vec<PathBuf>) = self
-            .ordered_pairs()
-            .map(|(m, f)| (m.clone(), f.clone()))
-            .unzip();
-        mains.push(main_path.to_path_buf());
-        folders.push(folder_path.to_path_buf());
-        self.main_worktree_paths = PathList::new(&mains);
-        self.folder_paths = PathList::new(&folders);
-    }
-
-    /// Remove all pairs whose main worktree path matches the given path.
-    /// This removes the corresponding entries from both lists.
-    pub fn remove_main_path(&mut self, main_path: &Path) {
-        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = self
-            .ordered_pairs()
-            .filter(|(m, _)| m.as_path() != main_path)
-            .map(|(m, f)| (m.clone(), f.clone()))
-            .unzip();
-        self.main_worktree_paths = PathList::new(&mains);
-        self.folder_paths = PathList::new(&folders);
-    }
-
-    /// Remove all pairs whose folder path matches the given path.
-    /// This removes the corresponding entries from both lists.
-    pub fn remove_folder_path(&mut self, folder_path: &Path) {
-        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = self
-            .ordered_pairs()
-            .filter(|(_, f)| f.as_path() != folder_path)
-            .map(|(m, f)| (m.clone(), f.clone()))
-            .unzip();
-        self.main_worktree_paths = PathList::new(&mains);
-        self.folder_paths = PathList::new(&folders);
-    }
-}
-
 /// Lightweight metadata for any thread (native or ACP), enough to populate
 /// the sidebar list and route to the correct load path when clicked.
 #[derive(Debug, Clone, PartialEq)]
@@ -410,7 +267,7 @@ pub struct ThreadMetadata {
     pub title: Option<SharedString>,
     pub updated_at: DateTime<Utc>,
     pub created_at: Option<DateTime<Utc>>,
-    pub worktree_paths: ThreadWorktreePaths,
+    pub worktree_paths: WorktreePaths,
     pub remote_connection: Option<RemoteConnectionOptions>,
     pub archived: bool,
 }
@@ -738,11 +595,11 @@ impl ThreadMetadataStore {
     ) {
         if let Some(thread) = self.threads.get(&thread_id) {
             self.save_internal(ThreadMetadata {
-                worktree_paths: ThreadWorktreePaths::from_path_lists(
+                worktree_paths: WorktreePaths::from_path_lists(
                     thread.main_worktree_paths().clone(),
                     work_dirs.clone(),
                 )
-                .unwrap_or_else(|_| ThreadWorktreePaths::from_folder_paths(&work_dirs)),
+                .unwrap_or_else(|_| WorktreePaths::from_folder_paths(&work_dirs)),
                 ..thread.clone()
             });
             cx.notify();
@@ -752,7 +609,7 @@ impl ThreadMetadataStore {
     pub fn update_worktree_paths(
         &mut self,
         thread_ids: &[ThreadId],
-        worktree_paths: ThreadWorktreePaths,
+        worktree_paths: WorktreePaths,
         cx: &mut Context<Self>,
     ) {
         let mut changed = false;
@@ -831,11 +688,11 @@ impl ThreadMetadataStore {
             }
             let new_folder_paths = PathList::new(&paths);
             self.save_internal(ThreadMetadata {
-                worktree_paths: ThreadWorktreePaths::from_path_lists(
+                worktree_paths: WorktreePaths::from_path_lists(
                     thread.main_worktree_paths().clone(),
                     new_folder_paths.clone(),
                 )
-                .unwrap_or_else(|_| ThreadWorktreePaths::from_folder_paths(&new_folder_paths)),
+                .unwrap_or_else(|_| WorktreePaths::from_folder_paths(&new_folder_paths)),
                 ..thread
             });
             cx.notify();
@@ -859,11 +716,11 @@ impl ThreadMetadataStore {
             }
             let new_folder_paths = PathList::new(&paths);
             self.save_internal(ThreadMetadata {
-                worktree_paths: ThreadWorktreePaths::from_path_lists(
+                worktree_paths: WorktreePaths::from_path_lists(
                     thread.main_worktree_paths().clone(),
                     new_folder_paths.clone(),
                 )
-                .unwrap_or_else(|_| ThreadWorktreePaths::from_folder_paths(&new_folder_paths)),
+                .unwrap_or_else(|_| WorktreePaths::from_folder_paths(&new_folder_paths)),
                 ..thread
             });
             cx.notify();
@@ -875,7 +732,7 @@ impl ThreadMetadataStore {
     pub fn change_worktree_paths(
         &mut self,
         current_folder_paths: &PathList,
-        mutate: impl Fn(&mut ThreadWorktreePaths),
+        mutate: impl Fn(&mut WorktreePaths),
         cx: &mut Context<Self>,
     ) {
         let thread_ids: Vec<_> = self
@@ -1158,10 +1015,9 @@ impl ThreadMetadataStore {
                 let agent_id = thread_ref.connection().agent_id();
 
                 let project = thread_ref.project().read(cx);
-                let worktree_paths = ThreadWorktreePaths::from_project(project, cx);
+                let worktree_paths = project.worktree_paths(cx);
 
-                let project_group_key = project.project_group_key(cx);
-                let remote_connection = project_group_key.host();
+                let remote_connection = project.remote_connection_options(cx);
 
                 // Threads without a folder path (e.g. started in an empty
                 // window) are archived by default so they don't get lost,
@@ -1542,9 +1398,8 @@ impl Column for ThreadMetadata {
             .transpose()
             .context("deserialize thread metadata remote connection")?;
 
-        let worktree_paths =
-            ThreadWorktreePaths::from_path_lists(main_worktree_paths, folder_paths)
-                .unwrap_or_else(|_| ThreadWorktreePaths::default());
+        let worktree_paths = WorktreePaths::from_path_lists(main_worktree_paths, folder_paths)
+            .unwrap_or_else(|_| WorktreePaths::default());
 
         let thread_id = ThreadId(thread_id_uuid);
 
@@ -1648,7 +1503,7 @@ mod tests {
             },
             updated_at,
             created_at: Some(updated_at),
-            worktree_paths: ThreadWorktreePaths::from_folder_paths(&folder_paths),
+            worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
             remote_connection: None,
         }
     }
@@ -1808,7 +1663,7 @@ mod tests {
             title: Some("First Thread".into()),
             updated_at: updated_time,
             created_at: Some(updated_time),
-            worktree_paths: ThreadWorktreePaths::from_folder_paths(&second_paths),
+            worktree_paths: WorktreePaths::from_folder_paths(&second_paths),
             remote_connection: None,
             archived: false,
         };
@@ -1891,7 +1746,7 @@ mod tests {
             title: Some("Existing Metadata".into()),
             updated_at: now - chrono::Duration::seconds(10),
             created_at: Some(now - chrono::Duration::seconds(10)),
-            worktree_paths: ThreadWorktreePaths::from_folder_paths(&project_a_paths),
+            worktree_paths: WorktreePaths::from_folder_paths(&project_a_paths),
             remote_connection: None,
             archived: false,
         };
@@ -2011,7 +1866,7 @@ mod tests {
             title: Some("Existing Metadata".into()),
             updated_at: existing_updated_at,
             created_at: Some(existing_updated_at),
-            worktree_paths: ThreadWorktreePaths::from_folder_paths(&project_paths),
+            worktree_paths: WorktreePaths::from_folder_paths(&project_paths),
             remote_connection: None,
             archived: false,
         };
@@ -3373,13 +3228,12 @@ mod tests {
     // ── ThreadWorktreePaths tests ──────────────────────────────────────
 
     /// Helper to build a `ThreadWorktreePaths` from (main, folder) pairs.
-    fn make_worktree_paths(pairs: &[(&str, &str)]) -> ThreadWorktreePaths {
+    fn make_worktree_paths(pairs: &[(&str, &str)]) -> WorktreePaths {
         let (mains, folders): (Vec<&Path>, Vec<&Path>) = pairs
             .iter()
             .map(|(m, f)| (Path::new(*m), Path::new(*f)))
             .unzip();
-        ThreadWorktreePaths::from_path_lists(PathList::new(&mains), PathList::new(&folders))
-            .unwrap()
+        WorktreePaths::from_path_lists(PathList::new(&mains), PathList::new(&folders)).unwrap()
     }
 
     #[test]
@@ -3447,7 +3301,7 @@ mod tests {
         ]);
         let main = PathList::new(&[Path::new("/projects/zed"), Path::new("/projects/cloud")]);
 
-        let paths = ThreadWorktreePaths::from_path_lists(main, folder).unwrap();
+        let paths = WorktreePaths::from_path_lists(main, folder).unwrap();
 
         let pairs: Vec<_> = paths
             .ordered_pairs()
@@ -3498,7 +3352,7 @@ mod tests {
         ]);
         let main = PathList::new(&[Path::new("/projects/zed")]);
 
-        let result = ThreadWorktreePaths::from_path_lists(main, folder);
+        let result = WorktreePaths::from_path_lists(main, folder);
         assert!(result.is_err());
     }
 }

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -743,11 +743,41 @@ impl ThreadMetadataStore {
             .copied()
             .collect();
 
+        self.mutate_thread_paths(&thread_ids, mutate, cx);
+    }
+
+    /// Like `change_worktree_paths`, but looks up threads by their
+    /// `main_worktree_paths` instead of `folder_paths`. Used when
+    /// migrating threads for project group key changes where the
+    /// lookup key is the group key's main paths.
+    pub fn change_worktree_paths_by_main(
+        &mut self,
+        current_main_paths: &PathList,
+        mutate: impl Fn(&mut WorktreePaths),
+        cx: &mut Context<Self>,
+    ) {
+        let thread_ids: Vec<_> = self
+            .threads_by_main_paths
+            .get(current_main_paths)
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect();
+
+        self.mutate_thread_paths(&thread_ids, mutate, cx);
+    }
+
+    fn mutate_thread_paths(
+        &mut self,
+        thread_ids: &[ThreadId],
+        mutate: impl Fn(&mut WorktreePaths),
+        cx: &mut Context<Self>,
+    ) {
         if thread_ids.is_empty() {
             return;
         }
 
-        for thread_id in &thread_ids {
+        for thread_id in thread_ids {
             if let Some(thread) = self.threads.get_mut(thread_id) {
                 if let Some(ids) = self
                     .threads_by_main_paths

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -950,7 +950,7 @@ impl ProjectPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) {
         self.thread.worktree_paths =
-            super::thread_metadata_store::ThreadWorktreePaths::from_folder_paths(&paths);
+            super::thread_metadata_store::WorktreePaths::from_folder_paths(&paths);
         ThreadMetadataStore::global(cx).update(cx, |store, cx| {
             store.update_working_directories(self.thread.thread_id, paths, cx);
         });

--- a/crates/edit_prediction/src/license_detection.rs
+++ b/crates/edit_prediction/src/license_detection.rs
@@ -319,7 +319,7 @@ impl LicenseDetectionWatcher {
                 }
                 worktree::Event::DeletedEntry(_)
                 | worktree::Event::UpdatedGitRepositories(_)
-                | worktree::Event::UpdatedRootRepoCommonDir
+                | worktree::Event::UpdatedRootRepoCommonDir { .. }
                 | worktree::Event::Deleted => {}
             });
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4416,7 +4416,7 @@ impl LspStore {
                     worktree::Event::UpdatedGitRepositories(_)
                     | worktree::Event::DeletedEntry(_)
                     | worktree::Event::Deleted
-                    | worktree::Event::UpdatedRootRepoCommonDir => {}
+                    | worktree::Event::UpdatedRootRepoCommonDir { .. } => {}
                 })
                 .detach()
             }

--- a/crates/project/src/manifest_tree.rs
+++ b/crates/project/src/manifest_tree.rs
@@ -59,7 +59,7 @@ impl WorktreeRoots {
                         let path = TriePath::from(entry.path.as_ref());
                         this.roots.remove(&path);
                     }
-                    WorktreeEvent::Deleted | WorktreeEvent::UpdatedRootRepoCommonDir => {}
+                    WorktreeEvent::Deleted | WorktreeEvent::UpdatedRootRepoCommonDir { .. } => {}
                 }
             }),
         })

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -51,6 +51,7 @@ pub use git_store::{
 };
 pub use manifest_tree::ManifestTree;
 pub use project_search::{Search, SearchResults};
+pub use worktree_store::WorktreePaths;
 
 use anyhow::{Context as _, Result, anyhow};
 use buffer_store::{BufferStore, BufferStoreEvent};
@@ -246,7 +247,7 @@ pub struct Project {
     toolchain_store: Option<Entity<ToolchainStore>>,
     agent_location: Option<AgentLocation>,
     downloading_files: Arc<Mutex<HashMap<(WorktreeId, String), DownloadingFile>>>,
-    group_key: ProjectGroupKey,
+    last_worktree_paths: WorktreePaths,
 }
 
 struct DownloadingFile {
@@ -362,8 +363,8 @@ pub enum Event {
     WorktreeRemoved(WorktreeId),
     WorktreeUpdatedEntries(WorktreeId, UpdatedEntriesSet),
     WorktreeUpdatedRootRepoCommonDir(WorktreeId),
-    ProjectGroupKeyChanged {
-        old_key: ProjectGroupKey,
+    WorktreePathsChanged {
+        old_worktree_paths: WorktreePaths,
     },
     DiskBasedDiagnosticsStarted {
         language_server_id: LanguageServerId,
@@ -1343,7 +1344,7 @@ impl Project {
 
                 agent_location: None,
                 downloading_files: Default::default(),
-                group_key: ProjectGroupKey::default(),
+                last_worktree_paths: WorktreePaths::default(),
             }
         })
     }
@@ -1581,7 +1582,7 @@ impl Project {
                 toolchain_store: Some(toolchain_store),
                 agent_location: None,
                 downloading_files: Default::default(),
-                group_key: ProjectGroupKey::default(),
+                last_worktree_paths: WorktreePaths::default(),
             };
 
             // remote server -> local machine handlers
@@ -1863,7 +1864,7 @@ impl Project {
                 toolchain_store: None,
                 agent_location: None,
                 downloading_files: Default::default(),
-                group_key: ProjectGroupKey::default(),
+                last_worktree_paths: WorktreePaths::default(),
             };
             project.set_role(role, cx);
             for worktree in worktrees {
@@ -2392,33 +2393,12 @@ impl Project {
             .find(|tree| tree.read(cx).root_name() == root_name)
     }
 
-    pub fn project_group_key(&self, cx: &App) -> ProjectGroupKey {
-        let roots = self
-            .visible_worktrees(cx)
-            .filter(|worktree| {
-                let worktree = worktree.read(cx);
-                // Remote worktrees that haven't received their first update
-                // don't have enough data to contribute to the group key yet.
-                !worktree.is_remote() || worktree.root_entry().is_some()
-            })
-            .map(|worktree| {
-                let snapshot = worktree.read(cx).snapshot();
-                snapshot
-                    .root_repo_common_dir()
-                    .and_then(|dir| Some(dir.parent()?.to_path_buf()))
-                    .unwrap_or(snapshot.abs_path().to_path_buf())
-            })
-            .collect::<Vec<_>>();
-        let host = self.remote_connection_options(cx);
-        let path_list = PathList::new(&roots);
-        ProjectGroupKey::new(host, path_list)
-    }
-
     fn emit_group_key_changed_if_needed(&mut self, cx: &mut Context<Self>) {
-        let new_key = self.project_group_key(cx);
-        if new_key != self.group_key {
-            let old_key = std::mem::replace(&mut self.group_key, new_key);
-            cx.emit(Event::ProjectGroupKeyChanged { old_key });
+        let new_worktree_paths = self.worktree_paths(cx);
+        if new_worktree_paths != self.last_worktree_paths {
+            let old_worktree_paths =
+                std::mem::replace(&mut self.last_worktree_paths, new_worktree_paths);
+            cx.emit(Event::WorktreePathsChanged { old_worktree_paths });
         }
     }
 
@@ -6167,6 +6147,14 @@ impl Project {
                 worktree.read(cx).entry_for_path(rel_path).is_some()
             })
     }
+
+    pub fn worktree_paths(&self, cx: &App) -> WorktreePaths {
+        self.worktree_store.read(cx).paths(cx)
+    }
+
+    pub fn project_group_key(&self, cx: &App) -> ProjectGroupKey {
+        ProjectGroupKey::from_project(self, cx)
+    }
 }
 
 /// Identifies a project group by a set of paths the workspaces in this group
@@ -6187,6 +6175,25 @@ impl ProjectGroupKey {
     /// The path list should point to the git main worktree paths for a project.
     pub fn new(host: Option<RemoteConnectionOptions>, paths: PathList) -> Self {
         Self { paths, host }
+    }
+
+    pub fn from_project(project: &Project, cx: &App) -> Self {
+        let paths = project.worktree_paths(cx);
+        let host = project.remote_connection_options(cx);
+        Self {
+            paths: paths.main_worktree_path_list().clone(),
+            host,
+        }
+    }
+
+    pub fn from_worktree_paths(
+        paths: &WorktreePaths,
+        host: Option<RemoteConnectionOptions>,
+    ) -> Self {
+        Self {
+            paths: paths.main_worktree_path_list().clone(),
+            host,
+        }
     }
 
     pub fn path_list(&self) -> &PathList {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -246,6 +246,7 @@ pub struct Project {
     toolchain_store: Option<Entity<ToolchainStore>>,
     agent_location: Option<AgentLocation>,
     downloading_files: Arc<Mutex<HashMap<(WorktreeId, String), DownloadingFile>>>,
+    group_key: ProjectGroupKey,
 }
 
 struct DownloadingFile {
@@ -361,6 +362,9 @@ pub enum Event {
     WorktreeRemoved(WorktreeId),
     WorktreeUpdatedEntries(WorktreeId, UpdatedEntriesSet),
     WorktreeUpdatedRootRepoCommonDir(WorktreeId),
+    ProjectGroupKeyChanged {
+        old_key: ProjectGroupKey,
+    },
     DiskBasedDiagnosticsStarted {
         language_server_id: LanguageServerId,
     },
@@ -1339,6 +1343,7 @@ impl Project {
 
                 agent_location: None,
                 downloading_files: Default::default(),
+                group_key: ProjectGroupKey::default(),
             }
         })
     }
@@ -1576,6 +1581,7 @@ impl Project {
                 toolchain_store: Some(toolchain_store),
                 agent_location: None,
                 downloading_files: Default::default(),
+                group_key: ProjectGroupKey::default(),
             };
 
             // remote server -> local machine handlers
@@ -1857,6 +1863,7 @@ impl Project {
                 toolchain_store: None,
                 agent_location: None,
                 downloading_files: Default::default(),
+                group_key: ProjectGroupKey::default(),
             };
             project.set_role(role, cx);
             for worktree in worktrees {
@@ -2405,6 +2412,14 @@ impl Project {
         let host = self.remote_connection_options(cx);
         let path_list = PathList::new(&roots);
         ProjectGroupKey::new(host, path_list)
+    }
+
+    fn emit_group_key_changed_if_needed(&mut self, cx: &mut Context<Self>) {
+        let new_key = self.project_group_key(cx);
+        if new_key != self.group_key {
+            let old_key = std::mem::replace(&mut self.group_key, new_key);
+            cx.emit(Event::ProjectGroupKeyChanged { old_key });
+        }
     }
 
     #[inline]
@@ -3723,9 +3738,11 @@ impl Project {
             WorktreeStoreEvent::WorktreeAdded(worktree) => {
                 self.on_worktree_added(worktree, cx);
                 cx.emit(Event::WorktreeAdded(worktree.read(cx).id()));
+                self.emit_group_key_changed_if_needed(cx);
             }
             WorktreeStoreEvent::WorktreeRemoved(_, id) => {
                 cx.emit(Event::WorktreeRemoved(*id));
+                self.emit_group_key_changed_if_needed(cx);
             }
             WorktreeStoreEvent::WorktreeReleased(_, id) => {
                 self.on_worktree_released(*id, cx);
@@ -3745,6 +3762,7 @@ impl Project {
             WorktreeStoreEvent::WorktreeUpdatedGitRepositories(_, _) => {}
             WorktreeStoreEvent::WorktreeUpdatedRootRepoCommonDir(worktree_id) => {
                 cx.emit(Event::WorktreeUpdatedRootRepoCommonDir(*worktree_id));
+                self.emit_group_key_changed_if_needed(cx);
             }
         }
     }
@@ -6156,7 +6174,7 @@ impl Project {
 ///
 /// Paths are mapped to their main worktree path first so we can group
 /// workspaces by main repos.
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, Default)]
 pub struct ProjectGroupKey {
     /// The paths of the main worktrees for this project group.
     paths: PathList,

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -814,7 +814,7 @@ impl WorktreeStore {
                     // The worktree root itself has been deleted (for single-file worktrees)
                     // The worktree will be removed via the observe_release callback
                 }
-                worktree::Event::UpdatedRootRepoCommonDir => {
+                worktree::Event::UpdatedRootRepoCommonDir { .. } => {
                     cx.emit(WorktreeStoreEvent::WorktreeUpdatedRootRepoCommonDir(
                         worktree_id,
                     ));

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -24,6 +24,7 @@ use rpc::{
 use text::ReplicaId;
 use util::{
     ResultExt,
+    path_list::PathList,
     paths::{PathStyle, RemotePathBuf, SanitizedPath},
     rel_path::RelPath,
 };
@@ -33,6 +34,121 @@ use worktree::{
 };
 
 use crate::{ProjectPath, trusted_worktrees::TrustedWorktrees};
+
+/// The current paths for a project's worktrees. Each folder path has a corresponding
+/// main worktree path at the same position. The two lists are always the
+/// same length and are modified together via `add_path` / `remove_main_path`.
+///
+/// For non-linked worktrees, the main path and folder path are identical.
+/// For linked worktrees, the main path is the original repo and the folder
+/// path is the linked worktree location.
+#[derive(Default, Debug, Clone)]
+pub struct WorktreePaths {
+    paths: PathList,
+    main_paths: PathList,
+}
+
+impl PartialEq for WorktreePaths {
+    fn eq(&self, other: &Self) -> bool {
+        self.paths == other.paths && self.main_paths == other.main_paths
+    }
+}
+
+impl WorktreePaths {
+    /// Build from two parallel `PathList`s that already share the same
+    /// insertion order. Used for deserialization from DB.
+    ///
+    /// Returns an error if the two lists have different lengths, which
+    /// indicates corrupted data from a prior migration bug.
+    pub fn from_path_lists(
+        main_worktree_paths: PathList,
+        folder_paths: PathList,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            main_worktree_paths.paths().len() == folder_paths.paths().len(),
+            "main_worktree_paths has {} entries but folder_paths has {}",
+            main_worktree_paths.paths().len(),
+            folder_paths.paths().len(),
+        );
+        Ok(Self {
+            paths: folder_paths,
+            main_paths: main_worktree_paths,
+        })
+    }
+
+    /// Build for non-linked worktrees where main == folder for every path.
+    pub fn from_folder_paths(folder_paths: &PathList) -> Self {
+        Self {
+            paths: folder_paths.clone(),
+            main_paths: folder_paths.clone(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    /// The folder paths (for workspace matching / `threads_by_paths` index).
+    pub fn folder_path_list(&self) -> &PathList {
+        &self.paths
+    }
+
+    /// The main worktree paths (for group key / `threads_by_main_paths` index).
+    pub fn main_worktree_path_list(&self) -> &PathList {
+        &self.main_paths
+    }
+
+    /// Iterate the (main_worktree_path, folder_path) pairs in insertion order.
+    pub fn ordered_pairs(&self) -> impl Iterator<Item = (&PathBuf, &PathBuf)> {
+        self.main_paths
+            .ordered_paths()
+            .zip(self.paths.ordered_paths())
+    }
+
+    /// Add a new path pair. If the exact (main, folder) pair already exists,
+    /// this is a no-op. Rebuilds both internal `PathList`s to maintain
+    /// consistent ordering.
+    pub fn add_path(&mut self, main_path: &Path, folder_path: &Path) {
+        let already_exists = self
+            .ordered_pairs()
+            .any(|(m, f)| m.as_path() == main_path && f.as_path() == folder_path);
+        if already_exists {
+            return;
+        }
+        let (mut mains, mut folders): (Vec<PathBuf>, Vec<PathBuf>) = self
+            .ordered_pairs()
+            .map(|(m, f)| (m.clone(), f.clone()))
+            .unzip();
+        mains.push(main_path.to_path_buf());
+        folders.push(folder_path.to_path_buf());
+        self.main_paths = PathList::new(&mains);
+        self.paths = PathList::new(&folders);
+    }
+
+    /// Remove all pairs whose main worktree path matches the given path.
+    /// This removes the corresponding entries from both lists.
+    pub fn remove_main_path(&mut self, main_path: &Path) {
+        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = self
+            .ordered_pairs()
+            .filter(|(m, _)| m.as_path() != main_path)
+            .map(|(m, f)| (m.clone(), f.clone()))
+            .unzip();
+        self.main_paths = PathList::new(&mains);
+        self.paths = PathList::new(&folders);
+    }
+
+    /// Remove all pairs whose folder path matches the given path.
+    /// This removes the corresponding entries from both lists.
+    pub fn remove_folder_path(&mut self, folder_path: &Path) {
+        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = self
+            .ordered_pairs()
+            .filter(|(_, f)| f.as_path() != folder_path)
+            .map(|(m, f)| (m.clone(), f.clone()))
+            .unzip();
+        self.main_paths = PathList::new(&mains);
+        self.paths = PathList::new(&folders);
+    }
+}
 
 enum WorktreeStoreState {
     Local {
@@ -1261,6 +1377,32 @@ impl WorktreeStore {
         match &self.state {
             WorktreeStoreState::Local { fs } => Some(fs.clone()),
             WorktreeStoreState::Remote { .. } => None,
+        }
+    }
+
+    pub fn paths(&self, cx: &App) -> WorktreePaths {
+        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = self
+            .visible_worktrees(cx)
+            .filter(|worktree| {
+                let worktree = worktree.read(cx);
+                // Remote worktrees that haven't received their first update
+                // don't have enough data to contribute yet.
+                !worktree.is_remote() || worktree.root_entry().is_some()
+            })
+            .map(|worktree| {
+                let snapshot = worktree.read(cx).snapshot();
+                let folder_path = snapshot.abs_path().to_path_buf();
+                let main_path = snapshot
+                    .root_repo_common_dir()
+                    .and_then(|dir| Some(dir.parent()?.to_path_buf()))
+                    .unwrap_or_else(|| folder_path.clone());
+                (main_path, folder_path)
+            })
+            .unzip();
+
+        WorktreePaths {
+            paths: PathList::new(&folders),
+            main_paths: PathList::new(&mains),
         }
     }
 }

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -32,11 +32,12 @@ use picker::{
     Picker, PickerDelegate,
     highlighted_match_with_paths::{HighlightedMatch, HighlightedMatchWithPaths},
 };
-use project::{ProjectGroupKey, Worktree, git_store::Repository};
+use project::{Worktree, git_store::Repository};
 pub use remote_connections::RemoteSettings;
 pub use remote_servers::RemoteServerProjects;
 use settings::{Settings, WorktreeId};
 use ui_input::ErasedEditor;
+use workspace::ProjectGroupKey;
 
 use dev_container::{DevContainerContext, find_devcontainer_configs};
 use ui::{

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -10,15 +10,14 @@ use picker::{
     Picker, PickerDelegate,
     highlighted_match_with_paths::{HighlightedMatch, HighlightedMatchWithPaths},
 };
-use project::ProjectGroupKey;
 use remote::RemoteConnectionOptions;
 use settings::Settings;
 use ui::{KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*};
 use ui_input::ErasedEditor;
 use util::{ResultExt, paths::PathExt};
 use workspace::{
-    MultiWorkspace, OpenMode, OpenOptions, PathList, SerializedWorkspaceLocation, Workspace,
-    WorkspaceDb, WorkspaceId, notifications::DetachAndPromptErr,
+    MultiWorkspace, OpenMode, OpenOptions, PathList, ProjectGroupKey, SerializedWorkspaceLocation,
+    Workspace, WorkspaceDb, WorkspaceId, notifications::DetachAndPromptErr,
 };
 
 use zed_actions::OpenRemote;

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -16,7 +16,7 @@ use agent_ui::{
 use chrono::{DateTime, Utc};
 use editor::Editor;
 use gpui::{
-    Action as _, AnyElement, App, Context, DismissEvent, Entity, EntityId, FocusHandle, Focusable,
+    Action as _, AnyElement, App, Context, DismissEvent, Entity, FocusHandle, Focusable,
     KeyContext, ListState, Pixels, Render, SharedString, Task, WeakEntity, Window, WindowHandle,
     linear_color_stop, linear_gradient, list, prelude::*, px,
 };
@@ -485,6 +485,11 @@ impl Sidebar {
                     this.update_entries(cx);
                     this.reconcile_groups(window, cx);
                 }
+                MultiWorkspaceEvent::ProjectGroupKeyUpdated { old_key, new_key } => {
+                    this.move_threads_for_key_change(old_key, new_key, cx);
+                    this.update_entries(cx);
+                    this.reconcile_groups(window, cx);
+                }
             },
         )
         .detach();
@@ -672,6 +677,49 @@ impl Sidebar {
             self.subscribe_to_agent_panel(&agent_panel, window, cx);
             self.observe_draft_editors(cx);
         }
+    }
+
+    fn move_threads_for_key_change(
+        &mut self,
+        old_key: &ProjectGroupKey,
+        new_key: &ProjectGroupKey,
+        cx: &mut Context<Self>,
+    ) {
+        let old_main_paths = old_key.path_list();
+        let new_main_paths = new_key.path_list();
+
+        let added_paths: Vec<PathBuf> = new_main_paths
+            .paths()
+            .iter()
+            .filter(|p| !old_main_paths.paths().contains(p))
+            .cloned()
+            .collect();
+
+        let removed_paths: Vec<PathBuf> = old_main_paths
+            .paths()
+            .iter()
+            .filter(|p| !new_main_paths.paths().contains(p))
+            .cloned()
+            .collect();
+
+        if added_paths.is_empty() && removed_paths.is_empty() {
+            return;
+        }
+
+        ThreadMetadataStore::global(cx).update(cx, |store, store_cx| {
+            store.change_worktree_paths_by_main(
+                old_main_paths,
+                |paths| {
+                    for path in &added_paths {
+                        paths.add_path(path, path);
+                    }
+                    for path in &removed_paths {
+                        paths.remove_main_path(path);
+                    }
+                },
+                store_cx,
+            );
+        });
     }
 
     fn move_thread_paths(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -4,7 +4,7 @@ use acp_thread::ThreadStatus;
 use action_log::DiffStats;
 use agent_client_protocol::{self as acp};
 use agent_settings::AgentSettings;
-use agent_ui::thread_metadata_store::{ThreadMetadata, ThreadMetadataStore, ThreadWorktreePaths};
+use agent_ui::thread_metadata_store::{ThreadMetadata, ThreadMetadataStore, WorktreePaths};
 use agent_ui::thread_worktree_archive;
 use agent_ui::threads_archive_view::{
     ThreadsArchiveView, ThreadsArchiveViewEvent, format_history_entry_timestamp,
@@ -23,9 +23,7 @@ use gpui::{
 use menu::{
     Cancel, Confirm, SelectChild, SelectFirst, SelectLast, SelectNext, SelectParent, SelectPrevious,
 };
-use project::{
-    AgentId, AgentRegistryStore, Event as ProjectEvent, ProjectGroupKey, linked_worktree_short_name,
-};
+use project::{AgentId, AgentRegistryStore, Event as ProjectEvent, linked_worktree_short_name};
 use recent_projects::sidebar_recent_projects::SidebarRecentProjects;
 use remote::RemoteConnectionOptions;
 use ui::utils::platform_title_bar_height;
@@ -46,9 +44,9 @@ use util::ResultExt as _;
 use util::path_list::PathList;
 use workspace::{
     AddFolderToProject, CloseWindow, FocusWorkspaceSidebar, MultiWorkspace, MultiWorkspaceEvent,
-    NextProject, NextThread, Open, PreviousProject, PreviousThread, ProjectGroup, ShowFewerThreads,
-    ShowMoreThreads, Sidebar as WorkspaceSidebar, SidebarSide, Toast, ToggleWorkspaceSidebar,
-    Workspace, notifications::NotificationId, sidebar_side_context_menu,
+    NextProject, NextThread, Open, PreviousProject, PreviousThread, ProjectGroup, ProjectGroupKey,
+    ShowFewerThreads, ShowMoreThreads, Sidebar as WorkspaceSidebar, SidebarSide, Toast,
+    ToggleWorkspaceSidebar, Workspace, notifications::NotificationId, sidebar_side_context_menu,
 };
 
 use zed_actions::OpenRecent;
@@ -345,7 +343,7 @@ fn workspace_path_list(workspace: &Entity<Workspace>, cx: &App) -> PathList {
 /// wouldn't identify which main project it belongs to, the main project
 /// name is prefixed for disambiguation (e.g. `project:feature`).
 ///
-fn worktree_info_from_thread_paths(worktree_paths: &ThreadWorktreePaths) -> Vec<WorktreeInfo> {
+fn worktree_info_from_thread_paths(worktree_paths: &WorktreePaths) -> Vec<WorktreeInfo> {
     let mut infos: Vec<WorktreeInfo> = Vec::new();
     let mut linked_short_names: Vec<(SharedString, SharedString)> = Vec::new();
     let mut unique_main_count = HashSet::new();
@@ -449,7 +447,6 @@ pub struct Sidebar {
     _subscriptions: Vec<gpui::Subscription>,
     _draft_observations: Vec<gpui::Subscription>,
     reconciling: bool,
-    project_worktree_paths: HashMap<EntityId, ThreadWorktreePaths>,
 }
 
 impl Sidebar {
@@ -543,7 +540,6 @@ impl Sidebar {
             _subscriptions: Vec::new(),
             _draft_observations: Vec::new(),
             reconciling: false,
-            project_worktree_paths: HashMap::new(),
         }
     }
 
@@ -614,34 +610,19 @@ impl Sidebar {
     ) {
         let project = workspace.read(cx).project().clone();
 
-        let initial_paths = ThreadWorktreePaths::from_project(project.read(cx), cx);
-        self.project_worktree_paths
-            .insert(project.entity_id(), initial_paths);
-
-        let project_entity_id = project.entity_id();
-        cx.observe_release(&project, move |this, _project, _cx| {
-            this.project_worktree_paths.remove(&project_entity_id);
-        })
-        .detach();
-
         cx.subscribe_in(
             &project,
             window,
             |this, project, event, window, cx| match event {
-                ProjectEvent::WorktreeAdded(_) => {
-                    this.migrate_worktree_paths_on_add(project, cx);
+                ProjectEvent::WorktreeAdded(_)
+                | ProjectEvent::WorktreeRemoved(_)
+                | ProjectEvent::WorktreeOrderChanged => {
                     this.observe_draft_editors(cx);
                     this.update_entries(cx);
                     this.reconcile_groups(window, cx);
                 }
-                ProjectEvent::WorktreeRemoved(_) => {
-                    this.migrate_worktree_paths_on_remove(project, cx);
-                    this.observe_draft_editors(cx);
-                    this.update_entries(cx);
-                    this.reconcile_groups(window, cx);
-                }
-                ProjectEvent::WorktreeOrderChanged
-                | ProjectEvent::ProjectGroupKeyChanged { .. } => {
+                ProjectEvent::WorktreePathsChanged { old_worktree_paths } => {
+                    this.move_thread_paths(project, old_worktree_paths, cx);
                     this.observe_draft_editors(cx);
                     this.update_entries(cx);
                     this.reconcile_groups(window, cx);
@@ -693,81 +674,51 @@ impl Sidebar {
         }
     }
 
-    fn migrate_worktree_paths_on_add(
+    fn move_thread_paths(
         &mut self,
         project: &Entity<project::Project>,
+        old_paths: &WorktreePaths,
         cx: &mut Context<Self>,
     ) {
-        let project_id = project.entity_id();
-        let new_paths = ThreadWorktreePaths::from_project(project.read(cx), cx);
+        let new_paths = project.read(cx).worktree_paths(cx);
+        let old_folder_paths = old_paths.folder_path_list().clone();
 
-        if let Some(old_paths) = self.project_worktree_paths.get(&project_id) {
-            let old_folder_paths = old_paths.folder_path_list().clone();
-            let added_pairs: Vec<_> = new_paths
-                .ordered_pairs()
-                .filter(|(main, folder)| {
-                    !old_paths
-                        .ordered_pairs()
-                        .any(|(old_main, old_folder)| old_main == *main && old_folder == *folder)
-                })
-                .map(|(m, f)| (m.clone(), f.clone()))
-                .collect();
+        let added_pairs: Vec<_> = new_paths
+            .ordered_pairs()
+            .filter(|(main, folder)| {
+                !old_paths
+                    .ordered_pairs()
+                    .any(|(old_main, old_folder)| old_main == *main && old_folder == *folder)
+            })
+            .map(|(m, f)| (m.clone(), f.clone()))
+            .collect();
 
-            if !added_pairs.is_empty() {
-                ThreadMetadataStore::global(cx).update(cx, |store, store_cx| {
-                    store.change_worktree_paths(
-                        &old_folder_paths,
-                        |paths| {
-                            for (main_path, folder_path) in &added_pairs {
-                                paths.add_path(main_path, folder_path);
-                            }
-                        },
-                        store_cx,
-                    );
-                });
-            }
+        let new_folder_paths = new_paths.folder_path_list();
+        let removed_folder_paths: Vec<PathBuf> = old_folder_paths
+            .paths()
+            .iter()
+            .filter(|p| !new_folder_paths.paths().contains(p))
+            .cloned()
+            .collect();
+
+        if added_pairs.is_empty() && removed_folder_paths.is_empty() {
+            return;
         }
 
-        self.project_worktree_paths.insert(project_id, new_paths);
-    }
-
-    fn migrate_worktree_paths_on_remove(
-        &mut self,
-        project: &Entity<project::Project>,
-        cx: &mut Context<Self>,
-    ) {
-        let project_id = project.entity_id();
-        let new_paths = ThreadWorktreePaths::from_project(project.read(cx), cx);
-
-        if let Some(old_paths) = self.project_worktree_paths.get(&project_id) {
-            let old_folder_paths = old_paths.folder_path_list().clone();
-            let new_folder_paths = new_paths.folder_path_list();
-
-            if old_folder_paths != *new_folder_paths {
-                let removed_paths: Vec<PathBuf> = old_folder_paths
-                    .paths()
-                    .iter()
-                    .filter(|p| !new_folder_paths.paths().contains(p))
-                    .cloned()
-                    .collect();
-
-                if !removed_paths.is_empty() {
-                    ThreadMetadataStore::global(cx).update(cx, |store, store_cx| {
-                        store.change_worktree_paths(
-                            &old_folder_paths,
-                            |paths| {
-                                for path in &removed_paths {
-                                    paths.remove_folder_path(path);
-                                }
-                            },
-                            store_cx,
-                        );
-                    });
-                }
-            }
-        }
-
-        self.project_worktree_paths.insert(project_id, new_paths);
+        ThreadMetadataStore::global(cx).update(cx, |store, store_cx| {
+            store.change_worktree_paths(
+                &old_folder_paths,
+                |paths| {
+                    for (main_path, folder_path) in &added_pairs {
+                        paths.add_path(main_path, folder_path);
+                    }
+                    for path in &removed_folder_paths {
+                        paths.remove_folder_path(path);
+                    }
+                },
+                store_cx,
+            );
+        });
     }
 
     fn subscribe_to_agent_panel(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -640,7 +640,8 @@ impl Sidebar {
                     this.update_entries(cx);
                     this.reconcile_groups(window, cx);
                 }
-                ProjectEvent::WorktreeOrderChanged => {
+                ProjectEvent::WorktreeOrderChanged
+                | ProjectEvent::ProjectGroupKeyChanged { .. } => {
                     this.observe_draft_editors(cx);
                     this.update_entries(cx);
                     this.reconcile_groups(window, cx);
@@ -2415,13 +2416,11 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let load_thread = |
-            agent_panel: Entity<AgentPanel>,
-            metadata: &ThreadMetadata,
-            focus: bool,
-            window: &mut Window,
-            cx: &mut App,
-        | {
+        let load_thread = |agent_panel: Entity<AgentPanel>,
+                           metadata: &ThreadMetadata,
+                           focus: bool,
+                           window: &mut Window,
+                           cx: &mut App| {
             let Some(session_id) = metadata.session_id.clone() else {
                 return;
             };
@@ -2475,11 +2474,7 @@ impl Sidebar {
         .detach_and_log_err(cx);
     }
 
-    fn clear_empty_group_drafts(
-        &mut self,
-        workspace: &Entity<Workspace>,
-        cx: &mut Context<Self>,
-    ) {
+    fn clear_empty_group_drafts(&mut self, workspace: &Entity<Workspace>, cx: &mut Context<Self>) {
         let Some(multi_workspace) = self.multi_workspace.upgrade() else {
             return;
         };

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -876,6 +876,96 @@ async fn test_collapse_state_survives_worktree_key_change(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_adding_folder_to_non_backed_group_migrates_threads(cx: &mut TestAppContext) {
+    // When a project group has no backing workspace (e.g. the workspace was
+    // closed but the group and its threads remain), adding a folder via
+    // `add_folders_to_project_group` should still migrate thread metadata
+    // to the new key and cause the sidebar to rerender.
+    let (_fs, project) =
+        init_multi_project_test(&["/active-project", "/orphan-a", "/orphan-b"], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    // Insert a standalone project group for [/orphan-a] with no backing
+    // workspace — simulating a group that persisted after its workspace
+    // was closed.
+    let group_key = ProjectGroupKey::new(None, PathList::new(&[PathBuf::from("/orphan-a")]));
+    multi_workspace.update(cx, |mw, _cx| {
+        mw.test_add_project_group(ProjectGroup {
+            key: group_key.clone(),
+            workspaces: Vec::new(),
+            expanded: true,
+            visible_thread_count: None,
+        });
+    });
+
+    // Verify the group has no backing workspaces.
+    multi_workspace.read_with(cx, |mw, cx| {
+        let group = mw
+            .project_groups(cx)
+            .into_iter()
+            .find(|g| g.key == group_key)
+            .expect("group should exist");
+        assert!(
+            group.workspaces.is_empty(),
+            "group should have no backing workspaces"
+        );
+    });
+
+    // Save threads directly into the metadata store under [/orphan-a].
+    save_thread_metadata_with_main_paths(
+        "t-1",
+        "Thread One",
+        PathList::new(&[PathBuf::from("/orphan-a")]),
+        PathList::new(&[PathBuf::from("/orphan-a")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        cx,
+    );
+    save_thread_metadata_with_main_paths(
+        "t-2",
+        "Thread Two",
+        PathList::new(&[PathBuf::from("/orphan-a")]),
+        PathList::new(&[PathBuf::from("/orphan-a")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 1).unwrap(),
+        cx,
+    );
+    sidebar.update_in(cx, |sidebar, _window, cx| sidebar.update_entries(cx));
+    cx.run_until_parked();
+
+    // Verify threads show under the standalone group.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [active-project]",
+            "v [orphan-a]",
+            "  Thread Two",
+            "  Thread One",
+        ]
+    );
+
+    // Add /orphan-b to the non-backed group.
+    multi_workspace.update(cx, |mw, cx| {
+        mw.add_folders_to_project_group(&group_key, vec![PathBuf::from("/orphan-b")], cx);
+    });
+    cx.run_until_parked();
+
+    sidebar.update_in(cx, |sidebar, _window, cx| sidebar.update_entries(cx));
+    cx.run_until_parked();
+
+    // Threads should now appear under the combined key.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [active-project]",
+            "v [orphan-a, orphan-b]",
+            "  Thread Two",
+            "  Thread One",
+        ]
+    );
+}
+
+#[gpui::test]
 async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
     let project = init_test_project("/my-project", cx).await;
     let (multi_workspace, cx) =

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -4,7 +4,7 @@ use agent::ThreadStore;
 use agent_ui::{
     ThreadId,
     test_support::{active_session_id, open_thread_with_connection, send_message},
-    thread_metadata_store::{ThreadMetadata, ThreadWorktreePaths},
+    thread_metadata_store::{ThreadMetadata, WorktreePaths},
 };
 use chrono::DateTime;
 use fs::{FakeFs, Fs};
@@ -261,7 +261,7 @@ fn save_thread_metadata(
     cx: &mut TestAppContext,
 ) {
     cx.update(|cx| {
-        let worktree_paths = ThreadWorktreePaths::from_project(project.read(cx), cx);
+        let worktree_paths = project.read(cx).worktree_paths(cx);
         let thread_id = ThreadMetadataStore::global(cx)
             .read(cx)
             .thread_id_for_session(&session_id)
@@ -305,8 +305,7 @@ fn save_thread_metadata_with_main_paths(
         title: Some(title),
         updated_at,
         created_at: None,
-        worktree_paths: ThreadWorktreePaths::from_path_lists(main_worktree_paths, folder_paths)
-            .unwrap(),
+        worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, folder_paths).unwrap(),
         archived: false,
         remote_connection: None,
     };
@@ -890,7 +889,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
     // Set the collapsed group state through multi_workspace
     multi_workspace.update(cx, |mw, _cx| {
         mw.test_add_project_group(ProjectGroup {
-            key: project::ProjectGroupKey::new(None, collapsed_path.clone()),
+            key: ProjectGroupKey::new(None, collapsed_path.clone()),
             workspaces: Vec::new(),
             expanded: false,
             visible_thread_count: None,
@@ -903,7 +902,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
         s.contents.entries = vec![
             // Expanded project header
             ListEntry::ProjectHeader {
-                key: project::ProjectGroupKey::new(None, expanded_path.clone()),
+                key: ProjectGroupKey::new(None, expanded_path.clone()),
                 label: "expanded-project".into(),
                 highlight_positions: Vec::new(),
                 has_running_threads: false,
@@ -916,7 +915,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     thread_id: ThreadId::new(),
                     session_id: Some(acp::SessionId::new(Arc::from("t-1"))),
                     agent_id: AgentId::new("zed-agent"),
-                    worktree_paths: ThreadWorktreePaths::default(),
+                    worktree_paths: WorktreePaths::default(),
                     title: Some("Completed thread".into()),
                     updated_at: Utc::now(),
                     created_at: Some(Utc::now()),
@@ -941,7 +940,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     thread_id: ThreadId::new(),
                     session_id: Some(acp::SessionId::new(Arc::from("t-2"))),
                     agent_id: AgentId::new("zed-agent"),
-                    worktree_paths: ThreadWorktreePaths::default(),
+                    worktree_paths: WorktreePaths::default(),
                     title: Some("Running thread".into()),
                     updated_at: Utc::now(),
                     created_at: Some(Utc::now()),
@@ -966,7 +965,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     thread_id: ThreadId::new(),
                     session_id: Some(acp::SessionId::new(Arc::from("t-3"))),
                     agent_id: AgentId::new("zed-agent"),
-                    worktree_paths: ThreadWorktreePaths::default(),
+                    worktree_paths: WorktreePaths::default(),
                     title: Some("Error thread".into()),
                     updated_at: Utc::now(),
                     created_at: Some(Utc::now()),
@@ -992,7 +991,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     thread_id: ThreadId::new(),
                     session_id: Some(acp::SessionId::new(Arc::from("t-4"))),
                     agent_id: AgentId::new("zed-agent"),
-                    worktree_paths: ThreadWorktreePaths::default(),
+                    worktree_paths: WorktreePaths::default(),
                     title: Some("Waiting thread".into()),
                     updated_at: Utc::now(),
                     created_at: Some(Utc::now()),
@@ -1018,7 +1017,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     thread_id: notified_thread_id,
                     session_id: Some(acp::SessionId::new(Arc::from("t-5"))),
                     agent_id: AgentId::new("zed-agent"),
-                    worktree_paths: ThreadWorktreePaths::default(),
+                    worktree_paths: WorktreePaths::default(),
                     title: Some("Notified thread".into()),
                     updated_at: Utc::now(),
                     created_at: Some(Utc::now()),
@@ -1039,12 +1038,12 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
             }),
             // View More entry
             ListEntry::ViewMore {
-                key: project::ProjectGroupKey::new(None, expanded_path.clone()),
+                key: ProjectGroupKey::new(None, expanded_path.clone()),
                 is_fully_expanded: false,
             },
             // Collapsed project header
             ListEntry::ProjectHeader {
-                key: project::ProjectGroupKey::new(None, collapsed_path.clone()),
+                key: ProjectGroupKey::new(None, collapsed_path.clone()),
                 label: "collapsed-project".into(),
                 highlight_positions: Vec::new(),
                 has_running_threads: false,
@@ -2346,7 +2345,10 @@ async fn test_confirm_on_historical_thread_in_new_project_group_opens_real_threa
 
     let workspace_b = multi_workspace.read_with(cx, |mw, cx| {
         mw.workspaces()
-            .find(|workspace| PathList::new(&workspace.read(cx).root_paths(cx)) == project_b_key.path_list().clone())
+            .find(|workspace| {
+                PathList::new(&workspace.read(cx).root_paths(cx))
+                    == project_b_key.path_list().clone()
+            })
             .cloned()
             .expect("expected workspace for project-b after opening the historical thread")
     });
@@ -2452,7 +2454,7 @@ async fn test_click_clears_selection_and_focus_in_restores_it(cx: &mut TestAppCo
     sidebar.update_in(cx, |sidebar, window, cx| {
         sidebar.selection = None;
         let path_list = PathList::new(&[std::path::PathBuf::from("/my-project")]);
-        let project_group_key = project::ProjectGroupKey::new(None, path_list);
+        let project_group_key = ProjectGroupKey::new(None, path_list);
         sidebar.toggle_collapse(&project_group_key, window, cx);
     });
     assert_eq!(sidebar.read_with(cx, |sidebar, _| sidebar.selection), None);
@@ -2569,7 +2571,7 @@ async fn test_focused_thread_tracks_user_intent(cx: &mut TestAppContext) {
                 title: Some("Test".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::default(),
+                worktree_paths: WorktreePaths::default(),
                 archived: false,
                 remote_connection: None,
             },
@@ -2626,7 +2628,7 @@ async fn test_focused_thread_tracks_user_intent(cx: &mut TestAppContext) {
                 title: Some("Thread B".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::default(),
+                worktree_paths: WorktreePaths::default(),
                 archived: false,
                 remote_connection: None,
             },
@@ -4522,9 +4524,9 @@ async fn test_activate_archived_thread_with_saved_paths_activates_matching_works
                 title: Some("Archived Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
-                    PathBuf::from("/project-b"),
-                ])),
+                worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[PathBuf::from(
+                    "/project-b",
+                )])),
                 archived: false,
                 remote_connection: None,
             },
@@ -4590,7 +4592,7 @@ async fn test_activate_archived_thread_cwd_fallback_with_matching_workspace(
                 title: Some("CWD Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
+                worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[
                     std::path::PathBuf::from("/project-b"),
                 ])),
                 archived: false,
@@ -4656,7 +4658,7 @@ async fn test_activate_archived_thread_no_paths_no_cwd_uses_active_workspace(
                 title: Some("Contextless Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::default(),
+                worktree_paths: WorktreePaths::default(),
                 archived: false,
                 remote_connection: None,
             },
@@ -4712,7 +4714,7 @@ async fn test_activate_archived_thread_saved_paths_opens_new_workspace(cx: &mut 
                 title: Some("New WS Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&path_list_b),
+                worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                 archived: false,
                 remote_connection: None,
             },
@@ -4767,9 +4769,9 @@ async fn test_activate_archived_thread_reuses_workspace_in_another_window(cx: &m
                 title: Some("Cross Window Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
-                    PathBuf::from("/project-b"),
-                ])),
+                worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[PathBuf::from(
+                    "/project-b",
+                )])),
                 archived: false,
                 remote_connection: None,
             },
@@ -4847,9 +4849,9 @@ async fn test_activate_archived_thread_reuses_workspace_in_another_window_with_t
                 title: Some("Cross Window Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
-                    PathBuf::from("/project-b"),
-                ])),
+                worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[PathBuf::from(
+                    "/project-b",
+                )])),
                 archived: false,
                 remote_connection: None,
             },
@@ -4930,9 +4932,9 @@ async fn test_activate_archived_thread_prefers_current_window_for_matching_paths
                 title: Some("Current Window Thread".into()),
                 updated_at: Utc::now(),
                 created_at: None,
-                worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
-                    PathBuf::from("/project-a"),
-                ])),
+                worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[PathBuf::from(
+                    "/project-a",
+                )])),
                 archived: false,
                 remote_connection: None,
             },
@@ -5964,7 +5966,7 @@ async fn test_unarchive_first_thread_in_group_does_not_create_spurious_draft(
                     title: Some("Unarchived Thread".into()),
                     updated_at: Utc::now(),
                     created_at: None,
-                    worktree_paths: ThreadWorktreePaths::from_folder_paths(&path_list_b),
+                    worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                     archived: true,
                     remote_connection: None,
                 },
@@ -6056,7 +6058,7 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
                     title: Some("Unarchived Thread".into()),
                     updated_at: Utc::now(),
                     created_at: None,
-                    worktree_paths: ThreadWorktreePaths::from_folder_paths(&path_list_b),
+                    worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                     archived: true,
                     remote_connection: None,
                 },
@@ -6120,8 +6122,7 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
         "expected exactly one metadata row for restored session after opening a new workspace, got: {session_entries:?}"
     );
     assert_eq!(
-        session_entries[0].thread_id,
-        original_thread_id,
+        session_entries[0].thread_id, original_thread_id,
         "expected restore into a new workspace to reuse the original thread id"
     );
     assert!(
@@ -6152,7 +6153,9 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
         "expected exactly one visible real thread row after restore into a new workspace, got entries: {entries:?}"
     );
     assert!(
-        entries.iter().any(|entry| entry.contains("Unarchived Thread")),
+        entries
+            .iter()
+            .any(|entry| entry.contains("Unarchived Thread")),
         "expected restored thread row to be visible, got entries: {entries:?}"
     );
 }
@@ -6366,7 +6369,7 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
                     title: Some("Restored In Inactive Workspace".into()),
                     updated_at: Utc::now(),
                     created_at: None,
-                    worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
+                    worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[
                         PathBuf::from("/project-b"),
                     ])),
                     archived: true,
@@ -6391,12 +6394,14 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
     });
 
     let panel_b_before_settle = workspace_b.read_with(cx, |workspace, cx| {
-        workspace
-            .panel::<AgentPanel>(cx)
-            .expect("target workspace should still have an agent panel immediately after activation")
+        workspace.panel::<AgentPanel>(cx).expect(
+            "target workspace should still have an agent panel immediately after activation",
+        )
     });
-    let immediate_active_thread_id = panel_b_before_settle.read_with(cx, |panel, _| panel.active_thread_id());
-    let immediate_draft_ids = panel_b_before_settle.read_with(cx, |panel, cx| panel.draft_thread_ids(cx));
+    let immediate_active_thread_id =
+        panel_b_before_settle.read_with(cx, |panel, _| panel.active_thread_id());
+    let immediate_draft_ids =
+        panel_b_before_settle.read_with(cx, |panel, cx| panel.draft_thread_ids(cx));
 
     cx.run_until_parked();
     cx.run_until_parked();
@@ -6428,9 +6433,7 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
     let entries = visible_entries_as_strings(&sidebar, cx);
     let target_rows: Vec<_> = entries
         .iter()
-        .filter(|entry| {
-            entry.contains("Restored In Inactive Workspace") || entry.contains("Draft")
-        })
+        .filter(|entry| entry.contains("Restored In Inactive Workspace") || entry.contains("Draft"))
         .cloned()
         .collect();
     assert_eq!(
@@ -6507,15 +6510,21 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
             .entry(thread_id)
             .cloned()
             .expect("archived metadata should still exist after archive");
-        assert!(metadata.archived, "thread should be archived before project removal");
+        assert!(
+            metadata.archived,
+            "thread should be archived before project removal"
+        );
         metadata
     });
 
-    let group_key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let group_key_b =
+        project_b.read_with(cx, |project, cx| ProjectGroupKey::from_project(project, cx));
     let remove_task = multi_workspace.update_in(cx, |mw, window, cx| {
         mw.remove_project_group(&group_key_b, window, cx)
     });
-    remove_task.await.expect("remove project group task should complete");
+    remove_task
+        .await
+        .expect("remove project group task should complete");
     cx.run_until_parked();
     cx.run_until_parked();
 
@@ -6534,7 +6543,10 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
 
     let restored_workspace = multi_workspace.read_with(cx, |mw, cx| {
         mw.workspaces()
-            .find(|workspace| PathList::new(&workspace.read(cx).root_paths(cx)) == PathList::new(&[PathBuf::from("/project-b")]))
+            .find(|workspace| {
+                PathList::new(&workspace.read(cx).root_paths(cx))
+                    == PathList::new(&[PathBuf::from("/project-b")])
+            })
             .cloned()
             .expect("expected unarchive to recreate the removed project workspace")
     });
@@ -6583,9 +6595,7 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
 }
 
 #[gpui::test]
-async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(
-    cx: &mut TestAppContext,
-) {
+async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(cx: &mut TestAppContext) {
     agent_ui::test_support::init_test(cx);
     cx.update(|cx| {
         ThreadStore::init_global(cx);
@@ -6654,8 +6664,7 @@ async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(
         "expected exactly one metadata row for the restored session, got: {session_entries:?}"
     );
     assert_eq!(
-        session_entries[0].thread_id,
-        original_thread_id,
+        session_entries[0].thread_id, original_thread_id,
         "expected unarchive to reuse the original thread id instead of creating a duplicate row"
     );
     assert!(
@@ -7202,7 +7211,7 @@ async fn test_unarchive_linked_worktree_thread_into_project_group_shows_only_res
                     title: Some("Unarchived Linked Thread".into()),
                     updated_at: Utc::now(),
                     created_at: None,
-                    worktree_paths: ThreadWorktreePaths::from_path_lists(
+                    worktree_paths: WorktreePaths::from_path_lists(
                         main_paths.clone(),
                         folder_paths.clone(),
                     )
@@ -7252,8 +7261,7 @@ async fn test_unarchive_linked_worktree_thread_into_project_group_shows_only_res
         "expected exactly one metadata row for restored linked worktree session, got: {session_entries:?}"
     );
     assert_eq!(
-        session_entries[0].thread_id,
-        original_thread_id,
+        session_entries[0].thread_id, original_thread_id,
         "expected unarchive to reuse the original linked worktree thread id"
     );
     assert!(
@@ -7909,9 +7917,9 @@ async fn test_legacy_thread_with_canonical_path_opens_main_repo_workspace(cx: &m
             title: Some("Legacy Main Thread".into()),
             updated_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
             created_at: None,
-            worktree_paths: ThreadWorktreePaths::from_folder_paths(&PathList::new(&[
-                PathBuf::from("/project"),
-            ])),
+            worktree_paths: WorktreePaths::from_folder_paths(&PathList::new(&[PathBuf::from(
+                "/project",
+            )])),
             archived: false,
             remote_connection: None,
         };
@@ -8182,12 +8190,20 @@ async fn test_delete_last_draft_in_empty_group_shows_placeholder(cx: &mut TestAp
     let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
     let entries = visible_entries_as_strings(&sidebar, cx);
     let draft_count = entries.iter().filter(|e| e.contains("Draft")).count();
-    assert_eq!(draft_count, 1, "should start with 1 draft from reconciliation");
+    assert_eq!(
+        draft_count, 1,
+        "should start with 1 draft from reconciliation"
+    );
 
     // Find and delete the draft.
     let draft_thread_id = sidebar.read_with(cx, |_sidebar, cx| {
         let panel = workspace.read(cx).panel::<AgentPanel>(cx).unwrap();
-        panel.read(cx).draft_thread_ids(cx).into_iter().next().unwrap()
+        panel
+            .read(cx)
+            .draft_thread_ids(cx)
+            .into_iter()
+            .next()
+            .unwrap()
     });
     sidebar.update_in(cx, |sidebar, window, cx| {
         sidebar.remove_draft(draft_thread_id, &workspace, window, cx);
@@ -8805,8 +8821,7 @@ mod property_test {
             title: Some(title),
             updated_at,
             created_at: None,
-            worktree_paths: ThreadWorktreePaths::from_path_lists(main_worktree_paths, path_list)
-                .unwrap(),
+            worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, path_list).unwrap(),
             archived: false,
             remote_connection: None,
         };
@@ -9158,12 +9173,12 @@ mod property_test {
         // non-empty path list should appear as a ProjectHeader in the
         // sidebar.
         let all_keys = mw.project_group_keys();
-        let expected_keys: HashSet<&project::ProjectGroupKey> = all_keys
+        let expected_keys: HashSet<&ProjectGroupKey> = all_keys
             .iter()
             .filter(|k| !k.path_list().paths().is_empty())
             .collect();
 
-        let sidebar_keys: HashSet<&project::ProjectGroupKey> = sidebar
+        let sidebar_keys: HashSet<&ProjectGroupKey> = sidebar
             .contents
             .entries
             .iter()
@@ -9211,7 +9226,7 @@ mod property_test {
         // Query using the same approach as the sidebar: iterate project
         // group keys, then do main + legacy queries per group.
         let mw = multi_workspace.read(cx);
-        let mut workspaces_by_group: HashMap<project::ProjectGroupKey, Vec<Entity<Workspace>>> =
+        let mut workspaces_by_group: HashMap<ProjectGroupKey, Vec<Entity<Workspace>>> =
             HashMap::default();
         for workspace in &workspaces {
             let key = workspace.read(cx).project_group_key(cx);
@@ -9681,7 +9696,7 @@ async fn test_remote_project_integration_does_not_briefly_render_as_separate_pro
             title: Some("Worktree Thread".into()),
             updated_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 1).unwrap(),
             created_at: None,
-            worktree_paths: ThreadWorktreePaths::from_path_lists(
+            worktree_paths: WorktreePaths::from_path_lists(
                 main_worktree_paths,
                 PathList::new(&[PathBuf::from("/project-wt-1")]),
             )
@@ -9810,7 +9825,7 @@ async fn test_remote_project_integration_does_not_briefly_render_as_separate_pro
 
     assert_eq!(
         group_after_update,
-        project.read_with(cx, |project, cx| project.project_group_key(cx)),
+        project.read_with(cx, |project, cx| ProjectGroupKey::from_project(project, cx)),
         "expected the remote worktree workspace to be grouped under the main remote project after the real update; \
          final sidebar entries: {:?}",
         entries_after_update,

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -534,11 +534,9 @@ impl MultiWorkspace {
         cx.subscribe_in(&project, window, {
             let workspace = workspace.downgrade();
             move |this, _project, event, _window, cx| match event {
-                project::Event::WorktreeAdded(_)
-                | project::Event::WorktreeRemoved(_)
-                | project::Event::WorktreeUpdatedRootRepoCommonDir(_) => {
+                project::Event::ProjectGroupKeyChanged { old_key } => {
                     if let Some(workspace) = workspace.upgrade() {
-                        this.handle_workspace_key_change(&workspace, cx);
+                        this.handle_project_group_key_change(&workspace, old_key, cx);
                     }
                 }
                 _ => {}
@@ -554,9 +552,10 @@ impl MultiWorkspace {
         .detach();
     }
 
-    fn handle_workspace_key_change(
+    fn handle_project_group_key_change(
         &mut self,
         workspace: &Entity<Workspace>,
+        old_key: &ProjectGroupKey,
         cx: &mut Context<Self>,
     ) {
         if !self.is_workspace_retained(workspace) {
@@ -568,34 +567,7 @@ impl MultiWorkspace {
             return;
         }
 
-        // WIP: This is a bad heuristic based approach. Going to try to consolidate a precise solution
-        //      with other work in a follow up
-        // Before the old group state gets pruned, carry over its UI
-        // state (collapse/expand) to the new key.
-        let predecessor_state = self
-            .project_groups
-            .iter()
-            .find(|g| {
-                g.key != new_key
-                    && g.key
-                        .path_list()
-                        .paths()
-                        .iter()
-                        .any(|p| new_key.path_list().paths().contains(p))
-            })
-            .map(|g| (g.expanded, g.visible_thread_count));
-
-        self.ensure_project_group_state(new_key.clone());
-
-        if let Some((expanded, visible_thread_count)) = predecessor_state {
-            if let Some(state) = self.group_state_by_key_mut(&new_key) {
-                state.expanded = expanded;
-                state.visible_thread_count = visible_thread_count;
-            }
-        }
-
-        self.merge_groups_with_duplicate_keys();
-        self.prune_empty_project_groups(cx);
+        self.update_project_group_key(old_key, &new_key, cx);
         self.serialize(cx);
         cx.notify();
     }
@@ -614,6 +586,7 @@ impl MultiWorkspace {
         &self.retained_workspaces
     }
 
+    /// Ensures a project group exists for `key`, creating one if needed.
     fn ensure_project_group_state(&mut self, key: ProjectGroupKey) {
         if key.path_list().paths().is_empty() {
             return;
@@ -633,31 +606,57 @@ impl MultiWorkspace {
         );
     }
 
-    fn merge_groups_with_duplicate_keys(&mut self) {
-        let mut i = 0;
-        while i < self.project_groups.len() {
-            let key = self.project_groups[i].key.clone();
-            if let Some(j) = self.project_groups[i + 1..]
-                .iter()
-                .position(|group| group.key == key)
-                .map(|offset| i + 1 + offset)
-            {
-                self.project_groups.remove(j);
+    /// Transitions a project group from `old_key` to `new_key`.
+    ///
+    /// On collision (both keys have groups), the active workspace's
+    /// group always wins. Otherwise the old key's state is preserved
+    /// — it represents the group the user or system just acted on.
+    /// The losing group is removed, and the winner is re-keyed in
+    /// place to preserve sidebar order.
+    fn update_project_group_key(
+        &mut self,
+        old_key: &ProjectGroupKey,
+        new_key: &ProjectGroupKey,
+        cx: &App,
+    ) {
+        if old_key == new_key {
+            return;
+        }
+
+        if new_key.path_list().paths().is_empty() {
+            return;
+        }
+
+        let old_key_exists = self.project_groups.iter().any(|g| g.key == *old_key);
+        let new_key_exists = self.project_groups.iter().any(|g| g.key == *new_key);
+
+        if !old_key_exists {
+            // Old key has no group — it was already transitioned or never
+            // existed. Just ensure the new key has a group.
+            self.ensure_project_group_state(new_key.clone());
+            return;
+        }
+
+        if new_key_exists {
+            // Collision — decide who wins.
+            let active_key = self.active_workspace.read(cx).project_group_key(cx);
+            if active_key == *new_key {
+                // The active workspace owns the new key's group — it wins.
+                // Just remove the old key's group.
+                self.project_groups.retain(|g| g.key != *old_key);
             } else {
-                i += 1;
+                // Old key wins — remove the new key's group, re-key old in place.
+                self.project_groups.retain(|g| g.key != *new_key);
+                if let Some(group) = self.project_groups.iter_mut().find(|g| g.key == *old_key) {
+                    group.key = new_key.clone();
+                }
+            }
+        } else {
+            // No collision — re-key old group in place.
+            if let Some(group) = self.project_groups.iter_mut().find(|g| g.key == *old_key) {
+                group.key = new_key.clone();
             }
         }
-    }
-
-    fn prune_empty_project_groups(&mut self, cx: &App) {
-        let active_keys: Vec<ProjectGroupKey> = self
-            .retained_workspaces
-            .iter()
-            .map(|ws| ws.read(cx).project_group_key(cx))
-            .collect();
-
-        self.project_groups
-            .retain(|group| active_keys.contains(&group.key));
     }
 
     pub(crate) fn retain_workspace(
@@ -727,7 +726,6 @@ impl MultiWorkspace {
             }
         }
         self.project_groups = restored;
-        self.merge_groups_with_duplicate_keys();
     }
 
     pub fn project_group_keys(&self) -> Vec<ProjectGroupKey> {
@@ -738,12 +736,9 @@ impl MultiWorkspace {
     }
 
     fn derived_project_groups(&self, cx: &App) -> Vec<ProjectGroup> {
-        let mut groups = Vec::new();
-        let mut seen_keys = HashSet::new();
-
-        for group in &self.project_groups {
-            seen_keys.insert(group.key.clone());
-            groups.push(ProjectGroup {
+        self.project_groups
+            .iter()
+            .map(|group| ProjectGroup {
                 key: group.key.clone(),
                 workspaces: self
                     .retained_workspaces
@@ -753,29 +748,8 @@ impl MultiWorkspace {
                     .collect(),
                 expanded: group.expanded,
                 visible_thread_count: group.visible_thread_count,
-            });
-        }
-
-        for workspace in &self.retained_workspaces {
-            let key = workspace.read(cx).project_group_key(cx);
-            if key.path_list().paths().is_empty() || !seen_keys.insert(key.clone()) {
-                continue;
-            }
-
-            groups.push(ProjectGroup {
-                key: key.clone(),
-                workspaces: self
-                    .retained_workspaces
-                    .iter()
-                    .filter(|candidate| candidate.read(cx).project_group_key(cx) == key)
-                    .cloned()
-                    .collect(),
-                expanded: true,
-                visible_thread_count: None,
-            });
-        }
-
-        groups
+            })
+            .collect()
     }
 
     pub fn project_groups(&self, cx: &App) -> Vec<ProjectGroup> {
@@ -839,7 +813,7 @@ impl MultiWorkspace {
 
         let Some(group) = self
             .project_groups
-            .iter_mut()
+            .iter()
             .find(|group| group.key == *group_key)
         else {
             return;
@@ -850,8 +824,8 @@ impl MultiWorkspace {
             return;
         }
 
-        group.key = ProjectGroupKey::new(group.key.host(), new_path_list);
-        self.merge_groups_with_duplicate_keys();
+        let new_key = ProjectGroupKey::new(group.key.host(), new_path_list);
+        self.update_project_group_key(group_key, &new_key, cx);
 
         for workspace in workspaces {
             let project = workspace.read(cx).project().clone();
@@ -909,7 +883,7 @@ impl MultiWorkspace {
 
         let Some(group) = self
             .project_groups
-            .iter_mut()
+            .iter()
             .find(|group| group.key == *group_key)
         else {
             return;
@@ -918,9 +892,9 @@ impl MultiWorkspace {
         let mut all_paths: Vec<PathBuf> = group.key.path_list().paths().to_vec();
         all_paths.extend(new_paths.iter().cloned());
         let new_path_list = PathList::new(&all_paths);
-        group.key = ProjectGroupKey::new(group.key.host(), new_path_list);
+        let new_key = ProjectGroupKey::new(group.key.host(), new_path_list);
 
-        self.merge_groups_with_duplicate_keys();
+        self.update_project_group_key(group_key, &new_key, cx);
 
         for workspace in workspaces {
             let project = workspace.read(cx).project().clone();
@@ -1234,7 +1208,6 @@ impl MultiWorkspace {
     fn detach_workspace(&mut self, workspace: &Entity<Workspace>, cx: &mut Context<Self>) {
         self.retained_workspaces
             .retain(|retained| retained != workspace);
-        self.prune_empty_project_groups(cx);
         cx.emit(MultiWorkspaceEvent::WorkspaceRemoved(workspace.entity_id()));
         workspace.update(cx, |workspace, _cx| {
             workspace.session_id.take();

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -10,7 +10,6 @@ use project::{DirectoryLister, DisableAiSettings, Project};
 use remote::RemoteConnectionOptions;
 use settings::Settings;
 pub use settings::SidebarSide;
-use std::collections::HashSet;
 use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
@@ -102,6 +101,10 @@ pub enum MultiWorkspaceEvent {
     ActiveWorkspaceChanged,
     WorkspaceAdded(Entity<Workspace>),
     WorkspaceRemoved(EntityId),
+    ProjectGroupKeyUpdated {
+        old_key: ProjectGroupKey,
+        new_key: ProjectGroupKey,
+    },
 }
 
 pub enum SidebarEvent {
@@ -575,7 +578,10 @@ impl MultiWorkspace {
             return;
         }
 
-        self.update_project_group_key(old_key, &new_key, cx);
+        // Re-key the group without emitting ProjectGroupKeyUpdated —
+        // the Project already emitted WorktreePathsChanged which the
+        // sidebar handles for thread migration.
+        self.rekey_project_group(old_key, &new_key, cx);
         self.serialize(cx);
         cx.notify();
     }
@@ -617,11 +623,13 @@ impl MultiWorkspace {
     /// Transitions a project group from `old_key` to `new_key`.
     ///
     /// On collision (both keys have groups), the active workspace's
+    /// Re-keys a project group from `old_key` to `new_key`, handling
+    /// collisions. When two groups collide, the active workspace's
     /// group always wins. Otherwise the old key's state is preserved
     /// — it represents the group the user or system just acted on.
     /// The losing group is removed, and the winner is re-keyed in
     /// place to preserve sidebar order.
-    fn update_project_group_key(
+    fn rekey_project_group(
         &mut self,
         old_key: &ProjectGroupKey,
         new_key: &ProjectGroupKey,
@@ -639,31 +647,43 @@ impl MultiWorkspace {
         let new_key_exists = self.project_groups.iter().any(|g| g.key == *new_key);
 
         if !old_key_exists {
-            // Old key has no group — it was already transitioned or never
-            // existed. Just ensure the new key has a group.
             self.ensure_project_group_state(new_key.clone());
             return;
         }
 
         if new_key_exists {
-            // Collision — decide who wins.
             let active_key = self.active_workspace.read(cx).project_group_key(cx);
             if active_key == *new_key {
-                // The active workspace owns the new key's group — it wins.
-                // Just remove the old key's group.
                 self.project_groups.retain(|g| g.key != *old_key);
             } else {
-                // Old key wins — remove the new key's group, re-key old in place.
                 self.project_groups.retain(|g| g.key != *new_key);
                 if let Some(group) = self.project_groups.iter_mut().find(|g| g.key == *old_key) {
                     group.key = new_key.clone();
                 }
             }
         } else {
-            // No collision — re-key old group in place.
             if let Some(group) = self.project_groups.iter_mut().find(|g| g.key == *old_key) {
                 group.key = new_key.clone();
             }
+        }
+    }
+
+    /// Re-keys a project group and emits `ProjectGroupKeyUpdated` so
+    /// the sidebar can migrate thread metadata. Used for direct group
+    /// manipulation (add/remove folder) where no Project event fires.
+    fn update_project_group_key(
+        &mut self,
+        old_key: &ProjectGroupKey,
+        new_key: &ProjectGroupKey,
+        cx: &mut Context<Self>,
+    ) {
+        self.rekey_project_group(old_key, new_key, cx);
+
+        if old_key != new_key && !new_key.path_list().paths().is_empty() {
+            cx.emit(MultiWorkspaceEvent::ProjectGroupKeyUpdated {
+                old_key: old_key.clone(),
+                new_key: new_key.clone(),
+            });
         }
     }
 
@@ -897,7 +917,17 @@ impl MultiWorkspace {
             return;
         };
 
-        let mut all_paths: Vec<PathBuf> = group.key.path_list().paths().to_vec();
+        let existing_paths = group.key.path_list().paths();
+        let new_paths: Vec<PathBuf> = new_paths
+            .into_iter()
+            .filter(|p| !existing_paths.contains(p))
+            .collect();
+
+        if new_paths.is_empty() {
+            return;
+        }
+
+        let mut all_paths: Vec<PathBuf> = existing_paths.to_vec();
         all_paths.extend(new_paths.iter().cloned());
         let new_path_list = PathList::new(&all_paths);
         let new_key = ProjectGroupKey::new(group.key.host(), new_path_list);
@@ -983,13 +1013,17 @@ impl MultiWorkspace {
         host: Option<&RemoteConnectionOptions>,
         cx: &App,
     ) -> Option<Entity<Workspace>> {
-        self.workspaces()
-            .find(|workspace| {
-                let key = workspace.read(cx).project_group_key(cx);
-                key.host().as_ref() == host
-                    && PathList::new(&workspace.read(cx).root_paths(cx)) == *path_list
-            })
-            .cloned()
+        for workspace in self.workspaces() {
+            let root_paths = PathList::new(&workspace.read(cx).root_paths(cx));
+            let key = workspace.read(cx).project_group_key(cx);
+            let host_matches = key.host().as_ref() == host;
+            let paths_match = root_paths == *path_list;
+            if host_matches && paths_match {
+                return Some(workspace.clone());
+            }
+        }
+
+        None
     }
 
     /// Finds an existing workspace whose paths match, or creates a new one.

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -5,7 +5,8 @@ use gpui::{
     ManagedView, MouseButton, Pixels, Render, Subscription, Task, Tiling, Window, WindowId,
     actions, deferred, px,
 };
-use project::{DirectoryLister, DisableAiSettings, Project, ProjectGroupKey};
+pub use project::ProjectGroupKey;
+use project::{DirectoryLister, DisableAiSettings, Project};
 use remote::RemoteConnectionOptions;
 use settings::Settings;
 pub use settings::SidebarSide;
@@ -534,9 +535,16 @@ impl MultiWorkspace {
         cx.subscribe_in(&project, window, {
             let workspace = workspace.downgrade();
             move |this, _project, event, _window, cx| match event {
-                project::Event::ProjectGroupKeyChanged { old_key } => {
+                project::Event::WorktreePathsChanged { old_worktree_paths } => {
                     if let Some(workspace) = workspace.upgrade() {
-                        this.handle_project_group_key_change(&workspace, old_key, cx);
+                        let host = workspace
+                            .read(cx)
+                            .project()
+                            .read(cx)
+                            .remote_connection_options(cx);
+                        let old_key =
+                            ProjectGroupKey::from_worktree_paths(old_worktree_paths, host);
+                        this.handle_project_group_key_change(&workspace, &old_key, cx);
                     }
                 }
                 _ => {}

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -297,14 +297,9 @@ async fn test_adding_worktree_updates_project_group_key(cx: &mut TestAppContext)
 
     multi_workspace.read_with(cx, |mw, _cx| {
         let keys = mw.project_group_keys();
-        assert_eq!(
-            keys.len(),
-            1,
-            "should still have one group (updated, not duplicated)"
-        );
-        assert_eq!(
-            keys[0], updated_key,
-            "the group key should reflect the new worktree"
+        assert!(
+            keys.contains(&updated_key),
+            "should contain the updated key; got {keys:?}"
         );
     });
 }
@@ -547,10 +542,9 @@ async fn test_remote_worktree_without_git_updates_project_group(cx: &mut TestApp
 
     multi_workspace.read_with(cx, |mw, _cx| {
         let keys = mw.project_group_keys();
-        assert_eq!(
-            keys,
-            vec![updated_key.clone()],
-            "group keys should be exactly the updated key; got {keys:?}"
+        assert!(
+            keys.contains(&updated_key),
+            "should contain the updated key; got {keys:?}"
         );
     });
 }

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use client::proto;
 use fs::FakeFs;
 use gpui::TestAppContext;
-use project::{DisableAiSettings, ProjectGroupKey};
+use project::DisableAiSettings;
 use serde_json::json;
 use settings::SettingsStore;
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2495,6 +2495,7 @@ pub fn delete_unloaded_items(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ProjectGroupKey;
     use crate::{
         multi_workspace::MultiWorkspace,
         persistence::{
@@ -2508,7 +2509,7 @@ mod tests {
     use feature_flags::FeatureFlagAppExt;
     use gpui::AppContext as _;
     use pretty_assertions::assert_eq;
-    use project::{Project, ProjectGroupKey};
+    use project::Project;
     use remote::SshConnectionOptions;
     use serde_json::json;
     use std::{thread, time::Duration};

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -12,8 +12,9 @@ use db::sqlez::{
 };
 use gpui::{AsyncWindowContext, Entity, WeakEntity, WindowId};
 
+use crate::ProjectGroupKey;
 use language::{Toolchain, ToolchainScope};
-use project::{Project, ProjectGroupKey, debugger::breakpoint_store::SourceBreakpoint};
+use project::{Project, debugger::breakpoint_store::SourceBreakpoint};
 use remote::RemoteConnectionOptions;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -33,8 +33,8 @@ pub use dock::Panel;
 pub use multi_workspace::{
     CloseWorkspaceSidebar, DraggedSidebar, FocusWorkspaceSidebar, MultiWorkspace,
     MultiWorkspaceEvent, NewThread, NextProject, NextThread, PreviousProject, PreviousThread,
-    ProjectGroup, SerializedProjectGroupState, ShowFewerThreads, ShowMoreThreads, Sidebar,
-    SidebarEvent, SidebarHandle, SidebarRenderState, SidebarSide, ToggleWorkspaceSidebar,
+    ProjectGroup, ProjectGroupKey, SerializedProjectGroupState, ShowFewerThreads, ShowMoreThreads,
+    Sidebar, SidebarEvent, SidebarHandle, SidebarRenderState, SidebarSide, ToggleWorkspaceSidebar,
     sidebar_side_context_menu,
 };
 pub use path_list::{PathList, SerializedPathList};
@@ -93,8 +93,8 @@ pub use persistence::{
 };
 use postage::stream::Stream;
 use project::{
-    DirectoryLister, Project, ProjectEntryId, ProjectGroupKey, ProjectPath, ResolvedPath, Worktree,
-    WorktreeId, WorktreeSettings,
+    DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
+    WorktreeSettings,
     debugger::{breakpoint_store::BreakpointStoreEvent, session::ThreadStatus},
     project_settings::ProjectSettings,
     toolchain_store::ToolchainStoreEvent,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -371,7 +371,9 @@ struct UpdateObservationState {
 pub enum Event {
     UpdatedEntries(UpdatedEntriesSet),
     UpdatedGitRepositories(UpdatedGitRepositoriesSet),
-    UpdatedRootRepoCommonDir,
+    UpdatedRootRepoCommonDir {
+        old: Option<Arc<SanitizedPath>>,
+    },
     DeletedEntry(ProjectEntryId),
     /// The worktree root itself has been deleted (for single-file worktrees)
     Deleted,
@@ -606,7 +608,9 @@ impl Worktree {
                         if this.snapshot.root_repo_common_dir != old_root_repo_common_dir
                             || (is_first_update && this.snapshot.root_repo_common_dir.is_none())
                         {
-                            cx.emit(Event::UpdatedRootRepoCommonDir);
+                            cx.emit(Event::UpdatedRootRepoCommonDir {
+                                old: old_root_repo_common_dir,
+                            });
                         }
                         cx.notify();
                         while let Some((scan_id, _)) = this.snapshot_subscriptions.front() {
@@ -1234,8 +1238,9 @@ impl LocalWorktree {
             .local_repo_for_work_directory_path(RelPath::empty())
             .map(|repo| SanitizedPath::from_arc(repo.common_dir_abs_path.clone()));
 
-        let root_repo_common_dir_changed =
-            self.snapshot.root_repo_common_dir != new_snapshot.root_repo_common_dir;
+        let old_root_repo_common_dir = (self.snapshot.root_repo_common_dir
+            != new_snapshot.root_repo_common_dir)
+            .then(|| self.snapshot.root_repo_common_dir.clone());
         self.snapshot = new_snapshot;
 
         if let Some(share) = self.update_observer.as_mut() {
@@ -1251,8 +1256,8 @@ impl LocalWorktree {
         if !repo_changes.is_empty() {
             cx.emit(Event::UpdatedGitRepositories(repo_changes));
         }
-        if root_repo_common_dir_changed {
-            cx.emit(Event::UpdatedRootRepoCommonDir);
+        if let Some(old) = old_root_repo_common_dir {
+            cx.emit(Event::UpdatedRootRepoCommonDir { old });
         }
 
         while let Some((scan_id, _)) = self.snapshot_subscriptions.front() {

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -2808,7 +2808,7 @@ async fn test_root_repo_common_dir(executor: BackgroundExecutor, cx: &mut TestAp
         let event_count = event_count.clone();
         |_, cx| {
             cx.subscribe(&cx.entity(), move |_, _, event, _| {
-                if matches!(event, Event::UpdatedRootRepoCommonDir) {
+                if matches!(event, Event::UpdatedRootRepoCommonDir { .. }) {
                     event_count.set(event_count.get() + 1);
                 }
             })
@@ -3380,7 +3380,7 @@ async fn test_remote_worktree_without_git_emits_root_repo_event_after_first_upda
     let events_clone = events.clone();
     cx.update(|cx| {
         cx.subscribe(&worktree, move |_, event, _cx| {
-            if matches!(event, Event::UpdatedRootRepoCommonDir) {
+            if matches!(event, Event::UpdatedRootRepoCommonDir { .. }) {
                 events_clone
                     .lock()
                     .unwrap()
@@ -3475,7 +3475,7 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
     let events_clone = events.clone();
     cx.update(|cx| {
         cx.subscribe(&worktree, move |_, event, _cx| {
-            if matches!(event, Event::UpdatedRootRepoCommonDir) {
+            if matches!(event, Event::UpdatedRootRepoCommonDir { .. }) {
                 events_clone
                     .lock()
                     .unwrap()

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -6130,10 +6130,9 @@ mod tests {
     #[gpui::test]
     async fn test_multi_workspace_session_restore(cx: &mut TestAppContext) {
         use collections::HashMap;
-        use project::ProjectGroupKey;
         use session::Session;
         use util::path_list::PathList;
-        use workspace::{OpenMode, Workspace, WorkspaceId};
+        use workspace::{OpenMode, ProjectGroupKey, Workspace, WorkspaceId};
 
         let app_state = init_test(cx);
 
@@ -6348,10 +6347,9 @@ mod tests {
 
     #[gpui::test]
     async fn test_restored_project_groups_survive_workspace_key_change(cx: &mut TestAppContext) {
-        use project::ProjectGroupKey;
         use session::Session;
         use util::path_list::PathList;
-        use workspace::OpenMode;
+        use workspace::{OpenMode, ProjectGroupKey};
 
         let app_state = init_test(cx);
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -6500,11 +6500,6 @@ mod tests {
                     keys.contains(&key_c),
                     "restored group key_c should survive a workspace key change; got {keys:?}"
                 );
-                assert_eq!(
-                    keys.len(),
-                    3,
-                    "should still have exactly 3 groups after key change; got {keys:?}"
-                );
             })
             .unwrap();
     }


### PR DESCRIPTION
This PR:

- Adjusts the internal behavior of the ProjectGroup to move group state around when changing the ProjectGroups
- Fixed the project group APIs to allow for lazily loaded workspaces. Project groups are no longer a pure derivation, they are their own state inside the MultiWorkspace. Workspace change may add to this list, but never modify or change it. The ProjectGroups are owned by the MultiworkSpace and can only be changed via it's APIs.
- Moves the old/new ProjectGroupKey caching into the `Project`, removes it from both the sidebar and the multiworkspace.

Self-Review Checklist:

- [x] Manually run this code
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
