### PR TITLE
title_bar: Hide plan badge next to username when there are organizations

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1115,7 +1115,9 @@ impl TitleBar {
                                     .w_full()
                                     .justify_between()
                                     .child(Label::new(user_login))
-                                    .child(PlanChip::new(plan.unwrap_or(Plan::ZedFree)))
+                                    .when(!has_organization, |parent| {
+                                        parent.child(PlanChip::new(plan.unwrap_or(Plan::ZedFree)))
+                                    })
                                     .into_any_element()
                             },
                             move |_, cx| {


### PR DESCRIPTION
This PR makes it so we hide the plan badge next to the username in the user menu when there are organizations.

We instead show the plans next to each organization:

<img width="257" height="317" alt="Screenshot 2026-04-13 at 1 29 26 PM" src="https://github.com/user-attachments/assets/0111e7ff-af09-48ba-a043-9e25c2dd24bd" />

Closes CLO-649.

Release Notes:

- N/A
