### PR TITLE
gpui: Track and forward damage regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10790,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -20252,7 +20252,7 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 [[package]]
 name = "wgpu"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -20263,7 +20263,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga 29.0.0 (git+https://github.com/zed-industries/wgpu.git?branch=v29)",
+ "naga 29.0.0 (git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105)",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -20281,7 +20281,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -20293,7 +20293,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "naga 29.0.0 (git+https://github.com/zed-industries/wgpu.git?branch=v29)",
+ "naga 29.0.0 (git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105)",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -20313,7 +20313,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-apple"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "wgpu-hal",
 ]
@@ -20321,7 +20321,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-emscripten"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "wgpu-hal",
 ]
@@ -20329,7 +20329,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "wgpu-hal",
 ]
@@ -20337,7 +20337,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -20358,7 +20358,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "naga 29.0.0 (git+https://github.com/zed-industries/wgpu.git?branch=v29)",
+ "naga 29.0.0 (git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105)",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
@@ -20389,16 +20389,16 @@ dependencies = [
 [[package]]
 name = "wgpu-naga-bridge"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
- "naga 29.0.0 (git+https://github.com/zed-industries/wgpu.git?branch=v29)",
+ "naga 29.0.0 (git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105)",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
 version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+source = "git+https://github.com/loadingalias/wgpu.git?rev=bb070fec2ca45625855581ba894a6cb0b55e2105#bb070fec2ca45625855581ba894a6cb0b55e2105"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -875,6 +875,20 @@ livekit = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "
 libwebrtc = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "147fbca3d4b592d96d33f5e6a84b59fc0b5d9bf1" }
 webrtc-sys = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "147fbca3d4b592d96d33f5e6a84b59fc0b5d9bf1" }
 
+# DEV ONLY: local wgpu override for damage/present-regions work.
+# Remove this section before opening the Zed PR — the final PR should
+# point at a merged commit on zed-industries/wgpu v29 instead.
+[patch.'https://github.com/zed-industries/wgpu.git']
+wgpu = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-core = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-hal = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-types = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-naga-bridge = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+naga = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-core-deps-apple = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-core-deps-emscripten = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+wgpu-core-deps-windows-linux-android = { git = "https://github.com/loadingalias/wgpu.git", rev = "bb070fec2ca45625855581ba894a6cb0b55e2105" }
+
 [profile.dev]
 split-debuginfo = "unpacked"
 incremental = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1261,6 +1261,9 @@ pub struct Editor {
     next_color_inlay_id: usize,
     _subscriptions: Vec<Subscription>,
     pixel_position_of_newest_cursor: Option<gpui::Point<Pixels>>,
+    cursor_damage_bounds: Option<gpui::Bounds<Pixels>>,
+    selection_damage_bounds: Option<gpui::Bounds<Pixels>>,
+    hover_damage_bounds: Option<gpui::Bounds<Pixels>>,
     gutter_dimensions: GutterDimensions,
     style: Option<EditorStyle>,
     text_style_refinement: Option<TextStyleRefinement>,
@@ -2511,6 +2514,9 @@ impl Editor {
             inline_value_cache: InlineValueCache::new(inlay_hint_settings.show_value_hints),
             gutter_hovered: false,
             pixel_position_of_newest_cursor: None,
+            cursor_damage_bounds: None,
+            selection_damage_bounds: None,
+            hover_damage_bounds: None,
             last_bounds: None,
             last_position_map: None,
             expect_bounds_change: None,
@@ -2558,7 +2564,9 @@ impl Editor {
                         cx.observe(&multi_buffer, Self::on_buffer_changed),
                         cx.subscribe_in(&multi_buffer, window, Self::on_buffer_event),
                         cx.observe_in(&display_map, window, Self::on_display_map_changed),
-                        cx.observe(&blink_manager, |_, _, cx| cx.notify()),
+                        cx.observe(&blink_manager, |editor, _, cx| {
+                            editor.notify_cursor_damage(cx);
+                        }),
                         cx.observe_global_in::<SettingsStore>(window, Self::settings_changed),
                         cx.observe_global_in::<GlobalTheme>(window, Self::theme_changed),
                         observe_buffer_font_size_adjustment(cx, |_, cx| cx.notify()),
@@ -3650,6 +3658,27 @@ impl Editor {
         self.use_modal_editing
     }
 
+    fn notify_cursor_damage(&self, cx: &mut Context<Self>) {
+        if let Some(bounds) = self.cursor_damage_bounds.or(self.last_bounds) {
+            cx.notify_with_damage(bounds);
+        } else {
+            cx.notify();
+        }
+    }
+
+    /// Compute the union of cursor, selection, and hover damage bounds from
+    /// the previous frame. Returns `None` if none are known.
+    fn combined_damage_bounds(&self) -> Option<gpui::Bounds<Pixels>> {
+        [
+            self.cursor_damage_bounds,
+            self.selection_damage_bounds,
+            self.hover_damage_bounds,
+        ]
+        .into_iter()
+        .flatten()
+        .reduce(|acc, b| acc.union(&b))
+    }
+
     fn selections_did_change(
         &mut self,
         local: bool,
@@ -3857,7 +3886,13 @@ impl Editor {
             }
         }
 
-        cx.notify();
+        // Notify with old cursor/selection/hover bounds as damage. New
+        // positions will be added during layout via widen_pending_damage.
+        if let Some(bounds) = self.combined_damage_bounds() {
+            cx.notify_with_damage(bounds);
+        } else {
+            cx.notify();
+        }
     }
 
     fn folds_did_change(&mut self, cx: &mut Context<Self>) {
@@ -24346,7 +24381,11 @@ impl Editor {
     }
 
     fn on_buffer_changed(&mut self, _: Entity<MultiBuffer>, cx: &mut Context<Self>) {
-        cx.notify();
+        if let Some(bounds) = self.last_bounds {
+            cx.notify_with_damage(bounds);
+        } else {
+            cx.notify();
+        }
     }
 
     fn on_debug_session_event(
@@ -24644,7 +24683,11 @@ impl Editor {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        cx.notify();
+        if let Some(bounds) = self.last_bounds {
+            cx.notify_with_damage(bounds);
+        } else {
+            cx.notify();
+        }
     }
 
     fn fetch_accent_data(&self, cx: &App) -> Option<AccentData> {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1960,6 +1960,66 @@ impl EditorElement {
                 }
             }
 
+            let prev_cursor_bounds = editor.cursor_damage_bounds;
+
+            let new_cursor_bounds = cursors.iter().fold(None, |acc, cursor| {
+                let rect = cursor.bounding_rect(content_origin);
+                Some(acc.map_or(rect, |existing: gpui::Bounds<Pixels>| existing.union(&rect)))
+            });
+            if let Some(bounds) = new_cursor_bounds {
+                editor.cursor_damage_bounds = Some(bounds);
+            }
+
+            // Compute the bounding rect of all visible selection backgrounds.
+            // Uses the full content width (conservative) since selections can
+            // span arbitrary columns.
+            let prev_selection_bounds = editor.selection_damage_bounds;
+
+            let new_selection_bounds = selections.iter().flat_map(|(_, sels)| sels).fold(
+                None,
+                |acc: Option<gpui::Bounds<Pixels>>, selection| {
+                    if selection.range.start == selection.range.end {
+                        return acc;
+                    }
+                    let sel_start_row = selection.range.start.row();
+                    let sel_end_row = if selection.range.end.column() == 0 {
+                        selection.range.end.row()
+                    } else {
+                        selection.range.end.row().next_row()
+                    };
+                    let start_y = content_origin.y
+                        + Pixels::from(
+                            (sel_start_row.as_f64() - scroll_position.y)
+                                * ScrollOffset::from(line_height),
+                        );
+                    let end_y = content_origin.y
+                        + Pixels::from(
+                            (sel_end_row.as_f64() - scroll_position.y)
+                                * ScrollOffset::from(line_height),
+                        );
+                    let rect = gpui::Bounds::from_corners(
+                        gpui::point(content_origin.x, start_y),
+                        gpui::point(content_origin.x + text_hitbox.bounds.size.width, end_y),
+                    );
+                    Some(acc.map_or(rect, |existing| existing.union(&rect)))
+                },
+            );
+            editor.selection_damage_bounds = new_selection_bounds;
+
+            // Widen the frame's pending damage to include new cursor and selection
+            // positions when they differ from the previous frame. Old positions
+            // were submitted during `selections_did_change`.
+            if let Some(new) = new_cursor_bounds {
+                if prev_cursor_bounds.as_ref() != Some(&new) {
+                    window.widen_pending_damage(new);
+                }
+            }
+            if let Some(new) = new_selection_bounds {
+                if prev_selection_bounds.as_ref() != Some(&new) {
+                    window.widen_pending_damage(new);
+                }
+            }
+
             cursors
         });
 
@@ -5381,6 +5441,9 @@ impl EditorElement {
             )
         });
         let Some((popover_position, hover_popovers)) = hover_popovers else {
+            self.editor.update(cx, |editor, _| {
+                editor.hover_damage_bounds = None;
+            });
             return;
         };
 
@@ -5419,6 +5482,27 @@ impl EditorElement {
                 horizontal_offset,
             });
         }
+
+        // Compute a conservative bounding rect covering all possible popover
+        // placements (above, below, or beside the hovered point). This is
+        // stored as damage bounds so hiding the hover can use partial damage.
+        let max_popover_width = measured_hover_popovers
+            .iter()
+            .map(|p| p.size.width)
+            .fold(Pixels::ZERO, |a, b| a.max(b));
+        let hover_bounds = gpui::Bounds::from_corners(
+            gpui::point(
+                hovered_point.x - max_popover_width,
+                hovered_point.y - overall_height - HOVER_POPOVER_GAP,
+            ),
+            gpui::point(
+                hovered_point.x + max_popover_width,
+                hovered_point.y + line_height + overall_height + HOVER_POPOVER_GAP,
+            ),
+        );
+        self.editor.update(cx, |editor, _| {
+            editor.hover_damage_bounds = Some(hover_bounds);
+        });
 
         fn draw_occluder(
             width: Pixels,
@@ -9825,6 +9909,9 @@ impl Element for EditorElement {
                             );
                         if was_scrolled.0 {
                             snapshot = editor.snapshot(window, cx);
+                            // Scrolling invalidates the entire viewport — partial
+                            // damage from cursor movement is no longer sufficient.
+                            window.set_full_pending_damage();
                         }
                         (
                             autoscroll_request,
@@ -10459,6 +10546,7 @@ impl Element for EditorElement {
                             )
                         {
                             scroll_position = new_scroll_position;
+                            window.set_full_pending_damage();
                         }
                     });
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -259,7 +259,11 @@ pub fn hide_hover(editor: &mut Editor, cx: &mut Context<Editor>) -> bool {
     editor.clear_background_highlights(HighlightKey::HoverState, cx);
 
     if did_hide {
-        cx.notify();
+        if let Some(bounds) = editor.hover_damage_bounds.take() {
+            cx.notify_with_damage(bounds);
+        } else {
+            cx.notify();
+        }
     }
 
     did_hide

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2277,6 +2277,19 @@ impl App {
 
     /// Tell GPUI that an entity has changed and observers of it should be notified.
     pub fn notify(&mut self, entity_id: EntityId) {
+        self.notify_inner(entity_id, None);
+    }
+
+    /// Tell GPUI that an entity has changed within the given damage bounds.
+    ///
+    /// This provides a spatial hint so GPUI can limit compositor-visible damage
+    /// to the affected region. Multiple calls in the same frame union their
+    /// bounds.
+    pub fn notify_with_damage(&mut self, entity_id: EntityId, damage_bounds: Bounds<Pixels>) {
+        self.notify_inner(entity_id, Some(damage_bounds));
+    }
+
+    fn notify_inner(&mut self, entity_id: EntityId, damage: Option<Bounds<Pixels>>) {
         let window_invalidators = mem::take(
             self.window_invalidators_by_entity
                 .entry(entity_id)
@@ -2290,7 +2303,14 @@ impl App {
             }
         } else {
             for invalidator in window_invalidators.values() {
-                invalidator.invalidate_view(entity_id, self);
+                match damage {
+                    Some(bounds) => {
+                        invalidator.invalidate_view_with_damage(entity_id, bounds, self);
+                    }
+                    None => {
+                        invalidator.invalidate_view(entity_id, self);
+                    }
+                }
             }
         }
 

--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -1,7 +1,8 @@
 use crate::{
-    AnyView, AnyWindowHandle, AppContext, AsyncApp, DispatchPhase, Effect, EntityId, EventEmitter,
-    FocusHandle, FocusOutEvent, Focusable, Global, KeystrokeObserver, Priority, Reservation,
-    SubscriberSet, Subscription, Task, WeakEntity, WeakFocusHandle, Window, WindowHandle,
+    AnyView, AnyWindowHandle, AppContext, AsyncApp, Bounds, DispatchPhase, Effect, EntityId,
+    EventEmitter, FocusHandle, FocusOutEvent, Focusable, Global, KeystrokeObserver, Pixels,
+    Priority, Reservation, SubscriberSet, Subscription, Task, WeakEntity, WeakFocusHandle, Window,
+    WindowHandle,
 };
 use anyhow::Result;
 use futures::FutureExt;
@@ -228,6 +229,16 @@ impl<'a, T: 'static> Context<'a, T> {
     /// Tell GPUI that this entity has changed and observers of it should be notified.
     pub fn notify(&mut self) {
         self.app.notify(self.entity_state.entity_id);
+    }
+
+    /// Tell GPUI that this entity has changed within the given damage bounds.
+    ///
+    /// This is the damage-aware variant of [`notify`](Self::notify). The bounds
+    /// describe the screen region that changed, allowing GPUI to limit
+    /// compositor-visible damage. See [`App::notify_with_damage`] for semantics.
+    pub fn notify_with_damage(&mut self, damage_bounds: Bounds<Pixels>) {
+        self.app
+            .notify_with_damage(self.entity_state.entity_id, damage_bounds);
     }
 
     /// Spawn the future returned by the given function.

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -635,7 +635,15 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn on_button_layout_changed(&self, _callback: Box<dyn FnMut()>) {}
-    fn draw(&self, scene: &Scene);
+    /// Draw the scene to the window surface.
+    ///
+    /// `damage` describes the region that changed since the last frame:
+    /// - `None` means the full window should be considered damaged.
+    /// - `Some(bounds)` constrains the damage to `bounds` in device pixels.
+    ///
+    /// Backends may use this hint to limit compositor-visible damage. Backends
+    /// that do not yet support partial presentation can ignore the parameter.
+    fn draw(&self, scene: &Scene, damage: Option<Bounds<DevicePixels>>);
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -285,7 +285,7 @@ impl PlatformWindow for TestWindow {
 
     fn on_appearance_changed(&self, _callback: Box<dyn FnMut()>) {}
 
-    fn draw(&self, _scene: &Scene) {}
+    fn draw(&self, _scene: &Scene, _damage: Option<Bounds<DevicePixels>>) {}
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {
         self.0.lock().sprite_atlas.clone()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -101,10 +101,26 @@ impl DispatchPhase {
     }
 }
 
+/// Tracks the spatial extent of damage accumulated between frames.
+///
+/// When entities notify the system of changes, damage is accumulated here.
+/// At draw time, the accumulated region is extracted and forwarded to the
+/// platform backend so it can limit compositor-visible damage.
+#[derive(Clone, Copy, Debug)]
+enum DamageRegion {
+    /// No damage has been recorded since the last draw.
+    Empty,
+    /// All recorded damage fits within this bounding rectangle.
+    Partial(Bounds<Pixels>),
+    /// Damage is unknown or covers the full window.
+    Full,
+}
+
 struct WindowInvalidatorInner {
     pub dirty: bool,
     pub draw_phase: DrawPhase,
     pub dirty_views: FxHashSet<EntityId>,
+    pub damage: DamageRegion,
 }
 
 #[derive(Clone)]
@@ -119,6 +135,7 @@ impl WindowInvalidator {
                 dirty: true,
                 draw_phase: DrawPhase::None,
                 dirty_views: FxHashSet::default(),
+                damage: DamageRegion::Full,
             })),
         }
     }
@@ -126,6 +143,33 @@ impl WindowInvalidator {
     pub fn invalidate_view(&self, entity: EntityId, cx: &mut App) -> bool {
         let mut inner = self.inner.borrow_mut();
         inner.dirty_views.insert(entity);
+        inner.damage = DamageRegion::Full;
+        Self::commit_invalidation(&mut inner, entity, cx)
+    }
+
+    pub fn invalidate_view_with_damage(
+        &self,
+        entity: EntityId,
+        damage_bounds: Bounds<Pixels>,
+        cx: &mut App,
+    ) -> bool {
+        let mut inner = self.inner.borrow_mut();
+        inner.dirty_views.insert(entity);
+        inner.damage = match inner.damage {
+            DamageRegion::Empty => DamageRegion::Partial(damage_bounds),
+            DamageRegion::Partial(existing) => {
+                DamageRegion::Partial(existing.union(&damage_bounds))
+            }
+            DamageRegion::Full => DamageRegion::Full,
+        };
+        Self::commit_invalidation(&mut inner, entity, cx)
+    }
+
+    fn commit_invalidation(
+        inner: &mut WindowInvalidatorInner,
+        entity: EntityId,
+        cx: &mut App,
+    ) -> bool {
         if inner.draw_phase == DrawPhase::None {
             inner.dirty = true;
             cx.push_effect(Effect::Notify { emitter: entity });
@@ -153,6 +197,23 @@ impl WindowInvalidator {
 
     pub fn replace_views(&self, views: FxHashSet<EntityId>) {
         self.inner.borrow_mut().dirty_views = views;
+    }
+
+    /// Extracts the accumulated damage region and resets it to `Empty` for the
+    /// next frame. Returns `None` for full-window damage, `Some(bounds)` for
+    /// partial damage constrained to `bounds`.
+    pub fn take_damage(&self) -> Option<Bounds<Pixels>> {
+        let mut inner = self.inner.borrow_mut();
+        let damage = mem::replace(&mut inner.damage, DamageRegion::Empty);
+        match damage {
+            DamageRegion::Empty => Some(Bounds::default()),
+            DamageRegion::Partial(bounds) => Some(bounds),
+            DamageRegion::Full => None,
+        }
+    }
+
+    pub fn set_full_damage(&self) {
+        self.inner.borrow_mut().damage = DamageRegion::Full;
     }
 
     pub fn not_drawing(&self) -> bool {
@@ -955,6 +1016,7 @@ pub struct Window {
     active: Rc<Cell<bool>>,
     hovered: Rc<Cell<bool>>,
     pub(crate) needs_present: Rc<Cell<bool>>,
+    pending_damage: Cell<Option<Bounds<DevicePixels>>>,
     /// Tracks recent input event timestamps to determine if input is arriving at a high rate.
     /// Used to selectively enable VRR optimization only when input rate exceeds 60fps.
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
@@ -1481,6 +1543,7 @@ impl Window {
             active,
             hovered,
             needs_present,
+            pending_damage: Cell::new(None),
             input_rate_tracker,
             last_input_modality: InputModality::Mouse,
             refreshing: false,
@@ -1621,6 +1684,7 @@ impl Window {
         if self.invalidator.not_drawing() {
             self.refreshing = true;
             self.invalidator.set_dirty(true);
+            self.invalidator.set_full_damage();
         }
     }
 
@@ -2275,6 +2339,9 @@ impl Window {
         let _arena_scope = ElementArenaScope::enter(&cx.element_arena);
 
         self.invalidate_entities();
+        let damage_bounds = self.invalidator.take_damage();
+        self.pending_damage
+            .set(damage_bounds.map(|bounds| bounds.to_device_pixels(self.scale_factor)));
         cx.entities.clear_accessed();
         debug_assert!(self.rendered_entity_stack.is_empty());
         self.invalidator.set_dirty(false);
@@ -2348,12 +2415,7 @@ impl Window {
         let mut entities_ref = cx.entities.accessed_entities.get_mut();
         let mut entities = mem::take(entities_ref.deref_mut());
         let handle = self.handle;
-        cx.record_entities_accessed(
-            handle,
-            // Try moving window invalidator into the Window
-            self.invalidator.clone(),
-            &entities,
-        );
+        cx.record_entities_accessed(handle, self.invalidator.clone(), &entities);
         let mut entities_ref = cx.entities.accessed_entities.get_mut();
         mem::swap(&mut entities, entities_ref.deref_mut());
     }
@@ -2366,9 +2428,31 @@ impl Window {
         self.invalidator.replace_views(views);
     }
 
+    /// Expand the current frame's pending damage to include additional bounds.
+    ///
+    /// When damage is currently partial (`Some`), unions the new bounds in.
+    /// When damage is already full (`None`), this is a no-op.
+    pub fn widen_pending_damage(&self, bounds: Bounds<Pixels>) {
+        if let Some(existing) = self.pending_damage.get() {
+            let new_device = bounds.to_device_pixels(self.scale_factor);
+            self.pending_damage.set(Some(existing.union(&new_device)));
+        }
+        // If pending_damage is None, damage is already full — nothing to widen.
+    }
+
+    /// Upgrade the current frame's pending damage to full-window damage.
+    ///
+    /// Use this when layout discovers that partial damage is insufficient
+    /// (e.g., autoscroll actually moved the viewport).
+    pub fn set_full_pending_damage(&self) {
+        self.pending_damage.set(None);
+    }
+
     #[profiling::function]
     fn present(&self) {
-        self.platform_window.draw(&self.rendered_frame.scene);
+        let damage = self.pending_damage.get();
+        self.platform_window
+            .draw(&self.rendered_frame.scene, damage);
         self.needs_present.set(false);
         profiling::finish_frame!();
     }
@@ -5762,5 +5846,394 @@ pub fn outline(
         border_widths: (1.).into(),
         border_color: border_color.into(),
         border_style,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Entity, TestAppContext, div, px, size};
+
+    fn bounds(x: f32, y: f32, w: f32, h: f32) -> Bounds<Pixels> {
+        Bounds::new(point(px(x), px(y)), size(px(w), px(h)))
+    }
+
+    struct DamageTestView;
+
+    impl Render for DamageTestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+        }
+    }
+
+    struct DependencyModel;
+
+    struct ObservingDamageView {
+        model: Entity<DependencyModel>,
+        render_count: Rc<Cell<usize>>,
+        _subscription: Subscription,
+    }
+
+    impl ObservingDamageView {
+        fn new(
+            model: Entity<DependencyModel>,
+            render_count: Rc<Cell<usize>>,
+            cx: &mut Context<Self>,
+        ) -> Self {
+            let subscription = cx.observe(&model, |_, _, cx| cx.notify());
+            Self {
+                model,
+                render_count,
+                _subscription: subscription,
+            }
+        }
+    }
+
+    impl Render for ObservingDamageView {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let _ = self.model.read(cx);
+            self.render_count.set(self.render_count.get() + 1);
+            div()
+        }
+    }
+
+    #[test]
+    fn test_invalidator_initial_damage_is_full() {
+        let invalidator = WindowInvalidator::new();
+        let damage = invalidator.take_damage();
+        assert!(damage.is_none(), "new invalidator should have Full damage");
+    }
+
+    #[test]
+    fn test_invalidate_view_sets_full_damage() {
+        let cx = TestAppContext::single();
+        cx.update(|cx| {
+            let invalidator = WindowInvalidator::new();
+            invalidator.take_damage(); // clear initial Full
+
+            let entity_id = EntityId::from(1u64);
+            invalidator.invalidate_view(entity_id, cx);
+
+            let damage = invalidator.take_damage();
+            assert!(damage.is_none(), "invalidate_view should set Full damage");
+        });
+    }
+
+    #[test]
+    fn test_damage_aware_invalidation_sets_partial_from_empty() {
+        let cx = TestAppContext::single();
+        cx.update(|cx| {
+            let invalidator = WindowInvalidator::new();
+            invalidator.take_damage(); // clear initial Full
+
+            let entity_id = EntityId::from(1u64);
+            let region = bounds(10.0, 20.0, 100.0, 50.0);
+            invalidator.invalidate_view_with_damage(entity_id, region, cx);
+
+            let damage = invalidator.take_damage();
+            assert_eq!(damage, Some(region));
+        });
+    }
+
+    #[test]
+    fn test_damage_aware_invalidation_unions_bounds() {
+        let cx = TestAppContext::single();
+        cx.update(|cx| {
+            let invalidator = WindowInvalidator::new();
+            invalidator.take_damage(); // clear initial Full
+
+            let entity_a = EntityId::from(1u64);
+            let entity_b = EntityId::from(2u64);
+            let region_a = bounds(10.0, 10.0, 50.0, 50.0);
+            let region_b = bounds(100.0, 100.0, 50.0, 50.0);
+            invalidator.invalidate_view_with_damage(entity_a, region_a, cx);
+            invalidator.invalidate_view_with_damage(entity_b, region_b, cx);
+
+            let damage = invalidator.take_damage();
+            let expected = region_a.union(&region_b);
+            assert_eq!(damage, Some(expected));
+        });
+    }
+
+    #[test]
+    fn test_plain_notify_collapses_partial_to_full() {
+        let cx = TestAppContext::single();
+        cx.update(|cx| {
+            let invalidator = WindowInvalidator::new();
+            invalidator.take_damage(); // clear initial Full
+
+            let entity_a = EntityId::from(1u64);
+            let entity_b = EntityId::from(2u64);
+            let region = bounds(10.0, 20.0, 100.0, 50.0);
+            invalidator.invalidate_view_with_damage(entity_a, region, cx);
+            invalidator.invalidate_view(entity_b, cx);
+
+            let damage = invalidator.take_damage();
+            assert!(
+                damage.is_none(),
+                "plain invalidate_view after partial should collapse to Full"
+            );
+        });
+    }
+
+    #[test]
+    fn test_full_damage_not_overridden_by_partial() {
+        let cx = TestAppContext::single();
+        cx.update(|cx| {
+            let invalidator = WindowInvalidator::new();
+            invalidator.take_damage(); // clear initial Full
+
+            let entity_a = EntityId::from(1u64);
+            let entity_b = EntityId::from(2u64);
+            invalidator.invalidate_view(entity_a, cx);
+
+            let region = bounds(10.0, 20.0, 100.0, 50.0);
+            invalidator.invalidate_view_with_damage(entity_b, region, cx);
+
+            let damage = invalidator.take_damage();
+            assert!(
+                damage.is_none(),
+                "damage-aware notify cannot narrow Full back to Partial"
+            );
+        });
+    }
+
+    #[test]
+    fn test_take_damage_resets_to_empty() {
+        let cx = TestAppContext::single();
+        cx.update(|cx| {
+            let invalidator = WindowInvalidator::new();
+            invalidator.take_damage(); // clear initial Full
+
+            let entity_id = EntityId::from(1u64);
+            let region = bounds(10.0, 20.0, 100.0, 50.0);
+            invalidator.invalidate_view_with_damage(entity_id, region, cx);
+            invalidator.take_damage(); // consume
+
+            // Second take should return Empty (zero-sized bounds)
+            let damage = invalidator.take_damage();
+            assert_eq!(
+                damage,
+                Some(Bounds::default()),
+                "after take_damage, state should be Empty"
+            );
+        });
+    }
+
+    #[crate::test]
+    fn test_notify_with_damage_sets_partial_pending_damage(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        // The initial draw consumes the Full damage and registers the entity
+        // with the window invalidator. Now trigger a damage-aware notify
+        // followed by a redraw to verify pending_damage is set to partial.
+        let region = bounds(10.0, 20.0, 100.0, 50.0);
+        cx.update(|cx| cx.notify_with_damage(entity_id, region));
+
+        // After flush_effects draws the window, pending_damage should
+        // have been set during draw(). Read it from the window.
+        window
+            .update(cx, |_view, window, _cx| {
+                let damage = window.pending_damage.get();
+                let expected = region.to_device_pixels(window.scale_factor);
+                assert_eq!(
+                    damage,
+                    Some(expected),
+                    "pending_damage should match the notified region in device pixels"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_plain_notify_sets_full_pending_damage(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        cx.update(|cx| cx.notify(entity_id));
+
+        window
+            .update(cx, |_view, window, _cx| {
+                let damage = window.pending_damage.get();
+                assert_eq!(
+                    damage, None,
+                    "pending_damage should be None (full) after plain notify"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_mixed_notify_sets_full_pending_damage(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        cx.update(|cx| {
+            cx.notify_with_damage(entity_id, bounds(10.0, 20.0, 50.0, 30.0));
+            cx.notify(entity_id);
+        });
+
+        window
+            .update(cx, |_view, window, _cx| {
+                let damage = window.pending_damage.get();
+                assert_eq!(
+                    damage, None,
+                    "pending_damage should be None (full) when partial + full are mixed"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_widen_pending_damage_unions_with_partial(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        let region = bounds(10.0, 20.0, 30.0, 40.0);
+        cx.update(|cx| cx.notify_with_damage(entity_id, region));
+
+        window
+            .update(cx, |_view, window, _cx| {
+                let before = window.pending_damage.get();
+                assert!(before.is_some(), "should start as partial");
+
+                let widen_region = bounds(100.0, 100.0, 50.0, 50.0);
+                window.widen_pending_damage(widen_region);
+
+                let after = window.pending_damage.get();
+                let expected = region
+                    .union(&widen_region)
+                    .to_device_pixels(window.scale_factor);
+                assert_eq!(
+                    after,
+                    Some(expected),
+                    "widened bounds should be the exact union of both regions"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_widen_pending_damage_noop_when_full(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        cx.update(|cx| cx.notify(entity_id));
+
+        window
+            .update(cx, |_view, window, _cx| {
+                assert_eq!(window.pending_damage.get(), None, "should be full (None)");
+
+                window.widen_pending_damage(bounds(10.0, 10.0, 50.0, 50.0));
+
+                assert_eq!(
+                    window.pending_damage.get(),
+                    None,
+                    "should remain full after widen"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_set_full_pending_damage_upgrades_partial(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        let region = bounds(10.0, 20.0, 100.0, 50.0);
+        cx.update(|cx| cx.notify_with_damage(entity_id, region));
+
+        window
+            .update(cx, |_view, window, _cx| {
+                assert!(
+                    window.pending_damage.get().is_some(),
+                    "should be partial before"
+                );
+                window.set_full_pending_damage();
+                assert_eq!(
+                    window.pending_damage.get(),
+                    None,
+                    "should be full after set_full_pending_damage"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_present_keeps_pending_damage_for_presentation_only_frames(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        let region = bounds(10.0, 20.0, 100.0, 50.0);
+        cx.update(|cx| cx.notify_with_damage(entity_id, region));
+
+        window
+            .update(cx, |_view, window, _cx| {
+                let expected = Some(region.to_device_pixels(window.scale_factor));
+                assert_eq!(window.pending_damage.get(), expected);
+
+                window.present();
+
+                assert_eq!(
+                    window.pending_damage.get(),
+                    expected,
+                    "present-only frames should retain the last damage region"
+                );
+            })
+            .unwrap();
+    }
+
+    #[crate::test]
+    fn test_observed_non_view_notify_reaches_the_view(cx: &mut TestAppContext) {
+        let render_count = Rc::new(Cell::new(0));
+        let model = cx.update(|cx| cx.new(|_| DependencyModel));
+        let initial_renders = render_count.clone();
+        let _window = cx.add_window(|_window, cx| {
+            ObservingDamageView::new(model.clone(), initial_renders.clone(), cx)
+        });
+
+        assert_eq!(
+            render_count.get(),
+            1,
+            "initial window creation should draw once"
+        );
+
+        model.update(cx, |_model, cx| cx.notify());
+
+        assert_eq!(
+            render_count.get(),
+            2,
+            "observed non-view notifications should still trigger a redraw through the view"
+        );
+    }
+
+    #[crate::test]
+    fn test_refresh_sets_full_damage(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_window, _cx| DamageTestView);
+        let entity_id = window.root(cx).unwrap().entity_id();
+
+        // First, set partial damage so we can verify refresh upgrades it
+        let region = bounds(10.0, 20.0, 100.0, 50.0);
+        cx.update(|cx| cx.notify_with_damage(entity_id, region));
+
+        // Now call refresh, which should set damage to Full
+        window
+            .update(cx, |_view, window, _cx| {
+                window.refresh();
+            })
+            .unwrap();
+
+        // Flush effects to draw the window
+        cx.run_until_parked();
+
+        window
+            .update(cx, |_view, window, _cx| {
+                // After refresh + draw, pending_damage should have been set from Full
+                // damage (None), not the earlier partial damage
+                let damage = window.pending_damage.get();
+                assert_eq!(damage, None, "refresh should produce full damage");
+            })
+            .unwrap();
     }
 }

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1356,7 +1356,7 @@ impl PlatformWindow for WaylandWindow {
         self.0.callbacks.borrow_mut().button_layout_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, damage: Option<Bounds<DevicePixels>>) {
         let mut state = self.borrow_mut();
 
         if state.renderer.device_lost() {
@@ -1384,7 +1384,7 @@ impl PlatformWindow for WaylandWindow {
             return;
         }
 
-        state.renderer.draw(scene);
+        state.renderer.draw(scene, damage);
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -1653,7 +1653,7 @@ impl PlatformWindow for X11Window {
         self.0.callbacks.borrow_mut().button_layout_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, damage: Option<Bounds<DevicePixels>>) {
         let mut inner = self.0.state.borrow_mut();
 
         if inner.renderer.device_lost() {
@@ -1679,7 +1679,7 @@ impl PlatformWindow for X11Window {
             return;
         }
 
-        inner.renderer.draw(scene);
+        inner.renderer.draw(scene, damage);
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -133,6 +133,11 @@ pub(crate) struct MetalRenderer {
     path_intermediate_texture: Option<metal::Texture>,
     path_intermediate_msaa_texture: Option<metal::Texture>,
     path_sample_count: u32,
+    /// Persistent render target for damage-aware rendering. Metal drawables come
+    /// from a triple-buffered pool, so their previous content is 2-3 frames stale.
+    /// This texture always holds the latest complete frame, enabling partial updates
+    /// via LoadAction::Load + scissor rect.
+    persistent_texture: Option<metal::Texture>,
 }
 
 #[repr(C)]
@@ -347,6 +352,7 @@ impl MetalRenderer {
             path_intermediate_texture: None,
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
+            persistent_texture: None,
         }
     }
 
@@ -386,6 +392,32 @@ impl MetalRenderer {
             }
         }
         self.update_path_intermediate_textures(size);
+        // Invalidate persistent texture so it is recreated at the new size.
+        self.persistent_texture = None;
+    }
+
+    /// Ensures the persistent render target exists and matches the viewport size.
+    /// Returns `true` if the texture was just created (caller must do a full render).
+    fn ensure_persistent_texture(&mut self, viewport_size: Size<DevicePixels>) -> bool {
+        let needs_recreate = match &self.persistent_texture {
+            Some(tex) => {
+                tex.width() != i32::from(viewport_size.width) as u64
+                    || tex.height() != i32::from(viewport_size.height) as u64
+            }
+            None => true,
+        };
+        if needs_recreate {
+            let desc = metal::TextureDescriptor::new();
+            desc.set_width(i32::from(viewport_size.width) as u64);
+            desc.set_height(i32::from(viewport_size.height) as u64);
+            desc.set_pixel_format(MTLPixelFormat::BGRA8Unorm);
+            desc.set_storage_mode(metal::MTLStorageMode::Private);
+            desc.set_usage(
+                metal::MTLTextureUsage::RenderTarget | metal::MTLTextureUsage::ShaderRead,
+            );
+            self.persistent_texture = Some(self.device.new_texture(&desc));
+        }
+        needs_recreate
     }
 
     fn update_path_intermediate_textures(&mut self, size: Size<DevicePixels>) {
@@ -437,7 +469,7 @@ impl MetalRenderer {
         // nothing to do
     }
 
-    pub fn draw(&mut self, scene: &Scene) {
+    pub fn draw(&mut self, scene: &Scene, damage: Option<Bounds<DevicePixels>>) {
         let layer = match &self.layer {
             Some(l) => l.clone(),
             None => {
@@ -462,17 +494,72 @@ impl MetalRenderer {
             return;
         };
 
+        // Ensure persistent texture exists; force full render if just created.
+        let texture_is_new = self.ensure_persistent_texture(viewport_size);
+
+        // Compute scissor for partial damage. Skip scissor if the persistent texture
+        // was just created (its content is undefined, so we must do a full render).
+        let scissor = if texture_is_new {
+            None
+        } else {
+            damage.map(|bounds| {
+                let vp_w = i32::from(viewport_size.width) as u64;
+                let vp_h = i32::from(viewport_size.height) as u64;
+                let x = (bounds.origin.x.0.max(0) as u64).min(vp_w);
+                let y = (bounds.origin.y.0.max(0) as u64).min(vp_h);
+                metal::MTLScissorRect {
+                    x,
+                    y,
+                    width: (bounds.size.width.0.max(0) as u64).min(vp_w.saturating_sub(x)),
+                    height: (bounds.size.height.0.max(0) as u64).min(vp_h.saturating_sub(y)),
+                }
+            })
+        };
+
         loop {
             let mut instance_buffer = self
                 .instance_buffer_pool
                 .lock()
                 .acquire(&self.device, self.is_unified_memory);
 
-            let command_buffer =
-                self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
+            // Render to persistent texture (not the drawable). On partial damage,
+            // LoadAction::Load preserves previous content and the scissor rect
+            // limits fragment work to the damaged region.
+            let Some(persistent_texture) = self.persistent_texture.take() else {
+                log::error!("persistent texture missing after creation");
+                return;
+            };
+            let command_buffer = self.draw_primitives_to_texture(
+                scene,
+                &mut instance_buffer,
+                &persistent_texture,
+                viewport_size,
+                scissor,
+            );
 
             match command_buffer {
                 Ok(command_buffer) => {
+                    // Blit the persistent texture to the drawable.
+                    let blit = command_buffer.new_blit_command_encoder();
+                    let origin = metal::MTLOrigin { x: 0, y: 0, z: 0 };
+                    let tex_size = metal::MTLSize {
+                        width: i32::from(viewport_size.width) as u64,
+                        height: i32::from(viewport_size.height) as u64,
+                        depth: 1,
+                    };
+                    blit.copy_from_texture(
+                        &persistent_texture,
+                        0,
+                        0,
+                        origin,
+                        tex_size,
+                        drawable.texture(),
+                        0,
+                        0,
+                        origin,
+                    );
+                    blit.end_encoding();
+
                     let instance_buffer_pool = self.instance_buffer_pool.clone();
                     let instance_buffer = Cell::new(Some(instance_buffer));
                     let block = ConcreteBlock::new(move |_| {
@@ -491,9 +578,11 @@ impl MetalRenderer {
                         command_buffer.present_drawable(drawable);
                         command_buffer.commit();
                     }
+                    self.persistent_texture = Some(persistent_texture);
                     return;
                 }
                 Err(err) => {
+                    self.persistent_texture = Some(persistent_texture);
                     log::error!(
                         "failed to render: {}. retrying with larger instance buffer size",
                         err
@@ -647,8 +736,13 @@ impl MetalRenderer {
                 .lock()
                 .acquire(&self.device, self.is_unified_memory);
 
-            let command_buffer =
-                self.draw_primitives_to_texture(scene, &mut instance_buffer, &target_texture, size);
+            let command_buffer = self.draw_primitives_to_texture(
+                scene,
+                &mut instance_buffer,
+                &target_texture,
+                size,
+                None,
+            );
 
             match command_buffer {
                 Ok(command_buffer) => {
@@ -729,6 +823,7 @@ impl MetalRenderer {
         }
     }
 
+    #[cfg(any(test, feature = "test-support"))]
     fn draw_primitives(
         &mut self,
         scene: &Scene,
@@ -736,7 +831,13 @@ impl MetalRenderer {
         drawable: &metal::MetalDrawableRef,
         viewport_size: Size<DevicePixels>,
     ) -> Result<metal::CommandBuffer> {
-        self.draw_primitives_to_texture(scene, instance_buffer, drawable.texture(), viewport_size)
+        self.draw_primitives_to_texture(
+            scene,
+            instance_buffer,
+            drawable.texture(),
+            viewport_size,
+            None,
+        )
     }
 
     fn draw_primitives_to_texture(
@@ -745,6 +846,7 @@ impl MetalRenderer {
         instance_buffer: &mut InstanceBuffer,
         texture: &metal::TextureRef,
         viewport_size: Size<DevicePixels>,
+        scissor: Option<metal::MTLScissorRect>,
     ) -> Result<metal::CommandBuffer> {
         let command_queue = self.command_queue.clone();
         let command_buffer = command_queue.new_command_buffer();
@@ -756,10 +858,20 @@ impl MetalRenderer {
             texture,
             viewport_size,
             |color_attachment| {
-                color_attachment.set_load_action(metal::MTLLoadAction::Clear);
-                color_attachment.set_clear_color(metal::MTLClearColor::new(0., 0., 0., alpha));
+                if scissor.is_some() {
+                    // Partial damage: preserve existing content in the persistent
+                    // texture; the scissor rect limits fragment work to the changed
+                    // region.
+                    color_attachment.set_load_action(metal::MTLLoadAction::Load);
+                } else {
+                    color_attachment.set_load_action(metal::MTLLoadAction::Clear);
+                    color_attachment.set_clear_color(metal::MTLClearColor::new(0., 0., 0., alpha));
+                }
             },
         );
+        if let Some(rect) = scissor {
+            command_encoder.set_scissor_rect(rect);
+        }
 
         for batch in scene.batches() {
             let ok = match batch {
@@ -797,6 +909,9 @@ impl MetalRenderer {
                             color_attachment.set_load_action(metal::MTLLoadAction::Load);
                         },
                     );
+                    if let Some(rect) = scissor {
+                        command_encoder.set_scissor_rect(rect);
+                    }
 
                     if did_draw {
                         self.draw_paths_from_intermediate(

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1589,9 +1589,9 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().toggle_tab_bar_callback = Some(callback);
     }
 
-    fn draw(&self, scene: &gpui::Scene) {
+    fn draw(&self, scene: &gpui::Scene, damage: Option<gpui::Bounds<gpui::DevicePixels>>) {
         let mut this = self.0.lock();
-        this.renderer.draw(scene);
+        this.renderer.draw(scene, damage);
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -664,7 +664,7 @@ impl PlatformWindow for WebWindow {
         self.inner.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, damage: Option<Bounds<DevicePixels>>) {
         if let Some((width, height)) = self.inner.pending_physical_size.take() {
             if self.inner.canvas.width() != width || self.inner.canvas.height() != height {
                 self.inner.canvas.set_width(width);
@@ -679,7 +679,7 @@ impl PlatformWindow for WebWindow {
             drop(state);
         }
 
-        self.inner.state.borrow_mut().renderer.draw(scene);
+        self.inner.state.borrow_mut().renderer.draw(scene, damage);
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -149,6 +149,27 @@ pub struct WgpuRenderer {
 }
 
 impl WgpuRenderer {
+    fn clamp_damage_rect(&self, bounds: Bounds<DevicePixels>) -> wgpu::DamageRect {
+        let surface_width = self.surface_config.width as i64;
+        let surface_height = self.surface_config.height as i64;
+        let origin_x = i64::from(bounds.origin.x.0);
+        let origin_y = i64::from(bounds.origin.y.0);
+        let end_x = origin_x.saturating_add(i64::from(bounds.size.width.0.max(0)));
+        let end_y = origin_y.saturating_add(i64::from(bounds.size.height.0.max(0)));
+
+        let clamped_origin_x = origin_x.clamp(0, surface_width);
+        let clamped_origin_y = origin_y.clamp(0, surface_height);
+        let clamped_end_x = end_x.clamp(0, surface_width);
+        let clamped_end_y = end_y.clamp(0, surface_height);
+
+        wgpu::DamageRect {
+            x: clamped_origin_x as i32,
+            y: clamped_origin_y as i32,
+            width: clamped_end_x.saturating_sub(clamped_origin_x) as u32,
+            height: clamped_end_y.saturating_sub(clamped_origin_y) as u32,
+        }
+    }
+
     fn resources(&self) -> &WgpuResources {
         self.resources
             .as_ref()
@@ -1064,7 +1085,7 @@ impl WgpuRenderer {
         self.max_texture_size
     }
 
-    pub fn draw(&mut self, scene: &Scene) {
+    pub fn draw(&mut self, scene: &Scene, damage: Option<Bounds<DevicePixels>>) {
         // Bail out early if the surface has been unconfigured (e.g. during
         // Android background/rotation transitions).  Attempting to acquire
         // a texture from an unconfigured surface can block indefinitely on
@@ -1072,6 +1093,15 @@ impl WgpuRenderer {
         if !self.surface_configured {
             return;
         }
+
+        let damage_rect;
+        let damage_rects: &[wgpu::DamageRect] = match damage {
+            Some(bounds) => {
+                damage_rect = self.clamp_damage_rect(bounds);
+                std::slice::from_ref(&damage_rect)
+            }
+            None => &[],
+        };
 
         let last_error = self.last_error.lock().unwrap().take();
         if let Some(error) = last_error {
@@ -1294,7 +1324,7 @@ impl WgpuRenderer {
                         "instance buffer size grew too large: {}",
                         self.instance_buffer_capacity
                     );
-                    frame.present();
+                    frame.present_with_damage(&damage_rects);
                     return;
                 }
                 self.grow_instance_buffer();
@@ -1304,7 +1334,7 @@ impl WgpuRenderer {
             self.resources()
                 .queue
                 .submit(std::iter::once(encoder.finish()));
-            frame.present();
+            frame.present_with_damage(&damage_rects);
             return;
         }
     }

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -921,7 +921,7 @@ impl PlatformWindow for WindowsWindow {
             .set(Some(callback));
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, _damage: Option<Bounds<DevicePixels>>) {
         self.state
             .renderer
             .borrow_mut()


### PR DESCRIPTION
Part 2/2 for #15166 fix.
The companion PR is in WGPU (v29): https://github.com/zed-industries/wgpu/pull/2

## Summary
• add coarse damage tracking to GPUI w/ `DamageRegion` plus `Context::notify_with_damage(bounds)`, while keeping `notify()` as the conservative full damage fallback
• forward `damage: Option<Bounds<DevicePixels>>` through `PlatformWindow::draw` so each backend can either consume damage explicitly or safely ignore it
• make the Linux / `wgpu` path call `SurfaceTexture::present_with_damage()` and update the editor hot paths that matter here: caret blink, caret movement, selections, hover popovers, and coarse editor area updates for buffer and display map changes
• teach the macOS Metal renderer to keep a persistent render target and use scissoring for partial redraws, reducing local fragment work without depending on compositor present region support
• preserve GPUI's existing invalidation semantics for accessed entities; damage remains an explicit optimization hint and does not narrow redraw scheduling rules
• add regression coverage for observer driven non-view invalidation, present only frames retaining computed damage, and the editor behaviors that regressed when invalidation semantics were narrowed

### Why
The issue here was not just that Zed repainted too much. It was that the editor had no end-to-end path to express small visual changes as damage and carry that information down to presentation.

This patch fixes that in the minimal places that matter. Zed now computes meaningful damage for cursor blink, cursor movement, selections, hover state, and edits. GPUI can carry that damage without changing its redraw contract. Linux can forward it into the companion `wgpu` present-with-damage path. macOS can reduce local render work with scissoring even though Metal does not have compositor facing present regions.

## Testing
Local (MacOS):
- `cargo fmt --all --check`
- `./script/clippy -p gpui`
- `./script/clippy -p gpui_macos`
- `./script/clippy -p editor`
- `cargo test -p gpui window::tests::test_observed_non_view_notify_reaches_the_view -- --exact --nocapture`
- `cargo test -p gpui window::tests::test_present_keeps_pending_damage_for_presentation_only_frames -- --exact --nocapture`
- `cargo test -p agent_ui message_editor::tests::test_autoscroll_after_insert_selections -- --exact --nocapture`
- `cargo test -p vim change_list::test::test_change_list_insert -- --exact --nocapture`

Manual verification still **required** before claiming full closure of `#15166`:
- Linux / Wayland protocol proof showing narrowed `damage_buffer` output during idle caret blink
- Windows no-regression verification

## Notes
• This PR depends on the companion `wgpu` PR and temporarily pins to WGPU commit `bb070fec2ca45625855581ba894a6cb0b55e2105` on `loadingalias/wgpu` through `[patch.'https://github.com/zed-industries/wgpu.git']`.
• Zed now computes and forwards meaningful damage correctly; however, it really should have the Linux/Wayland tests done and Windows regressions checks run.

Release Notes:

- Improved rendering efficiency by tracking and forwarding damage regions for small editor updates such as caret blink, caret movement, selections, hover popovers, and edits.