### PR TITLE
cli: Hide -r/--reuse from --help in favor of -e/--existing

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -73,7 +73,7 @@ struct Args {
     #[arg(short, long, overrides_with_all = ["add", "reuse", "existing"])]
     new: bool,
     /// Reuse an existing window, replacing its workspace
-    #[arg(short, long, overrides_with_all = ["add", "new", "existing"])]
+    #[arg(short, long, overrides_with_all = ["add", "new", "existing"], hide = true)]
     reuse: bool,
     /// Open in existing Zed window
     #[arg(short = 'e', long = "existing", overrides_with_all = ["add", "new", "reuse"])]


### PR DESCRIPTION
Soft-deprecates the `-r`/`--reuse` CLI flag by hiding it from `--help` output. The flag remains fully functional for backward compatibility, but new users will discover `-e`/`--existing` instead.

The change is a single `hide = true` addition to the clap arg attribute.

Release Notes:

- N/A