### PR TITLE
agent: Re-evaluate project-derived mentions on message restore

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -319,6 +319,50 @@ impl MentionUri {
         MentionLink(self)
     }
 
+    /// Describes how a mention should be restored when deserializing a message
+    /// back into the editor (e.g. after reopening a thread or spawning a new
+    /// worktree).
+    ///
+    /// Some mention kinds derive their text from live project state (the
+    /// currently active git repo, LSP diagnostics, etc.). For those, simply
+    /// trusting the serialized text is wrong if the project has changed since
+    /// the mention was originally resolved. Other mention kinds (a pasted
+    /// image, a captured selection) are inherently point-in-time snapshots,
+    /// and their serialized text is authoritative.
+    pub fn restore_behavior(&self) -> MentionRestoreBehavior {
+        match self {
+            // Derived from live project state; re-evaluate on restore so that
+            // the mention reflects the project we're restoring into rather
+            // than the project it was originally captured from. Fall back to
+            // the serialized text if re-evaluation fails (e.g. no active repo).
+            MentionUri::Diagnostics { .. } | MentionUri::GitDiff { .. } => {
+                MentionRestoreBehavior::Reevaluate {
+                    fallback_to_serialized: true,
+                }
+            }
+
+            // Point-in-time snapshots; serialized text is authoritative.
+            MentionUri::PastedImage { .. }
+            | MentionUri::Selection { .. }
+            | MentionUri::TerminalSelection { .. } => MentionRestoreBehavior::UseSerialized,
+
+            // These *could* also be re-evaluated against the current project
+            // (buffer contents may have changed, a rule may have been edited,
+            // a fetched page may have updated), but re-evaluation either
+            // requires additional state (e.g. MergeConflict, which is built
+            // from a workflow action rather than by querying the project) or
+            // has side effects we don't want on restore (re-fetching URLs).
+            // For now, keep today's behavior of trusting the serialized text.
+            MentionUri::File { .. }
+            | MentionUri::Directory { .. }
+            | MentionUri::Symbol { .. }
+            | MentionUri::Rule { .. }
+            | MentionUri::Thread { .. }
+            | MentionUri::Fetch { .. }
+            | MentionUri::MergeConflict { .. } => MentionRestoreBehavior::UseSerialized,
+        }
+    }
+
     pub fn to_uri(&self) -> Url {
         match self {
             MentionUri::File { abs_path } => {
@@ -421,6 +465,22 @@ impl MentionUri {
             }
         }
     }
+}
+
+/// Describes how a [`MentionUri`] should be handled when restoring a
+/// mention from a serialized `acp::ContentBlock`.
+///
+/// See [`MentionUri::restore_behavior`] for details.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MentionRestoreBehavior {
+    /// Re-evaluate this mention against the current project state instead of
+    /// trusting the serialized text. If re-evaluation fails and
+    /// `fallback_to_serialized` is true, use the serialized text instead of
+    /// dropping the mention.
+    Reevaluate { fallback_to_serialized: bool },
+
+    /// Use the serialized text as-is.
+    UseSerialized,
 }
 
 pub struct MentionLink<'a>(&'a MentionUri);

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{DiagnosticsOptions, codeblock_fence_for_path, collect_diagnostics};
-use acp_thread::{MentionUri, selection_name};
+use acp_thread::{MentionRestoreBehavior, MentionUri, selection_name};
 use agent::{ThreadStore, outline};
 use agent_client_protocol as acp;
 use agent_servers::{AgentServer, AgentServerDelegate};
@@ -116,6 +116,64 @@ impl MentionSet {
 
     pub fn insert_mention(&mut self, crease_id: CreaseId, uri: MentionUri, task: MentionTask) {
         self.mentions.insert(crease_id, (uri, task));
+    }
+
+    /// Builds a mention task for a mention being restored from a serialized
+    /// `acp::ContentBlock` (e.g. on draft reload or when a worktree is spawned
+    /// and the draft is rehydrated into the new workspace's editor).
+    ///
+    /// If the URI's [`MentionRestoreBehavior`] is `UseSerialized`, returns
+    /// `None` and callers should wrap the serialized text directly.
+    ///
+    /// Otherwise, re-resolves against current project state. When
+    /// re-resolution fails and the behavior allows falling back, the returned
+    /// task resolves to the serialized text so the user doesn't lose context.
+    pub fn resolve_for_restore(
+        &mut self,
+        mention_uri: &MentionUri,
+        serialized_text: &str,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<Mention>>> {
+        let behavior = mention_uri.restore_behavior();
+        let MentionRestoreBehavior::Reevaluate {
+            fallback_to_serialized,
+        } = behavior
+        else {
+            return None;
+        };
+
+        let resolve_task = match mention_uri.clone() {
+            MentionUri::Diagnostics {
+                include_errors,
+                include_warnings,
+            } => self.confirm_mention_for_diagnostics(include_errors, include_warnings, cx),
+            MentionUri::GitDiff { base_ref } => {
+                self.confirm_mention_for_git_diff(base_ref.into(), cx)
+            }
+            // Other variants are `UseSerialized` per `restore_behavior`; the
+            // early return above handles them.
+            _ => return None,
+        };
+
+        if !fallback_to_serialized {
+            return Some(resolve_task);
+        }
+
+        let serialized_text = serialized_text.to_string();
+        Some(cx.spawn(async move |_, _| {
+            match resolve_task.await {
+                Ok(mention) => Ok(mention),
+                Err(err) => {
+                    log::warn!(
+                        "failed to re-evaluate mention on restore, falling back to serialized text: {err:#}"
+                    );
+                    Ok(Mention::Text {
+                        content: serialized_text,
+                        tracked_buffers: Vec::new(),
+                    })
+                }
+            }
+        }))
     }
 
     /// Creates the appropriate confirmation task for a mention based on its URI type.
@@ -723,6 +781,134 @@ mod tests {
             }
             other => panic!("Expected selection mention to resolve as text, got {other:?}"),
         }
+    }
+
+    #[gpui::test]
+    async fn test_restore_git_diff_reevaluates_against_current_project(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            json!({
+                ".git": {},
+                "file.rs": "fn main() {}\n",
+            }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/project/.git"), Some("main"));
+        fs.insert_branches(Path::new("/project/.git"), &["main"]);
+
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        cx.run_until_parked();
+
+        let mention_set = cx.new(|_cx| MentionSet::new(project.downgrade(), None, None));
+
+        // Simulate restoring a branch-diff mention whose serialized text was
+        // captured in a *different* project. The restored mention should
+        // re-resolve against the current project's active repository, so the
+        // stale text must not leak through.
+        let stale_serialized_text = "this diff came from a different worktree";
+        let task = mention_set
+            .update(cx, |mention_set, cx| {
+                mention_set.resolve_for_restore(
+                    &MentionUri::GitDiff {
+                        base_ref: "main".to_string(),
+                    },
+                    stale_serialized_text,
+                    cx,
+                )
+            })
+            .expect("GitDiff mentions should always request re-evaluation on restore");
+
+        let mention = task.await.expect("resolution should succeed");
+        match mention {
+            Mention::Text { content, .. } => {
+                assert_ne!(
+                    content, stale_serialized_text,
+                    "restored GitDiff mention must not reuse the serialized text verbatim"
+                );
+            }
+            other => panic!("expected a text mention, got {other:?}"),
+        }
+    }
+
+    #[gpui::test]
+    async fn test_restore_git_diff_falls_back_to_serialized_text_when_no_repo(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        // No `.git` directory here, so the project has no active repository.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", json!({"file.rs": "fn main() {}\n"}))
+            .await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        cx.run_until_parked();
+
+        let mention_set = cx.new(|_cx| MentionSet::new(project.downgrade(), None, None));
+
+        let serialized_text = "diff captured from the original workspace";
+        let task = mention_set
+            .update(cx, |mention_set, cx| {
+                mention_set.resolve_for_restore(
+                    &MentionUri::GitDiff {
+                        base_ref: "main".to_string(),
+                    },
+                    serialized_text,
+                    cx,
+                )
+            })
+            .expect("GitDiff mentions should always request re-evaluation on restore");
+
+        let mention = task.await.expect("fallback should succeed");
+        match mention {
+            Mention::Text { content, .. } => {
+                assert_eq!(
+                    content, serialized_text,
+                    "fallback should preserve the user's serialized context when re-evaluation fails"
+                );
+            }
+            other => panic!("expected a text mention, got {other:?}"),
+        }
+    }
+
+    #[gpui::test]
+    async fn test_restore_returns_none_for_serialized_only_uri_types(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", json!({"file.rs": ""})).await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+
+        let mention_set = cx.new(|_cx| MentionSet::new(project.downgrade(), None, None));
+
+        mention_set.update(cx, |mention_set, cx| {
+            let task = mention_set.resolve_for_restore(
+                &MentionUri::File {
+                    abs_path: path!("/project/file.rs").into(),
+                },
+                "some file contents",
+                cx,
+            );
+            assert!(
+                task.is_none(),
+                "File mentions should use serialized text on restore (see MentionRestoreBehavior)"
+            );
+
+            let task = mention_set.resolve_for_restore(
+                &MentionUri::Selection {
+                    abs_path: Some(path!("/project/file.rs").into()),
+                    line_range: 0..=0,
+                },
+                "selection text",
+                cx,
+            );
+            assert!(
+                task.is_none(),
+                "Selection mentions are point-in-time snapshots and must not be re-resolved"
+            );
+        });
     }
 }
 

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -166,6 +166,40 @@ enum MentionInsertPosition {
     EndOfBuffer,
 }
 
+/// A mention collected while deserializing `acp::ContentBlock`s in
+/// [`MessageEditor::insert_message_blocks`].
+///
+/// `SerializedResource` mentions may be re-evaluated against the current
+/// project state (see [`MentionUri::restore_behavior`]). Everything else is
+/// already fully resolved at collection time.
+enum PendingRestoredMention {
+    Resolved(Mention),
+    SerializedResource { text: String },
+}
+
+fn build_restored_mention_task(
+    mention_set: &mut MentionSet,
+    mention_uri: &MentionUri,
+    pending: PendingRestoredMention,
+    cx: &mut Context<MentionSet>,
+) -> crate::mention_set::MentionTask {
+    match pending {
+        PendingRestoredMention::Resolved(mention) => Task::ready(Ok(mention)).shared(),
+        PendingRestoredMention::SerializedResource { text } => {
+            if let Some(task) = mention_set.resolve_for_restore(mention_uri, &text, cx) {
+                cx.spawn(async move |_, _| task.await.map_err(|e| e.to_string()))
+                    .shared()
+            } else {
+                Task::ready(Ok(Mention::Text {
+                    content: text,
+                    tracked_buffers: Vec::new(),
+                }))
+                .shared()
+            }
+        }
+    }
+}
+
 fn insert_mention_for_project_path(
     project_path: &ProjectPath,
     position: MentionInsertPosition,
@@ -1595,7 +1629,7 @@ impl MessageEditor {
 
         let path_style = workspace.read(cx).project().read(cx).path_style(cx);
         let mut text = String::new();
-        let mut mentions = Vec::new();
+        let mut mentions: Vec<(Range<usize>, MentionUri, PendingRestoredMention)> = Vec::new();
 
         for chunk in message {
             match chunk {
@@ -1616,9 +1650,8 @@ impl MessageEditor {
                     mentions.push((
                         start..end,
                         mention_uri,
-                        Mention::Text {
-                            content: resource.text,
-                            tracked_buffers: Vec::new(),
+                        PendingRestoredMention::SerializedResource {
+                            text: resource.text,
                         },
                     ));
                 }
@@ -1629,7 +1662,11 @@ impl MessageEditor {
                         let start = text.len();
                         write!(&mut text, "{}", mention_uri.as_link()).ok();
                         let end = text.len();
-                        mentions.push((start..end, mention_uri, Mention::Link));
+                        mentions.push((
+                            start..end,
+                            mention_uri,
+                            PendingRestoredMention::Resolved(Mention::Link),
+                        ));
                     }
                 }
                 acp::ContentBlock::Image(acp::ImageContent {
@@ -1658,10 +1695,10 @@ impl MessageEditor {
                     mentions.push((
                         start..end,
                         mention_uri,
-                        Mention::Image(MentionImage {
+                        PendingRestoredMention::Resolved(Mention::Image(MentionImage {
                             data: data.into(),
                             format,
-                        }),
+                        })),
                     ));
                 }
                 _ => {}
@@ -1690,7 +1727,7 @@ impl MessageEditor {
             })
         };
 
-        for (range, mention_uri, mention) in mentions {
+        for (range, mention_uri, pending) in mentions {
             let adjusted_start = insertion_start + range.start;
             let anchor = snapshot.anchor_before(MultiBufferOffset(adjusted_start));
             let Some((crease_id, tx)) = insert_crease_for_mention(
@@ -1710,12 +1747,12 @@ impl MessageEditor {
             };
             drop(tx);
 
+            let task = self.mention_set.update(cx, |mention_set, cx| {
+                build_restored_mention_task(mention_set, &mention_uri, pending, cx)
+            });
+
             self.mention_set.update(cx, |mention_set, _cx| {
-                mention_set.insert_mention(
-                    crease_id,
-                    mention_uri.clone(),
-                    Task::ready(Ok(mention)).shared(),
-                )
+                mention_set.insert_mention(crease_id, mention_uri.clone(), task)
             });
         }
 


### PR DESCRIPTION
Mentions whose content is derived from live project state (currently `@branch diff` and `@diagnostics`) were being restored from their originally-captured serialized text whenever a message was rehydrated into an editor. This is most visible when spawning a new worktree from the agent panel: the `@branch diff` that was inserted in the original workspace gets carried over verbatim, so the agent sees a diff against the *old* repository rather than the new worktree's repository.

The same code path also runs when a draft is reloaded from disk on thread open, so the staleness affected any session that persisted a draft containing one of these mentions.

## Approach

Introduce `MentionUri::restore_behavior()` to declare per-variant policy for deserialization:

- `Reevaluate { fallback_to_serialized }` — re-resolve against the current project. Today: `GitDiff`, `Diagnostics`.
- `UseSerialized` — trust the serialized text. Today: everything else.

`MessageEditor::insert_message_blocks` now consults this policy and delegates to `MentionSet::resolve_for_restore` when a mention should be re-evaluated. If re-resolution fails (e.g. the new workspace has no active repository), it falls back to the serialized text so the user does not silently lose context.

## Scope

This PR addresses the reported bug (`@branch diff` using the original worktree's diff) and the parallel `@diagnostics` staleness. Intentionally **not** included:

- `File`/`Directory`/`Symbol` mentions still reference absolute paths under the original worktree after a worktree switch. Fixing that requires threading the existing `path_remapping` table from `open_worktree_workspace_and_start_thread` down to the restored mentions before they are resolved. Planned as a follow-up PR.
- `Rule`/`Thread`/`Fetch` could also be re-evaluated but have either side effects (re-fetching URLs) or content that is usually stable across sessions; behavior unchanged.
- `MergeConflict` has no `MentionSet` resolver today — it is only produced by workflow actions — so it stays `UseSerialized`.

## Tests

Three new unit tests in `mention_set`:

- `test_restore_git_diff_reevaluates_against_current_project` — with an active repo, a restored `GitDiff` mention does not reuse the stale serialized text.
- `test_restore_git_diff_falls_back_to_serialized_text_when_no_repo` — without an active repo, the fallback preserves the user's context instead of dropping the mention.
- `test_restore_returns_none_for_serialized_only_uri_types` — `File` and `Selection` mentions opt out of re-evaluation.

All existing `message_editor` and `mention_set` tests continue to pass.

Release Notes:

- Fixed `@branch diff` mentions showing the original worktree's diff when a thread was moved to a new worktree, and `@diagnostics` mentions showing the original project's diagnostics after restoring a draft.
