### PR TITLE
markdown_preview: Reduce markdown preview update churn

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -530,6 +530,9 @@ impl Markdown {
         source_index: usize,
         cx: &mut Context<Self>,
     ) {
+        if self.autoscroll_request == Some(source_index) {
+            return;
+        }
         self.autoscroll_request = Some(source_index);
         cx.refresh_windows();
     }
@@ -1380,7 +1383,7 @@ impl MarkdownElement {
                                     markdown.selection = Selection::default();
                                     markdown.pressed_link = None;
                                     window.prevent_default();
-                                    cx.notify();
+                                    cx.refresh_windows();
                                     return;
                                 }
                             }
@@ -1417,12 +1420,12 @@ impl MarkdownElement {
                         }
 
                         window.prevent_default();
-                        cx.notify();
+                        cx.refresh_windows();
                     }
                 } else if phase.capture() && event.button == MouseButton::Left {
                     markdown.selection = Selection::default();
                     markdown.pressed_link = None;
-                    cx.notify();
+                    cx.refresh_windows();
                 }
             }
         });
@@ -1442,8 +1445,8 @@ impl MarkdownElement {
                     };
                     markdown.selection.set_head(source_index, &rendered_text);
                     markdown.autoscroll_code_block(source_index, event.position);
-                    markdown.autoscroll_request = Some(source_index);
-                    cx.notify();
+                    markdown.request_autoscroll_to_source_index(source_index, cx);
+                    cx.refresh_windows();
                 } else {
                     let is_hovering_clickable = hitbox.is_hovered(window)
                         && rendered_text
@@ -1456,7 +1459,7 @@ impl MarkdownElement {
                                         .is_some()
                             });
                     if is_hovering_clickable != was_hovering_clickable {
-                        cx.notify();
+                        cx.refresh_windows();
                     }
                 }
             }
@@ -1474,8 +1477,8 @@ impl MarkdownElement {
                         if let Some(source_index) =
                             markdown.footnote_definition_content_start(&pressed_footnote_ref.label)
                         {
-                            markdown.autoscroll_request = Some(source_index);
-                            cx.notify();
+                            markdown.request_autoscroll_to_source_index(source_index, cx);
+                            cx.refresh_windows();
                         }
                     } else if let Some(pressed_link) = markdown.pressed_link.take()
                         && source_index.and_then(|ix| rendered_text.link_for_source_index(ix))
@@ -1495,7 +1498,7 @@ impl MarkdownElement {
                             .text_for_range(markdown.selection.start..markdown.selection.end);
                         cx.write_to_primary(ClipboardItem::new_string(text))
                     }
-                    cx.notify();
+                    cx.refresh_windows();
                 }
             }
         });

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -48,6 +48,8 @@ pub struct MarkdownPreviewView {
     image_cache: Entity<RetainAllImageCache>,
     base_directory: Option<PathBuf>,
     pending_update_task: Option<Task<Result<()>>>,
+    pending_selection_sync_request: Option<SelectionSyncRequest>,
+    selection_sync_scheduled: bool,
     mode: MarkdownPreviewMode,
 }
 
@@ -62,6 +64,12 @@ pub enum MarkdownPreviewMode {
 struct EditorState {
     editor: Entity<Editor>,
     _subscription: Subscription,
+}
+
+#[derive(Clone, Copy)]
+struct SelectionSyncRequest {
+    source_index: usize,
+    reveal: bool,
 }
 
 impl MarkdownPreviewView {
@@ -242,6 +250,8 @@ impl MarkdownPreviewView {
                 image_cache: RetainAllImageCache::new(cx),
                 base_directory: None,
                 pending_update_task: None,
+                pending_selection_sync_request: None,
+                selection_sync_scheduled: false,
                 mode,
             };
 
@@ -313,8 +323,12 @@ impl MarkdownPreviewView {
                                 let focused = editor.focus_handle(cx).is_focused(window);
                                 (index, focused)
                             });
-                        this.sync_preview_to_source_index(selection_start, editor_is_focused, cx);
-                        cx.notify();
+                        this.schedule_selection_sync(
+                            selection_start,
+                            editor_is_focused,
+                            window,
+                            cx,
+                        );
                     }
                     _ => {}
                 };
@@ -322,6 +336,8 @@ impl MarkdownPreviewView {
         );
 
         self.base_directory = Self::get_folder_for_active_editor(editor.read(cx), cx);
+        self.pending_selection_sync_request = None;
+        self.selection_sync_scheduled = false;
         self.active_editor = Some(EditorState {
             editor,
             _subscription: subscription,
@@ -407,12 +423,48 @@ impl MarkdownPreviewView {
             .0
     }
 
+    fn schedule_selection_sync(
+        &mut self,
+        source_index: usize,
+        reveal: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.pending_selection_sync_request = Some(SelectionSyncRequest {
+            source_index,
+            reveal,
+        });
+
+        if self.selection_sync_scheduled {
+            return;
+        }
+
+        self.selection_sync_scheduled = true;
+        cx.on_next_frame(window, |this, _window, cx| {
+            this.flush_pending_selection_sync(cx);
+        });
+    }
+
+    fn flush_pending_selection_sync(&mut self, cx: &mut Context<Self>) {
+        self.selection_sync_scheduled = false;
+
+        let Some(request) = self.pending_selection_sync_request.take() else {
+            return;
+        };
+
+        self.sync_preview_to_source_index(request.source_index, request.reveal, cx);
+    }
+
     fn sync_preview_to_source_index(
         &mut self,
         source_index: usize,
         reveal: bool,
         cx: &mut Context<Self>,
     ) {
+        if self.active_source_index == Some(source_index) && !reveal {
+            return;
+        }
+
         self.active_source_index = Some(source_index);
         self.sync_active_root_block(cx);
         self.markdown.update(cx, |markdown, cx| {
@@ -477,7 +529,7 @@ impl MarkdownPreviewView {
         }
 
         self.scroll_by_amount(-viewport_height);
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_page_down(
@@ -492,7 +544,7 @@ impl MarkdownPreviewView {
         }
 
         self.scroll_by_amount(viewport_height);
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_up(&mut self, _: &ScrollUp, window: &mut Window, cx: &mut Context<Self>) {
@@ -511,7 +563,7 @@ impl MarkdownPreviewView {
                 self.scroll_by_amount(-scroll_height);
             }
         }
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_down(&mut self, _: &ScrollDown, window: &mut Window, cx: &mut Context<Self>) {
@@ -530,7 +582,7 @@ impl MarkdownPreviewView {
                 self.scroll_by_amount(scroll_height);
             }
         }
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_up_by_item(
@@ -545,7 +597,7 @@ impl MarkdownPreviewView {
         {
             self.scroll_by_amount(-bounds.size.height);
         }
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_down_by_item(
@@ -560,12 +612,12 @@ impl MarkdownPreviewView {
         {
             self.scroll_by_amount(bounds.size.height);
         }
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_to_top(&mut self, _: &ScrollToTop, _window: &mut Window, cx: &mut Context<Self>) {
         self.scroll_handle.scroll_to_item(0);
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn scroll_to_bottom(
@@ -575,7 +627,7 @@ impl MarkdownPreviewView {
         cx: &mut Context<Self>,
     ) {
         self.scroll_handle.scroll_to_bottom();
-        cx.notify();
+        cx.refresh_windows();
     }
 
     fn render_markdown_element(


### PR DESCRIPTION

Release Notes:

- Improved markdown preview update churn

Coalesce selection syncs in the markdown preview to one update per frame, switch preview scroll actions to window refreshes, and avoid rerendering the full preview for high-frequency mouse interactions inside rendered markdown.
