### PR TITLE
sidebar: Fix ellipsis menu options

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1751,25 +1751,19 @@ impl Sidebar {
                             )
                             .selectable(!is_active);
 
-                        menu.when(show_multi_project_entries, |menu| {
-                            let project_group_key = project_group_key.clone();
-                            let multi_workspace = multi_workspace.clone();
-                            menu.separator()
-                                .entry("Remove Project", None, move |window, cx| {
-                                    multi_workspace
-                                        .update(cx, |multi_workspace, cx| {
-                                            multi_workspace
-                                                .remove_project_group(
-                                                    &project_group_key,
-                                                    window,
-                                                    cx,
-                                                )
-                                                .detach_and_log_err(cx);
-                                        })
-                                        .ok();
-                                    weak_menu.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
-                                })
-                        })
+                        let project_group_key = project_group_key.clone();
+                        let multi_workspace = multi_workspace.clone();
+                        menu.separator()
+                            .entry("Remove Project", None, move |window, cx| {
+                                multi_workspace
+                                    .update(cx, |multi_workspace, cx| {
+                                        multi_workspace
+                                            .remove_project_group(&project_group_key, window, cx)
+                                            .detach_and_log_err(cx);
+                                    })
+                                    .ok();
+                                weak_menu.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
+                            })
                     });
 
                 let this = this.clone();


### PR DESCRIPTION
Just a quick follow up to https://github.com/zed-industries/zed/pull/54025 where I incorrectly wrapped the "Remove Project" button in a conditional, when it should be available at all times.

<img width="300" height="246" alt="Screenshot 2026-04-16 at 12  00@2x" src="https://github.com/user-attachments/assets/4218d24f-fe15-43d3-8d60-5c9d83d90d7e" />

Release Notes:

- N/A
