### PR TITLE
repl: Graduate notebook editor and add VSCode-parity polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14510,6 +14510,7 @@ dependencies = [
  "client",
  "collections",
  "command_palette_hooks",
+ "db",
  "editor",
  "feature_flags",
  "file_icons",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1475,6 +1475,7 @@
       "enter": "notebook::EnterEditMode",
       "down": "menu::SelectNext",
       "up": "menu::SelectPrevious",
+      "ctrl-backspace": "notebook::DeleteCell",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1610,6 +1610,7 @@
       "enter": "notebook::EnterEditMode",
       "down": "menu::SelectNext",
       "up": "menu::SelectPrevious",
+      "cmd-backspace": "notebook::DeleteCell",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1526,6 +1526,7 @@
       "enter": "notebook::EnterEditMode",
       "down": "menu::SelectNext",
       "up": "menu::SelectPrevious",
+      "ctrl-backspace": "notebook::DeleteCell",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1136,6 +1136,7 @@
       "enter": "notebook::EnterEditMode",
       "shift-enter": "notebook::RunAndAdvance",
       "ctrl-enter": "notebook::Run",
+      "d d": "notebook::DeleteCell",
     },
   },
   {

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -4,6 +4,10 @@ pub struct NotebookFeatureFlag;
 
 impl FeatureFlag for NotebookFeatureFlag {
     const NAME: &'static str = "notebooks";
+
+    fn enabled_for_all() -> bool {
+        true
+    }
 }
 
 pub struct PanicFeatureFlag;

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -25,6 +25,7 @@ base64.workspace = true
 client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
+db.workspace = true
 editor.workspace = true
 feature_flags.workspace = true
 file_icons.workspace = true

--- a/crates/repl/src/notebook.rs
+++ b/crates/repl/src/notebook.rs
@@ -1,4 +1,6 @@
 mod cell;
+mod notebook_toolbar;
 mod notebook_ui;
 pub use cell::*;
+pub use notebook_toolbar::*;
 pub use notebook_ui::*;

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -308,6 +308,44 @@ pub trait RenderableCell: Render {
 
     fn cell_position(&self) -> Option<&CellPosition>;
     fn set_cell_position(&mut self, position: CellPosition) -> &mut Self;
+
+    /// Wrap a cell's body (gutter + content) in the standard horizontal chrome
+    /// (rounded selection background, items-start alignment, base spacing).
+    /// Used by every cell type — extracting it here keeps the visual styling
+    /// consistent and avoids the per-cell duplication called out by the prior
+    /// `// TODO: Move base cell render into trait impl` comments.
+    fn cell_chrome(
+        &mut self,
+        gutter: gpui::AnyElement,
+        body: gpui::AnyElement,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
+        h_flex()
+            .w_full()
+            .pr_6()
+            .rounded_xs()
+            .items_start()
+            .gap(DynamicSpacing::Base08.rems(cx))
+            .bg(self.selected_bg_color(window, cx))
+            .child(gutter)
+            .child(body)
+    }
+
+    /// Wrap the chrome row(s) with the position-aware top/bottom spacers used at
+    /// the first and last cells in the notebook.
+    fn cell_outer<E: IntoElement>(
+        &mut self,
+        inner: E,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
+        v_flex()
+            .size_full()
+            .children(self.cell_position_spacer(true, window, cx))
+            .child(inner)
+            .children(self.cell_position_spacer(false, window, cx))
+    }
 }
 
 pub trait RunnableCell: RenderableCell {
@@ -518,76 +556,46 @@ impl RenderableCell for MarkdownCell {
 
 impl Render for MarkdownCell {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // If editing, show the editor
-        if self.editing {
-            return v_flex()
-                .size_full()
-                .children(self.cell_position_spacer(true, window, cx))
-                .child(
-                    h_flex()
-                        .w_full()
-                        .pr_6()
-                        .rounded_xs()
-                        .items_start()
-                        .gap(DynamicSpacing::Base08.rems(cx))
-                        .bg(self.selected_bg_color(window, cx))
-                        .child(self.gutter(window, cx))
-                        .child(
-                            div()
-                                .flex_1()
-                                .p_3()
-                                .bg(cx.theme().colors().editor_background)
-                                .rounded_sm()
-                                .child(self.editor.clone())
-                                .on_mouse_down(
-                                    gpui::MouseButton::Left,
-                                    cx.listener(|_this, _event, _window, _cx| {
-                                        // Prevent the click from propagating
-                                    }),
-                                ),
-                        ),
+        let body = if self.editing {
+            div()
+                .flex_1()
+                .p_3()
+                .bg(cx.theme().colors().editor_background)
+                .rounded_sm()
+                .child(self.editor.clone())
+                .on_mouse_down(
+                    gpui::MouseButton::Left,
+                    cx.listener(|_this, _event, _window, _cx| {
+                        // Prevent the click from propagating
+                    }),
                 )
-                .children(self.cell_position_spacer(false, window, cx));
-        }
-
-        // Preview mode - show rendered markdown
-
-        let style = MarkdownStyle {
-            base_text_style: window.text_style(),
-            ..Default::default()
+                .into_any_element()
+        } else {
+            let style = MarkdownStyle {
+                base_text_style: window.text_style(),
+                ..Default::default()
+            };
+            v_flex()
+                .image_cache(self.image_cache.clone())
+                .id("markdown-content")
+                .size_full()
+                .flex_1()
+                .p_3()
+                .font_ui(cx)
+                .text_size(TextSize::Default.rems(cx))
+                .cursor_pointer()
+                .on_click(cx.listener(|this, _event, window, cx| {
+                    this.editing = true;
+                    window.focus(&this.editor.focus_handle(cx), cx);
+                    cx.notify();
+                }))
+                .child(MarkdownElement::new(self.markdown.clone(), style))
+                .into_any_element()
         };
 
-        v_flex()
-            .size_full()
-            .children(self.cell_position_spacer(true, window, cx))
-            .child(
-                h_flex()
-                    .w_full()
-                    .pr_6()
-                    .rounded_xs()
-                    .items_start()
-                    .gap(DynamicSpacing::Base08.rems(cx))
-                    .bg(self.selected_bg_color(window, cx))
-                    .child(self.gutter(window, cx))
-                    .child(
-                        v_flex()
-                            .image_cache(self.image_cache.clone())
-                            .id("markdown-content")
-                            .size_full()
-                            .flex_1()
-                            .p_3()
-                            .font_ui(cx)
-                            .text_size(TextSize::Default.rems(cx))
-                            .cursor_pointer()
-                            .on_click(cx.listener(|this, _event, window, cx| {
-                                this.editing = true;
-                                window.focus(&this.editor.focus_handle(cx), cx);
-                                cx.notify();
-                            }))
-                            .child(MarkdownElement::new(self.markdown.clone(), style)),
-                    ),
-            )
-            .children(self.cell_position_spacer(false, window, cx))
+        let gutter = self.gutter(window, cx).into_any_element();
+        let chrome = self.cell_chrome(gutter, body, window, cx);
+        self.cell_outer(chrome, window, cx)
     }
 }
 
@@ -1051,7 +1059,6 @@ impl Render for CodeCell {
         };
         let output_max_width =
             plain::max_width_for_columns(ReplSettings::get_global(cx).max_columns, window, cx);
-        // get the language from the editor's buffer
         let language_name = self
             .editor
             .read(cx)
@@ -1061,151 +1068,124 @@ impl Render for CodeCell {
             .and_then(|buffer| buffer.read(cx).language())
             .map(|lang| lang.name().to_string());
 
-        v_flex()
-            .size_full()
-            // TODO: Move base cell render into trait impl so we don't have to repeat this
-            .children(self.cell_position_spacer(true, window, cx))
-            // Editor portion
+        let editor_body = div()
+            .py_1p5()
+            .w_full()
             .child(
-                h_flex()
-                    .w_full()
-                    .pr_6()
-                    .rounded_xs()
-                    .items_start()
-                    .gap(DynamicSpacing::Base08.rems(cx))
-                    .bg(self.selected_bg_color(window, cx))
-                    .child(self.gutter(window, cx))
-                    .child(
-                        div().py_1p5().w_full().child(
+                div()
+                    .relative()
+                    .flex()
+                    .size_full()
+                    .flex_1()
+                    .py_3()
+                    .px_5()
+                    .rounded_lg()
+                    .border_1()
+                    .border_color(cx.theme().colors().border)
+                    .bg(cx.theme().colors().editor_background)
+                    .child(div().w_full().child(self.editor.clone()))
+                    .when_some(language_name, |this, name| {
+                        this.child(
                             div()
-                                .relative()
-                                .flex()
-                                .size_full()
-                                .flex_1()
-                                .py_3()
-                                .px_5()
-                                .rounded_lg()
-                                .border_1()
-                                .border_color(cx.theme().colors().border)
-                                .bg(cx.theme().colors().editor_background)
-                                .child(div().w_full().child(self.editor.clone()))
-                                // lang badge in top-right corner
-                                .when_some(language_name, |this, name| {
-                                    this.child(
-                                        div()
-                                            .absolute()
-                                            .top_1()
-                                            .right_2()
-                                            .px_2()
-                                            .py_0p5()
-                                            .rounded_md()
-                                            .bg(cx.theme().colors().element_background.opacity(0.7))
-                                            .text_xs()
-                                            .text_color(cx.theme().colors().text_muted)
-                                            .child(name),
-                                    )
-                                }),
-                        ),
-                    ),
+                                .absolute()
+                                .top_1()
+                                .right_2()
+                                .px_2()
+                                .py_0p5()
+                                .rounded_md()
+                                .bg(cx.theme().colors().element_background.opacity(0.7))
+                                .text_xs()
+                                .text_color(cx.theme().colors().text_muted)
+                                .child(name),
+                        )
+                    }),
             )
-            .when(
-                self.has_outputs() || self.execution_duration.is_some() || self.is_executing,
-                |this| {
-                    let execution_time_label = self.execution_duration.map(Self::format_duration);
-                    let is_executing = self.is_executing;
-                    this.child(
-                        h_flex()
-                            .w_full()
-                            .pr_6()
-                            .rounded_xs()
-                            .items_start()
-                            .gap(DynamicSpacing::Base08.rems(cx))
-                            .bg(self.selected_bg_color(window, cx))
-                            .child(self.gutter_output(window, cx))
-                            .child(
-                                div().py_1p5().w_full().child(
-                                    v_flex()
-                                        .size_full()
-                                        .flex_1()
-                                        .py_3()
-                                        .px_5()
-                                        .rounded_lg()
-                                        .border_1()
-                                        // execution status/time at the TOP
-                                        .when(
-                                            is_executing || execution_time_label.is_some(),
-                                            |this| {
-                                                let time_element = if is_executing {
-                                                    h_flex()
-                                                        .gap_1()
-                                                        .items_center()
-                                                        .child(
-                                                            Icon::new(IconName::ArrowCircle)
-                                                                .size(IconSize::XSmall)
-                                                                .color(Color::Warning)
-                                                                .with_rotate_animation(2)
-                                                                .into_any_element(),
-                                                        )
-                                                        .child(
-                                                            div()
-                                                                .text_xs()
-                                                                .text_color(
-                                                                    cx.theme().colors().text_muted,
-                                                                )
-                                                                .child("Running..."),
-                                                        )
-                                                        .into_any_element()
-                                                } else if let Some(duration_text) =
-                                                    execution_time_label.clone()
-                                                {
-                                                    h_flex()
-                                                        .gap_1()
-                                                        .items_center()
-                                                        .child(
-                                                            Icon::new(IconName::Check)
-                                                                .size(IconSize::XSmall)
-                                                                .color(Color::Success),
-                                                        )
-                                                        .child(
-                                                            div()
-                                                                .text_xs()
-                                                                .text_color(
-                                                                    cx.theme().colors().text_muted,
-                                                                )
-                                                                .child(duration_text),
-                                                        )
-                                                        .into_any_element()
-                                                } else {
-                                                    div().into_any_element()
-                                                };
-                                                this.child(div().mb_2().child(time_element))
-                                            },
+            .into_any_element();
+
+        let editor_gutter = self.gutter(window, cx).into_any_element();
+        let editor_row = self.cell_chrome(editor_gutter, editor_body, window, cx);
+
+        let show_output_row =
+            self.has_outputs() || self.execution_duration.is_some() || self.is_executing;
+        let inner = v_flex().size_full().child(editor_row).when(
+            show_output_row,
+            |this| {
+                let execution_time_label = self.execution_duration.map(Self::format_duration);
+                let is_executing = self.is_executing;
+                let output_body = div()
+                    .py_1p5()
+                    .w_full()
+                    .child(
+                        v_flex()
+                            .size_full()
+                            .flex_1()
+                            .py_3()
+                            .px_5()
+                            .rounded_lg()
+                            .border_1()
+                            .when(is_executing || execution_time_label.is_some(), |this| {
+                                let time_element = if is_executing {
+                                    h_flex()
+                                        .gap_1()
+                                        .items_center()
+                                        .child(
+                                            Icon::new(IconName::ArrowCircle)
+                                                .size(IconSize::XSmall)
+                                                .color(Color::Warning)
+                                                .with_rotate_animation(2)
+                                                .into_any_element(),
                                         )
-                                        // output at bottom
                                         .child(
                                             div()
-                                                .id((
-                                                    ElementId::from(self.id.to_string()),
-                                                    "output-scroll",
-                                                ))
-                                                .w_full()
-                                                .when_some(output_max_width, |div, max_width| {
-                                                    div.max_w(max_width).overflow_x_scroll()
-                                                })
-                                                .when_some(output_max_height, |div, max_height| {
-                                                    div.max_h(max_height).overflow_y_scroll()
-                                                })
-                                                .children(self.outputs.iter().map(|output| {
-                                                    div().children(output.content(window, cx))
-                                                })),
-                                        ),
-                                ),
+                                                .text_xs()
+                                                .text_color(cx.theme().colors().text_muted)
+                                                .child("Running..."),
+                                        )
+                                        .into_any_element()
+                                } else if let Some(duration_text) = execution_time_label.clone() {
+                                    h_flex()
+                                        .gap_1()
+                                        .items_center()
+                                        .child(
+                                            Icon::new(IconName::Check)
+                                                .size(IconSize::XSmall)
+                                                .color(Color::Success),
+                                        )
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(cx.theme().colors().text_muted)
+                                                .child(duration_text),
+                                        )
+                                        .into_any_element()
+                                } else {
+                                    div().into_any_element()
+                                };
+                                this.child(div().mb_2().child(time_element))
+                            })
+                            .child(
+                                div()
+                                    .id((ElementId::from(self.id.to_string()), "output-scroll"))
+                                    .w_full()
+                                    .when_some(output_max_width, |div, max_width| {
+                                        div.max_w(max_width).overflow_x_scroll()
+                                    })
+                                    .when_some(output_max_height, |div, max_height| {
+                                        div.max_h(max_height).overflow_y_scroll()
+                                    })
+                                    .children(self.outputs.iter().map(|output| {
+                                        div().children(output.content(window, cx))
+                                    })),
                             ),
                     )
-                },
-            )
-            // TODO: Move base cell render into trait impl so we don't have to repeat this
-            .children(self.cell_position_spacer(false, window, cx))
+                    .into_any_element();
+
+                let output_gutter = self.gutter_output(window, cx).into_any_element();
+                this.child(self.cell_chrome(output_gutter, output_body, window, cx))
+            },
+        );
+
+        self.cell_outer(inner, window, cx)
     }
 }
 
@@ -1269,31 +1249,17 @@ impl RenderableCell for RawCell {
 
 impl Render for RawCell {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex()
+        let body = div()
+            .flex()
             .size_full()
-            // TODO: Move base cell render into trait impl so we don't have to repeat this
-            .children(self.cell_position_spacer(true, window, cx))
-            .child(
-                h_flex()
-                    .w_full()
-                    .pr_2()
-                    .rounded_xs()
-                    .items_start()
-                    .gap(DynamicSpacing::Base08.rems(cx))
-                    .bg(self.selected_bg_color(window, cx))
-                    .child(self.gutter(window, cx))
-                    .child(
-                        div()
-                            .flex()
-                            .size_full()
-                            .flex_1()
-                            .p_3()
-                            .font_ui(cx)
-                            .text_size(TextSize::Default.rems(cx))
-                            .child(self.source.clone()),
-                    ),
-            )
-            // TODO: Move base cell render into trait impl so we don't have to repeat this
-            .children(self.cell_position_spacer(false, window, cx))
+            .flex_1()
+            .p_3()
+            .font_ui(cx)
+            .text_size(TextSize::Default.rems(cx))
+            .child(self.source.clone())
+            .into_any_element();
+        let gutter = self.gutter(window, cx).into_any_element();
+        let chrome = self.cell_chrome(gutter, body, window, cx);
+        self.cell_outer(chrome, window, cx)
     }
 }

--- a/crates/repl/src/notebook/notebook_toolbar.rs
+++ b/crates/repl/src/notebook/notebook_toolbar.rs
@@ -1,0 +1,191 @@
+use gpui::{
+    Context, EventEmitter, Render, Styled as _, WeakEntity, Window, prelude::*,
+};
+use ui::{ButtonCommon, Color, Divider, IconButton, IconName, IconSize, Tooltip, prelude::*};
+use workspace::{
+    ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,
+};
+use zed_actions::notebook::{
+    AddCodeBlock, AddMarkdownBlock, ClearOutputs, DeleteCell, InterruptKernel, RestartKernel,
+    RunAll,
+};
+
+use super::{NotebookEditor, NotebookToolbarState};
+use crate::kernels::KernelStatus;
+
+/// Top toolbar shown above a notebook (between the tab bar and the cells).
+///
+/// Mirrors VSCode's notebook toolbar: cell-creation, run-all, clear-outputs,
+/// restart/interrupt kernel, and the kernel name + status. Hides itself when
+/// the active pane item is not a [`NotebookEditor`].
+pub struct NotebookToolbar {
+    notebook: Option<WeakEntity<NotebookEditor>>,
+    _notebook_subscription: Option<gpui::Subscription>,
+}
+
+impl Default for NotebookToolbar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NotebookToolbar {
+    pub fn new() -> Self {
+        Self {
+            notebook: None,
+            _notebook_subscription: None,
+        }
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for NotebookToolbar {}
+
+impl ToolbarItemView for NotebookToolbar {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        let Some(item) = active_pane_item else {
+            self.notebook = None;
+            self._notebook_subscription = None;
+            return ToolbarItemLocation::Hidden;
+        };
+
+        if let Some(notebook) = item.act_as::<NotebookEditor>(cx) {
+            self.notebook = Some(notebook.downgrade());
+            let toolbar_id = cx.entity_id();
+            self._notebook_subscription = Some(item.subscribe_to_item_events(
+                window,
+                cx,
+                Box::new(move |_event, _window, cx| cx.notify(toolbar_id)),
+            ));
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            self.notebook = None;
+            self._notebook_subscription = None;
+            ToolbarItemLocation::Hidden
+        }
+    }
+}
+
+impl Render for NotebookToolbar {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(notebook) = self
+            .notebook
+            .as_ref()
+            .and_then(|notebook| notebook.upgrade())
+        else {
+            return div();
+        };
+
+        let state = notebook.read(cx).toolbar_state(cx);
+        self.render_contents(state, cx)
+    }
+}
+
+impl NotebookToolbar {
+    fn render_contents(
+        &self,
+        state: NotebookToolbarState,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
+        let kernel_busy = matches!(state.kernel_status, KernelStatus::Busy);
+        let kernel_unavailable = matches!(
+            state.kernel_status,
+            KernelStatus::Shutdown | KernelStatus::Error | KernelStatus::ShuttingDown
+        );
+        let can_delete_cell = state.cell_count > 1;
+
+        h_flex()
+            .w_full()
+            .py_1()
+            .px_2()
+            .gap_1()
+            .items_center()
+            .child(
+                IconButton::new("notebook-add-code", IconName::Code)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Add code cell", &AddCodeBlock, cx))
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(AddCodeBlock), cx);
+                    })),
+            )
+            .child(
+                IconButton::new("notebook-add-md", IconName::Plus)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Add markdown cell", &AddMarkdownBlock, cx)
+                    })
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(AddMarkdownBlock), cx);
+                    })),
+            )
+            .child(Divider::vertical())
+            .child(
+                IconButton::new("notebook-run-all", IconName::PlayFilled)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Run all cells", &RunAll, cx))
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(RunAll), cx);
+                    })),
+            )
+            .child(
+                IconButton::new("notebook-clear", IconName::ListX)
+                    .icon_size(IconSize::Small)
+                    .disabled(!state.has_outputs)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Clear outputs of all cells", &ClearOutputs, cx)
+                    })
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(ClearOutputs), cx);
+                    })),
+            )
+            .child(Divider::vertical())
+            .child(
+                IconButton::new("notebook-restart", IconName::RotateCw)
+                    .icon_size(IconSize::Small)
+                    .disabled(kernel_unavailable)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Restart kernel", &RestartKernel, cx)
+                    })
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(RestartKernel), cx);
+                    })),
+            )
+            .child(
+                IconButton::new("notebook-interrupt", IconName::Stop)
+                    .icon_size(IconSize::Small)
+                    .disabled(!kernel_busy)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Interrupt kernel", &InterruptKernel, cx)
+                    })
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(InterruptKernel), cx);
+                    })),
+            )
+            .child(Divider::vertical())
+            .child(
+                IconButton::new("notebook-delete-cell", IconName::Trash)
+                    .icon_size(IconSize::Small)
+                    .disabled(!can_delete_cell)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Delete cell", &DeleteCell, cx)
+                    })
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(DeleteCell), cx);
+                    })),
+            )
+            .child(div().flex_1())
+            .child(
+                ui::Label::new(format!("Kernel: {}", state.kernel_name))
+                    .size(LabelSize::Small)
+                    .color(if kernel_unavailable {
+                        Color::Muted
+                    } else {
+                        Color::Default
+                    }),
+            )
+    }
+}

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1,50 +1,44 @@
-#![allow(unused, dead_code)]
-use std::future::Future;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
-use client::proto::ViewId;
 use collections::HashMap;
-use editor::DisplayPoint;
 use feature_flags::{FeatureFlagAppExt as _, NotebookFeatureFlag};
-use futures::FutureExt;
+use futures::FutureExt as _;
 use futures::future::Shared;
 use gpui::{
-    AnyElement, App, Entity, EventEmitter, FocusHandle, Focusable, KeyContext, ListScrollEvent,
-    ListState, Point, Task, actions, list, prelude::*,
+    AnyElement, App, Entity, EventEmitter, FocusHandle, Focusable, KeyContext, ListState, Point,
+    Task, WeakEntity, list, prelude::*,
 };
-use jupyter_protocol::JupyterKernelspec;
 use language::{Language, LanguageRegistry};
-use log;
 use project::{Project, ProjectEntryId, ProjectPath};
-use settings::Settings as _;
-use ui::{CommonAnimationExt, Tooltip, prelude::*};
+use ui::{PopoverMenuHandle, Tooltip, prelude::*};
 use workspace::item::{ItemEvent, SaveOptions, TabContentParams};
 use workspace::searchable::SearchableItemHandle;
-use workspace::{Item, ItemHandle, Pane, ProjectItem, ToolbarItemLocation};
+use workspace::{
+    ItemId, Item, Pane, ProjectItem, SerializableItem, Workspace, WorkspaceId,
+    delete_unloaded_items,
+};
 
 use super::{Cell, CellEvent, CellPosition, MarkdownCellEvent, RenderableCell};
 
 use nbformat::v4::CellId;
-use nbformat::v4::Metadata as NotebookMetadata;
-use serde_json;
 use uuid::Uuid;
 
 use crate::components::{KernelPickerDelegate, KernelSelector};
 use crate::kernels::{
-    Kernel, KernelSession, KernelSpecification, KernelStatus, LocalKernelSpecification,
-    NativeRunningKernel, RemoteRunningKernel, SshRunningKernel, WslRunningKernel,
+    Kernel, KernelSession, KernelSpecification, KernelStatus, NativeRunningKernel,
+    RemoteRunningKernel, SshRunningKernel, WslRunningKernel,
 };
 use crate::repl_store::ReplStore;
 
 use picker::Picker;
 use runtimelib::{ExecuteRequest, JupyterMessage, JupyterMessageContent};
-use ui::PopoverMenuHandle;
 use zed_actions::editor::{MoveDown, MoveUp};
 use zed_actions::notebook::{
-    AddCodeBlock, AddMarkdownBlock, ClearOutputs, EnterCommandMode, EnterEditMode, InterruptKernel,
-    MoveCellDown, MoveCellUp, NotebookMoveDown, NotebookMoveUp, OpenNotebook, RestartKernel, Run,
-    RunAll, RunAndAdvance,
+    AddCodeBlock, AddMarkdownBlock, ClearOutputs, DeleteCell, EnterCommandMode, EnterEditMode,
+    InterruptKernel, MoveCellDown, MoveCellUp, NotebookMoveDown, NotebookMoveUp, OpenNotebook,
+    RestartKernel, Run, RunAll, RunAndAdvance,
 };
 
 /// Whether the notebook is in command mode (navigating cells) or edit mode (editing a cell).
@@ -54,26 +48,43 @@ pub(crate) enum NotebookMode {
     Edit,
 }
 
-pub(crate) const MAX_TEXT_BLOCK_WIDTH: f32 = 9999.0;
-pub(crate) const SMALL_SPACING_SIZE: f32 = 8.0;
+/// Events emitted by `NotebookEditor` so the workspace can update the tab dirty
+/// indicator, schedule autosave, and trigger the unsaved-changes prompt on close.
+pub enum NotebookEditorEvent {
+    /// A cell was edited, added, removed, or moved.
+    Edit,
+    /// The displayed title (filename) changed.
+    TitleChanged,
+}
+
+/// Toolbar-relevant snapshot of a `NotebookEditor`. Kept as a plain struct so
+/// the toolbar can render without holding a borrow on the notebook itself.
+pub struct NotebookToolbarState {
+    pub kernel_status: KernelStatus,
+    pub kernel_name: String,
+    pub has_outputs: bool,
+    pub cell_count: usize,
+}
+
 pub(crate) const MEDIUM_SPACING_SIZE: f32 = 12.0;
-pub(crate) const LARGE_SPACING_SIZE: f32 = 16.0;
 pub(crate) const GUTTER_WIDTH: f32 = 19.0;
 pub(crate) const CODE_BLOCK_INSET: f32 = MEDIUM_SPACING_SIZE;
 pub(crate) const CONTROL_SIZE: f32 = 20.0;
 
 pub fn init(cx: &mut App) {
-    if cx.has_flag::<NotebookFeatureFlag>() || std::env::var("LOCAL_NOTEBOOK_DEV").is_ok() {
+    if cx.has_flag::<NotebookFeatureFlag>() {
         workspace::register_project_item::<NotebookEditor>(cx);
+        workspace::register_serializable_item::<NotebookEditor>(cx);
     }
 
     cx.observe_flag::<NotebookFeatureFlag, _>({
         move |is_enabled, cx| {
             if is_enabled {
                 workspace::register_project_item::<NotebookEditor>(cx);
+                workspace::register_serializable_item::<NotebookEditor>(cx);
             } else {
-                // todo: there is no way to unregister a project item, so if the feature flag
-                // gets turned off they need to restart Zed.
+                // There is no way to unregister a project item; if the flag is turned off
+                // server-side, the user must restart Zed for it to take effect.
             }
         }
     })
@@ -89,7 +100,6 @@ pub struct NotebookEditor {
     notebook_item: Entity<NotebookItem>,
     notebook_language: Shared<Task<Option<Arc<Language>>>>,
 
-    remote_id: Option<ViewId>,
     cell_list: ListState,
 
     notebook_mode: NotebookMode,
@@ -113,7 +123,6 @@ impl NotebookEditor {
         let focus_handle = cx.focus_handle();
 
         let languages = project.read(cx).languages().clone();
-        let language_name = notebook_item.read(cx).language_name();
         let worktree_id = notebook_item.read(cx).project_path.worktree_id;
 
         let notebook_language = notebook_item.read(cx).notebook_language();
@@ -133,52 +142,10 @@ impl NotebookEditor {
 
             match &cell_entity {
                 Cell::Code(code_cell) => {
-                    let cell_id_for_focus = cell_id.clone();
-                    cx.subscribe(code_cell, move |this, _cell, event, cx| match event {
-                        CellEvent::Run(cell_id) => this.execute_cell(cell_id.clone(), cx),
-                        CellEvent::FocusedIn(_) => this.select_cell_by_id(&cell_id_for_focus, cx),
-                    })
-                    .detach();
-
-                    let cell_id_for_editor = cell_id.clone();
-                    let editor = code_cell.read(cx).editor().clone();
-                    cx.subscribe(&editor, move |this, _editor, event, cx| {
-                        if let editor::EditorEvent::Focused = event {
-                            this.select_cell_by_id(&cell_id_for_editor, cx);
-                        }
-                    })
-                    .detach();
+                    Self::subscribe_to_code_cell(code_cell, cell_id.clone(), cx);
                 }
                 Cell::Markdown(markdown_cell) => {
-                    cx.subscribe(
-                        markdown_cell,
-                        move |_this, cell, event: &MarkdownCellEvent, cx| {
-                            match event {
-                                MarkdownCellEvent::FinishedEditing => {
-                                    cell.update(cx, |cell, cx| {
-                                        cell.reparse_markdown(cx);
-                                    });
-                                }
-                                MarkdownCellEvent::Run(_cell_id) => {
-                                    // run is handled separately by move_to_next_cell
-                                    // Just reparse here
-                                    cell.update(cx, |cell, cx| {
-                                        cell.reparse_markdown(cx);
-                                    });
-                                }
-                            }
-                        },
-                    )
-                    .detach();
-
-                    let cell_id_for_editor = cell_id.clone();
-                    let editor = markdown_cell.read(cx).editor().clone();
-                    cx.subscribe(&editor, move |this, _editor, event, cx| {
-                        if let editor::EditorEvent::Focused = event {
-                            this.select_cell_by_id(&cell_id_for_editor, cx);
-                        }
-                    })
-                    .detach();
+                    Self::subscribe_to_markdown_cell(markdown_cell, cell_id.clone(), cx);
                 }
                 Cell::Raw(_) => {}
             }
@@ -186,11 +153,7 @@ impl NotebookEditor {
             cell_map.insert(cell_id.clone(), cell_entity);
         }
 
-        let notebook_handle = cx.entity().downgrade();
-        let cell_count = cell_order.len();
-
-        let this = cx.entity();
-        let cell_list = ListState::new(cell_count, gpui::ListAlignment::Top, px(1000.));
+        let cell_list = ListState::new(cell_order.len(), gpui::ListAlignment::Top, px(1000.));
 
         let mut editor = Self {
             project,
@@ -199,14 +162,17 @@ impl NotebookEditor {
             focus_handle,
             notebook_item: notebook_item.clone(),
             notebook_language,
-            remote_id: None,
             cell_list,
             notebook_mode: NotebookMode::Command,
             selected_cell_index: 0,
             cell_order: cell_order.clone(),
             original_cell_order: cell_order.clone(),
             cell_map: cell_map.clone(),
-            kernel: Kernel::Shutdown, // TODO: use recommended kernel after the implementation is done in repl
+            // Initial kernel state — `launch_kernel` below picks a real one from
+            // `ReplStore::active_kernelspec` if the user's worktree has a Python with
+            // ipykernel installed. Otherwise the kernel stays Shutdown until the user
+            // picks one via the kernel picker.
+            kernel: Kernel::Shutdown,
             kernel_specification: None,
             execution_requests: HashMap::default(),
             kernel_picker_handle: PopoverMenuHandle::default(),
@@ -219,7 +185,113 @@ impl NotebookEditor {
         })
         .detach();
 
+        // Reload the notebook when its underlying buffer changes on disk
+        // (e.g. external editor save, `git checkout`, file revert).
+        let buffer = notebook_item.read(cx).buffer.clone();
+        cx.subscribe_in(
+            &buffer,
+            window,
+            |this, _buffer, event, window, cx| {
+                if matches!(event, language::BufferEvent::Reloaded) {
+                    let project = this.project.clone();
+                    this.reload(project, window, cx)
+                        .detach_and_log_err(cx);
+                }
+            },
+        )
+        .detach();
+
         editor
+    }
+
+    /// Subscribe `NotebookEditor` to a code cell so its run/focus events route here
+    /// and edits inside the cell's embedded editor bubble up as `NotebookEditorEvent::Edit`.
+    fn subscribe_to_code_cell(
+        code_cell: &Entity<super::CodeCell>,
+        cell_id: CellId,
+        cx: &mut Context<Self>,
+    ) {
+        let cell_id_for_focus = cell_id.clone();
+        cx.subscribe(code_cell, move |this, _cell, event, cx| match event {
+            CellEvent::Run(cell_id) => this.execute_cell(cell_id.clone(), cx),
+            CellEvent::FocusedIn(_) => this.select_cell_by_id(&cell_id_for_focus, cx),
+        })
+        .detach();
+
+        let editor = code_cell.read(cx).editor().clone();
+        cx.subscribe(&editor, move |this, _editor, event, cx| match event {
+            editor::EditorEvent::Focused => {
+                this.select_cell_by_id(&cell_id, cx);
+            }
+            editor::EditorEvent::BufferEdited => {
+                this.note_edit(cx);
+            }
+            _ => {}
+        })
+        .detach();
+    }
+
+    /// Subscribe `NotebookEditor` to a markdown cell so render/run events route here
+    /// and edits inside the cell's embedded editor bubble up as `NotebookEditorEvent::Edit`.
+    fn subscribe_to_markdown_cell(
+        markdown_cell: &Entity<super::MarkdownCell>,
+        cell_id: CellId,
+        cx: &mut Context<Self>,
+    ) {
+        cx.subscribe(
+            markdown_cell,
+            move |_this, cell, event: &MarkdownCellEvent, cx| match event {
+                MarkdownCellEvent::FinishedEditing | MarkdownCellEvent::Run(_) => {
+                    cell.update(cx, |cell, cx| {
+                        cell.reparse_markdown(cx);
+                    });
+                }
+            },
+        )
+        .detach();
+
+        let editor = markdown_cell.read(cx).editor().clone();
+        cx.subscribe(&editor, move |this, _editor, event, cx| match event {
+            editor::EditorEvent::Focused => {
+                this.select_cell_by_id(&cell_id, cx);
+            }
+            editor::EditorEvent::BufferEdited => {
+                this.note_edit(cx);
+            }
+            _ => {}
+        })
+        .detach();
+    }
+
+    /// Mark the notebook as edited, propagating the change to the workspace tab indicator,
+    /// autosave, and the unsaved-changes prompt via `to_item_events`.
+    fn note_edit(&mut self, cx: &mut Context<Self>) {
+        self.notebook_item.update(cx, |item, _cx| {
+            item.dirty = true;
+        });
+        cx.emit(NotebookEditorEvent::Edit);
+    }
+
+    /// Snapshot of the notebook state needed by the toolbar.
+    pub fn toolbar_state(&self, cx: &App) -> NotebookToolbarState {
+        let has_outputs = self.cell_map.values().any(|cell| {
+            if let Cell::Code(code) = cell {
+                code.read(cx).has_outputs()
+            } else {
+                false
+            }
+        });
+        let kernel_name = self
+            .kernel_specification
+            .as_ref()
+            .map(|spec| spec.name().to_string())
+            .unwrap_or_else(|| "Select Kernel".to_string());
+        NotebookToolbarState {
+            kernel_status: self.kernel.status(),
+            kernel_name,
+            has_outputs,
+            cell_count: self.cell_map.len(),
+        }
     }
 
     fn refresh_language(&mut self, cx: &mut Context<Self>) {
@@ -309,33 +381,56 @@ impl NotebookEditor {
                 Cell::Raw(_) => {}
             }
         }
+        self.notebook_item.update(cx, |item, _cx| {
+            item.dirty = false;
+        });
+        cx.emit(NotebookEditorEvent::Edit);
         cx.notify();
     }
 
+    /// Pick a sensible kernel and launch it. Reuses `ReplStore::active_kernelspec`,
+    /// which prefers the worktree's active Python toolchain if it has `ipykernel`
+    /// installed and falls back to other discovered Python environments.
+    ///
+    /// If no kernel can be picked yet (the async kernelspec discovery is still in
+    /// flight, or the user has no Python with ipykernel installed), we leave the
+    /// kernel in `Shutdown` state and wait — either for `ReplStore` to discover
+    /// new specs (we observe it once and retry), or for the user to pick a kernel
+    /// manually via the kernel picker.
     fn launch_kernel(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        // use default Python kernel if no specification is set
-        let spec = self.kernel_specification.clone().unwrap_or_else(|| {
-            KernelSpecification::Jupyter(LocalKernelSpecification {
-                name: "python3".to_string(),
-                path: PathBuf::from("python3"),
-                kernelspec: JupyterKernelspec {
-                    argv: vec![
-                        "python3".to_string(),
-                        "-m".to_string(),
-                        "ipykernel_launcher".to_string(),
-                        "-f".to_string(),
-                        "{connection_file}".to_string(),
-                    ],
-                    display_name: "Python 3".to_string(),
-                    language: "python".to_string(),
-                    interrupt_mode: None,
-                    metadata: None,
-                    env: None,
-                },
-            })
-        });
+        if let Some(spec) = self.kernel_specification.clone() {
+            self.launch_kernel_with_spec(spec, window, cx);
+            return;
+        }
 
-        self.launch_kernel_with_spec(spec, window, cx);
+        if let Some(spec) = self.pick_recommended_kernel(cx) {
+            self.launch_kernel_with_spec(spec, window, cx);
+            return;
+        }
+
+        // The notebook's language may not have resolved yet, or `ReplStore` may
+        // still be scanning Python environments. Spawn a one-shot retry that
+        // awaits the language and tries again.
+        let language_task = self.notebook_language.clone();
+        cx.spawn_in(window, async move |this, cx| {
+            let _ = language_task.await;
+            this.update_in(cx, |this, window, cx| {
+                if matches!(this.kernel, Kernel::Shutdown)
+                    && let Some(spec) = this.pick_recommended_kernel(cx)
+                {
+                    this.launch_kernel_with_spec(spec, window, cx);
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn pick_recommended_kernel(&self, cx: &App) -> Option<KernelSpecification> {
+        let language = self.notebook_language.clone().now_or_never().flatten();
+        ReplStore::global(cx)
+            .read(cx)
+            .active_kernelspec(self.worktree_id, language, cx)
     }
 
     fn launch_kernel_with_spec(
@@ -521,9 +616,13 @@ impl NotebookEditor {
         if let Kernel::RunningKernel(kernel) = &mut self.kernel {
             kernel.request_tx().try_send(message).ok();
         }
+
+        // Outputs and execution_count are persisted in the .ipynb file, so an
+        // execution always dirties the notebook.
+        self.note_edit(cx);
     }
 
-    fn has_outputs(&self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+    fn has_outputs(&self, _window: &mut Window, cx: &mut Context<Self>) -> bool {
         self.cell_map.values().any(|cell| {
             if let Cell::Code(code_cell) = cell {
                 code_cell.read(cx).has_outputs()
@@ -533,19 +632,27 @@ impl NotebookEditor {
         })
     }
 
-    fn clear_outputs(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn clear_outputs(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let mut cleared_any = false;
         for cell in self.cell_map.values() {
             if let Cell::Code(code_cell) = cell {
                 code_cell.update(cx, |cell, cx| {
-                    cell.clear_outputs();
-                    cx.notify();
+                    if cell.has_outputs() {
+                        cell.clear_outputs();
+                        cleared_any = true;
+                        cx.notify();
+                    }
                 });
             }
         }
-        cx.notify();
+        if cleared_any {
+            self.note_edit(cx);
+        } else {
+            cx.notify();
+        }
     }
 
-    fn run_cells(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn run_cells(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         for cell_id in self.cell_order.clone() {
             self.execute_cell(cell_id, cx);
         }
@@ -659,56 +766,42 @@ impl NotebookEditor {
         cx.notify();
     }
 
-    // Discussion can be done on this default implementation
-    /// Moves focus to the next cell editor (used when already in edit mode).
-    fn move_to_next_cell(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.cell_order.is_empty() && self.selected_cell_index < self.cell_order.len() - 1 {
-            self.selected_cell_index += 1;
-            // focus the new cell's editor
-            if let Some(cell_id) = self.cell_order.get(self.selected_cell_index) {
-                if let Some(cell) = self.cell_map.get(cell_id) {
-                    match cell {
-                        Cell::Code(code_cell) => {
-                            let editor = code_cell.read(cx).editor();
-                            window.focus(&editor.focus_handle(cx), cx);
-                        }
-                        Cell::Markdown(markdown_cell) => {
-                            // Don't auto-enter edit mode for next markdown cell
-                            // Just select it
-                        }
-                        Cell::Raw(_) => {}
-                    }
-                }
-            }
-            cx.notify();
-        } else {
-            // in the end, could optionally create a new cell
-            // For now, just stay on the current cell
-        }
-    }
+    fn open_notebook(&mut self, _: &OpenNotebook, _window: &mut Window, _cx: &mut Context<Self>) {}
 
-    fn open_notebook(&mut self, _: &OpenNotebook, _window: &mut Window, _cx: &mut Context<Self>) {
-        println!("Open notebook triggered");
-    }
-
-    fn move_cell_up(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        println!("Move cell up triggered");
+    fn move_cell_up(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         if self.selected_cell_index > 0 {
             self.cell_order
                 .swap(self.selected_cell_index, self.selected_cell_index - 1);
             self.selected_cell_index -= 1;
-            cx.notify();
+            self.note_edit(cx);
         }
     }
 
-    fn move_cell_down(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        println!("Move cell down triggered");
+    fn move_cell_down(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         if !self.cell_order.is_empty() && self.selected_cell_index < self.cell_order.len() - 1 {
             self.cell_order
                 .swap(self.selected_cell_index, self.selected_cell_index + 1);
             self.selected_cell_index += 1;
-            cx.notify();
+            self.note_edit(cx);
         }
+    }
+
+    /// Delete the currently selected cell. Refuses to delete the last cell so
+    /// the notebook always has at least one cell to focus.
+    fn delete_cell(&mut self, _: &DeleteCell, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.cell_count() <= 1 {
+            return;
+        }
+        let cell_id = self.cell_order.remove(self.selected_cell_index);
+        self.cell_map.remove(&cell_id);
+        self.cell_list
+            .splice(self.selected_cell_index..self.selected_cell_index + 1, 0);
+        if self.selected_cell_index >= self.cell_count() {
+            self.selected_cell_index = self.cell_count().saturating_sub(1);
+        }
+        self.cell_list
+            .scroll_to_reveal_item(self.selected_cell_index);
+        self.note_edit(cx);
     }
 
     fn insert_cell_at_current_position(&mut self, cell_id: CellId, cell: Cell) {
@@ -741,26 +834,7 @@ impl NotebookEditor {
             )
         });
 
-        cx.subscribe(
-            &markdown_cell,
-            move |_this, cell, event: &MarkdownCellEvent, cx| match event {
-                MarkdownCellEvent::FinishedEditing | MarkdownCellEvent::Run(_) => {
-                    cell.update(cx, |cell, cx| {
-                        cell.reparse_markdown(cx);
-                    });
-                }
-            },
-        )
-        .detach();
-
-        let cell_id_for_editor = new_cell_id.clone();
-        let editor = markdown_cell.read(cx).editor().clone();
-        cx.subscribe(&editor, move |this, _editor, event, cx| {
-            if let editor::EditorEvent::Focused = event {
-                this.select_cell_by_id(&cell_id_for_editor, cx);
-            }
-        })
-        .detach();
+        Self::subscribe_to_markdown_cell(&markdown_cell, new_cell_id.clone(), cx);
 
         self.insert_cell_at_current_position(new_cell_id, Cell::Markdown(markdown_cell.clone()));
         markdown_cell.update(cx, |cell, cx| {
@@ -770,7 +844,7 @@ impl NotebookEditor {
         let editor = markdown_cell.read(cx).editor().clone();
         window.focus(&editor.focus_handle(cx), cx);
         self.notebook_mode = NotebookMode::Edit;
-        cx.notify();
+        self.note_edit(cx);
     }
 
     fn add_code_block(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -790,27 +864,13 @@ impl NotebookEditor {
             )
         });
 
-        let cell_id_for_run = new_cell_id.clone();
-        cx.subscribe(&code_cell, move |this, _cell, event, cx| match event {
-            CellEvent::Run(cell_id) => this.execute_cell(cell_id.clone(), cx),
-            CellEvent::FocusedIn(_) => this.select_cell_by_id(&cell_id_for_run, cx),
-        })
-        .detach();
-
-        let cell_id_for_editor = new_cell_id.clone();
-        let editor = code_cell.read(cx).editor().clone();
-        cx.subscribe(&editor, move |this, _editor, event, cx| {
-            if let editor::EditorEvent::Focused = event {
-                this.select_cell_by_id(&cell_id_for_editor, cx);
-            }
-        })
-        .detach();
+        Self::subscribe_to_code_cell(&code_cell, new_cell_id.clone(), cx);
 
         self.insert_cell_at_current_position(new_cell_id, Cell::Code(code_cell.clone()));
         let editor = code_cell.read(cx).editor().clone();
         window.focus(&editor.focus_handle(cx), cx);
         self.notebook_mode = NotebookMode::Edit;
-        cx.notify();
+        self.note_edit(cx);
     }
 
     fn cell_count(&self) -> usize {
@@ -911,7 +971,7 @@ impl NotebookEditor {
         self.cell_list.scroll_to_reveal_item(index);
     }
 
-    fn button_group(window: &mut Window, cx: &mut Context<Self>) -> Div {
+    fn button_group(_window: &mut Window, cx: &mut Context<Self>) -> Div {
         v_flex()
             .gap(DynamicSpacing::Base04.rems(cx))
             .items_center()
@@ -961,7 +1021,7 @@ impl NotebookEditor {
                                     window,
                                     cx,
                                 )
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Execute all cells", &RunAll, cx)
                                 })
                                 .on_click(|_, window, cx| {
@@ -976,7 +1036,7 @@ impl NotebookEditor {
                                     cx,
                                 )
                                 .disabled(!has_outputs)
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Clear all outputs", &ClearOutputs, cx)
                                 })
                                 .on_click(|_, window, cx| {
@@ -993,7 +1053,7 @@ impl NotebookEditor {
                                     window,
                                     cx,
                                 )
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Move cell up", &MoveCellUp, cx)
                                 })
                                 .on_click(|_, window, cx| {
@@ -1007,7 +1067,7 @@ impl NotebookEditor {
                                     window,
                                     cx,
                                 )
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Move cell down", &MoveCellDown, cx)
                                 })
                                 .on_click(|_, window, cx| {
@@ -1024,7 +1084,7 @@ impl NotebookEditor {
                                     window,
                                     cx,
                                 )
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Add markdown block", &AddMarkdownBlock, cx)
                                 })
                                 .on_click(|_, window, cx| {
@@ -1038,7 +1098,7 @@ impl NotebookEditor {
                                     window,
                                     cx,
                                 )
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Add code block", &AddCodeBlock, cx)
                                 })
                                 .on_click(|_, window, cx| {
@@ -1109,27 +1169,6 @@ impl NotebookEditor {
             KernelStatus::Restarting => (IconName::ArrowCircle, Color::Warning),
         };
 
-        let is_spinning = matches!(
-            kernel_status,
-            KernelStatus::Busy
-                | KernelStatus::Starting
-                | KernelStatus::ShuttingDown
-                | KernelStatus::Restarting
-        );
-
-        let status_icon_element = if is_spinning {
-            Icon::new(status_icon)
-                .size(IconSize::Small)
-                .color(status_color)
-                .with_rotate_animation(2)
-                .into_any_element()
-        } else {
-            Icon::new(status_icon)
-                .size(IconSize::Small)
-                .color(status_color)
-                .into_any_element()
-        };
-
         let worktree_id = self.worktree_id;
         let kernel_picker_handle = self.kernel_picker_handle.clone();
         let view = cx.entity().downgrade();
@@ -1173,7 +1212,7 @@ impl NotebookEditor {
                     .child(
                         IconButton::new("restart-kernel", IconName::RotateCw)
                             .icon_size(IconSize::Small)
-                            .tooltip(|window, cx| {
+                            .tooltip(|_window, cx| {
                                 Tooltip::for_action("Restart Kernel", &RestartKernel, cx)
                             })
                             .on_click(cx.listener(|this, _, window, cx| {
@@ -1184,7 +1223,7 @@ impl NotebookEditor {
                         IconButton::new("interrupt-kernel", IconName::Stop)
                             .icon_size(IconSize::Small)
                             .disabled(!matches!(kernel_status, KernelStatus::Busy))
-                            .tooltip(|window, cx| {
+                            .tooltip(|_window, cx| {
                                 Tooltip::for_action("Interrupt Kernel", &InterruptKernel, cx)
                             })
                             .on_click(cx.listener(|this, _, window, cx| {
@@ -1218,7 +1257,7 @@ impl NotebookEditor {
         &self,
         index: usize,
         cell: &Cell,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let cell_position = self.cell_position(index);
@@ -1285,6 +1324,9 @@ impl Render for NotebookEditor {
             )
             .on_action(
                 cx.listener(|this, _: &MoveCellDown, window, cx| this.move_cell_down(window, cx)),
+            )
+            .on_action(
+                cx.listener(|this, action, window, cx| this.delete_cell(action, window, cx)),
             )
             .on_action(cx.listener(|this, _: &AddMarkdownBlock, window, cx| {
                 this.add_markdown_block(window, cx)
@@ -1517,6 +1559,14 @@ pub struct NotebookItem {
     notebook: nbformat::v4::Notebook,
     // Store our version of the notebook in memory (cell_order, cell_map)
     id: ProjectEntryId,
+    /// Mirrors `NotebookEditor::is_dirty`. The `project::ProjectItem::is_dirty`
+    /// trait method takes `&self` only, so the editor pushes its dirty state here
+    /// via `note_edit` / `mark_as_saved` instead of reading it back through `cx`.
+    pub(super) dirty: bool,
+    /// The underlying file buffer. We hold on to it so `NotebookEditor` can
+    /// subscribe to `BufferEvent::Reloaded` and reload the cells in response to
+    /// external edits (e.g. `git checkout`, save from another editor).
+    pub(super) buffer: Entity<language::Buffer>,
 }
 
 impl project::ProjectItem for NotebookItem {
@@ -1527,7 +1577,6 @@ impl project::ProjectItem for NotebookItem {
     ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
         let path = path.clone();
         let project = project.clone();
-        let fs = project.read(cx).fs().clone();
         let languages = project.read(cx).languages().clone();
 
         if path.path.extension().unwrap_or_default() == "ipynb" {
@@ -1597,6 +1646,8 @@ impl project::ProjectItem for NotebookItem {
                     languages,
                     notebook,
                     id,
+                    dirty: false,
+                    buffer,
                 }))
             }))
         } else {
@@ -1613,8 +1664,7 @@ impl project::ProjectItem for NotebookItem {
     }
 
     fn is_dirty(&self) -> bool {
-        // TODO: Track if notebook metadata or structure has changed
-        false
+        self.dirty
     }
 }
 
@@ -1649,55 +1699,22 @@ impl NotebookItem {
 
 impl EventEmitter<()> for NotebookItem {}
 
-impl EventEmitter<()> for NotebookEditor {}
-
-// pub struct NotebookControls {
-//     pane_focused: bool,
-//     active_item: Option<Box<dyn ItemHandle>>,
-//     // subscription: Option<Subscription>,
-// }
-
-// impl NotebookControls {
-//     pub fn new() -> Self {
-//         Self {
-//             pane_focused: false,
-//             active_item: Default::default(),
-//             // subscription: Default::default(),
-//         }
-//     }
-// }
-
-// impl EventEmitter<ToolbarItemEvent> for NotebookControls {}
-
-// impl Render for NotebookControls {
-//     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-//         div().child("notebook controls")
-//     }
-// }
-
-// impl ToolbarItemView for NotebookControls {
-//     fn set_active_pane_item(
-//         &mut self,
-//         active_pane_item: Option<&dyn workspace::ItemHandle>,
-//         window: &mut Window, cx: &mut Context<Self>,
-//     ) -> workspace::ToolbarItemLocation {
-//         cx.notify();
-//         self.active_item = None;
-
-//         let Some(item) = active_pane_item else {
-//             return ToolbarItemLocation::Hidden;
-//         };
-
-//         ToolbarItemLocation::PrimaryLeft
-//     }
-
-//     fn pane_focus_update(&mut self, pane_focused: bool, _window: &mut Window, _cx: &mut Context<Self>) {
-//         self.pane_focused = pane_focused;
-//     }
-// }
+impl EventEmitter<NotebookEditorEvent> for NotebookEditor {}
 
 impl Item for NotebookEditor {
-    type Event = ();
+    type Event = NotebookEditorEvent;
+
+    fn to_item_events(event: &Self::Event, f: &mut dyn FnMut(ItemEvent)) {
+        match event {
+            NotebookEditorEvent::Edit => {
+                f(ItemEvent::Edit);
+                f(ItemEvent::UpdateTab);
+            }
+            NotebookEditorEvent::TitleChanged => {
+                f(ItemEvent::UpdateTab);
+            }
+        }
+    }
 
     fn can_split(&self) -> bool {
         true
@@ -1740,7 +1757,7 @@ impl Item for NotebookEditor {
             .into()
     }
 
-    fn tab_content(&self, params: TabContentParams, window: &Window, cx: &App) -> AnyElement {
+    fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
         Label::new(self.tab_content_text(params.detail.unwrap_or(0), cx))
             .single_line()
             .color(params.text_color())
@@ -1752,8 +1769,12 @@ impl Item for NotebookEditor {
         Some(IconName::Book.into())
     }
 
+    fn telemetry_event_text(&self) -> Option<&'static str> {
+        Some("Notebook Editor")
+    }
+
     fn show_toolbar(&self) -> bool {
-        false
+        true
     }
 
     // TODO
@@ -1825,7 +1846,7 @@ impl Item for NotebookEditor {
 
     fn reload(
         &mut self,
-        project: Entity<Project>,
+        _project: Entity<Project>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
@@ -1910,6 +1931,20 @@ impl ProjectItem for NotebookEditor {
     }
 }
 
+/// Whether a kernel message updates state that gets serialized into the .ipynb
+/// file (outputs or execution_count). Used to keep the notebook's dirty state
+/// in sync with kernel responses.
+fn mutates_persisted_cell_state(content: &JupyterMessageContent) -> bool {
+    matches!(
+        content,
+        JupyterMessageContent::StreamContent(_)
+            | JupyterMessageContent::DisplayData(_)
+            | JupyterMessageContent::ExecuteResult(_)
+            | JupyterMessageContent::ExecuteInput(_)
+            | JupyterMessageContent::ErrorOutput(_)
+    )
+}
+
 impl KernelSession for NotebookEditor {
     fn route(&mut self, message: &JupyterMessage, window: &mut Window, cx: &mut Context<Self>) {
         // Handle kernel status updates (these are broadcast to all)
@@ -1939,6 +1974,9 @@ impl KernelSession for NotebookEditor {
                     cell.update(cx, |cell, cx| {
                         cell.handle_message(message, window, cx);
                     });
+                    if mutates_persisted_cell_state(&message.content) {
+                        self.note_edit(cx);
+                    }
                 }
             }
         }
@@ -1947,5 +1985,140 @@ impl KernelSession for NotebookEditor {
     fn kernel_errored(&mut self, error_message: String, cx: &mut Context<Self>) {
         self.kernel = Kernel::ErroredLaunch(error_message);
         cx.notify();
+    }
+}
+
+impl SerializableItem for NotebookEditor {
+    fn serialized_item_kind() -> &'static str {
+        "NotebookEditor"
+    }
+
+    fn cleanup(
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        delete_unloaded_items(
+            alive_items,
+            workspace_id,
+            "notebook_editors",
+            &persistence::NotebookEditorDb::global(cx),
+            cx,
+        )
+    }
+
+    fn deserialize(
+        project: Entity<Project>,
+        _workspace: WeakEntity<Workspace>,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<Entity<Self>>> {
+        use project::ProjectItem as _;
+
+        let db = persistence::NotebookEditorDb::global(cx);
+        window.spawn(cx, async move |cx| {
+            let abs_path = db
+                .get_notebook_path(item_id, workspace_id)?
+                .context("No notebook path found")?;
+
+            let (worktree, relative_path) = project
+                .update(cx, |project, cx| {
+                    project.find_or_create_worktree(abs_path.clone(), false, cx)
+                })
+                .await
+                .context("Worktree not found")?;
+            let worktree_id = worktree.read_with(cx, |worktree, _cx| worktree.id());
+            let project_path = ProjectPath {
+                worktree_id,
+                path: relative_path,
+            };
+
+            let open_task = cx.update(|_window, cx| {
+                NotebookItem::try_open(&project, &project_path, cx)
+            })?;
+            let notebook_item = open_task
+                .context("Notebook items must claim .ipynb files")?
+                .await?;
+
+            cx.update(|window, cx| {
+                cx.new(|cx| NotebookEditor::new(project, notebook_item, window, cx))
+            })
+        })
+    }
+
+    fn serialize(
+        &mut self,
+        workspace: &mut Workspace,
+        item_id: ItemId,
+        _closing: bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<()>>> {
+        let workspace_id = workspace.database_id()?;
+        let abs_path = self.notebook_item.read(cx).path.clone();
+        let db = persistence::NotebookEditorDb::global(cx);
+        Some(cx.background_spawn(async move {
+            db.save_notebook_path(item_id, workspace_id, abs_path).await
+        }))
+    }
+
+    fn should_serialize(&self, _event: &Self::Event) -> bool {
+        false
+    }
+}
+
+mod persistence {
+    use std::path::PathBuf;
+
+    use db::{
+        query,
+        sqlez::{domain::Domain, thread_safe_connection::ThreadSafeConnection},
+        sqlez_macros::sql,
+    };
+    use workspace::{ItemId, WorkspaceDb, WorkspaceId};
+
+    pub struct NotebookEditorDb(ThreadSafeConnection);
+
+    impl Domain for NotebookEditorDb {
+        const NAME: &str = stringify!(NotebookEditorDb);
+
+        const MIGRATIONS: &[&str] = &[sql!(
+            CREATE TABLE notebook_editors (
+                workspace_id INTEGER,
+                item_id INTEGER UNIQUE,
+
+                notebook_path BLOB,
+
+                PRIMARY KEY(workspace_id, item_id),
+                FOREIGN KEY(workspace_id) REFERENCES workspaces(workspace_id)
+                ON DELETE CASCADE
+            ) STRICT;
+        )];
+    }
+
+    db::static_connection!(NotebookEditorDb, [WorkspaceDb]);
+
+    impl NotebookEditorDb {
+        query! {
+            pub async fn save_notebook_path(
+                item_id: ItemId,
+                workspace_id: WorkspaceId,
+                notebook_path: PathBuf
+            ) -> Result<()> {
+                INSERT OR REPLACE INTO notebook_editors(item_id, workspace_id, notebook_path)
+                VALUES (?, ?, ?)
+            }
+        }
+
+        query! {
+            pub fn get_notebook_path(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<PathBuf>> {
+                SELECT notebook_path
+                FROM notebook_editors
+                WHERE item_id = ? AND workspace_id = ?
+            }
+        }
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1218,6 +1218,8 @@ fn initialize_pane(
             toolbar.add_item(quick_action_bar, window, cx);
             let diagnostic_editor_controls = cx.new(|_| diagnostics::ToolbarControls::new());
             toolbar.add_item(diagnostic_editor_controls, window, cx);
+            let notebook_toolbar = cx.new(|_| repl::notebook::NotebookToolbar::new());
+            toolbar.add_item(notebook_toolbar, window, cx);
             let project_search_bar = cx.new(|_| ProjectSearchBar::new());
             toolbar.add_item(project_search_bar, window, cx);
             let lsp_log_item = cx.new(|_| LspLogToolbarItemView::new());

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -814,6 +814,8 @@ pub mod notebook {
             AddMarkdownBlock,
             /// Adds a new code cell.
             AddCodeBlock,
+            /// Deletes the currently selected cell.
+            DeleteCell,
             /// Restarts the kernel.
             RestartKernel,
             /// Interrupts the current execution.


### PR DESCRIPTION
## Summary

- Enables the `NotebookEditor` for all users by graduating the `NotebookFeatureFlag` (`enabled_for_all() -> true`). The notebook view was already ~95% built behind the flag — this PR fixes ship-blocking correctness issues and adds polish for VSCode/Cursor feature parity.
- Fixes event propagation (`to_item_events`) so the tab dirty dot, autosave, and unsaved-changes prompt all work correctly.
- Replaces the hardcoded `python3` kernel fallback with `ReplStore::active_kernelspec()` for robust kernel selection.
- Adds a VSCode-style top toolbar, session restore via `SerializableItem`, external file-change detection, `DeleteCell` action with keymaps, and a cell render refactor to eliminate duplication.

## Test plan

- [ ] Open a `.ipynb` file from the file tree, command palette, and CLI — verify cell view renders (not raw JSON)
- [ ] Edit code and markdown cells, confirm dirty dot appears on tab
- [ ] Run single cell (Shift-Enter), Run All, RunAndAdvance — verify output, execution count, spinner
- [ ] Save (Cmd-S), verify round-trip fidelity on disk
- [ ] Switch kernel via picker, restart kernel, interrupt a running cell
- [ ] Add code/markdown cells, move cells up/down, delete cell — verify dirty tracking
- [ ] Close with unsaved changes — verify prompt appears
- [ ] Restart Zed with a notebook open — verify it reopens via session restore
- [ ] Open a notebook with no Python installed — verify graceful degradation (no crash)

Release Notes:

- Added native Jupyter notebook (.ipynb) support with cell-based editing, kernel execution, output rendering, and a VSCode-style toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)