### PR TITLE
acp_thread: Internal error on subagent permission req

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2944,6 +2944,17 @@ impl AcpThread {
                     });
                 }
 
+                for (ix, entry) in self.entries.iter_mut().enumerate() {
+                    if let AgentThreadEntry::ToolCall(call) = entry {
+                        if call.pending_terminal_id.as_ref() == Some(&terminal_id) {
+                            call.content
+                                .push(ToolCallContent::Terminal(entity.clone()));
+                            call.pending_terminal_id = None;
+                            cx.emit(AcpThreadEvent::EntryUpdated(ix));
+                        }
+                    }
+                }
+
                 cx.notify();
             }
             TerminalProviderEvent::Output { terminal_id, data } => {
@@ -3257,6 +3268,98 @@ mod tests {
         assert!(
             result.is_ok(),
             "Should succeed even though the terminal doesn't exist yet"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_pending_terminal_resolved_on_creation(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(
+                    project,
+                    PathList::new(&[std::path::Path::new(path!("/test"))]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        let terminal_id = acp::TerminalId::new("pending-terminal");
+        let tool_call_id = acp::ToolCallId::new("test-bash-tool");
+
+        thread.update(cx, |thread, cx| {
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new(tool_call_id.clone(), "odin test .")
+                            .kind(acp::ToolKind::Execute)
+                            .status(acp::ToolCallStatus::InProgress)
+                            .content(vec![acp::ToolCallContent::Terminal(
+                                acp::Terminal::new(terminal_id.clone()),
+                            )]),
+                    ),
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let has_terminal_content = thread.read_with(cx, |thread, _cx| {
+            if let Some(AgentThreadEntry::ToolCall(call)) = thread.entries.last() {
+                call.content
+                    .iter()
+                    .any(|c| matches!(c, ToolCallContent::Terminal(_)))
+            } else {
+                false
+            }
+        });
+        assert!(
+            !has_terminal_content,
+            "Tool call should have no terminal content yet"
+        );
+
+        let lower = cx.new(|cx| {
+            let builder = ::terminal::TerminalBuilder::new_display_only(
+                ::terminal::terminal_settings::CursorShape::default(),
+                ::terminal::terminal_settings::AlternateScroll::On,
+                None,
+                0,
+                cx.background_executor(),
+                PathStyle::local(),
+            )
+            .unwrap();
+            builder.subscribe(cx)
+        });
+
+        thread.update(cx, |thread, cx| {
+            thread.on_terminal_provider_event(
+                TerminalProviderEvent::Created {
+                    terminal_id: terminal_id.clone(),
+                    label: "odin test .".to_string(),
+                    cwd: None,
+                    output_byte_limit: None,
+                    terminal: lower,
+                },
+                cx,
+            );
+        });
+
+        let has_terminal_content_after = thread.read_with(cx, |thread, _cx| {
+            if let Some(AgentThreadEntry::ToolCall(call)) = thread.entries.last() {
+                call.content
+                    .iter()
+                    .any(|c| matches!(c, ToolCallContent::Terminal(_)))
+            } else {
+                false
+            }
+        });
+        assert!(
+            has_terminal_content_after,
+            "Tool call should have terminal content after terminal creation"
         );
     }
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -814,7 +814,14 @@ impl ToolCallContent {
                 .get(&terminal_id)
                 .cloned()
                 .map(|terminal| Some(Self::Terminal(terminal)))
-                .ok_or_else(|| anyhow::anyhow!("Terminal with id `{}` not found", terminal_id)),
+                .ok_or_else(|| {
+                    log::warn!(
+                        "ToolCallContent::from_acp: terminal {:?} not found ({} registered)",
+                        terminal_id,
+                        terminals.len(),
+                    );
+                    anyhow::anyhow!("Terminal with id `{}` not found", terminal_id)
+                }),
             _ => Ok(None),
         }
     }
@@ -1874,6 +1881,11 @@ impl AcpThread {
         }
 
         if let Some(ix) = self.index_for_tool_call(&id) {
+            log::info!(
+                "upsert_tool_call_inner: UPDATE path for {:?} ({} terminals registered)",
+                id,
+                self.terminals.len(),
+            );
             let AgentThreadEntry::ToolCall(call) = &mut self.entries[ix] else {
                 unreachable!()
             };
@@ -1890,6 +1902,11 @@ impl AcpThread {
 
             cx.emit(AcpThreadEvent::EntryUpdated(ix));
         } else {
+            log::info!(
+                "upsert_tool_call_inner: CREATE path for {:?} ({} terminals registered)",
+                id,
+                self.terminals.len(),
+            );
             let call = ToolCall::from_acp(
                 update.try_into()?,
                 status,
@@ -2861,6 +2878,11 @@ impl AcpThread {
             )
         });
         self.terminals.insert(terminal_id.clone(), entity.clone());
+        log::info!(
+            "register_terminal_created: terminal {:?} registered ({} total)",
+            terminal_id,
+            self.terminals.len(),
+        );
         entity
     }
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -352,7 +352,18 @@ impl ToolCall {
         }
 
         if let Some(status) = status {
-            self.status = status.into();
+            let new_status: ToolCallStatus = status.into();
+            if matches!(
+                (&self.status, &new_status),
+                (ToolCallStatus::WaitingForConfirmation { .. }, ToolCallStatus::Pending)
+            ) {
+                log::warn!(
+                    "update_fields: skipping status downgrade from WaitingForConfirmation to Pending for tool_call {:?}",
+                    self.id,
+                );
+            } else {
+                self.status = new_status;
+            }
         }
 
         if let Some(subagent_session_info) = subagent_session_info_from_meta(&meta) {
@@ -1908,7 +1919,17 @@ impl AcpThread {
                 &self.terminals,
                 cx,
             )?;
-            call.status = status;
+            if matches!(
+                (&call.status, &status),
+                (ToolCallStatus::WaitingForConfirmation { .. }, ToolCallStatus::Pending)
+            ) {
+                log::warn!(
+                    "upsert_tool_call_inner: skipping status downgrade from WaitingForConfirmation to Pending for tool_call {:?}",
+                    id,
+                );
+            } else {
+                call.status = status;
+            }
 
             cx.emit(AcpThreadEvent::EntryUpdated(ix));
         } else {
@@ -3268,6 +3289,189 @@ mod tests {
         assert!(
             result.is_ok(),
             "Should succeed even though the terminal doesn't exist yet"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_session_update_does_not_clobber_waiting_for_confirmation(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(
+                    project,
+                    PathList::new(&[std::path::Path::new(path!("/test"))]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        let terminal_id = acp::TerminalId::new("term-1");
+        let tool_call_id = acp::ToolCallId::new("tc-1");
+
+        let _auth_task = thread.update(cx, |thread, cx| {
+            thread
+                .request_tool_call_authorization(
+                    acp::ToolCallUpdate::new(
+                        tool_call_id.clone(),
+                        acp::ToolCallUpdateFields::new()
+                            .title("odin test .".to_string())
+                            .kind(acp::ToolKind::Execute)
+                            .content(vec![acp::ToolCallContent::Terminal(
+                                acp::Terminal::new(terminal_id.clone()),
+                            )]),
+                    ),
+                    PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                        "allow",
+                        "Allow",
+                        acp::PermissionOptionKind::AllowOnce,
+                    )]),
+                    cx,
+                )
+                .unwrap()
+        });
+
+        let is_waiting = thread.read_with(cx, |thread, _cx| {
+            thread.entries.iter().any(|e| {
+                matches!(
+                    e,
+                    AgentThreadEntry::ToolCall(c)
+                        if matches!(c.status, ToolCallStatus::WaitingForConfirmation { .. })
+                )
+            })
+        });
+        assert!(is_waiting, "Tool call should be WaitingForConfirmation");
+
+        thread.update(cx, |thread, cx| {
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new(tool_call_id.clone(), "odin test .")
+                            .kind(acp::ToolKind::Execute)
+                            .status(acp::ToolCallStatus::Pending)
+                            .content(vec![acp::ToolCallContent::Terminal(
+                                acp::Terminal::new(terminal_id.clone()),
+                            )]),
+                    ),
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let still_waiting = thread.read_with(cx, |thread, _cx| {
+            thread.entries.iter().any(|e| {
+                matches!(
+                    e,
+                    AgentThreadEntry::ToolCall(c)
+                        if matches!(c.status, ToolCallStatus::WaitingForConfirmation { .. })
+                )
+            })
+        });
+        assert!(
+            still_waiting,
+            "Tool call should still be WaitingForConfirmation after session update"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_pending_terminal_resolved_on_register(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(
+                    project,
+                    PathList::new(&[std::path::Path::new(path!("/test"))]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        let terminal_id = acp::TerminalId::new("pending-terminal");
+        let tool_call_id = acp::ToolCallId::new("test-bash-tool");
+
+        thread.update(cx, |thread, cx| {
+            let _auth_task = thread
+                .request_tool_call_authorization(
+                    acp::ToolCallUpdate::new(
+                        tool_call_id.clone(),
+                        acp::ToolCallUpdateFields::new()
+                            .title("odin test .".to_string())
+                            .kind(acp::ToolKind::Execute)
+                            .content(vec![acp::ToolCallContent::Terminal(
+                                acp::Terminal::new(terminal_id.clone()),
+                            )]),
+                    ),
+                    PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                        "allow",
+                        "Allow",
+                        acp::PermissionOptionKind::AllowOnce,
+                    )]),
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let has_terminal_content = thread.read_with(cx, |thread, _cx| {
+            if let Some(AgentThreadEntry::ToolCall(call)) = thread.entries.last() {
+                call.content
+                    .iter()
+                    .any(|c| matches!(c, ToolCallContent::Terminal(_)))
+            } else {
+                false
+            }
+        });
+        assert!(
+            !has_terminal_content,
+            "Tool call should have no terminal content yet"
+        );
+
+        let lower = cx.new(|cx| {
+            let builder = ::terminal::TerminalBuilder::new_display_only(
+                ::terminal::terminal_settings::CursorShape::default(),
+                ::terminal::terminal_settings::AlternateScroll::On,
+                None,
+                0,
+                cx.background_executor(),
+                PathStyle::local(),
+            )
+            .unwrap();
+            builder.subscribe(cx)
+        });
+
+        thread.update(cx, |thread, cx| {
+            thread.register_terminal_created(
+                terminal_id.clone(),
+                "odin test .".to_string(),
+                None,
+                None,
+                lower,
+                cx,
+            );
+        });
+
+        let has_terminal_content_after = thread.read_with(cx, |thread, _cx| {
+            if let Some(AgentThreadEntry::ToolCall(call)) = thread.entries.last() {
+                call.content
+                    .iter()
+                    .any(|c| matches!(c, ToolCallContent::Terminal(_)))
+            } else {
+                false
+            }
+        });
+        assert!(
+            has_terminal_content_after,
+            "Tool call should have terminal content after register_terminal_created"
         );
     }
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -256,6 +256,7 @@ pub struct ToolCall {
     pub raw_output: Option<serde_json::Value>,
     pub tool_name: Option<SharedString>,
     pub subagent_session_info: Option<SubagentSessionInfo>,
+    pub pending_terminal_id: Option<acp::TerminalId>,
 }
 
 impl ToolCall {
@@ -277,15 +278,24 @@ impl ToolCall {
             tool_call.title
         };
         let mut content = Vec::with_capacity(tool_call.content.len());
+        let mut pending_terminal_id = None;
         for item in tool_call.content {
-            if let Some(item) = ToolCallContent::from_acp(
+            let unresolved_terminal_id =
+                if let acp::ToolCallContent::Terminal(acp::Terminal { terminal_id, .. }) = &item {
+                    Some(terminal_id.clone())
+                } else {
+                    None
+                };
+            if let Some(resolved) = ToolCallContent::from_acp(
                 item,
                 language_registry.clone(),
                 path_style,
                 terminals,
                 cx,
             )? {
-                content.push(item);
+                content.push(resolved);
+            } else if unresolved_terminal_id.is_some() {
+                pending_terminal_id = unresolved_terminal_id;
             }
         }
 
@@ -312,6 +322,7 @@ impl ToolCall {
             raw_output: tool_call.raw_output,
             tool_name,
             subagent_session_info,
+            pending_terminal_id,
         };
         Ok(result)
     }
@@ -810,18 +821,16 @@ impl ToolCallContent {
                     cx,
                 )
             })))),
-            acp::ToolCallContent::Terminal(acp::Terminal { terminal_id, .. }) => terminals
-                .get(&terminal_id)
-                .cloned()
-                .map(|terminal| Some(Self::Terminal(terminal)))
-                .ok_or_else(|| {
+            acp::ToolCallContent::Terminal(acp::Terminal { terminal_id, .. }) => {
+                if !terminals.contains_key(&terminal_id) {
                     log::warn!(
                         "ToolCallContent::from_acp: terminal {:?} not found ({} registered)",
                         terminal_id,
                         terminals.len(),
                     );
-                    anyhow::anyhow!("Terminal with id `{}` not found", terminal_id)
-                }),
+                }
+                Ok(terminals.get(&terminal_id).cloned().map(Self::Terminal))
+            }
             _ => Ok(None),
         }
     }
@@ -1801,6 +1810,7 @@ impl AcpThread {
                     raw_output: None,
                     tool_name: None,
                     subagent_session_info: None,
+                    pending_terminal_id: None,
                 };
                 self.push_entry(AgentThreadEntry::ToolCall(failed_tool_call), cx);
                 return Ok(());
@@ -3198,6 +3208,55 @@ mod tests {
         assert!(
             content.contains("pre-exit data"),
             "expected pre-exit data to render, got: {content}"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_request_tool_call_authorization_succeeds_with_unknown_terminal(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(
+                    project,
+                    PathList::new(&[std::path::Path::new(path!("/test"))]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        let terminal_id = acp::TerminalId::new("nonexistent-terminal");
+        let tool_call_id = acp::ToolCallId::new("test-bash-tool");
+
+        let result = thread.update(cx, |thread, cx| {
+            thread.request_tool_call_authorization(
+                acp::ToolCallUpdate::new(
+                    tool_call_id.clone(),
+                    acp::ToolCallUpdateFields::new()
+                        .title("odin test .".to_string())
+                        .kind(acp::ToolKind::Execute)
+                        .content(vec![acp::ToolCallContent::Terminal(
+                            acp::Terminal::new(terminal_id.clone()),
+                        )]),
+                ),
+                PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                    "allow",
+                    "Allow",
+                    acp::PermissionOptionKind::AllowOnce,
+                )]),
+                cx,
+            )
+        });
+
+        assert!(
+            result.is_ok(),
+            "Should succeed even though the terminal doesn't exist yet"
         );
     }
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -355,7 +355,10 @@ impl ToolCall {
             let new_status: ToolCallStatus = status.into();
             if matches!(
                 (&self.status, &new_status),
-                (ToolCallStatus::WaitingForConfirmation { .. }, ToolCallStatus::Pending)
+                (
+                    ToolCallStatus::WaitingForConfirmation { .. },
+                    ToolCallStatus::Pending
+                )
             ) {
                 log::warn!(
                     "update_fields: skipping status downgrade from WaitingForConfirmation to Pending for tool_call {:?}",
@@ -1921,7 +1924,10 @@ impl AcpThread {
             )?;
             if matches!(
                 (&call.status, &status),
-                (ToolCallStatus::WaitingForConfirmation { .. }, ToolCallStatus::Pending)
+                (
+                    ToolCallStatus::WaitingForConfirmation { .. },
+                    ToolCallStatus::Pending
+                )
             ) {
                 log::warn!(
                     "upsert_tool_call_inner: skipping status downgrade from WaitingForConfirmation to Pending for tool_call {:?}",
@@ -2968,8 +2974,7 @@ impl AcpThread {
                 for (ix, entry) in self.entries.iter_mut().enumerate() {
                     if let AgentThreadEntry::ToolCall(call) = entry {
                         if call.pending_terminal_id.as_ref() == Some(&terminal_id) {
-                            call.content
-                                .push(ToolCallContent::Terminal(entity.clone()));
+                            call.content.push(ToolCallContent::Terminal(entity.clone()));
                             call.pending_terminal_id = None;
                             cx.emit(AcpThreadEvent::EntryUpdated(ix));
                         }
@@ -3273,9 +3278,9 @@ mod tests {
                     acp::ToolCallUpdateFields::new()
                         .title("odin test .".to_string())
                         .kind(acp::ToolKind::Execute)
-                        .content(vec![acp::ToolCallContent::Terminal(
-                            acp::Terminal::new(terminal_id.clone()),
-                        )]),
+                        .content(vec![acp::ToolCallContent::Terminal(acp::Terminal::new(
+                            terminal_id.clone(),
+                        ))]),
                 ),
                 PermissionOptions::Flat(vec![acp::PermissionOption::new(
                     "allow",
@@ -3323,9 +3328,9 @@ mod tests {
                         acp::ToolCallUpdateFields::new()
                             .title("odin test .".to_string())
                             .kind(acp::ToolKind::Execute)
-                            .content(vec![acp::ToolCallContent::Terminal(
-                                acp::Terminal::new(terminal_id.clone()),
-                            )]),
+                            .content(vec![acp::ToolCallContent::Terminal(acp::Terminal::new(
+                                terminal_id.clone(),
+                            ))]),
                     ),
                     PermissionOptions::Flat(vec![acp::PermissionOption::new(
                         "allow",
@@ -3355,9 +3360,9 @@ mod tests {
                         acp::ToolCall::new(tool_call_id.clone(), "odin test .")
                             .kind(acp::ToolKind::Execute)
                             .status(acp::ToolCallStatus::Pending)
-                            .content(vec![acp::ToolCallContent::Terminal(
-                                acp::Terminal::new(terminal_id.clone()),
-                            )]),
+                            .content(vec![acp::ToolCallContent::Terminal(acp::Terminal::new(
+                                terminal_id.clone(),
+                            ))]),
                     ),
                     cx,
                 )
@@ -3408,9 +3413,9 @@ mod tests {
                         acp::ToolCallUpdateFields::new()
                             .title("odin test .".to_string())
                             .kind(acp::ToolKind::Execute)
-                            .content(vec![acp::ToolCallContent::Terminal(
-                                acp::Terminal::new(terminal_id.clone()),
-                            )]),
+                            .content(vec![acp::ToolCallContent::Terminal(acp::Terminal::new(
+                                terminal_id.clone(),
+                            ))]),
                     ),
                     PermissionOptions::Flat(vec![acp::PermissionOption::new(
                         "allow",
@@ -3503,9 +3508,9 @@ mod tests {
                         acp::ToolCall::new(tool_call_id.clone(), "odin test .")
                             .kind(acp::ToolKind::Execute)
                             .status(acp::ToolCallStatus::InProgress)
-                            .content(vec![acp::ToolCallContent::Terminal(
-                                acp::Terminal::new(terminal_id.clone()),
-                            )]),
+                            .content(vec![acp::ToolCallContent::Terminal(acp::Terminal::new(
+                                terminal_id.clone(),
+                            ))]),
                     ),
                     cx,
                 )

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -1572,6 +1572,16 @@ impl acp::Client for ClientDelegate {
 
         // Pre-handle: if a ToolCall carries terminal_info, create/register a display-only terminal.
         if let acp::SessionUpdate::ToolCall(tc) = &update_clone {
+            let has_terminal_content = tc
+                .content
+                .iter()
+                .any(|c| matches!(c, acp::ToolCallContent::Terminal(_)));
+            log::info!(
+                "session_notification: ToolCall {:?} has_terminal_content={}, has_terminal_info_meta={}",
+                tc.tool_call_id,
+                has_terminal_content,
+                tc.meta.as_ref().and_then(|m| m.get("terminal_info")).is_some(),
+            );
             if let Some(meta) = &tc.meta {
                 if let Some(terminal_info) = meta.get("terminal_info") {
                     if let Some(id_str) = terminal_info.get("terminal_id").and_then(|v| v.as_str())


### PR DESCRIPTION
Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #53843

Release Notes:

- Claude ACP sessions correctly handle out-of-order terminal creation when permission prompt required.
