### PR TITLE
settings_ui: Gate CLI open behavior setting on feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15896,6 +15896,7 @@ dependencies = [
  "edit_prediction",
  "edit_prediction_ui",
  "editor",
+ "feature_flags",
  "fs",
  "futures 0.3.32",
  "fuzzy",

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -29,6 +29,7 @@ edit_prediction.workspace = true
 edit_prediction_ui.workspace = true
 editor.workspace = true
 fs.workspace = true
+feature_flags.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -63,7 +63,7 @@ macro_rules! concat_sections {
 
 pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
     vec![
-        general_page(),
+        general_page(cx),
         appearance_page(),
         keymap_page(),
         editor_page(),
@@ -80,9 +80,9 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
     ]
 }
 
-fn general_page() -> SettingsPage {
-    fn general_settings_section() -> [SettingsPageItem; 9] {
-        [
+fn general_page(cx: &App) -> SettingsPage {
+    fn general_settings_section(cx: &App) -> Vec<SettingsPageItem> {
+        let mut items = vec![
             SettingsPageItem::SectionHeader("General Settings"),
             SettingsPageItem::SettingItem(SettingItem {
                 files: PROJECT,
@@ -139,27 +139,6 @@ fn general_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
-                files: USER,
-            }),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "CLI Default Open Behavior",
-                description: "How `zed <path>` opens directories when no flag is specified.",
-                field: Box::new(SettingField {
-                    json_path: Some("cli_default_open_behavior"),
-                    pick: |settings_content| {
-                        settings_content
-                            .workspace
-                            .cli_default_open_behavior
-                            .as_ref()
-                    },
-                    write: |settings_content, value| {
-                        settings_content.workspace.cli_default_open_behavior = value;
-                    },
-                }),
-                metadata: Some(Box::new(SettingsFieldMetadata {
-                    should_do_titlecase: Some(false),
-                    ..Default::default()
-                })),
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
@@ -221,7 +200,34 @@ fn general_page() -> SettingsPage {
                 metadata: None,
                 files: USER,
             }),
-        ]
+        ];
+
+        use feature_flags::FeatureFlagAppExt;
+        if cx.has_flag::<feature_flags::AgentV2FeatureFlag>() {
+            items.push(SettingsPageItem::SettingItem(SettingItem {
+                title: "CLI Default Open Behavior",
+                description: "How `zed <path>` opens directories when no flag is specified.",
+                field: Box::new(SettingField {
+                    json_path: Some("cli_default_open_behavior"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .cli_default_open_behavior
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content.workspace.cli_default_open_behavior = value;
+                    },
+                }),
+                metadata: Some(Box::new(SettingsFieldMetadata {
+                    should_do_titlecase: Some(false),
+                    ..Default::default()
+                })),
+                files: USER,
+            }));
+        }
+
+        items
     }
     fn security_section() -> [SettingsPageItem; 2] {
         [
@@ -391,13 +397,15 @@ fn general_page() -> SettingsPage {
     SettingsPage {
         title: "General",
         items: concat_sections!(
-            general_settings_section(),
+            @vec,
+            general_settings_section(cx),
             security_section(),
             workspace_restoration_section(),
             scoped_settings_section(),
             privacy_section(),
             auto_update_section(),
-        ),
+        )
+        .into(),
     }
 }
 


### PR DESCRIPTION
The `cli_default_open_behavior` setting controls how `zed <path>` opens directories, but the underlying behavior is gated behind the `AgentV2FeatureFlag` in `open_listener.rs`. Without the flag enabled, the setting has no effect — Zed always falls back to `NewWindow` behavior.

This change gates the settings UI entry behind the same feature flag so it only appears when the feature is actually active.

**Changes:**
- Converted `general_settings_section()` from a fixed-size array to a `Vec` so the CLI setting can be conditionally appended
- Added `feature_flags` as a dependency to `settings_ui`

Release Notes:

- N/A