### PR TITLE
languages: Respect tab_size in Ruff and CSS formatters

### DIFF
--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use gpui::AsyncApp;
-use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
+use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain, language_settings::AllLanguageSettings};
 use lsp::{LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::lsp_store::language_server_settings;
 use semver::Version;
 use serde_json::json;
+use settings::{Settings, SettingsLocation};
+use util::rel_path::RelPath;
 use std::{
     ffi::OsString,
     path::{Path, PathBuf},
@@ -148,14 +150,34 @@ impl LspAdapter for CssLspAdapter {
         _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<serde_json::Value> {
+        let location = SettingsLocation {
+            worktree_id: delegate.worktree_id(),
+            path: RelPath::empty(),
+        };
+
+        let tab_size = cx.update(|cx| {
+            AllLanguageSettings::get(Some(location), cx)
+                .language(Some(location), Some(&"CSS".into()), cx)
+                .tab_size
+        });
+
         let mut default_config = json!({
             "css": {
+                "format": {
+                    "tabSize": tab_size
+                },
                 "lint": {}
             },
             "less": {
+                "format": {
+                    "tabSize": tab_size
+                },
                 "lint": {}
             },
             "scss": {
+                "format": {
+                    "tabSize": tab_size
+                },
                 "lint": {}
             }
         });

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -7,7 +7,7 @@ use futures::lock::OwnedMutexGuard;
 use futures::{AsyncBufReadExt, StreamExt as _};
 use gpui::{App, AsyncApp, Entity, SharedString, Task};
 use http_client::github::{AssetKind, GitHubLspBinaryVersion, latest_github_release};
-use language::language_settings::LanguageSettings;
+use language::language_settings::{AllLanguageSettings, LanguageSettings};
 use language::{
     Buffer, ContextLocation, DynLspInstaller, LanguageToolchainStore, LspInstaller, Symbol,
 };
@@ -26,7 +26,7 @@ use project::lsp_store::language_server_settings;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use settings::{SemanticTokenRules, Settings};
+use settings::{SemanticTokenRules, Settings, SettingsLocation};
 use terminal::terminal_settings::TerminalSettings;
 
 use smol::lock::OnceCell;
@@ -49,7 +49,7 @@ use std::{
     sync::Arc,
 };
 use task::{ShellKind, TaskTemplate, TaskTemplates, VariableName};
-use util::{ResultExt, maybe};
+use util::{ResultExt, maybe, merge_json_value_into};
 
 pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
     let content = grammars::get_file("python/semantic_token_rules.json")
@@ -2410,6 +2410,42 @@ impl RuffLspAdapter {
 impl LspAdapter for RuffLspAdapter {
     fn name(&self) -> LanguageServerName {
         Self::SERVER_NAME
+    }
+
+    async fn workspace_configuration(
+        self: Arc<Self>,
+        adapter: &Arc<dyn LspAdapterDelegate>,
+        _: Option<Toolchain>,
+        _: Option<Uri>,
+        cx: &mut AsyncApp,
+    ) -> Result<Value> {
+        let location = SettingsLocation {
+            worktree_id: adapter.worktree_id(),
+            path: RelPath::empty(),
+        };
+
+        let tab_size = cx.update(|cx| {
+            AllLanguageSettings::get(Some(location), cx)
+                .language(Some(location), Some(&"Python".into()), cx)
+                .tab_size
+        });
+
+        let mut config = json!({
+            "format": {
+                "indent-width": tab_size
+            }
+        });
+
+        let project_options = cx.update(|cx| {
+            language_server_settings(adapter.as_ref(), &Self::SERVER_NAME, cx)
+                .and_then(|s| s.settings.clone())
+        });
+
+        if let Some(override_options) = project_options {
+            merge_json_value_into(override_options, &mut config);
+        }
+
+        Ok(config)
     }
 
     async fn initialization_options_schema(


### PR DESCRIPTION
## Summary

- **Ruff (Python, #47841)**: `RuffLspAdapter` was missing a `workspace_configuration` implementation, so Zed's `tab_size` setting was never passed to the formatter. Added `workspace_configuration` that reads the Python language's `tab_size` and sends it to Ruff as `format.indent-width`. User LSP settings overrides are still respected via `merge_json_value_into`.
- **CSS/Less/SCSS (#51378)**: `CssLspAdapter.workspace_configuration` existed but didn't include any format settings. Added `css.format.tabSize`, `less.format.tabSize`, and `scss.format.tabSize` derived from Zed's `tab_size` for the CSS language.

Both fixes follow the same pattern already used by the YAML adapter (`AllLanguageSettings::get` → `.language(...).tab_size`).

## Test plan

- [ ] Set `"tab_size": 2` in Zed settings, open a Python file, run Ruff format → output should use 2-space indentation
- [ ] Set `"tab_size": 2` in Zed settings, open a CSS/Less/SCSS file, run formatter → output should use 2-space indentation
- [ ] Verify that explicit `lsp.ruff.settings.format.indent-width` overrides still take precedence

Fixes #47841
Fixes #51378

🤖 Generated with [Claude Code](https://claude.com/claude-code)