### PR TITLE
agent: Auto-select user model when there's no default

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -99,7 +99,6 @@ pub struct LanguageModels {
     model_list: acp_thread::AgentModelList,
     refresh_models_rx: watch::Receiver<()>,
     refresh_models_tx: watch::Sender<()>,
-    _authenticate_all_providers_task: Task<()>,
 }
 
 impl LanguageModels {
@@ -111,7 +110,6 @@ impl LanguageModels {
             model_list: acp_thread::AgentModelList::Grouped(IndexMap::default()),
             refresh_models_rx,
             refresh_models_tx,
-            _authenticate_all_providers_task: Self::authenticate_all_language_model_providers(cx),
         };
         this.refresh_list(cx);
         this
@@ -191,60 +189,6 @@ impl LanguageModels {
 
     fn model_id(model: &Arc<dyn LanguageModel>) -> acp::ModelId {
         acp::ModelId::new(format!("{}/{}", model.provider_id().0, model.id().0))
-    }
-
-    fn authenticate_all_language_model_providers(cx: &mut App) -> Task<()> {
-        let authenticate_all_providers = LanguageModelRegistry::global(cx)
-            .read(cx)
-            .visible_providers()
-            .iter()
-            .map(|provider| (provider.id(), provider.name(), provider.authenticate(cx)))
-            .collect::<Vec<_>>();
-
-        cx.background_spawn(async move {
-            for (provider_id, provider_name, authenticate_task) in authenticate_all_providers {
-                if let Err(err) = authenticate_task.await {
-                    match err {
-                        language_model::AuthenticateError::CredentialsNotFound => {
-                            // Since we're authenticating these providers in the
-                            // background for the purposes of populating the
-                            // language selector, we don't care about providers
-                            // where the credentials are not found.
-                        }
-                        language_model::AuthenticateError::ConnectionRefused => {
-                            // Not logging connection refused errors as they are mostly from LM Studio's noisy auth failures.
-                            // LM Studio only has one auth method (endpoint call) which fails for users who haven't enabled it.
-                            // TODO: Better manage LM Studio auth logic to avoid these noisy failures.
-                        }
-                        _ => {
-                            // Some providers have noisy failure states that we
-                            // don't want to spam the logs with every time the
-                            // language model selector is initialized.
-                            //
-                            // Ideally these should have more clear failure modes
-                            // that we know are safe to ignore here, like what we do
-                            // with `CredentialsNotFound` above.
-                            match provider_id.0.as_ref() {
-                                "lmstudio" | "ollama" => {
-                                    // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
-                                    //
-                                    // These fail noisily, so we don't log them.
-                                }
-                                "copilot_chat" => {
-                                    // Copilot Chat returns an error if Copilot is not enabled, so we don't log those errors.
-                                }
-                                _ => {
-                                    log::error!(
-                                        "Failed to authenticate provider: {}: {err:#}",
-                                        provider_name.0
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        })
     }
 }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -753,10 +753,6 @@ impl NativeAgent {
 
         for session in self.sessions.values_mut() {
             session.thread.update(cx, |thread, cx| {
-                // When the default model changes, update threads that
-                // don't yet have a model or haven't been used yet, so
-                // that a newly-picked environment fallback (e.g. Zed
-                // hosted models after sign in) replaces a stale choice.
                 let should_update_model = thread.model().is_none()
                     || (thread.is_empty()
                         && matches!(event, language_model::Event::DefaultModelChanged));

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -99,6 +99,7 @@ pub struct LanguageModels {
     model_list: acp_thread::AgentModelList,
     refresh_models_rx: watch::Receiver<()>,
     refresh_models_tx: watch::Sender<()>,
+    _authenticate_all_providers_task: Task<()>,
 }
 
 impl LanguageModels {
@@ -110,6 +111,7 @@ impl LanguageModels {
             model_list: acp_thread::AgentModelList::Grouped(IndexMap::default()),
             refresh_models_rx,
             refresh_models_tx,
+            _authenticate_all_providers_task: Self::authenticate_all_language_model_providers(cx),
         };
         this.refresh_list(cx);
         this
@@ -189,6 +191,62 @@ impl LanguageModels {
 
     fn model_id(model: &Arc<dyn LanguageModel>) -> acp::ModelId {
         acp::ModelId::new(format!("{}/{}", model.provider_id().0, model.id().0))
+    }
+
+    fn authenticate_all_language_model_providers(cx: &mut App) -> Task<()> {
+        let authenticate_all_providers = LanguageModelRegistry::global(cx)
+            .read(cx)
+            .visible_providers()
+            .iter()
+            .map(|provider| (provider.id(), provider.name(), provider.authenticate(cx)))
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |cx| {
+            for (provider_id, provider_name, authenticate_task) in authenticate_all_providers {
+                if let Err(err) = authenticate_task.await {
+                    match err {
+                        language_model::AuthenticateError::CredentialsNotFound => {
+                            // Since we're authenticating these providers in the
+                            // background for the purposes of populating the
+                            // language selector, we don't care about providers
+                            // where the credentials are not found.
+                        }
+                        language_model::AuthenticateError::ConnectionRefused => {
+                            // Not logging connection refused errors as they are mostly from LM Studio's noisy auth failures.
+                            // LM Studio only has one auth method (endpoint call) which fails for users who haven't enabled it.
+                            // TODO: Better manage LM Studio auth logic to avoid these noisy failures.
+                        }
+                        _ => {
+                            // Some providers have noisy failure states that we
+                            // don't want to spam the logs with every time the
+                            // language model selector is initialized.
+                            //
+                            // Ideally these should have more clear failure modes
+                            // that we know are safe to ignore here, like what we do
+                            // with `CredentialsNotFound` above.
+                            match provider_id.0.as_ref() {
+                                "lmstudio" | "ollama" => {
+                                    // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
+                                    //
+                                    // These fail noisily, so we don't log them.
+                                }
+                                "copilot_chat" => {
+                                    // Copilot Chat returns an error if Copilot is not enabled, so we don't log those errors.
+                                }
+                                _ => {
+                                    log::error!(
+                                        "Failed to authenticate provider: {}: {err:#}",
+                                        provider_name.0
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            cx.update(language_models::update_environment_fallback_model);
+        })
     }
 }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -365,7 +365,7 @@ impl NativeAgent {
         });
 
         let registry = LanguageModelRegistry::read_global(cx);
-        let summarization_model = registry.thread_summary_model().map(|c| c.model);
+        let summarization_model = registry.thread_summary_model(cx).map(|c| c.model);
 
         let weak = cx.weak_entity();
         let weak_thread = thread_handle.downgrade();
@@ -749,13 +749,18 @@ impl NativeAgent {
 
         let registry = LanguageModelRegistry::read_global(cx);
         let default_model = registry.default_model().map(|m| m.model);
-        let summarization_model = registry.thread_summary_model().map(|m| m.model);
+        let summarization_model = registry.thread_summary_model(cx).map(|m| m.model);
 
         for session in self.sessions.values_mut() {
             session.thread.update(cx, |thread, cx| {
-                if thread.model().is_none()
-                    && let Some(model) = default_model.clone()
-                {
+                // When the default model changes, update threads that
+                // don't yet have a model or haven't been used yet, so
+                // that a newly-picked environment fallback (e.g. Zed
+                // hosted models after sign in) replaces a stale choice.
+                let should_update_model = thread.model().is_none()
+                    || (thread.is_empty()
+                        && matches!(event, language_model::Event::DefaultModelChanged));
+                if should_update_model && let Some(model) = default_model.clone() {
                     thread.set_model(model, cx);
                     cx.notify();
                 }
@@ -910,7 +915,7 @@ impl NativeAgent {
                     .get(&project_id)
                     .context("project state not found")?;
                 let summarization_model = LanguageModelRegistry::read_global(cx)
-                    .thread_summary_model()
+                    .thread_summary_model(cx)
                     .map(|c| c.model);
 
                 Ok(cx.new(|cx| {

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -8,8 +8,8 @@ use gpui::{
     Subscription, Task,
 };
 use language_model::{
-    AuthenticateError, ConfiguredModel, IconOrSvg, LanguageModel, LanguageModelId,
-    LanguageModelProvider, LanguageModelProviderId, LanguageModelRegistry,
+    ConfiguredModel, IconOrSvg, LanguageModel, LanguageModelId, LanguageModelProvider,
+    LanguageModelProviderId, LanguageModelRegistry,
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
@@ -124,7 +124,6 @@ pub struct LanguageModelPickerDelegate {
     all_models: Arc<GroupedModels>,
     filtered_entries: Vec<LanguageModelPickerEntry>,
     selected_index: usize,
-    _authenticate_all_providers_task: Task<()>,
     _subscriptions: Vec<Subscription>,
     popover_styles: bool,
     focus_handle: FocusHandle,
@@ -151,7 +150,6 @@ impl LanguageModelPickerDelegate {
             filtered_entries: entries,
             get_active_model: Arc::new(get_active_model),
             on_toggle_favorite: Arc::new(on_toggle_favorite),
-            _authenticate_all_providers_task: Self::authenticate_all_providers(cx),
             _subscriptions: vec![cx.subscribe_in(
                 &LanguageModelRegistry::global(cx),
                 window,
@@ -195,56 +193,6 @@ impl LanguageModelPickerDelegate {
                 }
             })
             .unwrap_or(0)
-    }
-
-    /// Authenticates all providers in the [`LanguageModelRegistry`].
-    ///
-    /// We do this so that we can populate the language selector with all of the
-    /// models from the configured providers.
-    fn authenticate_all_providers(cx: &mut App) -> Task<()> {
-        let authenticate_all_providers = LanguageModelRegistry::global(cx)
-            .read(cx)
-            .visible_providers()
-            .iter()
-            .map(|provider| (provider.id(), provider.name(), provider.authenticate(cx)))
-            .collect::<Vec<_>>();
-
-        cx.spawn(async move |_cx| {
-            for (provider_id, provider_name, authenticate_task) in authenticate_all_providers {
-                if let Err(err) = authenticate_task.await {
-                    if matches!(err, AuthenticateError::CredentialsNotFound) {
-                        // Since we're authenticating these providers in the
-                        // background for the purposes of populating the
-                        // language selector, we don't care about providers
-                        // where the credentials are not found.
-                    } else {
-                        // Some providers have noisy failure states that we
-                        // don't want to spam the logs with every time the
-                        // language model selector is initialized.
-                        //
-                        // Ideally these should have more clear failure modes
-                        // that we know are safe to ignore here, like what we do
-                        // with `CredentialsNotFound` above.
-                        match provider_id.0.as_ref() {
-                            "lmstudio" | "ollama" => {
-                                // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
-                                //
-                                // These fail noisily, so we don't log them.
-                            }
-                            "copilot_chat" => {
-                                // Copilot Chat returns an error if Copilot is not enabled, so we don't log those errors.
-                            }
-                            _ => {
-                                log::error!(
-                                    "Failed to authenticate provider: {}: {err:#}",
-                                    provider_name.0
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        })
     }
 
     pub fn active_model(&self, cx: &App) -> Option<ConfiguredModel> {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2688,7 +2688,7 @@ impl GitPanel {
         }
 
         let Some(ConfiguredModel { provider, model }) =
-            LanguageModelRegistry::read_global(cx).commit_message_model()
+            LanguageModelRegistry::read_global(cx).commit_message_model(cx)
         else {
             return;
         };
@@ -4056,7 +4056,7 @@ impl GitPanel {
 
         let model_registry = LanguageModelRegistry::read_global(cx);
         let has_commit_model_configuration_error = model_registry
-            .configuration_error(model_registry.commit_message_model(), cx)
+            .configuration_error(model_registry.commit_message_model(cx), cx)
             .is_some();
         let can_commit = self.can_commit();
 

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -358,9 +358,6 @@ impl LanguageModelRegistry {
         self.default_model = model;
     }
 
-    /// Sets the model used as the default when the user hasn't explicitly
-    /// configured a default model. Picked by authenticating all available
-    /// providers in the user's environment.
     pub fn set_environment_fallback_model(
         &mut self,
         model: Option<ConfiguredModel>,

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -6,7 +6,6 @@ use collections::{BTreeMap, HashSet};
 use gpui::{App, Context, Entity, EventEmitter, Global, prelude::*};
 use std::{str::FromStr, sync::Arc};
 use thiserror::Error;
-use util::maybe;
 
 /// Function type for checking if a built-in provider should be hidden.
 /// Returns Some(extension_id) if the provider should be hidden when that extension is installed.
@@ -46,7 +45,9 @@ impl std::fmt::Debug for ConfigurationError {
 #[derive(Default)]
 pub struct LanguageModelRegistry {
     default_model: Option<ConfiguredModel>,
-    default_fast_model: Option<ConfiguredModel>,
+    /// This model is automatically configured by a user's environment after
+    /// authenticating all providers. It's only used when `default_model` is not set.
+    environment_fallback_model: Option<ConfiguredModel>,
     inline_assistant_model: Option<ConfiguredModel>,
     commit_message_model: Option<ConfiguredModel>,
     thread_summary_model: Option<ConfiguredModel>,
@@ -349,20 +350,30 @@ impl LanguageModelRegistry {
     }
 
     pub fn set_default_model(&mut self, model: Option<ConfiguredModel>, cx: &mut Context<Self>) {
-        match (self.default_model.as_ref(), model.as_ref()) {
+        match (self.default_model(), model.as_ref()) {
             (Some(old), Some(new)) if old.is_same_as(new) => {}
             (None, None) => {}
             _ => cx.emit(Event::DefaultModelChanged),
         }
-        self.default_fast_model = maybe!({
-            let provider = &model.as_ref()?.provider;
-            let fast_model = provider.default_fast_model(cx)?;
-            Some(ConfiguredModel {
-                provider: provider.clone(),
-                model: fast_model,
-            })
-        });
         self.default_model = model;
+    }
+
+    /// Sets the model used as the default when the user hasn't explicitly
+    /// configured a default model. Picked by authenticating all available
+    /// providers in the user's environment.
+    pub fn set_environment_fallback_model(
+        &mut self,
+        model: Option<ConfiguredModel>,
+        cx: &mut Context<Self>,
+    ) {
+        if self.default_model.is_none() {
+            match (self.environment_fallback_model.as_ref(), model.as_ref()) {
+                (Some(old), Some(new)) if old.is_same_as(new) => {}
+                (None, None) => {}
+                _ => cx.emit(Event::DefaultModelChanged),
+            }
+        }
+        self.environment_fallback_model = model;
     }
 
     pub fn set_inline_assistant_model(
@@ -410,7 +421,18 @@ impl LanguageModelRegistry {
             return None;
         }
 
-        self.default_model.clone()
+        self.default_model
+            .clone()
+            .or_else(|| self.environment_fallback_model.clone())
+    }
+
+    pub fn default_fast_model(&self, cx: &App) -> Option<ConfiguredModel> {
+        let configured = self.default_model()?;
+        let fast_model = configured.provider.default_fast_model(cx)?;
+        Some(ConfiguredModel {
+            provider: configured.provider,
+            model: fast_model,
+        })
     }
 
     pub fn inline_assistant_model(&self) -> Option<ConfiguredModel> {
@@ -424,7 +446,7 @@ impl LanguageModelRegistry {
             .or_else(|| self.default_model.clone())
     }
 
-    pub fn commit_message_model(&self) -> Option<ConfiguredModel> {
+    pub fn commit_message_model(&self, cx: &App) -> Option<ConfiguredModel> {
         #[cfg(debug_assertions)]
         if std::env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
             return None;
@@ -432,11 +454,11 @@ impl LanguageModelRegistry {
 
         self.commit_message_model
             .clone()
-            .or_else(|| self.default_fast_model.clone())
-            .or_else(|| self.default_model.clone())
+            .or_else(|| self.default_fast_model(cx))
+            .or_else(|| self.default_model())
     }
 
-    pub fn thread_summary_model(&self) -> Option<ConfiguredModel> {
+    pub fn thread_summary_model(&self, cx: &App) -> Option<ConfiguredModel> {
         #[cfg(debug_assertions)]
         if std::env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
             return None;
@@ -444,8 +466,8 @@ impl LanguageModelRegistry {
 
         self.thread_summary_model
             .clone()
-            .or_else(|| self.default_fast_model.clone())
-            .or_else(|| self.default_model.clone())
+            .or_else(|| self.default_fast_model(cx))
+            .or_else(|| self.default_model())
     }
 
     /// The models to use for inline assists. Returns the union of the active
@@ -574,6 +596,35 @@ mod tests {
         assert!(!registry_read.should_hide_provider(&LanguageModelProviderId("openai".into())));
 
         assert!(!registry_read.should_hide_provider(&LanguageModelProviderId("unknown".into())));
+    }
+
+    #[gpui::test]
+    async fn test_configure_environment_fallback_model(cx: &mut gpui::TestAppContext) {
+        let registry = cx.new(|_| LanguageModelRegistry::default());
+
+        let provider = Arc::new(FakeLanguageModelProvider::default());
+        registry.update(cx, |registry, cx| {
+            registry.register_provider(provider.clone(), cx);
+        });
+
+        cx.update(|cx| provider.authenticate(cx)).await.unwrap();
+
+        registry.update(cx, |registry, cx| {
+            let provider = registry.provider(&provider.id()).unwrap();
+            let model = provider.default_model(cx).unwrap();
+
+            registry.set_environment_fallback_model(
+                Some(ConfiguredModel {
+                    provider: provider.clone(),
+                    model: model.clone(),
+                }),
+                cx,
+            );
+
+            let default_model = registry.default_model().unwrap();
+            assert_eq!(default_model.model.id(), model.id());
+            assert_eq!(default_model.provider.id(), provider.id());
+        });
     }
 
     #[gpui::test]

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -47,7 +47,7 @@ pub struct LanguageModelRegistry {
     default_model: Option<ConfiguredModel>,
     /// This model is automatically configured by a user's environment after
     /// authenticating all providers. It's only used when `default_model` is not set.
-    environment_fallback_model: Option<ConfiguredModel>,
+    available_fallback_model: Option<ConfiguredModel>,
     inline_assistant_model: Option<ConfiguredModel>,
     commit_message_model: Option<ConfiguredModel>,
     thread_summary_model: Option<ConfiguredModel>,
@@ -364,13 +364,13 @@ impl LanguageModelRegistry {
         cx: &mut Context<Self>,
     ) {
         if self.default_model.is_none() {
-            match (self.environment_fallback_model.as_ref(), model.as_ref()) {
+            match (self.available_fallback_model.as_ref(), model.as_ref()) {
                 (Some(old), Some(new)) if old.is_same_as(new) => {}
                 (None, None) => {}
                 _ => cx.emit(Event::DefaultModelChanged),
             }
         }
-        self.environment_fallback_model = model;
+        self.available_fallback_model = model;
     }
 
     pub fn set_inline_assistant_model(
@@ -420,7 +420,7 @@ impl LanguageModelRegistry {
 
         self.default_model
             .clone()
-            .or_else(|| self.environment_fallback_model.clone())
+            .or_else(|| self.available_fallback_model.clone())
     }
 
     pub fn default_fast_model(&self, cx: &App) -> Option<ConfiguredModel> {

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -181,27 +181,11 @@ fn authenticate_all_providers(registry: Entity<LanguageModelRegistry>, cx: &mut 
         tasks.push(cx.background_spawn(async move {
             if let Err(err) = authenticate_task.await {
                 if matches!(err, AuthenticateError::CredentialsNotFound) {
-                    // Since we're authenticating these providers in the
-                    // background for the purposes of populating the
-                    // language selector, we don't care about providers
-                    // where the credentials are not found.
                 } else {
-                    // Some providers have noisy failure states that we
-                    // don't want to spam the logs with every time the
-                    // language model selector is initialized.
-                    //
-                    // Ideally these should have more clear failure modes
-                    // that we know are safe to ignore here, like what we do
-                    // with `CredentialsNotFound` above.
+                    // ignore noisy providers
                     match provider_id.0.as_ref() {
-                        "lmstudio" | "ollama" => {
-                            // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
-                            //
-                            // These fail noisily, so we don't log them.
-                        }
-                        "copilot_chat" => {
-                            // Copilot Chat returns an error if Copilot is not enabled, so we don't log those errors.
-                        }
+                        "lmstudio" | "ollama" => {}
+                        "copilot_chat" => {}
                         _ => {
                             log::error!(
                                 "Failed to authenticate provider: {}: {err}",

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -180,19 +180,32 @@ fn authenticate_all_providers(registry: Entity<LanguageModelRegistry>, cx: &mut 
     for (provider_id, provider_name, authenticate_task) in providers_to_authenticate {
         tasks.push(cx.background_spawn(async move {
             if let Err(err) = authenticate_task.await {
-                if matches!(err, AuthenticateError::CredentialsNotFound) {
-                } else {
-                    // ignore noisy providers
-                    match provider_id.0.as_ref() {
-                        "lmstudio" | "ollama" => {}
-                        "copilot_chat" => {}
+                match err {
+                    AuthenticateError::CredentialsNotFound => {
+                        // We authenticate all providers in the background to
+                        // populate the language selector and pick a fallback
+                        // model, so missing credentials are expected.
+                    }
+                    AuthenticateError::ConnectionRefused => {
+                        // LM Studio only has one auth method (endpoint call)
+                        // that fails noisily for users who haven't enabled it.
+                    }
+                    _ => match provider_id.0.as_ref() {
+                        "lmstudio" | "ollama" => {
+                            // LM Studio and Ollama fetch the local API to
+                            // determine if they are "authenticated", which
+                            // fails noisily.
+                        }
+                        "copilot_chat" => {
+                            // Copilot Chat errors when Copilot is not enabled.
+                        }
                         _ => {
                             log::error!(
                                 "Failed to authenticate provider: {}: {err}",
                                 provider_name.0
                             );
                         }
-                    }
+                    },
                 }
             }
         }));

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -4,11 +4,9 @@ use ::settings::{Settings, SettingsStore};
 use client::{Client, UserStore};
 use collections::HashSet;
 use credentials_provider::CredentialsProvider;
-use futures::future;
-use gpui::{App, AppContext as _, Context, Entity};
+use gpui::{App, Context, Entity};
 use language_model::{
-    AuthenticateError, ConfiguredModel, LanguageModelProviderId, LanguageModelRegistry,
-    ZED_CLOUD_PROVIDER_ID,
+    ConfiguredModel, LanguageModelProviderId, LanguageModelRegistry, ZED_CLOUD_PROVIDER_ID,
 };
 use provider::deepseek::DeepSeekLanguageModelProvider;
 
@@ -120,15 +118,14 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
             cx,
         );
     });
-    authenticate_all_providers(registry.clone(), cx);
 
     cx.subscribe(
         &registry,
-        |registry, event: &language_model::Event, cx| match event {
+        |_registry, event: &language_model::Event, cx| match event {
             language_model::Event::ProviderStateChanged(_)
             | language_model::Event::AddedProvider(_)
             | language_model::Event::RemovedProvider(_) => {
-                update_environment_fallback_model(&registry, cx);
+                update_environment_fallback_model(cx);
             }
             _ => {}
         },
@@ -162,64 +159,6 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
     .detach();
 }
 
-/// Authenticates all providers in the [`LanguageModelRegistry`].
-///
-/// We do this so that we can populate the language selector with all of the
-/// models from the configured providers, and so that we have a fallback model
-/// to use when the user hasn't explicitly configured one.
-fn authenticate_all_providers(registry: Entity<LanguageModelRegistry>, cx: &mut App) {
-    let providers_to_authenticate = registry
-        .read(cx)
-        .providers()
-        .iter()
-        .map(|provider| (provider.id(), provider.name(), provider.authenticate(cx)))
-        .collect::<Vec<_>>();
-
-    let mut tasks = Vec::with_capacity(providers_to_authenticate.len());
-
-    for (provider_id, provider_name, authenticate_task) in providers_to_authenticate {
-        tasks.push(cx.background_spawn(async move {
-            if let Err(err) = authenticate_task.await {
-                match err {
-                    AuthenticateError::CredentialsNotFound => {
-                        // We authenticate all providers in the background to
-                        // populate the language selector and pick a fallback
-                        // model, so missing credentials are expected.
-                    }
-                    AuthenticateError::ConnectionRefused => {
-                        // LM Studio only has one auth method (endpoint call)
-                        // that fails noisily for users who haven't enabled it.
-                    }
-                    _ => match provider_id.0.as_ref() {
-                        "lmstudio" | "ollama" => {
-                            // LM Studio and Ollama fetch the local API to
-                            // determine if they are "authenticated", which
-                            // fails noisily.
-                        }
-                        "copilot_chat" => {
-                            // Copilot Chat errors when Copilot is not enabled.
-                        }
-                        _ => {
-                            log::error!(
-                                "Failed to authenticate provider: {}: {err}",
-                                provider_name.0
-                            );
-                        }
-                    },
-                }
-            }
-        }));
-    }
-
-    let all_authenticated_future = future::join_all(tasks);
-
-    cx.spawn(async move |cx| {
-        all_authenticated_future.await;
-        cx.update(|cx| update_environment_fallback_model(&registry, cx));
-    })
-    .detach();
-}
-
 /// Recomputes and sets the [`LanguageModelRegistry`]'s environment fallback
 /// model based on currently authenticated providers.
 ///
@@ -228,7 +167,8 @@ fn authenticate_all_providers(registry: Entity<LanguageModelRegistry>, cx: &mut 
 /// providers in the environment. If the Zed cloud provider is authenticated
 /// but hasn't finished loading its models yet, we don't fall back to another
 /// provider to avoid flickering between providers during sign in.
-fn update_environment_fallback_model(registry: &Entity<LanguageModelRegistry>, cx: &mut App) {
+pub fn update_environment_fallback_model(cx: &mut App) {
+    let registry = LanguageModelRegistry::global(cx);
     let fallback_model = {
         let registry = registry.read(cx);
         let cloud_provider = registry.provider(&ZED_CLOUD_PROVIDER_ID);

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -4,8 +4,12 @@ use ::settings::{Settings, SettingsStore};
 use client::{Client, UserStore};
 use collections::HashSet;
 use credentials_provider::CredentialsProvider;
-use gpui::{App, Context, Entity};
-use language_model::{LanguageModelProviderId, LanguageModelRegistry};
+use futures::future;
+use gpui::{App, AppContext as _, Context, Entity};
+use language_model::{
+    AuthenticateError, ConfiguredModel, LanguageModelProviderId, LanguageModelRegistry,
+    ZED_CLOUD_PROVIDER_ID,
+};
 use provider::deepseek::DeepSeekLanguageModelProvider;
 
 pub mod extension;
@@ -116,6 +120,21 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
             cx,
         );
     });
+    authenticate_all_providers(registry.clone(), cx);
+
+    cx.subscribe(
+        &registry,
+        |registry, event: &language_model::Event, cx| match event {
+            language_model::Event::ProviderStateChanged(_)
+            | language_model::Event::AddedProvider(_)
+            | language_model::Event::RemovedProvider(_) => {
+                update_environment_fallback_model(&registry, cx);
+            }
+            _ => {}
+        },
+    )
+    .detach();
+
     let registry = registry.downgrade();
     cx.observe_global::<SettingsStore>(move |cx| {
         let Some(registry) = registry.upgrade() else {
@@ -141,6 +160,110 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
         }
     })
     .detach();
+}
+
+/// Authenticates all providers in the [`LanguageModelRegistry`].
+///
+/// We do this so that we can populate the language selector with all of the
+/// models from the configured providers, and so that we have a fallback model
+/// to use when the user hasn't explicitly configured one.
+fn authenticate_all_providers(registry: Entity<LanguageModelRegistry>, cx: &mut App) {
+    let providers_to_authenticate = registry
+        .read(cx)
+        .providers()
+        .iter()
+        .map(|provider| (provider.id(), provider.name(), provider.authenticate(cx)))
+        .collect::<Vec<_>>();
+
+    let mut tasks = Vec::with_capacity(providers_to_authenticate.len());
+
+    for (provider_id, provider_name, authenticate_task) in providers_to_authenticate {
+        tasks.push(cx.background_spawn(async move {
+            if let Err(err) = authenticate_task.await {
+                if matches!(err, AuthenticateError::CredentialsNotFound) {
+                    // Since we're authenticating these providers in the
+                    // background for the purposes of populating the
+                    // language selector, we don't care about providers
+                    // where the credentials are not found.
+                } else {
+                    // Some providers have noisy failure states that we
+                    // don't want to spam the logs with every time the
+                    // language model selector is initialized.
+                    //
+                    // Ideally these should have more clear failure modes
+                    // that we know are safe to ignore here, like what we do
+                    // with `CredentialsNotFound` above.
+                    match provider_id.0.as_ref() {
+                        "lmstudio" | "ollama" => {
+                            // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
+                            //
+                            // These fail noisily, so we don't log them.
+                        }
+                        "copilot_chat" => {
+                            // Copilot Chat returns an error if Copilot is not enabled, so we don't log those errors.
+                        }
+                        _ => {
+                            log::error!(
+                                "Failed to authenticate provider: {}: {err}",
+                                provider_name.0
+                            );
+                        }
+                    }
+                }
+            }
+        }));
+    }
+
+    let all_authenticated_future = future::join_all(tasks);
+
+    cx.spawn(async move |cx| {
+        all_authenticated_future.await;
+        cx.update(|cx| update_environment_fallback_model(&registry, cx));
+    })
+    .detach();
+}
+
+/// Recomputes and sets the [`LanguageModelRegistry`]'s environment fallback
+/// model based on currently authenticated providers.
+///
+/// Prefers the Zed cloud provider so that, once the user is signed in, we
+/// always pick a Zed-hosted model over models from other authenticated
+/// providers in the environment. If the Zed cloud provider is authenticated
+/// but hasn't finished loading its models yet, we don't fall back to another
+/// provider to avoid flickering between providers during sign in.
+fn update_environment_fallback_model(registry: &Entity<LanguageModelRegistry>, cx: &mut App) {
+    let fallback_model = {
+        let registry = registry.read(cx);
+        let cloud_provider = registry.provider(&ZED_CLOUD_PROVIDER_ID);
+        if cloud_provider
+            .as_ref()
+            .is_some_and(|provider| provider.is_authenticated(cx))
+        {
+            cloud_provider.and_then(|provider| {
+                let model = provider
+                    .default_model(cx)
+                    .or_else(|| provider.recommended_models(cx).first().cloned())?;
+                Some(ConfiguredModel { provider, model })
+            })
+        } else {
+            registry
+                .providers()
+                .iter()
+                .filter(|provider| provider.is_authenticated(cx))
+                .find_map(|provider| {
+                    let model = provider
+                        .default_model(cx)
+                        .or_else(|| provider.recommended_models(cx).first().cloned())?;
+                    Some(ConfiguredModel {
+                        provider: provider.clone(),
+                        model,
+                    })
+                })
+        }
+    };
+    registry.update(cx, |registry, cx| {
+        registry.set_environment_fallback_model(fallback_model, cx);
+    });
 }
 
 fn register_openai_compatible_providers(


### PR DESCRIPTION
Reimplements #36722 while fixing the race that required the revert in #36932.

When no default model is configured, this picks an environment fallback by authenticating all providers. It always prefers the Zed cloud provider when it's authenticated, and waits for its models to load before picking another provider as the fallback, so we don't flicker from Zed models to Anthropic while sign-in is in flight.

The fallback is recomputed whenever provider state changes (via `ProviderStateChanged`/`AddedProvider`/`RemovedProvider` events), so the selection becomes correct as soon as cloud models arrive.

### What changed vs. the original PR

- `language_models::init` now owns `authenticate_all_providers` (previously done in `LanguageModelPickerDelegate` and `agent`'s `LanguageModels`).
- After all authentications settle, and on any subsequent provider state change, `update_environment_fallback_model` recomputes the fallback.
- The fallback logic prefers Zed cloud: if the cloud provider is authenticated, only use it (waiting for its models to load). Otherwise, fall through to the first authenticated provider with a default or recommended model.
- `LanguageModelRegistry::default_model()` falls back to `environment_fallback_model` when no explicit default is set.
- Existing `Thread`s that are empty are updated to the new default when `DefaultModelChanged` fires, so a blank thread started before sign-in switches to Zed models once the user signs in.

Release Notes:

- agent: Automatically select a default model based on environment when there's no selected model