### PR TITLE
gpui: Record input-to-frame latency histogram

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7510,6 +7510,7 @@ dependencies = [
  "gpui_shared_string",
  "gpui_util",
  "gpui_web",
+ "hdrhistogram",
  "http_client",
  "image",
  "inventory",
@@ -7988,6 +7989,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8756,6 +8756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "input_latency_ui"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "gpui",
+ "hdrhistogram",
+]
+
+[[package]]
 name = "inspector_ui"
 version = "0.1.0"
 dependencies = [
@@ -22195,6 +22204,7 @@ dependencies = [
  "http_client",
  "image",
  "image_viewer",
+ "input_latency_ui",
  "inspector_ui",
  "install_cli",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -582,6 +582,7 @@ globset = "0.4"
 heapless = "0.9.2"
 handlebars = "4.3"
 heck = "0.5"
+hdrhistogram = "7"
 heed = { version = "0.21.0", features = ["read-txn-no-tls"] }
 hex = "0.4.3"
 human_bytes = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ members = [
     "crates/http_client_tls",
     "crates/icons",
     "crates/image_viewer",
+    "crates/input_latency_ui",
     "crates/inspector_ui",
     "crates/install_cli",
     "crates/journal",
@@ -356,6 +357,7 @@ image_viewer = { path = "crates/image_viewer" }
 edit_prediction_types = { path = "crates/edit_prediction_types" }
 edit_prediction_ui = { path = "crates/edit_prediction_ui" }
 edit_prediction_context = { path = "crates/edit_prediction_context" }
+input_latency_ui = { path = "crates/input_latency_ui" }
 inspector_ui = { path = "crates/inspector_ui" }
 install_cli = { path = "crates/install_cli" }
 journal = { path = "crates/journal" }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -96,6 +96,7 @@ sum_tree.workspace = true
 taffy = "=0.9.0"
 thiserror.workspace = true
 gpui_util.workspace = true
+hdrhistogram.workspace = true
 waker-fn = "1.2.0"
 lyon = "1.0"
 pin-project = "1.1.10"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -38,6 +38,7 @@ screen-capture = [
     "scap",
 ]
 windows-manifest = ["dep:embed-resource"]
+input-latency-histogram = ["dep:hdrhistogram"]
 
 [lib]
 path = "src/gpui.rs"
@@ -96,7 +97,7 @@ sum_tree.workspace = true
 taffy = "=0.9.0"
 thiserror.workspace = true
 gpui_util.workspace = true
-hdrhistogram.workspace = true
+hdrhistogram = { workspace = true, optional = true }
 waker-fn = "1.2.0"
 lyon = "1.0"
 pin-project = "1.1.10"

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -959,11 +959,15 @@ pub struct Window {
     /// Tracks recent input event timestamps to determine if input is arriving at a high rate.
     /// Used to selectively enable VRR optimization only when input rate exceeds 60fps.
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
-    /// Timestamp recorded at the start of dispatch_event; cleared when a frame is presented.
-    /// Used to compute input-to-frame latency.
-    last_input_at: Option<Instant>,
+    /// Timestamp of the first unrendered input event in the current frame; cleared when a frame
+    /// is presented. Captures worst-case latency when multiple events are coalesced per frame.
+    first_input_at: Option<Instant>,
+    /// Count of input events received since the last frame was presented.
+    pending_input_count: u64,
     /// Histogram of input-to-frame latency samples, in nanoseconds.
     input_latency_histogram: Histogram<u64>,
+    /// Histogram of input events coalesced per rendered frame.
+    input_events_per_frame_histogram: Histogram<u64>,
     last_input_modality: InputModality,
     pub(crate) refreshing: bool,
     pub(crate) activation_observers: SubscriberSet<(), AnyObserver>,
@@ -1482,9 +1486,12 @@ impl Window {
             hovered,
             needs_present,
             input_rate_tracker,
-            last_input_at: None,
+            first_input_at: None,
+            pending_input_count: 0,
             input_latency_histogram: Histogram::new(3)
                 .map_err(|e| anyhow!("Failed to create input latency histogram: {e}"))?,
+            input_events_per_frame_histogram: Histogram::new(3)
+                .map_err(|e| anyhow!("Failed to create input events per frame histogram: {e}"))?,
             last_input_modality: InputModality::Mouse,
             refreshing: false,
             activation_observers: SubscriberSet::new(),
@@ -2372,9 +2379,15 @@ impl Window {
     #[profiling::function]
     fn present(&mut self) {
         self.platform_window.draw(&self.rendered_frame.scene);
-        if let Some(input_received_at) = self.last_input_at.take() {
-            let latency_nanos = input_received_at.elapsed().as_nanos() as u64;
+        if let Some(first_input_at) = self.first_input_at.take() {
+            let latency_nanos = first_input_at.elapsed().as_nanos() as u64;
             self.input_latency_histogram.record(latency_nanos).ok();
+        }
+        if self.pending_input_count > 0 {
+            self.input_events_per_frame_histogram
+                .record(self.pending_input_count)
+                .ok();
+            self.pending_input_count = 0;
         }
         self.needs_present.set(false);
         profiling::finish_frame!();
@@ -2446,6 +2459,23 @@ impl Window {
                 "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
                 fraction * 100.0,
             ));
+        }
+
+        let coalesce = &self.input_events_per_frame_histogram;
+        let coalesce_total = coalesce.len();
+        if coalesce_total > 0 {
+            report.push('\n');
+            report.push_str("Events coalesced per frame:\n");
+            for (label, quantile) in percentiles {
+                let value = if *quantile == 0.0 {
+                    coalesce.min()
+                } else if *quantile == 1.0 {
+                    coalesce.max()
+                } else {
+                    coalesce.value_at_quantile(*quantile)
+                };
+                report.push_str(&format!("  {label}: {value:>6} events\n"));
+            }
         }
 
         report
@@ -4197,7 +4227,8 @@ impl Window {
     /// Dispatch a mouse or keyboard event on the window.
     #[profiling::function]
     pub fn dispatch_event(&mut self, event: PlatformInput, cx: &mut App) -> DispatchEventResult {
-        self.last_input_at = Some(Instant::now());
+        self.first_input_at.get_or_insert_with(Instant::now);
+        self.pending_input_count += 1;
         // Track input modality for focus-visible styling and hover suppression.
         // Hover is suppressed during keyboard modality so that keyboard navigation
         // doesn't show hover highlights on the item under the mouse cursor.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2476,6 +2476,27 @@ impl Window {
                 };
                 report.push_str(&format!("  {label}: {value:>6} events\n"));
             }
+
+            report.push('\n');
+            report.push_str("Distribution:\n");
+            let max_count = coalesce.max();
+            for n in 1..=max_count {
+                let count = coalesce
+                    .iter_recorded()
+                    .filter(|value| value.value_iterated_to() == n)
+                    .map(|value| value.count_at_value())
+                    .sum::<u64>();
+                if count == 0 {
+                    continue;
+                }
+                let fraction = count as f64 / coalesce_total as f64;
+                let bar_len = (fraction * bar_width as f64) as usize;
+                let bar = "█".repeat(bar_len);
+                report.push_str(&format!(
+                    "  {n:>6} events: {count:>6} ({:>5.1}%) {bar}\n",
+                    fraction * 100.0,
+                ));
+            }
         }
 
         report

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -20,7 +20,6 @@ use crate::{
     point, prelude::*, px, rems, size, transparent_black,
 };
 use anyhow::{Context as _, Result, anyhow};
-use hdrhistogram::Histogram;
 use collections::{FxHashMap, FxHashSet};
 #[cfg(target_os = "macos")]
 use core_video::pixel_buffer::CVPixelBuffer;
@@ -29,6 +28,7 @@ use futures::FutureExt;
 use futures::channel::oneshot;
 use gpui_util::post_inc;
 use gpui_util::{ResultExt, measure};
+use hdrhistogram::Histogram;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -106,6 +106,7 @@ struct WindowInvalidatorInner {
     pub dirty: bool,
     pub draw_phase: DrawPhase,
     pub dirty_views: FxHashSet<EntityId>,
+    pub update_count: usize,
 }
 
 #[derive(Clone)]
@@ -120,12 +121,14 @@ impl WindowInvalidator {
                 dirty: true,
                 draw_phase: DrawPhase::None,
                 dirty_views: FxHashSet::default(),
+                update_count: 0,
             })),
         }
     }
 
     pub fn invalidate_view(&self, entity: EntityId, cx: &mut App) -> bool {
         let mut inner = self.inner.borrow_mut();
+        inner.update_count += 1;
         inner.dirty_views.insert(entity);
         if inner.draw_phase == DrawPhase::None {
             inner.dirty = true;
@@ -141,11 +144,19 @@ impl WindowInvalidator {
     }
 
     pub fn set_dirty(&self, dirty: bool) {
-        self.inner.borrow_mut().dirty = dirty
+        let mut inner = self.inner.borrow_mut();
+        inner.dirty = dirty;
+        if dirty {
+            inner.update_count += 1;
+        }
     }
 
     pub fn set_phase(&self, phase: DrawPhase) {
         self.inner.borrow_mut().draw_phase = phase
+    }
+
+    pub fn update_count(&self) -> usize {
+        self.inner.borrow().update_count
     }
 
     pub fn take_views(&self) -> FxHashSet<EntityId> {
@@ -959,15 +970,7 @@ pub struct Window {
     /// Tracks recent input event timestamps to determine if input is arriving at a high rate.
     /// Used to selectively enable VRR optimization only when input rate exceeds 60fps.
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
-    /// Timestamp of the first unrendered input event in the current frame; cleared when a frame
-    /// is presented. Captures worst-case latency when multiple events are coalesced per frame.
-    first_input_at: Option<Instant>,
-    /// Count of input events received since the last frame was presented.
-    pending_input_count: u64,
-    /// Histogram of input-to-frame latency samples, in nanoseconds.
-    input_latency_histogram: Histogram<u64>,
-    /// Histogram of input events coalesced per rendered frame.
-    input_events_per_frame_histogram: Histogram<u64>,
+    input_latency_tracker: InputLatencyTracker,
     last_input_modality: InputModality,
     pub(crate) refreshing: bool,
     pub(crate) activation_observers: SubscriberSet<(), AnyObserver>,
@@ -1033,6 +1036,193 @@ impl InputRateTracker {
     fn prune_old_timestamps(&mut self, now: Instant) {
         self.timestamps
             .retain(|&t| now.duration_since(t) <= self.window);
+    }
+}
+
+/// Tracks input-to-frame latency and event coalescing statistics.
+///
+/// Records the time between when the first input event in a frame is dispatched
+/// and when the resulting frame is presented, capturing worst-case latency when
+/// multiple events are coalesced into a single frame.
+struct InputLatencyTracker {
+    /// Timestamp of the first unrendered input event in the current frame;
+    /// cleared when a frame is presented.
+    first_input_at: Option<Instant>,
+    /// Count of input events received since the last frame was presented.
+    pending_input_count: u64,
+    /// Histogram of input-to-frame latency samples, in nanoseconds.
+    latency_histogram: Histogram<u64>,
+    /// Histogram of input events coalesced per rendered frame.
+    events_per_frame_histogram: Histogram<u64>,
+    /// Count of input events that arrived mid-draw and were excluded from
+    /// latency recording because their effects won't appear until the next frame.
+    mid_draw_events_dropped: u64,
+}
+
+impl InputLatencyTracker {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            first_input_at: None,
+            pending_input_count: 0,
+            latency_histogram: Histogram::new(3)
+                .map_err(|e| anyhow!("Failed to create input latency histogram: {e}"))?,
+            events_per_frame_histogram: Histogram::new(3)
+                .map_err(|e| anyhow!("Failed to create events per frame histogram: {e}"))?,
+            mid_draw_events_dropped: 0,
+        })
+    }
+
+    /// Record that an input event was dispatched at the given time.
+    /// Only the first event's timestamp per frame is retained (worst-case latency).
+    fn record_input(&mut self, dispatch_time: Instant) {
+        self.first_input_at.get_or_insert(dispatch_time);
+        self.pending_input_count += 1;
+    }
+
+    /// Record that an input event arrived during a draw phase and was excluded
+    /// from latency tracking.
+    fn record_mid_draw_input(&mut self) {
+        self.mid_draw_events_dropped += 1;
+    }
+
+    /// Record that a frame was presented, flushing pending latency and coalescing samples.
+    fn record_frame_presented(&mut self) {
+        if let Some(first_input_at) = self.first_input_at.take() {
+            let latency_nanos = first_input_at.elapsed().as_nanos() as u64;
+            self.latency_histogram.record(latency_nanos).ok();
+        }
+        if self.pending_input_count > 0 {
+            self.events_per_frame_histogram
+                .record(self.pending_input_count)
+                .ok();
+            self.pending_input_count = 0;
+        }
+    }
+
+    /// Returns a formatted text report of the latency and coalescing histograms.
+    fn format_report(&self) -> String {
+        let histogram = &self.latency_histogram;
+        let total = histogram.len();
+
+        if total == 0 {
+            return "No input latency samples recorded yet.\n\nTry typing or clicking in a buffer first.".to_string();
+        }
+
+        let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
+
+        let mut report = String::new();
+        report.push_str("Input Latency Histogram\n");
+        report.push_str("=======================\n");
+        report.push_str(&format!("Samples: {total}\n"));
+        if self.mid_draw_events_dropped > 0 {
+            report.push_str(&format!(
+                "Mid-draw events excluded: {}\n",
+                self.mid_draw_events_dropped
+            ));
+        }
+        report.push('\n');
+
+        report.push_str("Percentiles:\n");
+        let percentiles: &[(&str, f64)] = &[
+            ("min  ", 0.0),
+            ("p50  ", 0.50),
+            ("p75  ", 0.75),
+            ("p90  ", 0.90),
+            ("p95  ", 0.95),
+            ("p99  ", 0.99),
+            ("p99.9", 0.999),
+            ("max  ", 1.0),
+        ];
+        for (label, quantile) in percentiles {
+            let value_ns = if *quantile == 0.0 {
+                histogram.min()
+            } else if *quantile == 1.0 {
+                histogram.max()
+            } else {
+                histogram.value_at_quantile(*quantile)
+            };
+            let hz = if value_ns > 0 {
+                1_000_000_000.0 / value_ns as f64
+            } else {
+                f64::INFINITY
+            };
+            report.push_str(&format!(
+                "  {label}: {:>8.2}ms  ({:>7.1} Hz)\n",
+                ns_to_ms(value_ns),
+                hz
+            ));
+        }
+
+        report.push('\n');
+        report.push_str("Distribution:\n");
+
+        // Perceptual latency buckets. Upper bounds are exclusive except for the last.
+        let buckets: &[(u64, u64, &str, &str)] = &[
+            (0, 4_000_000, "0\u{2013}4ms", "(excellent)"),
+            (4_000_000, 8_000_000, "4\u{2013}8ms", "(120fps)"),
+            (8_000_000, 16_000_000, "8\u{2013}16ms", "(60fps)"),
+            (16_000_000, 33_000_000, "16\u{2013}33ms", "(30fps)"),
+            (33_000_000, 100_000_000, "33\u{2013}100ms", ""),
+            (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
+        ];
+
+        let bar_width = 30usize;
+        for (low, high, range, note) in buckets {
+            let count: u64 = histogram
+                .iter_recorded()
+                .filter(|value| {
+                    value.value_iterated_to() >= *low && value.value_iterated_to() < *high
+                })
+                .map(|value| value.count_at_value())
+                .sum();
+            let fraction = count as f64 / total as f64;
+            let bar_len = (fraction * bar_width as f64) as usize;
+            let bar = "\u{2588}".repeat(bar_len);
+            report.push_str(&format!(
+                "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
+                fraction * 100.0,
+            ));
+        }
+
+        let coalesce = &self.events_per_frame_histogram;
+        let coalesce_total = coalesce.len();
+        if coalesce_total > 0 {
+            report.push('\n');
+            report.push_str("Events coalesced per frame:\n");
+            for (label, quantile) in percentiles {
+                let value = if *quantile == 0.0 {
+                    coalesce.min()
+                } else if *quantile == 1.0 {
+                    coalesce.max()
+                } else {
+                    coalesce.value_at_quantile(*quantile)
+                };
+                report.push_str(&format!("  {label}: {value:>6} events\n"));
+            }
+
+            report.push('\n');
+            report.push_str("Distribution:\n");
+            let max_count = coalesce.max();
+            for n in 1..=max_count {
+                let count = coalesce
+                    .iter_recorded()
+                    .filter(|value| value.value_iterated_to() == n)
+                    .map(|value| value.count_at_value())
+                    .sum::<u64>();
+                if count == 0 {
+                    continue;
+                }
+                let fraction = count as f64 / coalesce_total as f64;
+                let bar_len = (fraction * bar_width as f64) as usize;
+                let bar = "\u{2588}".repeat(bar_len);
+                report.push_str(&format!(
+                    "  {n:>6} events: {count:>6} ({:>5.1}%) {bar}\n",
+                    fraction * 100.0,
+                ));
+            }
+        }
+
+        report
     }
 }
 
@@ -1486,12 +1676,7 @@ impl Window {
             hovered,
             needs_present,
             input_rate_tracker,
-            first_input_at: None,
-            pending_input_count: 0,
-            input_latency_histogram: Histogram::new(3)
-                .map_err(|e| anyhow!("Failed to create input latency histogram: {e}"))?,
-            input_events_per_frame_histogram: Histogram::new(3)
-                .map_err(|e| anyhow!("Failed to create input events per frame histogram: {e}"))?,
+            input_latency_tracker: InputLatencyTracker::new()?,
             last_input_modality: InputModality::Mouse,
             refreshing: false,
             activation_observers: SubscriberSet::new(),
@@ -2379,127 +2564,14 @@ impl Window {
     #[profiling::function]
     fn present(&mut self) {
         self.platform_window.draw(&self.rendered_frame.scene);
-        if let Some(first_input_at) = self.first_input_at.take() {
-            let latency_nanos = first_input_at.elapsed().as_nanos() as u64;
-            self.input_latency_histogram.record(latency_nanos).ok();
-        }
-        if self.pending_input_count > 0 {
-            self.input_events_per_frame_histogram
-                .record(self.pending_input_count)
-                .ok();
-            self.pending_input_count = 0;
-        }
+        self.input_latency_tracker.record_frame_presented();
         self.needs_present.set(false);
         profiling::finish_frame!();
     }
 
     /// Returns a formatted text report of the input-to-frame latency histogram.
     pub fn format_input_latency_report(&self) -> String {
-        let histogram = &self.input_latency_histogram;
-        let total = histogram.len();
-
-        if total == 0 {
-            return "No input latency samples recorded yet.\n\nTry typing or clicking in a buffer first.".to_string();
-        }
-
-        let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
-
-        let mut report = String::new();
-        report.push_str("Input Latency Histogram\n");
-        report.push_str("=======================\n");
-        report.push_str(&format!("Samples: {total}\n\n"));
-
-        report.push_str("Percentiles:\n");
-        let percentiles: &[(&str, f64)] = &[
-            ("min  ", 0.0),
-            ("p50  ", 0.50),
-            ("p75  ", 0.75),
-            ("p90  ", 0.90),
-            ("p95  ", 0.95),
-            ("p99  ", 0.99),
-            ("p99.9", 0.999),
-            ("max  ", 1.0),
-        ];
-        for (label, quantile) in percentiles {
-            let value_ns = if *quantile == 0.0 {
-                histogram.min()
-            } else if *quantile == 1.0 {
-                histogram.max()
-            } else {
-                histogram.value_at_quantile(*quantile)
-            };
-            report.push_str(&format!("  {label}: {:>8.2}ms\n", ns_to_ms(value_ns)));
-        }
-
-        report.push('\n');
-        report.push_str("Distribution:\n");
-
-        // Perceptual latency buckets. Upper bounds are exclusive except for the last.
-        // range is right-aligned to 8 chars; note is left-aligned to 11 chars.
-        let buckets: &[(u64, u64, &str, &str)] = &[
-            (0, 4_000_000, "0–4ms", "(excellent)"),
-            (4_000_000, 8_000_000, "4–8ms", "(120fps)"),
-            (8_000_000, 16_000_000, "8–16ms", "(60fps)"),
-            (16_000_000, 33_000_000, "16–33ms", "(30fps)"),
-            (33_000_000, 100_000_000, "33–100ms", ""),
-            (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
-        ];
-
-        let bar_width = 30usize;
-        for (low, high, range, note) in buckets {
-            let count: u64 = histogram
-                .iter_recorded()
-                .filter(|value| value.value_iterated_to() >= *low && value.value_iterated_to() < *high)
-                .map(|value| value.count_at_value())
-                .sum();
-            let fraction = count as f64 / total as f64;
-            let bar_len = (fraction * bar_width as f64) as usize;
-            let bar = "█".repeat(bar_len);
-            report.push_str(&format!(
-                "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
-                fraction * 100.0,
-            ));
-        }
-
-        let coalesce = &self.input_events_per_frame_histogram;
-        let coalesce_total = coalesce.len();
-        if coalesce_total > 0 {
-            report.push('\n');
-            report.push_str("Events coalesced per frame:\n");
-            for (label, quantile) in percentiles {
-                let value = if *quantile == 0.0 {
-                    coalesce.min()
-                } else if *quantile == 1.0 {
-                    coalesce.max()
-                } else {
-                    coalesce.value_at_quantile(*quantile)
-                };
-                report.push_str(&format!("  {label}: {value:>6} events\n"));
-            }
-
-            report.push('\n');
-            report.push_str("Distribution:\n");
-            let max_count = coalesce.max();
-            for n in 1..=max_count {
-                let count = coalesce
-                    .iter_recorded()
-                    .filter(|value| value.value_iterated_to() == n)
-                    .map(|value| value.count_at_value())
-                    .sum::<u64>();
-                if count == 0 {
-                    continue;
-                }
-                let fraction = count as f64 / coalesce_total as f64;
-                let bar_len = (fraction * bar_width as f64) as usize;
-                let bar = "█".repeat(bar_len);
-                report.push_str(&format!(
-                    "  {n:>6} events: {count:>6} ({:>5.1}%) {bar}\n",
-                    fraction * 100.0,
-                ));
-            }
-        }
-
-        report
+        self.input_latency_tracker.format_report()
     }
 
     fn draw_roots(&mut self, cx: &mut App) {
@@ -4249,6 +4321,7 @@ impl Window {
     #[profiling::function]
     pub fn dispatch_event(&mut self, event: PlatformInput, cx: &mut App) -> DispatchEventResult {
         let dispatch_time = Instant::now();
+        let update_count_before = self.invalidator.update_count();
         // Track input modality for focus-visible styling and hover suppression.
         // Hover is suppressed during keyboard modality so that keyboard navigation
         // doesn't show hover highlights on the item under the mouse cursor.
@@ -4358,10 +4431,13 @@ impl Window {
             self.dispatch_key_event(any_key_event, cx);
         }
 
-        if self.invalidator.is_dirty() {
+        if self.invalidator.update_count() > update_count_before {
             self.input_rate_tracker.borrow_mut().record_input();
-            self.first_input_at.get_or_insert(dispatch_time);
-            self.pending_input_count += 1;
+            if self.invalidator.not_drawing() {
+                self.input_latency_tracker.record_input(dispatch_time);
+            } else {
+                self.input_latency_tracker.record_mid_draw_input();
+            }
         }
 
         DispatchEventResult {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4248,8 +4248,7 @@ impl Window {
     /// Dispatch a mouse or keyboard event on the window.
     #[profiling::function]
     pub fn dispatch_event(&mut self, event: PlatformInput, cx: &mut App) -> DispatchEventResult {
-        self.first_input_at.get_or_insert_with(Instant::now);
-        self.pending_input_count += 1;
+        let dispatch_time = Instant::now();
         // Track input modality for focus-visible styling and hover suppression.
         // Hover is suppressed during keyboard modality so that keyboard navigation
         // doesn't show hover highlights on the item under the mouse cursor.
@@ -4361,6 +4360,8 @@ impl Window {
 
         if self.invalidator.is_dirty() {
             self.input_rate_tracker.borrow_mut().record_input();
+            self.first_input_at.get_or_insert(dispatch_time);
+            self.pending_input_count += 1;
         }
 
         DispatchEventResult {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -20,6 +20,7 @@ use crate::{
     point, prelude::*, px, rems, size, transparent_black,
 };
 use anyhow::{Context as _, Result, anyhow};
+use hdrhistogram::Histogram;
 use collections::{FxHashMap, FxHashSet};
 #[cfg(target_os = "macos")]
 use core_video::pixel_buffer::CVPixelBuffer;
@@ -958,6 +959,11 @@ pub struct Window {
     /// Tracks recent input event timestamps to determine if input is arriving at a high rate.
     /// Used to selectively enable VRR optimization only when input rate exceeds 60fps.
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
+    /// Timestamp recorded at the start of dispatch_event; cleared when a frame is presented.
+    /// Used to compute input-to-frame latency.
+    last_input_at: Option<Instant>,
+    /// Histogram of input-to-frame latency samples, in nanoseconds.
+    input_latency_histogram: Histogram<u64>,
     last_input_modality: InputModality,
     pub(crate) refreshing: bool,
     pub(crate) activation_observers: SubscriberSet<(), AnyObserver>,
@@ -1476,6 +1482,9 @@ impl Window {
             hovered,
             needs_present,
             input_rate_tracker,
+            last_input_at: None,
+            input_latency_histogram: Histogram::new(3)
+                .map_err(|e| anyhow!("Failed to create input latency histogram: {e}"))?,
             last_input_modality: InputModality::Mouse,
             refreshing: false,
             activation_observers: SubscriberSet::new(),
@@ -2361,10 +2370,85 @@ impl Window {
     }
 
     #[profiling::function]
-    fn present(&self) {
+    fn present(&mut self) {
         self.platform_window.draw(&self.rendered_frame.scene);
+        if let Some(input_received_at) = self.last_input_at.take() {
+            let latency_nanos = input_received_at.elapsed().as_nanos() as u64;
+            self.input_latency_histogram.record(latency_nanos).ok();
+        }
         self.needs_present.set(false);
         profiling::finish_frame!();
+    }
+
+    /// Returns a formatted text report of the input-to-frame latency histogram.
+    pub fn format_input_latency_report(&self) -> String {
+        let histogram = &self.input_latency_histogram;
+        let total = histogram.len();
+
+        if total == 0 {
+            return "No input latency samples recorded yet.\n\nTry typing or clicking in a buffer first.".to_string();
+        }
+
+        let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
+
+        let mut report = String::new();
+        report.push_str("Input Latency Histogram\n");
+        report.push_str("=======================\n");
+        report.push_str(&format!("Samples: {total}\n\n"));
+
+        report.push_str("Percentiles:\n");
+        let percentiles: &[(&str, f64)] = &[
+            ("min  ", 0.0),
+            ("p50  ", 0.50),
+            ("p75  ", 0.75),
+            ("p90  ", 0.90),
+            ("p95  ", 0.95),
+            ("p99  ", 0.99),
+            ("p99.9", 0.999),
+            ("max  ", 1.0),
+        ];
+        for (label, quantile) in percentiles {
+            let value_ns = if *quantile == 0.0 {
+                histogram.min()
+            } else if *quantile == 1.0 {
+                histogram.max()
+            } else {
+                histogram.value_at_quantile(*quantile)
+            };
+            report.push_str(&format!("  {label}: {:>8.2}ms\n", ns_to_ms(value_ns)));
+        }
+
+        report.push('\n');
+        report.push_str("Distribution:\n");
+
+        // Perceptual latency buckets. Upper bounds are exclusive except for the last.
+        let buckets: &[(u64, u64, &str)] = &[
+            (0, 4_000_000, "   0–4ms  (excellent)"),
+            (4_000_000, 8_000_000, "   4–8ms  (120fps)  "),
+            (8_000_000, 16_000_000, "  8–16ms  (60fps)   "),
+            (16_000_000, 33_000_000, " 16–33ms  (30fps)   "),
+            (33_000_000, 100_000_000, "33–100ms            "),
+            (100_000_000, u64::MAX, "   100ms+ (sluggish) "),
+        ];
+
+        let bar_width = 30usize;
+        for (low, high, label) in buckets {
+            let count: u64 = histogram
+                .iter_recorded()
+                .filter(|value| value.value_iterated_to() >= *low && value.value_iterated_to() < *high)
+                .map(|value| value.count_at_value())
+                .sum();
+            let fraction = count as f64 / total as f64;
+            let bar_len = (fraction * bar_width as f64) as usize;
+            let bar = "█".repeat(bar_len);
+            report.push_str(&format!(
+                "  {label}: {:>6} ({:>5.1}%) {bar}\n",
+                count,
+                fraction * 100.0,
+            ));
+        }
+
+        report
     }
 
     fn draw_roots(&mut self, cx: &mut App) {
@@ -4113,6 +4197,7 @@ impl Window {
     /// Dispatch a mouse or keyboard event on the window.
     #[profiling::function]
     pub fn dispatch_event(&mut self, event: PlatformInput, cx: &mut App) -> DispatchEventResult {
+        self.last_input_at = Some(Instant::now());
         // Track input modality for focus-visible styling and hover suppression.
         // Hover is suppressed during keyboard modality so that keyboard navigation
         // doesn't show hover highlights on the item under the mouse cursor.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2422,17 +2422,18 @@ impl Window {
         report.push_str("Distribution:\n");
 
         // Perceptual latency buckets. Upper bounds are exclusive except for the last.
-        let buckets: &[(u64, u64, &str)] = &[
-            (0, 4_000_000, "   0–4ms  (excellent)"),
-            (4_000_000, 8_000_000, "   4–8ms  (120fps)  "),
-            (8_000_000, 16_000_000, "  8–16ms  (60fps)   "),
-            (16_000_000, 33_000_000, " 16–33ms  (30fps)   "),
-            (33_000_000, 100_000_000, "33–100ms            "),
-            (100_000_000, u64::MAX, "   100ms+ (sluggish) "),
+        // range is right-aligned to 8 chars; note is left-aligned to 11 chars.
+        let buckets: &[(u64, u64, &str, &str)] = &[
+            (0, 4_000_000, "0–4ms", "(excellent)"),
+            (4_000_000, 8_000_000, "4–8ms", "(120fps)"),
+            (8_000_000, 16_000_000, "8–16ms", "(60fps)"),
+            (16_000_000, 33_000_000, "16–33ms", "(30fps)"),
+            (33_000_000, 100_000_000, "33–100ms", ""),
+            (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
         ];
 
         let bar_width = 30usize;
-        for (low, high, label) in buckets {
+        for (low, high, range, note) in buckets {
             let count: u64 = histogram
                 .iter_recorded()
                 .filter(|value| value.value_iterated_to() >= *low && value.value_iterated_to() < *high)
@@ -2442,8 +2443,7 @@ impl Window {
             let bar_len = (fraction * bar_width as f64) as usize;
             let bar = "█".repeat(bar_len);
             report.push_str(&format!(
-                "  {label}: {:>6} ({:>5.1}%) {bar}\n",
-                count,
+                "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
                 fraction * 100.0,
             ));
         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1113,6 +1113,9 @@ impl InputLatencyTracker {
         let mut report = String::new();
         report.push_str("Input Latency Histogram\n");
         report.push_str("=======================\n");
+
+        let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
+        report.push_str(&format!("Timestamp: {timestamp}\n"));
         report.push_str(&format!("Samples: {total}\n"));
         if self.mid_draw_events_dropped > 0 {
             report.push_str(&format!(

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1041,8 +1041,19 @@ impl InputRateTracker {
     }
 }
 
-/// Tracks input-to-frame latency and event coalescing statistics.
-///
+/// A point-in-time snapshot of the input-latency histograms for a window,
+/// suitable for external formatting.
+#[cfg(feature = "input-latency-histogram")]
+pub struct InputLatencySnapshot {
+    /// Histogram of input-to-frame latency samples, in nanoseconds.
+    pub latency_histogram: Histogram<u64>,
+    /// Histogram of input events coalesced per rendered frame.
+    pub events_per_frame_histogram: Histogram<u64>,
+    /// Count of input events that arrived mid-draw and were excluded from
+    /// latency recording.
+    pub mid_draw_events_dropped: u64,
+}
+
 /// Records the time between when the first input event in a frame is dispatched
 /// and when the resulting frame is presented, capturing worst-case latency when
 /// multiple events are coalesced into a single frame.
@@ -1060,12 +1071,6 @@ struct InputLatencyTracker {
     /// Count of input events that arrived mid-draw and were excluded from
     /// latency recording because their effects won't appear until the next frame.
     mid_draw_events_dropped: u64,
-    /// Snapshot of `latency_histogram` at the time of the last report.
-    previous_latency_histogram: Option<Histogram<u64>>,
-    /// Snapshot of `events_per_frame_histogram` at the time of the last report.
-    previous_events_per_frame_histogram: Option<Histogram<u64>>,
-    /// Timestamp of the last report.
-    previous_report_timestamp: Option<chrono::DateTime<chrono::Local>>,
 }
 
 #[cfg(feature = "input-latency-histogram")]
@@ -1079,9 +1084,6 @@ impl InputLatencyTracker {
             events_per_frame_histogram: Histogram::new(3)
                 .map_err(|e| anyhow!("Failed to create events per frame histogram: {e}"))?,
             mid_draw_events_dropped: 0,
-            previous_latency_histogram: None,
-            previous_events_per_frame_histogram: None,
-            previous_report_timestamp: None,
         })
     }
 
@@ -1112,197 +1114,12 @@ impl InputLatencyTracker {
         }
     }
 
-    /// Returns a formatted text report of the latency and coalescing histograms.
-    /// Also saves a snapshot of the current histograms so the next report can
-    /// show a delta.
-    fn format_report(&mut self) -> String {
-        let histogram = &self.latency_histogram;
-        let total = histogram.len();
-
-        if total == 0 {
-            return "No input latency samples recorded yet.\n\nTry typing or clicking in a buffer first.".to_string();
+    fn snapshot(&self) -> InputLatencySnapshot {
+        InputLatencySnapshot {
+            latency_histogram: self.latency_histogram.clone(),
+            events_per_frame_histogram: self.events_per_frame_histogram.clone(),
+            mid_draw_events_dropped: self.mid_draw_events_dropped,
         }
-
-        let percentiles: &[(&str, f64)] = &[
-            ("min  ", 0.0),
-            ("p50  ", 0.50),
-            ("p75  ", 0.75),
-            ("p90  ", 0.90),
-            ("p95  ", 0.95),
-            ("p99  ", 0.99),
-            ("p99.9", 0.999),
-            ("max  ", 1.0),
-        ];
-
-        let now = chrono::Local::now();
-
-        let mut report = String::new();
-        report.push_str("Input Latency Histogram\n");
-        report.push_str("=======================\n");
-
-        let timestamp = now.format("%Y-%m-%d %H:%M:%S %Z");
-        report.push_str(&format!("Timestamp: {timestamp}\n"));
-        report.push_str(&format!("Samples: {total}\n"));
-        if self.mid_draw_events_dropped > 0 {
-            report.push_str(&format!(
-                "Mid-draw events excluded: {}\n",
-                self.mid_draw_events_dropped
-            ));
-        }
-
-        write_latency_percentiles(&mut report, "Percentiles", histogram, percentiles);
-        write_latency_distribution(&mut report, "Distribution", histogram);
-
-        let coalesce = &self.events_per_frame_histogram;
-        let coalesce_total = coalesce.len();
-        if coalesce_total > 0 {
-            report.push('\n');
-            report.push_str("Events coalesced per frame:\n");
-            for (label, quantile) in percentiles {
-                let value = if *quantile == 0.0 {
-                    coalesce.min()
-                } else if *quantile == 1.0 {
-                    coalesce.max()
-                } else {
-                    coalesce.value_at_quantile(*quantile)
-                };
-                report.push_str(&format!("  {label}: {value:>6} events\n"));
-            }
-
-            report.push('\n');
-            report.push_str("Distribution:\n");
-            let bar_width = 30usize;
-            let max_count = coalesce.max();
-            for n in 1..=max_count {
-                let count = coalesce
-                    .iter_recorded()
-                    .filter(|value| value.value_iterated_to() == n)
-                    .map(|value| value.count_at_value())
-                    .sum::<u64>();
-                if count == 0 {
-                    continue;
-                }
-                let fraction = count as f64 / coalesce_total as f64;
-                let bar_len = (fraction * bar_width as f64) as usize;
-                let bar = "\u{2588}".repeat(bar_len);
-                report.push_str(&format!(
-                    "  {n:>6} events: {count:>6} ({:>5.1}%) {bar}\n",
-                    fraction * 100.0,
-                ));
-            }
-        }
-
-        // Delta section: compare against the previous report's snapshot.
-        if let (Some(prev_latency), Some(prev_timestamp)) = (
-            &self.previous_latency_histogram,
-            &self.previous_report_timestamp,
-        ) {
-            let prev_total = prev_latency.len();
-            let delta_total = total - prev_total;
-
-            report.push('\n');
-            report.push_str("Delta Since Last Report\n");
-            report.push_str("-----------------------\n");
-            let prev_ts = prev_timestamp.format("%Y-%m-%d %H:%M:%S %Z");
-            let elapsed_secs = (now - *prev_timestamp).num_seconds().max(0);
-            report.push_str(&format!(
-                "Previous report: {prev_ts} ({elapsed_secs}s ago)\n"
-            ));
-            report.push_str(&format!("New samples: {delta_total}\n"));
-
-            if delta_total > 0 {
-                let mut delta_histogram = histogram.clone();
-                delta_histogram.subtract(prev_latency).ok();
-
-                write_latency_percentiles(
-                    &mut report,
-                    "Percentiles (new samples only)",
-                    &delta_histogram,
-                    percentiles,
-                );
-                write_latency_distribution(
-                    &mut report,
-                    "Distribution (new samples only)",
-                    &delta_histogram,
-                );
-            }
-        }
-
-        // Save snapshots for next report's delta.
-        self.previous_latency_histogram = Some(self.latency_histogram.clone());
-        self.previous_events_per_frame_histogram = Some(self.events_per_frame_histogram.clone());
-        self.previous_report_timestamp = Some(now);
-
-        report
-    }
-}
-
-#[cfg(feature = "input-latency-histogram")]
-fn write_latency_percentiles(
-    report: &mut String,
-    heading: &str,
-    histogram: &Histogram<u64>,
-    percentiles: &[(&str, f64)],
-) {
-    let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
-
-    report.push('\n');
-    report.push_str(heading);
-    report.push_str(":\n");
-    for (label, quantile) in percentiles {
-        let value_ns = if *quantile == 0.0 {
-            histogram.min()
-        } else if *quantile == 1.0 {
-            histogram.max()
-        } else {
-            histogram.value_at_quantile(*quantile)
-        };
-        let hz = if value_ns > 0 {
-            1_000_000_000.0 / value_ns as f64
-        } else {
-            f64::INFINITY
-        };
-        report.push_str(&format!(
-            "  {label}: {:>8.2}ms  ({:>7.1} Hz)\n",
-            ns_to_ms(value_ns),
-            hz
-        ));
-    }
-}
-
-#[cfg(feature = "input-latency-histogram")]
-fn write_latency_distribution(report: &mut String, heading: &str, histogram: &Histogram<u64>) {
-    const BUCKETS: &[(u64, u64, &str, &str)] = &[
-        (0, 4_000_000, "0\u{2013}4ms", "(excellent)"),
-        (4_000_000, 8_000_000, "4\u{2013}8ms", "(120fps)"),
-        (8_000_000, 16_000_000, "8\u{2013}16ms", "(60fps)"),
-        (16_000_000, 33_000_000, "16\u{2013}33ms", "(30fps)"),
-        (33_000_000, 100_000_000, "33\u{2013}100ms", ""),
-        (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
-    ];
-    let bar_width = 30usize;
-    let total = histogram.len() as f64;
-
-    report.push('\n');
-    report.push_str(heading);
-    report.push_str(":\n");
-    for (low, high, range, note) in BUCKETS {
-        let count: u64 = histogram
-            .iter_recorded()
-            .filter(|value| value.value_iterated_to() >= *low && value.value_iterated_to() < *high)
-            .map(|value| value.count_at_value())
-            .sum();
-        let fraction = if total > 0.0 {
-            count as f64 / total
-        } else {
-            0.0
-        };
-        let bar_len = (fraction * bar_width as f64) as usize;
-        let bar = "\u{2588}".repeat(bar_len);
-        report.push_str(&format!(
-            "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
-            fraction * 100.0,
-        ));
     }
 }
 
@@ -2651,12 +2468,10 @@ impl Window {
         profiling::finish_frame!();
     }
 
-    /// Returns a formatted text report of the input-to-frame latency histogram.
-    /// If a previous report was generated, includes a delta section showing
-    /// changes since that report.
+    /// Returns a snapshot of the current input-latency histograms.
     #[cfg(feature = "input-latency-histogram")]
-    pub fn format_input_latency_report(&mut self) -> String {
-        self.input_latency_tracker.format_report()
+    pub fn input_latency_snapshot(&self) -> InputLatencySnapshot {
+        self.input_latency_tracker.snapshot()
     }
 
     fn draw_roots(&mut self, cx: &mut App) {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1057,6 +1057,12 @@ struct InputLatencyTracker {
     /// Count of input events that arrived mid-draw and were excluded from
     /// latency recording because their effects won't appear until the next frame.
     mid_draw_events_dropped: u64,
+    /// Snapshot of `latency_histogram` at the time of the last report.
+    previous_latency_histogram: Option<Histogram<u64>>,
+    /// Snapshot of `events_per_frame_histogram` at the time of the last report.
+    previous_events_per_frame_histogram: Option<Histogram<u64>>,
+    /// Timestamp of the last report.
+    previous_report_timestamp: Option<chrono::DateTime<chrono::Local>>,
 }
 
 impl InputLatencyTracker {
@@ -1069,6 +1075,9 @@ impl InputLatencyTracker {
             events_per_frame_histogram: Histogram::new(3)
                 .map_err(|e| anyhow!("Failed to create events per frame histogram: {e}"))?,
             mid_draw_events_dropped: 0,
+            previous_latency_histogram: None,
+            previous_events_per_frame_histogram: None,
+            previous_report_timestamp: None,
         })
     }
 
@@ -1100,7 +1109,9 @@ impl InputLatencyTracker {
     }
 
     /// Returns a formatted text report of the latency and coalescing histograms.
-    fn format_report(&self) -> String {
+    /// Also saves a snapshot of the current histograms so the next report can
+    /// show a delta.
+    fn format_report(&mut self) -> String {
         let histogram = &self.latency_histogram;
         let total = histogram.len();
 
@@ -1108,24 +1119,6 @@ impl InputLatencyTracker {
             return "No input latency samples recorded yet.\n\nTry typing or clicking in a buffer first.".to_string();
         }
 
-        let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
-
-        let mut report = String::new();
-        report.push_str("Input Latency Histogram\n");
-        report.push_str("=======================\n");
-
-        let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
-        report.push_str(&format!("Timestamp: {timestamp}\n"));
-        report.push_str(&format!("Samples: {total}\n"));
-        if self.mid_draw_events_dropped > 0 {
-            report.push_str(&format!(
-                "Mid-draw events excluded: {}\n",
-                self.mid_draw_events_dropped
-            ));
-        }
-        report.push('\n');
-
-        report.push_str("Percentiles:\n");
         let percentiles: &[(&str, f64)] = &[
             ("min  ", 0.0),
             ("p50  ", 0.50),
@@ -1136,56 +1129,25 @@ impl InputLatencyTracker {
             ("p99.9", 0.999),
             ("max  ", 1.0),
         ];
-        for (label, quantile) in percentiles {
-            let value_ns = if *quantile == 0.0 {
-                histogram.min()
-            } else if *quantile == 1.0 {
-                histogram.max()
-            } else {
-                histogram.value_at_quantile(*quantile)
-            };
-            let hz = if value_ns > 0 {
-                1_000_000_000.0 / value_ns as f64
-            } else {
-                f64::INFINITY
-            };
+
+        let now = chrono::Local::now();
+
+        let mut report = String::new();
+        report.push_str("Input Latency Histogram\n");
+        report.push_str("=======================\n");
+
+        let timestamp = now.format("%Y-%m-%d %H:%M:%S %Z");
+        report.push_str(&format!("Timestamp: {timestamp}\n"));
+        report.push_str(&format!("Samples: {total}\n"));
+        if self.mid_draw_events_dropped > 0 {
             report.push_str(&format!(
-                "  {label}: {:>8.2}ms  ({:>7.1} Hz)\n",
-                ns_to_ms(value_ns),
-                hz
+                "Mid-draw events excluded: {}\n",
+                self.mid_draw_events_dropped
             ));
         }
 
-        report.push('\n');
-        report.push_str("Distribution:\n");
-
-        // Perceptual latency buckets. Upper bounds are exclusive except for the last.
-        let buckets: &[(u64, u64, &str, &str)] = &[
-            (0, 4_000_000, "0\u{2013}4ms", "(excellent)"),
-            (4_000_000, 8_000_000, "4\u{2013}8ms", "(120fps)"),
-            (8_000_000, 16_000_000, "8\u{2013}16ms", "(60fps)"),
-            (16_000_000, 33_000_000, "16\u{2013}33ms", "(30fps)"),
-            (33_000_000, 100_000_000, "33\u{2013}100ms", ""),
-            (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
-        ];
-
-        let bar_width = 30usize;
-        for (low, high, range, note) in buckets {
-            let count: u64 = histogram
-                .iter_recorded()
-                .filter(|value| {
-                    value.value_iterated_to() >= *low && value.value_iterated_to() < *high
-                })
-                .map(|value| value.count_at_value())
-                .sum();
-            let fraction = count as f64 / total as f64;
-            let bar_len = (fraction * bar_width as f64) as usize;
-            let bar = "\u{2588}".repeat(bar_len);
-            report.push_str(&format!(
-                "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
-                fraction * 100.0,
-            ));
-        }
+        write_latency_percentiles(&mut report, "Percentiles", histogram, percentiles);
+        write_latency_distribution(&mut report, "Distribution", histogram);
 
         let coalesce = &self.events_per_frame_histogram;
         let coalesce_total = coalesce.len();
@@ -1205,6 +1167,7 @@ impl InputLatencyTracker {
 
             report.push('\n');
             report.push_str("Distribution:\n");
+            let bar_width = 30usize;
             let max_count = coalesce.max();
             for n in 1..=max_count {
                 let count = coalesce
@@ -1225,7 +1188,115 @@ impl InputLatencyTracker {
             }
         }
 
+        // Delta section: compare against the previous report's snapshot.
+        if let (Some(prev_latency), Some(prev_timestamp)) = (
+            &self.previous_latency_histogram,
+            &self.previous_report_timestamp,
+        ) {
+            let prev_total = prev_latency.len();
+            let delta_total = total - prev_total;
+
+            report.push('\n');
+            report.push_str("Delta Since Last Report\n");
+            report.push_str("-----------------------\n");
+            let prev_ts = prev_timestamp.format("%Y-%m-%d %H:%M:%S %Z");
+            let elapsed_secs = (now - *prev_timestamp).num_seconds().max(0);
+            report.push_str(&format!(
+                "Previous report: {prev_ts} ({elapsed_secs}s ago)\n"
+            ));
+            report.push_str(&format!("New samples: {delta_total}\n"));
+
+            if delta_total > 0 {
+                let mut delta_histogram = histogram.clone();
+                delta_histogram.subtract(prev_latency).ok();
+
+                write_latency_percentiles(
+                    &mut report,
+                    "Percentiles (new samples only)",
+                    &delta_histogram,
+                    percentiles,
+                );
+                write_latency_distribution(
+                    &mut report,
+                    "Distribution (new samples only)",
+                    &delta_histogram,
+                );
+            }
+        }
+
+        // Save snapshots for next report's delta.
+        self.previous_latency_histogram = Some(self.latency_histogram.clone());
+        self.previous_events_per_frame_histogram = Some(self.events_per_frame_histogram.clone());
+        self.previous_report_timestamp = Some(now);
+
         report
+    }
+}
+
+fn write_latency_percentiles(
+    report: &mut String,
+    heading: &str,
+    histogram: &Histogram<u64>,
+    percentiles: &[(&str, f64)],
+) {
+    let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
+
+    report.push('\n');
+    report.push_str(heading);
+    report.push_str(":\n");
+    for (label, quantile) in percentiles {
+        let value_ns = if *quantile == 0.0 {
+            histogram.min()
+        } else if *quantile == 1.0 {
+            histogram.max()
+        } else {
+            histogram.value_at_quantile(*quantile)
+        };
+        let hz = if value_ns > 0 {
+            1_000_000_000.0 / value_ns as f64
+        } else {
+            f64::INFINITY
+        };
+        report.push_str(&format!(
+            "  {label}: {:>8.2}ms  ({:>7.1} Hz)\n",
+            ns_to_ms(value_ns),
+            hz
+        ));
+    }
+}
+
+fn write_latency_distribution(report: &mut String, heading: &str, histogram: &Histogram<u64>) {
+    const BUCKETS: &[(u64, u64, &str, &str)] = &[
+        (0, 4_000_000, "0\u{2013}4ms", "(excellent)"),
+        (4_000_000, 8_000_000, "4\u{2013}8ms", "(120fps)"),
+        (8_000_000, 16_000_000, "8\u{2013}16ms", "(60fps)"),
+        (16_000_000, 33_000_000, "16\u{2013}33ms", "(30fps)"),
+        (33_000_000, 100_000_000, "33\u{2013}100ms", ""),
+        (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
+    ];
+    let bar_width = 30usize;
+    let total = histogram.len() as f64;
+
+    report.push('\n');
+    report.push_str(heading);
+    report.push_str(":\n");
+    for (low, high, range, note) in BUCKETS {
+        let count: u64 = histogram
+            .iter_recorded()
+            .filter(|value| value.value_iterated_to() >= *low && value.value_iterated_to() < *high)
+            .map(|value| value.count_at_value())
+            .sum();
+        let fraction = if total > 0.0 {
+            count as f64 / total
+        } else {
+            0.0
+        };
+        let bar_len = (fraction * bar_width as f64) as usize;
+        let bar = "\u{2588}".repeat(bar_len);
+        report.push_str(&format!(
+            "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
+            fraction * 100.0,
+        ));
     }
 }
 
@@ -2571,9 +2642,16 @@ impl Window {
         self.needs_present.set(false);
         profiling::finish_frame!();
     }
+    
+    #[cfg(feature = "input_latency_histogram")]
+    pub fn take_histogra(&mut self) -> Histogram {
+        
+    }
 
     /// Returns a formatted text report of the input-to-frame latency histogram.
-    pub fn format_input_latency_report(&self) -> String {
+    /// If a previous report was generated, includes a delta section showing
+    /// changes since that report.
+    pub fn format_input_latency_report(&mut self) -> String {
         self.input_latency_tracker.format_report()
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -28,6 +28,7 @@ use futures::FutureExt;
 use futures::channel::oneshot;
 use gpui_util::post_inc;
 use gpui_util::{ResultExt, measure};
+#[cfg(feature = "input-latency-histogram")]
 use hdrhistogram::Histogram;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
@@ -970,6 +971,7 @@ pub struct Window {
     /// Tracks recent input event timestamps to determine if input is arriving at a high rate.
     /// Used to selectively enable VRR optimization only when input rate exceeds 60fps.
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
+    #[cfg(feature = "input-latency-histogram")]
     input_latency_tracker: InputLatencyTracker,
     last_input_modality: InputModality,
     pub(crate) refreshing: bool,
@@ -1044,6 +1046,7 @@ impl InputRateTracker {
 /// Records the time between when the first input event in a frame is dispatched
 /// and when the resulting frame is presented, capturing worst-case latency when
 /// multiple events are coalesced into a single frame.
+#[cfg(feature = "input-latency-histogram")]
 struct InputLatencyTracker {
     /// Timestamp of the first unrendered input event in the current frame;
     /// cleared when a frame is presented.
@@ -1065,6 +1068,7 @@ struct InputLatencyTracker {
     previous_report_timestamp: Option<chrono::DateTime<chrono::Local>>,
 }
 
+#[cfg(feature = "input-latency-histogram")]
 impl InputLatencyTracker {
     fn new() -> Result<Self> {
         Ok(Self {
@@ -1233,6 +1237,7 @@ impl InputLatencyTracker {
     }
 }
 
+#[cfg(feature = "input-latency-histogram")]
 fn write_latency_percentiles(
     report: &mut String,
     heading: &str,
@@ -1265,6 +1270,7 @@ fn write_latency_percentiles(
     }
 }
 
+#[cfg(feature = "input-latency-histogram")]
 fn write_latency_distribution(report: &mut String, heading: &str, histogram: &Histogram<u64>) {
     const BUCKETS: &[(u64, u64, &str, &str)] = &[
         (0, 4_000_000, "0\u{2013}4ms", "(excellent)"),
@@ -1750,6 +1756,7 @@ impl Window {
             hovered,
             needs_present,
             input_rate_tracker,
+            #[cfg(feature = "input-latency-histogram")]
             input_latency_tracker: InputLatencyTracker::new()?,
             last_input_modality: InputModality::Mouse,
             refreshing: false,
@@ -2638,19 +2645,16 @@ impl Window {
     #[profiling::function]
     fn present(&mut self) {
         self.platform_window.draw(&self.rendered_frame.scene);
+        #[cfg(feature = "input-latency-histogram")]
         self.input_latency_tracker.record_frame_presented();
         self.needs_present.set(false);
         profiling::finish_frame!();
-    }
-    
-    #[cfg(feature = "input_latency_histogram")]
-    pub fn take_histogra(&mut self) -> Histogram {
-        
     }
 
     /// Returns a formatted text report of the input-to-frame latency histogram.
     /// If a previous report was generated, includes a delta section showing
     /// changes since that report.
+    #[cfg(feature = "input-latency-histogram")]
     pub fn format_input_latency_report(&mut self) -> String {
         self.input_latency_tracker.format_report()
     }
@@ -4401,6 +4405,7 @@ impl Window {
     /// Dispatch a mouse or keyboard event on the window.
     #[profiling::function]
     pub fn dispatch_event(&mut self, event: PlatformInput, cx: &mut App) -> DispatchEventResult {
+        #[cfg(feature = "input-latency-histogram")]
         let dispatch_time = Instant::now();
         let update_count_before = self.invalidator.update_count();
         // Track input modality for focus-visible styling and hover suppression.
@@ -4514,6 +4519,7 @@ impl Window {
 
         if self.invalidator.update_count() > update_count_before {
             self.input_rate_tracker.borrow_mut().record_input();
+            #[cfg(feature = "input-latency-histogram")]
             if self.invalidator.not_drawing() {
                 self.input_latency_tracker.record_input(dispatch_time);
             } else {

--- a/crates/input_latency_ui/Cargo.toml
+++ b/crates/input_latency_ui/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "input_latency_ui"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/input_latency_ui.rs"
+
+[dependencies]
+chrono.workspace = true
+gpui = { workspace = true, features = ["input-latency-histogram"] }
+hdrhistogram.workspace = true

--- a/crates/input_latency_ui/LICENSE-GPL
+++ b/crates/input_latency_ui/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/input_latency_ui/src/input_latency_ui.rs
+++ b/crates/input_latency_ui/src/input_latency_ui.rs
@@ -1,0 +1,216 @@
+use gpui::{App, Global, InputLatencySnapshot, Window, actions};
+use hdrhistogram::Histogram;
+
+actions!(
+    dev,
+    [
+        /// Opens a buffer showing the input-to-frame latency histogram for the current window.
+        DumpInputLatencyHistogram,
+    ]
+);
+
+/// Generates a formatted text report of the input-to-frame latency histogram
+/// for the given window. If a previous report was generated (tracked via a
+/// global on the `App`), includes a delta section showing changes since that
+/// report.
+pub fn format_input_latency_report(window: &Window, cx: &mut App) -> String {
+    let snapshot = window.input_latency_snapshot();
+    let state = cx.default_global::<ReporterState>();
+    let report = format_report(&snapshot, state);
+
+    state.previous_snapshot = Some(snapshot);
+    state.previous_timestamp = Some(chrono::Local::now());
+
+    report
+}
+
+#[derive(Default)]
+struct ReporterState {
+    previous_snapshot: Option<InputLatencySnapshot>,
+    previous_timestamp: Option<chrono::DateTime<chrono::Local>>,
+}
+
+impl Global for ReporterState {}
+
+fn format_report(snapshot: &InputLatencySnapshot, previous: &ReporterState) -> String {
+    let histogram = &snapshot.latency_histogram;
+    let total = histogram.len();
+
+    if total == 0 {
+        return "No input latency samples recorded yet.\n\nTry typing or clicking in a buffer first.".to_string();
+    }
+
+    let percentiles: &[(&str, f64)] = &[
+        ("min  ", 0.0),
+        ("p50  ", 0.50),
+        ("p75  ", 0.75),
+        ("p90  ", 0.90),
+        ("p95  ", 0.95),
+        ("p99  ", 0.99),
+        ("p99.9", 0.999),
+        ("max  ", 1.0),
+    ];
+
+    let now = chrono::Local::now();
+
+    let mut report = String::new();
+    report.push_str("Input Latency Histogram\n");
+    report.push_str("=======================\n");
+
+    let timestamp = now.format("%Y-%m-%d %H:%M:%S %Z");
+    report.push_str(&format!("Timestamp: {timestamp}\n"));
+    report.push_str(&format!("Samples: {total}\n"));
+    if snapshot.mid_draw_events_dropped > 0 {
+        report.push_str(&format!(
+            "Mid-draw events excluded: {}\n",
+            snapshot.mid_draw_events_dropped
+        ));
+    }
+
+    write_latency_percentiles(&mut report, "Percentiles", histogram, percentiles);
+    write_latency_distribution(&mut report, "Distribution", histogram);
+
+    let coalesce = &snapshot.events_per_frame_histogram;
+    let coalesce_total = coalesce.len();
+    if coalesce_total > 0 {
+        report.push('\n');
+        report.push_str("Events coalesced per frame:\n");
+        for (label, quantile) in percentiles {
+            let value = if *quantile == 0.0 {
+                coalesce.min()
+            } else if *quantile == 1.0 {
+                coalesce.max()
+            } else {
+                coalesce.value_at_quantile(*quantile)
+            };
+            report.push_str(&format!("  {label}: {value:>6} events\n"));
+        }
+
+        report.push('\n');
+        report.push_str("Distribution:\n");
+        let bar_width = 30usize;
+        let max_count = coalesce.max();
+        for n in 1..=max_count {
+            let count = coalesce
+                .iter_recorded()
+                .filter(|value| value.value_iterated_to() == n)
+                .map(|value| value.count_at_value())
+                .sum::<u64>();
+            if count == 0 {
+                continue;
+            }
+            let fraction = count as f64 / coalesce_total as f64;
+            let bar_len = (fraction * bar_width as f64) as usize;
+            let bar = "\u{2588}".repeat(bar_len);
+            report.push_str(&format!(
+                "  {n:>6} events: {count:>6} ({:>5.1}%) {bar}\n",
+                fraction * 100.0,
+            ));
+        }
+    }
+
+    // Delta section: compare against the previous report's snapshot.
+    if let (Some(prev_snapshot), Some(prev_timestamp)) =
+        (&previous.previous_snapshot, &previous.previous_timestamp)
+    {
+        let prev_latency = &prev_snapshot.latency_histogram;
+        let prev_total = prev_latency.len();
+        let delta_total = total - prev_total;
+
+        report.push('\n');
+        report.push_str("Delta Since Last Report\n");
+        report.push_str("-----------------------\n");
+        let prev_ts = prev_timestamp.format("%Y-%m-%d %H:%M:%S %Z");
+        let elapsed_secs = (now - *prev_timestamp).num_seconds().max(0);
+        report.push_str(&format!(
+            "Previous report: {prev_ts} ({elapsed_secs}s ago)\n"
+        ));
+        report.push_str(&format!("New samples: {delta_total}\n"));
+
+        if delta_total > 0 {
+            let mut delta_histogram = histogram.clone();
+            delta_histogram.subtract(prev_latency).ok();
+
+            write_latency_percentiles(
+                &mut report,
+                "Percentiles (new samples only)",
+                &delta_histogram,
+                percentiles,
+            );
+            write_latency_distribution(
+                &mut report,
+                "Distribution (new samples only)",
+                &delta_histogram,
+            );
+        }
+    }
+
+    report
+}
+
+fn write_latency_percentiles(
+    report: &mut String,
+    heading: &str,
+    histogram: &Histogram<u64>,
+    percentiles: &[(&str, f64)],
+) {
+    let ns_to_ms = |ns: u64| ns as f64 / 1_000_000.0;
+
+    report.push('\n');
+    report.push_str(heading);
+    report.push_str(":\n");
+    for (label, quantile) in percentiles {
+        let value_ns = if *quantile == 0.0 {
+            histogram.min()
+        } else if *quantile == 1.0 {
+            histogram.max()
+        } else {
+            histogram.value_at_quantile(*quantile)
+        };
+        let hz = if value_ns > 0 {
+            1_000_000_000.0 / value_ns as f64
+        } else {
+            f64::INFINITY
+        };
+        report.push_str(&format!(
+            "  {label}: {:>8.2}ms  ({:>7.1} Hz)\n",
+            ns_to_ms(value_ns),
+            hz
+        ));
+    }
+}
+
+fn write_latency_distribution(report: &mut String, heading: &str, histogram: &Histogram<u64>) {
+    const BUCKETS: &[(u64, u64, &str, &str)] = &[
+        (0, 4_000_000, "0\u{2013}4ms", "(excellent)"),
+        (4_000_000, 8_000_000, "4\u{2013}8ms", "(120fps)"),
+        (8_000_000, 16_000_000, "8\u{2013}16ms", "(60fps)"),
+        (16_000_000, 33_000_000, "16\u{2013}33ms", "(30fps)"),
+        (33_000_000, 100_000_000, "33\u{2013}100ms", ""),
+        (100_000_000, u64::MAX, "100ms+", "(sluggish)"),
+    ];
+    let bar_width = 30usize;
+    let total = histogram.len() as f64;
+
+    report.push('\n');
+    report.push_str(heading);
+    report.push_str(":\n");
+    for (low, high, range, note) in BUCKETS {
+        let count: u64 = histogram
+            .iter_recorded()
+            .filter(|value| value.value_iterated_to() >= *low && value.value_iterated_to() < *high)
+            .map(|value| value.count_at_value())
+            .sum();
+        let fraction = if total > 0.0 {
+            count as f64 / total
+        } else {
+            0.0
+        };
+        let bar_len = (fraction * bar_width as f64) as usize;
+        let bar = "\u{2588}".repeat(bar_len);
+        report.push_str(&format!(
+            "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
+            fraction * 100.0,
+        ));
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -117,7 +117,7 @@ git_hosting_providers.workspace = true
 git_ui.workspace = true
 go_to_line.workspace = true
 system_specs.workspace = true
-gpui.workspace = true
+gpui = { workspace = true, features = ["input-latency-histogram"] }
 gpui_platform = {workspace = true, features=["screen-capture", "font-kit", "wayland", "x11"]}
 image = { workspace = true, optional = true }
 semver.workspace = true
@@ -228,6 +228,7 @@ zlog_settings.workspace = true
 etw_tracing.workspace = true
 windows.workspace = true
 gpui = { workspace = true, features = [
+    "input-latency-histogram",
     "windows-manifest",
 ] }
 
@@ -236,6 +237,7 @@ winresource = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 gpui = { workspace = true, features = [
+    "input-latency-histogram",
     "wayland",
     "x11",
 ] }
@@ -247,7 +249,7 @@ pkg-config = "0.3.22"
 [dev-dependencies]
 call = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
-gpui = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["input-latency-histogram", "test-support"] }
 image_viewer = { workspace = true, features = ["test-support"] }
 itertools.workspace = true
 language = { workspace = true, features = ["test-support"] }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -133,6 +133,7 @@ edit_prediction.workspace = true
 edit_prediction_ui.workspace = true
 http_client.workspace = true
 image_viewer.workspace = true
+input_latency_ui.workspace = true
 inspector_ui.workspace = true
 install_cli.workspace = true
 journal.workspace = true

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -106,6 +106,8 @@ actions!(
     [
         /// Opens the element inspector for debugging UI.
         DebugElements,
+        /// Opens a buffer showing the input-to-frame latency histogram for the current window.
+        DumpInputLatencyHistogram,
         /// Hides the application window.
         Hide,
         /// Hides all other application windows.
@@ -765,6 +767,21 @@ fn register_actions(
 ) {
     workspace
         .register_action(|_, _: &OpenDocs, _, cx| cx.open_url(DOCS_URL))
+        .register_action(
+            |workspace: &mut Workspace,
+             _: &DumpInputLatencyHistogram,
+             window: &mut Window,
+             cx: &mut Context<Workspace>| {
+                let report = window.format_input_latency_report();
+                let project = workspace.project().clone();
+                let buffer = project.update(cx, |project, cx| {
+                    project.create_local_buffer(&report, None, true, cx)
+                });
+                let editor =
+                    cx.new(|cx| Editor::for_buffer(buffer, Some(project), window, cx));
+                workspace.add_item_to_active_pane(Box::new(editor), None, true, window, cx);
+            },
+        )
         .register_action(|_, _: &Minimize, window, _| {
             window.minimize_window();
         })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -102,14 +102,6 @@ use zed_actions::{
 };
 
 actions!(
-    dev,
-    [
-        /// Opens a buffer showing the input-to-frame latency histogram for the current window.
-        DumpInputLatencyHistogram,
-    ]
-);
-
-actions!(
     zed,
     [
         /// Opens the element inspector for debugging UI.
@@ -775,10 +767,11 @@ fn register_actions(
         .register_action(|_, _: &OpenDocs, _, cx| cx.open_url(DOCS_URL))
         .register_action(
             |workspace: &mut Workspace,
-             _: &DumpInputLatencyHistogram,
+             _: &input_latency_ui::DumpInputLatencyHistogram,
              window: &mut Window,
              cx: &mut Context<Workspace>| {
-                let report = window.format_input_latency_report();
+                let report =
+                    input_latency_ui::format_input_latency_report(window, cx);
                 let project = workspace.project().clone();
                 let buffer = project.update(cx, |project, cx| {
                     project.create_local_buffer(&report, None, true, cx)

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -102,12 +102,18 @@ use zed_actions::{
 };
 
 actions!(
+    dev,
+    [
+        /// Opens a buffer showing the input-to-frame latency histogram for the current window.
+        DumpInputLatencyHistogram,
+    ]
+);
+
+actions!(
     zed,
     [
         /// Opens the element inspector for debugging UI.
         DebugElements,
-        /// Opens a buffer showing the input-to-frame latency histogram for the current window.
-        DumpInputLatencyHistogram,
         /// Hides the application window.
         Hide,
         /// Hides all other application windows.


### PR DESCRIPTION
Adds instrumentation to track input-to-frame latency in GPUI windows, helping diagnose input responsiveness issues.

## What this does

- Records the time between when an input event is dispatched and when the resulting frame is presented, capturing worst-case latency when multiple events are coalesced into a single frame.
- Tracks how many input events get coalesced per rendered frame.
- Both metrics are stored in [HdrHistogram](https://docs.rs/hdrhistogram) instances with 3 significant digits of precision.
- Latency is only recorded when the input event actually causes a redraw (i.e. marks the window dirty), so idle mouse moves and other no-op events don't skew the data.
- Adds a `Dump Input Latency Histogram` command that opens a buffer with a formatted report including percentile breakdowns and visual distribution bars.

## Example output

The report shows percentile latencies, a bucketed distribution with bar charts, and a per-frame event coalescing breakdown.

Release Notes:

- N/A