### PR TITLE
Do not open the sidebar when opening a directory in a new window (#53815)

### DIFF
--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -201,6 +201,62 @@ async fn test_open_new_window_does_not_open_sidebar_on_existing_window(cx: &mut 
 }
 
 #[gpui::test]
+async fn test_open_directory_in_empty_workspace_does_not_open_sidebar(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let app_state = cx.update(AppState::test);
+    let fs = app_state.fs.as_fake();
+    fs.insert_tree(path!("/project"), json!({ "file.txt": "" }))
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [], cx).await;
+    let window = cx.add_window(|window, cx| {
+        let mw = MultiWorkspace::test_new(project, window, cx);
+        // Simulate a blank project that has an untitled editor tab,
+        // so that workspace_windows_for_location finds this window.
+        mw.workspace().update(cx, |workspace, cx| {
+            workspace.active_pane().update(cx, |pane, cx| {
+                let item = cx.new(|cx| item::test::TestItem::new(cx));
+                pane.add_item(Box::new(item), false, false, None, window, cx);
+            });
+        });
+        mw
+    });
+
+    window
+        .read_with(cx, |mw, _cx| {
+            assert!(!mw.sidebar_open(), "sidebar should start closed");
+        })
+        .unwrap();
+
+    // Simulate what open_workspace_for_paths does for an empty workspace:
+    // it downgrades OpenMode::NewWindow to Activate and sets requesting_window.
+    cx.update(|cx| {
+        open_paths(
+            &[PathBuf::from(path!("/project"))],
+            app_state,
+            OpenOptions {
+                requesting_window: Some(window),
+                open_mode: OpenMode::Activate,
+                ..OpenOptions::default()
+            },
+            cx,
+        )
+    })
+    .await
+    .unwrap();
+
+    window
+        .read_with(cx, |mw, _cx| {
+            assert!(
+                !mw.sidebar_open(),
+                "opening a directory in a blank project via the file picker must not open the sidebar",
+            );
+        })
+        .unwrap();
+}
+
+#[gpui::test]
 async fn test_project_group_keys_duplicate_not_added(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.executor());

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9509,7 +9509,13 @@ pub fn open_paths(
         // Fallback for directories: when no flag is specified and no existing
         // workspace matched, add the directory as a new workspace in the
         // active window's MultiWorkspace (instead of opening a new window).
-        if open_options.should_reuse_existing_window() && existing.is_none() {
+        // Skip when requesting_window is already set: the caller (e.g.
+        // open_workspace_for_paths reusing an empty window) already chose the
+        // target window, so we must not open the sidebar as a side-effect.
+        if open_options.should_reuse_existing_window()
+            && existing.is_none()
+            && open_options.requesting_window.is_none()
+        {
             let target_window = cx.update(|cx| {
                 let windows = workspace_windows_for_location(
                     &SerializedWorkspaceLocation::Local,


### PR DESCRIPTION
A cherry-pick of https://github.com/zed-industries/zed/pull/53815

Follow-up to https://github.com/zed-industries/zed/pull/53778

Covers another case when opening a directory via the file picker _from a blank project_

<img width="865" height="539" alt="image"
src="https://github.com/user-attachments/assets/43eb035b-4f0f-4e8c-bfa3-fbcd7b4beb13" />

resulted in

<img width="1072" height="1162" alt="image"
src="https://github.com/user-attachments/assets/59c588b9-8925-41bb-b9fb-e4906c43c723" />

Release Notes:

- Fixed the sidebar opening when a new directory in a new window was opened