### PR TITLE
Update v0.232.x Stable Release Channel

### DIFF
--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-preview
+stable


### PR DESCRIPTION
Set `crates/zed/RELEASE_CHANNEL` from `dev` to `stable` for the v0.232.x release branch.