### PR TITLE
Add more harness to the CI scripts

### DIFF
--- a/script/download-wasi-sdk
+++ b/script/download-wasi-sdk
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Check if ./target/wasi-sdk exists
 if [ ! -d "./target/wasi-sdk" ]; then
@@ -49,7 +50,7 @@ if [ ! -d "./target/wasi-sdk" ]; then
     mkdir -p ./target
 
     # Download and extract
-    curl -L "$WASI_SDK_URL" | tar -xz -C ./target
+    curl -fL "$WASI_SDK_URL" | tar -xz -C ./target
 
     # Rename the extracted directory to wasi-sdk
     mv "./target/wasi-sdk-${WASI_SDK_VERSION}.0-${ARCH}-${OS}" "./target/wasi-sdk"

--- a/script/upload-nightly
+++ b/script/upload-nightly
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-bash -euo pipefail
+set -euo pipefail
 source script/lib/blob-store.sh
 
 bucket_name="zed-nightly-host"


### PR DESCRIPTION
Fixes 
<img width="1238" height="520" alt="image" src="https://github.com/user-attachments/assets/5e6c0d93-660f-4d1a-ab8c-c9c269292eaa" />


If a parent script with `-euo pipefail` invokes a script, that does not inherit the `-euo pipefail` option. Fix that by adding the flags to the scripts needed and adjust the curl command to fail too.

Release Notes:

- N/A 
