### PR TITLE
gpui: Fix wasm build by explicitly typing f32 literals in taffy grid templates

### DIFF
--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -314,20 +314,23 @@ impl ToTaffy<taffy::style::Style> for Style {
                 match template.min_size {
                     // grid-template-*: repeat(<number>, minmax(0, 1fr));
                     crate::TemplateColumnMinSize::Zero => {
-                        vec![repeat(template.repeat, vec![minmax(length(0.0), fr(1.0))])]
+                        vec![repeat(
+                            template.repeat,
+                            vec![minmax(length(0.0_f32), fr(1.0_f32))],
+                        )]
                     }
                     // grid-template-*: repeat(<number>, minmax(min-content, 1fr));
                     crate::TemplateColumnMinSize::MinContent => {
                         vec![repeat(
                             template.repeat,
-                            vec![minmax(min_content(), fr(1.0))],
+                            vec![minmax(min_content(), fr(1.0_f32))],
                         )]
                     }
                     // grid-template-*: repeat(<number>, minmax(0, max-content))
                     crate::TemplateColumnMinSize::MaxContent => {
                         vec![repeat(
                             template.repeat,
-                            vec![minmax(length(0.0), max_content())],
+                            vec![minmax(length(0.0_f32), max_content())],
                         )]
                     }
                 }


### PR DESCRIPTION
The `check_wasm` CI job has been failing on this branch because the nightly compiler emits `float_literal_f32_fallback` warnings when generic functions (like taffy's `length()` and `fr()`) rely on `f32` fallback for untyped float literals. See rust-lang/rust#154024.

CI's `check_wasm` job sets `-D warnings` via `.cargo/ci-config.toml`, which turns those warnings into hard errors. This adds `_f32` suffixes to the affected literals in `crates/gpui/src/taffy.rs`.

Verified locally with the same command CI runs:

```
CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -D warnings" \
  cargo +nightly -Zbuild-std=std,panic_abort check --target wasm32-unknown-unknown -p gpui_platform
```

Release Notes:

- N/A
