### PR TITLE
lsp: Enable LSP features for unsaved buffers

### DIFF
--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -222,7 +222,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .chain(for_buffer.and_then(|buffer_id| self.buffer.read(cx).buffer(buffer_id)))
             .filter(|editor_buffer| {
                 let editor_buffer_id = editor_buffer.read(cx).remote_id();

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -136,17 +136,20 @@ impl Editor {
         }
     }
 
-    pub(super) fn is_lsp_relevant(&self, file: Option<&Arc<dyn language::File>>, cx: &App) -> bool {
+    pub(crate) fn is_lsp_relevant(&self, buffer: &impl LspBufferContext, cx: &App) -> bool {
         let Some(project) = self.project() else {
             return false;
         };
-        let Some(buffer_file) = project::File::from_dyn(file) else {
-            return false;
+        let project = project.read(cx);
+        let Some(buffer_file) = project::File::from_dyn(buffer.file()) else {
+            return project
+                .lsp_store()
+                .read(cx)
+                .has_buffer_uri(buffer.remote_id());
         };
         let Some(entry_id) = buffer_file.project_entry_id() else {
             return false;
         };
-        let project = project.read(cx);
         let Some(buffer_worktree) = project.worktree_for_id(buffer_file.worktree_id(cx), cx) else {
             return false;
         };

--- a/crates/editor/src/document_colors.rs
+++ b/crates/editor/src/document_colors.rs
@@ -162,7 +162,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .chain(buffer_id.and_then(|buffer_id| self.buffer.read(cx).buffer(buffer_id)))
             .filter(|editor_buffer| {
                 let editor_buffer_id = editor_buffer.read(cx).remote_id();

--- a/crates/editor/src/document_links.rs
+++ b/crates/editor/src/document_links.rs
@@ -43,7 +43,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .chain(for_buffer.and_then(|id| self.buffer.read(cx).buffer(id)))
             .filter(|buffer| {
                 let id = buffer.read(cx).remote_id();

--- a/crates/editor/src/document_symbols.rs
+++ b/crates/editor/src/document_symbols.rs
@@ -155,7 +155,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .filter_map(|buffer| {
                 let id = buffer.read(cx).remote_id();
                 if for_buffer.is_none_or(|target| target == id)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11294,7 +11294,7 @@ impl Editor {
         let visible_buffers: Vec<_> = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .collect();
         for visible_buffer in visible_buffers {
             self.register_buffer(visible_buffer.read(cx).remote_id(), cx);
@@ -11655,6 +11655,35 @@ impl CollaborationHub for Entity<Project> {
         let this = self.read(cx);
         let user_ids = this.collaborators().values().map(|c| c.user_id);
         this.user_store().read(cx).participant_names(user_ids, cx)
+    }
+}
+
+/// Abstracts over `Buffer` and `BufferSnapshot` so `is_lsp_relevant` can be
+/// called with either without forcing every caller to destructure manually.
+pub(crate) trait LspBufferContext {
+    fn remote_id(&self) -> BufferId;
+    fn file(&self) -> Option<&Arc<dyn language::File>>;
+}
+
+impl LspBufferContext for Buffer {
+    fn remote_id(&self) -> BufferId {
+        // `language::Buffer` and `language::BufferSnapshot` expose `remote_id`
+        // via `Deref` to `text::Buffer` / `text::BufferSnapshot`; calling the
+        // method via the `language` type names would resolve back to this
+        // trait impl and recurse. Use the deref target type explicitly.
+        text::Buffer::remote_id(self)
+    }
+    fn file(&self) -> Option<&Arc<dyn language::File>> {
+        Buffer::file(self)
+    }
+}
+
+impl LspBufferContext for BufferSnapshot {
+    fn remote_id(&self) -> BufferId {
+        text::BufferSnapshot::remote_id(self)
+    }
+    fn file(&self) -> Option<&Arc<dyn language::File>> {
+        BufferSnapshot::file(self)
     }
 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10870,7 +10870,7 @@ impl Editor {
         let visible_buffers: Vec<_> = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .collect();
         for visible_buffer in visible_buffers {
             self.register_buffer(visible_buffer.read(cx).remote_id(), cx);
@@ -11231,6 +11231,35 @@ impl CollaborationHub for Entity<Project> {
         let this = self.read(cx);
         let user_ids = this.collaborators().values().map(|c| c.user_id);
         this.user_store().read(cx).participant_names(user_ids, cx)
+    }
+}
+
+/// Abstracts over `Buffer` and `BufferSnapshot` so `is_lsp_relevant` can be
+/// called with either without forcing every caller to destructure manually.
+pub(crate) trait LspBufferContext {
+    fn remote_id(&self) -> BufferId;
+    fn file(&self) -> Option<&Arc<dyn language::File>>;
+}
+
+impl LspBufferContext for Buffer {
+    fn remote_id(&self) -> BufferId {
+        // `language::Buffer` and `language::BufferSnapshot` expose `remote_id`
+        // via `Deref` to `text::Buffer` / `text::BufferSnapshot`; calling the
+        // method via the `language` type names would resolve back to this
+        // trait impl and recurse. Use the deref target type explicitly.
+        text::Buffer::remote_id(self)
+    }
+    fn file(&self) -> Option<&Arc<dyn language::File>> {
+        Buffer::file(self)
+    }
+}
+
+impl LspBufferContext for BufferSnapshot {
+    fn remote_id(&self) -> BufferId {
+        text::BufferSnapshot::remote_id(self)
+    }
+    fn file(&self) -> Option<&Arc<dyn language::File>> {
+        BufferSnapshot::file(self)
     }
 }
 

--- a/crates/editor/src/folding_ranges.rs
+++ b/crates/editor/src/folding_ranges.rs
@@ -23,7 +23,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .chain(for_buffer.and_then(|id| self.buffer.read(cx).buffer(id)))
             .filter(|buffer| {
                 let id = buffer.read(cx).remote_id();

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -314,7 +314,7 @@ impl Editor {
         };
 
         let mut visible_excerpts = self.visible_buffer_ranges(cx);
-        visible_excerpts.retain(|(snapshot, _, _)| self.is_lsp_relevant(snapshot.file(), cx));
+        visible_excerpts.retain(|(snapshot, _, _)| self.is_lsp_relevant(snapshot, cx));
 
         let mut invalidate_hints_for_buffers = HashSet::default();
         let ignore_previous_fetches = match reason {

--- a/crates/editor/src/runnables.rs
+++ b/crates/editor/src/runnables.rs
@@ -563,7 +563,7 @@ impl Editor {
         let buffers = if visible_only {
             self.visible_buffers(cx)
                 .into_iter()
-                .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+                .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
                 .collect()
         } else {
             self.buffer().read(cx).all_buffers()

--- a/crates/editor/src/semantic_tokens.rs
+++ b/crates/editor/src/semantic_tokens.rs
@@ -152,7 +152,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .chain(buffer_id.and_then(|buffer_id| self.buffer.read(cx).buffer(buffer_id)))
             .filter_map(|editor_buffer| {
                 let editor_buffer_id = editor_buffer.read(cx).remote_id();

--- a/crates/editor/src/semantic_tokens.rs
+++ b/crates/editor/src/semantic_tokens.rs
@@ -150,7 +150,7 @@ impl Editor {
         let buffers_to_query = self
             .visible_buffers(cx)
             .into_iter()
-            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx).file(), cx))
+            .filter(|buffer| self.is_lsp_relevant(buffer.read(cx), cx))
             .chain(buffer_id.and_then(|buffer_id| self.buffer.read(cx).buffer(buffer_id)))
             .filter_map(|editor_buffer| {
                 let editor_buffer_id = editor_buffer.read(cx).remote_id();

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -981,11 +981,18 @@ impl LspButton {
                 ..
             } => {
                 self.server_state.update(cx, |state, cx| {
+                    // For unsaved buffers `buffer_abs_path` carries an LSP URI
+                    // (e.g. "untitled:Untitled-1") instead of a filesystem path.
+                    // They have no real worktree, so skip them from this map.
+                    if update.buffer_abs_path.starts_with("untitled:") {
+                        return;
+                    }
+                    let path = Path::new(&update.buffer_abs_path);
                     let Ok(worktree) = state.workspace.update(cx, |workspace, cx| {
                         workspace
                             .project()
                             .read(cx)
-                            .find_worktree(Path::new(&update.buffer_abs_path), cx)
+                            .find_worktree(path, cx)
                             .map(|(worktree, _)| worktree.downgrade())
                     }) else {
                         return;

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -1031,11 +1031,18 @@ impl LspButton {
                 ..
             } => {
                 self.server_state.update(cx, |state, cx| {
+                    // For unsaved buffers `buffer_abs_path` carries an LSP URI
+                    // (e.g. "untitled:Untitled-1") instead of a filesystem path.
+                    // They have no real worktree, so skip them from this map.
+                    if update.buffer_abs_path.starts_with("untitled:") {
+                        return;
+                    }
+                    let path = Path::new(&update.buffer_abs_path);
                     let Ok(worktree) = state.workspace.update(cx, |workspace, cx| {
                         workspace
                             .project()
                             .read(cx)
-                            .find_worktree(Path::new(&update.buffer_abs_path), cx)
+                            .find_worktree(path, cx)
                             .map(|(worktree, _)| worktree.downgrade())
                     }) else {
                         return;

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -71,20 +71,23 @@ pub fn file_path_to_lsp_url(path: &Path) -> Result<lsp::Uri> {
     }
 }
 
-pub(crate) fn make_text_document_identifier(path: &Path) -> Result<lsp::TextDocumentIdentifier> {
-    Ok(lsp::TextDocumentIdentifier {
-        uri: file_path_to_lsp_url(path)?,
-    })
+pub(crate) fn untitled_buffer_uri(buffer_id: BufferId) -> lsp::Uri {
+    lsp::Uri::from_str(&format!("untitled:Untitled-{}", buffer_id))
+        .expect("untitled URI is always valid")
+}
+
+pub(crate) fn make_text_document_identifier(uri: &lsp::Uri) -> lsp::TextDocumentIdentifier {
+    lsp::TextDocumentIdentifier { uri: uri.clone() }
 }
 
 pub(crate) fn make_lsp_text_document_position(
-    path: &Path,
+    uri: &lsp::Uri,
     position: PointUtf16,
-) -> Result<lsp::TextDocumentPositionParams> {
-    Ok(lsp::TextDocumentPositionParams {
-        text_document: make_text_document_identifier(path)?,
+) -> lsp::TextDocumentPositionParams {
+    lsp::TextDocumentPositionParams {
+        text_document: make_text_document_identifier(uri),
         position: point_to_lsp(position),
-    })
+    }
 }
 
 #[async_trait(?Send)]
@@ -101,7 +104,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
 
     fn to_lsp_params_or_response(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         cx: &App,
@@ -110,7 +113,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
     > {
         if self.check_capabilities(language_server.adapter_server_capabilities()) {
             Ok(LspParamsOrResponse::Params(self.to_lsp(
-                path,
+                uri,
                 buffer,
                 language_server,
                 cx,
@@ -125,7 +128,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         cx: &App,
@@ -366,7 +369,7 @@ impl LspCommand for PrepareRename {
 
     fn to_lsp_params_or_response(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         cx: &App,
@@ -380,7 +383,7 @@ impl LspCommand for PrepareRename {
                 prepare_provider: Some(true),
                 ..
             })) => Ok(LspParamsOrResponse::Params(self.to_lsp(
-                path,
+                uri,
                 buffer,
                 language_server,
                 cx,
@@ -397,12 +400,12 @@ impl LspCommand for PrepareRename {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::TextDocumentPositionParams> {
-        make_lsp_text_document_position(path, self.position)
+        Ok(make_lsp_text_document_position(uri, self.position))
     }
 
     async fn response_from_lsp(
@@ -558,13 +561,13 @@ impl LspCommand for PerformRename {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::RenameParams> {
         Ok(lsp::RenameParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             new_name: self.new_name.clone(),
             work_done_progress_params: Default::default(),
         })
@@ -687,13 +690,13 @@ impl LspCommand for GetDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoDefinitionParams> {
         Ok(lsp::GotoDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -789,13 +792,13 @@ impl LspCommand for GetEditPredictionDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoDefinitionParams> {
         Ok(lsp::GotoDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -890,13 +893,13 @@ impl LspCommand for GetDeclarations {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoDeclarationParams> {
         Ok(lsp::GotoDeclarationParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -992,13 +995,13 @@ impl LspCommand for GetImplementations {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoImplementationParams> {
         Ok(lsp::GotoImplementationParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1091,13 +1094,13 @@ impl LspCommand for GetTypeDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoTypeDefinitionParams> {
         Ok(lsp::GotoTypeDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1190,13 +1193,13 @@ impl LspCommand for GetEditPredictionTypeDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoTypeDefinitionParams> {
         Ok(lsp::GotoTypeDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1671,13 +1674,13 @@ impl LspCommand for GetReferences {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::ReferenceParams> {
         Ok(lsp::ReferenceParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
             context: lsp::ReferenceContext {
@@ -1848,13 +1851,13 @@ impl LspCommand for GetDocumentHighlights {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentHighlightParams> {
         Ok(lsp::DocumentHighlightParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -2004,13 +2007,13 @@ impl LspCommand for GetDocumentSymbols {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentSymbolParams> {
         Ok(lsp::DocumentSymbolParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -2198,13 +2201,13 @@ impl LspCommand for GetSignatureHelp {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _cx: &App,
     ) -> Result<lsp::SignatureHelpParams> {
         Ok(lsp::SignatureHelpParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             context: None,
             work_done_progress_params: Default::default(),
         })
@@ -2323,13 +2326,13 @@ impl LspCommand for GetHover {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::HoverParams> {
         Ok(lsp::HoverParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
         })
     }
@@ -2562,13 +2565,13 @@ impl LspCommand for GetCompletions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CompletionParams> {
         Ok(lsp::CompletionParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             context: Some(self.context.clone()),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -2944,7 +2947,7 @@ impl LspCommand for GetCodeActions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         _: &App,
@@ -2979,7 +2982,7 @@ impl LspCommand for GetCodeActions {
         };
 
         Ok(lsp::CodeActionParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             range: range_to_lsp(self.range.to_point_utf16(buffer))?,
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -3190,13 +3193,13 @@ impl LspCommand for OnTypeFormatting {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentOnTypeFormattingParams> {
         Ok(lsp::DocumentOnTypeFormattingParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             ch: self.trigger.clone(),
             options: self.options.clone(),
         })
@@ -3696,15 +3699,13 @@ impl LspCommand for InlayHints {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::InlayHintParams> {
         Ok(lsp::InlayHintParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             range: range_to_lsp(self.range.to_point_utf16(buffer))?,
             work_done_progress_params: Default::default(),
         })
@@ -3865,15 +3866,13 @@ impl LspCommand for SemanticTokensFull {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::SemanticTokensParams> {
         Ok(lsp::SemanticTokensParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             partial_result_params: Default::default(),
             work_done_progress_params: Default::default(),
         })
@@ -4016,15 +4015,13 @@ impl LspCommand for SemanticTokensDelta {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::SemanticTokensDeltaParams> {
         Ok(lsp::SemanticTokensDeltaParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             previous_result_id: self.previous_result_id.clone().map(|s| s.to_string()),
             partial_result_params: Default::default(),
             work_done_progress_params: Default::default(),
@@ -4155,15 +4152,13 @@ impl LspCommand for GetCodeLens {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CodeLensParams> {
         Ok(lsp::CodeLensParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
             partial_result_params: lsp::PartialResultParams::default(),
         })
@@ -4289,14 +4284,14 @@ impl LspCommand for LinkedEditingRange {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _server: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::LinkedEditingRangeParams> {
         let position = self.position.to_point_utf16(&buffer.snapshot());
         Ok(lsp::LinkedEditingRangeParams {
-            text_document_position_params: make_lsp_text_document_position(path, position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, position),
             work_done_progress_params: Default::default(),
         })
     }
@@ -4720,15 +4715,13 @@ impl LspCommand for GetDocumentDiagnostics {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentDiagnosticParams> {
         Ok(lsp::DocumentDiagnosticParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             identifier: self.identifier.as_ref().map(ToString::to_string),
             previous_result_id: self.previous_result_id.as_ref().map(ToString::to_string),
             partial_result_params: Default::default(),
@@ -4739,21 +4732,23 @@ impl LspCommand for GetDocumentDiagnostics {
     async fn response_from_lsp(
         self,
         message: lsp::DocumentDiagnosticReportResult,
-        _: Entity<LspStore>,
+        lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
         cx: AsyncApp,
     ) -> Result<Self::Response> {
-        let url = buffer.read_with(&cx, |buffer, cx| {
-            buffer
-                .file()
-                .and_then(|file| file.as_local())
-                .map(|file| {
-                    let abs_path = file.abs_path(cx);
-                    file_path_to_lsp_url(&abs_path)
-                })
-                .transpose()?
-                .with_context(|| format!("missing url on buffer {}", buffer.remote_id()))
+        let url = lsp_store.read_with(&cx, |lsp_store, cx| {
+            let buffer = buffer.read(cx);
+            let buffer_id = buffer.remote_id();
+            if let Some(file) = buffer.file().and_then(|file| file.as_local()) {
+                let abs_path = file.abs_path(cx);
+                file_path_to_lsp_url(&abs_path)
+            } else {
+                lsp_store
+                    .as_local()
+                    .and_then(|local| local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone()))
+                    .with_context(|| format!("missing url on buffer {buffer_id}"))
+            }
         })?;
 
         let mut pulled_diagnostics = HashMap::default();
@@ -4917,13 +4912,13 @@ impl LspCommand for GetDocumentColor {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentColorParams> {
         Ok(lsp::DocumentColorParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -5060,13 +5055,13 @@ impl LspCommand for GetFoldingRanges {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::FoldingRangeParams> {
         Ok(lsp::FoldingRangeParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -5211,13 +5206,13 @@ impl LspCommand for GetDocumentLinks {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentLinkParams> {
         Ok(lsp::DocumentLinkParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
             partial_result_params: lsp::PartialResultParams::default(),
         })

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -71,20 +71,23 @@ pub fn file_path_to_lsp_url(path: &Path) -> Result<lsp::Uri> {
     }
 }
 
-pub(crate) fn make_text_document_identifier(path: &Path) -> Result<lsp::TextDocumentIdentifier> {
-    Ok(lsp::TextDocumentIdentifier {
-        uri: file_path_to_lsp_url(path)?,
-    })
+pub(crate) fn untitled_buffer_uri(buffer_id: BufferId) -> lsp::Uri {
+    lsp::Uri::from_str(&format!("untitled:Untitled-{}", buffer_id))
+        .expect("untitled URI is always valid")
+}
+
+pub(crate) fn make_text_document_identifier(uri: &lsp::Uri) -> lsp::TextDocumentIdentifier {
+    lsp::TextDocumentIdentifier { uri: uri.clone() }
 }
 
 pub(crate) fn make_lsp_text_document_position(
-    path: &Path,
+    uri: &lsp::Uri,
     position: PointUtf16,
-) -> Result<lsp::TextDocumentPositionParams> {
-    Ok(lsp::TextDocumentPositionParams {
-        text_document: make_text_document_identifier(path)?,
+) -> lsp::TextDocumentPositionParams {
+    lsp::TextDocumentPositionParams {
+        text_document: make_text_document_identifier(uri),
         position: point_to_lsp(position),
-    })
+    }
 }
 
 #[async_trait(?Send)]
@@ -115,7 +118,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         cx: &App,
@@ -385,7 +388,7 @@ fn anchor_range_from_lsp(range: lsp::Range, buffer: &Buffer) -> Range<Anchor> {
 
 fn call_hierarchy_item_to_lsp(
     item: &CallHierarchyItem,
-    path: &Path,
+    uri: &lsp::Uri,
     buffer: &Buffer,
 ) -> Result<lsp::CallHierarchyItem> {
     Ok(lsp::CallHierarchyItem {
@@ -393,7 +396,7 @@ fn call_hierarchy_item_to_lsp(
         kind: item.kind,
         tags: None,
         detail: item.detail.clone(),
-        uri: file_path_to_lsp_url(path)?,
+        uri: uri.clone(),
         range: range_to_lsp(item.range.to_point_utf16(buffer))?,
         selection_range: range_to_lsp(item.selection_range.to_point_utf16(buffer))?,
         data: item.data.clone(),
@@ -511,13 +514,13 @@ impl LspCommand for PrepareCallHierarchy {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CallHierarchyPrepareParams> {
         Ok(lsp::CallHierarchyPrepareParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
         })
     }
@@ -682,13 +685,13 @@ impl LspCommand for GetIncomingCalls {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CallHierarchyIncomingCallsParams> {
         Ok(lsp::CallHierarchyIncomingCallsParams {
-            item: call_hierarchy_item_to_lsp(&self.item, path, buffer)?,
+            item: call_hierarchy_item_to_lsp(&self.item, uri, buffer)?,
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
             partial_result_params: lsp::PartialResultParams::default(),
         })
@@ -824,13 +827,13 @@ impl LspCommand for GetOutgoingCalls {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CallHierarchyOutgoingCallsParams> {
         Ok(lsp::CallHierarchyOutgoingCallsParams {
-            item: call_hierarchy_item_to_lsp(&self.item, path, buffer)?,
+            item: call_hierarchy_item_to_lsp(&self.item, uri, buffer)?,
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
             partial_result_params: lsp::PartialResultParams::default(),
         })
@@ -981,12 +984,12 @@ impl LspCommand for PrepareRename {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::TextDocumentPositionParams> {
-        make_lsp_text_document_position(path, self.position)
+        Ok(make_lsp_text_document_position(uri, self.position))
     }
 
     async fn response_from_lsp(
@@ -1158,13 +1161,13 @@ impl LspCommand for PerformRename {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::RenameParams> {
         Ok(lsp::RenameParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             new_name: self.new_name.clone(),
             work_done_progress_params: Default::default(),
         })
@@ -1303,13 +1306,13 @@ impl LspCommand for GetDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoDefinitionParams> {
         Ok(lsp::GotoDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1406,13 +1409,13 @@ impl LspCommand for GetEditPredictionDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoDefinitionParams> {
         Ok(lsp::GotoDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1508,13 +1511,13 @@ impl LspCommand for GetDeclarations {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoDeclarationParams> {
         Ok(lsp::GotoDeclarationParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1611,13 +1614,13 @@ impl LspCommand for GetImplementations {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoImplementationParams> {
         Ok(lsp::GotoImplementationParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1710,13 +1713,13 @@ impl LspCommand for GetTypeDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoTypeDefinitionParams> {
         Ok(lsp::GotoTypeDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -1809,13 +1812,13 @@ impl LspCommand for GetEditPredictionTypeDefinitions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::GotoTypeDefinitionParams> {
         Ok(lsp::GotoTypeDefinitionParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -2286,13 +2289,13 @@ impl LspCommand for GetReferences {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::ReferenceParams> {
         Ok(lsp::ReferenceParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
             context: lsp::ReferenceContext {
@@ -2463,13 +2466,13 @@ impl LspCommand for GetDocumentHighlights {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentHighlightParams> {
         Ok(lsp::DocumentHighlightParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -2619,13 +2622,13 @@ impl LspCommand for GetDocumentSymbols {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentSymbolParams> {
         Ok(lsp::DocumentSymbolParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -2813,13 +2816,13 @@ impl LspCommand for GetSignatureHelp {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _cx: &App,
     ) -> Result<lsp::SignatureHelpParams> {
         Ok(lsp::SignatureHelpParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             context: None,
             work_done_progress_params: Default::default(),
         })
@@ -2938,13 +2941,13 @@ impl LspCommand for GetHover {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::HoverParams> {
         Ok(lsp::HoverParams {
-            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, self.position),
             work_done_progress_params: Default::default(),
         })
     }
@@ -3177,13 +3180,13 @@ impl LspCommand for GetCompletions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CompletionParams> {
         Ok(lsp::CompletionParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             context: Some(self.context.clone()),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -3559,12 +3562,12 @@ impl LspCommand for GetCodeActions {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CodeActionParams> {
-        let text_document = make_text_document_identifier(path)?;
+        let text_document = make_text_document_identifier(uri);
         let snapshot = buffer.snapshot();
         let mut relevant_diagnostics = Vec::new();
         let target_server_id = language_server.server_id();
@@ -3585,7 +3588,7 @@ impl LspCommand for GetCodeActions {
         }
 
         Ok(lsp::CodeActionParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document,
             range: range_to_lsp(self.range.to_point_utf16(buffer))?,
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -3800,13 +3803,13 @@ impl LspCommand for OnTypeFormatting {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentOnTypeFormattingParams> {
         Ok(lsp::DocumentOnTypeFormattingParams {
-            text_document_position: make_lsp_text_document_position(path, self.position)?,
+            text_document_position: make_lsp_text_document_position(uri, self.position),
             ch: self.trigger.clone(),
             options: self.options.clone(),
         })
@@ -4306,15 +4309,13 @@ impl LspCommand for InlayHints {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::InlayHintParams> {
         Ok(lsp::InlayHintParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             range: range_to_lsp(self.range.to_point_utf16(buffer))?,
             work_done_progress_params: Default::default(),
         })
@@ -4484,15 +4485,13 @@ impl LspCommand for SemanticTokensFull {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::SemanticTokensParams> {
         Ok(lsp::SemanticTokensParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             partial_result_params: Default::default(),
             work_done_progress_params: Default::default(),
         })
@@ -4635,15 +4634,13 @@ impl LspCommand for SemanticTokensDelta {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::SemanticTokensDeltaParams> {
         Ok(lsp::SemanticTokensDeltaParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             previous_result_id: self.previous_result_id.clone().map(|s| s.to_string()),
             partial_result_params: Default::default(),
             work_done_progress_params: Default::default(),
@@ -4774,15 +4771,13 @@ impl LspCommand for GetCodeLens {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CodeLensParams> {
         Ok(lsp::CodeLensParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
             partial_result_params: lsp::PartialResultParams::default(),
         })
@@ -4909,14 +4904,14 @@ impl LspCommand for LinkedEditingRange {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _server: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::LinkedEditingRangeParams> {
         let position = self.position.to_point_utf16(&buffer.snapshot());
         Ok(lsp::LinkedEditingRangeParams {
-            text_document_position_params: make_lsp_text_document_position(path, position)?,
+            text_document_position_params: make_lsp_text_document_position(uri, position),
             work_done_progress_params: Default::default(),
         })
     }
@@ -5363,15 +5358,13 @@ impl LspCommand for GetDocumentDiagnostics {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentDiagnosticParams> {
         Ok(lsp::DocumentDiagnosticParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: file_path_to_lsp_url(path)?,
-            },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             identifier: self.identifier.as_ref().map(ToString::to_string),
             previous_result_id: self.previous_result_id.as_ref().map(ToString::to_string),
             partial_result_params: Default::default(),
@@ -5382,21 +5375,23 @@ impl LspCommand for GetDocumentDiagnostics {
     async fn response_from_lsp(
         self,
         message: lsp::DocumentDiagnosticReportResult,
-        _: Entity<LspStore>,
+        lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
         cx: AsyncApp,
     ) -> Result<Self::Response> {
-        let url = buffer.read_with(&cx, |buffer, cx| {
-            buffer
-                .file()
-                .and_then(|file| file.as_local())
-                .map(|file| {
-                    let abs_path = file.abs_path(cx);
-                    file_path_to_lsp_url(&abs_path)
-                })
-                .transpose()?
-                .with_context(|| format!("missing url on buffer {}", buffer.remote_id()))
+        let url = lsp_store.read_with(&cx, |lsp_store, cx| {
+            let buffer = buffer.read(cx);
+            let buffer_id = buffer.remote_id();
+            if let Some(file) = buffer.file().and_then(|file| file.as_local()) {
+                let abs_path = file.abs_path(cx);
+                file_path_to_lsp_url(&abs_path)
+            } else {
+                lsp_store
+                    .as_local()
+                    .and_then(|local| local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone()))
+                    .with_context(|| format!("missing url on buffer {buffer_id}"))
+            }
         })?;
 
         let mut pulled_diagnostics = HashMap::default();
@@ -5560,13 +5555,13 @@ impl LspCommand for GetDocumentColor {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentColorParams> {
         Ok(lsp::DocumentColorParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -5703,13 +5698,13 @@ impl LspCommand for GetFoldingRanges {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::FoldingRangeParams> {
         Ok(lsp::FoldingRangeParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
@@ -5854,13 +5849,13 @@ impl LspCommand for GetDocumentLinks {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentLinkParams> {
         Ok(lsp::DocumentLinkParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             work_done_progress_params: lsp::WorkDoneProgressParams::default(),
             partial_result_params: lsp::PartialResultParams::default(),
         })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -309,6 +309,16 @@ struct DocumentSelectorContext {
     scheme: &'static str,
 }
 
+/// Per-untitled-buffer LSP state. File-backed buffers don't need this — their
+/// URI and worktree are derivable from `file.abs_path()` / `file.worktree_id()`.
+#[derive(Debug, Clone)]
+pub(crate) struct UntitledBufferState {
+    pub(crate) uri: lsp::Uri,
+    /// The worktree the buffer was registered against (the first visible
+    /// worktree at registration time). Tracked so that when the worktree is
+    /// removed we can drop the corresponding `buffer_uris` entry.
+    pub(crate) host_worktree: WorktreeId,
+}
 pub struct LocalLspStore {
     weak: WeakEntity<LspStore>,
     pub worktree_store: Entity<WorktreeStore>,
@@ -348,6 +358,7 @@ pub struct LocalLspStore {
     lsp_tree: LanguageServerTree,
     registered_buffers: HashMap<BufferId, usize>,
     buffers_opened_in_servers: HashMap<BufferId, HashSet<LanguageServerId>>,
+    pub(crate) buffer_uris: HashMap<BufferId, UntitledBufferState>,
     buffer_pull_diagnostics_result_ids: HashMap<
         LanguageServerId,
         HashMap<Option<SharedString>, HashMap<PathBuf, Option<SharedString>>>,
@@ -1424,6 +1435,11 @@ impl LocalLspStore {
                 .unwrap_or_else(|| file.path().clone());
             let worktree_path = ProjectPath { worktree_id, path };
             self.language_server_ids_for_project_path(worktree_path, language, cx)
+        } else if buffer.file().is_none() {
+            self.buffers_opened_in_servers
+                .get(&buffer.remote_id())
+                .map(|server_ids| server_ids.iter().copied().collect())
+                .unwrap_or_default()
         } else {
             Vec::new()
         }
@@ -1943,8 +1959,18 @@ impl LocalLspStore {
                 zlog::trace!(logger => "formatting");
                 let _timer = zlog::time!(logger => "Formatting buffer using language server");
 
-                let Some(buffer_path_abs) = buffer.abs_path.as_ref() else {
-                    zlog::warn!(logger => "Cannot format buffer that is not backed by a file on disk using language servers. Skipping");
+                let buffer_uri = if let Some(abs_path) = buffer.abs_path.as_ref() {
+                    Some(file_path_to_lsp_url(abs_path)?)
+                } else {
+                    lsp_store.read_with(cx, |lsp_store, cx| {
+                        let buffer_id = buffer.handle.read(cx).remote_id();
+                        lsp_store.as_local().and_then(|local| {
+                            local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone())
+                        })
+                    })?
+                };
+                let Some(buffer_uri) = buffer_uri else {
+                    zlog::warn!(logger => "Cannot format buffer that has no LSP URI. Skipping");
                     return Ok(());
                 };
 
@@ -2010,14 +2036,16 @@ impl LocalLspStore {
                 let Some((adapter, language_server)) = adapter_and_server else {
                     zlog::debug!(
                         logger =>
-                        "No language server found to format buffer {buffer_path_abs:?}. Skipping",
+                        "No language server found to format buffer '{:?}'. Skipping",
+                        buffer_uri
                     );
                     return Ok(());
                 };
 
                 zlog::trace!(
                     logger =>
-                    "Formatting buffer {buffer_path_abs:?} using language server {:?}",
+                    "Formatting buffer '{:?}' using language server '{:?}'",
+                    buffer_uri,
                     language_server.name()
                 );
 
@@ -2027,7 +2055,7 @@ impl LocalLspStore {
                         &lsp_store,
                         &buffer.handle,
                         ranges,
-                        buffer_path_abs,
+                        &buffer_uri,
                         &adapter,
                         &language_server,
                         &settings,
@@ -2049,7 +2077,7 @@ impl LocalLspStore {
                                 Self::format_via_lsp(
                                     &lsp_store,
                                     &buffer.handle,
-                                    buffer_path_abs,
+                                    &buffer_uri,
                                     &adapter,
                                     &language_server,
                                     &settings,
@@ -2072,7 +2100,7 @@ impl LocalLspStore {
                     Self::format_via_lsp(
                         &lsp_store,
                         &buffer.handle,
-                        buffer_path_abs,
+                        &buffer_uri,
                         &adapter,
                         &language_server,
                         &settings,
@@ -2100,8 +2128,18 @@ impl LocalLspStore {
                 zlog::trace!(logger => "formatting");
                 let _timer = zlog::time!(logger => "Formatting buffer using code actions");
 
-                let Some(buffer_path_abs) = buffer.abs_path.as_ref() else {
-                    zlog::warn!(logger => "Cannot format buffer that is not backed by a file on disk using code actions. Skipping");
+                let buffer_uri = if let Some(abs_path) = buffer.abs_path.as_ref() {
+                    Some(file_path_to_lsp_url(abs_path)?)
+                } else {
+                    lsp_store.read_with(cx, |lsp_store, cx| {
+                        let buffer_id = buffer.handle.read(cx).remote_id();
+                        lsp_store.as_local().and_then(|local| {
+                            local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone())
+                        })
+                    })?
+                };
+                let Some(buffer_uri) = buffer_uri else {
+                    zlog::warn!(logger => "Cannot format buffer that has no LSP URI. Skipping");
                     return Ok(());
                 };
 
@@ -2260,21 +2298,23 @@ impl LocalLspStore {
                                     continue 'actions;
                                 }
                             };
-                            let Ok(file_path) = op.text_document.uri.to_file_path() else {
-                                zlog::warn!(
-                                    logger =>
-                                    "Failed to convert URI '{:?}' to file path. Skipping {}",
-                                    &op.text_document.uri,
-                                    describe_code_action(&action),
+                            // For file URIs, fall back to path equality so that case-insensitive
+                            // filesystems and minor URI normalization differences (e.g. trailing
+                            // slash, percent-encoding) don't cause spurious mismatches.
+                            let uris_match = op.text_document.uri == buffer_uri
+                                || matches!(
+                                    (
+                                        op.text_document.uri.to_file_path(),
+                                        buffer_uri.to_file_path(),
+                                    ),
+                                    (Ok(op_path), Ok(buf_path)) if op_path == buf_path
                                 );
-                                continue 'actions;
-                            };
-                            if &file_path != buffer_path_abs {
+                            if !uris_match {
                                 zlog::warn!(
                                     logger =>
-                                    "File path '{:?}' does not match buffer path '{:?}'. Skipping {}",
-                                    file_path,
-                                    buffer_path_abs,
+                                    "URI '{:?}' does not match buffer URI '{:?}'. Skipping {}",
+                                    op.text_document.uri,
+                                    buffer_uri,
                                     describe_code_action(&action),
                                 );
                                 continue 'actions;
@@ -2318,7 +2358,7 @@ impl LocalLspStore {
                                 zlog::warn!(
                                     logger =>
                                     "Failed to resolve edits from LSP for buffer {:?} while handling {}",
-                                    buffer_path_abs.as_path(),
+                                    buffer_uri,
                                     describe_code_action(&action),
                                 );
                                 continue 'actions;
@@ -2475,7 +2515,7 @@ impl LocalLspStore {
         this: &WeakEntity<LspStore>,
         buffer_handle: &Entity<Buffer>,
         ranges: &[Range<Anchor>],
-        abs_path: &Path,
+        uri: &lsp::Uri,
         adapter: &Arc<CachedLspAdapter>,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
@@ -2499,7 +2539,7 @@ impl LocalLspStore {
             return Ok(None);
         }
 
-        let uri = file_path_to_lsp_url(abs_path)?;
+        let uri = uri.clone();
         let text_document = lsp::TextDocumentIdentifier::new(uri);
 
         let request_timeout = cx.update(|app| {
@@ -2618,7 +2658,7 @@ impl LocalLspStore {
     async fn format_via_lsp(
         this: &WeakEntity<LspStore>,
         buffer: &Entity<Buffer>,
-        abs_path: &Path,
+        uri: &lsp::Uri,
         adapter: &Arc<CachedLspAdapter>,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
@@ -2627,7 +2667,7 @@ impl LocalLspStore {
         let logger = zlog::scoped!("lsp_format");
         zlog::debug!(logger => "Formatting via LSP");
 
-        let uri = file_path_to_lsp_url(abs_path)?;
+        let uri = uri.clone();
         let text_document = lsp::TextDocumentIdentifier::new(uri);
 
         let (formatting_supported, range_formatting_supported) =
@@ -3015,13 +3055,20 @@ impl LocalLspStore {
         let set = DiagnosticSet::new(sanitized_diagnostics, &snapshot);
         buffer.update(cx, |buffer, cx| {
             if let Some(registration_id) = registration_id {
-                if let Some(abs_path) = File::from_dyn(buffer.file()).map(|f| f.abs_path(cx)) {
+                let key = File::from_dyn(buffer.file())
+                    .map(|f| f.abs_path(cx))
+                    .or_else(|| {
+                        self.buffer_uris
+                            .get(&buffer.remote_id())
+                            .map(|state| PathBuf::from(state.uri.to_string()))
+                    });
+                if let Some(key) = key {
                     self.buffer_pull_diagnostics_result_ids
                         .entry(server_id)
                         .or_default()
                         .entry(registration_id)
                         .or_default()
-                        .insert(abs_path, result_id);
+                        .insert(key, result_id);
                 }
             }
 
@@ -3077,45 +3124,75 @@ impl LocalLspStore {
         let buffer = buffer_handle.read(cx);
         let buffer_id = buffer.remote_id();
 
-        let Some(file) = File::from_dyn(buffer.file()) else {
-            return;
-        };
-        if !file.is_local() {
+        let file = File::from_dyn(buffer.file());
+        if file.is_some_and(|file| !file.is_local()) {
             return;
         }
 
-        let abs_path = file.abs_path(cx);
+        let Some(language) = buffer.language().cloned() else {
+            return;
+        };
+
         if let Some((longest_line_length, maximum_line_length)) =
             Self::language_server_line_length_limit_exceeded(buffer, cx)
         {
+            let buffer_display_name = file
+                .map(|file| file.abs_path(cx).to_string_lossy().into_owned())
+                .unwrap_or_else(|| untitled_buffer_uri(buffer_id).to_string());
             log::debug!(
                 "not registering {} with language servers because its longest line has {} characters, exceeding the configured limit of {}",
-                abs_path.display(),
+                buffer_display_name,
                 longest_line_length,
                 maximum_line_length,
             );
             return;
         }
-        let Some(uri) = file_path_to_lsp_url(&abs_path).log_err() else {
-            return;
-        };
-        let initial_snapshot = buffer.text_snapshot();
-        let worktree_id = file.worktree_id(cx);
 
-        let Some(language) = buffer.language().cloned() else {
-            return;
-        };
-        let path: Arc<RelPath> = file
-            .path()
-            .parent()
-            .map(Arc::from)
-            .unwrap_or_else(|| file.path().clone());
-        let Some(worktree) = self
-            .worktree_store
-            .read(cx)
-            .worktree_for_id(worktree_id, cx)
-        else {
-            return;
+        let (uri, uri_display, initial_snapshot, worktree_id, path, worktree);
+        if let Some(file) = file {
+            let abs_path = file.abs_path(cx);
+            let Some(file_uri) = file_path_to_lsp_url(&abs_path).log_err() else {
+                return;
+            };
+            uri = file_uri;
+            uri_display = abs_path.to_string_lossy().into_owned();
+            initial_snapshot = buffer.text_snapshot();
+            worktree_id = file.worktree_id(cx);
+            path = file
+                .path()
+                .parent()
+                .map(Arc::from)
+                .unwrap_or_else(|| file.path().clone());
+            let Some(wt) = self
+                .worktree_store
+                .read(cx)
+                .worktree_for_id(worktree_id, cx)
+            else {
+                return;
+            };
+            worktree = wt;
+        } else {
+            uri = untitled_buffer_uri(buffer_id);
+            uri_display = uri.to_string();
+            initial_snapshot = buffer.text_snapshot();
+            let Some(wt) = self.worktree_store.read(cx).visible_worktrees(cx).next() else {
+                log::debug!(
+                    "Skipping LSP registration for untitled buffer {buffer_id}: no visible worktree"
+                );
+                return;
+            };
+            worktree = wt;
+            worktree_id = worktree.read(cx).id();
+            path = Arc::from(RelPath::empty());
+            // Only untitled buffers need stored state, file-backed buffers can
+            // derive their URI/worktree from `file.abs_path()` / `file.worktree_id()`.
+            self.buffer_uris.insert(
+                buffer_id,
+                UntitledBufferState {
+                    uri: uri.clone(),
+                    host_worktree: worktree_id,
+                },
+            );
         };
         let language_name = language.name();
         let (reused, delegate, servers) = self
@@ -3241,12 +3318,39 @@ impl LocalLspStore {
                     name: None,
                     message: proto::update_language_server::Variant::RegisteredForBuffer(
                         proto::RegisteredForBuffer {
-                            buffer_abs_path: abs_path.to_string_lossy().into_owned(),
+                            buffer_abs_path: uri_display.clone(),
                             buffer_id: buffer_id.to_proto(),
                         },
                     ),
                 });
             }
+        }
+    }
+
+    /// Re-attempts LSP registration for untitled buffers that were registered
+    /// before any visible worktree existed. Such buffers got their refcount
+    /// bumped in `LspStore::register_buffer_with_language_servers` but bailed
+    /// out of `LocalLspStore::register_buffer_with_language_servers` (no host
+    /// worktree available), leaving them in `registered_buffers` but not in
+    /// `buffer_uris`. When a worktree is later added, we can pick them up here.
+    fn register_pending_untitled_buffers(
+        &mut self,
+        buffer_store: &Entity<BufferStore>,
+        cx: &mut Context<LspStore>,
+    ) {
+        let candidates: Vec<Entity<Buffer>> = buffer_store
+            .read(cx)
+            .buffers()
+            .filter(|buffer| {
+                let buffer = buffer.read(cx);
+                buffer.file().is_none()
+                    && buffer.language().is_some()
+                    && self.registered_buffers.contains_key(&buffer.remote_id())
+                    && !self.buffer_uris.contains_key(&buffer.remote_id())
+            })
+            .collect();
+        for buffer in candidates {
+            self.register_buffer_with_language_servers(&buffer, HashSet::default(), cx);
         }
     }
 
@@ -4016,6 +4120,14 @@ impl LocalLspStore {
             }
             cx.emit(LspStoreEvent::LanguageServerRemoved(*server_id_to_remove));
         }
+
+        // Untitled buffers anchored to the removed worktree have no remaining
+        // host: drop their `buffer_uris` entry so `is_lsp_relevant` stops
+        // returning true for them. The associated language servers were already
+        // removed above, so there's nothing to unregister at the LSP level.
+        self.buffer_uris
+            .retain(|_, state| state.host_worktree != id_to_remove);
+
         servers_to_remove.into_iter().collect()
     }
 
@@ -4795,6 +4907,11 @@ impl LspStore {
         }
     }
 
+    pub fn has_buffer_uri(&self, buffer_id: BufferId) -> bool {
+        self.as_local()
+            .is_some_and(|local| local.buffer_uris.contains_key(&buffer_id))
+    }
+
     pub fn upstream_client(&self) -> Option<(AnyProtoClient, u64)> {
         match &self.mode {
             LspStoreMode::Remote(RemoteLspStore {
@@ -4881,6 +4998,7 @@ impl LspStore {
                 toolchain_store,
                 registered_buffers: HashMap::default(),
                 buffers_opened_in_servers: HashMap::default(),
+                buffer_uris: HashMap::default(),
                 buffer_pull_diagnostics_result_ids: HashMap::default(),
                 workspace_pull_diagnostics_result_ids: HashMap::default(),
                 restricted_worktrees_tasks: HashMap::default(),
@@ -4986,13 +5104,17 @@ impl LspStore {
             }
             BufferStoreEvent::BufferChangedFilePath { buffer, old_file } => {
                 let buffer_id = buffer.read(cx).remote_id();
-                if let Some(local) = self.as_local_mut()
-                    && let Some(old_file) = File::from_dyn(old_file.as_ref())
-                {
-                    local.reset_buffer(buffer, old_file, cx);
+                if let Some(local) = self.as_local_mut() {
+                    if let Some(old_file) = File::from_dyn(old_file.as_ref()) {
+                        local.reset_buffer(buffer, old_file, cx);
 
-                    if local.registered_buffers.contains_key(&buffer_id) {
-                        local.unregister_old_buffer_from_language_servers(buffer, old_file, cx);
+                        if local.registered_buffers.contains_key(&buffer_id) {
+                            local.unregister_old_buffer_from_language_servers(buffer, old_file, cx);
+                        }
+                    } else if local.registered_buffers.contains_key(&buffer_id) {
+                        if let Some(state) = local.buffer_uris.remove(&buffer_id) {
+                            local.unregister_buffer_from_language_servers(buffer, &state.uri, cx);
+                        }
                     }
                 }
 
@@ -5028,7 +5150,14 @@ impl LspStore {
                     | worktree::Event::Deleted
                     | worktree::Event::UpdatedRootRepoCommonDir { .. } => {}
                 })
-                .detach()
+                .detach();
+
+                // Untitled buffers created before any visible worktree existed
+                // get registered now that one is available.
+                let buffer_store = self.buffer_store.clone();
+                if let Some(local) = self.as_local_mut() {
+                    local.register_pending_untitled_buffers(&buffer_store, cx);
+                }
             }
             WorktreeStoreEvent::WorktreeRemoved(_, id) => self.remove_worktree(*id, cx),
             WorktreeStoreEvent::WorktreeUpdateSent(worktree) => {
@@ -5242,15 +5371,10 @@ impl LspStore {
                 *refcount += 1;
             }
 
-            // We run early exits on non-existing buffers AFTER we mark the buffer as registered in order to handle buffer saving.
-            // When a new unnamed buffer is created and saved, we will start loading it's language. Once the language is loaded, we go over all "language-less" buffers and try to fit that new language
-            // with them. However, we do that only for the buffers that we think are open in at least one editor; thus, we need to keep tab of unnamed buffers as well, even though they're not actually registered with any language
-            // servers in practice (we don't support non-file URI schemes in our LSP impl).
-            let Some(file) = File::from_dyn(buffer.read(cx).file()) else {
-                return handle;
-            };
-            if !file.is_local() {
-                return handle;
+            if let Some(file) = File::from_dyn(buffer.read(cx).file()) {
+                if !file.is_local() {
+                    return handle;
+                }
             }
 
             if ignore_refcounts || *refcount == 1 {
@@ -5274,7 +5398,6 @@ impl LspStore {
                         let local = lsp_store.as_local_mut().unwrap();
                         local.registered_buffers.remove(&buffer_id);
 
-                        local.buffers_opened_in_servers.remove(&buffer_id);
                         if let Some(file) = File::from_dyn(buffer.0.read(cx).file()).cloned() {
                             local.unregister_old_buffer_from_language_servers(&buffer.0, &file, cx);
 
@@ -5311,7 +5434,15 @@ impl LspStore {
                                 },
                                 cx,
                             );
+                        } else if let Some(state) = local.buffer_uris.remove(&buffer_id) {
+                            local
+                                .unregister_buffer_from_language_servers(&buffer.0, &state.uri, cx);
                         }
+                        lsp_store
+                            .as_local_mut()
+                            .unwrap()
+                            .buffers_opened_in_servers
+                            .remove(&buffer_id);
                     }
                 })
                 .detach();
@@ -5574,13 +5705,26 @@ impl LspStore {
         let mut detached_abs_path = None;
         if let Some(local_store) = self.as_local_mut()
             && local_store.registered_buffers.contains_key(&buffer_id)
-            && let Some(abs_path) =
-                File::from_dyn(buffer_file.as_ref()).map(|file| file.abs_path(cx))
-            && let Some(file_url) = file_path_to_lsp_url(&abs_path).log_err()
         {
-            detached_servers =
-                local_store.unregister_buffer_from_language_servers(buffer_entity, &file_url, cx);
-            detached_abs_path = Some(abs_path);
+            if let Some(abs_path) =
+                File::from_dyn(buffer_file.as_ref()).map(|file| file.abs_path(cx))
+            {
+                if let Some(uri) = file_path_to_lsp_url(&abs_path).log_err() {
+                    detached_servers = local_store.unregister_buffer_from_language_servers(
+                        buffer_entity,
+                        &uri,
+                        cx,
+                    );
+                    detached_abs_path = Some(abs_path);
+                }
+            } else if let Some(uri) = local_store
+                .buffer_uris
+                .get(&buffer_id)
+                .map(|state| state.uri.clone())
+            {
+                detached_servers =
+                    local_store.unregister_buffer_from_language_servers(buffer_entity, &uri, cx);
+            }
         }
         buffer_entity.update(cx, |buffer, cx| {
             if buffer
@@ -5598,18 +5742,12 @@ impl LspStore {
         );
         let buffer_file = File::from_dyn(buffer_file.as_ref());
 
-        let worktree_id = if let Some(file) = buffer_file {
-            let worktree = file.worktree.clone();
-
-            if let Some(local) = self.as_local_mut()
-                && local.registered_buffers.contains_key(&buffer_id)
-            {
-                local.register_buffer_with_language_servers(buffer_entity, HashSet::default(), cx);
-            }
-            Some(worktree.read(cx).id())
-        } else {
-            None
-        };
+        if let Some(local) = self.as_local_mut()
+            && local.registered_buffers.contains_key(&buffer_id)
+        {
+            local.register_buffer_with_language_servers(buffer_entity, HashSet::default(), cx);
+        }
+        let worktree_id = buffer_file.map(|file| file.worktree.read(cx).id());
 
         // A detached server keeps running and may legitimately re-publish for this path,
         // since publishes are applied by path with no regard for registration. So only
@@ -6113,28 +6251,38 @@ impl LspStore {
             LanguageServerQueryOutcome::Respond(response) => return Task::ready(Ok(response)),
         };
 
-        let file = File::from_dyn(buffer.read(cx).file()).and_then(File::as_local);
-
-        let Some(file) = file else {
-            return Task::ready(Ok(Default::default()));
-        };
-
-        let lsp_params =
-            match request.to_lsp(&file.abs_path(cx), buffer.read(cx), &language_server, cx) {
-                Ok(lsp_params) => lsp_params,
-                Err(err) => {
-                    let err = err.context(format!(
-                        "{} via {} failed",
-                        request.display_name(),
-                        language_server.name(),
-                    ));
-                    let message = format!("{err:#}");
-                    if should_log_lsp_request_failure(&message) {
-                        log::warn!("{message}");
-                    }
-                    return Task::ready(Err(err));
+        let uri =
+            if let Some(file) = File::from_dyn(buffer.read(cx).file()).and_then(File::as_local) {
+                match file_path_to_lsp_url(&file.abs_path(cx)) {
+                    Ok(uri) => uri,
+                    Err(err) => return Task::ready(Err(err)),
                 }
+            } else if let Some(uri) = self.as_local().and_then(|local| {
+                local
+                    .buffer_uris
+                    .get(&buffer.read(cx).remote_id())
+                    .map(|state| state.uri.clone())
+            }) {
+                uri
+            } else {
+                return Task::ready(Ok(Default::default()));
             };
+
+        let lsp_params = match request.to_lsp(&uri, buffer.read(cx), &language_server, cx) {
+            Ok(lsp_params) => lsp_params,
+            Err(err) => {
+                let err = err.context(format!(
+                    "{} via {} failed",
+                    request.display_name(),
+                    language_server.name(),
+                ));
+                let message = format!("{err:#}");
+                if should_log_lsp_request_failure(&message) {
+                    log::warn!("{message}");
+                }
+                return Task::ready(Err(err));
+            }
+        };
 
         let status = request.status();
         let request_timeout = ProjectSettings::get_global(cx)
@@ -6279,6 +6427,7 @@ impl LspStore {
         let mut messages_to_report = Vec::new();
         let (new_tree, to_stop) = {
             let mut rebase = local.lsp_tree.rebase();
+            let host_worktree = local.worktree_store.read(cx).visible_worktrees(cx).next();
             let buffers = buffer_store
                 .read(cx)
                 .buffers()
@@ -6290,19 +6439,44 @@ impl LspStore {
                     {
                         return None;
                     }
-                    let file = File::from_dyn(raw_buffer.file()).cloned()?;
                     let language = raw_buffer.language().cloned()?;
-                    Some((file, language, raw_buffer.remote_id()))
+                    if let Some(file) = File::from_dyn(raw_buffer.file()).cloned() {
+                        Some((Some(file), language, raw_buffer.remote_id()))
+                    } else if host_worktree.is_some() {
+                        Some((None, language, raw_buffer.remote_id()))
+                    } else {
+                        log::debug!(
+                            "Skipping LSP refresh for untitled buffer {}: no visible worktree",
+                            raw_buffer.remote_id()
+                        );
+                        None
+                    }
                 })
-                .sorted_by_key(|(file, _, _)| Reverse(file.worktree.read(cx).is_visible()));
+                .sorted_by_key(|(file, _, _)| {
+                    Reverse(
+                        file.as_ref()
+                            .map(|f| f.worktree.read(cx).is_visible())
+                            .unwrap_or(false),
+                    )
+                });
             for (file, language, buffer_id) in buffers {
-                let worktree_id = file.worktree_id(cx);
-                let Some(worktree) = local
-                    .worktree_store
-                    .read(cx)
-                    .worktree_for_id(worktree_id, cx)
-                else {
-                    continue;
+                let (worktree_id, worktree);
+                if let Some(file) = &file {
+                    worktree_id = file.worktree_id(cx);
+                    let Some(wt) = local
+                        .worktree_store
+                        .read(cx)
+                        .worktree_for_id(worktree_id, cx)
+                    else {
+                        continue;
+                    };
+                    worktree = wt;
+                } else {
+                    let Some(wt) = host_worktree.clone() else {
+                        continue;
+                    };
+                    worktree = wt;
+                    worktree_id = worktree.read(cx).id();
                 };
 
                 if let Some((_, apply)) = local.reuse_existing_language_server(
@@ -6319,13 +6493,20 @@ impl LspStore {
                 {
                     let delegate =
                         Arc::new(ManifestQueryDelegate::new(worktree.read(cx).snapshot()));
-                    let path = file
-                        .path()
-                        .parent()
-                        .map(Arc::from)
-                        .unwrap_or_else(|| file.path().clone());
+                    let (path, uri_display) = if let Some(file) = &file {
+                        let path: Arc<RelPath> = file
+                            .path()
+                            .parent()
+                            .map(Arc::from)
+                            .unwrap_or_else(|| file.path().clone());
+                        (path, file.abs_path(cx).to_string_lossy().into_owned())
+                    } else {
+                        (
+                            Arc::from(RelPath::empty()),
+                            untitled_buffer_uri(buffer_id).to_string(),
+                        )
+                    };
                     let worktree_path = ProjectPath { worktree_id, path };
-                    let abs_path = file.abs_path(cx);
                     let nodes = rebase
                         .walk(
                             worktree_path,
@@ -6384,9 +6565,7 @@ impl LspStore {
                                 message:
                                     proto::update_language_server::Variant::RegisteredForBuffer(
                                         proto::RegisteredForBuffer {
-                                            buffer_abs_path: abs_path
-                                                .to_string_lossy()
-                                                .into_owned(),
+                                            buffer_abs_path: uri_display.clone(),
                                             buffer_id: buffer_id.to_proto(),
                                         },
                                     ),
@@ -9394,12 +9573,16 @@ impl LspStore {
         })?;
 
         let buffer = buffer.read(cx);
-        let file = File::from_dyn(buffer.file())?;
-        let abs_path = file.as_local()?.abs_path(cx);
-        let uri = lsp::Uri::from_file_path(&abs_path)
-            .ok()
-            .with_context(|| format!("Failed to convert path to URI: {}", abs_path.display()))
-            .log_err()?;
+        let buffer_id = buffer.remote_id();
+        let uri = if let Some(file) = File::from_dyn(buffer.file()) {
+            let abs_path = file.as_local()?.abs_path(cx);
+            lsp::Uri::from_file_path(&abs_path)
+                .ok()
+                .with_context(|| format!("Failed to convert path to URI: {}", abs_path.display()))
+                .log_err()?
+        } else {
+            self.as_local()?.buffer_uris.get(&buffer_id)?.uri.clone()
+        };
         let next_snapshot = buffer.text_snapshot();
         let line_ending = next_snapshot.line_ending();
 
@@ -10263,6 +10446,19 @@ impl LspStore {
         language_server_id: LanguageServerId,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
+        if let Some(local) = self.as_local() {
+            if let Some((buffer_id, _)) = local
+                .buffer_uris
+                .iter()
+                .find(|(_, state)| state.uri == abs_path)
+            {
+                let buffer_id = *buffer_id;
+                if let Some(buffer) = self.buffer_store.read(cx).get(buffer_id) {
+                    return Task::ready(Ok(buffer));
+                }
+            }
+        }
+
         let path_style = self.worktree_store.read(cx).path_style();
         cx.spawn(async move |lsp_store, cx| {
             // Escape percent-encoded string.
@@ -11418,18 +11614,17 @@ impl LspStore {
                         .buffer_id
                         .map(|id| BufferId::new(id))
                         .transpose()?;
-                    buffer_id
-                        .and_then(|buffer_id| {
-                            lsp_store
-                                .buffer_store()
-                                .read(cx)
-                                .get(buffer_id)
-                                .and_then(|buffer| {
-                                    Some(buffer.read(cx).file()?.as_local()?.abs_path(cx))
-                                })
-                                .map(|path| make_text_document_identifier(&path))
-                        })
-                        .transpose()?
+                    buffer_id.and_then(|buffer_id| {
+                        lsp_store
+                            .buffer_store()
+                            .read(cx)
+                            .get(buffer_id)
+                            .and_then(|buffer| {
+                                let path = buffer.read(cx).file()?.as_local()?.abs_path(cx);
+                                let uri = file_path_to_lsp_url(&path).ok()?;
+                                Some(make_text_document_identifier(&uri))
+                            })
+                    })
                 } else {
                     None
                 };
@@ -13059,11 +13254,11 @@ impl LspStore {
         cx: &mut Context<Self>,
     ) -> Result<()> {
         anyhow::ensure!(self.mode.is_local(), "called update_diagnostics on remote");
-        let updates = lsp_diagnostics
-            .into_iter()
-            .filter_map(|update| {
-                let abs_path = update.diagnostics.uri.to_file_path().ok()?;
-                Some(DocumentDiagnosticsUpdate {
+        let mut file_updates = Vec::new();
+        for update in lsp_diagnostics {
+            let uri = update.diagnostics.uri.clone();
+            if let Ok(abs_path) = uri.to_file_path() {
+                file_updates.push(DocumentDiagnosticsUpdate {
                     diagnostics: self.lsp_to_document_diagnostics(
                         abs_path,
                         source_kind,
@@ -13076,11 +13271,93 @@ impl LspStore {
                     server_id: update.server_id,
                     disk_based_sources: update.disk_based_sources,
                     registration_id: update.registration_id,
+                });
+            } else {
+                self.merge_untitled_buffer_diagnostics(
+                    &uri,
+                    source_kind,
+                    update.server_id,
+                    update.diagnostics,
+                    &update.disk_based_sources,
+                    update.registration_id,
+                    update.result_id,
+                    &merge,
+                    cx,
+                );
+            }
+        }
+        self.merge_diagnostic_entries(file_updates, merge, cx)?;
+        Ok(())
+    }
+
+    fn merge_untitled_buffer_diagnostics(
+        &mut self,
+        uri: &lsp::Uri,
+        source_kind: DiagnosticSourceKind,
+        server_id: LanguageServerId,
+        lsp_diagnostics: lsp::PublishDiagnosticsParams,
+        disk_based_sources: &[String],
+        registration_id: Option<SharedString>,
+        result_id: Option<SharedString>,
+        merge: &impl Fn(&lsp::Uri, &Diagnostic, &App) -> bool,
+        cx: &mut Context<Self>,
+    ) {
+        let local = match self.as_local() {
+            Some(local) => local,
+            None => return,
+        };
+        let buffer_id = local
+            .buffer_uris
+            .iter()
+            .find(|(_, state)| &state.uri == uri)
+            .map(|(id, _)| *id);
+        let Some(buffer_id) = buffer_id else {
+            return;
+        };
+        let Some(buffer_handle) = self.buffer_store.read(cx).get(buffer_id) else {
+            return;
+        };
+
+        let snapshot = buffer_handle.read(cx).snapshot();
+        let reused_diagnostics = buffer_handle
+            .read(cx)
+            .buffer_diagnostics(Some(server_id))
+            .into_iter()
+            .filter(|entry| merge(uri, &entry.diagnostic, cx))
+            .map(|entry| {
+                entry.to_owned().map_coordinates(|range| {
+                    Unclipped(range.start.to_point_utf16(&snapshot))
+                        ..Unclipped(range.end.to_point_utf16(&snapshot))
                 })
             })
-            .collect();
-        self.merge_diagnostic_entries(updates, merge, cx)?;
-        Ok(())
+            .collect::<Vec<_>>();
+
+        // `document_abs_path` is unused here — only `diagnostics` and `version` are
+        // extracted below, so an empty path is safe.
+        let document_diagnostics = self.lsp_to_document_diagnostics(
+            PathBuf::new(),
+            source_kind,
+            server_id,
+            lsp_diagnostics,
+            disk_based_sources,
+            registration_id.clone(),
+        );
+
+        let Some(local) = self.as_local_mut() else {
+            return;
+        };
+        local
+            .update_buffer_diagnostics(
+                &buffer_handle,
+                server_id,
+                Some(registration_id),
+                result_id,
+                document_diagnostics.version,
+                document_diagnostics.diagnostics,
+                reused_diagnostics,
+                cx,
+            )
+            .log_err();
     }
 
     fn lsp_to_document_diagnostics(
@@ -13389,15 +13666,11 @@ impl LspStore {
             }
         }
 
-        let mut buffer_paths_registered = Vec::new();
+        let mut buffer_registrations: Vec<(BufferId, String)> = Vec::new();
         self.buffer_store.clone().update(cx, |buffer_store, cx| {
             let mut lsp_adapters = HashMap::default();
             for buffer_handle in buffer_store.buffers() {
                 let buffer = buffer_handle.read(cx);
-                let file = match File::from_dyn(buffer.file()) {
-                    Some(file) => file,
-                    None => continue,
-                };
                 let language = match buffer.language() {
                     Some(language) => language,
                     None => continue,
@@ -13406,68 +13679,83 @@ impl LspStore {
                     continue;
                 }
 
-                if !worktrees_using_server.contains(&file.worktree.read(cx).id())
-                    || !lsp_adapters
-                        .entry(language.name())
-                        .or_insert_with(|| self.languages.lsp_adapters(&language.name()))
-                        .iter()
-                        .any(|a| a.name == key.name)
+                if !lsp_adapters
+                    .entry(language.name())
+                    .or_insert_with(|| self.languages.lsp_adapters(&language.name()))
+                    .iter()
+                    .any(|a| a.name == key.name)
                 {
                     continue;
                 }
-                // didOpen
-                let file = match file.as_local() {
-                    Some(file) => file,
-                    None => continue,
-                };
-
-                let local = self.as_local_mut().unwrap();
 
                 let buffer_id = buffer.remote_id();
-                if local.registered_buffers.contains_key(&buffer_id) {
+                let local = self.as_local_mut().unwrap();
+                if !local.registered_buffers.contains_key(&buffer_id) {
+                    continue;
+                }
+
+                let uri;
+                let uri_display;
+                if let Some(file) = File::from_dyn(buffer.file()) {
+                    if !worktrees_using_server.contains(&file.worktree.read(cx).id()) {
+                        continue;
+                    }
+                    let file = match file.as_local() {
+                        Some(file) => file,
+                        None => continue,
+                    };
                     let abs_path = file.abs_path(cx);
-                    let uri = match lsp::Uri::from_file_path(&abs_path) {
+                    uri = match lsp::Uri::from_file_path(&abs_path) {
                         Ok(uri) => uri,
                         Err(()) => {
                             log::error!("failed to convert path to URI: {:?}", abs_path);
                             continue;
                         }
                     };
+                    uri_display = abs_path.to_string_lossy().into_owned();
+                } else {
+                    let Some(stored_uri) = local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone())
+                    else {
+                        continue;
+                    };
+                    uri = stored_uri;
+                    uri_display = uri.to_string();
+                }
 
-                    let versions = local
-                        .buffer_snapshots
-                        .entry(buffer_id)
-                        .or_default()
-                        .entry(server_id)
-                        .and_modify(|_| {
-                            assert!(
+                let versions = local
+                    .buffer_snapshots
+                    .entry(buffer_id)
+                    .or_default()
+                    .entry(server_id)
+                    .and_modify(|_| {
+                        assert!(
                             false,
                             "There should not be an existing snapshot for a newly inserted buffer"
                         )
-                        })
-                        .or_insert_with(|| {
-                            vec![LspBufferSnapshot {
-                                version: 0,
-                                snapshot: buffer.text_snapshot(),
-                            }]
-                        });
+                    })
+                    .or_insert_with(|| {
+                        vec![LspBufferSnapshot {
+                            version: 0,
+                            snapshot: buffer.text_snapshot(),
+                        }]
+                    });
 
-                    let snapshot = versions.last().unwrap();
-                    let version = snapshot.version;
-                    let initial_snapshot = &snapshot.snapshot;
-                    language_server.register_buffer(
-                        uri,
-                        adapter.language_id(&language.name()),
-                        version,
-                        initial_snapshot.text_with_line_endings(),
-                    );
-                    buffer_paths_registered.push((buffer_id, abs_path));
-                    local
-                        .buffers_opened_in_servers
-                        .entry(buffer_id)
-                        .or_default()
-                        .insert(server_id);
-                }
+                let snapshot = versions.last().unwrap();
+                let version = snapshot.version;
+                let initial_snapshot = &snapshot.snapshot;
+                language_server.register_buffer(
+                    uri,
+                    adapter.language_id(&language.name()),
+                    version,
+                    initial_snapshot.text_with_line_endings(),
+                );
+                buffer_registrations.push((buffer_id, uri_display));
+                local
+                    .buffers_opened_in_servers
+                    .entry(buffer_id)
+                    .or_default()
+                    .insert(server_id);
+
                 buffer_handle.update(cx, |buffer, cx| {
                     buffer.set_completion_triggers(
                         server_id,
@@ -13488,13 +13776,13 @@ impl LspStore {
             }
         });
 
-        for (buffer_id, abs_path) in buffer_paths_registered {
+        for (buffer_id, uri_display) in buffer_registrations {
             cx.emit(LspStoreEvent::LanguageServerUpdate {
                 language_server_id: server_id,
                 name: Some(adapter.name()),
                 message: proto::update_language_server::Variant::RegisteredForBuffer(
                     proto::RegisteredForBuffer {
-                        buffer_abs_path: abs_path.to_string_lossy().into_owned(),
+                        buffer_abs_path: uri_display,
                         buffer_id: buffer_id.to_proto(),
                     },
                 ),
@@ -14027,17 +14315,24 @@ impl LspStore {
         registration_id: &Option<SharedString>,
         cx: &App,
     ) -> Option<SharedString> {
-        let abs_path = self
+        let local = self.as_local()?;
+        let key = self
             .buffer_store
             .read(cx)
             .get(buffer_id)
             .and_then(|b| File::from_dyn(b.read(cx).file()))
-            .map(|f| f.abs_path(cx))?;
-        self.as_local()?
+            .map(|f| f.abs_path(cx))
+            .or_else(|| {
+                local
+                    .buffer_uris
+                    .get(&buffer_id)
+                    .map(|state| PathBuf::from(state.uri.to_string()))
+            })?;
+        local
             .buffer_pull_diagnostics_result_ids
             .get(&server_id)?
             .get(registration_id)?
-            .get(&abs_path)?
+            .get(&key)?
             .clone()
     }
 
@@ -14682,10 +14977,9 @@ fn document_selector_context_for_buffer(
     adapter: &CachedLspAdapter,
 ) -> Option<DocumentSelectorContext> {
     let language = buffer.language()?;
-    Some(document_selector_context_for_language(
-        &language.name(),
-        adapter,
-    ))
+    let mut context = document_selector_context_for_language(&language.name(), adapter);
+    context.scheme = document_scheme(buffer);
+    Some(context)
 }
 
 fn document_selector_context_for_language(
@@ -14695,6 +14989,14 @@ fn document_selector_context_for_language(
     DocumentSelectorContext {
         language_id: adapter.language_id(language),
         scheme: "file",
+    }
+}
+
+fn document_scheme(buffer: &Buffer) -> &'static str {
+    if buffer.file().is_some() {
+        "file"
+    } else {
+        "untitled"
     }
 }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -78,7 +78,7 @@ use itertools::Itertools as _;
 use language::{
     Bias, BinaryStatus, Buffer, BufferRow, BufferSnapshot, CachedLspAdapter, Capability, CodeLabel,
     CodeLabelExt, Diagnostic, DiagnosticEntry, DiagnosticMessage, DiagnosticSet,
-    DiagnosticSourceKind, Diff, File as _, Language, LanguageAwareStyling, LanguageName,
+    DiagnosticSourceKind, Diff, DiskState, File as _, Language, LanguageAwareStyling, LanguageName,
     LanguageRegistry, LocalFile, LspAdapter, LspAdapterDelegate, LspInstaller, ManifestDelegate,
     ManifestName, ModelineSettings, OffsetUtf16, Patch, PointUtf16, RelatedInformation,
     RelatedLocation, TextBufferSnapshot, ToOffset, ToOffsetUtf16, ToPointUtf16, Toolchain,
@@ -5365,6 +5365,16 @@ impl LspStore {
     ) -> OpenLspBufferHandle {
         let buffer_id = buffer.read(cx).remote_id();
         let handle = OpenLspBufferHandle(cx.new(|_| OpenLspBuffer(buffer.clone())));
+        // Historic buffers represent past file content (e.g. the commit view)
+        // and would otherwise be treated as untitled, which starts a language
+        // server against content that is not the current file state.
+        if buffer
+            .read(cx)
+            .file()
+            .is_some_and(|file| matches!(file.disk_state(), DiskState::Historic { .. }))
+        {
+            return handle;
+        }
         if let Some(local) = self.as_local_mut() {
             let refcount = local.registered_buffers.entry(buffer_id).or_insert(0);
             if !ignore_refcounts {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -296,6 +296,16 @@ pub struct DocumentDiagnostics {
     version: Option<i32>,
 }
 
+/// Per-untitled-buffer LSP state. File-backed buffers don't need this — their
+/// URI and worktree are derivable from `file.abs_path()` / `file.worktree_id()`.
+#[derive(Debug, Clone)]
+pub(crate) struct UntitledBufferState {
+    pub(crate) uri: lsp::Uri,
+    /// The worktree the buffer was registered against (the first visible
+    /// worktree at registration time). Tracked so that when the worktree is
+    /// removed we can drop the corresponding `buffer_uris` entry.
+    pub(crate) host_worktree: WorktreeId,
+}
 pub struct LocalLspStore {
     weak: WeakEntity<LspStore>,
     pub worktree_store: Entity<WorktreeStore>,
@@ -333,6 +343,7 @@ pub struct LocalLspStore {
     lsp_tree: LanguageServerTree,
     registered_buffers: HashMap<BufferId, usize>,
     buffers_opened_in_servers: HashMap<BufferId, HashSet<LanguageServerId>>,
+    pub(crate) buffer_uris: HashMap<BufferId, UntitledBufferState>,
     buffer_pull_diagnostics_result_ids: HashMap<
         LanguageServerId,
         HashMap<Option<SharedString>, HashMap<PathBuf, Option<SharedString>>>,
@@ -1403,6 +1414,11 @@ impl LocalLspStore {
                 .unwrap_or_else(|| file.path().clone());
             let worktree_path = ProjectPath { worktree_id, path };
             self.language_server_ids_for_project_path(worktree_path, language, cx)
+        } else if buffer.file().is_none() {
+            self.buffers_opened_in_servers
+                .get(&buffer.remote_id())
+                .map(|server_ids| server_ids.iter().copied().collect())
+                .unwrap_or_default()
         } else {
             Vec::new()
         }
@@ -1911,8 +1927,18 @@ impl LocalLspStore {
                 zlog::trace!(logger => "formatting");
                 let _timer = zlog::time!(logger => "Formatting buffer using language server");
 
-                let Some(buffer_path_abs) = buffer.abs_path.as_ref() else {
-                    zlog::warn!(logger => "Cannot format buffer that is not backed by a file on disk using language servers. Skipping");
+                let buffer_uri = if let Some(abs_path) = buffer.abs_path.as_ref() {
+                    Some(file_path_to_lsp_url(abs_path)?)
+                } else {
+                    lsp_store.read_with(cx, |lsp_store, cx| {
+                        let buffer_id = buffer.handle.read(cx).remote_id();
+                        lsp_store.as_local().and_then(|local| {
+                            local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone())
+                        })
+                    })?
+                };
+                let Some(buffer_uri) = buffer_uri else {
+                    zlog::warn!(logger => "Cannot format buffer that has no LSP URI. Skipping");
                     return Ok(());
                 };
 
@@ -1935,14 +1961,16 @@ impl LocalLspStore {
                 let Some(language_server) = language_server else {
                     zlog::debug!(
                         logger =>
-                        "No language server found to format buffer {buffer_path_abs:?}. Skipping",
+                        "No language server found to format buffer '{:?}'. Skipping",
+                        buffer_uri
                     );
                     return Ok(());
                 };
 
                 zlog::trace!(
                     logger =>
-                    "Formatting buffer {buffer_path_abs:?} using language server {:?}",
+                    "Formatting buffer '{:?}' using language server '{:?}'",
+                    buffer_uri,
                     language_server.name()
                 );
 
@@ -1952,7 +1980,7 @@ impl LocalLspStore {
                         &lsp_store,
                         &buffer.handle,
                         ranges,
-                        buffer_path_abs,
+                        &buffer_uri,
                         &language_server,
                         &settings,
                         cx,
@@ -1973,7 +2001,7 @@ impl LocalLspStore {
                                 Self::format_via_lsp(
                                     &lsp_store,
                                     &buffer.handle,
-                                    buffer_path_abs,
+                                    &buffer_uri,
                                     &language_server,
                                     &settings,
                                     cx,
@@ -1995,7 +2023,7 @@ impl LocalLspStore {
                     Self::format_via_lsp(
                         &lsp_store,
                         &buffer.handle,
-                        buffer_path_abs,
+                        &buffer_uri,
                         &language_server,
                         &settings,
                         cx,
@@ -2022,8 +2050,18 @@ impl LocalLspStore {
                 zlog::trace!(logger => "formatting");
                 let _timer = zlog::time!(logger => "Formatting buffer using code actions");
 
-                let Some(buffer_path_abs) = buffer.abs_path.as_ref() else {
-                    zlog::warn!(logger => "Cannot format buffer that is not backed by a file on disk using code actions. Skipping");
+                let buffer_uri = if let Some(abs_path) = buffer.abs_path.as_ref() {
+                    Some(file_path_to_lsp_url(abs_path)?)
+                } else {
+                    lsp_store.read_with(cx, |lsp_store, cx| {
+                        let buffer_id = buffer.handle.read(cx).remote_id();
+                        lsp_store.as_local().and_then(|local| {
+                            local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone())
+                        })
+                    })?
+                };
+                let Some(buffer_uri) = buffer_uri else {
+                    zlog::warn!(logger => "Cannot format buffer that has no LSP URI. Skipping");
                     return Ok(());
                 };
 
@@ -2164,21 +2202,23 @@ impl LocalLspStore {
                                     continue 'actions;
                                 }
                             };
-                            let Ok(file_path) = op.text_document.uri.to_file_path() else {
-                                zlog::warn!(
-                                    logger =>
-                                    "Failed to convert URI '{:?}' to file path. Skipping {}",
-                                    &op.text_document.uri,
-                                    describe_code_action(&action),
+                            // For file URIs, fall back to path equality so that case-insensitive
+                            // filesystems and minor URI normalization differences (e.g. trailing
+                            // slash, percent-encoding) don't cause spurious mismatches.
+                            let uris_match = op.text_document.uri == buffer_uri
+                                || matches!(
+                                    (
+                                        op.text_document.uri.to_file_path(),
+                                        buffer_uri.to_file_path(),
+                                    ),
+                                    (Ok(op_path), Ok(buf_path)) if op_path == buf_path
                                 );
-                                continue 'actions;
-                            };
-                            if &file_path != buffer_path_abs {
+                            if !uris_match {
                                 zlog::warn!(
                                     logger =>
-                                    "File path '{:?}' does not match buffer path '{:?}'. Skipping {}",
-                                    file_path,
-                                    buffer_path_abs,
+                                    "URI '{:?}' does not match buffer URI '{:?}'. Skipping {}",
+                                    op.text_document.uri,
+                                    buffer_uri,
                                     describe_code_action(&action),
                                 );
                                 continue 'actions;
@@ -2222,7 +2262,7 @@ impl LocalLspStore {
                                 zlog::warn!(
                                     logger =>
                                     "Failed to resolve edits from LSP for buffer {:?} while handling {}",
-                                    buffer_path_abs.as_path(),
+                                    buffer_uri,
                                     describe_code_action(&action),
                                 );
                                 continue 'actions;
@@ -2379,7 +2419,7 @@ impl LocalLspStore {
         this: &WeakEntity<LspStore>,
         buffer_handle: &Entity<Buffer>,
         ranges: &[Range<Anchor>],
-        abs_path: &Path,
+        uri: &lsp::Uri,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
         cx: &mut AsyncApp,
@@ -2397,7 +2437,7 @@ impl LocalLspStore {
             return Ok(None);
         }
 
-        let uri = file_path_to_lsp_url(abs_path)?;
+        let uri = uri.clone();
         let text_document = lsp::TextDocumentIdentifier::new(uri);
 
         let request_timeout = cx.update(|app| {
@@ -2469,7 +2509,7 @@ impl LocalLspStore {
     async fn format_via_lsp(
         this: &WeakEntity<LspStore>,
         buffer: &Entity<Buffer>,
-        abs_path: &Path,
+        uri: &lsp::Uri,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
         cx: &mut AsyncApp,
@@ -2477,7 +2517,7 @@ impl LocalLspStore {
         let logger = zlog::scoped!("lsp_format");
         zlog::debug!(logger => "Formatting via LSP");
 
-        let uri = file_path_to_lsp_url(abs_path)?;
+        let uri = uri.clone();
         let text_document = lsp::TextDocumentIdentifier::new(uri);
         let capabilities = &language_server.capabilities();
 
@@ -2834,13 +2874,20 @@ impl LocalLspStore {
         let set = DiagnosticSet::new(sanitized_diagnostics, &snapshot);
         buffer.update(cx, |buffer, cx| {
             if let Some(registration_id) = registration_id {
-                if let Some(abs_path) = File::from_dyn(buffer.file()).map(|f| f.abs_path(cx)) {
+                let key = File::from_dyn(buffer.file())
+                    .map(|f| f.abs_path(cx))
+                    .or_else(|| {
+                        self.buffer_uris
+                            .get(&buffer.remote_id())
+                            .map(|state| PathBuf::from(state.uri.to_string()))
+                    });
+                if let Some(key) = key {
                     self.buffer_pull_diagnostics_result_ids
                         .entry(server_id)
                         .or_default()
                         .entry(registration_id)
                         .or_default()
-                        .insert(abs_path, result_id);
+                        .insert(key, result_id);
                 }
             }
 
@@ -2896,45 +2943,75 @@ impl LocalLspStore {
         let buffer = buffer_handle.read(cx);
         let buffer_id = buffer.remote_id();
 
-        let Some(file) = File::from_dyn(buffer.file()) else {
-            return;
-        };
-        if !file.is_local() {
+        let file = File::from_dyn(buffer.file());
+        if file.is_some_and(|file| !file.is_local()) {
             return;
         }
 
-        let abs_path = file.abs_path(cx);
+        let Some(language) = buffer.language().cloned() else {
+            return;
+        };
+
         if let Some((longest_line_length, maximum_line_length)) =
             Self::language_server_line_length_limit_exceeded(buffer, cx)
         {
+            let buffer_display_name = file
+                .map(|file| file.abs_path(cx).to_string_lossy().into_owned())
+                .unwrap_or_else(|| untitled_buffer_uri(buffer_id).to_string());
             log::debug!(
                 "not registering {} with language servers because its longest line has {} characters, exceeding the configured limit of {}",
-                abs_path.display(),
+                buffer_display_name,
                 longest_line_length,
                 maximum_line_length,
             );
             return;
         }
-        let Some(uri) = file_path_to_lsp_url(&abs_path).log_err() else {
-            return;
-        };
-        let initial_snapshot = buffer.text_snapshot();
-        let worktree_id = file.worktree_id(cx);
 
-        let Some(language) = buffer.language().cloned() else {
-            return;
-        };
-        let path: Arc<RelPath> = file
-            .path()
-            .parent()
-            .map(Arc::from)
-            .unwrap_or_else(|| file.path().clone());
-        let Some(worktree) = self
-            .worktree_store
-            .read(cx)
-            .worktree_for_id(worktree_id, cx)
-        else {
-            return;
+        let (uri, uri_display, initial_snapshot, worktree_id, path, worktree);
+        if let Some(file) = file {
+            let abs_path = file.abs_path(cx);
+            let Some(file_uri) = file_path_to_lsp_url(&abs_path).log_err() else {
+                return;
+            };
+            uri = file_uri;
+            uri_display = abs_path.to_string_lossy().into_owned();
+            initial_snapshot = buffer.text_snapshot();
+            worktree_id = file.worktree_id(cx);
+            path = file
+                .path()
+                .parent()
+                .map(Arc::from)
+                .unwrap_or_else(|| file.path().clone());
+            let Some(wt) = self
+                .worktree_store
+                .read(cx)
+                .worktree_for_id(worktree_id, cx)
+            else {
+                return;
+            };
+            worktree = wt;
+        } else {
+            uri = untitled_buffer_uri(buffer_id);
+            uri_display = uri.to_string();
+            initial_snapshot = buffer.text_snapshot();
+            let Some(wt) = self.worktree_store.read(cx).visible_worktrees(cx).next() else {
+                log::debug!(
+                    "Skipping LSP registration for untitled buffer {buffer_id}: no visible worktree"
+                );
+                return;
+            };
+            worktree = wt;
+            worktree_id = worktree.read(cx).id();
+            path = Arc::from(RelPath::empty());
+            // Only untitled buffers need stored state, file-backed buffers can
+            // derive their URI/worktree from `file.abs_path()` / `file.worktree_id()`.
+            self.buffer_uris.insert(
+                buffer_id,
+                UntitledBufferState {
+                    uri: uri.clone(),
+                    host_worktree: worktree_id,
+                },
+            );
         };
         let language_name = language.name();
         let (reused, delegate, servers) = self
@@ -3065,12 +3142,39 @@ impl LocalLspStore {
                     name: None,
                     message: proto::update_language_server::Variant::RegisteredForBuffer(
                         proto::RegisteredForBuffer {
-                            buffer_abs_path: abs_path.to_string_lossy().into_owned(),
+                            buffer_abs_path: uri_display.clone(),
                             buffer_id: buffer_id.to_proto(),
                         },
                     ),
                 });
             }
+        }
+    }
+
+    /// Re-attempts LSP registration for untitled buffers that were registered
+    /// before any visible worktree existed. Such buffers got their refcount
+    /// bumped in `LspStore::register_buffer_with_language_servers` but bailed
+    /// out of `LocalLspStore::register_buffer_with_language_servers` (no host
+    /// worktree available), leaving them in `registered_buffers` but not in
+    /// `buffer_uris`. When a worktree is later added, we can pick them up here.
+    fn register_pending_untitled_buffers(
+        &mut self,
+        buffer_store: &Entity<BufferStore>,
+        cx: &mut Context<LspStore>,
+    ) {
+        let candidates: Vec<Entity<Buffer>> = buffer_store
+            .read(cx)
+            .buffers()
+            .filter(|buffer| {
+                let buffer = buffer.read(cx);
+                buffer.file().is_none()
+                    && buffer.language().is_some()
+                    && self.registered_buffers.contains_key(&buffer.remote_id())
+                    && !self.buffer_uris.contains_key(&buffer.remote_id())
+            })
+            .collect();
+        for buffer in candidates {
+            self.register_buffer_with_language_servers(&buffer, HashSet::default(), cx);
         }
     }
 
@@ -3767,6 +3871,14 @@ impl LocalLspStore {
             }
             cx.emit(LspStoreEvent::LanguageServerRemoved(*server_id_to_remove));
         }
+
+        // Untitled buffers anchored to the removed worktree have no remaining
+        // host: drop their `buffer_uris` entry so `is_lsp_relevant` stops
+        // returning true for them. The associated language servers were already
+        // removed above, so there's nothing to unregister at the LSP level.
+        self.buffer_uris
+            .retain(|_, state| state.host_worktree != id_to_remove);
+
         servers_to_remove.into_iter().collect()
     }
 
@@ -4513,6 +4625,11 @@ impl LspStore {
         }
     }
 
+    pub fn has_buffer_uri(&self, buffer_id: BufferId) -> bool {
+        self.as_local()
+            .is_some_and(|local| local.buffer_uris.contains_key(&buffer_id))
+    }
+
     pub fn upstream_client(&self) -> Option<(AnyProtoClient, u64)> {
         match &self.mode {
             LspStoreMode::Remote(RemoteLspStore {
@@ -4597,6 +4714,7 @@ impl LspStore {
                 toolchain_store,
                 registered_buffers: HashMap::default(),
                 buffers_opened_in_servers: HashMap::default(),
+                buffer_uris: HashMap::default(),
                 buffer_pull_diagnostics_result_ids: HashMap::default(),
                 workspace_pull_diagnostics_result_ids: HashMap::default(),
                 restricted_worktrees_tasks: HashMap::default(),
@@ -4699,13 +4817,17 @@ impl LspStore {
             }
             BufferStoreEvent::BufferChangedFilePath { buffer, old_file } => {
                 let buffer_id = buffer.read(cx).remote_id();
-                if let Some(local) = self.as_local_mut()
-                    && let Some(old_file) = File::from_dyn(old_file.as_ref())
-                {
-                    local.reset_buffer(buffer, old_file, cx);
+                if let Some(local) = self.as_local_mut() {
+                    if let Some(old_file) = File::from_dyn(old_file.as_ref()) {
+                        local.reset_buffer(buffer, old_file, cx);
 
-                    if local.registered_buffers.contains_key(&buffer_id) {
-                        local.unregister_old_buffer_from_language_servers(buffer, old_file, cx);
+                        if local.registered_buffers.contains_key(&buffer_id) {
+                            local.unregister_old_buffer_from_language_servers(buffer, old_file, cx);
+                        }
+                    } else if local.registered_buffers.contains_key(&buffer_id) {
+                        if let Some(state) = local.buffer_uris.remove(&buffer_id) {
+                            local.unregister_buffer_from_language_servers(buffer, &state.uri, cx);
+                        }
                     }
                 }
 
@@ -4741,7 +4863,14 @@ impl LspStore {
                     | worktree::Event::Deleted
                     | worktree::Event::UpdatedRootRepoCommonDir { .. } => {}
                 })
-                .detach()
+                .detach();
+
+                // Untitled buffers created before any visible worktree existed
+                // get registered now that one is available.
+                let buffer_store = self.buffer_store.clone();
+                if let Some(local) = self.as_local_mut() {
+                    local.register_pending_untitled_buffers(&buffer_store, cx);
+                }
             }
             WorktreeStoreEvent::WorktreeRemoved(_, id) => self.remove_worktree(*id, cx),
             WorktreeStoreEvent::WorktreeUpdateSent(worktree) => {
@@ -4910,15 +5039,10 @@ impl LspStore {
                 *refcount += 1;
             }
 
-            // We run early exits on non-existing buffers AFTER we mark the buffer as registered in order to handle buffer saving.
-            // When a new unnamed buffer is created and saved, we will start loading it's language. Once the language is loaded, we go over all "language-less" buffers and try to fit that new language
-            // with them. However, we do that only for the buffers that we think are open in at least one editor; thus, we need to keep tab of unnamed buffers as well, even though they're not actually registered with any language
-            // servers in practice (we don't support non-file URI schemes in our LSP impl).
-            let Some(file) = File::from_dyn(buffer.read(cx).file()) else {
-                return handle;
-            };
-            if !file.is_local() {
-                return handle;
+            if let Some(file) = File::from_dyn(buffer.read(cx).file()) {
+                if !file.is_local() {
+                    return handle;
+                }
             }
 
             if ignore_refcounts || *refcount == 1 {
@@ -4942,7 +5066,6 @@ impl LspStore {
                         let local = lsp_store.as_local_mut().unwrap();
                         local.registered_buffers.remove(&buffer_id);
 
-                        local.buffers_opened_in_servers.remove(&buffer_id);
                         if let Some(file) = File::from_dyn(buffer.0.read(cx).file()).cloned() {
                             local.unregister_old_buffer_from_language_servers(&buffer.0, &file, cx);
 
@@ -4998,7 +5121,15 @@ impl LspStore {
                                 )
                                 .context("Clearing diagnostics for the closed buffer")
                                 .log_err();
+                        } else if let Some(state) = local.buffer_uris.remove(&buffer_id) {
+                            local
+                                .unregister_buffer_from_language_servers(&buffer.0, &state.uri, cx);
                         }
+                        lsp_store
+                            .as_local_mut()
+                            .unwrap()
+                            .buffers_opened_in_servers
+                            .remove(&buffer_id);
                     }
                 })
                 .detach();
@@ -5252,11 +5383,20 @@ impl LspStore {
         let buffer_id = buffer.remote_id();
         if let Some(local_store) = self.as_local_mut()
             && local_store.registered_buffers.contains_key(&buffer_id)
-            && let Some(abs_path) =
-                File::from_dyn(buffer_file.as_ref()).map(|file| file.abs_path(cx))
-            && let Some(file_url) = file_path_to_lsp_url(&abs_path).log_err()
         {
-            local_store.unregister_buffer_from_language_servers(buffer_entity, &file_url, cx);
+            let uri = if let Some(abs_path) =
+                File::from_dyn(buffer_file.as_ref()).map(|file| file.abs_path(cx))
+            {
+                file_path_to_lsp_url(&abs_path).log_err()
+            } else {
+                local_store
+                    .buffer_uris
+                    .get(&buffer_id)
+                    .map(|s| s.uri.clone())
+            };
+            if let Some(uri) = uri {
+                local_store.unregister_buffer_from_language_servers(buffer_entity, &uri, cx);
+            }
         }
         buffer_entity.update(cx, |buffer, cx| {
             if buffer
@@ -5275,18 +5415,12 @@ impl LspStore {
         .into_owned();
         let buffer_file = File::from_dyn(buffer_file.as_ref());
 
-        let worktree_id = if let Some(file) = buffer_file {
-            let worktree = file.worktree.clone();
-
-            if let Some(local) = self.as_local_mut()
-                && local.registered_buffers.contains_key(&buffer_id)
-            {
-                local.register_buffer_with_language_servers(buffer_entity, HashSet::default(), cx);
-            }
-            Some(worktree.read(cx).id())
-        } else {
-            None
-        };
+        if let Some(local) = self.as_local_mut()
+            && local.registered_buffers.contains_key(&buffer_id)
+        {
+            local.register_buffer_with_language_servers(buffer_entity, HashSet::default(), cx);
+        }
+        let worktree_id = buffer_file.map(|file| file.worktree.read(cx).id());
 
         if settings.prettier.allowed
             && let Some(prettier_plugins) = prettier_store::prettier_plugins_for_language(&settings)
@@ -5532,33 +5666,40 @@ impl LspStore {
             return Task::ready(Ok(Default::default()));
         };
 
-        let file = File::from_dyn(buffer.read(cx).file()).and_then(File::as_local);
-
-        let Some(file) = file else {
-            return Task::ready(Ok(Default::default()));
-        };
-
-        let lsp_params = match request.to_lsp_params_or_response(
-            &file.abs_path(cx),
-            buffer.read(cx),
-            &language_server,
-            cx,
-        ) {
-            Ok(LspParamsOrResponse::Params(lsp_params)) => lsp_params,
-            Ok(LspParamsOrResponse::Response(response)) => return Task::ready(Ok(response)),
-            Err(err) => {
-                let message = format!(
-                    "{} via {} failed: {}",
-                    request.display_name(),
-                    language_server.name(),
-                    err
-                );
-                if should_log_lsp_request_failure(&message) {
-                    log::warn!("{message}");
+        let uri =
+            if let Some(file) = File::from_dyn(buffer.read(cx).file()).and_then(File::as_local) {
+                match file_path_to_lsp_url(&file.abs_path(cx)) {
+                    Ok(uri) => uri,
+                    Err(err) => return Task::ready(Err(err)),
                 }
-                return Task::ready(Err(anyhow!(message)));
-            }
-        };
+            } else if let Some(uri) = self.as_local().and_then(|local| {
+                local
+                    .buffer_uris
+                    .get(&buffer.read(cx).remote_id())
+                    .map(|s| s.uri.clone())
+            }) {
+                uri
+            } else {
+                return Task::ready(Ok(Default::default()));
+            };
+
+        let lsp_params =
+            match request.to_lsp_params_or_response(&uri, buffer.read(cx), &language_server, cx) {
+                Ok(LspParamsOrResponse::Params(lsp_params)) => lsp_params,
+                Ok(LspParamsOrResponse::Response(response)) => return Task::ready(Ok(response)),
+                Err(err) => {
+                    let message = format!(
+                        "{} via {} failed: {}",
+                        request.display_name(),
+                        language_server.name(),
+                        err
+                    );
+                    if should_log_lsp_request_failure(&message) {
+                        log::warn!("{message}");
+                    }
+                    return Task::ready(Err(anyhow!(message)));
+                }
+            };
 
         let status = request.status();
         let request_timeout = ProjectSettings::get_global(cx)
@@ -5720,6 +5861,7 @@ impl LspStore {
         let mut messages_to_report = Vec::new();
         let (new_tree, to_stop) = {
             let mut rebase = local.lsp_tree.rebase();
+            let host_worktree = local.worktree_store.read(cx).visible_worktrees(cx).next();
             let buffers = buffer_store
                 .read(cx)
                 .buffers()
@@ -5731,19 +5873,44 @@ impl LspStore {
                     {
                         return None;
                     }
-                    let file = File::from_dyn(raw_buffer.file()).cloned()?;
                     let language = raw_buffer.language().cloned()?;
-                    Some((file, language, raw_buffer.remote_id()))
+                    if let Some(file) = File::from_dyn(raw_buffer.file()).cloned() {
+                        Some((Some(file), language, raw_buffer.remote_id()))
+                    } else if host_worktree.is_some() {
+                        Some((None, language, raw_buffer.remote_id()))
+                    } else {
+                        log::debug!(
+                            "Skipping LSP refresh for untitled buffer {}: no visible worktree",
+                            raw_buffer.remote_id()
+                        );
+                        None
+                    }
                 })
-                .sorted_by_key(|(file, _, _)| Reverse(file.worktree.read(cx).is_visible()));
+                .sorted_by_key(|(file, _, _)| {
+                    Reverse(
+                        file.as_ref()
+                            .map(|f| f.worktree.read(cx).is_visible())
+                            .unwrap_or(false),
+                    )
+                });
             for (file, language, buffer_id) in buffers {
-                let worktree_id = file.worktree_id(cx);
-                let Some(worktree) = local
-                    .worktree_store
-                    .read(cx)
-                    .worktree_for_id(worktree_id, cx)
-                else {
-                    continue;
+                let (worktree_id, worktree);
+                if let Some(file) = &file {
+                    worktree_id = file.worktree_id(cx);
+                    let Some(wt) = local
+                        .worktree_store
+                        .read(cx)
+                        .worktree_for_id(worktree_id, cx)
+                    else {
+                        continue;
+                    };
+                    worktree = wt;
+                } else {
+                    let Some(wt) = host_worktree.clone() else {
+                        continue;
+                    };
+                    worktree = wt;
+                    worktree_id = worktree.read(cx).id();
                 };
 
                 if let Some((_, apply)) = local.reuse_existing_language_server(
@@ -5760,13 +5927,20 @@ impl LspStore {
                 {
                     let delegate =
                         Arc::new(ManifestQueryDelegate::new(worktree.read(cx).snapshot()));
-                    let path = file
-                        .path()
-                        .parent()
-                        .map(Arc::from)
-                        .unwrap_or_else(|| file.path().clone());
+                    let (path, uri_display) = if let Some(file) = &file {
+                        let path: Arc<RelPath> = file
+                            .path()
+                            .parent()
+                            .map(Arc::from)
+                            .unwrap_or_else(|| file.path().clone());
+                        (path, file.abs_path(cx).to_string_lossy().into_owned())
+                    } else {
+                        (
+                            Arc::from(RelPath::empty()),
+                            untitled_buffer_uri(buffer_id).to_string(),
+                        )
+                    };
                     let worktree_path = ProjectPath { worktree_id, path };
-                    let abs_path = file.abs_path(cx);
                     let nodes = rebase
                         .walk(
                             worktree_path,
@@ -5825,9 +5999,7 @@ impl LspStore {
                                 message:
                                     proto::update_language_server::Variant::RegisteredForBuffer(
                                         proto::RegisteredForBuffer {
-                                            buffer_abs_path: abs_path
-                                                .to_string_lossy()
-                                                .into_owned(),
+                                            buffer_abs_path: uri_display.clone(),
                                             buffer_id: buffer_id.to_proto(),
                                         },
                                     ),
@@ -8539,12 +8711,16 @@ impl LspStore {
         })?;
 
         let buffer = buffer.read(cx);
-        let file = File::from_dyn(buffer.file())?;
-        let abs_path = file.as_local()?.abs_path(cx);
-        let uri = lsp::Uri::from_file_path(&abs_path)
-            .ok()
-            .with_context(|| format!("Failed to convert path to URI: {}", abs_path.display()))
-            .log_err()?;
+        let buffer_id = buffer.remote_id();
+        let uri = if let Some(file) = File::from_dyn(buffer.file()) {
+            let abs_path = file.as_local()?.abs_path(cx);
+            lsp::Uri::from_file_path(&abs_path)
+                .ok()
+                .with_context(|| format!("Failed to convert path to URI: {}", abs_path.display()))
+                .log_err()?
+        } else {
+            self.as_local()?.buffer_uris.get(&buffer_id)?.uri.clone()
+        };
         let next_snapshot = buffer.text_snapshot();
         for language_server in language_servers {
             let language_server = language_server.clone();
@@ -9324,6 +9500,19 @@ impl LspStore {
         language_server_id: LanguageServerId,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
+        if let Some(local) = self.as_local() {
+            if let Some((buffer_id, _)) = local
+                .buffer_uris
+                .iter()
+                .find(|(_, state)| state.uri == abs_path)
+            {
+                let buffer_id = *buffer_id;
+                if let Some(buffer) = self.buffer_store.read(cx).get(buffer_id) {
+                    return Task::ready(Ok(buffer));
+                }
+            }
+        }
+
         let path_style = self.worktree_store.read(cx).path_style();
         cx.spawn(async move |lsp_store, cx| {
             // Escape percent-encoded string.
@@ -10417,18 +10606,17 @@ impl LspStore {
                         .buffer_id
                         .map(|id| BufferId::new(id))
                         .transpose()?;
-                    buffer_id
-                        .and_then(|buffer_id| {
-                            lsp_store
-                                .buffer_store()
-                                .read(cx)
-                                .get(buffer_id)
-                                .and_then(|buffer| {
-                                    Some(buffer.read(cx).file()?.as_local()?.abs_path(cx))
-                                })
-                                .map(|path| make_text_document_identifier(&path))
-                        })
-                        .transpose()?
+                    buffer_id.and_then(|buffer_id| {
+                        lsp_store
+                            .buffer_store()
+                            .read(cx)
+                            .get(buffer_id)
+                            .and_then(|buffer| {
+                                let path = buffer.read(cx).file()?.as_local()?.abs_path(cx);
+                                let uri = file_path_to_lsp_url(&path).ok()?;
+                                Some(make_text_document_identifier(&uri))
+                            })
+                    })
                 } else {
                     None
                 };
@@ -12036,11 +12224,11 @@ impl LspStore {
         cx: &mut Context<Self>,
     ) -> Result<()> {
         anyhow::ensure!(self.mode.is_local(), "called update_diagnostics on remote");
-        let updates = lsp_diagnostics
-            .into_iter()
-            .filter_map(|update| {
-                let abs_path = update.diagnostics.uri.to_file_path().ok()?;
-                Some(DocumentDiagnosticsUpdate {
+        let mut file_updates = Vec::new();
+        for update in lsp_diagnostics {
+            let uri = update.diagnostics.uri.clone();
+            if let Ok(abs_path) = uri.to_file_path() {
+                file_updates.push(DocumentDiagnosticsUpdate {
                     diagnostics: self.lsp_to_document_diagnostics(
                         abs_path,
                         source_kind,
@@ -12053,11 +12241,95 @@ impl LspStore {
                     server_id: update.server_id,
                     disk_based_sources: update.disk_based_sources,
                     registration_id: update.registration_id,
-                })
-            })
-            .collect();
-        self.merge_diagnostic_entries(updates, merge, cx)?;
+                });
+            } else {
+                self.merge_untitled_buffer_diagnostics(
+                    &uri,
+                    source_kind,
+                    update.server_id,
+                    update.diagnostics,
+                    &update.disk_based_sources,
+                    update.registration_id,
+                    update.result_id,
+                    &merge,
+                    cx,
+                );
+            }
+        }
+        self.merge_diagnostic_entries(file_updates, merge, cx)?;
         Ok(())
+    }
+
+    fn merge_untitled_buffer_diagnostics(
+        &mut self,
+        uri: &lsp::Uri,
+        source_kind: DiagnosticSourceKind,
+        server_id: LanguageServerId,
+        lsp_diagnostics: lsp::PublishDiagnosticsParams,
+        disk_based_sources: &[String],
+        registration_id: Option<SharedString>,
+        result_id: Option<SharedString>,
+        merge: &impl Fn(&lsp::Uri, &Diagnostic, &App) -> bool,
+        cx: &mut Context<Self>,
+    ) {
+        let local = match self.as_local() {
+            Some(local) => local,
+            None => return,
+        };
+        let buffer_id = local
+            .buffer_uris
+            .iter()
+            .find(|(_, state)| &state.uri == uri)
+            .map(|(id, _)| *id);
+        let Some(buffer_id) = buffer_id else {
+            return;
+        };
+        let Some(buffer_handle) = self.buffer_store.read(cx).get(buffer_id) else {
+            return;
+        };
+
+        let snapshot = buffer_handle.read(cx).snapshot();
+        let reused_diagnostics = buffer_handle
+            .read(cx)
+            .buffer_diagnostics(Some(server_id))
+            .iter()
+            .filter(|v| merge(uri, &v.diagnostic, cx))
+            .map(|v| {
+                let start = Unclipped(v.range.start.to_point_utf16(&snapshot));
+                let end = Unclipped(v.range.end.to_point_utf16(&snapshot));
+                DiagnosticEntry {
+                    range: start..end,
+                    diagnostic: v.diagnostic.clone(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // `document_abs_path` is unused here — only `diagnostics` and `version` are
+        // extracted below, so an empty path is safe.
+        let document_diagnostics = self.lsp_to_document_diagnostics(
+            PathBuf::new(),
+            source_kind,
+            server_id,
+            lsp_diagnostics,
+            disk_based_sources,
+            registration_id.clone(),
+        );
+
+        let Some(local) = self.as_local_mut() else {
+            return;
+        };
+        local
+            .update_buffer_diagnostics(
+                &buffer_handle,
+                server_id,
+                Some(registration_id),
+                result_id,
+                document_diagnostics.version,
+                document_diagnostics.diagnostics,
+                reused_diagnostics,
+                cx,
+            )
+            .log_err();
     }
 
     fn lsp_to_document_diagnostics(
@@ -12345,15 +12617,11 @@ impl LspStore {
             }
         }
 
-        let mut buffer_paths_registered = Vec::new();
+        let mut buffer_registrations: Vec<(BufferId, String)> = Vec::new();
         self.buffer_store.clone().update(cx, |buffer_store, cx| {
             let mut lsp_adapters = HashMap::default();
             for buffer_handle in buffer_store.buffers() {
                 let buffer = buffer_handle.read(cx);
-                let file = match File::from_dyn(buffer.file()) {
-                    Some(file) => file,
-                    None => continue,
-                };
                 let language = match buffer.language() {
                     Some(language) => language,
                     None => continue,
@@ -12362,68 +12630,83 @@ impl LspStore {
                     continue;
                 }
 
-                if !worktrees_using_server.contains(&file.worktree.read(cx).id())
-                    || !lsp_adapters
-                        .entry(language.name())
-                        .or_insert_with(|| self.languages.lsp_adapters(&language.name()))
-                        .iter()
-                        .any(|a| a.name == key.name)
+                if !lsp_adapters
+                    .entry(language.name())
+                    .or_insert_with(|| self.languages.lsp_adapters(&language.name()))
+                    .iter()
+                    .any(|a| a.name == key.name)
                 {
                     continue;
                 }
-                // didOpen
-                let file = match file.as_local() {
-                    Some(file) => file,
-                    None => continue,
-                };
-
-                let local = self.as_local_mut().unwrap();
 
                 let buffer_id = buffer.remote_id();
-                if local.registered_buffers.contains_key(&buffer_id) {
+                let local = self.as_local_mut().unwrap();
+                if !local.registered_buffers.contains_key(&buffer_id) {
+                    continue;
+                }
+
+                let uri;
+                let uri_display;
+                if let Some(file) = File::from_dyn(buffer.file()) {
+                    if !worktrees_using_server.contains(&file.worktree.read(cx).id()) {
+                        continue;
+                    }
+                    let file = match file.as_local() {
+                        Some(file) => file,
+                        None => continue,
+                    };
                     let abs_path = file.abs_path(cx);
-                    let uri = match lsp::Uri::from_file_path(&abs_path) {
+                    uri = match lsp::Uri::from_file_path(&abs_path) {
                         Ok(uri) => uri,
                         Err(()) => {
                             log::error!("failed to convert path to URI: {:?}", abs_path);
                             continue;
                         }
                     };
+                    uri_display = abs_path.to_string_lossy().into_owned();
+                } else {
+                    let Some(stored_uri) = local.buffer_uris.get(&buffer_id).map(|s| s.uri.clone())
+                    else {
+                        continue;
+                    };
+                    uri = stored_uri;
+                    uri_display = uri.to_string();
+                }
 
-                    let versions = local
-                        .buffer_snapshots
-                        .entry(buffer_id)
-                        .or_default()
-                        .entry(server_id)
-                        .and_modify(|_| {
-                            assert!(
+                let versions = local
+                    .buffer_snapshots
+                    .entry(buffer_id)
+                    .or_default()
+                    .entry(server_id)
+                    .and_modify(|_| {
+                        assert!(
                             false,
                             "There should not be an existing snapshot for a newly inserted buffer"
                         )
-                        })
-                        .or_insert_with(|| {
-                            vec![LspBufferSnapshot {
-                                version: 0,
-                                snapshot: buffer.text_snapshot(),
-                            }]
-                        });
+                    })
+                    .or_insert_with(|| {
+                        vec![LspBufferSnapshot {
+                            version: 0,
+                            snapshot: buffer.text_snapshot(),
+                        }]
+                    });
 
-                    let snapshot = versions.last().unwrap();
-                    let version = snapshot.version;
-                    let initial_snapshot = &snapshot.snapshot;
-                    language_server.register_buffer(
-                        uri,
-                        adapter.language_id(&language.name()),
-                        version,
-                        initial_snapshot.text(),
-                    );
-                    buffer_paths_registered.push((buffer_id, abs_path));
-                    local
-                        .buffers_opened_in_servers
-                        .entry(buffer_id)
-                        .or_default()
-                        .insert(server_id);
-                }
+                let snapshot = versions.last().unwrap();
+                let version = snapshot.version;
+                let initial_snapshot = &snapshot.snapshot;
+                language_server.register_buffer(
+                    uri,
+                    adapter.language_id(&language.name()),
+                    version,
+                    initial_snapshot.text(),
+                );
+                buffer_registrations.push((buffer_id, uri_display));
+                local
+                    .buffers_opened_in_servers
+                    .entry(buffer_id)
+                    .or_default()
+                    .insert(server_id);
+
                 buffer_handle.update(cx, |buffer, cx| {
                     buffer.set_completion_triggers(
                         server_id,
@@ -12444,13 +12727,13 @@ impl LspStore {
             }
         });
 
-        for (buffer_id, abs_path) in buffer_paths_registered {
+        for (buffer_id, uri_display) in buffer_registrations {
             cx.emit(LspStoreEvent::LanguageServerUpdate {
                 language_server_id: server_id,
                 name: Some(adapter.name()),
                 message: proto::update_language_server::Variant::RegisteredForBuffer(
                     proto::RegisteredForBuffer {
-                        buffer_abs_path: abs_path.to_string_lossy().into_owned(),
+                        buffer_abs_path: uri_display,
                         buffer_id: buffer_id.to_proto(),
                     },
                 ),
@@ -12967,17 +13250,24 @@ impl LspStore {
         registration_id: &Option<SharedString>,
         cx: &App,
     ) -> Option<SharedString> {
-        let abs_path = self
+        let local = self.as_local()?;
+        let key = self
             .buffer_store
             .read(cx)
             .get(buffer_id)
             .and_then(|b| File::from_dyn(b.read(cx).file()))
-            .map(|f| f.abs_path(cx))?;
-        self.as_local()?
+            .map(|f| f.abs_path(cx))
+            .or_else(|| {
+                local
+                    .buffer_uris
+                    .get(&buffer_id)
+                    .map(|state| PathBuf::from(state.uri.to_string()))
+            })?;
+        local
             .buffer_pull_diagnostics_result_ids
             .get(&server_id)?
             .get(registration_id)?
-            .get(&abs_path)?
+            .get(&key)?
             .clone()
     }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -77,10 +77,10 @@ use itertools::Itertools as _;
 use language::{
     Bias, BinaryStatus, Buffer, BufferRow, BufferSnapshot, CachedLspAdapter, Capability, CodeLabel,
     CodeLabelExt, Diagnostic, DiagnosticEntry, DiagnosticSet, DiagnosticSourceKind, Diff,
-    File as _, Language, LanguageAwareStyling, LanguageName, LanguageRegistry, LocalFile,
-    LspAdapter, LspAdapterDelegate, LspInstaller, ManifestDelegate, ManifestName, ModelineSettings,
-    OffsetUtf16, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToOffsetUtf16, ToPointUtf16,
-    Toolchain, Transaction, Unclipped,
+    DiskState, File as _, Language, LanguageAwareStyling, LanguageName, LanguageRegistry,
+    LocalFile, LspAdapter, LspAdapterDelegate, LspInstaller, ManifestDelegate, ManifestName,
+    ModelineSettings, OffsetUtf16, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToOffsetUtf16,
+    ToPointUtf16, Toolchain, Transaction, Unclipped,
     language_settings::{
         AllLanguageSettings, FormatOnSave, Formatter, LanguageSettings, LineEndingSetting,
         all_language_settings,
@@ -5033,6 +5033,16 @@ impl LspStore {
     ) -> OpenLspBufferHandle {
         let buffer_id = buffer.read(cx).remote_id();
         let handle = OpenLspBufferHandle(cx.new(|_| OpenLspBuffer(buffer.clone())));
+        // Historic buffers represent past file content (e.g. the commit view)
+        // and would otherwise be treated as untitled, which starts a language
+        // server against content that is not the current file state.
+        if buffer
+            .read(cx)
+            .file()
+            .is_some_and(|file| matches!(file.disk_state(), DiskState::Historic { .. }))
+        {
+            return handle;
+        }
         if let Some(local) = self.as_local_mut() {
             let refcount = local.registered_buffers.entry(buffer_id).or_insert(0);
             if !ignore_refcounts {

--- a/crates/project/src/lsp_store/document_colors.rs
+++ b/crates/project/src/lsp_store/document_colors.rs
@@ -20,7 +20,9 @@ use worktree::File;
 
 use crate::{
     ColorPresentation, DocumentColor, LspStore,
-    lsp_command::{GetDocumentColor, LspCommand as _, make_text_document_identifier},
+    lsp_command::{
+        GetDocumentColor, LspCommand as _, file_path_to_lsp_url, make_text_document_identifier,
+    },
     lsp_store::{
         LspStoreEvent, RunningFetch, missing_servers_to_query, next_lsp_fetch_id,
         upstream_lsp_query_server_filter,
@@ -291,14 +293,11 @@ impl LspStore {
                 Ok(color)
             })
         } else {
-            let path = match buffer
-                .update(cx, |buffer, cx| {
-                    Some(File::from_dyn(buffer.file())?.abs_path(cx))
-                })
-                .context("buffer with the missing path")
-            {
-                Ok(path) => path,
-                Err(e) => return Task::ready(Err(e)),
+            let Some(uri) = buffer.update(cx, |buffer, cx| {
+                let path = File::from_dyn(buffer.file())?.abs_path(cx);
+                file_path_to_lsp_url(&path).ok()
+            }) else {
+                return Task::ready(Err(anyhow::anyhow!("buffer with the missing path")));
             };
             let Some(lang_server) = buffer.update(cx, |buffer, cx| {
                 self.language_server_for_local_buffer(buffer, server_id, cx)
@@ -313,7 +312,7 @@ impl LspStore {
             cx.background_spawn(async move {
                 let resolve_task = lang_server.request::<lsp::request::ColorPresentationRequest>(
                     lsp::ColorPresentationParams {
-                        text_document: make_text_document_identifier(&path)?,
+                        text_document: make_text_document_identifier(&uri),
                         color: color.color,
                         range: color.lsp_range,
                         work_done_progress_params: Default::default(),

--- a/crates/project/src/lsp_store/emmet_ext.rs
+++ b/crates/project/src/lsp_store/emmet_ext.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -87,7 +87,7 @@ impl LspCommand for ExpandAbbreviation {
 
     fn to_lsp(
         &self,
-        _: &Path,
+        _: &lsp::Uri,
         _: &Buffer,
         server: &Arc<LanguageServer>,
         _: &App,

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -1,9 +1,8 @@
 use crate::{
     LocationLink,
     lsp_command::{
-        LspCommand, file_path_to_lsp_url, location_link_from_lsp, location_link_from_proto,
-        location_link_to_proto, location_links_from_lsp, location_links_from_proto,
-        location_links_to_proto,
+        LspCommand, location_link_from_lsp, location_link_from_proto, location_link_to_proto,
+        location_links_from_lsp, location_links_from_proto, location_links_to_proto,
     },
     lsp_store::LspStore,
     make_lsp_text_document_position, make_text_document_identifier,
@@ -19,10 +18,7 @@ use language::{
 use lsp::{AdapterServerCapabilities, LanguageServer, LanguageServerId};
 use rpc::proto::{self, PeerId};
 use serde::{Deserialize, Serialize};
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 use task::TaskTemplate;
 use text::{BufferId, PointUtf16, ToPointUtf16};
 
@@ -74,13 +70,13 @@ impl LspCommand for ExpandMacro {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<ExpandMacroParams> {
         Ok(ExpandMacroParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             position: point_to_lsp(self.position),
         })
     }
@@ -206,15 +202,13 @@ impl LspCommand for OpenDocs {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<OpenDocsParams> {
-        let uri = lsp::Uri::from_file_path(path)
-            .map_err(|()| anyhow::anyhow!("{path:?} is not a valid URI"))?;
         Ok(OpenDocsParams {
-            text_document: lsp::TextDocumentIdentifier { uri },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             position: point_to_lsp(self.position),
         })
     }
@@ -340,14 +334,12 @@ impl LspCommand for SwitchSourceHeader {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<SwitchSourceHeaderParams> {
-        Ok(SwitchSourceHeaderParams(make_text_document_identifier(
-            path,
-        )?))
+        Ok(SwitchSourceHeaderParams(make_text_document_identifier(uri)))
     }
 
     async fn response_from_lsp(
@@ -422,12 +414,12 @@ impl LspCommand for GoToParentModule {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::TextDocumentPositionParams> {
-        make_lsp_text_document_position(path, self.position)
+        Ok(make_lsp_text_document_position(uri, self.position))
     }
 
     async fn response_from_lsp(
@@ -679,14 +671,13 @@ impl LspCommand for GetLspRunnables {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<RunnablesParams> {
-        let url = file_path_to_lsp_url(path)?;
         Ok(RunnablesParams {
-            text_document: lsp::TextDocumentIdentifier::new(url),
+            text_document: lsp::TextDocumentIdentifier::new(uri.clone()),
             position: self
                 .position
                 .map(|anchor| point_to_lsp(anchor.to_point_utf16(&buffer.snapshot()))),

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -1,9 +1,8 @@
 use crate::{
     LocationLink,
     lsp_command::{
-        LspCommand, file_path_to_lsp_url, location_link_from_lsp, location_link_from_proto,
-        location_link_to_proto, location_links_from_lsp, location_links_from_proto,
-        location_links_to_proto,
+        LspCommand, location_link_from_lsp, location_link_from_proto, location_link_to_proto,
+        location_links_from_lsp, location_links_from_proto, location_links_to_proto,
     },
     lsp_store::{LanguageServerToQuery, LspStore},
     make_lsp_text_document_position, make_text_document_identifier,
@@ -19,10 +18,7 @@ use language::{
 use lsp::{AdapterServerCapabilities, LanguageServer, LanguageServerId};
 use rpc::proto::{self, PeerId};
 use serde::{Deserialize, Serialize};
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 use task::TaskTemplate;
 use text::{BufferId, PointUtf16, ToPointUtf16};
 
@@ -79,13 +75,13 @@ impl LspCommand for ExpandMacro {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<ExpandMacroParams> {
         Ok(ExpandMacroParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document: make_text_document_identifier(uri),
             position: point_to_lsp(self.position),
         })
     }
@@ -218,15 +214,13 @@ impl LspCommand for OpenDocs {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<OpenDocsParams> {
-        let uri = lsp::Uri::from_file_path(path)
-            .map_err(|()| anyhow::anyhow!("{path:?} is not a valid URI"))?;
         Ok(OpenDocsParams {
-            text_document: lsp::TextDocumentIdentifier { uri },
+            text_document: lsp::TextDocumentIdentifier { uri: uri.clone() },
             position: point_to_lsp(self.position),
         })
     }
@@ -360,14 +354,12 @@ impl LspCommand for SwitchSourceHeader {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<SwitchSourceHeaderParams> {
-        Ok(SwitchSourceHeaderParams(make_text_document_identifier(
-            path,
-        )?))
+        Ok(SwitchSourceHeaderParams(make_text_document_identifier(uri)))
     }
 
     async fn response_from_lsp(
@@ -449,12 +441,12 @@ impl LspCommand for GoToParentModule {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::TextDocumentPositionParams> {
-        make_lsp_text_document_position(path, self.position)
+        Ok(make_lsp_text_document_position(uri, self.position))
     }
 
     async fn response_from_lsp(
@@ -713,14 +705,13 @@ impl LspCommand for GetLspRunnables {
 
     fn to_lsp(
         &self,
-        path: &Path,
+        uri: &lsp::Uri,
         buffer: &Buffer,
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<RunnablesParams> {
-        let url = file_path_to_lsp_url(path)?;
         Ok(RunnablesParams {
-            text_document: lsp::TextDocumentIdentifier::new(url),
+            text_document: lsp::TextDocumentIdentifier::new(uri.clone()),
             position: self
                 .position
                 .map(|anchor| point_to_lsp(anchor.to_point_utf16(&buffer.snapshot()))),

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8276,11 +8276,12 @@ async fn test_save_file_spawns_language_server(cx: &mut gpui::TestAppContext) {
         .update(cx, |this, cx| this.create_buffer(None, false, cx))
         .unwrap()
         .await;
-    project.update(cx, |this, cx| {
-        this.register_buffer_with_language_servers(&buffer, cx);
+    let _handle = project.update(cx, |this, cx| {
+        let handle = this.register_buffer_with_language_servers(&buffer, cx);
         buffer.update(cx, |buffer, cx| {
             assert!(!this.has_language_servers_for(buffer, cx));
-        })
+        });
+        handle
     });
 
     project
@@ -8317,6 +8318,315 @@ async fn test_save_file_spawns_language_server(cx: &mut gpui::TestAppContext) {
             assert!(this.has_language_servers_for(buffer, cx));
         })
     });
+}
+
+#[gpui::test]
+async fn test_lsp_register_untitled_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let open_notification = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+
+    let uri_str = open_notification.text_document.uri.to_string();
+    assert!(
+        uri_str.starts_with("untitled:Untitled-"),
+        "expected untitled URI, got {uri_str}"
+    );
+    assert_eq!(open_notification.text_document.language_id, "rust");
+    assert_eq!(open_notification.text_document.version, 0);
+}
+
+#[gpui::test]
+async fn test_lsp_did_change_untitled_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let open_notification = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "let x = 1;")], None, cx)
+    });
+
+    let change_notification = fake_server
+        .receive_notification::<lsp::notification::DidChangeTextDocument>()
+        .await;
+    assert_eq!(
+        change_notification.text_document.uri,
+        open_notification.text_document.uri
+    );
+    assert!(change_notification.text_document.version > open_notification.text_document.version);
+}
+
+#[gpui::test]
+async fn test_lsp_save_untitled_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let initial_open = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+    let untitled_uri = initial_open.text_document.uri.clone();
+    assert!(
+        untitled_uri.to_string().starts_with("untitled:"),
+        "expected untitled URI, got {untitled_uri:?}"
+    );
+
+    project
+        .update(cx, |project, cx| {
+            let worktree_id = project.worktrees(cx).next().unwrap().read(cx).id();
+            project.save_buffer_as(
+                buffer.clone(),
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("main.rs").into(),
+                },
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    let close_notification = fake_server
+        .receive_notification::<lsp::notification::DidCloseTextDocument>()
+        .await;
+    assert_eq!(close_notification.text_document.uri, untitled_uri);
+
+    let reopen_notification = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+    assert_eq!(
+        reopen_notification.text_document.uri,
+        lsp::Uri::from_file_path(path!("/dir/main.rs")).unwrap()
+    );
+}
+
+#[gpui::test]
+async fn test_buffer_uris_only_tracks_untitled(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({ "a.rs": "fn main() {}" }))
+        .await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    // File-backed buffer must NOT be tracked in `buffer_uris` (its URI is derivable
+    // from `file.abs_path()`, so storing it would be a leak).
+    let (file_buffer, _file_handle) = project
+        .update(cx, |p, cx| {
+            p.open_local_buffer_with_lsp(path!("/dir/a.rs"), cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+    let file_id = file_buffer.read_with(cx, |b, _| b.remote_id());
+    let file_tracked =
+        project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(file_id));
+    assert!(
+        !file_tracked,
+        "buffer_uris should not contain file-backed buffer"
+    );
+
+    // Untitled buffer must be tracked while open and removed on release.
+    let untitled_buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let untitled_handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&untitled_buffer, cx)
+    });
+    cx.executor().run_until_parked();
+    let untitled_id = untitled_buffer.read_with(cx, |b, _| b.remote_id());
+    let tracked_while_open = project.read_with(cx, |p, cx| {
+        p.lsp_store().read(cx).has_buffer_uri(untitled_id)
+    });
+    assert!(
+        tracked_while_open,
+        "buffer_uris should track open untitled buffer"
+    );
+
+    cx.update(|_| {
+        drop(untitled_handle);
+        drop(untitled_buffer);
+    });
+    cx.executor().run_until_parked();
+    let tracked_after_release = project.read_with(cx, |p, cx| {
+        p.lsp_store().read(cx).has_buffer_uri(untitled_id)
+    });
+    assert!(
+        !tracked_after_release,
+        "buffer_uris entry should be removed when untitled buffer is released"
+    );
+}
+
+#[gpui::test]
+async fn test_untitled_buffer_no_visible_worktree(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, Vec::<&Path>::new(), cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+    cx.executor().run_until_parked();
+
+    let buffer_id = buffer.read_with(cx, |b, _| b.remote_id());
+    let tracked = project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id));
+    assert!(
+        !tracked,
+        "untitled buffer should not be tracked when there is no visible worktree"
+    );
+}
+
+#[gpui::test]
+async fn test_untitled_buffer_cleanup_on_worktree_removal(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+    cx.executor().run_until_parked();
+    let buffer_id = buffer.read_with(cx, |b, _| b.remote_id());
+    assert!(
+        project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "untitled buffer should be tracked while host worktree exists"
+    );
+
+    project.update(cx, |project, cx| {
+        let worktree_id = project.worktrees(cx).next().unwrap().read(cx).id();
+        project.remove_worktree(worktree_id, cx);
+    });
+    cx.executor().run_until_parked();
+
+    assert!(
+        !project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "buffer_uris entry should be cleaned up when host worktree is removed"
+    );
+}
+
+#[gpui::test]
+async fn test_untitled_buffer_late_registration_on_worktree_add(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+
+    // Start with no worktrees.
+    let project = Project::test(fs.clone(), Vec::<&Path>::new(), cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    // Register an untitled buffer; registration bails because there's no
+    // visible worktree to host it.
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+    cx.executor().run_until_parked();
+    let buffer_id = buffer.read_with(cx, |b, _| b.remote_id());
+    assert!(
+        !project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "untitled buffer should not be tracked before any visible worktree exists"
+    );
+
+    // Add a worktree; the pending untitled buffer should be retroactively
+    // registered.
+    project
+        .update(cx, |project, cx| {
+            project.create_worktree(path!("/dir"), true, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert!(
+        project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "buffer should be retroactively registered once a worktree is added"
+    );
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let open = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+    assert!(
+        open.text_document.uri.to_string().starts_with("untitled:"),
+        "did_open URI should use untitled scheme, got {:?}",
+        open.text_document.uri
+    );
 }
 
 #[gpui::test(iterations = 30)]

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -6009,11 +6009,12 @@ async fn test_save_file_spawns_language_server(cx: &mut gpui::TestAppContext) {
         .update(cx, |this, cx| this.create_buffer(None, false, cx))
         .unwrap()
         .await;
-    project.update(cx, |this, cx| {
-        this.register_buffer_with_language_servers(&buffer, cx);
+    let _handle = project.update(cx, |this, cx| {
+        let handle = this.register_buffer_with_language_servers(&buffer, cx);
         buffer.update(cx, |buffer, cx| {
             assert!(!this.has_language_servers_for(buffer, cx));
-        })
+        });
+        handle
     });
 
     project
@@ -6050,6 +6051,315 @@ async fn test_save_file_spawns_language_server(cx: &mut gpui::TestAppContext) {
             assert!(this.has_language_servers_for(buffer, cx));
         })
     });
+}
+
+#[gpui::test]
+async fn test_lsp_register_untitled_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let open_notification = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+
+    let uri_str = open_notification.text_document.uri.to_string();
+    assert!(
+        uri_str.starts_with("untitled:Untitled-"),
+        "expected untitled URI, got {uri_str}"
+    );
+    assert_eq!(open_notification.text_document.language_id, "rust");
+    assert_eq!(open_notification.text_document.version, 0);
+}
+
+#[gpui::test]
+async fn test_lsp_did_change_untitled_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let open_notification = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "let x = 1;")], None, cx)
+    });
+
+    let change_notification = fake_server
+        .receive_notification::<lsp::notification::DidChangeTextDocument>()
+        .await;
+    assert_eq!(
+        change_notification.text_document.uri,
+        open_notification.text_document.uri
+    );
+    assert!(change_notification.text_document.version > open_notification.text_document.version);
+}
+
+#[gpui::test]
+async fn test_lsp_save_untitled_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let initial_open = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+    let untitled_uri = initial_open.text_document.uri.clone();
+    assert!(
+        untitled_uri.to_string().starts_with("untitled:"),
+        "expected untitled URI, got {untitled_uri:?}"
+    );
+
+    project
+        .update(cx, |project, cx| {
+            let worktree_id = project.worktrees(cx).next().unwrap().read(cx).id();
+            project.save_buffer_as(
+                buffer.clone(),
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("main.rs").into(),
+                },
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    let close_notification = fake_server
+        .receive_notification::<lsp::notification::DidCloseTextDocument>()
+        .await;
+    assert_eq!(close_notification.text_document.uri, untitled_uri);
+
+    let reopen_notification = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+    assert_eq!(
+        reopen_notification.text_document.uri,
+        lsp::Uri::from_file_path(path!("/dir/main.rs")).unwrap()
+    );
+}
+
+#[gpui::test]
+async fn test_buffer_uris_only_tracks_untitled(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({ "a.rs": "fn main() {}" }))
+        .await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    // File-backed buffer must NOT be tracked in `buffer_uris` (its URI is derivable
+    // from `file.abs_path()`, so storing it would be a leak).
+    let (file_buffer, _file_handle) = project
+        .update(cx, |p, cx| {
+            p.open_local_buffer_with_lsp(path!("/dir/a.rs"), cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+    let file_id = file_buffer.read_with(cx, |b, _| b.remote_id());
+    let file_tracked =
+        project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(file_id));
+    assert!(
+        !file_tracked,
+        "buffer_uris should not contain file-backed buffer"
+    );
+
+    // Untitled buffer must be tracked while open and removed on release.
+    let untitled_buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let untitled_handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&untitled_buffer, cx)
+    });
+    cx.executor().run_until_parked();
+    let untitled_id = untitled_buffer.read_with(cx, |b, _| b.remote_id());
+    let tracked_while_open = project.read_with(cx, |p, cx| {
+        p.lsp_store().read(cx).has_buffer_uri(untitled_id)
+    });
+    assert!(
+        tracked_while_open,
+        "buffer_uris should track open untitled buffer"
+    );
+
+    cx.update(|_| {
+        drop(untitled_handle);
+        drop(untitled_buffer);
+    });
+    cx.executor().run_until_parked();
+    let tracked_after_release = project.read_with(cx, |p, cx| {
+        p.lsp_store().read(cx).has_buffer_uri(untitled_id)
+    });
+    assert!(
+        !tracked_after_release,
+        "buffer_uris entry should be removed when untitled buffer is released"
+    );
+}
+
+#[gpui::test]
+async fn test_untitled_buffer_no_visible_worktree(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, Vec::<&Path>::new(), cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+    cx.executor().run_until_parked();
+
+    let buffer_id = buffer.read_with(cx, |b, _| b.remote_id());
+    let tracked = project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id));
+    assert!(
+        !tracked,
+        "untitled buffer should not be tracked when there is no visible worktree"
+    );
+}
+
+#[gpui::test]
+async fn test_untitled_buffer_cleanup_on_worktree_removal(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let _fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+    cx.executor().run_until_parked();
+    let buffer_id = buffer.read_with(cx, |b, _| b.remote_id());
+    assert!(
+        project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "untitled buffer should be tracked while host worktree exists"
+    );
+
+    project.update(cx, |project, cx| {
+        let worktree_id = project.worktrees(cx).next().unwrap().read(cx).id();
+        project.remove_worktree(worktree_id, cx);
+    });
+    cx.executor().run_until_parked();
+
+    assert!(
+        !project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "buffer_uris entry should be cleaned up when host worktree is removed"
+    );
+}
+
+#[gpui::test]
+async fn test_untitled_buffer_late_registration_on_worktree_add(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+
+    // Start with no worktrees.
+    let project = Project::test(fs.clone(), Vec::<&Path>::new(), cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    // Register an untitled buffer; registration bails because there's no
+    // visible worktree to host it.
+    let buffer = project
+        .update(cx, |p, cx| p.create_buffer(Some(rust_lang()), false, cx))
+        .await
+        .unwrap();
+    let _handle = project.update(cx, |p, cx| {
+        p.register_buffer_with_language_servers(&buffer, cx)
+    });
+    cx.executor().run_until_parked();
+    let buffer_id = buffer.read_with(cx, |b, _| b.remote_id());
+    assert!(
+        !project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "untitled buffer should not be tracked before any visible worktree exists"
+    );
+
+    // Add a worktree; the pending untitled buffer should be retroactively
+    // registered.
+    project
+        .update(cx, |project, cx| {
+            project.create_worktree(path!("/dir"), true, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert!(
+        project.read_with(cx, |p, cx| p.lsp_store().read(cx).has_buffer_uri(buffer_id)),
+        "buffer should be retroactively registered once a worktree is added"
+    );
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let open = fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+    assert!(
+        open.text_document.uri.to_string().starts_with("untitled:"),
+        "did_open URI should use untitled scheme, got {:?}",
+        open.text_document.uri
+    );
 }
 
 #[gpui::test(iterations = 30)]


### PR DESCRIPTION
## Rationale

Currently Zed does not start language servers for unsaved buffers, so even after the user explicitly selects a language via the language selector, the buffer gets none of the LSP-driven features: no diagnostics, completions, hover, formatting, inlay hints, semantic tokens, document symbols, etc.

This is a long-standing pain point that surfaces whenever a user wants to ad-hoc work on a snippet without committing to a file path:

- #17098 — JSON diagnostics/formatting requested for unsaved buffers
- #20839 — Emmet expansion requested based on language selector for unsaved files
- See also [this comment on #17098](https://github.com/zed-industries/zed/issues/17098#issuecomment-2461977893) noting the same root cause affects the Ruff and ty extensions

These issues were closed as `NOT_PLANNED` during the Feb 2026 cleanup of older feature requests, but the underlying demand is real and broad (it affects every language server, not just any one extension).

Related prior work in the same direction:
- #45631 / #45764 — enabling edit predictions / Copilot for untitled buffers

## Summary

This PR makes Zed support the LSP `untitled:` URI scheme so that buffers without a backing file participate in the same LSP machinery as file-backed buffers. The trigger is the user selecting a language for the untitled buffer (via the language selector). The buffer is registered with the matching language server using the first visible worktree as the host; on save it is unregistered under `untitled:` and re-registered under `file://`.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [-] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Addresses #17098, #20839

Release Notes:

- Added LSP support for unsaved buffers — selecting a language for an untitled buffer now starts the matching language server and enables completions, diagnostics, hover, formatting, inlay hints, and other LSP features
