### PR TITLE
agent_ui: Fix focus moving to buffer on worktree creation

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3512,7 +3512,10 @@ impl AgentPanel {
                 if !paths_to_open.is_empty() {
                     let open_task = workspace.open_paths(
                         paths_to_open,
-                        workspace::OpenOptions::default(),
+                        workspace::OpenOptions {
+                            focus: Some(false),
+                            ..Default::default()
+                        },
                         None,
                         window,
                         cx,


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/53941

Release Notes:

- N/A
