### PR TITLE
show the user the system prompt

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2969,6 +2969,23 @@ impl Thread {
         self.running_turn.is_none()
     }
 
+    /// Returns the fully rendered system prompt that would be sent to the model.
+    pub fn render_system_prompt(&self, cx: &App) -> anyhow::Result<String> {
+        let available_tools: Vec<_> = self
+            .running_turn
+            .as_ref()
+            .map(|turn| turn.tools.keys().cloned().collect())
+            .unwrap_or_default();
+
+        SystemPromptTemplate {
+            project: self.project_context.read(cx),
+            available_tools,
+            model_name: self.model.as_ref().map(|m| m.name().0.to_string()),
+        }
+        .render(&self.templates)
+        .context("failed to render system prompt")
+    }
+
     fn build_request_messages(
         &self,
         available_tools: Vec<SharedString>,

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -24,12 +24,11 @@ use zed_actions::{
     agent::{
         AddSelectionToThread, ConflictContent, OpenSettings, ReauthenticateAgent, ResetAgentZoom,
         ResetOnboarding, ResolveConflictedFilesWithAgent, ResolveConflictsWithAgent,
-        ReviewBranchDiff,
+        ReviewBranchDiff, ViewSystemPrompt,
     },
     assistant::{FocusAgent, OpenRulesLibrary, Toggle, ToggleFocus},
 };
 
-use crate::DEFAULT_THREAD_TITLE;
 use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore};
 use crate::{
     AddContextServer, AgentDiffPane, ConversationView, CopyThreadToClipboard, CreateWorktree,
@@ -46,6 +45,7 @@ use crate::{
     Agent, AgentInitialContent, ExternalSourcePrompt, NewExternalAgentThread,
     NewNativeAgentThreadFromSummary,
 };
+use crate::{DEFAULT_THREAD_TITLE, ViewSystemPromptModal};
 use crate::{ExpandMessageEditor, ThreadHistoryView};
 use crate::{ManageProfiles, ThreadHistoryViewEvent};
 use crate::{ThreadHistory, agent_connection_store::AgentConnectionStore};
@@ -284,6 +284,17 @@ pub fn init(cx: &mut App) {
                         panel.update(cx, |panel, cx| {
                             panel.toggle_worktree_selector(&ToggleWorktreeSelector, window, cx);
                         });
+                    }
+                })
+                .register_action(|workspace, _: &ViewSystemPrompt, window, cx| {
+                    if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                        if let Some(thread) = panel.read(cx).active_native_agent_thread(cx) {
+                            let system_prompt = match thread.read(cx).render_system_prompt(cx) {
+                                Ok(prompt) => prompt,
+                                Err(e) => format!("Failed to render system prompt: {}", e),
+                            };
+                            ViewSystemPromptModal::toggle(system_prompt, workspace, window, cx);
+                        }
                     }
                 })
                 .register_action(|_workspace, _: &ResetOnboarding, window, cx| {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -35,6 +35,7 @@ pub mod thread_worktree_archive;
 mod thread_worktree_picker;
 pub mod threads_archive_view;
 mod ui;
+mod view_system_prompt_modal;
 mod worktree_names;
 
 use std::path::PathBuf;
@@ -80,6 +81,7 @@ pub(crate) use model_selector_popover::ModelSelectorPopover;
 pub(crate) use thread_history::ThreadHistory;
 pub(crate) use thread_history_view::*;
 pub use thread_import::{AcpThreadImportOnboarding, ThreadImportModal};
+pub use view_system_prompt_modal::ViewSystemPromptModal;
 use zed_actions;
 
 pub const DEFAULT_THREAD_TITLE: &str = "New Agent Thread";

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4492,6 +4492,8 @@ impl ThreadView {
                     .as_ref()
                     .is_some_and(|checkpoint| checkpoint.show);
 
+                let is_native_thread = self.as_native_thread(cx).is_some();
+
                 let is_subagent = self.is_subagent();
                 let can_rewind = self.thread.read(cx).supports_truncate(cx);
                 let is_editable = can_rewind && message.id.is_some() && !is_subagent;
@@ -4514,6 +4516,28 @@ impl ThreadView {
                     .px_2()
                     .gap_1p5()
                     .w_full()
+                    .when(entry_ix == 0 && is_native_thread, |this| {
+                        this.child(
+                            h_flex()
+                                .px_3()
+                                .gap_2()
+                                .child(Divider::horizontal())
+                                .child(
+                                    Button::new("view-system-prompt", "View System Prompt")
+                                        .start_icon(Icon::new(IconName::FileTextFilled).size(IconSize::XSmall).color(Color::Muted))
+                                        .label_size(LabelSize::XSmall)
+                                        .color(Color::Muted)
+                                        .tooltip(Tooltip::text("View the fully templated system prompt the agent will see."))
+                                        .on_click(cx.listener(move |_this, _, window, cx| {
+                                            window.dispatch_action(
+                                                zed_actions::agent::ViewSystemPrompt.boxed_clone(),
+                                                cx,
+                                            );
+                                        }))
+                                )
+                                .child(Divider::horizontal())
+                        )
+                    })
                     .when(is_editable && has_checkpoint_button, |this| {
                         this.children(message.id.clone().map(|message_id| {
                             h_flex()

--- a/crates/agent_ui/src/view_system_prompt_modal.rs
+++ b/crates/agent_ui/src/view_system_prompt_modal.rs
@@ -1,0 +1,85 @@
+use gpui::{
+    App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Render, ScrollHandle,
+    SharedString, Window,
+};
+use markdown::{Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
+use ui::{KeyBinding, Modal, ModalFooter, ModalHeader, prelude::*};
+use workspace::{ModalView, Workspace};
+
+pub struct ViewSystemPromptModal {
+    focus_handle: FocusHandle,
+    scroll_handle: ScrollHandle,
+    markdown: Entity<Markdown>,
+}
+
+impl ViewSystemPromptModal {
+    pub fn toggle(
+        system_prompt: impl Into<SharedString>,
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let system_prompt = system_prompt.into();
+        let markdown = cx.new(|cx| Markdown::new(system_prompt, None, None, cx));
+
+        workspace.toggle_modal(window, cx, |_window, cx| Self {
+            focus_handle: cx.focus_handle(),
+            scroll_handle: ScrollHandle::new(),
+            markdown,
+        });
+    }
+
+    fn cancel(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent);
+    }
+}
+
+impl EventEmitter<DismissEvent> for ViewSystemPromptModal {}
+
+impl Focusable for ViewSystemPromptModal {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl ModalView for ViewSystemPromptModal {}
+
+impl Render for ViewSystemPromptModal {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let focus_handle = self.focus_handle(cx);
+        let markdown_style = MarkdownStyle::themed(MarkdownFont::Editor, window, cx);
+
+        v_flex()
+            .id("view-system-prompt-modal")
+            .key_context("ViewSystemPromptModal")
+            .w(rems(80.))
+            .max_h(rems(60.))
+            .elevation_3(cx)
+            .on_action(cx.listener(Self::cancel))
+            .capture_any_mouse_down(cx.listener(|this, _, window, cx| {
+                this.focus_handle(cx).focus(window, cx);
+            }))
+            .child(
+                Modal::new("view-system-prompt", Some(self.scroll_handle.clone()))
+                    .header(ModalHeader::new().headline("System Prompt"))
+                    .child(
+                        div()
+                            .px(DynamicSpacing::Base12.rems(cx))
+                            .py(DynamicSpacing::Base04.rems(cx))
+                            .child(MarkdownElement::new(self.markdown.clone(), markdown_style)),
+                    )
+                    .footer(
+                        ModalFooter::new().end_slot(
+                            Button::new("close", "Close")
+                                .key_binding(
+                                    KeyBinding::for_action_in(&menu::Cancel, &focus_handle, cx)
+                                        .map(|kb| kb.size(rems_from_px(12.))),
+                                )
+                                .on_click(cx.listener(|this, _event, window, cx| {
+                                    this.cancel(&menu::Cancel, window, cx)
+                                })),
+                        ),
+                    ),
+            )
+    }
+}

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -450,6 +450,12 @@ pub mod agent {
             OpenSettings,
             /// Opens the agent onboarding modal.
             OpenOnboardingModal,
+            /// Opens the ACP onboarding modal.
+            OpenAcpOnboardingModal,
+            /// Opens the Claude Agent onboarding modal.
+            OpenClaudeAgentOnboardingModal,
+            /// Opens a modal to view the system prompt for the current thread.
+            ViewSystemPrompt,
             /// Resets the agent onboarding state.
             ResetOnboarding,
             /// Starts a chat conversation with the agent.


### PR DESCRIPTION
Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Added: "View System Prompt" button to the top of all Zed Agent threads that the user can click in order to view the markdown-rendered, fully templated content of the system prompt that the agent is receiving.
