### PR TITLE
Fix click events leaking through the announcement toast

### DIFF
--- a/crates/ui/src/components/notification/announcement_toast.rs
+++ b/crates/ui/src/components/notification/announcement_toast.rs
@@ -101,6 +101,8 @@ impl RenderOnce for AnnouncementToast {
         let illustration = self.illustration;
 
         v_flex()
+            .id("announcement-toast")
+            .occlude()
             .relative()
             .w_full()
             .elevation_3(cx)


### PR DESCRIPTION
Quick fix here to prevent any click events in the announcement toast itself to leak through whatever is behind it.

Release Notes:

- N/A
