### PR TITLE
Add Claude Opus 4.7 to documentation

### DIFF
--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -167,7 +167,7 @@ Anthropic models on Bedrock support a 1M token extended context window through t
 }
 ```
 
-Zed enables extended context for supported models (Claude Sonnet 4.5 and Claude Opus 4.6). Extended context usage may increase API costs—refer to AWS Bedrock pricing for details.
+Zed enables extended context for supported models (Claude Sonnet 4.5, Claude Opus 4.6, and Claude Opus 4.7). Extended context usage may increase API costs—refer to AWS Bedrock pricing for details.
 
 #### Image Support {#bedrock-image-support}
 

--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -19,6 +19,10 @@ Zed's plans offer hosted versions of major LLMs with higher rate limits than dir
 |                        | Anthropic | Output              | $25.00                       | $27.50                  |
 |                        | Anthropic | Input - Cache Write | $6.25                        | $6.875                  |
 |                        | Anthropic | Input - Cache Read  | $0.50                        | $0.55                   |
+| Claude Opus 4.7        | Anthropic | Input               | $5.00                        | $5.50                   |
+|                        | Anthropic | Output              | $25.00                       | $27.50                  |
+|                        | Anthropic | Input - Cache Write | $6.25                        | $6.875                  |
+|                        | Anthropic | Input - Cache Read  | $0.50                        | $0.55                   |
 | Claude Sonnet 4.5      | Anthropic | Input               | $3.00                        | $3.30                   |
 |                        | Anthropic | Output              | $15.00                       | $16.50                  |
 |                        | Anthropic | Input - Cache Write | $3.75                        | $4.125                  |
@@ -72,7 +76,7 @@ Zed's plans offer hosted versions of major LLMs with higher rate limits than dir
 
 As of February 19, 2026, Zed Pro serves newer model versions in place of the retired models below:
 
-- Claude Opus 4.1 → Claude Opus 4.5 or Claude Opus 4.6
+- Claude Opus 4.1 → Claude Opus 4.5, Claude Opus 4.6, or Claude Opus 4.7
 - Claude Sonnet 4 → Claude Sonnet 4.5 or Claude Sonnet 4.6
 - Claude Sonnet 3.7 (retired Feb 19) → Claude Sonnet 4.5 or Claude Sonnet 4.6
 - GPT-5.1 and GPT-5 → GPT-5.2 or GPT-5.2-Codex
@@ -94,6 +98,7 @@ A context window is the maximum span of text and code an LLM can consider at onc
 | --------------------------- | --------- | ------------------------- |
 | Claude Opus 4.5             | Anthropic | 200k                      |
 | Claude Opus 4.6             | Anthropic | 1M                        |
+| Claude Opus 4.7             | Anthropic | 1M                        |
 | Claude Sonnet 4.5           | Anthropic | 200k                      |
 | Claude Sonnet 4.6           | Anthropic | 1M                        |
 | Claude Haiku 4.5            | Anthropic | 200k                      |


### PR DESCRIPTION
## Summary

- Add Claude Opus 4.7 to the pricing table with same rates as Opus 4.6
- Add Claude Opus 4.7 to context windows table (1M context)
- Update model retirements to include Opus 4.7 as upgrade path from Opus 4.1
- Add Opus 4.7 to Bedrock extended context section

Release Notes:

- N/A