### PR TITLE
Make UserMessageId non-optional to fix agent prompt crash

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1414,7 +1414,7 @@ impl AcpThread {
                     .and_then(|entry| entry.user_message())
                     .is_some_and(|message| message.chunks.contains(&content));
                 if !already_in_user_message {
-                    self.push_user_content_block(UserMessageId::new(), content, cx);
+                    self.push_user_content_block(None, content, cx);
                 }
             }
             acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk { content, .. }) => {
@@ -1466,7 +1466,7 @@ impl AcpThread {
 
     pub fn push_user_content_block(
         &mut self,
-        message_id: UserMessageId,
+        message_id: Option<UserMessageId>,
         chunk: acp::ContentBlock,
         cx: &mut Context<Self>,
     ) {
@@ -1475,7 +1475,7 @@ impl AcpThread {
 
     pub fn push_user_content_block_with_indent(
         &mut self,
-        message_id: UserMessageId,
+        message_id: Option<UserMessageId>,
         chunk: acp::ContentBlock,
         indented: bool,
         cx: &mut Context<Self>,
@@ -1495,7 +1495,9 @@ impl AcpThread {
             && *existing_indented == indented
         {
             Self::flush_streaming_text(&mut self.streaming_text_buffer, cx);
-            *id = message_id;
+            if let Some(new_id) = message_id {
+                *id = new_id;
+            }
             content.append(chunk.clone(), &language_registry, path_style, cx);
             chunks.push(chunk);
             let idx = entries_len - 1;
@@ -1504,7 +1506,7 @@ impl AcpThread {
             let content = ContentBlock::new(chunk.clone(), &language_registry, path_style, cx);
             self.push_entry(
                 AgentThreadEntry::UserMessage(UserMessage {
-                    id: message_id,
+                    id: message_id.unwrap_or_else(UserMessageId::new),
                     content,
                     chunks: vec![chunk],
                     checkpoint: None,
@@ -3337,7 +3339,7 @@ mod tests {
 
         // Test creating a new user message
         thread.update(cx, |thread, cx| {
-            thread.push_user_content_block(UserMessageId::new(), "Hello, ".into(), cx);
+            thread.push_user_content_block(None, "Hello, ".into(), cx);
         });
 
         thread.update(cx, |thread, cx| {
@@ -3352,7 +3354,7 @@ mod tests {
         // Test appending to existing user message
         let message_1_id = UserMessageId::new();
         thread.update(cx, |thread, cx| {
-            thread.push_user_content_block(message_1_id.clone(), "world!".into(), cx);
+            thread.push_user_content_block(Some(message_1_id.clone()), "world!".into(), cx);
         });
 
         thread.update(cx, |thread, cx| {
@@ -3372,7 +3374,11 @@ mod tests {
 
         let message_2_id = UserMessageId::new();
         thread.update(cx, |thread, cx| {
-            thread.push_user_content_block(message_2_id.clone(), "New user message".into(), cx);
+            thread.push_user_content_block(
+                Some(message_2_id.clone()),
+                "New user message".into(),
+                cx,
+            );
         });
 
         thread.update(cx, |thread, cx| {

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -88,7 +88,7 @@ pub fn subagent_session_info_from_meta(meta: &Option<acp::Meta>) -> Option<Subag
 
 #[derive(Debug)]
 pub struct UserMessage {
-    pub id: Option<UserMessageId>,
+    pub id: UserMessageId,
     pub content: ContentBlock,
     pub chunks: Vec<acp::ContentBlock>,
     pub checkpoint: Option<Checkpoint>,
@@ -1414,7 +1414,7 @@ impl AcpThread {
                     .and_then(|entry| entry.user_message())
                     .is_some_and(|message| message.chunks.contains(&content));
                 if !already_in_user_message {
-                    self.push_user_content_block(None, content, cx);
+                    self.push_user_content_block(UserMessageId::new(), content, cx);
                 }
             }
             acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk { content, .. }) => {
@@ -1466,7 +1466,7 @@ impl AcpThread {
 
     pub fn push_user_content_block(
         &mut self,
-        message_id: Option<UserMessageId>,
+        message_id: UserMessageId,
         chunk: acp::ContentBlock,
         cx: &mut Context<Self>,
     ) {
@@ -1475,7 +1475,7 @@ impl AcpThread {
 
     pub fn push_user_content_block_with_indent(
         &mut self,
-        message_id: Option<UserMessageId>,
+        message_id: UserMessageId,
         chunk: acp::ContentBlock,
         indented: bool,
         cx: &mut Context<Self>,
@@ -1495,7 +1495,7 @@ impl AcpThread {
             && *existing_indented == indented
         {
             Self::flush_streaming_text(&mut self.streaming_text_buffer, cx);
-            *id = message_id.or(id.take());
+            *id = message_id;
             content.append(chunk.clone(), &language_registry, path_style, cx);
             chunks.push(chunk);
             let idx = entries_len - 1;
@@ -2162,11 +2162,7 @@ impl AcpThread {
         let request = acp::PromptRequest::new(self.session_id.clone(), message.clone());
         let git_store = self.project.read(cx).git_store().clone();
 
-        let message_id = if self.connection.truncate(&self.session_id, cx).is_some() {
-            Some(UserMessageId::new())
-        } else {
-            None
-        };
+        let message_id = UserMessageId::new();
 
         self.run_turn(cx, async move |this, cx| {
             this.update(cx, |this, cx| {
@@ -2469,9 +2465,7 @@ impl AcpThread {
         let Some((_, message)) = self.last_user_message() else {
             return Task::ready(Ok(()));
         };
-        let Some(user_message_id) = message.id.clone() else {
-            return Task::ready(Ok(()));
-        };
+        let user_message_id = message.id.clone();
         let Some(checkpoint) = message.checkpoint.as_ref() else {
             return Task::ready(Ok(()));
         };
@@ -2524,7 +2518,7 @@ impl AcpThread {
     fn user_message_mut(&mut self, id: &UserMessageId) -> Option<(usize, &mut UserMessage)> {
         self.entries.iter_mut().enumerate().find_map(|(ix, entry)| {
             if let AgentThreadEntry::UserMessage(message) = entry {
-                if message.id.as_ref() == Some(id) {
+                if &message.id == id {
                     Some((ix, message))
                 } else {
                     None
@@ -3343,13 +3337,12 @@ mod tests {
 
         // Test creating a new user message
         thread.update(cx, |thread, cx| {
-            thread.push_user_content_block(None, "Hello, ".into(), cx);
+            thread.push_user_content_block(UserMessageId::new(), "Hello, ".into(), cx);
         });
 
         thread.update(cx, |thread, cx| {
             assert_eq!(thread.entries.len(), 1);
             if let AgentThreadEntry::UserMessage(user_msg) = &thread.entries[0] {
-                assert_eq!(user_msg.id, None);
                 assert_eq!(user_msg.content.to_markdown(cx), "Hello, ");
             } else {
                 panic!("Expected UserMessage");
@@ -3359,13 +3352,13 @@ mod tests {
         // Test appending to existing user message
         let message_1_id = UserMessageId::new();
         thread.update(cx, |thread, cx| {
-            thread.push_user_content_block(Some(message_1_id.clone()), "world!".into(), cx);
+            thread.push_user_content_block(message_1_id.clone(), "world!".into(), cx);
         });
 
         thread.update(cx, |thread, cx| {
             assert_eq!(thread.entries.len(), 1);
             if let AgentThreadEntry::UserMessage(user_msg) = &thread.entries[0] {
-                assert_eq!(user_msg.id, Some(message_1_id));
+                assert_eq!(user_msg.id, message_1_id);
                 assert_eq!(user_msg.content.to_markdown(cx), "Hello, world!");
             } else {
                 panic!("Expected UserMessage");
@@ -3379,17 +3372,13 @@ mod tests {
 
         let message_2_id = UserMessageId::new();
         thread.update(cx, |thread, cx| {
-            thread.push_user_content_block(
-                Some(message_2_id.clone()),
-                "New user message".into(),
-                cx,
-            );
+            thread.push_user_content_block(message_2_id.clone(), "New user message".into(), cx);
         });
 
         thread.update(cx, |thread, cx| {
             assert_eq!(thread.entries.len(), 3);
             if let AgentThreadEntry::UserMessage(user_msg) = &thread.entries[2] {
-                assert_eq!(user_msg.id, Some(message_2_id));
+                assert_eq!(user_msg.id, message_2_id);
                 assert_eq!(user_msg.content.to_markdown(cx), "New user message");
             } else {
                 panic!("Expected UserMessage at index 2");
@@ -4070,7 +4059,7 @@ mod tests {
                 let AgentThreadEntry::UserMessage(message) = &thread.entries[2] else {
                     panic!("unexpected entries {:?}", thread.entries)
                 };
-                thread.restore_checkpoint(message.id.clone().unwrap(), cx)
+                thread.restore_checkpoint(message.id.clone(), cx)
             })
             .await
             .unwrap();
@@ -4469,7 +4458,7 @@ mod tests {
 
         fn prompt(
             &self,
-            _id: Option<UserMessageId>,
+            _id: UserMessageId,
             params: acp::PromptRequest,
             cx: &mut App,
         ) -> Task<gpui::Result<acp::PromptResponse>> {
@@ -4736,7 +4725,7 @@ mod tests {
             let AgentThreadEntry::UserMessage(message) = &thread.entries[1] else {
                 panic!("expected user message at index 1");
             };
-            message.id.clone().unwrap()
+            message.id.clone()
         });
 
         // Create a terminal AFTER the checkpoint we'll restore to.
@@ -4943,7 +4932,7 @@ mod tests {
         thread.update(cx, |thread, cx| {
             thread.push_entry(
                 AgentThreadEntry::UserMessage(UserMessage {
-                    id: Some(UserMessageId::new()),
+                    id: UserMessageId::new(),
                     content: ContentBlock::Empty,
                     chunks: vec!["Injected message (no checkpoint)".into()],
                     checkpoint: None,

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -125,7 +125,7 @@ pub trait AgentConnection {
 
     fn prompt(
         &self,
-        user_message_id: Option<UserMessageId>,
+        user_message_id: UserMessageId,
         params: acp::PromptRequest,
         cx: &mut App,
     ) -> Task<Result<acp::PromptResponse>>;
@@ -875,7 +875,7 @@ mod test_support {
 
         fn prompt(
             &self,
-            _id: Option<UserMessageId>,
+            _id: UserMessageId,
             params: acp::PromptRequest,
             cx: &mut App,
         ) -> Task<gpui::Result<acp::PromptResponse>> {

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1071,7 +1071,7 @@ impl NativeAgent {
 
                         acp_thread.update(cx, |acp_thread, cx| {
                             acp_thread.push_user_content_block_with_indent(
-                                Some(id.clone()),
+                                id.clone(),
                                 block.clone(),
                                 true,
                                 cx,
@@ -1186,7 +1186,7 @@ impl NativeAgentConnection {
                                 acp_thread.update(cx, |thread, cx| {
                                     for content in message.content {
                                         thread.push_user_content_block(
-                                            Some(message.id.clone()),
+                                            message.id.clone(),
                                             content.into(),
                                             cx,
                                         );
@@ -1489,11 +1489,10 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
 
     fn prompt(
         &self,
-        id: Option<acp_thread::UserMessageId>,
+        id: acp_thread::UserMessageId,
         params: acp::PromptRequest,
         cx: &mut App,
     ) -> Task<Result<acp::PromptResponse>> {
-        let id = id.expect("UserMessageId is required");
         let session_id = params.session_id.clone();
         log::info!("Received prompt request for session: {}", session_id);
         log::debug!("Prompt blocks count: {}", params.prompt.len());

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1071,7 +1071,7 @@ impl NativeAgent {
 
                         acp_thread.update(cx, |acp_thread, cx| {
                             acp_thread.push_user_content_block_with_indent(
-                                id.clone(),
+                                Some(id.clone()),
                                 block.clone(),
                                 true,
                                 cx,
@@ -1186,7 +1186,7 @@ impl NativeAgentConnection {
                                 acp_thread.update(cx, |thread, cx| {
                                     for content in message.content {
                                         thread.push_user_content_block(
-                                            message.id.clone(),
+                                            Some(message.id.clone()),
                                             content.into(),
                                             cx,
                                         );

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3350,7 +3350,7 @@ async fn test_agent_connection(cx: &mut TestAppContext) {
     let result = cx
         .update(|cx| {
             connection.prompt(
-                Some(acp_thread::UserMessageId::new()),
+                acp_thread::UserMessageId::new(),
                 acp::PromptRequest::new(session_id.clone(), vec!["ghi".into()]),
                 cx,
             )

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -955,7 +955,7 @@ impl AgentConnection for AcpConnection {
 
     fn prompt(
         &self,
-        _id: Option<acp_thread::UserMessageId>,
+        _id: acp_thread::UserMessageId,
         params: acp::PromptRequest,
         cx: &mut App,
     ) -> Task<Result<acp::PromptResponse>> {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1972,12 +1972,7 @@ impl ConversationView {
                 .read(cx)
                 .entries()
                 .iter()
-                .any(|entry| {
-                    matches!(
-                        entry,
-                        AgentThreadEntry::UserMessage(user_message) if user_message.id.is_some()
-                    )
-                })
+                .any(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)))
         })
     }
 
@@ -4899,7 +4894,7 @@ pub(crate) mod tests {
             let AgentThreadEntry::UserMessage(user_message) = &thread.entries()[2] else {
                 panic!();
             };
-            user_message.id.clone().unwrap()
+            user_message.id.clone()
         });
 
         conversation_view.read_with(cx, |view, cx| {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -752,9 +752,8 @@ impl ThreadView {
                 self.expanded_tool_calls.remove(tool_call_id);
             }
             ViewEvent::MessageEditorEvent(_editor, MessageEditorEvent::Focus) => {
-                if let Some(AgentThreadEntry::UserMessage(user_message)) =
+                if let Some(AgentThreadEntry::UserMessage(_user_message)) =
                     self.thread.read(cx).entries().get(event.entry_index)
-                    && user_message.id.is_some()
                     && !self.is_subagent()
                 {
                     self.editing_message = Some(event.entry_index);
@@ -764,7 +763,6 @@ impl ThreadView {
             ViewEvent::MessageEditorEvent(editor, MessageEditorEvent::LostFocus) => {
                 if let Some(AgentThreadEntry::UserMessage(user_message)) =
                     self.thread.read(cx).entries().get(event.entry_index)
-                    && user_message.id.is_some()
                     && !self.is_subagent()
                 {
                     if editor.read(cx).text(cx).as_str() == user_message.content.to_markdown(cx) {
@@ -1392,7 +1390,7 @@ impl ThreadView {
         let thread = self.thread.clone();
 
         let Some(user_message_id) = thread.update(cx, |thread, _| {
-            thread.entries().get(entry_ix)?.user_message()?.id.clone()
+            Some(thread.entries().get(entry_ix)?.user_message()?.id.clone())
         }) else {
             return;
         };
@@ -4495,7 +4493,7 @@ impl ThreadView {
                     .is_some_and(|checkpoint| checkpoint.show);
 
                 let is_subagent = self.is_subagent();
-                let is_editable = message.id.is_some() && !is_subagent;
+                let is_editable = !is_subagent;
                 let agent_name = if is_subagent {
                     "subagents".into()
                 } else {
@@ -4516,7 +4514,8 @@ impl ThreadView {
                     .gap_1p5()
                     .w_full()
                     .when(is_editable && has_checkpoint_button, |this| {
-                        this.children(message.id.clone().map(|message_id| {
+                        let message_id = message.id.clone();
+                        this.child(
                             h_flex()
                                 .px_3()
                                 .gap_2()
@@ -4532,7 +4531,7 @@ impl ThreadView {
                                         }))
                                 )
                                 .child(Divider::horizontal())
-                        }))
+                        )
                     })
                     .child(
                         div()

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -72,7 +72,6 @@ impl EntryViewState {
 
         match thread_entry {
             AgentThreadEntry::UserMessage(message) => {
-                let has_id = message.id.is_some();
                 let is_subagent = thread.read(cx).parent_session_id().is_some();
                 let chunks = message.chunks.clone();
                 if let Some(Entry::UserMessage(editor)) = self.entries.get_mut(index) {
@@ -101,7 +100,7 @@ impl EntryViewState {
                             window,
                             cx,
                         );
-                        if !has_id || is_subagent {
+                        if is_subagent {
                             editor.set_read_only(true, cx);
                         }
                         editor.set_message(chunks, window, cx);

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -2166,7 +2166,7 @@ mod tests {
         // Pushing content makes entries non-empty, so the event handler
         // should now update metadata with the real session_id.
         thread.update_in(&mut vcx, |thread, _window, cx| {
-            thread.push_user_content_block(None, "Hello".into(), cx);
+            thread.push_user_content_block(acp_thread::UserMessageId::new(), "Hello".into(), cx);
         });
         vcx.run_until_parked();
 
@@ -2195,7 +2195,7 @@ mod tests {
         let thread = panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
 
         thread.update_in(&mut vcx, |thread, _window, cx| {
-            thread.push_user_content_block(None, "Hello".into(), cx);
+            thread.push_user_content_block(acp_thread::UserMessageId::new(), "Hello".into(), cx);
         });
         vcx.run_until_parked();
 
@@ -2238,7 +2238,7 @@ mod tests {
             panel.active_agent_thread(cx).unwrap()
         });
         thread_no_wt.update_in(&mut vcx_no_wt, |thread, _window, cx| {
-            thread.push_user_content_block(None, "content".into(), cx);
+            thread.push_user_content_block(acp_thread::UserMessageId::new(), "content".into(), cx);
             thread.set_title("No Project Thread".into(), cx).detach();
         });
         vcx_no_wt.run_until_parked();
@@ -2255,7 +2255,7 @@ mod tests {
         let thread_wt =
             panel_wt.read_with(&vcx_wt, |panel, cx| panel.active_agent_thread(cx).unwrap());
         thread_wt.update_in(&mut vcx_wt, |thread, _window, cx| {
-            thread.push_user_content_block(None, "content".into(), cx);
+            thread.push_user_content_block(acp_thread::UserMessageId::new(), "content".into(), cx);
             thread.set_title("Project Thread".into(), cx).detach();
         });
         vcx_wt.run_until_parked();
@@ -2305,7 +2305,7 @@ mod tests {
         let regular_session_id = regular_thread.read_with(&vcx, |t, _| t.session_id().clone());
 
         regular_thread.update_in(&mut vcx, |thread, _window, cx| {
-            thread.push_user_content_block(None, "content".into(), cx);
+            thread.push_user_content_block(acp_thread::UserMessageId::new(), "content".into(), cx);
             thread.set_title("Regular Thread".into(), cx).detach();
         });
         vcx.run_until_parked();

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -2166,7 +2166,7 @@ mod tests {
         // Pushing content makes entries non-empty, so the event handler
         // should now update metadata with the real session_id.
         thread.update_in(&mut vcx, |thread, _window, cx| {
-            thread.push_user_content_block(acp_thread::UserMessageId::new(), "Hello".into(), cx);
+            thread.push_user_content_block(None, "Hello".into(), cx);
         });
         vcx.run_until_parked();
 
@@ -2195,7 +2195,7 @@ mod tests {
         let thread = panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
 
         thread.update_in(&mut vcx, |thread, _window, cx| {
-            thread.push_user_content_block(acp_thread::UserMessageId::new(), "Hello".into(), cx);
+            thread.push_user_content_block(None, "Hello".into(), cx);
         });
         vcx.run_until_parked();
 
@@ -2238,7 +2238,7 @@ mod tests {
             panel.active_agent_thread(cx).unwrap()
         });
         thread_no_wt.update_in(&mut vcx_no_wt, |thread, _window, cx| {
-            thread.push_user_content_block(acp_thread::UserMessageId::new(), "content".into(), cx);
+            thread.push_user_content_block(None, "content".into(), cx);
             thread.set_title("No Project Thread".into(), cx).detach();
         });
         vcx_no_wt.run_until_parked();
@@ -2255,7 +2255,7 @@ mod tests {
         let thread_wt =
             panel_wt.read_with(&vcx_wt, |panel, cx| panel.active_agent_thread(cx).unwrap());
         thread_wt.update_in(&mut vcx_wt, |thread, _window, cx| {
-            thread.push_user_content_block(acp_thread::UserMessageId::new(), "content".into(), cx);
+            thread.push_user_content_block(None, "content".into(), cx);
             thread.set_title("Project Thread".into(), cx).detach();
         });
         vcx_wt.run_until_parked();
@@ -2305,7 +2305,7 @@ mod tests {
         let regular_session_id = regular_thread.read_with(&vcx, |t, _| t.session_id().clone());
 
         regular_thread.update_in(&mut vcx, |thread, _window, cx| {
-            thread.push_user_content_block(acp_thread::UserMessageId::new(), "content".into(), cx);
+            thread.push_user_content_block(None, "content".into(), cx);
             thread.set_title("Regular Thread".into(), cx).detach();
         });
         vcx.run_until_parked();


### PR DESCRIPTION
The `AgentConnection::prompt` trait method accepted `Option<UserMessageId>`, but `NativeAgentConnection::prompt` called `.expect()` on it, causing a crash (SIGABRT) when the id was `None`.

The id was `None` when `AcpThread::send()` found that `truncate()` returned `None` (session not found in `agent.sessions`), which caused it to skip generating a `UserMessageId`. This `None` then flowed through to `prompt()` and hit the `.expect()`.

This makes `UserMessageId` non-optional where it matters, eliminating the crash at the type level:

- `UserMessage.id` is now `UserMessageId` (not `Option<UserMessageId>`)
- `AgentConnection::prompt` takes `UserMessageId` (not `Option<UserMessageId>`)
- `AcpThread::send` always generates a `UserMessageId` — the only case where it previously didn't was the crash case (session missing), which now gracefully errors via the "Session not found" check in `prompt()` instead of panicking

`push_user_content_block` keeps taking `Option<UserMessageId>` because it's used to incrementally append content blocks, where callers either provide a specific ID (e.g. forwarding from Thread to AcpThread) or pass `None` to mean "keep the existing ID / auto-generate one". When creating a new message with `None`, it auto-generates via `UserMessageId::new()`.

Release Notes:

- Fixed a crash that could occur when sending a prompt to the AI agent