### PR TITLE
Add support for user configurable mouse bindings

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -946,3 +946,28 @@ pub struct ConfirmEditReviewComment {
 pub struct CancelEditReviewComment {
     pub id: usize,
 }
+
+/// Adds a cursor at the current mouse position (for use in mouse keybindings).
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct AddCursorAtMouse;
+
+/// Extends the current selection to the mouse position (for use in mouse keybindings).
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct ExtendSelectionToMouse;
+
+/// Goes to the definition of the symbol at the current mouse position.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct GoToDefinitionAtMouse;
+
+/// Goes to the type definition of the symbol at the current mouse position.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct GoToTypeDefinitionAtMouse;
+
+/// Starts a columnar (block) selection at the current mouse position.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct StartColumnarSelectionAtMouse;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -18293,6 +18293,116 @@ impl Editor {
         self.go_to_definition_of_kind(GotoDefinitionKind::Type, true, window, cx)
     }
 
+    fn mouse_position_map(&self, window: &Window) -> Option<(Rc<PositionMap>, PointForPosition)> {
+        let position_map = self.last_position_map.clone()?;
+        let mouse_position = window.mouse_position();
+        if !position_map.text_hitbox.contains(&mouse_position) {
+            return None;
+        }
+        let point = position_map.point_for_position(mouse_position);
+        Some((position_map, point))
+    }
+
+    fn goto_at_mouse(
+        &mut self,
+        kind: GotoDefinitionKind,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((position_map, point_for_position)) = self.mouse_position_map(window) else {
+            return;
+        };
+        let display_snapshot = &position_map.snapshot.display_snapshot;
+        let point = point_for_position.previous_valid.to_point(display_snapshot);
+        let anchor = display_snapshot.buffer_snapshot().anchor_before(point);
+        self.change_selections(SelectionEffects::default(), window, cx, |s| {
+            s.select_anchor_ranges([anchor..anchor]);
+        });
+        self.select(SelectPhase::End, window, cx);
+        self.go_to_definition_of_kind(kind, false, window, cx)
+            .detach_and_log_err(cx);
+    }
+
+    pub fn add_cursor_at_mouse(
+        &mut self,
+        _: &AddCursorAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_, point_for_position)) = self.mouse_position_map(window) else {
+            return;
+        };
+        self.select(
+            SelectPhase::Begin {
+                position: point_for_position.previous_valid,
+                add: true,
+                click_count: 1,
+            },
+            window,
+            cx,
+        );
+        self.select(SelectPhase::End, window, cx);
+    }
+
+    pub fn extend_selection_to_mouse(
+        &mut self,
+        _: &ExtendSelectionToMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_, point_for_position)) = self.mouse_position_map(window) else {
+            return;
+        };
+        self.select(
+            SelectPhase::Extend {
+                position: point_for_position.previous_valid,
+                click_count: 1,
+            },
+            window,
+            cx,
+        );
+        self.select(SelectPhase::End, window, cx);
+    }
+
+    pub fn go_to_definition_at_mouse(
+        &mut self,
+        _: &GoToDefinitionAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.goto_at_mouse(GotoDefinitionKind::Symbol, window, cx);
+    }
+
+    pub fn go_to_type_definition_at_mouse(
+        &mut self,
+        _: &GoToTypeDefinitionAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.goto_at_mouse(GotoDefinitionKind::Type, window, cx);
+    }
+
+    pub fn start_columnar_selection_at_mouse(
+        &mut self,
+        _: &StartColumnarSelectionAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_, point_for_position)) = self.mouse_position_map(window) else {
+            return;
+        };
+        self.select(
+            SelectPhase::BeginColumnar {
+                position: point_for_position.previous_valid,
+                reset: true,
+                mode: ColumnarMode::FromMouse,
+                goal_column: point_for_position.exact_unclipped.column(),
+            },
+            window,
+            cx,
+        );
+    }
+
     fn go_to_definition_of_kind(
         &mut self,
         kind: GotoDefinitionKind,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -466,6 +466,11 @@ impl EditorElement {
                 .go_to_type_definition_split(action, window, cx)
                 .detach_and_log_err(cx);
         });
+        register_action(editor, window, Editor::add_cursor_at_mouse);
+        register_action(editor, window, Editor::extend_selection_to_mouse);
+        register_action(editor, window, Editor::go_to_definition_at_mouse);
+        register_action(editor, window, Editor::go_to_type_definition_at_mouse);
+        register_action(editor, window, Editor::start_columnar_selection_at_mouse);
         register_action(editor, window, Editor::open_url);
         register_action(editor, window, Editor::open_selected_filename);
         register_action(editor, window, Editor::fold);

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -51,7 +51,7 @@
 
 use crate::{
     Action, ActionRegistry, App, DispatchPhase, EntityId, FocusId, KeyBinding, KeyContext, Keymap,
-    Keystroke, ModifiersChangedEvent, Window,
+    Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, ScrollDirection, Window,
 };
 use collections::FxHashMap;
 use smallvec::SmallVec;
@@ -437,7 +437,7 @@ impl DispatchTree {
         binding: &KeyBinding,
         context_stack: &[KeyContext],
     ) -> bool {
-        let (bindings, _) = keymap.bindings_for_input(&binding.keystrokes, context_stack);
+        let (bindings, _) = keymap.bindings_for_input(binding.keystrokes(), context_stack);
         if let Some(found) = bindings.iter().next() {
             found.action.partial_eq(binding.action.as_ref())
         } else {
@@ -558,6 +558,43 @@ impl DispatchTree {
             });
         }
         (input, to_replay)
+    }
+
+    fn context_stack(&self, dispatch_path: &SmallVec<[DispatchNodeId; 32]>) -> Vec<KeyContext> {
+        dispatch_path
+            .iter()
+            .filter_map(|node_id| self.node(*node_id).context.clone())
+            .collect()
+    }
+
+    /// Look up mouse bindings matching the given button/modifiers/click_count for the dispatch path.
+    pub fn dispatch_mouse(
+        &self,
+        button: &MouseButton,
+        modifiers: &Modifiers,
+        click_count: usize,
+        dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
+    ) -> SmallVec<[KeyBinding; 1]> {
+        self.keymap.borrow().bindings_for_mouse(
+            button,
+            modifiers,
+            click_count,
+            &self.context_stack(dispatch_path),
+        )
+    }
+
+    /// Look up scroll bindings matching the given direction/modifiers for the dispatch path.
+    pub fn dispatch_scroll(
+        &self,
+        direction: ScrollDirection,
+        modifiers: &Modifiers,
+        dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
+    ) -> SmallVec<[KeyBinding; 1]> {
+        self.keymap.borrow().bindings_for_scroll(
+            direction,
+            modifiers,
+            &self.context_stack(dispatch_path),
+        )
     }
 
     pub fn dispatch_path(&self, target: DispatchNodeId) -> SmallVec<[DispatchNodeId; 32]> {

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -667,8 +667,8 @@ mod tests {
 
     use crate::{
         ActionRegistry, App, Bounds, Context, DispatchTree, FocusHandle, InputHandler, IntoElement,
-        KeyBinding, KeyContext, Keymap, Pixels, Point, Render, Subscription, TestAppContext,
-        UTF16Selection, Unbind, Window,
+        KeyBinding, KeyBindingContextPredicate, KeyContext, Keymap, Modifiers, MouseButton, Pixels,
+        Point, Render, ScrollDirection, Subscription, TestAppContext, UTF16Selection, Unbind, Window,
     };
 
     actions!(dispatch_test, [TestAction, SecondaryTestAction]);
@@ -1168,5 +1168,93 @@ mod tests {
         });
         cx.simulate_keystrokes("ctrl-b [");
         test.update(cx, |test, _| assert_eq!(test.text.borrow().as_str(), "["))
+    }
+
+    #[test]
+    fn test_dispatch_mouse_finds_binding() {
+        let binding = KeyBinding::load_mouse("alt-mouse2", Box::new(TestAction), None, None)
+            .expect("valid mouse stroke");
+        let mut tree = test_dispatch_tree(vec![binding]);
+
+        let node_id = tree.push_node();
+        tree.pop_node();
+        let dispatch_path = tree.dispatch_path(node_id);
+
+        let alt = Modifiers {
+            alt: true,
+            ..Modifiers::none()
+        };
+
+        let matched = tree.dispatch_mouse(&MouseButton::Right, &alt, 1, &dispatch_path);
+        assert_eq!(matched.len(), 1);
+        assert!(matched[0].action.partial_eq(&TestAction));
+
+        // Wrong modifier — no match.
+        let not_matched =
+            tree.dispatch_mouse(&MouseButton::Right, &Modifiers::none(), 1, &dispatch_path);
+        assert!(not_matched.is_empty());
+
+        // Wrong button — no match.
+        let not_matched = tree.dispatch_mouse(&MouseButton::Left, &alt, 1, &dispatch_path);
+        assert!(not_matched.is_empty());
+    }
+
+    #[test]
+    fn test_dispatch_scroll_finds_binding() {
+        let binding =
+            KeyBinding::load_scroll("ctrl-scroll-down", Box::new(TestAction), None, None)
+                .expect("valid scroll stroke");
+        let mut tree = test_dispatch_tree(vec![binding]);
+
+        let node_id = tree.push_node();
+        tree.pop_node();
+        let dispatch_path = tree.dispatch_path(node_id);
+
+        let ctrl = Modifiers {
+            control: true,
+            ..Modifiers::none()
+        };
+
+        let matched = tree.dispatch_scroll(ScrollDirection::Down, &ctrl, &dispatch_path);
+        assert_eq!(matched.len(), 1);
+        assert!(matched[0].action.partial_eq(&TestAction));
+
+        // Wrong modifier — no match.
+        let not_matched =
+            tree.dispatch_scroll(ScrollDirection::Down, &Modifiers::none(), &dispatch_path);
+        assert!(not_matched.is_empty());
+
+        // Wrong direction — no match.
+        let not_matched = tree.dispatch_scroll(ScrollDirection::Up, &ctrl, &dispatch_path);
+        assert!(not_matched.is_empty());
+    }
+
+    #[test]
+    fn test_dispatch_mouse_respects_context() {
+        let context_predicate: std::rc::Rc<KeyBindingContextPredicate> =
+            KeyBindingContextPredicate::parse("Editor").unwrap().into();
+        let binding = KeyBinding::load_mouse(
+            "mouse1",
+            Box::new(TestAction),
+            Some(context_predicate),
+            None,
+        )
+        .expect("valid mouse stroke");
+        let mut tree = test_dispatch_tree(vec![binding]);
+
+        let node_id = tree.push_node();
+        tree.set_key_context(KeyContext::parse("Editor").unwrap());
+        tree.pop_node();
+        let dispatch_path = tree.dispatch_path(node_id);
+
+        let matched =
+            tree.dispatch_mouse(&MouseButton::Left, &Modifiers::none(), 1, &dispatch_path);
+        assert_eq!(matched.len(), 1);
+
+        // Does not fire on an empty dispatch path (no Editor context).
+        let empty_path: SmallVec<[super::DispatchNodeId; 32]> = SmallVec::new();
+        let not_matched =
+            tree.dispatch_mouse(&MouseButton::Left, &Modifiers::none(), 1, &empty_path);
+        assert!(not_matched.is_empty());
     }
 }

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -4,7 +4,10 @@ mod context;
 pub use binding::*;
 pub use context::*;
 
-use crate::{Action, AsKeystroke, Keystroke, Unbind, is_no_action, is_unbind};
+use crate::{
+    Action, AsKeystroke, KeybindingKeystroke, Keystroke, Modifiers, MouseButton, ScrollDirection,
+    Unbind, is_no_action, is_unbind,
+};
 use collections::{HashMap, HashSet};
 use smallvec::SmallVec;
 use std::any::TypeId;
@@ -39,7 +42,7 @@ fn disabled_binding_matches_context(disabled_binding: &KeyBinding, binding: &Key
 }
 
 fn binding_is_unbound(disabled_binding: &KeyBinding, binding: &KeyBinding) -> bool {
-    disabled_binding.keystrokes == binding.keystrokes
+    disabled_binding.input == binding.input
         && disabled_binding
             .action()
             .as_any()
@@ -113,7 +116,7 @@ impl Keymap {
             for disabled_ix in &self.disabled_binding_indices {
                 if disabled_ix > ix {
                     let disabled_binding = &self.bindings[*disabled_ix];
-                    if disabled_binding.keystrokes != binding.keystrokes {
+                    if disabled_binding.input != binding.input {
                         continue;
                     }
 
@@ -225,7 +228,7 @@ impl Keymap {
             first_binding_index.get_or_insert(ix);
         }
 
-        let mut pending = HashSet::default();
+        let mut pending: HashSet<&[KeybindingKeystroke]> = HashSet::default();
         for (ix, binding) in pending_bindings.into_iter().rev() {
             if let Some(binding_ix) = first_binding_index
                 && binding_ix > ix
@@ -233,10 +236,13 @@ impl Keymap {
                 continue;
             }
             if is_no_action(&*binding.action) || is_unbind(&*binding.action) {
-                pending.remove(&&binding.keystrokes);
+                pending.remove(binding.keystrokes());
                 continue;
             }
-            pending.insert(&binding.keystrokes);
+            let keystrokes = binding.keystrokes();
+            if !keystrokes.is_empty() {
+                pending.insert(keystrokes);
+            }
         }
 
         (bindings, !pending.is_empty())
@@ -287,6 +293,55 @@ impl Keymap {
             .into_iter()
             .map(|(_, _, binding)| binding.clone())
             .collect::<Vec<_>>()
+    }
+
+    /// Returns all bindings matching a mouse button event, in precedence order (higher first).
+    pub fn bindings_for_mouse(
+        &self,
+        button: &MouseButton,
+        modifiers: &Modifiers,
+        click_count: usize,
+        context_stack: &[KeyContext],
+    ) -> SmallVec<[KeyBinding; 1]> {
+        self.bindings_matching(context_stack, |binding| {
+            binding.is_mouse_binding() && binding.match_mouse(button, modifiers, click_count)
+        })
+    }
+
+    /// Returns all bindings matching a scroll wheel event, in precedence order (higher first).
+    pub fn bindings_for_scroll(
+        &self,
+        direction: ScrollDirection,
+        modifiers: &Modifiers,
+        context_stack: &[KeyContext],
+    ) -> SmallVec<[KeyBinding; 1]> {
+        self.bindings_matching(context_stack, |binding| {
+            binding.is_scroll_binding() && binding.match_scroll(direction, modifiers)
+        })
+    }
+
+    fn bindings_matching(
+        &self,
+        context_stack: &[KeyContext],
+        filter: impl Fn(&KeyBinding) -> bool,
+    ) -> SmallVec<[KeyBinding; 1]> {
+        let mut matched: SmallVec<[(usize, BindingIndex, &KeyBinding); 1]> = SmallVec::new();
+        for (ix, binding) in self.bindings().enumerate().rev() {
+            if !filter(binding) {
+                continue;
+            }
+            let Some(depth) = self.binding_enabled(binding, context_stack) else {
+                continue;
+            };
+            if is_no_action(&*binding.action) || is_unbind(&*binding.action) {
+                continue;
+            }
+            matched.push((depth, BindingIndex(ix), binding));
+        }
+        matched.sort_by(|(depth_a, ix_a, _), (depth_b, ix_b, _)| {
+            depth_b.cmp(depth_a).then(ix_b.cmp(ix_a))
+        });
+        matched.into_iter().map(|(_, _, b)| b.clone()).collect()
     }
 }
 
@@ -752,7 +807,7 @@ mod tests {
         fn assert_bindings(keymap: &Keymap, action: &dyn Action, expected: &[&str]) {
             let actual = keymap
                 .bindings_for_action(action)
-                .map(|binding| binding.keystrokes[0].inner().unparse())
+                .map(|binding| binding.keystrokes()[0].inner().unparse())
                 .collect::<Vec<_>>();
             assert_eq!(actual, expected, "{:?}", action);
         }
@@ -805,7 +860,7 @@ mod tests {
         fn assert_bindings(keymap: &Keymap, action: &dyn Action, expected: &[&str]) {
             let actual = keymap
                 .bindings_for_action(action)
-                .map(|binding| binding.keystrokes[0].inner().unparse())
+                .map(|binding| binding.keystrokes()[0].inner().unparse())
                 .collect::<Vec<_>>();
             assert_eq!(actual, expected, "{:?}", action);
         }

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -349,7 +349,7 @@ impl Keymap {
 mod tests {
     use super::*;
     use crate as gpui;
-    use gpui::{NoAction, Unbind};
+    use gpui::{Modifiers, MouseButton, NoAction, ScrollDirection, Unbind};
 
     actions!(
         test_only,
@@ -881,6 +881,110 @@ mod tests {
         keymap.add_bindings(bindings);
 
         assert!(keymap.bindings_for_action(&ActionAlpha {}).next().is_none());
+    }
+
+    fn make_mouse_binding<A: crate::Action>(
+        stroke: &str,
+        action: A,
+        context: Option<&str>,
+    ) -> KeyBinding {
+        let context_predicate =
+            context.map(|ctx| KeyBindingContextPredicate::parse(ctx).unwrap().into());
+        KeyBinding::load_mouse(stroke, Box::new(action), context_predicate, None).unwrap()
+    }
+
+    fn make_scroll_binding<A: crate::Action>(
+        stroke: &str,
+        action: A,
+        context: Option<&str>,
+    ) -> KeyBinding {
+        let context_predicate =
+            context.map(|ctx| KeyBindingContextPredicate::parse(ctx).unwrap().into());
+        KeyBinding::load_scroll(stroke, Box::new(action), context_predicate, None).unwrap()
+    }
+
+    #[test]
+    fn test_bindings_for_mouse() {
+        let mut keymap = Keymap::default();
+        keymap.add_bindings([make_mouse_binding("alt-mouse1", ActionAlpha {}, None)]);
+
+        let alt = Modifiers {
+            alt: true,
+            ..Modifiers::none()
+        };
+
+        let result = keymap.bindings_for_mouse(&MouseButton::Left, &alt, 1, &[]);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].action.partial_eq(&ActionAlpha {}));
+
+        // Wrong modifier — no match.
+        let result = keymap.bindings_for_mouse(&MouseButton::Left, &Modifiers::none(), 1, &[]);
+        assert!(result.is_empty());
+
+        // Wrong button — no match.
+        let result = keymap.bindings_for_mouse(&MouseButton::Right, &alt, 1, &[]);
+        assert!(result.is_empty());
+
+        // Wrong click count — no match.
+        let result = keymap.bindings_for_mouse(&MouseButton::Left, &alt, 2, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_bindings_for_scroll() {
+        let mut keymap = Keymap::default();
+        keymap.add_bindings([make_scroll_binding("ctrl-scroll-up", ActionAlpha {}, None)]);
+
+        let ctrl = Modifiers {
+            control: true,
+            ..Modifiers::none()
+        };
+
+        let result = keymap.bindings_for_scroll(ScrollDirection::Up, &ctrl, &[]);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].action.partial_eq(&ActionAlpha {}));
+
+        // Wrong modifier — no match.
+        let result = keymap.bindings_for_scroll(ScrollDirection::Up, &Modifiers::none(), &[]);
+        assert!(result.is_empty());
+
+        // Wrong direction — no match.
+        let result = keymap.bindings_for_scroll(ScrollDirection::Down, &ctrl, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_mouse_binding_context_depth_precedence() {
+        // Mirror the keystroke test_depth_precedence: with stack [pane, editor],
+        // the binding scoped to "editor" (depth=2) beats the one scoped to "pane" (depth=1).
+        let mut keymap = Keymap::default();
+        keymap.add_bindings([
+            make_mouse_binding("mouse1", ActionBeta {}, Some("pane")),
+            make_mouse_binding("mouse1", ActionGamma {}, Some("editor")),
+        ]);
+
+        let result = keymap.bindings_for_mouse(
+            &MouseButton::Left,
+            &Modifiers::none(),
+            1,
+            &[
+                KeyContext::parse("pane").unwrap(),
+                KeyContext::parse("editor").unwrap(),
+            ],
+        );
+        assert_eq!(result.len(), 2);
+        assert!(result[0].action.partial_eq(&ActionGamma {}));
+        assert!(result[1].action.partial_eq(&ActionBeta {}));
+    }
+
+    #[test]
+    fn test_mouse_binding_outside_context_not_matched() {
+        let mut keymap = Keymap::default();
+        keymap.add_bindings([make_mouse_binding("mouse1", ActionAlpha {}, Some("editor"))]);
+
+        let result =
+            keymap.bindings_for_mouse(&MouseButton::Left, &Modifiers::none(), 1, &[]);
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/crates/gpui/src/keymap/binding.rs
+++ b/crates/gpui/src/keymap/binding.rs
@@ -1,15 +1,28 @@
 use std::rc::Rc;
 
 use crate::{
-    Action, AsKeystroke, DummyKeyboardMapper, InvalidKeystrokeError, KeyBindingContextPredicate,
-    KeybindingKeystroke, Keystroke, PlatformKeyboardMapper, SharedString,
+    Action, AsKeystroke, DummyKeyboardMapper, InvalidKeystrokeError, InvalidMouseStrokeError,
+    InvalidScrollStrokeError, KeyBindingContextPredicate, KeybindingKeystroke, Keystroke,
+    Modifiers, MouseButton, MouseStroke, PlatformKeyboardMapper, ScrollDirection, ScrollStroke,
+    SharedString,
 };
 use smallvec::SmallVec;
+
+/// The kind of input that triggers a binding.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BindingInputKind {
+    /// A sequence of keystrokes (standard keyboard binding).
+    Keystrokes(SmallVec<[KeybindingKeystroke; 2]>),
+    /// A mouse button click.
+    Mouse(MouseStroke),
+    /// A scroll wheel event.
+    Scroll(ScrollStroke),
+}
 
 /// A keybinding and its associated metadata, from the keymap.
 pub struct KeyBinding {
     pub(crate) action: Box<dyn Action>,
-    pub(crate) keystrokes: SmallVec<[KeybindingKeystroke; 2]>,
+    pub(crate) input: BindingInputKind,
     pub(crate) context_predicate: Option<Rc<KeyBindingContextPredicate>>,
     pub(crate) meta: Option<KeyBindingMetaIndex>,
     /// The json input string used when building the keybinding, if any
@@ -20,7 +33,7 @@ impl Clone for KeyBinding {
     fn clone(&self) -> Self {
         KeyBinding {
             action: self.action.boxed_clone(),
-            keystrokes: self.keystrokes.clone(),
+            input: self.input.clone(),
             context_predicate: self.context_predicate.clone(),
             meta: self.meta,
             action_input: self.action_input.clone(),
@@ -29,7 +42,7 @@ impl Clone for KeyBinding {
 }
 
 impl KeyBinding {
-    /// Construct a new keybinding from the given data. Panics on parse error.
+    /// Construct a new keystroke keybinding from the given data. Panics on parse error.
     pub fn new<A: Action>(keystrokes: &str, action: A, context: Option<&str>) -> Self {
         let context_predicate =
             context.map(|context| KeyBindingContextPredicate::parse(context).unwrap().into());
@@ -44,7 +57,7 @@ impl KeyBinding {
         .unwrap()
     }
 
-    /// Load a keybinding from the given raw data.
+    /// Load a keystroke keybinding from the given raw data.
     pub fn load(
         keystrokes: &str,
         action: Box<dyn Action>,
@@ -66,7 +79,41 @@ impl KeyBinding {
             .collect::<std::result::Result<_, _>>()?;
 
         Ok(Self {
-            keystrokes,
+            input: BindingInputKind::Keystrokes(keystrokes),
+            action,
+            context_predicate,
+            meta: None,
+            action_input,
+        })
+    }
+
+    /// Load a mouse binding from a string like "alt-mouse1".
+    pub fn load_mouse(
+        input: &str,
+        action: Box<dyn Action>,
+        context_predicate: Option<Rc<KeyBindingContextPredicate>>,
+        action_input: Option<SharedString>,
+    ) -> std::result::Result<Self, InvalidMouseStrokeError> {
+        let stroke = MouseStroke::parse(input)?;
+        Ok(Self {
+            input: BindingInputKind::Mouse(stroke),
+            action,
+            context_predicate,
+            meta: None,
+            action_input,
+        })
+    }
+
+    /// Load a scroll binding from a string like "ctrl-scroll-up".
+    pub fn load_scroll(
+        input: &str,
+        action: Box<dyn Action>,
+        context_predicate: Option<Rc<KeyBindingContextPredicate>>,
+        action_input: Option<SharedString>,
+    ) -> std::result::Result<Self, InvalidScrollStrokeError> {
+        let stroke = ScrollStroke::parse(input)?;
+        Ok(Self {
+            input: BindingInputKind::Scroll(stroke),
             action,
             context_predicate,
             meta: None,
@@ -85,24 +132,65 @@ impl KeyBinding {
         self.meta = Some(meta);
     }
 
+    /// Returns true if this is a mouse binding.
+    pub fn is_mouse_binding(&self) -> bool {
+        matches!(self.input, BindingInputKind::Mouse(_))
+    }
+
+    /// Returns true if this is a scroll binding.
+    pub fn is_scroll_binding(&self) -> bool {
+        matches!(self.input, BindingInputKind::Scroll(_))
+    }
+
     /// Check if the given keystrokes match this binding.
     pub fn match_keystrokes(&self, typed: &[impl AsKeystroke]) -> Option<bool> {
-        if self.keystrokes.len() < typed.len() {
+        let BindingInputKind::Keystrokes(keystrokes) = &self.input else {
+            return None;
+        };
+
+        if keystrokes.len() < typed.len() {
             return None;
         }
 
-        for (target, typed) in self.keystrokes.iter().zip(typed.iter()) {
+        for (target, typed) in keystrokes.iter().zip(typed.iter()) {
             if !typed.as_keystroke().should_match(target) {
                 return None;
             }
         }
 
-        Some(self.keystrokes.len() > typed.len())
+        Some(keystrokes.len() > typed.len())
     }
 
-    /// Get the keystrokes associated with this binding
+    /// Check if this binding matches the given mouse event.
+    pub fn match_mouse(
+        &self,
+        button: &MouseButton,
+        modifiers: &Modifiers,
+        click_count: usize,
+    ) -> bool {
+        if let BindingInputKind::Mouse(stroke) = &self.input {
+            stroke.matches(button, modifiers, click_count)
+        } else {
+            false
+        }
+    }
+
+    /// Check if this binding matches the given scroll event.
+    pub fn match_scroll(&self, direction: ScrollDirection, modifiers: &Modifiers) -> bool {
+        if let BindingInputKind::Scroll(stroke) = &self.input {
+            stroke.matches(direction, modifiers)
+        } else {
+            false
+        }
+    }
+
+    /// Get the keystrokes associated with this binding (empty slice for non-keystroke bindings).
     pub fn keystrokes(&self) -> &[KeybindingKeystroke] {
-        self.keystrokes.as_slice()
+        if let BindingInputKind::Keystrokes(keystrokes) = &self.input {
+            keystrokes.as_slice()
+        } else {
+            &[]
+        }
     }
 
     /// Get the action associated with this binding
@@ -129,7 +217,7 @@ impl KeyBinding {
 impl std::fmt::Debug for KeyBinding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeyBinding")
-            .field("keystrokes", &self.keystrokes)
+            .field("input", &self.input)
             .field("context_predicate", &self.context_predicate)
             .field("action", &self.action.name())
             .finish()

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1,6 +1,8 @@
 mod app_menu;
 mod keyboard;
 mod keystroke;
+mod mouse_stroke;
+mod scroll_stroke;
 
 #[cfg(all(target_os = "linux", feature = "wayland"))]
 #[expect(missing_docs)]
@@ -70,6 +72,8 @@ use uuid::Uuid;
 pub use app_menu::*;
 pub use keyboard::*;
 pub use keystroke::*;
+pub use mouse_stroke::*;
+pub use scroll_stroke::*;
 
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) use test::*;

--- a/crates/gpui/src/platform/mouse_stroke.rs
+++ b/crates/gpui/src/platform/mouse_stroke.rs
@@ -1,0 +1,214 @@
+use std::{error::Error, fmt::Display};
+
+use crate::{Modifiers, MouseButton, NavigationDirection};
+
+/// Error type for `MouseStroke::parse`.
+#[derive(Debug)]
+pub struct InvalidMouseStrokeError {
+    /// The invalid mouse stroke string.
+    pub stroke: String,
+}
+
+impl Error for InvalidMouseStrokeError {}
+
+impl Display for InvalidMouseStrokeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Invalid mouse stroke \"{}\". {}",
+            self.stroke, MOUSE_STROKE_PARSE_EXPECTED_MESSAGE
+        )
+    }
+}
+
+/// Sentence explaining what mouse stroke parser expects.
+pub const MOUSE_STROKE_PARSE_EXPECTED_MESSAGE: &str = "Expected a sequence of optional modifiers \
+    (`ctrl`, `alt`, `shift`, `fn`, `cmd`, `super`, or `win`), an optional click count \
+    (`double` or `triple`), followed by a mouse button (`mouse1` through `mouse5`), separated by `-`.";
+
+const BUTTON_TOKENS: &[&str] = &["mouse1", "mouse2", "mouse3", "mouse4", "mouse5"];
+
+pub(super) fn try_parse_modifier_token(part: &str, modifiers: &mut Modifiers) -> bool {
+    if part.eq_ignore_ascii_case("ctrl") {
+        modifiers.control = true;
+    } else if part.eq_ignore_ascii_case("alt") {
+        modifiers.alt = true;
+    } else if part.eq_ignore_ascii_case("shift") {
+        modifiers.shift = true;
+    } else if part.eq_ignore_ascii_case("fn") {
+        modifiers.function = true;
+    } else if part.eq_ignore_ascii_case("secondary") {
+        if cfg!(target_os = "macos") {
+            modifiers.platform = true;
+        } else {
+            modifiers.control = true;
+        }
+    } else if part.eq_ignore_ascii_case("cmd")
+        || part.eq_ignore_ascii_case("super")
+        || part.eq_ignore_ascii_case("win")
+    {
+        modifiers.platform = true;
+    } else {
+        return false;
+    }
+    true
+}
+
+pub(super) fn append_modifiers(result: &mut String, modifiers: &Modifiers) {
+    if modifiers.function {
+        result.push_str("fn-");
+    }
+    if modifiers.control {
+        result.push_str("ctrl-");
+    }
+    if modifiers.alt {
+        result.push_str("alt-");
+    }
+    if modifiers.platform {
+        #[cfg(target_os = "macos")]
+        result.push_str("cmd-");
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        result.push_str("super-");
+        #[cfg(target_os = "windows")]
+        result.push_str("win-");
+    }
+    if modifiers.shift {
+        result.push_str("shift-");
+    }
+}
+
+/// The click count for a mouse binding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClickCount {
+    /// Single click.
+    Single,
+    /// Double click.
+    Double,
+    /// Triple click.
+    Triple,
+}
+
+impl ClickCount {
+    fn as_usize(self) -> usize {
+        match self {
+            ClickCount::Single => 1,
+            ClickCount::Double => 2,
+            ClickCount::Triple => 3,
+        }
+    }
+}
+
+/// A mouse button stroke that can be bound in a keymap.
+/// Syntax: `[modifiers-][clickcount-]mouse<1-5>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MouseStroke {
+    /// Modifier keys held during the click.
+    pub modifiers: Modifiers,
+    /// The mouse button that was pressed.
+    pub button: MouseButton,
+    /// The click count.
+    pub click_count: ClickCount,
+}
+
+impl MouseStroke {
+    /// Parse a mouse stroke from a string like "alt-mouse1" or "double-mouse3".
+    pub fn parse(source: &str) -> std::result::Result<Self, InvalidMouseStrokeError> {
+        let invalid = || InvalidMouseStrokeError {
+            stroke: source.to_owned(),
+        };
+        let mut modifiers = Modifiers::none();
+        let mut click_count = ClickCount::Single;
+        let mut button: Option<MouseButton> = None;
+
+        let mut parts = source.split('-').peekable();
+        while let Some(part) = parts.next() {
+            if try_parse_modifier_token(part, &mut modifiers) {
+                continue;
+            }
+            if part.eq_ignore_ascii_case("double") {
+                click_count = ClickCount::Double;
+                continue;
+            }
+            if part.eq_ignore_ascii_case("triple") {
+                click_count = ClickCount::Triple;
+                continue;
+            }
+            button = Some(match part {
+                p if p.eq_ignore_ascii_case("mouse1") => MouseButton::Left,
+                p if p.eq_ignore_ascii_case("mouse2") => MouseButton::Right,
+                p if p.eq_ignore_ascii_case("mouse3") => MouseButton::Middle,
+                p if p.eq_ignore_ascii_case("mouse4") => {
+                    MouseButton::Navigate(NavigationDirection::Back)
+                }
+                p if p.eq_ignore_ascii_case("mouse5") => {
+                    MouseButton::Navigate(NavigationDirection::Forward)
+                }
+                _ => return Err(invalid()),
+            });
+            // Button must be the last token.
+            if parts.peek().is_some() {
+                return Err(invalid());
+            }
+        }
+
+        Ok(MouseStroke {
+            modifiers,
+            button: button.ok_or_else(invalid)?,
+            click_count,
+        })
+    }
+
+    /// Returns true if this stroke matches the given event parameters.
+    pub fn matches(&self, button: &MouseButton, modifiers: &Modifiers, click_count: usize) -> bool {
+        self.click_count.as_usize() == click_count
+            && &self.button == button
+            && &self.modifiers == modifiers
+    }
+
+    /// Produces a string representation that `parse` can understand.
+    pub fn unparse(&self) -> String {
+        let mut result = String::new();
+        append_modifiers(&mut result, &self.modifiers);
+        match self.click_count {
+            ClickCount::Double => result.push_str("double-"),
+            ClickCount::Triple => result.push_str("triple-"),
+            ClickCount::Single => {}
+        }
+        let button_str = match &self.button {
+            MouseButton::Left => "mouse1",
+            MouseButton::Right => "mouse2",
+            MouseButton::Middle => "mouse3",
+            MouseButton::Navigate(NavigationDirection::Back) => "mouse4",
+            MouseButton::Navigate(NavigationDirection::Forward) => "mouse5",
+        };
+        result.push_str(button_str);
+        result
+    }
+}
+
+/// Returns true if the given string looks like a mouse button stroke.
+pub fn looks_like_mouse_stroke(s: &str) -> bool {
+    s.split('-')
+        .any(|tok| BUTTON_TOKENS.iter().any(|b| tok.eq_ignore_ascii_case(b)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_looks_like_mouse_stroke() {
+        assert!(looks_like_mouse_stroke("alt-mouse1"));
+        assert!(looks_like_mouse_stroke("double-mouse3"));
+        assert!(looks_like_mouse_stroke("ALT-MOUSE4"));
+        assert!(!looks_like_mouse_stroke("alt-mousescrolldown"));
+        assert!(!looks_like_mouse_stroke("ctrl-mousescrollup"));
+        assert!(!looks_like_mouse_stroke("mouse1foo"));
+    }
+
+    #[test]
+    fn test_parse_rejects_trailing_tokens() {
+        assert!(MouseStroke::parse("mouse1-alt").is_err());
+        assert!(MouseStroke::parse("alt-mouse1").is_ok());
+    }
+}

--- a/crates/gpui/src/platform/scroll_stroke.rs
+++ b/crates/gpui/src/platform/scroll_stroke.rs
@@ -1,0 +1,166 @@
+use std::{error::Error, fmt::Display};
+
+use super::mouse_stroke::{append_modifiers, try_parse_modifier_token};
+use crate::Modifiers;
+
+/// Error type for `ScrollStroke::parse`.
+#[derive(Debug)]
+pub struct InvalidScrollStrokeError {
+    /// The invalid scroll stroke string.
+    pub stroke: String,
+}
+
+impl Error for InvalidScrollStrokeError {}
+
+impl Display for InvalidScrollStrokeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Invalid scroll stroke \"{}\". {}",
+            self.stroke, SCROLL_STROKE_PARSE_EXPECTED_MESSAGE
+        )
+    }
+}
+
+/// Sentence explaining what scroll stroke parser expects.
+pub const SCROLL_STROKE_PARSE_EXPECTED_MESSAGE: &str = "Expected a sequence of optional modifiers \
+    (`ctrl`, `alt`, `shift`, `fn`, `cmd`, `super`, or `win`) followed by `scroll-up` or `scroll-down` \
+    (aliases: `mousescrollup`, `mousescrolldown`), \
+    separated by `-`.";
+
+/// The direction of a scroll wheel event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScrollDirection {
+    /// Scrolling upward.
+    Up,
+    /// Scrolling downward.
+    Down,
+}
+
+/// A scroll wheel binding.
+/// Syntax: `[modifiers-]scroll-<up|down>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ScrollStroke {
+    /// Modifier keys held during the scroll.
+    pub modifiers: Modifiers,
+    /// The direction of scroll.
+    pub direction: ScrollDirection,
+}
+
+fn match_direction_token(part: &str) -> Option<ScrollDirection> {
+    if part.eq_ignore_ascii_case("mousescrollup") || part.eq_ignore_ascii_case("scrollup") {
+        Some(ScrollDirection::Up)
+    } else if part.eq_ignore_ascii_case("mousescrolldown")
+        || part.eq_ignore_ascii_case("scrolldown")
+    {
+        Some(ScrollDirection::Down)
+    } else {
+        None
+    }
+}
+
+impl ScrollStroke {
+    /// Parse a scroll stroke from a string like "ctrl-scroll-up".
+    pub fn parse(source: &str) -> std::result::Result<Self, InvalidScrollStrokeError> {
+        let invalid = || InvalidScrollStrokeError {
+            stroke: source.to_owned(),
+        };
+        let mut modifiers = Modifiers::none();
+        let mut direction: Option<ScrollDirection> = None;
+
+        let mut parts = source.split('-').peekable();
+        while let Some(part) = parts.next() {
+            if try_parse_modifier_token(part, &mut modifiers) {
+                continue;
+            }
+
+            if part.eq_ignore_ascii_case("scroll") {
+                let next = parts.next().ok_or_else(invalid)?;
+                direction = Some(if next.eq_ignore_ascii_case("up") {
+                    ScrollDirection::Up
+                } else if next.eq_ignore_ascii_case("down") {
+                    ScrollDirection::Down
+                } else {
+                    return Err(invalid());
+                });
+            } else if let Some(d) = match_direction_token(part) {
+                direction = Some(d);
+            } else {
+                return Err(invalid());
+            }
+
+            // Direction must be the last token.
+            if parts.peek().is_some() {
+                return Err(invalid());
+            }
+        }
+
+        Ok(ScrollStroke {
+            modifiers,
+            direction: direction.ok_or_else(invalid)?,
+        })
+    }
+
+    /// Returns true if this stroke matches the given event parameters.
+    pub fn matches(&self, direction: ScrollDirection, modifiers: &Modifiers) -> bool {
+        self.direction == direction && &self.modifiers == modifiers
+    }
+
+    /// Produces a string representation that `parse` can understand.
+    pub fn unparse(&self) -> String {
+        let mut result = String::new();
+        append_modifiers(&mut result, &self.modifiers);
+        match self.direction {
+            ScrollDirection::Up => result.push_str("scroll-up"),
+            ScrollDirection::Down => result.push_str("scroll-down"),
+        }
+        result
+    }
+}
+
+/// Returns true if the given string looks like a scroll stroke.
+pub fn looks_like_scroll_stroke(s: &str) -> bool {
+    let tokens: Vec<&str> = s.split('-').collect();
+    tokens.iter().enumerate().any(|(i, tok)| {
+        if match_direction_token(tok).is_some() {
+            true
+        } else if tok.eq_ignore_ascii_case("scroll") {
+            tokens
+                .get(i + 1)
+                .is_some_and(|n| n.eq_ignore_ascii_case("up") || n.eq_ignore_ascii_case("down"))
+        } else {
+            false
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_mousescroll_aliases() {
+        let up = ScrollStroke::parse("ctrl-mousescrollup").unwrap();
+        assert_eq!(up.direction, ScrollDirection::Up);
+        assert!(up.modifiers.control);
+
+        let down = ScrollStroke::parse("alt-mousescrolldown").unwrap();
+        assert_eq!(down.direction, ScrollDirection::Down);
+        assert!(down.modifiers.alt);
+    }
+
+    #[test]
+    fn test_looks_like_scroll_stroke() {
+        assert!(looks_like_scroll_stroke("ctrl-scroll-down"));
+        assert!(looks_like_scroll_stroke("ctrl-mousescrollup"));
+        assert!(looks_like_scroll_stroke("ALT-MOUSESCROLLDOWN"));
+        assert!(!looks_like_scroll_stroke("scrolllock"));
+        assert!(!looks_like_scroll_stroke("alt-mouse1"));
+    }
+
+    #[test]
+    fn test_parse_rejects_trailing_tokens() {
+        assert!(ScrollStroke::parse("scroll-up-alt").is_err());
+        assert!(ScrollStroke::parse("alt-scroll-up").is_ok());
+    }
+}

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7,12 +7,13 @@ use crate::{
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
     KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
-    LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
-    MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
-    PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, Priority, PromptButton,
-    PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams,
-    Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y,
-    ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style, SubpixelSprite,
+    LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton,
+    MouseDownEvent, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
+    Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage,
+    RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
+    SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, ScrollDirection,
+    ScrollWheelEvent, Shadow, SharedString, Size, StrikethroughStyle, Style, SubpixelSprite,
     SubscriberSet, Subscription, SystemWindowTab, SystemWindowTabController, TabStopMap,
     TaffyLayoutEngine, Task, TextRenderingMode, TextStyle, TextStyleRefinement, ThermalState,
     TransformationMatrix, Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance,
@@ -1046,6 +1047,25 @@ pub(crate) struct ElementStateBox {
     pub(crate) inner: Box<dyn Any>,
     #[cfg(debug_assertions)]
     pub(crate) type_name: &'static str,
+}
+
+/// Primary direction of a vertical scroll delta, or `None` if the delta is
+/// zero or primarily horizontal.
+fn scroll_direction(delta: &crate::ScrollDelta) -> Option<ScrollDirection> {
+    let (x, y) = match delta {
+        crate::ScrollDelta::Pixels(p) => (p.x.0, p.y.0),
+        crate::ScrollDelta::Lines(p) => (p.x, p.y),
+    };
+    if y.abs() <= x.abs() {
+        return None;
+    }
+    if y > 0.0 {
+        Some(ScrollDirection::Up)
+    } else if y < 0.0 {
+        Some(ScrollDirection::Down)
+    } else {
+        None
+    }
 }
 
 fn default_bounds(display_id: Option<DisplayId>, cx: &mut App) -> WindowBounds {
@@ -4244,6 +4264,67 @@ impl Window {
             self.handle_inspector_mouse_event(event, cx);
             // When inspector is picking, all other mouse handling is skipped.
             return;
+        }
+
+        if let Some(mouse_down) = event.downcast_ref::<MouseDownEvent>() {
+            let node_id = self.focus_node_id_in_rendered_frame(self.focus);
+            let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
+            let bindings = self.rendered_frame.dispatch_tree.dispatch_mouse(
+                &mouse_down.button,
+                &mouse_down.modifiers,
+                mouse_down.click_count,
+                &dispatch_path,
+            );
+            if !bindings.is_empty() {
+                cx.propagate_event = true;
+                for binding in bindings {
+                    self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
+                    if !cx.propagate_event {
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Suppress the platform-level MouseUp (e.g. Linux middle-click paste)
+        // only when the matching MouseDown would have fired a user binding.
+        // Probing with the event's own modifiers/click_count avoids swallowing
+        // unrelated releases (e.g. plain mouse1 drag-release when only
+        // `shift-mouse1` is bound).
+        if let Some(mouse_up) = event.downcast_ref::<MouseUpEvent>() {
+            let node_id = self.focus_node_id_in_rendered_frame(self.focus);
+            let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
+            let bindings = self.rendered_frame.dispatch_tree.dispatch_mouse(
+                &mouse_up.button,
+                &mouse_up.modifiers,
+                mouse_up.click_count,
+                &dispatch_path,
+            );
+            if !bindings.is_empty() {
+                return;
+            }
+        }
+
+        // Scroll bindings only fire when modifiers are held, so unmodified scrolling
+        // reaches normal scroll handlers.
+        if let Some(scroll) = event.downcast_ref::<ScrollWheelEvent>()
+            && scroll.modifiers.number_of_modifiers() > 0
+            && let Some(direction) = scroll_direction(&scroll.delta)
+        {
+            let node_id = self.focus_node_id_in_rendered_frame(self.focus);
+            let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
+            let bindings = self.rendered_frame.dispatch_tree.dispatch_scroll(
+                direction,
+                &scroll.modifiers,
+                &dispatch_path,
+            );
+            cx.propagate_event = true;
+            for binding in bindings {
+                self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
+                if !cx.propagate_event {
+                    return;
+                }
+            }
         }
 
         let mut mouse_listeners = mem::take(&mut self.rendered_frame.mouse_listeners);

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -4,7 +4,9 @@ use fs::Fs;
 use gpui::{
     Action, ActionBuildError, App, InvalidKeystrokeError, KEYSTROKE_PARSE_EXPECTED_MESSAGE,
     KeyBinding, KeyBindingContextPredicate, KeyBindingMetaIndex, KeybindingKeystroke, Keystroke,
-    NoAction, SharedString, Unbind, generate_list_of_all_registered_actions, register_action,
+    MOUSE_STROKE_PARSE_EXPECTED_MESSAGE, NoAction, SCROLL_STROKE_PARSE_EXPECTED_MESSAGE,
+    SharedString, Unbind, generate_list_of_all_registered_actions, looks_like_mouse_stroke,
+    looks_like_scroll_stroke, register_action,
 };
 use schemars::{JsonSchema, json_schema};
 use serde::Deserialize;
@@ -386,6 +388,65 @@ impl KeymapFile {
         Self::load_keybinding_action_value(keystrokes, &action.0, context, use_key_equivalents, cx)
     }
 
+    /// Build a `KeyBinding` by auto-detecting whether `input` is a keystroke
+    /// sequence, a mouse button stroke, or a scroll stroke, and producing an
+    /// appropriately-scoped parse error for each kind.
+    fn load_any_binding(
+        input: &str,
+        action: Box<dyn Action>,
+        context: Option<Rc<KeyBindingContextPredicate>>,
+        use_key_equivalents: bool,
+        action_input: Option<SharedString>,
+        cx: &App,
+    ) -> std::result::Result<KeyBinding, String> {
+        let quoted = || MarkdownInlineCode(&format!("\"{}\"", input)).to_string();
+        if looks_like_mouse_stroke(input) {
+            if input.split_whitespace().count() > 1 {
+                return Err(format!(
+                    "mouse bindings cannot be key sequences: {}",
+                    quoted()
+                ));
+            }
+            KeyBinding::load_mouse(input, action, context, action_input).map_err(|_| {
+                format!(
+                    "invalid mouse stroke {}. {}",
+                    quoted(),
+                    MOUSE_STROKE_PARSE_EXPECTED_MESSAGE
+                )
+            })
+        } else if looks_like_scroll_stroke(input) {
+            if input.split_whitespace().count() > 1 {
+                return Err(format!(
+                    "scroll bindings cannot be key sequences: {}",
+                    quoted()
+                ));
+            }
+            KeyBinding::load_scroll(input, action, context, action_input).map_err(|_| {
+                format!(
+                    "invalid scroll stroke {}. {}",
+                    quoted(),
+                    SCROLL_STROKE_PARSE_EXPECTED_MESSAGE
+                )
+            })
+        } else {
+            KeyBinding::load(
+                input,
+                action,
+                context,
+                use_key_equivalents,
+                action_input,
+                cx.keyboard_mapper().as_ref(),
+            )
+            .map_err(|InvalidKeystrokeError { keystroke }| {
+                format!(
+                    "invalid keystroke {}. {}",
+                    MarkdownInlineCode(&format!("\"{}\"", &keystroke)),
+                    KEYSTROKE_PARSE_EXPECTED_MESSAGE
+                )
+            })
+        }
+    }
+
     fn load_keybinding_action_value(
         keystrokes: &str,
         action: &Value,
@@ -394,24 +455,14 @@ impl KeymapFile {
         cx: &App,
     ) -> std::result::Result<KeyBinding, String> {
         let (action, action_input_string) = Self::build_keymap_action_value(action, cx)?;
-
-        let key_binding = match KeyBinding::load(
+        let key_binding = Self::load_any_binding(
             keystrokes,
             action,
             context,
             use_key_equivalents,
             action_input_string.map(SharedString::from),
-            cx.keyboard_mapper().as_ref(),
-        ) {
-            Ok(key_binding) => key_binding,
-            Err(InvalidKeystrokeError { keystroke }) => {
-                return Err(format!(
-                    "invalid keystroke {}. {}",
-                    MarkdownInlineCode(&format!("\"{}\"", &keystroke)),
-                    KEYSTROKE_PARSE_EXPECTED_MESSAGE
-                ));
-            }
-        };
+            cx,
+        )?;
 
         if let Some(validator) = KEY_BINDING_VALIDATORS.get(&key_binding.action().type_id()) {
             match validator.validate(&key_binding) {
@@ -449,21 +500,14 @@ impl KeymapFile {
             ));
         }
 
-        KeyBinding::load(
+        Self::load_any_binding(
             keystrokes,
             Box::new(Unbind(key_binding.action().name().into())),
             key_binding.predicate(),
             use_key_equivalents,
             key_binding.action_input(),
-            cx.keyboard_mapper().as_ref(),
+            cx,
         )
-        .map_err(|InvalidKeystrokeError { keystroke }| {
-            format!(
-                "invalid keystroke {}. {}",
-                MarkdownInlineCode(&format!("\"{}\"", &keystroke)),
-                KEYSTROKE_PARSE_EXPECTED_MESSAGE
-            )
-        })
     }
 
     pub fn parse_action(

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -1533,7 +1533,7 @@ impl Action for ActionSequence {
 
 #[cfg(test)]
 mod tests {
-    use gpui::{Action, App, DummyKeyboardMapper, KeybindingKeystroke, Keystroke, Unbind};
+    use gpui::{Action, App, DummyKeyboardMapper, KeybindingKeystroke, Keystroke, MouseButton, Unbind};
     use serde_json::Value;
     use unindent::Unindent;
 
@@ -2612,6 +2612,105 @@ mod tests {
               },
             ]
             "#,
+        );
+    }
+
+    fn load_ok(json: &str, cx: &mut App) -> Vec<gpui::KeyBinding> {
+        match KeymapFile::load(json, cx) {
+            crate::keymap_file::KeymapFileLoadResult::Success { key_bindings } => key_bindings,
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    fn load_err(json: &str, cx: &mut App) -> String {
+        match KeymapFile::load(json, cx) {
+            crate::keymap_file::KeymapFileLoadResult::SomeFailedToLoad { error_message, .. } => {
+                error_message.0
+            }
+            other => panic!("expected SomeFailedToLoad, got {other:?}"),
+        }
+    }
+
+    #[gpui::test]
+    fn mouse_binding_loads_from_keymap(cx: &mut App) {
+        let bindings = load_ok(
+            r#"[{"bindings": {"alt-mouse1": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].is_mouse_binding());
+        assert_eq!(bindings[0].action().name(), "test_keymap_file::StringAction");
+    }
+
+    #[gpui::test]
+    fn scroll_binding_loads_from_keymap(cx: &mut App) {
+        let bindings = load_ok(
+            r#"[{"bindings": {"ctrl-scroll-up": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].is_scroll_binding());
+        assert_eq!(bindings[0].action().name(), "test_keymap_file::StringAction");
+    }
+
+    #[gpui::test]
+    fn mouse_binding_double_click_loads(cx: &mut App) {
+        let bindings = load_ok(
+            r#"[{"bindings": {"double-mouse1": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].is_mouse_binding());
+        assert!(bindings[0].match_mouse(&MouseButton::Left, &gpui::Modifiers::none(), 2));
+    }
+
+    #[gpui::test]
+    fn mouse_binding_unbind_produces_unbind_action(cx: &mut App) {
+        let bindings = load_ok(
+            r#"[{"unbind": {"alt-mouse1": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].is_mouse_binding());
+        assert!(bindings[0]
+            .action()
+            .partial_eq(&Unbind("test_keymap_file::StringAction".into())));
+    }
+
+    #[gpui::test]
+    fn scroll_binding_unbind_produces_unbind_action(cx: &mut App) {
+        let bindings = load_ok(
+            r#"[{"unbind": {"ctrl-scroll-up": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].is_scroll_binding());
+        assert!(bindings[0]
+            .action()
+            .partial_eq(&Unbind("test_keymap_file::StringAction".into())));
+    }
+
+    #[gpui::test]
+    fn mouse_binding_rejects_key_sequence(cx: &mut App) {
+        let error = load_err(
+            r#"[{"bindings": {"alt-mouse1 ctrl-mouse2": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert!(
+            error.contains("cannot be key sequences"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[gpui::test]
+    fn scroll_binding_rejects_key_sequence(cx: &mut App) {
+        let error = load_err(
+            r#"[{"bindings": {"ctrl-scroll-up ctrl-scroll-down": "test_keymap_file::StringAction"}}]"#,
+            cx,
+        );
+        assert!(
+            error.contains("cannot be key sequences"),
+            "unexpected error: {error}"
         );
     }
 }


### PR DESCRIPTION
#### Closes #10647

### Summary

- Added `MouseStroke` and `ScrollStroke` as first-class binding input types alongside keystrokes, with full modifier + click-count support
- Extended `KeyBinding` / `BindingInputKind` so the keymap can hold mouse and scroll bindings, and wired `Keymap` + `DispatchTree` to look them up by context
- `Window` now probes mouse and scroll bindings before the normal event chain: `MouseDown` fires matching actions, `MouseUp` is suppressed only when the same button+modifiers would have triggered a binding (preserving drag), and `ScrollWheel` fires only when a modifier is held so unmodified scrolling is unaffected
- `keymap_file.rs` auto-detects whether a binding string is a mouse stroke, scroll stroke, or keystroke and routes it to the right loader — both `bindings` and `unbind` entries work
- Added five editor actions (`AddCursorAtMouse`, `ExtendSelectionToMouse`, `GoToDefinitionAtMouse`, `GoToTypeDefinitionAtMouse`, `StartColumnarSelectionAtMouse`) so users can bind mouse buttons to common editor operations

### Example keymap entries

```json
[
  {
    "bindings": {
      "alt-mouse1":       "editor::GoToDefinitionAtMouse",
      "shift-mouse1":     "editor::ExtendSelectionToMouse",
      "ctrl-mouse1":      "editor::AddCursorAtMouse",
      "double-mouse1":    "editor::SelectToBeginningOfLine",
      "ctrl-mousescrolldown": "zed::IncreaseBufferFontSize",
      "ctrl-mousescrollup": "zed::DecreaseBufferFontSize",
    }
  }
]
```

### Self-Review Checklist
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


### Video:

[Screencast from 2026-04-14 17-02-06.webm](https://github.com/user-attachments/assets/53ac895d-fe75-4cca-af1b-6cc1b4ef5956)


Release Notes
Added support for user-configurable mouse button and scroll wheel keybindings in keymap.json