### PR TITLE
Add auto-compaction for agent context window

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use acp_thread::{
     AgentConnection, AgentModelGroupName, AgentModelList, PermissionOptions, ThreadStatus,
-    UserMessageId,
+    TokenUsageRatio, UserMessageId,
 };
 use agent_client_protocol::{self as acp};
 use agent_settings::AgentProfileId;
@@ -4449,6 +4449,89 @@ async fn test_tokens_before_message_after_truncate(cx: &mut TestAppContext) {
             thread.tokens_before_message(&message_1_id),
             None,
             "First message still has no tokens before it"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_auto_compact_on_token_warning(cx: &mut TestAppContext) {
+    init_test(cx);
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let summary_model = Arc::new(FakeLanguageModel::default());
+    thread.update(cx, |thread, cx| {
+        thread.set_summarization_model(Some(summary_model.clone()), cx)
+    });
+
+    let long_content: String = "This is a test message. ".repeat(100_000);
+    let msg_1_id = UserMessageId::new();
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(msg_1_id.clone(), [long_content.as_str()], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+    fake_model.send_last_completion_stream_text_chunk("Response 1");
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::UsageUpdate(
+        language_model::TokenUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let msg_2_id = UserMessageId::new();
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(msg_2_id.clone(), ["Message 2"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+    fake_model.send_last_completion_stream_text_chunk("Response 2");
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::UsageUpdate(
+        language_model::TokenUsage {
+            input_tokens: 190_000,
+            output_tokens: 50_000,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    summary_model.send_next_completion_stream_text_chunk(
+        "<analysis>Test analysis</analysis>\n<summary>\nPrimary Request: Testing auto-compaction\nKey Technical Concepts: context window management\nFiles: none\nErrors: none\nProblem Solving: verified compaction works\nUser Messages: Message 1, Message 2\nPending Tasks: none\nCurrent Work: testing\nNext Step: continue\n</summary>",
+    );
+    summary_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    thread.read_with(cx, |thread, _| {
+        assert_eq!(
+            thread.compaction_count(),
+            1,
+            "compaction_count should be 1, got {}",
+            thread.compaction_count()
+        );
+        assert_eq!(
+            thread.consecutive_compaction_failures(),
+            0,
+            "consecutive_compaction_failures should be 0"
+        );
+        assert!(
+            thread
+                .messages()
+                .iter()
+                .any(|m| matches!(m, Message::System(s) if s.content.contains("compacted"))),
+            "messages should contain compact boundary system message"
+        );
+        assert!(
+            thread.messages().len() >= 3,
+            "messages should have boundary + summary + recent messages. Got {}",
+            thread.messages().len()
         );
     });
 }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -38,8 +38,8 @@ use language_model::{
     LanguageModelId, LanguageModelImage, LanguageModelProviderId, LanguageModelRegistry,
     LanguageModelRequest, LanguageModelRequestMessage, LanguageModelRequestTool,
     LanguageModelToolResult, LanguageModelToolResultContent, LanguageModelToolSchemaFormat,
-    LanguageModelToolUse, LanguageModelToolUseId, Role, SelectedModel, Speed, StopReason,
-    TokenUsage, ZED_CLOUD_PROVIDER_ID,
+    LanguageModelToolUse, LanguageModelToolUseId, MessageContent, Role, SelectedModel, Speed,
+    StopReason, TokenUsage, ZED_CLOUD_PROVIDER_ID,
 };
 use project::Project;
 use prompt_store::ProjectContext;
@@ -63,6 +63,11 @@ use uuid::Uuid;
 const TOOL_CANCELED_MESSAGE: &str = "Tool canceled by user";
 pub const MAX_TOOL_NAME_LENGTH: usize = 64;
 pub const MAX_SUBAGENT_DEPTH: u8 = 1;
+
+const COMPACTION_AUTOCOMPACT_BUFFER_TOKENS: u64 = 13_000;
+const COMPACTION_MAX_OUTPUT_TOKENS_FOR_SUMMARY: u64 = 20_000;
+const COMPACTION_MAX_CONSECUTIVE_FAILURES: u32 = 3;
+const COMPACTION_KEEP_RECENT_TOKENS: u64 = 20_000;
 
 /// Returned when a turn is attempted but no language model has been selected.
 #[derive(Debug)]
@@ -124,6 +129,19 @@ pub enum Message {
     User(UserMessage),
     Agent(AgentMessage),
     Resume,
+    System(SystemMessage),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemMessage {
+    pub content: SharedString,
+    pub compact_metadata: Option<CompactMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompactMetadata {
+    pub trigger: CompactTrigger,
+    pub pre_tokens: u64,
 }
 
 impl Message {
@@ -150,6 +168,12 @@ impl Message {
                 cache: false,
                 reasoning_details: None,
             }],
+            Message::System(message) => vec![LanguageModelRequestMessage {
+                role: Role::System,
+                content: vec![MessageContent::Text(message.content.to_string())],
+                cache: false,
+                reasoning_details: None,
+            }],
         }
     }
 
@@ -158,6 +182,9 @@ impl Message {
             Message::User(message) => message.to_markdown(),
             Message::Agent(message) => message.to_markdown(),
             Message::Resume => "[resume]\n".into(),
+            Message::System(message) => {
+                format!("[system: {}]\n", message.content)
+            }
         }
     }
 
@@ -165,6 +192,7 @@ impl Message {
         match self {
             Message::User(_) | Message::Resume => Role::User,
             Message::Agent(_) => Role::Assistant,
+            Message::System(_) => Role::System,
         }
     }
 }
@@ -933,6 +961,12 @@ enum CompletionError {
     Other(#[from] anyhow::Error),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompactTrigger {
+    Manual,
+    Auto,
+}
+
 pub struct Thread {
     id: acp::SessionId,
     prompt_id: PromptId,
@@ -979,6 +1013,33 @@ pub struct Thread {
     ui_scroll_position: Option<gpui::ListOffset>,
     /// Weak references to running subagent threads for cancellation propagation
     running_subagents: Vec<WeakEntity<Thread>>,
+    /// LLM-generated summary of the conversation context, used to replace old messages
+    /// when the context window nears capacity. Prepended to each completion request.
+    context_summary: Option<SharedString>,
+    /// Number of times this thread has been auto-compacted.
+    compaction_count: u32,
+    /// Consecutive auto-compaction failures (circuit breaker).
+    consecutive_compaction_failures: u32,
+    /// Cumulative input tokens across all requests in this thread.
+    #[allow(unused)]
+    cumulative_input_tokens: u64,
+    /// Pending compaction task (prevents concurrent compactions).
+    pending_compaction: Option<Task<()>>,
+    /// Messages kept during compaction (applied atomically on success).
+    compaction_kept_messages: Vec<Message>,
+}
+
+#[cfg(test)]
+impl Thread {
+    pub(crate) fn compaction_count(&self) -> u32 {
+        self.compaction_count
+    }
+    pub(crate) fn consecutive_compaction_failures(&self) -> u32 {
+        self.consecutive_compaction_failures
+    }
+    pub(crate) fn messages(&self) -> &[Message] {
+        &self.messages
+    }
 }
 
 impl Thread {
@@ -1072,6 +1133,12 @@ impl Thread {
             running_turn: None,
             has_queued_message: false,
             pending_message: None,
+            context_summary: None,
+            compaction_count: 0,
+            consecutive_compaction_failures: 0,
+            cumulative_input_tokens: 0,
+            pending_compaction: None,
+            compaction_kept_messages: Vec::new(),
             tools: BTreeMap::default(),
             request_token_usage: HashMap::default(),
             cumulative_token_usage: TokenUsage::default(),
@@ -1153,6 +1220,7 @@ impl Thread {
                     }
                 }
                 Message::Resume => {}
+                Message::System(_) => {}
             }
         }
         rx
@@ -1305,6 +1373,12 @@ impl Thread {
             running_turn: None,
             has_queued_message: false,
             pending_message: None,
+            context_summary: None,
+            compaction_count: 0,
+            consecutive_compaction_failures: 0,
+            cumulative_input_tokens: 0,
+            pending_compaction: None,
+            compaction_kept_messages: Vec::new(),
             tools: BTreeMap::default(),
             request_token_usage: db_thread.request_token_usage.clone(),
             cumulative_token_usage: db_thread.cumulative_token_usage,
@@ -1650,8 +1724,248 @@ impl Thread {
 
         self.request_token_usage
             .insert(last_user_message.id.clone(), update);
-        cx.emit(TokenUsageUpdated(self.latest_token_usage()));
+        self.cumulative_input_tokens = self
+            .cumulative_input_tokens
+            .saturating_add(update.input_tokens);
+
+        let token_usage = self.latest_token_usage();
+        cx.emit(TokenUsageUpdated(token_usage));
         cx.notify();
+    }
+
+    fn effective_context_window(&self) -> Option<u64> {
+        let model = self.model.as_ref()?;
+        let max_tokens = model.max_token_count();
+        let max_output = model.max_output_tokens().unwrap_or(0);
+        let reserved = max_output.min(COMPACTION_MAX_OUTPUT_TOKENS_FOR_SUMMARY);
+        max_tokens.checked_sub(reserved)
+    }
+
+    fn auto_compact_threshold(&self) -> Option<u64> {
+        let effective_window = self.effective_context_window()?;
+        effective_window.checked_sub(COMPACTION_AUTOCOMPACT_BUFFER_TOKENS)
+    }
+
+    fn should_auto_compact(&self) -> bool {
+        if self.consecutive_compaction_failures >= COMPACTION_MAX_CONSECUTIVE_FAILURES {
+            return false;
+        }
+        let threshold = match self.auto_compact_threshold() {
+            Some(t) => t,
+            None => return false,
+        };
+        self.estimate_total_message_tokens() >= threshold
+    }
+
+    fn estimate_total_message_tokens(&self) -> u64 {
+        self.messages
+            .iter()
+            .map(Self::estimate_message_tokens)
+            .sum()
+    }
+
+    fn find_compact_boundary_index(&self) -> Option<usize> {
+        self.messages.iter().position(|msg| {
+            if let Message::System(sys_msg) = msg {
+                if let Some(metadata) = &sys_msg.compact_metadata {
+                    return metadata.trigger == CompactTrigger::Auto
+                        || metadata.trigger == CompactTrigger::Manual;
+                }
+            }
+            false
+        })
+    }
+
+    fn auto_compact(&mut self, cx: &mut Context<Self>) {
+        if self.pending_compaction.is_some() {
+            return;
+        }
+        if !self.should_auto_compact() {
+            return;
+        }
+
+        let model = self.summarization_model.clone();
+        let Some(model) = model else {
+            log::warn!("Auto-compaction: no summarization model available");
+            self.consecutive_compaction_failures += 1;
+            return;
+        };
+
+        let temperature = AgentSettings::temperature_for_model(&model, cx);
+
+        let pre_tokens = self.estimate_total_message_tokens();
+        self.compaction_count += 1;
+        let compaction_count = self.compaction_count;
+
+        let (kept_messages, old_messages): (Vec<Message>, Vec<Message>) = {
+            let boundary_idx = self.find_compact_boundary_index();
+            let messages_to_compact = if let Some(idx) = boundary_idx {
+                &self.messages[idx..]
+            } else {
+                &self.messages[..]
+            };
+
+            let mut total_tokens: u64 = 0;
+            let mut recent_indices: Vec<usize> = Vec::new();
+
+            for (i, msg) in messages_to_compact.iter().enumerate() {
+                let msg_tokens = Self::estimate_message_tokens(msg);
+                if total_tokens + msg_tokens > COMPACTION_KEEP_RECENT_TOKENS {
+                    break;
+                }
+                recent_indices.push(i);
+                total_tokens += msg_tokens;
+            }
+
+            let old_indices: Vec<usize> = (0..messages_to_compact.len())
+                .filter(|i| !recent_indices.contains(i))
+                .collect();
+
+            if old_indices.is_empty() {
+                self.consecutive_compaction_failures += 1;
+                return;
+            }
+
+            let old: Vec<Message> = old_indices
+                .iter()
+                .map(|&i| messages_to_compact[i].clone())
+                .collect();
+
+            let kept: Vec<Message> = recent_indices
+                .iter()
+                .map(|&i| messages_to_compact[i].clone())
+                .collect();
+
+            (kept, old)
+        };
+
+        let task = cx.spawn({
+            let model = model.clone();
+            let old_messages = old_messages;
+            let temperature = temperature.clone();
+            async move |this, cx| {
+                let mut summary_text = String::new();
+
+                let mut request = LanguageModelRequest {
+                    intent: Some(CompletionIntent::ThreadContextSummarization),
+                    temperature,
+                    ..Default::default()
+                };
+
+                for msg in &old_messages {
+                    request.messages.extend(msg.to_request());
+                }
+                request.messages.push(LanguageModelRequestMessage {
+                    role: Role::User,
+                    content: vec![SUMMARIZE_THREAD_DETAILED_PROMPT.into()],
+                    cache: false,
+                    reasoning_details: None,
+                });
+
+                let mut stream = match model.stream_completion(request, cx).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::error!("Auto-compaction: failed to start stream: {}", e);
+                        this.update(cx, |this, _| {
+                            this.pending_compaction = None;
+                            this.consecutive_compaction_failures += 1;
+                        })
+                        .ok();
+                        return;
+                    }
+                };
+                while let Some(event) = stream.next().await {
+                    if let Ok(LanguageModelCompletionEvent::Text(text)) = event {
+                        summary_text.push_str(&text);
+                    }
+                }
+
+                if summary_text.is_empty() {
+                    log::warn!("Auto-compaction: empty summary generated");
+                    this.update(cx, |this, _| {
+                        this.pending_compaction = None;
+                        this.consecutive_compaction_failures += 1;
+                    })
+                    .ok();
+                    return;
+                }
+
+                summary_text = Self::format_compact_summary(&summary_text);
+
+                log::info!(
+                    "Auto-compacted {} messages into summary ({} chars), compaction #{}",
+                    old_messages.len(),
+                    summary_text.len(),
+                    compaction_count
+                );
+
+                this.update(cx, |this, _| {
+                    let boundary = Message::System(SystemMessage {
+                        content: "Conversation compacted".into(),
+                        compact_metadata: Some(CompactMetadata {
+                            trigger: CompactTrigger::Auto,
+                            pre_tokens,
+                        }),
+                    });
+                    let summary_msg = Message::User(UserMessage {
+                        id: UserMessageId::new(),
+                        content: vec![UserMessageContent::Text(summary_text)],
+                    });
+                    let kept = std::mem::take(&mut this.compaction_kept_messages);
+                    if let Some(old_boundary_idx) = this.find_compact_boundary_index() {
+                        this.messages.drain(old_boundary_idx..old_boundary_idx + 2);
+                    }
+                    this.messages.insert(0, boundary);
+                    this.messages.insert(1, summary_msg);
+                    this.messages.extend(kept);
+                    this.consecutive_compaction_failures = 0;
+                    this.pending_compaction = None;
+                })
+                .ok();
+            }
+        });
+        self.pending_compaction = Some(task);
+        self.compaction_kept_messages = kept_messages;
+        for msg in &self.compaction_kept_messages {
+            if let Message::User(user_msg) = msg {
+                self.request_token_usage.remove(&user_msg.id);
+            }
+        }
+    }
+
+    fn estimate_message_tokens(msg: &Message) -> u64 {
+        let text = match msg {
+            Message::User(m) => m.to_markdown(),
+            Message::Agent(m) => m.to_markdown(),
+            Message::Resume => "Continue where you left off".to_string(),
+            Message::System(m) => m.content.to_string(),
+        };
+        (text.len() as u64 / 4).max(1)
+    }
+
+    fn format_compact_summary(summary: &str) -> String {
+        let mut result = summary.to_string();
+
+        result = result.trim().lines().collect::<Vec<_>>().join("\n");
+
+        if result.contains("<analysis>") || result.contains("<summary>") {
+            let analysis_re = regex::Regex::new(r"(?s)<analysis>.*?</analysis>").ok();
+            if let Some(re) = analysis_re {
+                result = re.replace_all(&result, "").to_string();
+            }
+            let summary_re = regex::Regex::new(r"(?s)<summary>\s*(.*?)\s*</summary>").ok();
+            if let Some(re) = summary_re {
+                if let Some(caps) = re.captures(&result) {
+                    let content = caps.get(1).map(|m| m.as_str()).unwrap_or("").trim();
+                    result = format!(
+                        "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\nSummary:\n{}\n\nContinue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary.",
+                        content.trim()
+                    );
+                }
+            }
+        }
+
+        result
     }
 
     pub fn truncate(&mut self, message_id: UserMessageId, cx: &mut Context<Self>) -> Result<()> {
@@ -1670,7 +1984,7 @@ impl Thread {
                 Message::User(message) => {
                     self.request_token_usage.remove(&message.id);
                 }
-                Message::Agent(_) | Message::Resume => {}
+                Message::Agent(_) | Message::Resume | Message::System(_) => {}
             }
         }
         self.clear_summary();
@@ -2058,6 +2372,7 @@ impl Thread {
 
             this.update(cx, |this, cx| {
                 this.flush_pending_message(cx);
+                this.auto_compact(cx);
                 if this.title.is_none() && this.pending_title_generation.is_none() {
                     this.generate_title(cx);
                 }
@@ -2696,6 +3011,7 @@ impl Thread {
     fn clear_summary(&mut self) {
         self.summary = None;
         self.pending_summary_generation = None;
+        self.context_summary = None;
     }
 
     fn last_user_message(&self) -> Option<&UserMessage> {
@@ -2706,6 +3022,7 @@ impl Thread {
                 Message::User(user_message) => Some(user_message),
                 Message::Agent(_) => None,
                 Message::Resume => None,
+                Message::System(_) => None,
             })
     }
 
@@ -2993,6 +3310,7 @@ impl Thread {
             cache: false,
             reasoning_details: None,
         }];
+
         for message in &self.messages {
             messages.extend(message.to_request());
         }
@@ -3018,6 +3336,7 @@ impl Thread {
                 Message::User(_) => markdown.push_str("## User\n\n"),
                 Message::Agent(_) => markdown.push_str("## Assistant\n\n"),
                 Message::Resume => {}
+                Message::System(_) => markdown.push_str("## System\n\n"),
             }
             markdown.push_str(&message.to_markdown());
         }

--- a/crates/agent_settings/src/prompts/summarize_thread_detailed_prompt.txt
+++ b/crates/agent_settings/src/prompts/summarize_thread_detailed_prompt.txt
@@ -1,6 +1,37 @@
-Generate a detailed summary of this conversation. Include:
-1. A brief overview of what was discussed
-2. Key facts or information discovered
-3. Outcomes or conclusions reached
-4. Any action items or next steps if any
-Format it in Markdown with headings and bullet points.
+CRITICAL: Respond with TEXT ONLY. Do not call any tools.
+
+- Do not use Read, Bash, Grep, Glob, Edit, Write, or any other tool.
+- You already have all the context you need in the conversation above.
+- Your entire response must be plain text: an analysis section followed by a summary section.
+
+<analysis>
+Draft your detailed analysis here. Include:
+- What the user was trying to accomplish
+- What approach was taken and why
+- Key technical decisions and their rationale
+- Files examined, modified, or created
+- Errors encountered and how they were resolved
+- Current state of the work
+</analysis>
+
+<summary>
+Generate a detailed summary of the conversation so far. Include ALL of the following sections:
+
+1. **Primary Request and Intent**: Capture all of the user's explicit requests and intents. What problem are they trying to solve?
+
+2. **Key Technical Concepts**: List all important technical concepts, technologies, frameworks, and patterns encountered or used.
+
+3. **Files and Code Sections**: Enumerate specific files and code sections examined, modified, or created. Include file paths and relevant code snippets.
+
+4. **Errors and Fixes**: List all errors that were encountered, and how they were fixed.
+
+5. **Problem Solving**: Document problems solved and any ongoing troubleshooting efforts. What approaches were tried?
+
+6. **All User Messages**: List ALL user messages that were not tool results. These are the actual requests from the user.
+
+7. **Pending Tasks**: Outline any remaining or pending tasks. What still needs to be done?
+
+8. **Current Work**: Describe precisely what was being worked on when the context limit was reached.
+
+9. **Next Step**: List the immediate next step that should be taken to continue the work.
+</summary>


### PR DESCRIPTION
## Self-Review Checklist
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments (N/A)
- [x] The content is consistent with the UI/UX checklist (N/A - no UI changes)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
Release Notes:
- Added auto-compaction for the agent panel that automatically summarizes older messages when context approaches capacity, preventing context window overflow errors.
---
**Summary:** 
When the agent's context window approaches capacity, older conversation messages are automatically summarized using an LLM and inserted back as a boundary marker followed by the condensed summary, preserving the most recent ~20K tokens.