### PR TITLE
repl: Enable REPL for unsaved buffers and empty projects

### DIFF
--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -30,7 +30,7 @@ fn build_grouped_entries(store: &ReplStore, worktree_id: WorktreeId) -> Vec<Kern
     let mut wsl_kernels = Vec::new();
     let mut remote_kernels = Vec::new();
 
-    for spec in store.kernel_specifications_for_worktree(worktree_id) {
+    for spec in store.kernel_specifications_for_worktree(Some(worktree_id)) {
         let is_recommended = store.is_recommended_kernel(worktree_id, spec);
         let is_selected = selected_kernel.map_or(false, |s| s == spec);
 
@@ -454,7 +454,7 @@ where
         let store = store.read(cx);
 
         let all_entries = build_grouped_entries(store, self.worktree_id);
-        let selected_kernelspec = store.active_kernelspec(self.worktree_id, None, cx);
+        let selected_kernelspec = store.active_kernelspec(Some(self.worktree_id), None, cx);
         let selected_index = all_entries
             .iter()
             .position(|entry| {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -333,7 +333,7 @@ impl NotebookEditor {
         let spec = self.kernel_specification.clone().or_else(|| {
             ReplStore::global(cx)
                 .read(cx)
-                .active_kernelspec(self.worktree_id, None, cx)
+                .active_kernelspec(Some(self.worktree_id), None, cx)
         });
 
         let spec = spec.unwrap_or_else(|| {

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -226,9 +226,7 @@ pub fn run(
         return Ok(());
     };
 
-    let Some(project_path) = buffer.read(cx).project_path(cx) else {
-        return Ok(());
-    };
+    let worktree_id = resolve_worktree_id(editor.read(cx), cx);
 
     let (runnable_ranges, next_cell_point) =
         runnable_ranges(&buffer.read(cx).snapshot(), selected_range, cx);
@@ -240,7 +238,7 @@ pub fn run(
 
         let kernel_specification = store
             .read(cx)
-            .active_kernelspec(project_path.worktree_id, Some(language.clone()), cx)
+            .active_kernelspec(worktree_id, Some(language.clone()), cx)
             .with_context(|| format!("No kernel found for language: {}", language.name()))?;
 
         let fs = store.read(cx).fs().clone();
@@ -311,17 +309,28 @@ pub enum SessionSupport {
     Unsupported,
 }
 
-pub fn worktree_id_for_editor(editor: WeakEntity<Editor>, cx: &mut App) -> Option<WorktreeId> {
-    editor.upgrade().and_then(|editor| {
+pub fn resolve_worktree_id(editor: &Editor, cx: &App) -> Option<WorktreeId> {
+    let from_buffer = editor
+        .buffer()
+        .read(cx)
+        .as_singleton()
+        .and_then(|buffer| buffer.read(cx).project_path(cx))
+        .map(|path| path.worktree_id);
+
+    from_buffer.or_else(|| {
         editor
+            .project()?
             .read(cx)
-            .buffer()
-            .read(cx)
-            .as_singleton()?
-            .read(cx)
-            .project_path(cx)
-            .map(|path| path.worktree_id)
+            .visible_worktrees(cx)
+            .next()
+            .map(|worktree| worktree.read(cx).id())
     })
+}
+
+pub fn worktree_id_for_editor(editor: WeakEntity<Editor>, cx: &mut App) -> Option<WorktreeId> {
+    editor
+        .upgrade()
+        .and_then(|editor| resolve_worktree_id(editor.read(cx), cx))
 }
 
 pub fn session(editor: WeakEntity<Editor>, cx: &mut App) -> SessionSupport {
@@ -337,10 +346,6 @@ pub fn session(editor: WeakEntity<Editor>, cx: &mut App) -> SessionSupport {
     };
 
     let worktree_id = worktree_id_for_editor(editor, cx);
-
-    let Some(worktree_id) = worktree_id else {
-        return SessionSupport::Unsupported;
-    };
 
     let kernelspec = store
         .read(cx)

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -27,13 +27,25 @@ fn refresh_python_kernelspecs_for_buffer(
         return;
     };
 
-    let Some(project_path) = buffer.project_path(cx) else {
+    let worktree_id = buffer
+        .project_path(cx)
+        .map(|path| path.worktree_id)
+        .or_else(|| {
+            project
+                .read(cx)
+                .visible_worktrees(cx)
+                .next()
+                .map(|worktree| worktree.read(cx).id())
+        });
+
+    let Some(worktree_id) = worktree_id else {
         return;
     };
+
     let store = ReplStore::global(cx);
     store.update(cx, |store, cx| {
         store
-            .refresh_python_kernelspecs(project_path.worktree_id, project, cx)
+            .refresh_python_kernelspecs(worktree_id, project, cx)
             .detach_and_log_err(cx);
     });
 }

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -90,19 +90,24 @@ impl ReplStore {
 
     pub fn kernel_specifications_for_worktree(
         &self,
-        worktree_id: WorktreeId,
+        worktree_id: Option<WorktreeId>,
     ) -> impl Iterator<Item = &KernelSpecification> {
-        let global_specs = if self.remote_worktrees.contains(&worktree_id) {
+        let is_remote = worktree_id
+            .map(|id| self.remote_worktrees.contains(&id))
+            .unwrap_or(false);
+
+        let global_specs = if is_remote {
             None
         } else {
             Some(self.kernel_specifications.iter())
         };
 
-        self.kernel_specifications_for_worktree
-            .get(&worktree_id)
+        let worktree_specs = worktree_id
+            .and_then(|id| self.kernel_specifications_for_worktree.get(&id))
             .into_iter()
-            .flat_map(|specs| specs.iter())
-            .chain(global_specs.into_iter().flatten())
+            .flat_map(|specs| specs.iter());
+
+        worktree_specs.chain(global_specs.into_iter().flatten())
     }
 
     pub fn pure_jupyter_kernel_specifications(&self) -> impl Iterator<Item = &KernelSpecification> {
@@ -323,18 +328,22 @@ impl ReplStore {
 
     pub fn active_kernelspec(
         &self,
-        worktree_id: WorktreeId,
+        worktree_id: Option<WorktreeId>,
         language_at_cursor: Option<Arc<Language>>,
         cx: &App,
     ) -> Option<KernelSpecification> {
-        if let Some(selected) = self.selected_kernel_for_worktree.get(&worktree_id).cloned() {
+        if let Some(selected) = worktree_id
+            .and_then(|id| self.selected_kernel_for_worktree.get(&id))
+            .cloned()
+        {
             return Some(selected);
         }
 
         let language_at_cursor = language_at_cursor?;
 
         // Prefer the recommended (active toolchain) kernel if it has ipykernel
-        if let Some(active_path) = self.active_python_toolchain_path(worktree_id) {
+        if let Some(active_path) = worktree_id.and_then(|id| self.active_python_toolchain_path(id))
+        {
             let recommended = self
                 .kernel_specifications_for_worktree(worktree_id)
                 .find(|spec| {
@@ -367,7 +376,7 @@ impl ReplStore {
 
     fn kernelspec_legacy_by_lang_only(
         &self,
-        worktree_id: WorktreeId,
+        worktree_id: Option<WorktreeId>,
         language_at_cursor: Arc<Language>,
         cx: &App,
     ) -> Option<KernelSpecification> {

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -269,33 +269,22 @@ impl Session {
         let kernel_language = self.kernel_specification.language();
         let entity_id = self.editor.entity_id();
 
-        // For WSL Remote kernels, use project root instead of potentially temporary working directory
-        // which causes .venv/bin/python checks to fail
-        let is_remote_execution = matches!(
-            self.kernel_specification,
-            crate::KernelSpecification::WslRemote(_) | crate::KernelSpecification::SshRemote(_)
-        );
-
-        let working_directory = if is_remote_execution {
-            // For WSL Remote kernels, use project root instead of potentially temporary working directory
-            // which causes .venv/bin/python checks to fail
-            self.editor
-                .upgrade()
-                .and_then(|editor| editor.read(cx).project().cloned())
-                .and_then(|project| {
-                    project
-                        .read(cx)
-                        .worktrees(cx)
-                        .next()
-                        .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+        let working_directory = self
+            .editor
+            .upgrade()
+            .and_then(|editor| {
+                let editor = editor.read(cx);
+                editor.working_directory(cx).or_else(|| {
+                    editor.project().and_then(|project| {
+                        project
+                            .read(cx)
+                            .visible_worktrees(cx)
+                            .next()
+                            .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+                    })
                 })
-                .unwrap_or_else(temp_dir)
-        } else {
-            self.editor
-                .upgrade()
-                .and_then(|editor| editor.read(cx).working_directory(cx))
-                .unwrap_or_else(temp_dir)
-        };
+            })
+            .unwrap_or_else(temp_dir);
 
         telemetry::event!(
             "Kernel Status Changed",


### PR DESCRIPTION
Allow REPL to work without a file-backed buffer by falling back to the first visible worktree for kernel spec lookup. Also make kernel spec resolution accept an optional worktree ID so that REPL can use globally installed kernels even when no worktree is available.

The kernel process working directory now also falls back to the project's
visible worktree root when the editor has no file-backed buffer, instead
of using the system temp directory.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior[^1]
- [x] Performance impact has been considered and is acceptable

[^1]: No new tests added: the change is a straightforward fallback in `resolve_worktree_id` and loosening `WorktreeId` → `Option<WorktreeId>` in kernel spec lookup. Both paths are covered by existing tests with `Some(worktree_id)`. Testing the `None` fallback path would require setting up Editor + Project + Worktree fixtures, which is disproportionate to the complexity of the change. Verified manually with unsaved buffers and empty projects.

Closes #ISSUE

Release Notes:

- Added REPL support for unsaved buffers and empty projects

