### PR TITLE
Fix autosave on focus change error when switching git diff via command palette

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -956,13 +956,13 @@ impl<T: Item> ItemHandle for Entity<T> {
 
                         if vim_mode || helix_mode {
                             // We use the command palette for executing commands in Vim and Helix modes (e.g., `:w`), so
-                            // in those cases we don't want to trigger auto-save if the focus has just been transferred
-                            // to the command palette.
-                            //
-                            // This isn't totally perfect, as you could still switch files indirectly via the command
-                            // palette (such as by opening up the tab switcher from it and then switching tabs that
-                            // way).
+                            // in those cases we don't want to immediately trigger auto-save if the focus has just been
+                            // transferred to the command palette. Instead, we defer the autosave until the command
+                            // palette is dismissed. If focus returns to this item (e.g., the user pressed Escape),
+                            // the deferred save is skipped. If focus moves elsewhere (e.g., the user opened a new
+                            // panel via the command palette), the item is saved at that point.
                             if workspace.is_active_modal_command_palette(cx) {
+                                workspace.deferred_autosave_items.push(item.downgrade_item());
                                 return;
                             }
                         }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -962,7 +962,9 @@ impl<T: Item> ItemHandle for Entity<T> {
                             // the deferred save is skipped. If focus moves elsewhere (e.g., the user opened a new
                             // panel via the command palette), the item is saved at that point.
                             if workspace.is_active_modal_command_palette(cx) {
-                                workspace.deferred_autosave_items.push(item.downgrade_item());
+                                workspace
+                                    .deferred_autosave_items
+                                    .push(item.downgrade_item());
                                 return;
                             }
                         }

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -80,8 +80,10 @@ pub struct ModalLayer {
 }
 
 pub(crate) struct ModalOpenedEvent;
+pub(crate) struct ModalDismissedEvent;
 
 impl EventEmitter<ModalOpenedEvent> for ModalLayer {}
+impl EventEmitter<ModalDismissedEvent> for ModalLayer {}
 
 impl Default for ModalLayer {
     fn default() -> Self {
@@ -185,6 +187,7 @@ impl ModalLayer {
             {
                 previous_focus.focus(window, cx);
             }
+            cx.emit(ModalDismissedEvent);
             cx.notify();
         }
         self.dismiss_on_focus_lost = false;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1333,6 +1333,7 @@ pub struct Workspace {
     status_bar: Entity<StatusBar>,
     pub(crate) modal_layer: Entity<ModalLayer>,
     toast_layer: Entity<ToastLayer>,
+    deferred_autosave_items: Vec<Box<dyn WeakItemHandle>>,
     titlebar_item: Option<AnyView>,
     notifications: Notifications,
     suppressed_notifications: HashSet<NotificationId>,
@@ -1660,6 +1661,16 @@ impl Workspace {
             },
         )
         .detach();
+        cx.subscribe_in(
+            &modal_layer,
+            window,
+            |_, _, _: &modal_layer::ModalDismissedEvent, window, cx| {
+                cx.defer_in(window, |this, window, cx| {
+                    this.autosave_deferred_items(window, cx);
+                });
+            },
+        )
+        .detach();
 
         let left_dock = Dock::new(DockPosition::Left, modal_layer.clone(), window, cx);
         let bottom_dock = Dock::new(DockPosition::Bottom, modal_layer.clone(), window, cx);
@@ -1757,6 +1768,7 @@ impl Workspace {
             status_bar,
             modal_layer,
             toast_layer,
+            deferred_autosave_items: Vec::new(),
             titlebar_item: None,
             notifications: Notifications::default(),
             suppressed_notifications: HashSet::default(),
@@ -6336,6 +6348,20 @@ impl Workspace {
     ) -> Option<Entity<SharedScreen>> {
         self.active_call()?
             .create_shared_screen(peer_id, pane, window, cx)
+    }
+
+    fn autosave_deferred_items(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let deferred = std::mem::take(&mut self.deferred_autosave_items);
+        for weak_item in deferred {
+            let Some(item) = weak_item.upgrade() else {
+                continue;
+            };
+            let focus_handle = item.item_focus_handle(cx);
+            if !focus_handle.contains_focused(window, cx) {
+                Pane::autosave_item(item.as_ref(), self.project.clone(), window, cx)
+                    .detach_and_log_err(cx);
+            }
+        }
     }
 
     pub fn on_window_activation_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -11645,6 +11645,101 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_autosave_on_focus_change_deferred_for_command_palette(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        item.update_in(cx, |item, window, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.autosave = Some(AutosaveSetting::OnFocusChange);
+                    settings.vim_mode = Some(true);
+                    settings.helix_mode = Some(false);
+                })
+            });
+            item.is_dirty = true;
+            cx.focus_self(window);
+        });
+        cx.executor().run_until_parked();
+
+        // Opening a command palette modal moves focus out of the item,
+        // but autosave should be deferred until that modal is dismissed.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_modal(window, cx, TestCommandPaletteModal::new);
+        });
+        cx.executor().run_until_parked();
+        item.read_with(cx, |item, _| {
+            assert_eq!(
+                item.save_count, 0,
+                "Autosave should be deferred while modal is open"
+            )
+        });
+        workspace.read_with(cx, |workspace, _| {
+            assert_eq!(
+                workspace.deferred_autosave_items.len(),
+                1,
+                "Focus transfer to command palette should queue one deferred autosave item"
+            );
+        });
+
+        // If focus returns to the same item, deferred autosave should be skipped.
+        item.update_in(cx, |_, window, cx| {
+            cx.focus_self(window);
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.autosave_deferred_items(window, cx);
+        });
+        cx.executor().run_until_parked();
+        item.read_with(cx, |item, _| {
+            assert_eq!(
+                item.save_count, 0,
+                "Deferred autosave should be skipped when focus returns to the item"
+            )
+        });
+
+        // Prepare another deferred autosave for the same item.
+        item.update_in(cx, |item, window, cx| {
+            item.is_dirty = true;
+            cx.focus_self(window);
+        });
+        workspace.update_in(cx, |workspace, _window, _cx| {
+            workspace
+                .deferred_autosave_items
+                .push(item.downgrade_item());
+        });
+        cx.executor().run_until_parked();
+
+        // If focus moves elsewhere, deferred autosave should run.
+        workspace.update_in(cx, |_workspace, window, _cx| {
+            window.blur();
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.autosave_deferred_items(window, cx);
+        });
+        cx.executor().run_until_parked();
+        item.read_with(cx, |item, _| {
+            assert_eq!(
+                item.save_count, 1,
+                "Deferred autosave should run when focus is not returned to the item"
+            )
+        });
+    }
+
+    #[gpui::test]
     async fn test_pane_navigation(cx: &mut gpui::TestAppContext) {
         init_test(cx);
 
@@ -13130,6 +13225,38 @@ mod tests {
     }
 
     impl ModalView for TestModal {}
+
+    struct TestCommandPaletteModal(FocusHandle);
+
+    impl TestCommandPaletteModal {
+        fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
+            Self(cx.focus_handle())
+        }
+    }
+
+    impl EventEmitter<DismissEvent> for TestCommandPaletteModal {}
+
+    impl Focusable for TestCommandPaletteModal {
+        fn focus_handle(&self, _cx: &App) -> FocusHandle {
+            self.0.clone()
+        }
+    }
+
+    impl ModalView for TestCommandPaletteModal {
+        fn is_command_palette(&self) -> bool {
+            true
+        }
+    }
+
+    impl Render for TestCommandPaletteModal {
+        fn render(
+            &mut self,
+            _window: &mut Window,
+            _cx: &mut Context<TestCommandPaletteModal>,
+        ) -> impl IntoElement {
+            div().track_focus(&self.0)
+        }
+    }
 
     impl Render for TestModal {
         fn render(


### PR DESCRIPTION

Summary of whats fixed:

- Fixed the autosave regression where focus change to the command palette could trigger autosave at the wrong time in Vim/Helix workflows.
- The behavior is now: defer autosave while command palette is active, then decide on dismiss:
- Skip autosave if focus returns to the same item.
- Run autosave if focus moved elsewhere. 

Files changed:

- Added deferred autosave queueing when focus leaves an item to command palette in crates/workspace/src/item.rs.
- Added a modal dismissed event so workspace can react after modal close in crates/workspace/src/modal_layer.rs.
- Wired workspace to process deferred autosaves on modal dismiss and added handling logic in crates/workspace/src/workspace.rs.


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53863

Video 

[Screencast from 2026-04-14 22-57-12.webm](https://github.com/user-attachments/assets/8403403a-3e2e-4e46-a46f-c30e827c1c63)


Release Notes:

- Fixed autosave-on-focus-change behavior around command palette dismissal in Vim/Helix mode by covering deferred autosave semantics (skip when focus returns to same item, save when focus moves elsewhere).
