### PR TITLE
client: Don't override organization plans with personal plan

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -755,10 +755,8 @@ impl UserStore {
             };
         }
 
-        if let Some(organization) = &self.current_organization
-            && let Some(plan) = self.plan_for_organization(&organization.id)
-        {
-            return Some(plan);
+        if let Some(organization) = &self.current_organization {
+            return self.plan_for_organization(&organization.id);
         }
 
         self.plan_info.as_ref().map(|info| info.plan())


### PR DESCRIPTION
This PR makes it so we don't override organization plans with the user's personal plan.

If an organization is selected and does not have a plan, we want to return `None` for the plan.

Closes CLO-655.

Release Notes:

- N/A
