### PR TITLE
Show better tab tooltip for multi buffers

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -645,20 +645,25 @@ impl Item for Editor {
     }
 
     fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
-        self.buffer()
-            .read(cx)
+        let multi_buffer = self.buffer().read(cx);
+        if let Some(file) = multi_buffer
             .as_singleton()
             .and_then(|buffer| buffer.read(cx).file())
             .and_then(|file| File::from_dyn(Some(file)))
-            .map(|file| {
+        {
+            Some(
                 file.worktree
                     .read(cx)
                     .absolutize(&file.path)
                     .compact()
                     .to_string_lossy()
                     .into_owned()
-                    .into()
-            })
+                    .into(),
+            )
+        } else {
+            let title = multi_buffer.title(cx);
+            (!title.is_empty()).then(|| title.to_string().into())
+        }
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {


### PR DESCRIPTION
Before, no tooltip was shown at all, now we show the full, not trimmed text:

<img width="437" height="80" alt="image" src="https://github.com/user-attachments/assets/f8220e04-e036-4175-b048-697e22504a6a" />


Release Notes:

- Show better tab tooltip for multi buffers
