### PR TITLE
lsp: Enforce stricter CSS selector highlights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5414,6 +5414,7 @@ dependencies = [
  "tracing",
  "tree-sitter-bash",
  "tree-sitter-c",
+ "tree-sitter-css",
  "tree-sitter-html",
  "tree-sitter-md",
  "tree-sitter-python",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -129,6 +129,7 @@ tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 tree-sitter-yaml.workspace = true
 tree-sitter-bash.workspace = true
+tree-sitter-css.workspace = true
 tree-sitter-md.workspace = true
 unicode-width.workspace = true
 unindent.workspace = true

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -30944,6 +30944,65 @@ async fn test_select_next_prev_syntax_node(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_css_document_highlights_ignore_parent_rule_selector(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let capabilities = lsp::ServerCapabilities {
+        document_highlight_provider: Some(lsp::OneOf::Left(true)),
+        ..Default::default()
+    };
+    let language = Arc::into_inner(languages::language("css", tree_sitter_css::LANGUAGE.into()))
+        .expect("unique Arc from languages::language");
+    let mut cx = EditorLspTestContext::new(language, capabilities, cx).await;
+
+    cx.set_state("div {\n  \u{02C7}div p {\n    color: red;\n  }\n}\n");
+
+    let outer_range = cx.lsp_range("«div» {\n  div p {\n    color: red;\n  }\n}\n");
+    let inner_range = cx.lsp_range("div {\n  «div» p {\n    color: red;\n  }\n}\n");
+    let mut requests =
+        cx.set_request_handler::<lsp::request::DocumentHighlightRequest, _, _>(move |_, _, _| {
+            let highlights = vec![
+                lsp::DocumentHighlight {
+                    range: outer_range,
+                    kind: Some(lsp::DocumentHighlightKind::READ),
+                },
+                lsp::DocumentHighlight {
+                    range: inner_range,
+                    kind: Some(lsp::DocumentHighlightKind::READ),
+                },
+            ];
+            async move { Ok(Some(highlights)) }
+        });
+
+    cx.update_editor(|editor, _, cx| {
+        editor.refresh_document_highlights(cx);
+    });
+    cx.run_until_parked();
+    cx.executor()
+        .advance_clock(std::time::Duration::from_millis(100));
+    requests.next().await.unwrap();
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, window, cx| {
+        let snapshot = editor.snapshot(window, cx);
+        let buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+        let full_range =
+            (Point::new(0, 0)..buffer_snapshot.max_point()).to_anchors(&buffer_snapshot);
+
+        let highlighted_ranges =
+            editor.sorted_background_highlights_in_range(full_range, &snapshot, cx.theme());
+
+        assert_eq!(
+            highlighted_ranges
+                .into_iter()
+                .map(|(range, _)| range)
+                .collect::<Vec<_>>(),
+            vec![DisplayPoint::new(DisplayRow(1), 2)..DisplayPoint::new(DisplayRow(1), 5)]
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_next_prev_document_highlight(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -16,7 +16,7 @@ use collections::HashMap;
 use futures::future;
 use gpui::{App, AsyncApp, Entity, SharedString, Task, prelude::FluentBuilder};
 use language::{
-    Anchor, Bias, Buffer, BufferSnapshot, CachedLspAdapter, CharKind, CharScopeContext,
+    Anchor, Bias, Buffer, BufferSnapshot, CachedLspAdapter, CharKind, CharScopeContext, Node,
     OffsetRangeExt, PointUtf16, ToOffset, ToPointUtf16, Transaction, Unclipped,
     language_settings::{InlayHintKind, LanguageSettings},
     point_from_lsp, point_to_lsp,
@@ -1547,7 +1547,12 @@ impl LspCommand for GetDocumentHighlights {
         cx: AsyncApp,
     ) -> Result<Vec<DocumentHighlight>> {
         Ok(buffer.read_with(&cx, |buffer, _| {
-            let mut lsp_highlights = lsp_highlights.unwrap_or_default();
+            let snapshot = buffer.snapshot();
+            let mut lsp_highlights = normalize_css_document_highlights(
+                &snapshot,
+                self.position,
+                lsp_highlights.unwrap_or_default(),
+            );
             lsp_highlights.sort_unstable_by_key(|h| (h.range.start, Reverse(h.range.end)));
             lsp_highlights
                 .into_iter()
@@ -1657,6 +1662,97 @@ impl LspCommand for GetDocumentHighlights {
 
     fn buffer_id_from_proto(message: &proto::GetDocumentHighlights) -> Result<BufferId> {
         BufferId::new(message.buffer_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CssTagHighlightContext {
+    rule_set_range: Range<usize>,
+    text: String,
+}
+
+fn normalize_css_document_highlights(
+    snapshot: &BufferSnapshot,
+    position: PointUtf16,
+    lsp_highlights: Vec<lsp::DocumentHighlight>,
+) -> Vec<lsp::DocumentHighlight> {
+    let Some(cursor_context) = css_tag_highlight_context_for_position(snapshot, position) else {
+        return lsp_highlights;
+    };
+
+    let filtered: Vec<_> = lsp_highlights
+        .iter()
+        .filter(|highlight| {
+            match css_tag_highlight_context_for_lsp_range(snapshot, highlight.range) {
+                Some(highlight_context) => highlight_context == cursor_context,
+                None => true,
+            }
+        })
+        .cloned()
+        .collect();
+
+    if filtered.is_empty() {
+        lsp_highlights
+    } else {
+        filtered
+    }
+}
+
+fn css_tag_highlight_context_for_position(
+    snapshot: &BufferSnapshot,
+    position: PointUtf16,
+) -> Option<CssTagHighlightContext> {
+    let (word_range, _) = snapshot.surrounding_word(position, None);
+    let word_range = word_range.start.to_offset(snapshot)..word_range.end.to_offset(snapshot);
+    css_tag_highlight_context_for_range(snapshot, word_range)
+}
+
+fn css_tag_highlight_context_for_lsp_range(
+    snapshot: &BufferSnapshot,
+    range: lsp::Range,
+) -> Option<CssTagHighlightContext> {
+    let start = snapshot.clip_point_utf16(point_from_lsp(range.start), Bias::Left);
+    let end = snapshot.clip_point_utf16(point_from_lsp(range.end), Bias::Left);
+    css_tag_highlight_context_for_range(
+        snapshot,
+        start.to_offset(snapshot)..end.to_offset(snapshot),
+    )
+}
+
+fn css_tag_highlight_context_for_range(
+    snapshot: &BufferSnapshot,
+    range: Range<usize>,
+) -> Option<CssTagHighlightContext> {
+    if range.is_empty() {
+        return None;
+    }
+
+    let layer = snapshot.smallest_syntax_layer_containing(range.clone())?;
+    let language_name = layer.language.lsp_id();
+    if !matches!(language_name.as_str(), "css" | "scss" | "less") {
+        return None;
+    }
+
+    let node = layer
+        .node()
+        .named_descendant_for_byte_range(range.start, range.end)?;
+    if node.kind() != "tag_name" || node.byte_range() != range {
+        return None;
+    }
+
+    let rule_set_range = syntax_ancestor_with_kind(node, "rule_set")?.byte_range();
+    Some(CssTagHighlightContext {
+        rule_set_range,
+        text: snapshot.text_for_range(range).collect(),
+    })
+}
+
+fn syntax_ancestor_with_kind<'a>(mut node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    loop {
+        if node.kind() == kind {
+            return Some(node);
+        }
+        node = node.parent()?;
     }
 }
 


### PR DESCRIPTION
**Self-Review Checklist:**
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

**Closes #51483.**

Proof: 

https://github.com/user-attachments/assets/afd5d656-b93d-4144-99a9-874b38baa19e

Release Notes:

- Fixed document highlights in CSS (and SCSS/Less) so a nested tag in a compound selector (for example `div p` inside an outer `div` rule) is not grouped with the parent rule’s tag name.
