### PR TITLE
sidebar: Fix non-empty draft threads getting discarded on load

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -205,6 +205,8 @@ struct SerializedAgentPanel {
 #[derive(Serialize, Deserialize, Debug)]
 struct SerializedActiveThread {
     session_id: String,
+    #[serde(default)]
+    thread_id: Option<ThreadId>,
     agent_type: Agent,
     title: Option<String>,
     work_dirs: Option<SerializedPathList>,
@@ -384,6 +386,7 @@ pub fn init(cx: &mut App) {
                             None,
                             None,
                             None,
+                            None,
                             Some(AgentInitialContent::ContentBlock {
                                 blocks: content_blocks,
                                 auto_submit: true,
@@ -406,6 +409,7 @@ pub fn init(cx: &mut App) {
 
                         panel.update(cx, |panel, cx| {
                             panel.external_thread(
+                                None,
                                 None,
                                 None,
                                 None,
@@ -434,6 +438,7 @@ pub fn init(cx: &mut App) {
 
                         panel.update(cx, |panel, cx| {
                             panel.external_thread(
+                                None,
                                 None,
                                 None,
                                 None,
@@ -904,6 +909,7 @@ impl AgentPanel {
             let work_dirs = thread.work_dirs().cloned();
             SerializedActiveThread {
                 session_id: thread.session_id().0.to_string(),
+                thread_id: self.active_thread_id(cx),
                 agent_type: self.selected_agent.clone(),
                 title: title.map(|t| t.to_string()),
                 work_dirs: work_dirs.map(|dirs| dirs.serialize()),
@@ -965,10 +971,15 @@ impl AgentPanel {
                 let is_restorable = cx
                     .update(|_window, cx| {
                         let store = ThreadMetadataStore::global(cx);
+                        let store = store.read(cx);
                         store
-                            .read(cx)
                             .entry_by_session(&session_id)
                             .is_some_and(|entry| !entry.archived)
+                            || thread_info.thread_id.is_some_and(|thread_id| {
+                                store
+                                    .entry(thread_id)
+                                    .is_some_and(|entry| entry.is_draft() && !entry.archived)
+                            })
                     })
                     .unwrap_or(false);
                 if is_restorable {
@@ -1034,9 +1045,10 @@ impl AgentPanel {
                     let agent = thread_info.agent_type.clone();
                     panel.update(cx, |panel, cx| {
                         panel.selected_agent = agent.clone();
-                        panel.load_agent_thread(
+                        panel.load_agent_thread_with_thread_id(
                             agent,
                             thread_info.session_id.clone().into(),
+                            thread_info.thread_id,
                             thread_info.work_dirs.as_ref().map(|dirs| PathList::deserialize(dirs)),
                             thread_info.title.as_ref().map(|t| t.clone().into()),
                             false,
@@ -1332,6 +1344,7 @@ impl AgentPanel {
         self.external_thread(
             Some(crate::Agent::NativeAgent),
             Some(session_id),
+            None,
             work_dirs,
             title,
             None,
@@ -1400,7 +1413,7 @@ impl AgentPanel {
         } else {
             self.selected_agent.clone()
         };
-        let thread = self.create_agent_thread(agent, None, None, None, None, window, cx);
+        let thread = self.create_agent_thread(agent, None, None, None, None, None, window, cx);
         let thread_id = thread.conversation_view.read(cx).thread_id;
         self.retained_threads
             .insert(thread_id, thread.conversation_view);
@@ -1591,6 +1604,7 @@ impl AgentPanel {
                     None,
                     None,
                     None,
+                    None,
                     Some(AgentInitialContent::ThreadSummary {
                         session_id: thread.session_id,
                         title: thread.title,
@@ -1609,6 +1623,7 @@ impl AgentPanel {
         &mut self,
         agent_choice: Option<crate::Agent>,
         resume_session_id: Option<acp::SessionId>,
+        preferred_thread_id: Option<ThreadId>,
         work_dirs: Option<PathList>,
         title: Option<SharedString>,
         initial_content: Option<AgentInitialContent>,
@@ -1626,6 +1641,7 @@ impl AgentPanel {
         let thread = self.create_agent_thread(
             agent,
             resume_session_id,
+            preferred_thread_id,
             work_dirs,
             title,
             initial_content,
@@ -2251,12 +2267,17 @@ impl AgentPanel {
             .conversation_views()
             .into_iter()
             .filter_map(|conversation_view| {
-                let thread_id = conversation_view.read(cx).thread_id;
-                let is_draft = match conversation_view.read(cx).root_thread(cx) {
+                let conversation_view = conversation_view.read(cx);
+                let thread_id = conversation_view.thread_id;
+                let is_loaded_or_loading_draft = match conversation_view.root_thread(cx) {
                     Some(tv) => tv.read(cx).is_draft(cx),
-                    None => false,
+                    None => conversation_view.is_loading(),
                 };
-                if is_draft { Some(thread_id) } else { None }
+                if is_loaded_or_loading_draft {
+                    Some(thread_id)
+                } else {
+                    None
+                }
             })
             .collect();
         let path_list = {
@@ -2766,6 +2787,7 @@ impl AgentPanel {
             None,
             None,
             None,
+            None,
             external_source_prompt.map(AgentInitialContent::from),
             true,
             window,
@@ -2791,6 +2813,7 @@ impl AgentPanel {
             None,
             None,
             None,
+            None,
             initial_content,
             focus,
             window,
@@ -2806,6 +2829,22 @@ impl AgentPanel {
         &mut self,
         agent: Agent,
         session_id: acp::SessionId,
+        work_dirs: Option<PathList>,
+        title: Option<SharedString>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.load_agent_thread_with_thread_id(
+            agent, session_id, None, work_dirs, title, focus, window, cx,
+        );
+    }
+
+    fn load_agent_thread_with_thread_id(
+        &mut self,
+        agent: Agent,
+        session_id: acp::SessionId,
+        preferred_thread_id: Option<ThreadId>,
         work_dirs: Option<PathList>,
         title: Option<SharedString>,
         focus: bool,
@@ -2862,6 +2901,7 @@ impl AgentPanel {
         self.external_thread(
             Some(agent),
             Some(session_id),
+            preferred_thread_id,
             work_dirs,
             title,
             None,
@@ -2876,6 +2916,7 @@ impl AgentPanel {
         &mut self,
         agent: Agent,
         resume_session_id: Option<acp::SessionId>,
+        preferred_thread_id: Option<ThreadId>,
         work_dirs: Option<PathList>,
         title: Option<SharedString>,
         initial_content: Option<AgentInitialContent>,
@@ -2886,6 +2927,7 @@ impl AgentPanel {
             agent,
             None,
             resume_session_id,
+            preferred_thread_id,
             work_dirs,
             title,
             initial_content,
@@ -2899,6 +2941,7 @@ impl AgentPanel {
         agent: Agent,
         server_override: Option<Rc<dyn AgentServer>>,
         resume_session_id: Option<acp::SessionId>,
+        preferred_thread_id: Option<ThreadId>,
         work_dirs: Option<PathList>,
         title: Option<SharedString>,
         initial_content: Option<AgentInitialContent>,
@@ -2912,6 +2955,7 @@ impl AgentPanel {
         let thread_id = existing_metadata
             .as_ref()
             .map(|m| m.thread_id)
+            .or(preferred_thread_id)
             .unwrap_or_else(ThreadId::new);
         let workspace = self.workspace.clone();
         let project = self.project.clone();
@@ -3735,6 +3779,7 @@ impl AgentPanel {
                     panel.update(cx, |panel, cx| {
                         panel.external_thread(
                             selected_agent,
+                            None,
                             None,
                             None,
                             None,
@@ -5166,6 +5211,7 @@ impl AgentPanel {
             None,
             None,
             None,
+            None,
             window,
             cx,
         );
@@ -5382,6 +5428,104 @@ mod tests {
                 "workspace B should have no active thread"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_create_agent_thread_preserves_preferred_thread_id_for_resumed_draft(
+        cx: &mut TestAppContext,
+    ) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        let preferred_thread_id = ThreadId::new();
+        let session_id = acp::SessionId::new("restored-draft-session");
+        let connection = StubAgentConnection::new().with_supports_load_session(true);
+
+        let thread_id = panel.update_in(&mut cx, |panel, window, cx| {
+            let thread = panel.create_agent_thread_with_server(
+                Agent::Custom { id: "Test".into() },
+                Some(std::rc::Rc::new(StubAgentServer::new(connection))),
+                Some(session_id),
+                Some(preferred_thread_id),
+                None,
+                None,
+                None,
+                window,
+                cx,
+            );
+            thread.conversation_view.read(cx).thread_id
+        });
+
+        assert_eq!(
+            thread_id, preferred_thread_id,
+            "resumed draft should preserve the persisted thread_id"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_remove_empty_draft_preserves_loading_restored_draft_metadata(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [Path::new("/project")], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let mut cx = VisualTestContext::from_window(multi_workspace.into(), cx);
+        let panel = workspace.update_in(&mut cx, |workspace, window, cx| {
+            cx.new(|cx| AgentPanel::new(workspace, None, window, cx))
+        });
+
+        let preferred_thread_id = ThreadId::new();
+        cx.update(|_, cx| {
+            let metadata = ThreadMetadata::new_draft(
+                preferred_thread_id,
+                AgentId::new("Test"),
+                None,
+                project.read(cx).worktree_paths(cx),
+                None,
+            );
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.save(metadata, cx);
+            });
+        });
+
+        let session_id = acp::SessionId::new("loading-restored-draft");
+        let connection = StubAgentConnection::new().with_supports_load_session(true);
+        panel.update_in(&mut cx, |panel, window, cx| {
+            let thread = panel.create_agent_thread_with_server(
+                Agent::Custom { id: "Test".into() },
+                Some(std::rc::Rc::new(StubAgentServer::new(connection))),
+                Some(session_id),
+                Some(preferred_thread_id),
+                None,
+                None,
+                None,
+                window,
+                cx,
+            );
+            panel.set_base_view(thread.into(), false, window, cx);
+            panel.remove_empty_draft(cx);
+        });
+
+        let still_present = cx.update(|_, cx| {
+            ThreadMetadataStore::global(cx)
+                .read(cx)
+                .entry(preferred_thread_id)
+                .is_some()
+        });
+        assert!(
+            still_present,
+            "loading restored draft metadata should not be deleted during cleanup"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1457,7 +1457,7 @@ impl AgentPanel {
             let cv = cv.read(cx);
             match cv.root_thread(cx) {
                 Some(tv) => tv.read(cx).is_draft(cx),
-                None => cv.is_new_draft(),
+                None => false,
             }
         };
 
@@ -1498,7 +1498,11 @@ impl AgentPanel {
                 }
                 _ => None,
             })?;
-        let tv = cv.read(cx).active_thread()?;
+        let tv = cv
+            .read(cx)
+            .active_thread()
+            .cloned()
+            .or_else(|| cv.read(cx).root_thread(cx))?;
         let text = tv.read(cx).message_editor.read(cx).text(cx);
         if text.trim().is_empty() {
             None
@@ -2210,8 +2214,8 @@ impl AgentPanel {
         }
 
         let is_empty_draft = match conversation_view.read(cx).root_thread(cx) {
-            Some(tv) => tv.read(cx).is_draft(cx),
-            None => conversation_view.read(cx).is_new_draft(),
+            Some(tv) => tv.read(cx).is_empty_draft(cx),
+            None => false,
         };
         if is_empty_draft {
             ThreadMetadataStore::global(cx).update(cx, |store, cx| {
@@ -2228,13 +2232,16 @@ impl AgentPanel {
         let draft_ids: Vec<ThreadId> = self
             .retained_threads
             .iter()
-            .filter(|(_, cv)| match cv.read(cx).root_thread(cx) {
-                Some(tv) => tv.read(cx).is_draft(cx),
-                None => cv.read(cx).is_new_draft(),
+            .filter_map(|(id, conversation_view)| {
+                let is_empty_draft = match conversation_view.read(cx).root_thread(cx) {
+                    Some(tv) => tv.read(cx).is_empty_draft(cx),
+                    None => false,
+                };
+                if is_empty_draft { Some(*id) } else { None }
             })
-            .map(|(id, _)| *id)
             .collect();
         for id in draft_ids {
+            dbg!(&id);
             self.retained_threads.remove(&id);
             ThreadMetadataStore::global(cx).update(cx, |store, cx| {
                 store.delete(id, cx);
@@ -2243,6 +2250,18 @@ impl AgentPanel {
 
         // Also clean up orphaned draft metadata in the store for this
         // panel's worktree paths (e.g. from a previously removed workspace).
+        let loaded_draft_ids: Vec<ThreadId> = self
+            .conversation_views()
+            .into_iter()
+            .filter_map(|conversation_view| {
+                let thread_id = conversation_view.read(cx).thread_id;
+                let is_draft = match conversation_view.read(cx).root_thread(cx) {
+                    Some(tv) => tv.read(cx).is_draft(cx),
+                    None => false,
+                };
+                if is_draft { Some(thread_id) } else { None }
+            })
+            .collect();
         let path_list = {
             let project = self.project.read(cx);
             let worktree_paths = project.worktree_paths(cx);
@@ -2254,7 +2273,9 @@ impl AgentPanel {
                 store
                     .entries_for_path(&path_list)
                     .chain(store.entries_for_main_worktree_path(&path_list))
-                    .filter(|entry| entry.is_draft())
+                    .filter(|entry| {
+                        entry.is_draft() && !loaded_draft_ids.contains(&entry.thread_id)
+                    })
                     .map(|entry| entry.thread_id)
                     .collect()
             };

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1453,24 +1453,22 @@ impl AgentPanel {
     }
 
     pub fn draft_thread_ids(&self, cx: &App) -> Vec<ThreadId> {
-        let is_draft = |cv: &Entity<ConversationView>| -> bool {
-            let cv = cv.read(cx);
-            match cv.root_thread(cx) {
-                Some(tv) => tv.read(cx).is_draft(cx),
-                None => false,
-            }
+        let is_draft = |thread_id: ThreadId| -> bool {
+            ThreadMetadataStore::try_global(cx)
+                .and_then(|store| store.read(cx).entry(thread_id).map(|s| s.is_draft()))
+                .unwrap_or(false)
         };
 
         let mut ids: Vec<ThreadId> = self
             .retained_threads
             .iter()
-            .filter(|(_, cv)| is_draft(cv))
+            .filter(|(id, _)| is_draft(**id))
             .map(|(id, _)| *id)
             .collect();
 
         if let BaseView::AgentThread { conversation_view } = &self.base_view {
             let thread_id = conversation_view.read(cx).thread_id;
-            if is_draft(conversation_view) && !ids.contains(&thread_id) {
+            if is_draft(thread_id) && !ids.contains(&thread_id) {
                 ids.push(thread_id);
             }
         }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2241,7 +2241,6 @@ impl AgentPanel {
             })
             .collect();
         for id in draft_ids {
-            dbg!(&id);
             self.retained_threads.remove(&id);
             ThreadMetadataStore::global(cx).update(cx, |store, cx| {
                 store.delete(id, cx);

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -431,9 +431,6 @@ pub struct ConversationView {
     notification_subscriptions: HashMap<WindowHandle<AgentNotification>, Vec<Subscription>>,
     auth_task: Option<Task<()>>,
     _subscriptions: Vec<Subscription>,
-    /// True when this conversation was created as a new draft (no resume
-    /// session). False when resuming an existing session from history.
-    is_new_draft: bool,
 }
 
 impl ConversationView {
@@ -441,10 +438,6 @@ impl ConversationView {
         self.as_connected().map_or(false, |connected| {
             !connected.connection.auth_methods().is_empty()
         })
-    }
-
-    pub fn is_new_draft(&self) -> bool {
-        self.is_new_draft
     }
 
     pub fn active_thread(&self) -> Option<&Entity<ThreadView>> {
@@ -688,7 +681,6 @@ impl ConversationView {
         })
         .detach();
 
-        let is_new_draft = resume_session_id.is_none();
         let thread_id = thread_id.unwrap_or_else(ThreadId::new);
 
         Self {
@@ -719,7 +711,6 @@ impl ConversationView {
             auth_task: None,
             _subscriptions: subscriptions,
             focus_handle: cx.focus_handle(),
-            is_new_draft,
         }
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -649,6 +649,10 @@ impl ThreadView {
         self.thread.read(cx).entries().is_empty()
     }
 
+    pub fn is_empty_draft(&self, cx: &App) -> bool {
+        self.is_draft(cx) && self.message_editor.read(cx).is_empty(cx)
+    }
+
     pub(crate) fn as_native_connection(
         &self,
         cx: &App,

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -518,6 +518,7 @@ impl Sidebar {
             for workspace in &workspaces {
                 this.subscribe_to_workspace(workspace, window, cx);
             }
+            this.sync_active_entry_from_active_workspace(cx);
             this.update_entries(cx);
             this.reconcile_groups(window, cx);
         });

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -784,14 +784,7 @@ impl Sidebar {
             window,
             |this, _agent_panel, event: &AgentPanelEvent, window, cx| match event {
                 AgentPanelEvent::ActiveViewChanged => {
-                    let resolved_pending_activation =
-                        this.sync_active_entry_from_panel(_agent_panel, cx);
-                    if resolved_pending_activation {
-                        let active_workspace = this.active_workspace(cx);
-                        if let Some(active_workspace) = active_workspace {
-                            this.clear_empty_group_drafts(&active_workspace, cx);
-                        }
-                    }
+                    this.sync_active_entry_from_panel(_agent_panel, cx);
                     this.observe_draft_editors(cx);
                     this.update_entries(cx);
                     this.reconcile_groups(window, cx);
@@ -2477,40 +2470,6 @@ impl Sidebar {
         .detach_and_log_err(cx);
     }
 
-    fn clear_empty_group_drafts(&mut self, workspace: &Entity<Workspace>, cx: &mut Context<Self>) {
-        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
-            return;
-        };
-
-        let group_key = workspace.read(cx).project_group_key(cx);
-        let group_workspaces: Vec<_> = multi_workspace
-            .read(cx)
-            .workspaces()
-            .filter(|candidate| candidate.read(cx).project_group_key(cx) == group_key)
-            .cloned()
-            .collect();
-
-        for group_workspace in group_workspaces {
-            group_workspace.update(cx, |workspace, cx| {
-                let Some(panel) = workspace.panel::<AgentPanel>(cx) else {
-                    return;
-                };
-
-                panel.update(cx, |panel, cx| {
-                    let empty_draft_ids: Vec<ThreadId> = panel
-                        .draft_thread_ids(cx)
-                        .into_iter()
-                        .filter(|id| panel.editor_text(*id, cx).is_none())
-                        .collect();
-
-                    for id in empty_draft_ids {
-                        panel.remove_thread(id, cx);
-                    }
-                });
-            });
-        }
-    }
-
     fn activate_thread_locally(
         &mut self,
         metadata: &ThreadMetadata,
@@ -2560,7 +2519,6 @@ impl Sidebar {
             self.observe_draft_editors(cx);
         } else {
             Self::load_agent_thread_in_workspace(workspace, metadata, true, window, cx);
-            self.clear_empty_group_drafts(workspace, cx);
         }
 
         self.update_entries(cx);
@@ -2603,7 +2561,6 @@ impl Sidebar {
                         workspace: workspace_for_entry.clone(),
                     });
                     sidebar.record_thread_access(&target_session_id);
-                    sidebar.clear_empty_group_drafts(&workspace_for_entry, cx);
                     sidebar.update_entries(cx);
                 });
             }

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1597,6 +1597,42 @@ fn setup_sidebar_with_agent_panel(
 }
 
 #[gpui::test]
+async fn test_sidebar_initialization_syncs_existing_active_thread(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+    let workspace = multi_workspace.read_with(cx, |mw, _cx| mw.workspace().clone());
+    let panel = add_agent_panel(&workspace, cx);
+
+    let connection = StubAgentConnection::new();
+    connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+        acp::ContentChunk::new("Done".into()),
+    )]);
+    open_thread_with_connection(&panel, connection, cx);
+    send_message(&panel, cx);
+
+    let session_id = active_session_id(&panel, cx);
+    save_test_thread_metadata(&session_id, &project, cx).await;
+    cx.run_until_parked();
+
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        assert_active_thread(
+            sidebar,
+            &session_id,
+            "Sidebar should sync an already-active panel thread during initialization",
+        );
+    });
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [my-project]", "  Hello *"]
+    );
+}
+
+#[gpui::test]
 async fn test_parallel_threads_shown_with_live_status(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -2401,8 +2401,6 @@ async fn test_confirm_on_historical_thread_preserves_typed_draft_in_same_group(
         sidebar.confirm(&Confirm, window, cx);
     });
     cx.run_until_parked();
-    cx.run_until_parked();
-    cx.run_until_parked();
 
     assert_eq!(
         visible_entries_as_strings(&sidebar, cx),

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -2355,6 +2355,89 @@ async fn test_confirm_on_historical_thread_activates_workspace(cx: &mut TestAppC
 }
 
 #[gpui::test]
+async fn test_confirm_on_historical_thread_preserves_typed_draft_in_same_group(
+    cx: &mut TestAppContext,
+) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let historical_session_id = acp::SessionId::new(Arc::from("historical-thread"));
+    save_thread_metadata(
+        historical_session_id.clone(),
+        Some("Historical Thread".into()),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 6, 1, 0, 0, 0).unwrap(),
+        None,
+        &project,
+        cx,
+    );
+    cx.run_until_parked();
+
+    let connection = StubAgentConnection::new();
+    open_thread_with_connection(&panel, connection, cx);
+
+    let thread_view = panel.read_with(cx, |panel, cx| panel.active_thread_view(cx).unwrap());
+    let message_editor = thread_view.read_with(cx, |view, _cx| view.message_editor.clone());
+    message_editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("Preserved draft text", window, cx);
+    });
+    cx.run_until_parked();
+
+    let historical_entry_index = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .position(|entry| {
+                matches!(entry, ListEntry::Thread(thread)
+                    if thread.metadata.session_id.as_ref() == Some(&historical_session_id))
+            })
+            .expect("expected Historical Thread to appear in the sidebar")
+    });
+
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.selection = Some(historical_entry_index);
+        sidebar.confirm(&Confirm, window, cx);
+    });
+    cx.run_until_parked();
+    cx.run_until_parked();
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [my-project]",
+            "  [~ Draft]",
+            "  Historical Thread  <== selected",
+        ],
+        "loading a historical thread in the same project group should keep the draft row visible"
+    );
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        let draft = sidebar
+            .contents
+            .entries
+            .iter()
+            .find_map(|entry| match entry {
+                ListEntry::Thread(thread) if thread.is_draft => Some(thread),
+                _ => None,
+            })
+            .expect("expected draft entry to remain visible after loading historical thread");
+        assert_eq!(
+            draft.metadata.title.as_ref().map(|title| title.as_ref()),
+            Some("Preserved draft text"),
+            "typed draft title should be preserved after loading a thread in the same group"
+        );
+        assert_active_thread(
+            sidebar,
+            &historical_session_id,
+            "historical thread should become active after confirm",
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_confirm_on_historical_thread_preserves_historical_timestamp_and_order(
     cx: &mut TestAppContext,
 ) {


### PR DESCRIPTION
When switching to another thread on the same project group a draft thread would just be discarded

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A
