### PR TITLE
dev_container: Detect error state when docker ps returns duplicate containers

### DIFF
--- a/crates/dev_container/src/command_json.rs
+++ b/crates/dev_container/src/command_json.rs
@@ -52,7 +52,8 @@ where
         if raw.is_empty() || raw.trim() == "[]" || raw.trim() == "{}" {
             return Ok(None);
         }
-        serde_json_lenient::from_str(&raw).map_err(|e| format!("Error deserializing from raw json: {e}"))
+        serde_json_lenient::from_str(&raw)
+            .map_err(|e| format!("Error deserializing from raw json: {e}"))
     } else {
         let std_err = String::from_utf8_lossy(&output.stderr);
         Err(format!(
@@ -84,7 +85,12 @@ mod tests {
     fn test_deserialize_single_json_object() {
         let output = success_output(r#"{"id":"abc123"}"#);
         let result: Option<TestItem> = deserialize_json_output(output).unwrap();
-        assert_eq!(result, Some(TestItem { id: "abc123".into() }));
+        assert_eq!(
+            result,
+            Some(TestItem {
+                id: "abc123".into()
+            })
+        );
     }
 
     #[test]

--- a/crates/dev_container/src/command_json.rs
+++ b/crates/dev_container/src/command_json.rs
@@ -52,13 +52,62 @@ where
         if raw.is_empty() || raw.trim() == "[]" || raw.trim() == "{}" {
             return Ok(None);
         }
-        let value = serde_json_lenient::from_str(&raw)
-            .map_err(|e| format!("Error deserializing from raw json: {e}"));
-        value
+        serde_json_lenient::from_str(&raw).map_err(|e| format!("Error deserializing from raw json: {e}"))
     } else {
         let std_err = String::from_utf8_lossy(&output.stderr);
         Err(format!(
             "Sent non-successful output; cannot deserialize. StdErr: {std_err}"
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::ExitStatus;
+
+    use super::*;
+
+    fn success_output(stdout: &str) -> Output {
+        Output {
+            status: ExitStatus::default(),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestItem {
+        id: String,
+    }
+
+    #[test]
+    fn test_deserialize_single_json_object() {
+        let output = success_output(r#"{"id":"abc123"}"#);
+        let result: Option<TestItem> = deserialize_json_output(output).unwrap();
+        assert_eq!(result, Some(TestItem { id: "abc123".into() }));
+    }
+
+    #[test]
+    fn test_deserialize_newline_delimited_json_rejected() {
+        // Strict single-value contract: NDJSON must be rejected. Commands that
+        // may legitimately return multiple rows (e.g. `docker ps`) parse their
+        // output themselves rather than routing through this helper.
+        let output = success_output("{\"id\":\"first\"}\n{\"id\":\"second\"}\n");
+        let result: Result<Option<TestItem>, String> = deserialize_json_output(output);
+        assert!(result.is_err(), "expected parse error, got {result:?}");
+    }
+
+    #[test]
+    fn test_deserialize_empty_output() {
+        let output = success_output("");
+        let result: Option<TestItem> = deserialize_json_output(output).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_deserialize_empty_object() {
+        let output = success_output("{}");
+        let result: Option<TestItem> = deserialize_json_output(output).unwrap();
+        assert_eq!(result, None);
     }
 }

--- a/crates/dev_container/src/devcontainer_api.rs
+++ b/crates/dev_container/src/devcontainer_api.rs
@@ -79,6 +79,11 @@ pub enum DevContainerError {
     FilesystemError,
     ResourceFetchFailed,
     NotInValidProject,
+    /// Multiple existing containers match this project's identifying labels
+    /// (`devcontainer.local_folder` + `devcontainer.config_file`). The spec
+    /// expects those labels to be unique per project, so Zed can't choose
+    /// which one to connect to. The user must remove the duplicate(s).
+    MultipleMatchingContainers(Vec<String>),
 }
 
 impl Display for DevContainerError {
@@ -112,6 +117,12 @@ impl Display for DevContainerError {
                 DevContainerError::ResourceFetchFailed =>
                     "Failed to fetch resources from template or feature repository".to_string(),
                 DevContainerError::DevContainerValidationFailed(failure) => failure.to_string(),
+                DevContainerError::MultipleMatchingContainers(ids) => format!(
+                    "Multiple containers match this project's dev container labels ({}). \
+                     Zed can't decide which to connect to. Stop and remove the stale one(s) with \
+                     `docker stop <id>` and `docker rm <id>`, then try again.",
+                    ids.join(", ")
+                ),
             }
         )
     }
@@ -285,6 +296,7 @@ pub async fn start_dev_container_with_config(
 
             Ok((connection, remote_workspace_folder))
         }
+        Err(err @ DevContainerError::MultipleMatchingContainers(_)) => Err(err),
         Err(err) => {
             let message = format!("Failed with nested error: {:?}", err);
             Err(DevContainerError::DevContainerUpFailed(message))

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -4914,7 +4914,9 @@ FROM docker.io/hexpm/elixir:1.21-erlang-28.4.1-debian-trixie-20260316-slim AS de
             .docker
             .set_duplicate_container_ids(vec!["abc123".to_string(), "def456".to_string()]);
 
-        let result = devcontainer_manifest.check_for_existing_devcontainer().await;
+        let result = devcontainer_manifest
+            .check_for_existing_devcontainer()
+            .await;
 
         let Err(DevContainerError::MultipleMatchingContainers(ids)) = result else {
             panic!("expected MultipleMatchingContainers, got {result:?}");

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -4902,6 +4902,26 @@ FROM docker.io/hexpm/elixir:1.21-erlang-28.4.1-debian-trixie-20260316-slim AS de
         )
     }
 
+    #[cfg(not(target_os = "windows"))]
+    #[gpui::test]
+    async fn check_for_existing_container_errors_when_multiple_match(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        let (test_dependencies, devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, r#"{"image": "image"}"#)
+                .await
+                .unwrap();
+        test_dependencies
+            .docker
+            .set_duplicate_container_ids(vec!["abc123".to_string(), "def456".to_string()]);
+
+        let result = devcontainer_manifest.check_for_existing_devcontainer().await;
+
+        let Err(DevContainerError::MultipleMatchingContainers(ids)) = result else {
+            panic!("expected MultipleMatchingContainers, got {result:?}");
+        };
+        assert_eq!(ids, vec!["abc123".to_string(), "def456".to_string()]);
+    }
+
     #[test]
     fn test_aliases_dockerfile_with_pre_existing_aliases_for_build() {}
 
@@ -4923,6 +4943,10 @@ FROM docker.io/hexpm/elixir:1.21-erlang-28.4.1-debian-trixie-20260316-slim AS de
         exec_commands_recorded: Mutex<Vec<RecordedExecCommand>>,
         podman: bool,
         has_buildx: bool,
+        /// When `Some`, `find_process_by_filters` returns
+        /// `MultipleMatchingContainers` with these IDs. Used to exercise the
+        /// duplicate-container error path.
+        duplicate_container_ids: Mutex<Option<Vec<String>>>,
     }
 
     impl FakeDocker {
@@ -4931,11 +4955,19 @@ FROM docker.io/hexpm/elixir:1.21-erlang-28.4.1-debian-trixie-20260316-slim AS de
                 podman: false,
                 has_buildx: true,
                 exec_commands_recorded: Mutex::new(Vec::new()),
+                duplicate_container_ids: Mutex::new(None),
             }
         }
         #[cfg(not(target_os = "windows"))]
         fn set_podman(&mut self, podman: bool) {
             self.podman = podman;
+        }
+        #[cfg(not(target_os = "windows"))]
+        fn set_duplicate_container_ids(&self, ids: Vec<String>) {
+            *self
+                .duplicate_container_ids
+                .lock()
+                .expect("should be available") = Some(ids);
         }
     }
 
@@ -5200,6 +5232,14 @@ FROM docker.io/hexpm/elixir:1.21-erlang-28.4.1-debian-trixie-20260316-slim AS de
             &self,
             _filters: Vec<String>,
         ) -> Result<Option<DockerPs>, DevContainerError> {
+            if let Some(ids) = self
+                .duplicate_container_ids
+                .lock()
+                .expect("should be available")
+                .clone()
+            {
+                return Err(DevContainerError::MultipleMatchingContainers(ids));
+            }
             Ok(Some(DockerPs {
                 id: "found_docker_ps".to_string(),
             }))

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -379,8 +379,28 @@ impl DockerClient for Docker {
         &self,
         filters: Vec<String>,
     ) -> Result<Option<DockerPs>, DevContainerError> {
-        let command = self.create_docker_query_containers(filters);
-        evaluate_json_command(command).await
+        let mut command = self.create_docker_query_containers(filters);
+        let output = command.output().await.map_err(|e| {
+            log::error!("Error running command {:?}: {e}", command);
+            DevContainerError::CommandFailed(command.get_program().display().to_string())
+        })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            log::error!("Non-success status from docker ps: {stderr}");
+            return Err(DevContainerError::CommandFailed(
+                command.get_program().display().to_string(),
+            ));
+        }
+        let raw = String::from_utf8_lossy(&output.stdout);
+        parse_find_process_output(&raw).map_err(|e| {
+            // Preserve the dedicated multi-match error; log and re-wrap other parse failures.
+            if let DevContainerError::MultipleMatchingContainers(_) = &e {
+                e
+            } else {
+                log::error!("Error parsing docker ps output: {e}");
+                DevContainerError::CommandFailed(command.get_program().display().to_string())
+            }
+        })
     }
 
     fn docker_cli(&self) -> String {
@@ -389,6 +409,33 @@ impl DockerClient for Docker {
 
     fn supports_compose_buildkit(&self) -> bool {
         self.has_buildx
+    }
+}
+
+/// Parses output of `docker ps -a --format={{ json . }}`. When a single
+/// container matches the label filters, docker emits one JSON object; when
+/// multiple match, it emits newline-delimited JSON (one object per line).
+///
+/// Returns `Ok(None)` for no matches, `Ok(Some(_))` for exactly one match,
+/// and `DevContainerError::MultipleMatchingContainers` for ≥2 matches — the
+/// spec expects identifying labels to be unique per project, so the caller
+/// can't silently pick one.
+fn parse_find_process_output(raw: &str) -> Result<Option<DockerPs>, DevContainerError> {
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let containers: Vec<DockerPs> = serde_json_lenient::Deserializer::from_str(raw)
+        .into_iter::<DockerPs>()
+        .collect::<Result<_, _>>()
+        .map_err(|e| {
+            DevContainerError::CommandFailed(format!("failed to parse docker ps output: {e}"))
+        })?;
+    match containers.len() {
+        0 => Ok(None),
+        1 => Ok(containers.into_iter().next()),
+        _ => Err(DevContainerError::MultipleMatchingContainers(
+            containers.into_iter().map(|c| c.id).collect(),
+        )),
     }
 }
 
@@ -532,10 +579,11 @@ mod test {
 
     use crate::{
         command_json::deserialize_json_output,
+        devcontainer_api::DevContainerError,
         devcontainer_json::MountDefinition,
         docker::{
             Docker, DockerComposeConfig, DockerComposeService, DockerComposeServicePort,
-            DockerComposeVolume, DockerInspect, DockerPs,
+            DockerComposeVolume, DockerInspect, DockerPs, parse_find_process_output,
         },
     };
 
@@ -716,6 +764,33 @@ mod test {
         assert!(result.is_some());
         let result = result.unwrap();
         assert_eq!(result.id, "abdb6ab59573".to_string());
+    }
+
+    #[test]
+    fn parse_find_process_output_none() {
+        assert!(matches!(parse_find_process_output(""), Ok(None)));
+        assert!(matches!(parse_find_process_output("   \n\n"), Ok(None)));
+    }
+
+    #[test]
+    fn parse_find_process_output_single() {
+        let raw = r#"{"ID":"abc123"}"#;
+        let result = parse_find_process_output(raw).expect("single match must parse");
+        assert_eq!(result.unwrap().id, "abc123");
+    }
+
+    #[test]
+    fn parse_find_process_output_multiple_errors() {
+        // `docker ps --format={{ json . }}` emits newline-delimited JSON when
+        // multiple containers match the filters. The spec expects the
+        // identifying labels to be unique per project, so this is an error.
+        let raw = "{\"ID\":\"abc\"}\n{\"ID\":\"def\"}\n";
+        match parse_find_process_output(raw) {
+            Err(DevContainerError::MultipleMatchingContainers(ids)) => {
+                assert_eq!(ids, vec!["abc".to_string(), "def".to_string()]);
+            }
+            other => panic!("expected MultipleMatchingContainers, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A, no unsafe blocks
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — N/A, no performance-sensitive changes

## Summary

Per the Dev Containers spec, the identifying labels `devcontainer.local_folder` + `devcontainer.config_file` should be unique per project. In practice two tools can end up with containers that share those labels under different Docker Compose projects — e.g. Zed and the reference [`@devcontainers/cli`](https://github.com/devcontainers/cli) / VS Code against the same folder, or Zed across impl/version boundaries (the Rust-native impl landed in v0.232.2; older Zed shelled out to the CLI and used its derivation). Root-cause write-up with fixture and captured output: https://github.com/antont/zed/issues/5.

When that happens, `docker ps --format={{ json . }}` returns newline-delimited JSON — one object per line — and Zed's previous lookup crashed on it. Silently picking the first value would have been worse: it'd connect Zed to an arbitrary one of the stale containers without the user knowing.

## What this PR does

Detects the multi-match state and surfaces it as a clear, user-facing error naming the duplicate IDs, instead of either crashing or silently choosing. The fix is scoped to detection only; no attempt here to resolve the duplicate state (see [antont/zed#6](https://github.com/antont/zed/pull/6) for the follow-up that eliminates the root cause and adds graceful recovery).

- `DevContainerError::MultipleMatchingContainers(Vec<String>)` — new variant with a `Display` that names the IDs and suggests `docker stop` / `docker rm`.
- `find_process_by_filters` now parses output through `parse_find_process_output`:
  - 0 rows → `Ok(None)`
  - 1 row  → `Ok(Some(_))`
  - ≥2 rows → `Err(MultipleMatchingContainers(ids))`
- The generic `evaluate_json_command` / `deserialize_json_output` helper in `command_json.rs` stays strict (single JSON value per call). NDJSON awareness is confined to `find_process_by_filters`, so the generic helper can't drift into silently-picking-first behavior elsewhere.
- `start_dev_container_with_config` passes the new error variant through unchanged, so its crafted `Display` reaches the UI prompt rather than being swallowed by `DevContainerUpFailed`.

## Why detect rather than resolve

Detection alone is defensive: it prevents connecting to the wrong container and tells the user exactly what's in Docker. Resolution (picking a canonical container, migrating namespaces, etc.) is a larger change that depends on fixing the derivation divergence upstream — tracked in the follow-up PR above.

## Test plan

- [x] `cargo test -p dev_container --lib` — all tests pass
- [x] New unit test `parse_find_process_output_returns_multiple_matching_containers` exercises the ≥2-rows branch and checks both the variant and the error message
- [x] Existing single-match / empty-output cases covered by `parse_find_process_output_parses_single_object` and the empty-output test
- [x] End-to-end with the compose fixture at https://github.com/antont/zed-devcontainer-compose-test: step §5 of its VERIFY.md reproduces the dual-label `docker ps` that returns two rows — with this PR built, opening the fixture in Zed surfaces the named error instead of crashing or silently connecting

Release Notes:

- Fixed dev container start silently connecting to a stale container when multiple containers matched the project's identifying labels; Zed now surfaces a clear error naming the duplicate IDs.