### PR TITLE
workspace: Native open dialog multi-select

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1939,7 +1939,7 @@ fn open_local_project(
             PathPromptOptions {
                 files: true,
                 directories: true,
-                multiple: false,
+                multiple: true,
                 prompt: None,
             },
             DirectoryLister::Local(


### PR DESCRIPTION
Re-enables selecting multiple projects in the native file picker

Release Notes:

- N/A or Added/Fixed/Improved ...
