### PR TITLE
workspace: Autosave when command palette moves focus away

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -965,6 +965,25 @@ impl<T: Item> ItemHandle for Entity<T> {
                             // palette (such as by opening up the tab switcher from it and then switching tabs that
                             // way).
                             if workspace.is_active_modal_command_palette(cx) {
+                                let item = item.clone();
+                                let project = workspace.project.clone();
+                                cx.defer_in(window, move |workspace, window, cx| {
+                                    if item.workspace_settings(cx).autosave
+                                        != AutosaveSetting::OnFocusChange
+                                    {
+                                        return;
+                                    }
+
+                                    let focus_handle = item.item_focus_handle(cx);
+                                    if focus_handle.contains_focused(window, cx)
+                                        || workspace.is_active_modal_command_palette(cx)
+                                    {
+                                        return;
+                                    }
+
+                                    Pane::autosave_item(&item, project.clone(), window, cx)
+                                        .detach_and_log_err(cx);
+                                });
                                 return;
                             }
                         }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -11631,6 +11631,104 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_vim_command_palette_focus_transfer_autosaves(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+        });
+        let other_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(2, "2.txt", cx)])
+        });
+        let pane = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+            workspace.add_item_to_active_pane(Box::new(other_item.clone()), None, true, window, cx);
+            let pane = workspace.active_pane().clone();
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(0, true, true, window, cx);
+            });
+            pane
+        });
+
+        item.update_in(cx, |item, window, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.autosave = Some(AutosaveSetting::OnFocusChange);
+                    settings.vim_mode = Some(true);
+                })
+            });
+            item.is_dirty = true;
+            cx.focus_self(window);
+        });
+        cx.executor().run_until_parked();
+        item.read_with(cx, |item, _| assert_eq!(item.save_count, 0));
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_modal(window, cx, TestCommandPaletteModal::new);
+            workspace.toggle_modal(window, cx, TestCommandPaletteModal::new);
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(1, true, true, window, cx);
+            });
+        });
+        cx.executor().run_until_parked();
+
+        item.read_with(cx, |item, _| {
+            assert_eq!(
+                item.save_count, 1,
+                "Focus transfers through the command palette should autosave once focus lands on another item"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_vim_command_palette_return_does_not_autosave(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        item.update_in(cx, |item, window, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.autosave = Some(AutosaveSetting::OnFocusChange);
+                    settings.vim_mode = Some(true);
+                })
+            });
+            item.is_dirty = true;
+            cx.focus_self(window);
+        });
+        cx.executor().run_until_parked();
+        item.read_with(cx, |item, _| assert_eq!(item.save_count, 0));
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_modal(window, cx, TestCommandPaletteModal::new);
+            workspace.toggle_modal(window, cx, TestCommandPaletteModal::new);
+        });
+        cx.executor().run_until_parked();
+
+        item.read_with(cx, |item, _| {
+            assert_eq!(
+                item.save_count, 0,
+                "Returning focus from the command palette to the same item should not autosave"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_pane_navigation(cx: &mut gpui::TestAppContext) {
         init_test(cx);
 
@@ -13122,6 +13220,38 @@ mod tests {
             &mut self,
             _window: &mut Window,
             _cx: &mut Context<TestModal>,
+        ) -> impl IntoElement {
+            div().track_focus(&self.0)
+        }
+    }
+
+    struct TestCommandPaletteModal(FocusHandle);
+
+    impl TestCommandPaletteModal {
+        fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
+            Self(cx.focus_handle())
+        }
+    }
+
+    impl EventEmitter<DismissEvent> for TestCommandPaletteModal {}
+
+    impl Focusable for TestCommandPaletteModal {
+        fn focus_handle(&self, _cx: &App) -> FocusHandle {
+            self.0.clone()
+        }
+    }
+
+    impl ModalView for TestCommandPaletteModal {
+        fn is_command_palette(&self) -> bool {
+            true
+        }
+    }
+
+    impl Render for TestCommandPaletteModal {
+        fn render(
+            &mut self,
+            _window: &mut Window,
+            _cx: &mut Context<TestCommandPaletteModal>,
         ) -> impl IntoElement {
             div().track_focus(&self.0)
         }


### PR DESCRIPTION
This fixes #53863.

Autosave was being skipped when Vim or Helix mode routed focus through the command palette on the way to a different item, like opening Git Diff. The existing guard was correct for commands that return to the same editor, but too broad for commands that actually move focus somewhere else.

This defers that check by one turn so we can tell the difference between those two cases, and adds regression coverage for both paths.

Release Notes:

- Fixed on-focus-change autosave when command palette actions open another item in Vim and Helix modes
