### PR TITLE
remote: Set current_dir for cargo zigbuild cross-compilation

### DIFF
--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -316,6 +316,7 @@ async fn build_remote_server_from_source(
         log::info!("building remote binary from source for {triple} with Zig");
         run_cmd(
             new_command("cargo")
+                .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."))
                 .args([
                     "zigbuild",
                     "--package",

--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -332,7 +332,8 @@ async fn build_remote_server_from_source(
         )
         .await?;
     };
-    let bin_path = Path::new("target")
+    let bin_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."))
+        .join("target")
         .join("remote_server")
         .join(&triple)
         .join("debug")


### PR DESCRIPTION
## Summary

- The cross-compile path for building `remote_server` via `cargo zigbuild` was missing `.current_dir()`, causing it to inherit the process cwd
- This fails with "cannot specify features for packages outside of workspace" when Zed is launched from outside its source tree
- The native build path at the same location already sets `.current_dir()` correctly — this aligns the cross-compile path

Closes #53950

## Test plan

- [x] Build Zed from source
- [x] Launch from `/tmp`: `cd /tmp && /path/to/zed some-project --dev-container`
- [x] Verify dev container cross-compilation succeeds

Release Notes:

- Fixed dev container cross-compilation failing when Zed is launched from outside its source directory