### PR TITLE
sidebar: Propagate workspace trust when creating new worktrees

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3145,7 +3145,7 @@ impl AgentPanel {
                         .has_restricted_worktrees(&source_worktree_store, cx)
                 })
                 .unwrap_or(false);
-            
+
             if !source_is_trusted {
                 return;
             }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -64,6 +64,7 @@ use language::LanguageRegistry;
 use language_model::LanguageModelRegistry;
 use project::git_store::{GitStoreEvent, RepositoryEvent};
 use project::project_settings::ProjectSettings;
+use project::trusted_worktrees::{PathTrust, TrustedWorktrees};
 use project::{Project, ProjectPath, Worktree, WorktreePaths, linked_worktree_short_name};
 use prompt_store::{PromptStore, UserPromptId};
 use remote::RemoteConnectionOptions;
@@ -3121,6 +3122,38 @@ impl AgentPanel {
         }
     }
 
+    fn should_propagate_worktree_trust(&self, cx: &App) -> bool {
+        if ProjectSettings::get_global(cx).session.trust_all_worktrees {
+            return false;
+        }
+        let Some(trusted_store) = TrustedWorktrees::try_get_global(cx) else {
+            return false;
+        };
+        let worktree_store = self.project.read(cx).worktree_store();
+        !trusted_store.read(cx).has_restricted_worktrees(&worktree_store, cx)
+    }
+
+    fn trust_worktree_paths(
+        new_workspace: &Entity<workspace::Workspace>,
+        paths: &[PathBuf],
+        cx: &mut AsyncWindowContext,
+    ) {
+        cx.update(|_, cx| {
+            let Some(trusted_store) = TrustedWorktrees::try_get_global(cx) else {
+                return;
+            };
+            let worktree_store = new_workspace.read(cx).project().read(cx).worktree_store();
+            let paths_to_trust: collections::HashSet<PathTrust> = paths
+                .iter()
+                .map(|p| PathTrust::AbsPath(p.clone()))
+                .collect();
+            trusted_store.update(cx, |store, cx| {
+                store.trust(&worktree_store, paths_to_trust, cx);
+            });
+        })
+        .ok();
+    }
+
     /// Kicks off an async git-worktree creation for each repository. Returns:
     ///
     /// - `creation_infos`: a vec of `(repo, new_path, receiver)` tuples—the
@@ -3397,6 +3430,7 @@ impl AgentPanel {
             .downcast::<workspace::MultiWorkspace>();
 
         let selected_agent = self.selected_agent();
+        let propagate_trust = self.should_propagate_worktree_trust(cx);
 
         let task = cx.spawn_in(window, async move |this, cx| {
             let (all_paths, path_remapping, has_non_git) = match args {
@@ -3542,6 +3576,7 @@ impl AgentPanel {
                 content,
                 selected_agent,
                 remote_connection_options,
+                propagate_trust,
                 cx,
             )
             .await
@@ -3575,6 +3610,7 @@ impl AgentPanel {
         content: Vec<acp::ContentBlock>,
         selected_agent: Option<Agent>,
         remote_connection_options: Option<RemoteConnectionOptions>,
+        propagate_trust: bool,
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
         let window_handle = window_handle
@@ -3636,6 +3672,10 @@ impl AgentPanel {
                 futures::future::join_all(tasks)
             })
             .await;
+
+        if propagate_trust {
+            Self::trust_worktree_paths(&new_workspace, &all_paths, cx);
+        }
 
         let initial_content = AgentInitialContent::ContentBlock {
             blocks: content,

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3130,7 +3130,9 @@ impl AgentPanel {
             return false;
         };
         let worktree_store = self.project.read(cx).worktree_store();
-        !trusted_store.read(cx).has_restricted_worktrees(&worktree_store, cx)
+        !trusted_store
+            .read(cx)
+            .has_restricted_worktrees(&worktree_store, cx)
     }
 
     fn trust_worktree_paths(

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3144,14 +3144,21 @@ impl AgentPanel {
             let Some(trusted_store) = TrustedWorktrees::try_get_global(cx) else {
                 return;
             };
+            
             let worktree_store = new_workspace.read(cx).project().read(cx).worktree_store();
-            let paths_to_trust: collections::HashSet<PathTrust> = paths
+            let paths_to_trust: HashSet<_> = paths
                 .iter()
-                .map(|p| PathTrust::AbsPath(p.clone()))
+                .filter_map(|path| {
+                    let (worktree, _) = worktree_store.read(cx).find_worktree(path, cx)?;
+                    Some(PathTrust::Worktree(worktree.read(cx).id()))
+                })
                 .collect();
-            trusted_store.update(cx, |store, cx| {
-                store.trust(&worktree_store, paths_to_trust, cx);
-            });
+            
+            if !paths_to_trust.is_empty() {
+                trusted_store.update(cx, |store, cx| {
+                    store.trust(&worktree_store, paths_to_trust, cx);
+                });
+            }
         })
         .ok();
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3122,29 +3122,34 @@ impl AgentPanel {
         }
     }
 
-    fn should_propagate_worktree_trust(&self, cx: &App) -> bool {
-        if ProjectSettings::get_global(cx).session.trust_all_worktrees {
-            return false;
-        }
-        let Some(trusted_store) = TrustedWorktrees::try_get_global(cx) else {
-            return false;
-        };
-        let worktree_store = self.project.read(cx).worktree_store();
-        !trusted_store
-            .read(cx)
-            .has_restricted_worktrees(&worktree_store, cx)
-    }
-
-    fn trust_worktree_paths(
+    fn maybe_propagate_worktree_trust(
+        this: &WeakEntity<Self>,
         new_workspace: &Entity<workspace::Workspace>,
         paths: &[PathBuf],
         cx: &mut AsyncWindowContext,
     ) {
         cx.update(|_, cx| {
+            if ProjectSettings::get_global(cx).session.trust_all_worktrees {
+                return;
+            }
             let Some(trusted_store) = TrustedWorktrees::try_get_global(cx) else {
                 return;
             };
+
+            let source_is_trusted = this
+                .upgrade()
+                .map(|panel| {
+                    let source_worktree_store = panel.read(cx).project.read(cx).worktree_store();
+                    !trusted_store
+                        .read(cx)
+                        .has_restricted_worktrees(&source_worktree_store, cx)
+                })
+                .unwrap_or(false);
             
+            if !source_is_trusted {
+                return;
+            }
+
             let worktree_store = new_workspace.read(cx).project().read(cx).worktree_store();
             let paths_to_trust: HashSet<_> = paths
                 .iter()
@@ -3153,7 +3158,7 @@ impl AgentPanel {
                     Some(PathTrust::Worktree(worktree.read(cx).id()))
                 })
                 .collect();
-            
+
             if !paths_to_trust.is_empty() {
                 trusted_store.update(cx, |store, cx| {
                     store.trust(&worktree_store, paths_to_trust, cx);
@@ -3439,7 +3444,6 @@ impl AgentPanel {
             .downcast::<workspace::MultiWorkspace>();
 
         let selected_agent = self.selected_agent();
-        let propagate_trust = self.should_propagate_worktree_trust(cx);
 
         let task = cx.spawn_in(window, async move |this, cx| {
             let (all_paths, path_remapping, has_non_git) = match args {
@@ -3585,7 +3589,6 @@ impl AgentPanel {
                 content,
                 selected_agent,
                 remote_connection_options,
-                propagate_trust,
                 cx,
             )
             .await
@@ -3619,7 +3622,6 @@ impl AgentPanel {
         content: Vec<acp::ContentBlock>,
         selected_agent: Option<Agent>,
         remote_connection_options: Option<RemoteConnectionOptions>,
-        propagate_trust: bool,
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
         let window_handle = window_handle
@@ -3682,9 +3684,7 @@ impl AgentPanel {
             })
             .await;
 
-        if propagate_trust {
-            Self::trust_worktree_paths(&new_workspace, &all_paths, cx);
-        }
+        Self::maybe_propagate_worktree_trust(&this, &new_workspace, &all_paths, cx);
 
         let initial_content = AgentInitialContent::ContentBlock {
             blocks: content,


### PR DESCRIPTION
When creating a new git worktree, if the workspace is currently trusted, trust the newly-created worktrees

Release Notes:

- N/A
