### PR TITLE
toolbar: Allow height adjustment

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -460,6 +460,8 @@
     "agent_review": true,
     // Whether to show code action buttons in the editor toolbar.
     "code_actions": false,
+    // Height of the editor toolbar row in pixels
+    "height": 32,
   },
   // Whether to allow windows to tab together based on the user’s tabbing preference (macOS only).
   "use_system_window_tabs": false,

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -50,7 +50,7 @@ impl Render for Breadcrumbs {
         let element = h_flex()
             .id("breadcrumb-container")
             .flex_grow()
-            .h_8()
+            .h_full()
             .overflow_x_scroll()
             .text_ui(cx);
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -83,6 +83,7 @@ pub struct Toolbar {
     pub selections_menu: bool,
     pub agent_review: bool,
     pub code_actions: bool,
+    pub height: u32,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -211,6 +212,7 @@ impl Settings for EditorSettings {
                 selections_menu: toolbar.selections_menu.unwrap(),
                 agent_review: toolbar.agent_review.unwrap(),
                 code_actions: toolbar.code_actions.unwrap(),
+                height: toolbar.height.unwrap_or(32).max(1),
             },
             scrollbar: Scrollbar {
                 show: scrollbar.show.map(ui_scrollbar_settings_from_raw).unwrap(),

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -322,6 +322,10 @@ pub struct ToolbarContent {
     ///
     /// Default: false
     pub code_actions: Option<bool>,
+    /// Height of the editor toolbar row in pixels
+    ///
+    /// Default: 32
+    pub height: Option<u32>,
 }
 
 /// Scrollbar related settings

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2354,7 +2354,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn toolbar_section() -> [SettingsPageItem; 6] {
+    fn toolbar_section() -> [SettingsPageItem; 7] {
         [
             SettingsPageItem::SectionHeader("Toolbar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -2472,6 +2472,25 @@ fn editor_page() -> SettingsPage {
                             .toolbar
                             .get_or_insert_default()
                             .code_actions = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Height",
+                description: "Height of the editor toolbar row in pixels",
+                field: Box::new(SettingField {
+                    json_path: Some("toolbar.height"),
+                    pick: |settings_content| {
+                        settings_content.editor.toolbar.as_ref()?.height.as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .editor
+                            .toolbar
+                            .get_or_insert_default()
+                            .height = value;
                     },
                 }),
                 metadata: None,

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -1,9 +1,10 @@
-use crate::ItemHandle;
+use crate::{EditorToolbarSettings, ItemHandle};
 use gpui::{
     AnyView, App, Context, Div, Entity, EntityId, EventEmitter, Global, KeyContext,
     ParentElement as _, Render, Styled, Window,
 };
 use language::LanguageRegistry;
+use settings::Settings;
 use std::sync::Arc;
 use ui::prelude::*;
 use ui::{h_flex, v_flex};
@@ -117,6 +118,8 @@ impl Render for Toolbar {
         let has_left_items = self.left_items().count() > 0;
         let has_right_items = self.right_items().count() > 0;
 
+        let toolbar_height = px(EditorToolbarSettings::get_global(cx).height as f32);
+
         v_flex()
             .group("toolbar")
             .relative()
@@ -131,14 +134,16 @@ impl Render for Toolbar {
             .when(has_left_items || has_right_items, |this| {
                 this.child(
                     h_flex()
-                        .items_start()
+                        .items_center()
+                        .h(toolbar_height)
                         .justify_between()
                         .gap(DynamicSpacing::Base08.rems(cx))
                         .when(has_left_items, |this| {
                             this.child(
                                 h_flex()
-                                    .min_h_8()
+                                    .h_full()
                                     .flex_auto()
+                                    .items_center()
                                     .justify_start()
                                     .overflow_x_hidden()
                                     .children(self.left_items().map(|item| item.to_any())),
@@ -147,9 +152,10 @@ impl Render for Toolbar {
                         .when(has_right_items, |this| {
                             this.child(
                                 h_flex()
-                                    .h_8()
+                                    .h_full()
                                     .flex_row_reverse()
                                     .when(has_left_items, |this| this.flex_none())
+                                    .items_center()
                                     .justify_end()
                                     .children(self.right_items().map(|item| item.to_any())),
                             )

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -149,8 +149,8 @@ use util::{
 };
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, FocusFollowsMouse, RestoreOnStartupBehavior,
-    StatusBarSettings, TabBarSettings, WorkspaceSettings,
+    AutosaveSetting, BottomDockLayout, EditorToolbarSettings, FocusFollowsMouse,
+    RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings, WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -72,6 +72,11 @@ pub struct TabBarSettings {
     pub show_pinned_tabs_in_separate_row: bool,
 }
 
+#[derive(Deserialize, RegisterSetting)]
+pub struct EditorToolbarSettings {
+    pub height: u32,
+}
+
 impl Settings for WorkspaceSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let workspace = &content.workspace;
@@ -149,6 +154,14 @@ impl Settings for TabBarSettings {
             show_tab_bar_buttons: tab_bar.show_tab_bar_buttons.unwrap(),
             show_pinned_tabs_in_separate_row: tab_bar.show_pinned_tabs_in_separate_row.unwrap(),
         }
+    }
+}
+
+impl Settings for EditorToolbarSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let toolbar = content.editor.toolbar.as_ref().unwrap();
+        let height = toolbar.height.unwrap_or(32).max(1);
+        Self { height }
     }
 }
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added option to adjust the editor's toolbar height

---

This PR adds a setting that allows the user to configure the height of the editor toolbar. Doing so allows users to recycle some space occupied by the toolbar. Smaller toolbars, especially on smaller screens, appear more aesthetically pleasing and make way for slightly more code to be displayed.

The toolbar style is migrated from `h_8()` -> `h(<settings value>)`. Child items of the toolbar are made to fit snuggly with a combination of height expansion (via `h_full()`) and positioning (via `items_center()`).

I have been successfully test-driving this change for several weeks. 

Disclaimer: I used GPT-5.3-Codex for the first version, then tried to adjust it to match the existing code style more closely.