### PR TITLE
Add range-based whitespace and newline removal to buffer formatting

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2285,6 +2285,88 @@ impl Buffer {
         self.edit([(offset..len, "\n")], None, cx);
     }
 
+    /// Like [`remove_trailing_whitespace`](Self::remove_trailing_whitespace), but only removes
+    /// trailing whitespace on lines whose row falls within one of the given `modified_rows` ranges.
+    pub fn remove_trailing_whitespace_in_ranges(
+        &self,
+        modified_rows: &[Range<u32>],
+        cx: &App,
+    ) -> Task<Diff> {
+        let old_text = self.as_rope().clone();
+        let line_ending = self.line_ending();
+        let base_version = self.version();
+        let modified_rows = modified_rows.to_vec();
+        cx.background_spawn(async move {
+            let all_ranges = trailing_whitespace_ranges(&old_text);
+            let empty = Arc::<str>::from("");
+            let edits = all_ranges
+                .into_iter()
+                .filter(|range| {
+                    let row = old_text.offset_to_point(range.start).row;
+                    modified_rows.iter().any(|modified| modified.contains(&row))
+                })
+                .map(|range| (range, empty.clone()))
+                .collect();
+            Diff {
+                base_version,
+                line_ending,
+                edits,
+            }
+        })
+    }
+
+    /// Like [`ensure_final_newline`](Self::ensure_final_newline), but only applies the fix when
+    /// the last line's row falls within one of the given `modified_rows` ranges. Returns an empty
+    /// [`Diff`] when the last line is not in any modified range.
+    pub fn ensure_final_newline_in_range(
+        &self,
+        modified_rows: &[Range<u32>],
+        cx: &App,
+    ) -> Task<Diff> {
+        let len = self.len();
+        let line_ending = self.line_ending();
+        let base_version = self.version();
+        let last_row = self.max_point().row;
+
+        let last_row_is_modified = modified_rows.iter().any(|r| r.contains(&last_row));
+        if len == 0 || !last_row_is_modified {
+            return Task::ready(Diff {
+                base_version,
+                line_ending,
+                edits: Vec::new(),
+            });
+        }
+
+        let old_text = self.as_rope().clone();
+        cx.background_spawn(async move {
+            let mut offset = len;
+            for chunk in old_text.reversed_chunks_in_range(0..len) {
+                let non_whitespace_len = chunk
+                    .trim_end_matches(|c: char| c.is_ascii_whitespace())
+                    .len();
+                offset -= chunk.len();
+                offset += non_whitespace_len;
+                if non_whitespace_len != 0 {
+                    if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
+                        // Buffer already ends with exactly one newline.
+                        return Diff {
+                            base_version,
+                            line_ending,
+                            edits: Vec::new(),
+                        };
+                    }
+                    break;
+                }
+            }
+            let newline: Arc<str> = Arc::from("\n");
+            Diff {
+                base_version,
+                line_ending,
+                edits: vec![(offset..len, newline)],
+            }
+        })
+    }
+
     /// Applies a diff to the buffer. If the buffer has changed since the given diff was
     /// calculated, then adjust the diff to account for those changes, and discard any
     /// parts of the diff that conflict with those changes.

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2297,20 +2297,15 @@ impl Buffer {
         let base_version = self.version();
         let modified_rows = modified_rows.to_vec();
         cx.background_spawn(async move {
-            let all_ranges = trailing_whitespace_ranges(&old_text);
+            let ranges = trailing_whitespace_ranges_in_rows(&old_text, &modified_rows);
             let empty = Arc::<str>::from("");
-            let edits = all_ranges
-                .into_iter()
-                .filter(|range| {
-                    let row = old_text.offset_to_point(range.start).row;
-                    modified_rows.iter().any(|modified| modified.contains(&row))
-                })
-                .map(|range| (range, empty.clone()))
-                .collect();
             Diff {
                 base_version,
                 line_ending,
-                edits,
+                edits: ranges
+                    .into_iter()
+                    .map(|range| (range, empty.clone()))
+                    .collect(),
             }
         })
     }
@@ -2348,7 +2343,6 @@ impl Buffer {
                 offset += non_whitespace_len;
                 if non_whitespace_len != 0 {
                     if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
-                        // Buffer already ends with exactly one newline.
                         return Diff {
                             base_version,
                             line_ending,
@@ -6182,6 +6176,57 @@ pub fn trailing_whitespace_ranges(rope: &Rope) -> Vec<Range<usize>> {
     }
 
     if !prev_chunk_trailing_whitespace_range.is_empty() {
+        ranges.push(prev_chunk_trailing_whitespace_range);
+    }
+
+    ranges
+}
+
+/// Like [`trailing_whitespace_ranges`], but only returns ranges for lines whose
+/// row falls within one of the given `row_ranges`. Performs a single pass over
+/// the rope, avoiding the quadratic cost of collecting all ranges and then filtering.
+pub fn trailing_whitespace_ranges_in_rows(
+    rope: &Rope,
+    row_ranges: &[Range<u32>],
+) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+
+    let mut offset = 0;
+    let mut current_row: u32 = 0;
+    let mut prev_row: Option<u32> = None;
+    let mut prev_chunk_trailing_whitespace_range = 0..0;
+    for chunk in rope.chunks() {
+        let mut prev_line_trailing_whitespace_range = 0..0;
+        for (i, line) in chunk.split('\n').enumerate() {
+            let line_end_offset = offset + line.len();
+            let trimmed_line_len = line.trim_end_matches([' ', '\t']).len();
+            let mut trailing_whitespace_range = (offset + trimmed_line_len)..line_end_offset;
+
+            if i == 0 && trimmed_line_len == 0 {
+                trailing_whitespace_range.start = prev_chunk_trailing_whitespace_range.start;
+            }
+            if let Some(row) = prev_row {
+                if !prev_line_trailing_whitespace_range.is_empty()
+                    && row_ranges.iter().any(|r| r.contains(&row))
+                {
+                    ranges.push(prev_line_trailing_whitespace_range);
+                }
+            }
+
+            prev_row = Some(current_row);
+            offset = line_end_offset + 1;
+            current_row += 1;
+            prev_line_trailing_whitespace_range = trailing_whitespace_range;
+        }
+
+        offset -= 1;
+        current_row -= 1;
+        prev_chunk_trailing_whitespace_range = prev_line_trailing_whitespace_range;
+    }
+
+    if !prev_chunk_trailing_whitespace_range.is_empty()
+        && row_ranges.iter().any(|r| r.contains(&current_row))
+    {
         ranges.push(prev_chunk_trailing_whitespace_range);
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2298,6 +2298,7 @@ impl Buffer {
             }
         } else {
             let mut offset = len;
+            let mut already_normalized = false;
             for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
                 let non_whitespace_len = chunk
                     .trim_end_matches(|c: char| c.is_ascii_whitespace())
@@ -2305,13 +2306,12 @@ impl Buffer {
                 offset -= chunk.len();
                 offset += non_whitespace_len;
                 if non_whitespace_len != 0 {
-                    if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
-                        offset = len;
-                    }
+                    already_normalized =
+                        offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n");
                     break;
                 }
             }
-            if offset == len {
+            if already_normalized {
                 Vec::new()
             } else {
                 Vec::from([(offset..len, newline)])

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2241,63 +2241,21 @@ impl Buffer {
         })
     }
 
-    /// Spawns a background task that searches the buffer for any whitespace
-    /// at the ends of a lines, and returns a `Diff` that removes that whitespace.
-    pub fn remove_trailing_whitespace(&self, cx: &App) -> Task<Diff> {
-        let old_text = self.as_rope().clone();
-        let line_ending = self.line_ending();
-        let base_version = self.version();
-        cx.background_spawn(async move {
-            let ranges = trailing_whitespace_ranges(&old_text);
-            let empty = Arc::<str>::from("");
-            Diff {
-                base_version,
-                line_ending,
-                edits: ranges
-                    .into_iter()
-                    .map(|range| (range, empty.clone()))
-                    .collect(),
-            }
-        })
-    }
-
-    /// Ensures that the buffer ends with a single newline character, and
-    /// no other whitespace. Skips if the buffer is empty.
-    pub fn ensure_final_newline(&mut self, cx: &mut Context<Self>) {
-        let len = self.len();
-        if len == 0 {
-            return;
-        }
-        let mut offset = len;
-        for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
-            let non_whitespace_len = chunk
-                .trim_end_matches(|c: char| c.is_ascii_whitespace())
-                .len();
-            offset -= chunk.len();
-            offset += non_whitespace_len;
-            if non_whitespace_len != 0 {
-                if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
-                    return;
-                }
-                break;
-            }
-        }
-        self.edit([(offset..len, "\n")], None, cx);
-    }
-
-    /// Like [`remove_trailing_whitespace`](Self::remove_trailing_whitespace), but only removes
-    /// trailing whitespace on lines whose row falls within one of the given `modified_rows` ranges.
-    pub fn remove_trailing_whitespace_in_ranges(
+    /// Spawns a background task that returns a `Diff` removing trailing whitespace from line ends.
+    ///
+    /// When `modified_rows` is `Some`, only lines whose row falls within one of the given ranges
+    /// are trimmed; when it is `None`, the whole buffer is scanned.
+    pub fn remove_trailing_whitespace(
         &self,
-        modified_rows: &[Range<u32>],
+        modified_rows: Option<&[Range<u32>]>,
         cx: &App,
     ) -> Task<Diff> {
         let old_text = self.as_rope().clone();
         let line_ending = self.line_ending();
         let base_version = self.version();
-        let modified_rows = modified_rows.to_vec();
+        let modified_rows = modified_rows.map(|rows| rows.to_vec());
         cx.background_spawn(async move {
-            let ranges = trailing_whitespace_ranges_in_rows(&old_text, &modified_rows);
+            let ranges = trailing_whitespace_ranges(&old_text, modified_rows.as_deref());
             let empty = Arc::<str>::from("");
             Diff {
                 base_version,
@@ -2310,28 +2268,54 @@ impl Buffer {
         })
     }
 
-    /// Like [`ensure_final_newline`](Self::ensure_final_newline), but scoped to a "Format
-    /// Selection" operation: it only inserts a final newline when the buffer's last line falls
-    /// within one of the given `modified_rows` ranges, and never modifies rows outside it.
+    /// Returns a `Diff` ensuring the buffer ends with a trailing newline.
     ///
-    /// Unlike the whole-buffer [`ensure_final_newline`](Self::ensure_final_newline) (which also
-    /// trims trailing whitespace and collapses blank lines at the end of the file), this only
-    /// appends a single newline when the last line is non-empty. Collapsing trailing blank lines
-    /// is intentionally omitted so that formatting a selection cannot delete unselected rows.
-    pub fn ensure_final_newline_in_range(&self, modified_rows: &[Range<u32>]) -> Diff {
+    /// When `modified_rows` is `None`, the whole buffer is considered: trailing whitespace and
+    /// blank lines at the end of the file are collapsed into a single newline.
+    ///
+    /// When `modified_rows` is `Some`, the operation is scoped to a "Format Selection": a single
+    /// newline is appended only when the last line is non-empty and its row falls within one of
+    /// the ranges. Trailing blank lines are left intact so that formatting a selection cannot
+    /// delete unselected rows.
+    pub fn ensure_final_newline(&self, modified_rows: Option<&[Range<u32>]>) -> Diff {
         let len = self.len();
         let line_ending = self.line_ending();
         let base_version = self.version();
-        let max_point = self.max_point();
+        let newline = Arc::<str>::from("\n");
 
-        let last_line_is_empty = max_point.column == 0;
-        let last_row_is_modified = modified_rows
-            .iter()
-            .any(|range| range.contains(&max_point.row));
-        let edits = if len == 0 || last_line_is_empty || !last_row_is_modified {
+        let edits = if len == 0 {
             Vec::new()
+        } else if let Some(modified_rows) = modified_rows {
+            let max_point = self.max_point();
+            let last_line_is_empty = max_point.column == 0;
+            let last_row_is_modified = modified_rows
+                .iter()
+                .any(|range| range.contains(&max_point.row));
+            if last_line_is_empty || !last_row_is_modified {
+                Vec::new()
+            } else {
+                Vec::from([(len..len, newline)])
+            }
         } else {
-            Vec::from([(len..len, Arc::<str>::from("\n"))])
+            let mut offset = len;
+            for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
+                let non_whitespace_len = chunk
+                    .trim_end_matches(|c: char| c.is_ascii_whitespace())
+                    .len();
+                offset -= chunk.len();
+                offset += non_whitespace_len;
+                if non_whitespace_len != 0 {
+                    if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
+                        offset = len;
+                    }
+                    break;
+                }
+            }
+            if offset == len {
+                Vec::new()
+            } else {
+                Vec::from([(offset..len, newline)])
+            }
         };
         Diff {
             base_version,
@@ -6127,48 +6111,20 @@ impl CharClassifier {
 ///
 /// This could also be done with a regex search, but this implementation
 /// avoids copying text.
-pub fn trailing_whitespace_ranges(rope: &Rope) -> Vec<Range<usize>> {
-    let mut ranges = Vec::new();
-
-    let mut offset = 0;
-    let mut prev_chunk_trailing_whitespace_range = 0..0;
-    for chunk in rope.chunks() {
-        let mut prev_line_trailing_whitespace_range = 0..0;
-        for (i, line) in chunk.split('\n').enumerate() {
-            let line_end_offset = offset + line.len();
-            let trimmed_line_len = line.trim_end_matches([' ', '\t']).len();
-            let mut trailing_whitespace_range = (offset + trimmed_line_len)..line_end_offset;
-
-            if i == 0 && trimmed_line_len == 0 {
-                trailing_whitespace_range.start = prev_chunk_trailing_whitespace_range.start;
-            }
-            if !prev_line_trailing_whitespace_range.is_empty() {
-                ranges.push(prev_line_trailing_whitespace_range);
-            }
-
-            offset = line_end_offset + 1;
-            prev_line_trailing_whitespace_range = trailing_whitespace_range;
-        }
-
-        offset -= 1;
-        prev_chunk_trailing_whitespace_range = prev_line_trailing_whitespace_range;
-    }
-
-    if !prev_chunk_trailing_whitespace_range.is_empty() {
-        ranges.push(prev_chunk_trailing_whitespace_range);
-    }
-
-    ranges
-}
-
-/// Like [`trailing_whitespace_ranges`], but only returns ranges for lines whose
-/// row falls within one of the given `row_ranges`. Performs a single pass over
-/// the rope, avoiding the quadratic cost of collecting all ranges and then filtering.
-pub fn trailing_whitespace_ranges_in_rows(
+/// Returns the byte ranges of trailing whitespace at the end of each line.
+///
+/// When `row_ranges` is `Some`, only lines whose row falls within one of the ranges are
+/// included. The single pass keeps filtering cheap, avoiding collecting every range up front.
+pub(crate) fn trailing_whitespace_ranges(
     rope: &Rope,
-    row_ranges: &[Range<u32>],
+    row_ranges: Option<&[Range<u32>]>,
 ) -> Vec<Range<usize>> {
     let mut ranges = Vec::new();
+
+    let is_row_included = |row: u32| match row_ranges {
+        Some(row_ranges) => row_ranges.iter().any(|range| range.contains(&row)),
+        None => true,
+    };
 
     let mut offset = 0;
     let mut current_row: u32 = 0;
@@ -6185,9 +6141,7 @@ pub fn trailing_whitespace_ranges_in_rows(
                 trailing_whitespace_range.start = prev_chunk_trailing_whitespace_range.start;
             }
             if let Some(row) = prev_row {
-                if !prev_line_trailing_whitespace_range.is_empty()
-                    && row_ranges.iter().any(|r| r.contains(&row))
-                {
+                if !prev_line_trailing_whitespace_range.is_empty() && is_row_included(row) {
                     ranges.push(prev_line_trailing_whitespace_range);
                 }
             }
@@ -6203,9 +6157,7 @@ pub fn trailing_whitespace_ranges_in_rows(
         prev_chunk_trailing_whitespace_range = prev_line_trailing_whitespace_range;
     }
 
-    if !prev_chunk_trailing_whitespace_range.is_empty()
-        && row_ranges.iter().any(|r| r.contains(&current_row))
-    {
+    if !prev_chunk_trailing_whitespace_range.is_empty() && is_row_included(current_row) {
         ranges.push(prev_chunk_trailing_whitespace_range);
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2310,55 +2310,34 @@ impl Buffer {
         })
     }
 
-    /// Like [`ensure_final_newline`](Self::ensure_final_newline), but only applies the fix when
-    /// the last line's row falls within one of the given `modified_rows` ranges. Returns an empty
-    /// [`Diff`] when the last line is not in any modified range.
-    pub fn ensure_final_newline_in_range(
-        &self,
-        modified_rows: &[Range<u32>],
-        cx: &App,
-    ) -> Task<Diff> {
+    /// Like [`ensure_final_newline`](Self::ensure_final_newline), but scoped to a "Format
+    /// Selection" operation: it only inserts a final newline when the buffer's last line falls
+    /// within one of the given `modified_rows` ranges, and never modifies rows outside it.
+    ///
+    /// Unlike the whole-buffer [`ensure_final_newline`](Self::ensure_final_newline) (which also
+    /// trims trailing whitespace and collapses blank lines at the end of the file), this only
+    /// appends a single newline when the last line is non-empty. Collapsing trailing blank lines
+    /// is intentionally omitted so that formatting a selection cannot delete unselected rows.
+    pub fn ensure_final_newline_in_range(&self, modified_rows: &[Range<u32>]) -> Diff {
         let len = self.len();
         let line_ending = self.line_ending();
         let base_version = self.version();
-        let last_row = self.max_point().row;
+        let max_point = self.max_point();
 
-        let last_row_is_modified = modified_rows.iter().any(|r| r.contains(&last_row));
-        if len == 0 || !last_row_is_modified {
-            return Task::ready(Diff {
-                base_version,
-                line_ending,
-                edits: Vec::new(),
-            });
+        let last_line_is_empty = max_point.column == 0;
+        let last_row_is_modified = modified_rows
+            .iter()
+            .any(|range| range.contains(&max_point.row));
+        let edits = if len == 0 || last_line_is_empty || !last_row_is_modified {
+            Vec::new()
+        } else {
+            Vec::from([(len..len, Arc::<str>::from("\n"))])
+        };
+        Diff {
+            base_version,
+            line_ending,
+            edits,
         }
-
-        let old_text = self.as_rope().clone();
-        cx.background_spawn(async move {
-            let mut offset = len;
-            for chunk in old_text.reversed_chunks_in_range(0..len) {
-                let non_whitespace_len = chunk
-                    .trim_end_matches(|c: char| c.is_ascii_whitespace())
-                    .len();
-                offset -= chunk.len();
-                offset += non_whitespace_len;
-                if non_whitespace_len != 0 {
-                    if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
-                        return Diff {
-                            base_version,
-                            line_ending,
-                            edits: Vec::new(),
-                        };
-                    }
-                    break;
-                }
-            }
-            let newline: Arc<str> = Arc::from("\n");
-            Diff {
-                base_version,
-                line_ending,
-                edits: vec![(offset..len, newline)],
-            }
-        })
     }
 
     /// Applies a diff to the buffer. If the buffer has changed since the given diff was

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3758,6 +3758,92 @@ fn test_trailing_whitespace_ranges(mut rng: StdRng) {
 }
 
 #[gpui::test]
+async fn test_trailing_whitespace_in_ranges(cx: &mut gpui::TestAppContext) {
+    // Lines 0-5:
+    // line 0: "zero"        (no trailing whitespace)
+    // line 1: "one  "       (2 trailing spaces)
+    // line 2: "two"         (no trailing whitespace)
+    // line 3: "three   "    (3 trailing spaces)
+    // line 4: "four"        (no trailing whitespace)
+    // line 5: "five    "    (4 trailing spaces)
+    let text = ["zero", "one  ", "two", "three   ", "four", "five    "].join("\n");
+    let buffer = cx.new(|cx| Buffer::local(text, cx));
+
+    // modified_rows covers rows 1..2 and 5..6, so lines 1 and 5 should be cleaned.
+    // Line 3 must remain untouched.
+    let modified_rows = vec![1u32..2u32, 5u32..6u32];
+    let diff = buffer
+        .update(cx, |buffer, cx| {
+            buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
+        })
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        assert_eq!(
+            buffer.text(),
+            ["zero", "one", "two", "three   ", "four", "five"].join("\n")
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_trailing_whitespace_empty_ranges(cx: &mut gpui::TestAppContext) {
+    let text = ["zero", "one  ", "two  "].join("\n");
+    let buffer = cx.new(|cx| Buffer::local(text.clone(), cx));
+
+    // Empty modified_rows → no changes.
+    let modified_rows: Vec<std::ops::Range<u32>> = vec![];
+    let diff = buffer
+        .update(cx, |buffer, cx| {
+            buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
+        })
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        assert_eq!(buffer.text(), text);
+    });
+}
+
+#[gpui::test]
+async fn test_final_newline_modified_last_line(cx: &mut gpui::TestAppContext) {
+    // Buffer without final newline. Modified ranges include the last line.
+    let text = "line0\nline1\nline2";
+    let buffer = cx.new(|cx| Buffer::local(text, cx));
+
+    // The text has 3 lines (rows 0, 1, 2). Modified range includes row 2.
+    let modified_rows = vec![0u32..3u32];
+    let diff = buffer
+        .update(cx, |buffer, cx| {
+            buffer.ensure_final_newline_in_range(&modified_rows, cx)
+        })
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        assert_eq!(buffer.text(), "line0\nline1\nline2\n");
+    });
+}
+
+#[gpui::test]
+async fn test_final_newline_unmodified_last_line(cx: &mut gpui::TestAppContext) {
+    // Buffer without final newline. Modified ranges do NOT include the last line.
+    let text = "line0\nline1\nline2";
+    let buffer = cx.new(|cx| Buffer::local(text, cx));
+
+    // The text has 3 lines (rows 0, 1, 2). Modified range only covers rows 0..2 (excludes row 2).
+    let modified_rows = vec![0u32..2u32];
+    let diff = buffer
+        .update(cx, |buffer, cx| {
+            buffer.ensure_final_newline_in_range(&modified_rows, cx)
+        })
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        // No newline should have been added.
+        assert_eq!(buffer.text(), "line0\nline1\nline2");
+    });
+}
+
+#[gpui::test]
 fn test_words_in_range(cx: &mut gpui::App) {
     init_settings(cx, |_| {});
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3844,6 +3844,50 @@ async fn test_final_newline_unmodified_last_line(cx: &mut gpui::TestAppContext) 
 }
 
 #[gpui::test]
+async fn test_trailing_whitespace_in_ranges_crlf(cx: &mut gpui::TestAppContext) {
+    let text = "zero\r\none  \r\ntwo\r\nthree   \r\nfour\r\nfive    ";
+    let buffer = cx.new(|cx| {
+        let buffer = Buffer::local(text, cx);
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+        buffer
+    });
+
+    let modified_rows = vec![1u32..2u32, 5u32..6u32];
+    let diff = buffer
+        .update(cx, |buffer, cx| {
+            buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
+        })
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        assert_eq!(buffer.text(), "zero\none\ntwo\nthree   \nfour\nfive");
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+    });
+}
+
+#[gpui::test]
+async fn test_final_newline_in_range_crlf(cx: &mut gpui::TestAppContext) {
+    let text = "line0\r\nline1\r\nline2";
+    let buffer = cx.new(|cx| {
+        let buffer = Buffer::local(text, cx);
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+        buffer
+    });
+
+    let modified_rows = vec![0u32..3u32];
+    let diff = buffer
+        .update(cx, |buffer, cx| {
+            buffer.ensure_final_newline_in_range(&modified_rows, cx)
+        })
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        assert_eq!(buffer.text(), "line0\nline1\nline2\n");
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+    });
+}
+
+#[gpui::test]
 fn test_words_in_range(cx: &mut gpui::App) {
     init_settings(cx, |_| {});
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -559,7 +559,7 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
 
     // Spawn a task to format the buffer's whitespace.
     // Pause so that the formatting task starts running.
-    let format = buffer.update(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx));
+    let format = buffer.update(cx, |buffer, cx| buffer.remove_trailing_whitespace(None, cx));
     yield_now().await;
 
     // Edit the buffer while the normalization task is running.
@@ -3744,7 +3744,7 @@ fn test_trailing_whitespace_ranges(mut rng: StdRng) {
     }
 
     let rope = Rope::from(text.as_str());
-    let actual_ranges = trailing_whitespace_ranges(&rope);
+    let actual_ranges = trailing_whitespace_ranges(&rope, None);
     let expected_ranges = TRAILING_WHITESPACE_REGEX
         .find_iter(&text)
         .map(|m| m.range())
@@ -3777,12 +3777,12 @@ fn test_trailing_whitespace_ranges_in_rows(mut rng: StdRng) {
     }
 
     let rope = Rope::from(text.as_str());
-    let all_ranges = trailing_whitespace_ranges(&rope);
+    let all_ranges = trailing_whitespace_ranges(&rope, None);
     let lines = text.split('\n').collect::<Vec<_>>();
 
     // A range covering every row must reproduce the unfiltered full scan exactly.
     assert_eq!(
-        trailing_whitespace_ranges_in_rows(&rope, &[0..u32::MAX]),
+        trailing_whitespace_ranges(&rope, Some(&[0..u32::MAX])),
         all_ranges,
         "full-coverage mismatch for lines:\n{lines:?}",
     );
@@ -3811,7 +3811,7 @@ fn test_trailing_whitespace_ranges_in_rows(mut rng: StdRng) {
         .cloned()
         .collect::<Vec<_>>();
     assert_eq!(
-        trailing_whitespace_ranges_in_rows(&rope, &row_ranges),
+        trailing_whitespace_ranges(&rope, Some(&row_ranges)),
         expected,
         "subset mismatch for ranges {row_ranges:?} and lines:\n{lines:?}",
     );
@@ -3832,7 +3832,7 @@ async fn test_trailing_whitespace_in_ranges(cx: &mut gpui::TestAppContext) {
     let modified_rows = [1u32..2, 5..6];
     let diff = buffer
         .update(cx, |buffer, cx| {
-            buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
+            buffer.remove_trailing_whitespace(Some(&modified_rows), cx)
         })
         .await;
     buffer.update(cx, |buffer, cx| {
@@ -3851,7 +3851,7 @@ async fn test_trailing_whitespace_empty_ranges(cx: &mut gpui::TestAppContext) {
 
     let diff = buffer
         .update(cx, |buffer, cx| {
-            buffer.remove_trailing_whitespace_in_ranges(&[], cx)
+            buffer.remove_trailing_whitespace(Some(&[]), cx)
         })
         .await;
     buffer.update(cx, |buffer, cx| {
@@ -3867,7 +3867,7 @@ async fn test_final_newline_modified_last_line(cx: &mut gpui::TestAppContext) {
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
     buffer.update(cx, |buffer, cx| {
-        let diff = buffer.ensure_final_newline_in_range(&[0u32..3]);
+        let diff = buffer.ensure_final_newline(Some(&[0u32..3]));
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1\nline2\n");
     });
@@ -3880,36 +3880,36 @@ async fn test_final_newline_unmodified_last_line(cx: &mut gpui::TestAppContext) 
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
     buffer.update(cx, |buffer, cx| {
-        let diff = buffer.ensure_final_newline_in_range(&[0u32..2]);
+        let diff = buffer.ensure_final_newline(Some(&[0u32..2]));
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1\nline2");
     });
 }
 
 // An empty last line (file already ends with a newline) is left untouched, even with extra
-// trailing blank lines. The whole-buffer `ensure_final_newline` would collapse these; the
-// range-scoped variant must not, to avoid deleting unselected rows.
+// trailing blank lines. With `None` these would collapse; scoped to rows they must not, to
+// avoid deleting unselected rows.
 #[gpui::test]
 async fn test_final_newline_does_not_collapse_trailing_blank_lines(cx: &mut gpui::TestAppContext) {
     let text = "line0\nline1\n\n";
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
     buffer.update(cx, |buffer, cx| {
-        let diff = buffer.ensure_final_newline_in_range(&[0u32..4]);
+        let diff = buffer.ensure_final_newline(Some(&[0u32..4]));
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1\n\n");
     });
 }
 
-// The range-scoped variant only inserts a newline; unlike the whole-buffer
-// `ensure_final_newline`, it does not trim trailing whitespace on the last line.
+// When scoped to rows, only a newline is inserted; unlike the `None` (whole-buffer) case, it
+// does not trim trailing whitespace on the last line.
 #[gpui::test]
 async fn test_final_newline_in_range_only_inserts(cx: &mut gpui::TestAppContext) {
     let text = "line0\nline1  ";
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
     buffer.update(cx, |buffer, cx| {
-        let diff = buffer.ensure_final_newline_in_range(&[0u32..2]);
+        let diff = buffer.ensure_final_newline(Some(&[0u32..2]));
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1  \n");
     });
@@ -3927,7 +3927,7 @@ async fn test_trailing_whitespace_in_ranges_crlf(cx: &mut gpui::TestAppContext) 
     let modified_rows = [1u32..2, 5..6];
     let diff = buffer
         .update(cx, |buffer, cx| {
-            buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
+            buffer.remove_trailing_whitespace(Some(&modified_rows), cx)
         })
         .await;
     buffer.update(cx, |buffer, cx| {
@@ -3947,7 +3947,7 @@ async fn test_final_newline_in_range_crlf(cx: &mut gpui::TestAppContext) {
     });
 
     buffer.update(cx, |buffer, cx| {
-        let diff = buffer.ensure_final_newline_in_range(&[0u32..3]);
+        let diff = buffer.ensure_final_newline(Some(&[0u32..3]));
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1\nline2\n");
         assert_eq!(buffer.line_ending(), LineEnding::Windows);

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3916,6 +3916,31 @@ async fn test_final_newline_in_range_only_inserts(cx: &mut gpui::TestAppContext)
 }
 
 #[gpui::test]
+async fn test_final_newline_whole_buffer(cx: &mut gpui::TestAppContext) {
+    // (input, expected) pairs for the whole-buffer (`None`) case.
+    let cases = [
+        // Content without a trailing newline gets exactly one appended.
+        ("line0\nline1", "line0\nline1\n"),
+        // A buffer already ending in a single newline is left untouched.
+        ("line0\nline1\n", "line0\nline1\n"),
+        // Trailing blank lines and whitespace at the end of the file collapse to one newline.
+        ("line0\nline1\n\n\n", "line0\nline1\n"),
+        ("line0\nline1  \n  ", "line0\nline1\n"),
+        // An empty buffer stays empty.
+        ("", ""),
+    ];
+
+    for (input, expected) in cases {
+        let buffer = cx.new(|cx| Buffer::local(input, cx));
+        buffer.update(cx, |buffer, cx| {
+            let diff = buffer.ensure_final_newline(None);
+            buffer.apply_diff(diff, cx);
+            assert_eq!(buffer.text(), expected, "wrong result for input {input:?}");
+        });
+    }
+}
+
+#[gpui::test]
 async fn test_trailing_whitespace_in_ranges_crlf(cx: &mut gpui::TestAppContext) {
     let text = "zero\r\none  \r\ntwo\r\nthree   \r\nfour\r\nfive    ";
     let buffer = cx.new(|cx| {

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3757,21 +3757,79 @@ fn test_trailing_whitespace_ranges(mut rng: StdRng) {
     );
 }
 
+#[gpui::test(iterations = 500)]
+fn test_trailing_whitespace_ranges_in_rows(mut rng: StdRng) {
+    let mut text = String::new();
+    for _ in 0..rng.random_range(0..16) {
+        for _ in 0..rng.random_range(0..36) {
+            text.push(match rng.random_range(0..10) {
+                0..=1 => ' ',
+                3 => '\t',
+                _ => rng.random_range('a'..='z'),
+            });
+        }
+        text.push('\n');
+    }
+    match rng.random_range(0..10) {
+        0..=1 => drop(text.pop()),
+        2..=3 => text.push_str(&"\n".repeat(rng.random_range(1..5))),
+        _ => {}
+    }
+
+    let rope = Rope::from(text.as_str());
+    let all_ranges = trailing_whitespace_ranges(&rope);
+    let lines = text.split('\n').collect::<Vec<_>>();
+
+    // A range covering every row must reproduce the unfiltered full scan exactly.
+    assert_eq!(
+        trailing_whitespace_ranges_in_rows(&rope, &[0..u32::MAX]),
+        all_ranges,
+        "full-coverage mismatch for lines:\n{lines:?}",
+    );
+
+    // For a random (possibly gappy) subset of rows, the filtered variant must equal
+    // the full scan restricted to ranges whose line is in the subset.
+    let max_row = rope.max_point().row;
+    let mut row_ranges = Vec::new();
+    let mut row = 0;
+    while row <= max_row {
+        let span = rng.random_range(0..=3);
+        if span > 0 {
+            let end = (row + span).min(max_row + 1);
+            row_ranges.push(row..end);
+            row = end;
+        }
+        row += 1;
+    }
+
+    let expected = all_ranges
+        .iter()
+        .filter(|range| {
+            let row = rope.offset_to_point(range.start).row;
+            row_ranges.iter().any(|r| r.contains(&row))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        trailing_whitespace_ranges_in_rows(&rope, &row_ranges),
+        expected,
+        "subset mismatch for ranges {row_ranges:?} and lines:\n{lines:?}",
+    );
+}
+
 #[gpui::test]
 async fn test_trailing_whitespace_in_ranges(cx: &mut gpui::TestAppContext) {
-    // Lines 0-5:
-    // line 0: "zero"        (no trailing whitespace)
-    // line 1: "one  "       (2 trailing spaces)
-    // line 2: "two"         (no trailing whitespace)
-    // line 3: "three   "    (3 trailing spaces)
-    // line 4: "four"        (no trailing whitespace)
-    // line 5: "five    "    (4 trailing spaces)
+    // line 0: "zero"      (no trailing whitespace)
+    // line 1: "one  "     (2 trailing spaces)
+    // line 2: "two"       (no trailing whitespace)
+    // line 3: "three   "  (3 trailing spaces)
+    // line 4: "four"      (no trailing whitespace)
+    // line 5: "five    "  (4 trailing spaces)
     let text = ["zero", "one  ", "two", "three   ", "four", "five    "].join("\n");
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
-    // modified_rows covers rows 1..2 and 5..6, so lines 1 and 5 should be cleaned.
-    // Line 3 must remain untouched.
-    let modified_rows = vec![1u32..2u32, 5u32..6u32];
+    // Only rows 1 and 5 are modified, so only those lines get cleaned; line 3 stays untouched.
+    let modified_rows = [1u32..2, 5..6];
     let diff = buffer
         .update(cx, |buffer, cx| {
             buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
@@ -3791,11 +3849,9 @@ async fn test_trailing_whitespace_empty_ranges(cx: &mut gpui::TestAppContext) {
     let text = ["zero", "one  ", "two  "].join("\n");
     let buffer = cx.new(|cx| Buffer::local(text.clone(), cx));
 
-    // Empty modified_rows → no changes.
-    let modified_rows: Vec<std::ops::Range<u32>> = vec![];
     let diff = buffer
         .update(cx, |buffer, cx| {
-            buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
+            buffer.remove_trailing_whitespace_in_ranges(&[], cx)
         })
         .await;
     buffer.update(cx, |buffer, cx| {
@@ -3806,18 +3862,12 @@ async fn test_trailing_whitespace_empty_ranges(cx: &mut gpui::TestAppContext) {
 
 #[gpui::test]
 async fn test_final_newline_modified_last_line(cx: &mut gpui::TestAppContext) {
-    // Buffer without final newline. Modified ranges include the last line.
+    // No final newline; the modified range (rows 0..3) includes the last line (row 2).
     let text = "line0\nline1\nline2";
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
-    // The text has 3 lines (rows 0, 1, 2). Modified range includes row 2.
-    let modified_rows = vec![0u32..3u32];
-    let diff = buffer
-        .update(cx, |buffer, cx| {
-            buffer.ensure_final_newline_in_range(&modified_rows, cx)
-        })
-        .await;
     buffer.update(cx, |buffer, cx| {
+        let diff = buffer.ensure_final_newline_in_range(&[0u32..3]);
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1\nline2\n");
     });
@@ -3825,21 +3875,43 @@ async fn test_final_newline_modified_last_line(cx: &mut gpui::TestAppContext) {
 
 #[gpui::test]
 async fn test_final_newline_unmodified_last_line(cx: &mut gpui::TestAppContext) {
-    // Buffer without final newline. Modified ranges do NOT include the last line.
+    // No final newline; the modified range (rows 0..2) excludes the last line (row 2), so nothing changes.
     let text = "line0\nline1\nline2";
     let buffer = cx.new(|cx| Buffer::local(text, cx));
 
-    // The text has 3 lines (rows 0, 1, 2). Modified range only covers rows 0..2 (excludes row 2).
-    let modified_rows = vec![0u32..2u32];
-    let diff = buffer
-        .update(cx, |buffer, cx| {
-            buffer.ensure_final_newline_in_range(&modified_rows, cx)
-        })
-        .await;
     buffer.update(cx, |buffer, cx| {
+        let diff = buffer.ensure_final_newline_in_range(&[0u32..2]);
         buffer.apply_diff(diff, cx);
-        // No newline should have been added.
         assert_eq!(buffer.text(), "line0\nline1\nline2");
+    });
+}
+
+// An empty last line (file already ends with a newline) is left untouched, even with extra
+// trailing blank lines. The whole-buffer `ensure_final_newline` would collapse these; the
+// range-scoped variant must not, to avoid deleting unselected rows.
+#[gpui::test]
+async fn test_final_newline_does_not_collapse_trailing_blank_lines(cx: &mut gpui::TestAppContext) {
+    let text = "line0\nline1\n\n";
+    let buffer = cx.new(|cx| Buffer::local(text, cx));
+
+    buffer.update(cx, |buffer, cx| {
+        let diff = buffer.ensure_final_newline_in_range(&[0u32..4]);
+        buffer.apply_diff(diff, cx);
+        assert_eq!(buffer.text(), "line0\nline1\n\n");
+    });
+}
+
+// The range-scoped variant only inserts a newline; unlike the whole-buffer
+// `ensure_final_newline`, it does not trim trailing whitespace on the last line.
+#[gpui::test]
+async fn test_final_newline_in_range_only_inserts(cx: &mut gpui::TestAppContext) {
+    let text = "line0\nline1  ";
+    let buffer = cx.new(|cx| Buffer::local(text, cx));
+
+    buffer.update(cx, |buffer, cx| {
+        let diff = buffer.ensure_final_newline_in_range(&[0u32..2]);
+        buffer.apply_diff(diff, cx);
+        assert_eq!(buffer.text(), "line0\nline1  \n");
     });
 }
 
@@ -3852,7 +3924,7 @@ async fn test_trailing_whitespace_in_ranges_crlf(cx: &mut gpui::TestAppContext) 
         buffer
     });
 
-    let modified_rows = vec![1u32..2u32, 5u32..6u32];
+    let modified_rows = [1u32..2, 5..6];
     let diff = buffer
         .update(cx, |buffer, cx| {
             buffer.remove_trailing_whitespace_in_ranges(&modified_rows, cx)
@@ -3874,13 +3946,8 @@ async fn test_final_newline_in_range_crlf(cx: &mut gpui::TestAppContext) {
         buffer
     });
 
-    let modified_rows = vec![0u32..3u32];
-    let diff = buffer
-        .update(cx, |buffer, cx| {
-            buffer.ensure_final_newline_in_range(&modified_rows, cx)
-        })
-        .await;
     buffer.update(cx, |buffer, cx| {
+        let diff = buffer.ensure_final_newline_in_range(&[0u32..3]);
         buffer.apply_diff(diff, cx);
         assert_eq!(buffer.text(), "line0\nline1\nline2\n");
         assert_eq!(buffer.line_ending(), LineEnding::Windows);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1931,7 +1931,6 @@ impl LocalLspStore {
                         buffer_path_abs,
                         &language_server,
                         &settings,
-                        logger,
                         cx,
                     )
                     .await
@@ -2333,7 +2332,6 @@ impl LocalLspStore {
         abs_path: &Path,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
-        logger: zlog::Logger,
         cx: &mut AsyncApp,
     ) -> Result<Option<Vec<(Range<Anchor>, Arc<str>)>>> {
         let capabilities = &language_server.capabilities();
@@ -2342,8 +2340,8 @@ impl LocalLspStore {
             range_formatting_provider,
             Some(OneOf::Left(true) | OneOf::Right(_))
         ) {
-            zlog::debug!(
-                logger => "Skipping range formatting - LSP {} does not support document_range_formatting_provider",
+            log::info!(
+                "Skipping range formatting - LSP {} does not support document_range_formatting_provider",
                 language_server.name()
             );
             return Ok(None);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1611,10 +1611,22 @@ impl LocalLspStore {
         // handle whitespace formatting
         if settings.remove_trailing_whitespace_on_save {
             zlog::trace!(logger => "removing trailing whitespace");
-            let diff = buffer
-                .handle
-                .read_with(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx))
-                .await;
+            let diff = if let Some(ranges) = buffer.ranges.as_ref() {
+                let row_ranges = buffer.handle.read_with(cx, |buffer, _cx| {
+                    anchor_ranges_to_row_ranges(ranges, buffer)
+                });
+                buffer
+                    .handle
+                    .read_with(cx, |buffer, cx| {
+                        buffer.remove_trailing_whitespace_in_ranges(&row_ranges, cx)
+                    })
+                    .await
+            } else {
+                buffer
+                    .handle
+                    .read_with(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx))
+                    .await
+            };
             extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
                 buffer.apply_diff(diff, cx);
             })?;
@@ -1622,9 +1634,34 @@ impl LocalLspStore {
 
         if settings.ensure_final_newline_on_save {
             zlog::trace!(logger => "ensuring final newline");
-            extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
-                buffer.ensure_final_newline(cx);
-            })?;
+            if let Some(ranges) = buffer.ranges.as_ref() {
+                let row_ranges = buffer.handle.read_with(cx, |buffer, _cx| {
+                    anchor_ranges_to_row_ranges(ranges, buffer)
+                });
+                let diff = buffer
+                    .handle
+                    .read_with(cx, |buffer, cx| {
+                        buffer.ensure_final_newline_in_range(&row_ranges, cx)
+                    })
+                    .await;
+                extend_formatting_transaction(
+                    buffer,
+                    formatting_transaction_id,
+                    cx,
+                    |buffer, cx| {
+                        buffer.apply_diff(diff, cx);
+                    },
+                )?;
+            } else {
+                extend_formatting_transaction(
+                    buffer,
+                    formatting_transaction_id,
+                    cx,
+                    |buffer, cx| {
+                        buffer.ensure_final_newline(cx);
+                    },
+                )?;
+            }
         }
 
         let line_ending_policy = match settings.line_ending {
@@ -1894,10 +1931,12 @@ impl LocalLspStore {
                         buffer_path_abs,
                         &language_server,
                         &settings,
+                        logger,
                         cx,
                     )
                     .await
                     .context("Failed to format ranges via language server")?
+                    .unwrap_or_default()
                 } else {
                     zlog::trace!(logger => "formatting full");
                     Self::format_via_lsp(
@@ -2294,15 +2333,20 @@ impl LocalLspStore {
         abs_path: &Path,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
+        logger: zlog::Logger,
         cx: &mut AsyncApp,
-    ) -> Result<Vec<(Range<Anchor>, Arc<str>)>> {
+    ) -> Result<Option<Vec<(Range<Anchor>, Arc<str>)>>> {
         let capabilities = &language_server.capabilities();
         let range_formatting_provider = capabilities.document_range_formatting_provider.as_ref();
-        if range_formatting_provider == Some(&OneOf::Left(false)) {
-            anyhow::bail!(
-                "{} language server does not support range formatting",
+        if !matches!(
+            range_formatting_provider,
+            Some(OneOf::Left(true) | OneOf::Right(_))
+        ) {
+            zlog::debug!(
+                logger => "Skipping range formatting - LSP {} does not support document_range_formatting_provider",
                 language_server.name()
             );
+            return Ok(None);
         }
 
         let uri = file_path_to_lsp_url(abs_path)?;
@@ -2361,8 +2405,9 @@ impl LocalLspStore {
                 )
             })?
             .await
+            .map(Some)
         } else {
-            Ok(Vec::with_capacity(0))
+            Ok(Some(Vec::with_capacity(0)))
         }
     }
 
@@ -3920,6 +3965,18 @@ impl LocalLspStore {
             None
         }
     }
+}
+
+fn anchor_ranges_to_row_ranges(ranges: &[Range<Anchor>], buffer: &Buffer) -> Vec<Range<u32>> {
+    let snapshot = buffer.snapshot();
+    ranges
+        .iter()
+        .map(|r| {
+            let start = r.start.to_point(&snapshot).row;
+            let end = r.end.to_point(&snapshot).row;
+            start..end + 1
+        })
+        .collect()
 }
 
 fn notify_server_capabilities_updated(server: &LanguageServer, cx: &mut Context<LspStore>) {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1608,17 +1608,36 @@ impl LocalLspStore {
             .handle
             .read_with(cx, |buffer, _| buffer.max_point().row > 0);
 
+        // When formatting a selection, only the rows it spans may be touched.
+        let selection_row_ranges = buffer.ranges.as_ref().map(|ranges| {
+            buffer.handle.read_with(cx, |buffer, _cx| {
+                let snapshot = buffer.snapshot();
+                ranges
+                    .iter()
+                    .map(|range| {
+                        let start = range.start.to_point(&snapshot);
+                        let end = range.end.to_point(&snapshot);
+                        // A selection ending at column 0 of a row only includes that row's
+                        // preceding line break, not its content, so it shouldn't be trimmed.
+                        let end_row = if end.column == 0 && end.row > start.row {
+                            end.row
+                        } else {
+                            end.row + 1
+                        };
+                        start.row..end_row
+                    })
+                    .collect::<Vec<_>>()
+            })
+        });
+
         // handle whitespace formatting
         if settings.remove_trailing_whitespace_on_save {
             zlog::trace!(logger => "removing trailing whitespace");
-            let diff = if let Some(ranges) = buffer.ranges.as_ref() {
-                let row_ranges = buffer.handle.read_with(cx, |buffer, _cx| {
-                    anchor_ranges_to_row_ranges(ranges, buffer)
-                });
+            let diff = if let Some(row_ranges) = &selection_row_ranges {
                 buffer
                     .handle
                     .read_with(cx, |buffer, cx| {
-                        buffer.remove_trailing_whitespace_in_ranges(&row_ranges, cx)
+                        buffer.remove_trailing_whitespace_in_ranges(row_ranges, cx)
                     })
                     .await
             } else {
@@ -1634,16 +1653,10 @@ impl LocalLspStore {
 
         if settings.ensure_final_newline_on_save {
             zlog::trace!(logger => "ensuring final newline");
-            if let Some(ranges) = buffer.ranges.as_ref() {
-                let row_ranges = buffer.handle.read_with(cx, |buffer, _cx| {
-                    anchor_ranges_to_row_ranges(ranges, buffer)
+            if let Some(row_ranges) = &selection_row_ranges {
+                let diff = buffer.handle.read_with(cx, |buffer, _cx| {
+                    buffer.ensure_final_newline_in_range(row_ranges)
                 });
-                let diff = buffer
-                    .handle
-                    .read_with(cx, |buffer, cx| {
-                        buffer.ensure_final_newline_in_range(&row_ranges, cx)
-                    })
-                    .await;
                 extend_formatting_transaction(
                     buffer,
                     formatting_transaction_id,
@@ -2186,12 +2199,8 @@ impl LocalLspStore {
                             formatting_transaction_id,
                             cx,
                             |buffer, cx| {
-                                zlog::info!(
-                                    "Applying edits {edits:?}. Content: {:?}",
-                                    buffer.text()
-                                );
+                                zlog::trace!("Applying {} edits", edits.len());
                                 buffer.edit(edits, None, cx);
-                                zlog::info!("Applied edits. New Content: {:?}", buffer.text());
                             },
                         )?;
                     }
@@ -2340,8 +2349,8 @@ impl LocalLspStore {
             range_formatting_provider,
             Some(OneOf::Left(true) | OneOf::Right(_))
         ) {
-            log::info!(
-                "Skipping range formatting - LSP {} does not support document_range_formatting_provider",
+            log::debug!(
+                "Skipping range formatting: language server {} does not support range formatting",
                 language_server.name()
             );
             return Ok(None);
@@ -3963,18 +3972,6 @@ impl LocalLspStore {
             None
         }
     }
-}
-
-fn anchor_ranges_to_row_ranges(ranges: &[Range<Anchor>], buffer: &Buffer) -> Vec<Range<u32>> {
-    let snapshot = buffer.snapshot();
-    ranges
-        .iter()
-        .map(|r| {
-            let start = r.start.to_point(&snapshot).row;
-            let end = r.end.to_point(&snapshot).row;
-            start..end + 1
-        })
-        .collect()
 }
 
 fn notify_server_capabilities_updated(server: &LanguageServer, cx: &mut Context<LspStore>) {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1633,19 +1633,12 @@ impl LocalLspStore {
         // handle whitespace formatting
         if settings.remove_trailing_whitespace_on_save {
             zlog::trace!(logger => "removing trailing whitespace");
-            let diff = if let Some(row_ranges) = &selection_row_ranges {
-                buffer
-                    .handle
-                    .read_with(cx, |buffer, cx| {
-                        buffer.remove_trailing_whitespace_in_ranges(row_ranges, cx)
-                    })
-                    .await
-            } else {
-                buffer
-                    .handle
-                    .read_with(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx))
-                    .await
-            };
+            let diff = buffer
+                .handle
+                .read_with(cx, |buffer, cx| {
+                    buffer.remove_trailing_whitespace(selection_row_ranges.as_deref(), cx)
+                })
+                .await;
             extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
                 buffer.apply_diff(diff, cx);
             })?;
@@ -1653,28 +1646,12 @@ impl LocalLspStore {
 
         if settings.ensure_final_newline_on_save {
             zlog::trace!(logger => "ensuring final newline");
-            if let Some(row_ranges) = &selection_row_ranges {
-                let diff = buffer.handle.read_with(cx, |buffer, _cx| {
-                    buffer.ensure_final_newline_in_range(row_ranges)
-                });
-                extend_formatting_transaction(
-                    buffer,
-                    formatting_transaction_id,
-                    cx,
-                    |buffer, cx| {
-                        buffer.apply_diff(diff, cx);
-                    },
-                )?;
-            } else {
-                extend_formatting_transaction(
-                    buffer,
-                    formatting_transaction_id,
-                    cx,
-                    |buffer, cx| {
-                        buffer.ensure_final_newline(cx);
-                    },
-                )?;
-            }
+            let diff = buffer.handle.read_with(cx, |buffer, _cx| {
+                buffer.ensure_final_newline(selection_row_ranges.as_deref())
+            });
+            extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
+                buffer.apply_diff(diff, cx);
+            })?;
         }
 
         let line_ending_policy = match settings.line_ending {


### PR DESCRIPTION
## Summary

When formatting specific ranges (e.g. via Format Selections), trailing whitespace removal and final newline enforcement currently operate on the entire file. This PR makes these operations range-aware, so they only affect lines within the target ranges.

As noted in #16509, users want `remove_trailing_whitespace_on_save` and `ensure_final_newline_on_save` to suppress jitter by only touching changed lines. This PR provides the foundational infrastructure for that — range-based whitespace and newline operations — which a follow-up PR will wire into the `format_on_save` modifications mode.

## Changes

- Added `remove_trailing_whitespace_in_ranges` and `ensure_final_newline_in_range` to `Buffer`
- When a `FormattableBuffer` has ranges set, whitespace and newline operations now use the range-based variants
- `format_ranges_via_lsp` returns `Ok(None)` instead of an error when the LSP doesn't support range formatting
- Extracted `anchor_ranges_to_row_ranges` helper to deduplicate conversion logic

<details><summary>Tests (4)</summary>

- `test_trailing_whitespace_in_ranges` — only modified lines have whitespace removed
- `test_trailing_whitespace_empty_ranges` — empty ranges → no changes
- `test_final_newline_modified_last_line` — newline added when last line is in range
- `test_final_newline_unmodified_last_line` — newline not added when last line is outside range

</details>

---

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved Format Selection to scope trailing whitespace removal and final newline enforcement to the selected range instead of the entire file
- Improved handling of LSP servers that do not support range formatting by gracefully skipping instead of producing an error