### PR TITLE
vim: Restore normal search jumps after dismissing cmd-f

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -132,6 +132,13 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 }
 
 impl Vim {
+    fn reset_cmd_f_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.search.cmd_f_search {
+            self.search.cmd_f_search = false;
+            self.sync_vim_settings(window, cx);
+        }
+    }
+
     fn search_under_cursor(
         &mut self,
         action: &SearchUnderCursor,
@@ -294,17 +301,41 @@ impl Vim {
     }
 
     // hook into the existing to clear out any vim search state on cmd+f or edit -> find.
-    fn search_deploy(&mut self, _: &buffer_search::Deploy, _: &mut Window, cx: &mut Context<Self>) {
+    fn search_deploy(
+        &mut self,
+        _: &buffer_search::Deploy,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let dismiss_subscription = self
+            .pane(window, cx)
+            .and_then(|pane| {
+                pane.read(cx)
+                    .toolbar()
+                    .read(cx)
+                    .item_of_type::<BufferSearchBar>()
+            })
+            .map(|search_bar| {
+                cx.subscribe_in(&search_bar, window, |vim, _, event, window, cx| {
+                    if matches!(event, buffer_search::Event::Dismissed) {
+                        vim.reset_cmd_f_search(window, cx);
+                    }
+                })
+            });
+
         // Preserve the current mode when resetting search state
         let current_mode = self.mode;
         self.search = Default::default();
         self.search.prior_mode = current_mode;
         self.search.cmd_f_search = true;
+        self.search._dismiss_subscription = dismiss_subscription;
+        self.sync_vim_settings(window, cx);
         cx.propagate();
     }
 
     pub fn search_submit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.store_visual_marks(window, cx);
+        self.reset_cmd_f_search(window, cx);
         let Some(pane) = self.pane(window, cx) else {
             return;
         };
@@ -387,6 +418,7 @@ impl Vim {
         let Some(pane) = self.pane(window, cx) else {
             return;
         };
+        self.reset_cmd_f_search(window, cx);
         let count = Vim::take_count(cx).unwrap_or(1);
         Vim::take_forced_motion(cx);
         let prior_selections = self.editor_selections(window, cx);
@@ -474,6 +506,9 @@ impl Vim {
                 let search_bar = search_bar.downgrade();
                 cx.spawn_in(window, async move |_, cx| {
                     search.await?;
+                    vim.update(cx, |vim, cx| {
+                        vim.reset_cmd_f_search(window, cx);
+                    })?;
                     search_bar.update_in(cx, |search_bar, window, cx| {
                         search_bar.select_match(direction, count, window, cx);
 
@@ -978,6 +1013,40 @@ mod test {
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
         cx.assert_state("«oneˇ» one one one", Mode::Visual);
+    }
+
+    #[gpui::test]
+    async fn test_cmd_f_search_dismissed_n_stays_in_normal_mode(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.set_state("ˇone two one two\n", Mode::Normal);
+
+        cx.simulate_keystrokes("cmd-f");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("o n e");
+        cx.run_until_parked();
+
+        cx.workspace(|workspace, window, cx| {
+            let pane = workspace.active_pane().read(cx);
+            let search_bar = pane
+                .toolbar()
+                .read(cx)
+                .item_of_type::<search::BufferSearchBar>()
+                .expect("Buffer search bar should be deployed");
+            search_bar.update(cx, |bar, cx| {
+                bar.dismiss(&search::buffer_search::Dismiss, window, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        cx.assert_state("oneˇ two one two\n", Mode::Normal);
+
+        cx.simulate_keystrokes("n");
+        cx.run_until_parked();
+
+        cx.assert_state("one two oneˇ two\n", Mode::Normal);
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -508,7 +508,7 @@ impl Vim {
                     search.await?;
                     vim.update(cx, |vim, cx| {
                         vim.reset_cmd_f_search(window, cx);
-                    })?;
+                    });
                     search_bar.update_in(cx, |search_bar, window, cx| {
                         search_bar.select_match(direction, count, window, cx);
 

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -506,13 +506,13 @@ impl Vim {
                 let search_bar = search_bar.downgrade();
                 cx.spawn_in(window, async move |_, cx| {
                     search.await?;
-                    vim.update(cx, |vim, cx| {
+                    vim.update_in(cx, |vim, window, cx| {
                         vim.reset_cmd_f_search(window, cx);
-                    });
+                    })?;
                     search_bar.update_in(cx, |search_bar, window, cx| {
                         search_bar.select_match(direction, count, window, cx);
 
-                        vim.update(cx, |vim, cx| {
+                        vim.update_in(cx, |vim, window, cx| {
                             let new_selections = vim.editor_selections(window, cx);
                             vim.search_motion(
                                 Motion::ZedSearchResult {
@@ -522,7 +522,7 @@ impl Vim {
                                 window,
                                 cx,
                             )
-                        });
+                        })
                     })?;
                     anyhow::Ok(())
                 })


### PR DESCRIPTION
This fixes #53896.

The editor was holding on to `cmd_f_search` state after the search UI was dismissed, so the next Vim `n` or `N` jump could behave like a Visual-mode selection instead of a normal search move.

This clears that state before native Vim search navigation, clears it again on submit and dismissal, and adds regression coverage for the reported `cmd-f` -> dismiss -> `n` flow.

## Validation
- `cargo fmt --all`
- manually verified the reported `cmd-f` dismissal + `n` flow works as expected
- added a regression test for the reported `cmd-f` dismissal + `n` flow

Release Notes:

- Fixed Vim search jumps after dismissing `cmd-f` search so `n`/`N` stay in Normal mode instead of selecting into Visual mode.
