### PR TITLE
Fix multi-character bracket auto-close in language injection contexts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4802,48 +4802,112 @@ impl Editor {
             }
             all_selections_read_only = false;
 
-            if let Some(scope) = snapshot.language_scope_at(selection.head()) {
+            {
+                let all_scopes = snapshot.language_scopes_at(selection.head());
+                // Track which scope the winning bracket pair comes from,
+                // so we use the correct autoclose_before setting.
+                let scope = snapshot.language_scope_at(selection.head());
+                let mut bracket_pair_scope: Option<&LanguageScope> = None;
+
                 // Determine if the inserted text matches the opening or closing
                 // bracket of any of this language's bracket pairs.
+                // We collect pairs from ALL scopes and prefer the longest match.
                 let mut bracket_pair = None;
                 let mut is_bracket_pair_start = false;
                 let mut is_bracket_pair_end = false;
                 if !text.is_empty() {
+                    // First, find the best match from the deepest scope only.
+                    let mut deepest_start_match: Option<BracketPair> = None;
+                    let mut deepest_start_len: usize = 0;
                     let mut bracket_pair_matching_end = None;
                     // `text` can be empty when a user is using IME (e.g. Chinese Wubi Simplified)
                     //  and they are removing the character that triggered IME popup.
-                    for (pair, enabled) in scope.brackets() {
-                        if !pair.close && !pair.surround {
-                            continue;
-                        }
+                    if let Some(deepest_scope) = all_scopes.first() {
+                        for (pair, enabled) in deepest_scope.brackets() {
+                            if !pair.close && !pair.surround {
+                                continue;
+                            }
 
-                        if enabled && pair.start.ends_with(text.as_ref()) {
-                            let prefix_len = pair.start.len() - text.len();
-                            let preceding_text_matches_prefix = prefix_len == 0
-                                || (selection.start.column >= (prefix_len as u32)
-                                    && snapshot.contains_str_at(
-                                        Point::new(
-                                            selection.start.row,
-                                            selection.start.column - (prefix_len as u32),
-                                        ),
-                                        &pair.start[..prefix_len],
-                                    ));
-                            if preceding_text_matches_prefix {
-                                bracket_pair = Some(pair.clone());
-                                is_bracket_pair_start = true;
-                                break;
+                            if enabled && pair.start.ends_with(text.as_ref()) {
+                                let prefix_len = pair.start.len() - text.len();
+                                let preceding_text_matches_prefix = prefix_len == 0
+                                    || (selection.start.column >= (prefix_len as u32)
+                                        && snapshot.contains_str_at(
+                                            Point::new(
+                                                selection.start.row,
+                                                selection.start.column - (prefix_len as u32),
+                                            ),
+                                            &pair.start[..prefix_len],
+                                        ));
+                                if preceding_text_matches_prefix
+                                    && pair.start.len() > deepest_start_len
+                                {
+                                    deepest_start_len = pair.start.len();
+                                    deepest_start_match = Some(pair.clone());
+                                }
+                            }
+                            if pair.end.as_str() == text.as_ref()
+                                && bracket_pair_matching_end.is_none()
+                            {
+                                bracket_pair_matching_end = Some(pair.clone());
                             }
                         }
-                        if pair.end.as_str() == text.as_ref() && bracket_pair_matching_end.is_none()
-                        {
-                            // take first bracket pair matching end, but don't break in case a later bracket
-                            // pair matches start
-                            bracket_pair_matching_end = Some(pair.clone());
+                    }
+
+                    // Check outer scopes for longer bracket pairs. Two cases:
+                    // 1. Deepest scope matched (e.g., `{`): look for longer pairs
+                    //    in outer scopes (e.g., `{{` from Liquid).
+                    // 2. Deepest scope had NO match: still check outer scopes, but
+                    //    only for multi-character pairs (start.len() > 1). This lets
+                    //    host language delimiters like `{%`/`%}` work inside injected
+                    //    regions, while preventing single-char bracket leaking (e.g.,
+                    //    HTML's `<`/`>` won't auto-close inside JavaScript).
+                    let mut best_start_match = deepest_start_match.clone();
+                    let mut best_start_len = deepest_start_len;
+                    if deepest_start_match.is_some() {
+                        bracket_pair_scope = all_scopes.first();
+                    }
+                    let min_outer_len = if deepest_start_len > 0 {
+                        // Must be strictly longer than the deepest match
+                        deepest_start_len + 1
+                    } else {
+                        // No deepest match: only consider multi-char pairs from outer scopes
+                        2
+                    };
+                    for current_scope in all_scopes.iter().skip(1) {
+                        for (pair, enabled) in current_scope.brackets() {
+                            if !pair.close && !pair.surround {
+                                continue;
+                            }
+                            if enabled
+                                && pair.start.ends_with(text.as_ref())
+                                && pair.start.len() >= min_outer_len
+                                && pair.start.len() > best_start_len
+                            {
+                                let prefix_len = pair.start.len() - text.len();
+                                let preceding_text_matches_prefix = prefix_len == 0
+                                    || (selection.start.column >= (prefix_len as u32)
+                                        && snapshot.contains_str_at(
+                                            Point::new(
+                                                selection.start.row,
+                                                selection.start.column
+                                                    - (prefix_len as u32),
+                                            ),
+                                            &pair.start[..prefix_len],
+                                        ));
+                                if preceding_text_matches_prefix {
+                                    best_start_len = pair.start.len();
+                                    best_start_match = Some(pair.clone());
+                                    bracket_pair_scope = Some(current_scope);
+                                }
+                            }
                         }
                     }
-                    if let Some(end) = bracket_pair_matching_end
-                        && bracket_pair.is_none()
-                    {
+
+                    if let Some(start) = best_start_match {
+                        bracket_pair = Some(start);
+                        is_bracket_pair_start = true;
+                    } else if let Some(end) = bracket_pair_matching_end {
                         bracket_pair = Some(end);
                         is_bracket_pair_end = true;
                     }
@@ -4859,10 +4923,19 @@ impl Editor {
                             // If the inserted text is a suffix of an opening bracket and the
                             // selection is preceded by the rest of the opening bracket, then
                             // insert the closing bracket.
-                            let following_text_allows_autoclose = snapshot
-                                .chars_at(selection.start)
-                                .next()
-                                .is_none_or(|c| scope.should_autoclose_before(c));
+                            // Use the scope that owns the bracket pair for the
+                            // autoclose_before check. When a bracket pair comes from
+                            // an outer scope (e.g., Liquid's `{%`/`%}`), the outer
+                            // scope's autoclose_before should be used, not the
+                            // injected language's (e.g., HTML's `>})`).
+                            let autoclose_scope = bracket_pair_scope.or(scope.as_ref());
+                            let following_text_allows_autoclose =
+                                autoclose_scope.is_none_or(|s| {
+                                    snapshot
+                                        .chars_at(selection.start)
+                                        .next()
+                                        .is_none_or(|c| s.should_autoclose_before(c))
+                                });
 
                             let preceding_text_allows_autoclose = selection.start.column == 0
                                 || snapshot
@@ -4929,11 +5002,30 @@ impl Editor {
                                 false
                             };
 
+                            // Don't auto-close if the cursor is inside an existing
+                            // autoclose region (but not at its end) and the new pair
+                            // extends the region's pair. This prevents `{%-`/`-%}` from
+                            // auto-closing when editing inside an existing `{%`/`%}` pair.
+                            let is_extending_inside_region =
+                                if let Some(region) = autoclose_region {
+                                    let region_end_point =
+                                        region.range.end.to_point(&snapshot);
+                                    selection.end != region_end_point
+                                        && bracket_pair.start.starts_with(
+                                            &region.pair.start,
+                                        )
+                                        && region.pair.start.len()
+                                            < bracket_pair.start.len()
+                                } else {
+                                    false
+                                };
+
                             if autoclose
                                 && bracket_pair.close
                                 && following_text_allows_autoclose
                                 && preceding_text_allows_autoclose
                                 && !is_closing_quote
+                                && !is_extending_inside_region
                             {
                                 let anchor = snapshot.anchor_before(selection.end);
                                 new_selections.push((selection.map(|_| anchor), text.len()));
@@ -4943,8 +5035,53 @@ impl Editor {
                                     selection.id,
                                     bracket_pair.clone(),
                                 ));
+                                // When a multi-character bracket pair supersedes a
+                                // previous auto-close, replace the stale closing bracket
+                                // with the typed character + new closing bracket.
+                                //
+                                // Example: `{|}` + type `{` for pair `{{`/`}}`:
+                                //   Range: cursor..end_of_`}` → insert `{` + `}}`
+                                //   Result: `{{|}}`
+                                //
+                                // Example: `{{|}}` + type `-` for pair `{{-`/`-}}`:
+                                //   Range: cursor..end_of_`}}` → insert `-` + `-}}`
+                                //   Result: `{{-|-}}`
+                                let edit_end = if bracket_pair.start.len() > 1 {
+                                    if let Some(region) = autoclose_region {
+                                        let region_end_point =
+                                            region.range.end.to_point(&snapshot);
+                                        // Only supersede if:
+                                        // 1. Cursor is at the autoclose region end
+                                        // 2. The previous pair's start is a proper prefix
+                                        //    of the new pair's start (e.g., `{` → `{{`,
+                                        //    `{{` → `{{-`). This prevents stale autoclose
+                                        //    regions from triggering supersession when the
+                                        //    user edits existing text.
+                                        let is_valid_supersession =
+                                            selection.end == region_end_point
+                                                && bracket_pair.start.starts_with(
+                                                    &region.pair.start,
+                                                )
+                                                && region.pair.start.len()
+                                                    < bracket_pair.start.len();
+                                        if is_valid_supersession {
+                                            // Extend past the stale auto-closed bracket
+                                            Point::new(
+                                                region_end_point.row,
+                                                region_end_point.column
+                                                    + region.pair.end.len() as u32,
+                                            )
+                                        } else {
+                                            selection.end
+                                        }
+                                    } else {
+                                        selection.end
+                                    }
+                                } else {
+                                    selection.end
+                                };
                                 edits.push((
-                                    selection.range(),
+                                    selection.start..edit_end,
                                     format!("{}{}", text, bracket_pair.end).into(),
                                 ));
                                 bracket_inserted = true;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -12410,6 +12410,350 @@ async fn test_autoclose_with_embedded_language(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_autoclose_multi_char_brackets_with_injection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Host language (like Liquid) with multi-character bracket pairs.
+    // We reuse the HTML grammar because it supports injections into <script>.
+    let host_language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: "HTML".into(),
+                brackets: BracketPairConfig {
+                    pairs: vec![
+                        BracketPair {
+                            start: "<".into(),
+                            end: ">".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                        BracketPair {
+                            start: "{".into(),
+                            end: "}".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                        BracketPair {
+                            start: "{{".into(),
+                            end: "}}".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                        BracketPair {
+                            start: "{{-".into(),
+                            end: "-}}".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                        BracketPair {
+                            start: "{%".into(),
+                            end: "%}".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                        BracketPair {
+                            start: "{%-".into(),
+                            end: "-%}".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                        BracketPair {
+                            start: "(".into(),
+                            end: ")".into(),
+                            close: true,
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+                autoclose_before: "%-:.,=}])<>'\" \n\t".into(),
+                ..Default::default()
+            },
+            Some(tree_sitter_html::LANGUAGE.into()),
+        )
+        .with_injection_query(
+            r#"
+            (script_element
+                (raw_text) @injection.content
+                (#set! injection.language "javascript"))
+            "#,
+        )
+        .unwrap(),
+    );
+
+    // Injected language with only single-character bracket pairs.
+    let injected_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "JavaScript".into(),
+            brackets: BracketPairConfig {
+                pairs: vec![
+                    BracketPair {
+                        start: "{".into(),
+                        end: "}".into(),
+                        close: true,
+                        ..Default::default()
+                    },
+                    BracketPair {
+                        start: "(".into(),
+                        end: ")".into(),
+                        close: true,
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            autoclose_before: "})]>".into(),
+            ..Default::default()
+        },
+        Some(tree_sitter_typescript::LANGUAGE_TSX.into()),
+    ));
+
+    cx.language_registry().add(host_language.clone());
+    cx.language_registry().add(injected_language);
+    cx.executor().run_until_parked();
+
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(Some(host_language), cx);
+    });
+
+    cx.set_state(
+        &r#"
+            <body>ˇ
+                <script>
+                    var x = 1;ˇ
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Precondition: different languages are active at different locations.
+    cx.update_editor(|editor, window, cx| {
+        let snapshot = editor.snapshot(window, cx);
+        let cursors = editor
+            .selections
+            .ranges::<MultiBufferOffset>(&editor.display_snapshot(cx));
+        let languages = cursors
+            .iter()
+            .map(|c| snapshot.language_at(c.start).unwrap().name())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            languages,
+            &[
+                LanguageName::from("HTML"),
+                LanguageName::from("JavaScript"),
+            ]
+        );
+    });
+
+    // When typing the first `{`, the injected language (JavaScript) matches `{`/`}`,
+    // but the host language (HTML) has a longer match `{{`/`}}`. The first `{`
+    // should still auto-close as `{}` because we don't yet know if the user will
+    // type a second `{`.
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("{", window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>{ˇ}
+                <script>
+                    var x = 1;{ˇ}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // When typing the second `{`, the host language's `{{`/`}}` pair should
+    // supersede the previous single-character auto-close. The stale `}` from
+    // the first auto-close should be replaced.
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("{", window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>{{ˇ}}
+                <script>
+                    var x = 1;{{ˇ}}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Verify that angle brackets from the host language do NOT auto-close
+    // inside the injected language (no bracket leaking).
+    cx.set_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;ˇ
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("<", window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;<ˇ
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Supersession chain: `{{` → `{{-`. Typing `-` after `{{|}}` should
+    // produce `{{-|-}}` by superseding the `{{`/`}}` pair with `{{-`/`-}}`.
+    cx.set_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;ˇ
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("{", window, cx);
+        editor.handle_input("{", window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{{ˇ}}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("-", window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{{-ˇ-}}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Multi-character bracket pairs from the host language should work inside
+    // injected regions even when the injected language has NO matching pair.
+    // Here `{%`/`%}` is only defined in the host, not in JavaScript.
+    cx.set_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;ˇ
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("{", window, cx);
+    });
+    // First `{` auto-closes from the injected language (JavaScript has `{`/`}`).
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{ˇ}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("%", window, cx);
+    });
+    // `{%` from the host language supersedes the `{`/`}` from the injected
+    // language, replacing the stale `}` with `%}`.
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{%ˇ%}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Regression: after typing content inside an auto-closed pair and then
+    // moving the cursor back, typing should NOT trigger supersession.
+    // Type some content after `{%`, then move cursor back and type `-`.
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input(" test ", window, cx);
+    });
+    // Cursor stays inside the autoclose region (before `%}`).
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{% test ˇ%}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Move cursor back to right after `{%` (6 chars left past ` test `).
+    cx.update_editor(|editor, window, cx| {
+        editor.move_left(&Default::default(), window, cx);
+        editor.move_left(&Default::default(), window, cx);
+        editor.move_left(&Default::default(), window, cx);
+        editor.move_left(&Default::default(), window, cx);
+        editor.move_left(&Default::default(), window, cx);
+        editor.move_left(&Default::default(), window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{%ˇ test %}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+
+    // Typing `-` inside the `{%`/`%}` region (not at its end) should just
+    // insert `-` without auto-closing `{%-`/`-%}`, because the enclosing
+    // `%}` already provides the correct closing.
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("-", window, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            <body>
+                <script>
+                    var x = 1;{%-ˇ test %}
+                </script>
+            </body>
+        "#
+        .unindent(),
+    );
+}
+
+#[gpui::test]
 async fn test_autoclose_with_overrides(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3944,6 +3944,74 @@ impl BufferSnapshot {
         })
     }
 
+    /// Returns all [`LanguageScope`]s at the given location, from deepest to shallowest.
+    /// This is useful for collecting bracket pairs from all injection layers.
+    pub fn language_scopes_at<D: ToOffset>(&self, position: D) -> Vec<LanguageScope> {
+        let offset = position.to_offset(self);
+        let text: &TextBufferSnapshot = self;
+
+        let mut scopes_with_depth: Vec<(LanguageScope, usize, usize)> = Vec::new();
+
+        for layer in self
+            .syntax
+            .layers_for_range(offset..offset, &self.text, false)
+        {
+            if let Some(ranges) = layer.included_sub_ranges
+                && !offset_in_sub_ranges(ranges, offset, text)
+            {
+                continue;
+            }
+
+            let mut cursor = layer.node().walk();
+
+            let mut range = None;
+            loop {
+                let child_range = cursor.node().byte_range();
+                if !child_range.contains(&offset) {
+                    break;
+                }
+
+                range = Some(child_range);
+                if cursor.goto_first_child_for_byte(offset).is_none() {
+                    break;
+                }
+            }
+
+            if let Some(range) = range {
+                scopes_with_depth.push((
+                    LanguageScope {
+                        language: layer.language.clone(),
+                        override_id: layer.override_id(offset, &self.text),
+                    },
+                    layer.depth,
+                    range.len(),
+                ));
+            }
+        }
+
+        // Sort by depth descending (deepest first), then by range length ascending (smallest first)
+        scopes_with_depth.sort_by(|a, b| {
+            b.1.cmp(&a.1).then_with(|| a.2.cmp(&b.2))
+        });
+
+        let mut scopes: Vec<LanguageScope> = scopes_with_depth
+            .into_iter()
+            .map(|(scope, _, _)| scope)
+            .collect();
+
+        // If no layers matched, fall back to the base language
+        if scopes.is_empty() {
+            if let Some(language) = self.language.clone() {
+                scopes.push(LanguageScope {
+                    language,
+                    override_id: None,
+                });
+            }
+        }
+
+        scopes
+    }
+
     /// Returns a tuple of the range and character kind of the word
     /// surrounding the given position.
     pub fn surrounding_word<T: ToOffset>(

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6139,6 +6139,12 @@ impl MultiBufferSnapshot {
             .and_then(|(buffer, offset)| buffer.language_scope_at(offset))
     }
 
+    pub fn language_scopes_at<T: ToOffset>(&self, point: T) -> Vec<LanguageScope> {
+        self.point_to_buffer_offset(point)
+            .map(|(buffer, offset)| buffer.language_scopes_at(offset))
+            .unwrap_or_default()
+    }
+
     pub fn char_classifier_at<T: ToOffset>(&self, point: T) -> CharClassifier {
         self.point_to_buffer_offset(point)
             .map(|(buffer, offset)| buffer.char_classifier_at(offset))


### PR DESCRIPTION
## Summary

Fixes #53291

When a file uses language injections (e.g., Liquid templates where `template_content` is injected as HTML), multi-character bracket pairs from the host language (like `{{`/`}}` and `{%`/`%}` in Liquid) were not working correctly. Only the deepest (injected) language's brackets were considered, so typing `{` would auto-close as `{}` (HTML behavior) instead of allowing the multi-character `{{`/`}}` pair to form.

### Changes

- **New API: `language_scopes_at()`** — Returns all language scopes at a position (deepest to shallowest), instead of just the deepest one. This allows bracket matching to consider pairs from all injection layers.

- **Multi-layer bracket matching** — The bracket auto-close logic now:
  1. Finds the best match in the deepest (injected) scope first
  2. Checks outer scopes for *longer* bracket pairs when the deepest scope has a match, or for multi-character pairs (len ≥ 2) when it doesn't — preventing single-char bracket leaking (e.g., HTML's `<`/`>` won't auto-close inside JavaScript)
  3. Prefers the longest matching bracket pair across all scopes

- **Stale bracket replacement (supersession)** — When typing the second character of a multi-character pair (e.g., the second `{` in `{{`), the stale closing bracket from the previous single-character auto-close is replaced. Supports chains like `{` → `{{` → `{{-`. Includes guards to prevent supersession from firing when editing inside existing balanced pairs.

- **Scope-aware `autoclose_before`** — The `autoclose_before` check now uses the scope that owns the winning bracket pair, not just the deepest scope. This fixes cases where the injected language's `autoclose_before` (e.g., HTML's `>})`) would block auto-closing for host language pairs that need different characters (e.g., Liquid's `{%`/`%}` needs `%` in `autoclose_before`).

### Who benefits

This fix applies to **any template language** that uses multi-character delimiters with language injections:
- **Liquid**: `{{`/`}}`, `{%`/`%}`, `{{-`/`-}}`, `{%-`/`-%}`
- **Handlebars/Mustache**: `{{`/`}}`
- **Jinja2/Twig**: `{{`/`}}`, `{%`/`%}`
- **ERB**: `<%`/`%>`

## Test plan

- [x] Added `test_autoclose_multi_char_brackets_with_injection` covering:
  - Multi-char bracket pairs from host language supersede single-char pairs from injected language
  - Stale auto-closed brackets are correctly replaced
  - Supersession chains (`{` → `{{` → `{{-`)
  - Bracket leaking prevention (host's `<`/`>` doesn't auto-close in injected language)
  - Multi-char pairs from host work even when injected language has no match (`{%`)
  - No spurious supersession when editing inside existing balanced pairs
- [x] All 9 existing autoclose tests pass
- [x] All bracket deletion tests pass
- [x] Manually tested with Liquid files in a local Zed build

Release Notes:

- Fixed multi-character bracket auto-close (e.g., `{{`/`}}`, `{%`/`%}`) not working in files with language injections (e.g., Liquid, Handlebars, Jinja2 templates).
- Fixed `autoclose_before` using the wrong language scope for bracket pairs from host languages in injection contexts.