### PR TITLE
docs: Add Dexter language server to Elixir documentation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2081,10 +2081,10 @@
       "ensure_final_newline_on_save": false,
     },
     "EEx": {
-      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!dexter", "!expert", "!next-ls", "!lexical", "..."],
     },
     "Elixir": {
-      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "!emmet-language-server", "..."],
+      "language_servers": ["elixir-ls", "!dexter", "!expert", "!next-ls", "!lexical", "!emmet-language-server", "..."],
     },
     "Elm": {
       "tab_size": 4,
@@ -2110,7 +2110,7 @@
       },
     },
     "HEEx": {
-      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!dexter", "!expert", "!next-ls", "!lexical", "..."],
     },
     "HTML": {
       "prettier": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2081,10 +2081,10 @@
       "ensure_final_newline_on_save": false,
     },
     "EEx": {
-      "language_servers": ["elixir-ls", "!dexter", "!expert", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "..."],
     },
     "Elixir": {
-      "language_servers": ["elixir-ls", "!dexter", "!expert", "!next-ls", "!lexical", "!emmet-language-server", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "!emmet-language-server", "..."],
     },
     "Elm": {
       "tab_size": 4,
@@ -2110,7 +2110,7 @@
       },
     },
     "HEEx": {
-      "language_servers": ["elixir-ls", "!dexter", "!expert", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "..."],
     },
     "HTML": {
       "prettier": {

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -27,57 +27,6 @@ Some of the language servers can also accept initialization or workspace configu
 
 Visit the [Configuring Zed](../configuring-zed.md#settings-files) guide for more information on how to edit your settings file.
 
-### Using Dexter
-
-[Dexter](https://github.com/remoteoss/dexter) is a fast, full-featured Elixir language server optimized for large codebases. It works by parsing source files directly, no compilation required. Supports go-to-definition, references, hover docs, autocompletion, rename, and format on save.
-
-Enable Dexter by adding the following to your settings file:
-
-```json [settings]
-  "languages": {
-    "Elixir": {
-      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
-    },
-    "EEx": {
-      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
-    },
-    "HEEx": {
-      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
-    }
-  }
-```
-
-The Dexter binary will be downloaded automatically on first use. If you already have Dexter installed (e.g. via [mise](https://mise.jdx.dev/)), the extension will use your local binary from PATH instead.
-
-Dexter can accept initialization options.
-
-The following example disables following `defdelegate` to the target function:
-
-```json [settings]
-  "lsp": {
-    "dexter": {
-      "initialization_options": {
-        "followDelegates": false
-      }
-    }
-  }
-```
-
-To use a custom Dexter binary, add the following to your settings file:
-
-```json [settings]
-  "lsp": {
-    "dexter": {
-      "binary": {
-        "path": "/path/to/dexter",
-        "arguments": ["lsp"]
-      }
-    }
-  }
-```
-
-See the [Dexter documentation](https://github.com/remoteoss/dexter) for more details.
-
 ### Using ElixirLS
 
 ElixirLS can accept workspace configuration options.
@@ -144,6 +93,55 @@ To use a custom Expert build, add the following to your settings file:
     }
   }
 ```
+
+### Using Dexter
+
+[Dexter](https://github.com/remoteoss/dexter) is a fast, full-featured Elixir language server optimized for large codebases. It works by parsing source files directly, no compilation required. Supports go-to-definition, references, hover docs, autocompletion, rename, and format on save.
+
+Enable Dexter by adding the following to your settings file:
+
+```json [settings]
+  "languages": {
+    "Elixir": {
+      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    },
+    "EEx": {
+      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    },
+    "HEEx": {
+      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    }
+  }
+```
+
+Dexter can accept initialization options.
+
+The following example disables following `defdelegate` to the target function:
+
+```json [settings]
+  "lsp": {
+    "dexter": {
+      "initialization_options": {
+        "followDelegates": false
+      }
+    }
+  }
+```
+
+To use a custom Dexter binary, add the following to your settings file:
+
+```json [settings]
+  "lsp": {
+    "dexter": {
+      "binary": {
+        "path": "/path/to/dexter",
+        "arguments": ["lsp"]
+      }
+    }
+  }
+```
+
+See the [Dexter documentation](https://github.com/remoteoss/dexter) for more details.
 
 ### Using Next LS
 

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -52,13 +52,13 @@ Enable Expert by adding the following to your settings file:
 ```json [settings]
   "languages": {
     "Elixir": {
-      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": ["expert", "!elixir-ls", "!dexter", "!next-ls", "!lexical", "..."]
     },
     "EEx": {
-      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": ["expert", "!elixir-ls", "!dexter", "!next-ls", "!lexical", "..."]
     },
     "HEEx": {
-      "language_servers": ["expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": ["expert", "!elixir-ls", "!dexter", "!next-ls", "!lexical", "..."]
     }
   }
 ```
@@ -150,13 +150,13 @@ Enable Next LS by adding the following to your settings file:
 ```json [settings]
   "languages": {
     "Elixir": {
-      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
+      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!dexter", "!lexical", "..."]
     },
     "EEx": {
-      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
+      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!dexter", "!lexical", "..."]
     },
     "HEEx": {
-      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!lexical", "..."]
+      "language_servers": ["next-ls", "!expert", "!elixir-ls", "!dexter", "!lexical", "..."]
     }
   }
 ```
@@ -220,13 +220,13 @@ Enable Lexical by adding the following to your settings file:
 ```json [settings]
   "languages": {
     "Elixir": {
-      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
+      "language_servers": ["lexical", "!expert", "!elixir-ls", "!dexter", "!next-ls", "..."]
     },
     "EEx": {
-      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
+      "language_servers": ["lexical", "!expert", "!elixir-ls", "!dexter", "!next-ls", "..."]
     },
     "HEEx": {
-      "language_servers": ["lexical", "!expert", "!elixir-ls", "!next-ls", "..."]
+      "language_servers": ["lexical", "!expert", "!elixir-ls", "!dexter", "!next-ls", "..."]
     }
   }
 ```

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -15,16 +15,63 @@ Elixir support is available through the [Elixir extension](https://github.com/ze
   - [elixir-lsp/elixir-ls](https://github.com/elixir-lsp/elixir-ls)
   - [elixir-tools/next-ls](https://github.com/elixir-tools/next-ls)
   - [lexical-lsp/lexical](https://github.com/lexical-lsp/lexical)
+  - [remoteoss/dexter](https://github.com/remoteoss/dexter)
 
 Furthermore, the extension provides support for [EEx](https://hexdocs.pm/eex/EEx.html) (Embedded Elixir) templates and [HEEx](https://hexdocs.pm/phoenix/components.html#heex) templates, a mix of HTML and EEx used by Phoenix LiveView applications.
 
 ## Language Servers
 
-The Elixir extension offers language server support for ElixirLS, Expert, Next LS, and Lexical. By default, only ElixirLS is enabled. You can change or disable the enabled language servers in your settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx or directly within your settings file.
+The Elixir extension offers language server support for Dexter, ElixirLS, Expert, Next LS, and Lexical. By default, only ElixirLS is enabled. You can change or disable the enabled language servers in your settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx or directly within your settings file.
 
 Some of the language servers can also accept initialization or workspace configuration options. See the sections below for an outline of what each server supports. The configuration can be passed in your settings file via `lsp.{language-server-id}.initialization_options` and `lsp.{language-server-id}.settings` respectively.
 
 Visit the [Configuring Zed](../configuring-zed.md#settings-files) guide for more information on how to edit your settings file.
+
+### Using Dexter
+
+[Dexter](https://github.com/remoteoss/dexter) is a fast, full-featured Elixir language server optimized for large codebases. It works by parsing source files directly, no compilation required. Supports go-to-definition, references, hover docs, autocompletion, rename, and format on save.
+
+Enable Dexter by adding the following to your settings file:
+
+```json [settings]
+  "languages": {
+    "Elixir": {
+      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    },
+    "HEEx": {
+      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    }
+  }
+```
+
+The Dexter binary will be downloaded automatically on first use. If you already have Dexter installed (e.g. via [mise](https://mise.jdx.dev/)), the extension will use your local binary from PATH instead.
+
+Dexter can accept initialization options. The following example disables following `defdelegate` to the target function:
+
+```json [settings]
+  "lsp": {
+    "dexter": {
+      "initialization_options": {
+        "followDelegates": false
+      }
+    }
+  }
+```
+
+To use a custom Dexter binary, add the following to your settings file:
+
+```json [settings]
+  "lsp": {
+    "dexter": {
+      "binary": {
+        "path": "/path/to/dexter",
+        "arguments": ["lsp"]
+      }
+    }
+  }
+```
+
+See the [Dexter documentation](https://github.com/remoteoss/dexter) for more details.
 
 ### Using ElixirLS
 

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -38,6 +38,9 @@ Enable Dexter by adding the following to your settings file:
     "Elixir": {
       "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
     },
+    "EEx": {
+      "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
+    },
     "HEEx": {
       "language_servers": ["dexter", "!expert", "!elixir-ls", "!next-ls", "!lexical", "..."]
     }

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -21,7 +21,7 @@ Furthermore, the extension provides support for [EEx](https://hexdocs.pm/eex/EEx
 
 ## Language Servers
 
-The Elixir extension offers language server support for Dexter, ElixirLS, Expert, Next LS, and Lexical. By default, only ElixirLS is enabled. You can change or disable the enabled language servers in your settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx or directly within your settings file.
+The Elixir extension offers language server support for ElixirLS, Expert, Dexter, Next LS, and Lexical. By default, only ElixirLS is enabled. You can change or disable the enabled language servers in your settings ({#kb zed::OpenSettings}) under Languages > Elixir/EEx/HEEx or directly within your settings file.
 
 Some of the language servers can also accept initialization or workspace configuration options. See the sections below for an outline of what each server supports. The configuration can be passed in your settings file via `lsp.{language-server-id}.initialization_options` and `lsp.{language-server-id}.settings` respectively.
 
@@ -49,7 +49,9 @@ Enable Dexter by adding the following to your settings file:
 
 The Dexter binary will be downloaded automatically on first use. If you already have Dexter installed (e.g. via [mise](https://mise.jdx.dev/)), the extension will use your local binary from PATH instead.
 
-Dexter can accept initialization options. The following example disables following `defdelegate` to the target function:
+Dexter can accept initialization options.
+
+The following example disables following `defdelegate` to the target function:
 
 ```json [settings]
   "lsp": {


### PR DESCRIPTION
### Docs update.

  - adding 'what is Dexter' one-liner
  - adding config examples

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [~] Unsafe blocks (if any) have justifying comments
- [~] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [~] Tests cover the new/changed behavior
- [~] Performance impact has been considered and is acceptable

✅  Elixir LS update - [PR](https://github.com/zed-extensions/elixir/pull/115) merged

Release Notes:
- N/A
