### PR TITLE
quick_action_bar: Re-render REPL menu when buffer language changes

### DIFF
--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -755,11 +755,18 @@ impl ToolbarItemView for QuickActionBar {
                     mut inlay_hints_enabled,
                     mut supports_inlay_hints,
                     mut supports_semantic_tokens,
+                    mut buffer_language,
                 ) = editor.update(cx, |editor, cx| {
                     (
                         editor.inlay_hints_enabled(),
                         editor.supports_inlay_hints(cx),
                         editor.supports_semantic_tokens(cx),
+                        editor
+                            .buffer()
+                            .read(cx)
+                            .as_singleton()
+                            .and_then(|buffer| buffer.read(cx).language())
+                            .map(|lang| lang.name()),
                     )
                 });
                 self._inlay_hints_enabled_subscription =
@@ -768,19 +775,28 @@ impl ToolbarItemView for QuickActionBar {
                             new_inlay_hints_enabled,
                             new_supports_inlay_hints,
                             new_supports_semantic_tokens,
+                            new_buffer_language,
                         ) = editor.update(cx, |editor, cx| {
                             (
                                 editor.inlay_hints_enabled(),
                                 editor.supports_inlay_hints(cx),
                                 editor.supports_semantic_tokens(cx),
+                                editor
+                                    .buffer()
+                                    .read(cx)
+                                    .as_singleton()
+                                    .and_then(|buffer| buffer.read(cx).language())
+                                    .map(|lang| lang.name()),
                             )
                         });
                         let should_notify = inlay_hints_enabled != new_inlay_hints_enabled
                             || supports_inlay_hints != new_supports_inlay_hints
-                            || supports_semantic_tokens != new_supports_semantic_tokens;
+                            || supports_semantic_tokens != new_supports_semantic_tokens
+                            || buffer_language != new_buffer_language;
                         inlay_hints_enabled = new_inlay_hints_enabled;
                         supports_inlay_hints = new_supports_inlay_hints;
                         supports_semantic_tokens = new_supports_semantic_tokens;
+                        buffer_language = new_buffer_language;
                         if should_notify {
                             cx.notify()
                         }


### PR DESCRIPTION
The QuickActionBar observer only triggered re-renders for inlay hints and semantic tokens changes. When a buffer's language was changed (e.g. manually setting language on an unsaved buffer), the REPL menu visibility was not updated. Track the buffer language in the observer so the REPL menu appears/disappears when the language changes.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [-] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Fixed REPL menu not updating when buffer language is changed
