### PR TITLE
title_bar: Don't show a badge for organizations without a plan

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1180,7 +1180,7 @@ impl TitleBar {
                                                         )
                                                     }),
                                             )
-                                            .child(PlanChip::new(plan.unwrap_or(Plan::ZedFree)))
+                                            .children(plan.map(|plan| PlanChip::new(plan)))
                                             .into_any_element()
                                     }
                                 },


### PR DESCRIPTION
This PR makes it so we don't show a plan badge for organizations that don't have a plan.

Closes CLO-654.

Release Notes:

- N/A
