### PR TITLE
sidebar: Move to new workspace non-Wayland

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -930,10 +930,16 @@ impl MultiWorkspace {
                 return Ok(());
             }
 
-            cx.update(|cx| {
+            let result = cx.update(|cx| {
                 Workspace::new_local(paths, app_state, None, None, None, OpenMode::NewWindow, cx)
             })
             .await?;
+
+            result.window
+                .update(cx, |_, window, _cx| {
+                    window.activate_window();
+                })
+                .log_err();
 
             Ok(())
         })

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -930,26 +930,10 @@ impl MultiWorkspace {
                 return Ok(());
             }
 
-            let result = cx
-                .update(|cx| {
-                    Workspace::new_local(
-                        paths,
-                        app_state,
-                        None,
-                        None,
-                        None,
-                        OpenMode::NewWindow,
-                        cx,
-                    )
-                })
-                .await?;
-
-            result
-                .window
-                .update(cx, |_, window, _cx| {
-                    window.activate_window();
-                })
-                .log_err();
+            cx.update(|cx| {
+                Workspace::new_local(paths, app_state, None, None, None, OpenMode::NewWindow, cx)
+            })
+            .await?;
 
             Ok(())
         })

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -930,12 +930,22 @@ impl MultiWorkspace {
                 return Ok(());
             }
 
-            let result = cx.update(|cx| {
-                Workspace::new_local(paths, app_state, None, None, None, OpenMode::NewWindow, cx)
-            })
-            .await?;
+            let result = cx
+                .update(|cx| {
+                    Workspace::new_local(
+                        paths,
+                        app_state,
+                        None,
+                        None,
+                        None,
+                        OpenMode::NewWindow,
+                        cx,
+                    )
+                })
+                .await?;
 
-            result.window
+            result
+                .window
                 .update(cx, |_, window, _cx| {
                     window.activate_window();
                 })

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2070,6 +2070,15 @@ impl Workspace {
                     });
                 })
                 .log_err();
+
+            if open_mode == OpenMode::NewWindow {
+                window
+                    .update(cx, |_, window, _cx| {
+                        window.activate_window();
+                    })
+                    .log_err();
+            }
+
             Ok(OpenResult {
                 window,
                 workspace,


### PR DESCRIPTION
We were just creating a window without showing it. However, wayland does not respect this setting, so it seemed to work.

Now we actually activate the window :)

Rather than changing the single call-site, we always do this when calling `Workspace::new_local`, since there were no code paths in the repo that pass `NewWindow` without immediately activating it

Release Notes:

- N/A or Added/Fixed/Improved ...
