### PR TITLE
Respect proxy settings when fetching JSON schemas

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -5,7 +5,10 @@ use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
 use gpui::{App, AsyncApp, Entity, Task};
-use http_client::github::{GitHubLspBinaryVersion, latest_github_release};
+use http_client::{
+    HttpClient as _,
+    github::{GitHubLspBinaryVersion, latest_github_release},
+};
 use language::{
     Buffer, ContextProvider, LanguageName, LanguageRegistry, LocalFile as _, LspAdapter,
     LspAdapterDelegate, LspInstaller, Toolchain,
@@ -296,6 +299,13 @@ impl LspAdapter for JsonLspAdapter {
                 }
             })
         });
+
+        if let Some(proxy_settings) = cx.update(|cx| {
+            json_schema_proxy_settings(cx.http_client().proxy().map(ToString::to_string))
+        }) {
+            merge_json_value_into(proxy_settings, &mut config);
+        }
+
         let project_options = cx.update(|cx| {
             language_server_settings(delegate.as_ref(), &self.name(), cx)
                 .and_then(|s| worktree_root(delegate, s.settings.clone()))
@@ -356,6 +366,16 @@ fn worktree_root(delegate: &Arc<dyn LspAdapterDelegate>, settings: Option<Value>
     Some(Value::Object(settings_map))
 }
 
+fn json_schema_proxy_settings(proxy: Option<String>) -> Option<Value> {
+    proxy.map(|proxy| {
+        json!({
+            "http": {
+                "proxy": proxy,
+            }
+        })
+    })
+}
+
 async fn get_cached_server_binary(
     container_dir: PathBuf,
     node: &NodeRuntime,
@@ -374,6 +394,30 @@ async fn get_cached_server_binary(
     })
     .await
     .log_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::json_schema_proxy_settings;
+
+    #[test]
+    fn test_json_schema_proxy_settings_includes_proxy() {
+        assert_eq!(
+            json_schema_proxy_settings(Some("http://proxy.example:8080".to_string())),
+            Some(json!({
+                "http": {
+                    "proxy": "http://proxy.example:8080",
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn test_json_schema_proxy_settings_ignores_missing_proxy() {
+        assert_eq!(json_schema_proxy_settings(None), None);
+    }
 }
 
 pub struct NodeVersionAdapter;

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -5,10 +5,7 @@ use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
 use gpui::{App, AsyncApp, Entity, Task};
-use http_client::{
-    HttpClient as _,
-    github::{GitHubLspBinaryVersion, latest_github_release},
-};
+use http_client::github::{GitHubLspBinaryVersion, latest_github_release};
 use language::{
     Buffer, ContextProvider, LanguageName, LanguageRegistry, LocalFile as _, LspAdapter,
     LspAdapterDelegate, LspInstaller, Toolchain,


### PR DESCRIPTION
This fixes #53819.

JSON schema downloads were still going through the JSON language server without picking up Zed's configured proxy. On networks that require the proxy, that made schema fetches fail even though the rest of the app could connect normally.

This passes the proxy setting through to the JSON language server configuration so schema requests follow the same network path as the rest of Zed.

## Test plan
- `rustfmt --edition 2024 crates/languages/src/json.rs`
- `git diff --check -- crates/languages/src/json.rs`

Release Notes:

- Fixed JSON schema downloads ignoring Zed's proxy setting.
