### PR TITLE
Fix YAML custom tags incorrectly showing as errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.95.1"
-source = "git+https://github.com/zed-industries/lsp-types?rev=c7396459fefc7886b4adfa3b596832405ae1e880#c7396459fefc7886b4adfa3b596832405ae1e880"
+source = "git+https://github.com/zed-industries/lsp-types?rev=9bceaf7d06bd9394dc6ed002e27d306348d5b83d#9bceaf7d06bd9394dc6ed002e27d306348d5b83d"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,7 +608,7 @@ linkify = "0.10.0"
 libwebrtc = "0.3.26"
 livekit = { version = "0.7.32", features = ["tokio", "rustls-tls-native-roots"] }
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
-lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "c7396459fefc7886b4adfa3b596832405ae1e880" }
+lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "9bceaf7d06bd9394dc6ed002e27d306348d5b83d" }
 mach2 = "0.5"
 markup5ever_rcdom = "0.3.0"
 metal = "0.33"


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/49568

Read more: https://github.com/zed-industries/lsp-types/pull/14

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed YAML language server settings (like `customTags`) being ignored, causing valid tags to show as errors.
