### PR TITLE
Taffy nightly lint updates

### DIFF
--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -314,20 +314,23 @@ impl ToTaffy<taffy::style::Style> for Style {
                 match template.min_size {
                     // grid-template-*: repeat(<number>, minmax(0, 1fr));
                     crate::TemplateColumnMinSize::Zero => {
-                        vec![repeat(template.repeat, vec![minmax(length(0.0), fr(1.0))])]
+                        vec![repeat(
+                            template.repeat,
+                            vec![minmax(length(0.0_f32), fr(1.0_f32))],
+                        )]
                     }
                     // grid-template-*: repeat(<number>, minmax(min-content, 1fr));
                     crate::TemplateColumnMinSize::MinContent => {
                         vec![repeat(
                             template.repeat,
-                            vec![minmax(min_content(), fr(1.0))],
+                            vec![minmax(min_content(), fr(1.0_f32))],
                         )]
                     }
                     // grid-template-*: repeat(<number>, minmax(0, max-content))
                     crate::TemplateColumnMinSize::MaxContent => {
                         vec![repeat(
                             template.repeat,
-                            vec![minmax(length(0.0), max_content())],
+                            vec![minmax(length(0.0_f32), max_content())],
                         )]
                     }
                 }


### PR DESCRIPTION
Fixes a new lint on nightly, which crops up in gpui's taffy integration [error logs from main's build](https://github.com/zed-industries/zed/actions/runs/24491477164/job/71577226631).

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A
