### PR TITLE
project: Avoid double-quoting activated task commands

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -5,7 +5,10 @@ use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
 use gpui::{App, AsyncApp, Entity, Task};
-use http_client::github::{GitHubLspBinaryVersion, latest_github_release};
+use http_client::{
+    HttpClient as _,
+    github::{GitHubLspBinaryVersion, latest_github_release},
+};
 use language::{
     Buffer, ContextProvider, LanguageName, LanguageRegistry, LocalFile as _, LspAdapter,
     LspAdapterDelegate, LspInstaller, Toolchain,
@@ -296,6 +299,13 @@ impl LspAdapter for JsonLspAdapter {
                 }
             })
         });
+
+        if let Some(proxy_settings) = cx.update(|cx| {
+            json_schema_proxy_settings(cx.http_client().proxy().map(ToString::to_string))
+        }) {
+            merge_json_value_into(proxy_settings, &mut config);
+        }
+
         let project_options = cx.update(|cx| {
             language_server_settings(delegate.as_ref(), &self.name(), cx)
                 .and_then(|s| worktree_root(delegate, s.settings.clone()))
@@ -356,6 +366,16 @@ fn worktree_root(delegate: &Arc<dyn LspAdapterDelegate>, settings: Option<Value>
     Some(Value::Object(settings_map))
 }
 
+fn json_schema_proxy_settings(proxy: Option<String>) -> Option<Value> {
+    proxy.map(|proxy| {
+        json!({
+            "http": {
+                "proxy": proxy,
+            }
+        })
+    })
+}
+
 async fn get_cached_server_binary(
     container_dir: PathBuf,
     node: &NodeRuntime,
@@ -374,6 +394,30 @@ async fn get_cached_server_binary(
     })
     .await
     .log_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::json_schema_proxy_settings;
+
+    #[test]
+    fn test_json_schema_proxy_settings_includes_proxy() {
+        assert_eq!(
+            json_schema_proxy_settings(Some("http://proxy.example:8080".to_string())),
+            Some(json!({
+                "http": {
+                    "proxy": "http://proxy.example:8080",
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn test_json_schema_proxy_settings_ignores_missing_proxy() {
+        assert_eq!(json_schema_proxy_settings(None), None);
+    }
 }
 
 pub struct NodeVersionAdapter;

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -138,12 +138,6 @@ impl Project {
                     let Some(toolchain) = toolchain.await else {
                         continue;
                     };
-                    if should_skip_toolchain_activation_for_task(
-                        &toolchain,
-                        spawn_task.command.as_deref(),
-                    ) {
-                        return Some(Vec::new());
-                    }
                     let language = lang_registry
                         .language_for_name(&toolchain.language_name.0)
                         .await
@@ -160,21 +154,8 @@ impl Project {
 
             let builder = project
                 .update(cx, move |_, cx| {
-                    let format_to_run = || {
-                        if let Some(command) = &spawn_task.command {
-                            let command = shell_kind.prepend_command_prefix(command);
-                            let command = shell_kind.try_quote_prefix_aware(&command);
-                            let args = spawn_task
-                                .args
-                                .iter()
-                                .filter_map(|arg| shell_kind.try_quote(&arg));
-
-                            command.into_iter().chain(args).join(" ")
-                        } else {
-                            // todo: this breaks for remotes to windows
-                            format!("exec {shell} -l")
-                        }
-                    };
+                    let format_to_run =
+                        format_task_for_shell(&spawn_task, shell.as_str(), shell_kind);
 
                     let (shell, env) = {
                         env.extend(spawn_task.env);
@@ -645,81 +626,96 @@ fn create_remote_shell(
     ))
 }
 
-fn should_skip_toolchain_activation_for_task(
-    toolchain: &language::Toolchain,
-    command: Option<&str>,
-) -> bool {
-    command.is_some_and(|command| {
-        toolchain.language_name.0 == "Python"
-            && toolchain.path.as_ref() == command
-            && toolchain
-                .as_json
-                .get("activation_scripts")
-                .and_then(serde_json::Value::as_object)
-                .is_some_and(|activation_scripts| !activation_scripts.is_empty())
-    })
+fn format_task_for_shell(
+    spawn_task: &SpawnInTerminal,
+    shell: &str,
+    shell_kind: ShellKind,
+) -> String {
+    if let Some(command) = spawn_task.command.as_deref() {
+        if command == shell
+            && let Some(command) = extract_shell_command_argument(&spawn_task.args, shell_kind)
+        {
+            return command.to_string();
+        }
+
+        let command = shell_kind.prepend_command_prefix(command);
+        let command = shell_kind.try_quote_prefix_aware(&command);
+        let args = spawn_task
+            .args
+            .iter()
+            .filter_map(|arg| shell_kind.try_quote(arg));
+
+        command.into_iter().chain(args).join(" ")
+    } else {
+        // todo: this breaks for remotes to windows
+        format!("exec {shell} -l")
+    }
+}
+
+fn extract_shell_command_argument<'a>(
+    args: &'a [String],
+    shell_kind: ShellKind,
+) -> Option<&'a str> {
+    match shell_kind {
+        ShellKind::PowerShell | ShellKind::Pwsh => args
+            .iter()
+            .rposition(|arg| arg == "-C")
+            .and_then(|index| args.get(index + 1))
+            .map(String::as_str),
+        ShellKind::Cmd => args
+            .iter()
+            .rposition(|arg| arg == "/C")
+            .and_then(|index| args.get(index + 1))
+            .map(String::as_str),
+        ShellKind::Posix
+        | ShellKind::Nushell
+        | ShellKind::Fish
+        | ShellKind::Csh
+        | ShellKind::Tcsh
+        | ShellKind::Rc
+        | ShellKind::Xonsh
+        | ShellKind::Elvish => args
+            .iter()
+            .rposition(|arg| arg == "-c")
+            .and_then(|index| args.get(index + 1))
+            .map(String::as_str),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use gpui::SharedString;
-    use language::{LanguageName, Toolchain};
-    use serde_json::json;
-
-    use super::should_skip_toolchain_activation_for_task;
+    use super::format_task_for_shell;
+    use task::{ShellKind, SpawnInTerminal};
 
     #[test]
-    fn skips_python_venv_activation_when_task_uses_the_same_interpreter() {
-        let toolchain = Toolchain {
-            name: SharedString::from("Python"),
-            path: SharedString::from("/tmp/folder with spaces/.venv/bin/python"),
-            language_name: LanguageName::new_static("Python"),
-            as_json: json!({
-                "activation_scripts": {
-                    "posix": "/tmp/folder with spaces/.venv/bin/activate",
-                }
-            }),
+    fn reuses_prepared_shell_command_without_requoting() {
+        let spawn_task = SpawnInTerminal {
+            command: Some("zsh".to_string()),
+            args: vec![
+                "-i".to_string(),
+                "-c".to_string(),
+                "echo '/tmp/folder with spaces/$project_id/example.py'".to_string(),
+            ],
+            ..Default::default()
         };
 
-        assert!(should_skip_toolchain_activation_for_task(
-            &toolchain,
-            Some("/tmp/folder with spaces/.venv/bin/python"),
-        ));
+        assert_eq!(
+            format_task_for_shell(&spawn_task, "zsh", ShellKind::Posix),
+            "echo '/tmp/folder with spaces/$project_id/example.py'"
+        );
     }
 
     #[test]
-    fn keeps_activation_for_python_toolchains_without_venv_scripts() {
-        let toolchain = Toolchain {
-            name: SharedString::from("Python"),
-            path: SharedString::from("/tmp/conda/bin/python"),
-            language_name: LanguageName::new_static("Python"),
-            as_json: json!({
-                "activation_scripts": {}
-            }),
+    fn quotes_unprepared_task_arguments_once() {
+        let spawn_task = SpawnInTerminal {
+            command: Some("python".to_string()),
+            args: vec!["/tmp/folder with spaces/$project_id/example.py".to_string()],
+            ..Default::default()
         };
 
-        assert!(!should_skip_toolchain_activation_for_task(
-            &toolchain,
-            Some("/tmp/conda/bin/python"),
-        ));
-    }
-
-    #[test]
-    fn keeps_activation_when_task_uses_a_different_command() {
-        let toolchain = Toolchain {
-            name: SharedString::from("Python"),
-            path: SharedString::from("/tmp/project/.venv/bin/python"),
-            language_name: LanguageName::new_static("Python"),
-            as_json: json!({
-                "activation_scripts": {
-                    "posix": "/tmp/project/.venv/bin/activate",
-                }
-            }),
-        };
-
-        assert!(!should_skip_toolchain_activation_for_task(
-            &toolchain,
-            Some("python3"),
-        ));
+        assert_eq!(
+            format_task_for_shell(&spawn_task, "zsh", ShellKind::Posix),
+            "python '/tmp/folder with spaces/$project_id/example.py'"
+        );
     }
 }

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -138,6 +138,12 @@ impl Project {
                     let Some(toolchain) = toolchain.await else {
                         continue;
                     };
+                    if should_skip_toolchain_activation_for_task(
+                        &toolchain,
+                        spawn_task.command.as_deref(),
+                    ) {
+                        return Some(Vec::new());
+                    }
                     let language = lang_registry
                         .language_for_name(&toolchain.language_name.0)
                         .await
@@ -637,4 +643,83 @@ fn create_remote_shell(
         },
         command.env,
     ))
+}
+
+fn should_skip_toolchain_activation_for_task(
+    toolchain: &language::Toolchain,
+    command: Option<&str>,
+) -> bool {
+    command.is_some_and(|command| {
+        toolchain.language_name.0 == "Python"
+            && toolchain.path.as_ref() == command
+            && toolchain
+                .as_json
+                .get("activation_scripts")
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|activation_scripts| !activation_scripts.is_empty())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::SharedString;
+    use language::{LanguageName, Toolchain};
+    use serde_json::json;
+
+    use super::should_skip_toolchain_activation_for_task;
+
+    #[test]
+    fn skips_python_venv_activation_when_task_uses_the_same_interpreter() {
+        let toolchain = Toolchain {
+            name: SharedString::from("Python"),
+            path: SharedString::from("/tmp/folder with spaces/.venv/bin/python"),
+            language_name: LanguageName::new_static("Python"),
+            as_json: json!({
+                "activation_scripts": {
+                    "posix": "/tmp/folder with spaces/.venv/bin/activate",
+                }
+            }),
+        };
+
+        assert!(should_skip_toolchain_activation_for_task(
+            &toolchain,
+            Some("/tmp/folder with spaces/.venv/bin/python"),
+        ));
+    }
+
+    #[test]
+    fn keeps_activation_for_python_toolchains_without_venv_scripts() {
+        let toolchain = Toolchain {
+            name: SharedString::from("Python"),
+            path: SharedString::from("/tmp/conda/bin/python"),
+            language_name: LanguageName::new_static("Python"),
+            as_json: json!({
+                "activation_scripts": {}
+            }),
+        };
+
+        assert!(!should_skip_toolchain_activation_for_task(
+            &toolchain,
+            Some("/tmp/conda/bin/python"),
+        ));
+    }
+
+    #[test]
+    fn keeps_activation_when_task_uses_a_different_command() {
+        let toolchain = Toolchain {
+            name: SharedString::from("Python"),
+            path: SharedString::from("/tmp/project/.venv/bin/python"),
+            language_name: LanguageName::new_static("Python"),
+            as_json: json!({
+                "activation_scripts": {
+                    "posix": "/tmp/project/.venv/bin/activate",
+                }
+            }),
+        };
+
+        assert!(!should_skip_toolchain_activation_for_task(
+            &toolchain,
+            Some("python3"),
+        ));
+    }
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1184,7 +1184,7 @@ pub fn prepare_task_for_spawn(
 ) -> SpawnInTerminal {
     let builder = ShellBuilder::new(shell, is_windows);
     let command_label = builder.command_label(task.command.as_deref().unwrap_or(""));
-    let (command, args) = builder.build_no_quote(task.command.clone(), &task.args);
+    let (command, args) = builder.build(task.command.clone(), &task.args);
 
     SpawnInTerminal {
         command_label,
@@ -1829,6 +1829,29 @@ mod tests {
                 interactive = if cfg!(windows) { "" } else { "-i " }
             ),
             "We want to show to the user the entire command spawned"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_task_with_spaces_quotes_args() {
+        let input = SpawnInTerminal {
+            command: Some("echo".to_string()),
+            args: vec!["/tmp/folder with spaces/file.txt".to_string()],
+            ..SpawnInTerminal::default()
+        };
+        let shell = Shell::Program("zsh".to_owned());
+
+        let result = prepare_task_for_spawn(&input, &shell, false);
+
+        assert_eq!(result.command, Some("zsh".to_string()));
+        assert_eq!(
+            result.args,
+            vec![
+                "-i".to_string(),
+                "-c".to_string(),
+                "echo '/tmp/folder with spaces/file.txt'".to_string(),
+            ]
         );
     }
 

--- a/crates/util/src/shell_builder.rs
+++ b/crates/util/src/shell_builder.rs
@@ -130,52 +130,6 @@ impl ShellBuilder {
         (self.program, self.args)
     }
 
-    // This should not exist, but our task infra is broken beyond repair right now
-    #[doc(hidden)]
-    pub fn build_no_quote(
-        mut self,
-        task_command: Option<String>,
-        task_args: &[String],
-    ) -> (String, Vec<String>) {
-        if let Some(task_command) = task_command {
-            let mut combined_command = task_args.iter().fold(task_command, |mut command, arg| {
-                command.push(' ');
-                command.push_str(&self.kind.to_shell_variable(arg));
-                command
-            });
-            if self.redirect_stdin {
-                match self.kind {
-                    ShellKind::Fish => {
-                        combined_command.insert_str(0, "begin; ");
-                        combined_command.push_str("; end </dev/null");
-                    }
-                    ShellKind::Posix
-                    | ShellKind::Nushell
-                    | ShellKind::Csh
-                    | ShellKind::Tcsh
-                    | ShellKind::Rc
-                    | ShellKind::Xonsh
-                    | ShellKind::Elvish => {
-                        combined_command.insert(0, '(');
-                        combined_command.push_str(") </dev/null");
-                    }
-                    ShellKind::PowerShell | ShellKind::Pwsh => {
-                        combined_command.insert_str(0, "$null | & {");
-                        combined_command.push_str("}");
-                    }
-                    ShellKind::Cmd => {
-                        combined_command.push_str("< NUL");
-                    }
-                }
-            }
-
-            self.args
-                .extend(self.kind.args_for_shell(self.interactive, combined_command));
-        }
-
-        (self.program, self.args)
-    }
-
     /// Builds a `smol::process::Command` with the given task command and arguments.
     ///
     /// Prefer this over manually constructing a command with the output of `Self::build`,


### PR DESCRIPTION
Fixes #53643

Tasks opened from the terminal panel are already shell-built before they reach `create_terminal_task`, but the venv activation path rebuilt and quoted them again. That broke commands with spaces or `$...` path segments whenever an activation script was injected.

This updates the activation path to reuse the existing shell command when the task is already wrapped, while still quoting raw task commands once when they need to be embedded under activation.

Release Notes:

- Fixed task commands with spaces breaking when terminal activation scripts are injected.
