### PR TITLE
agent: Parse reasoning tags

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1933,10 +1933,12 @@ impl Thread {
 
             log::debug!("Calling model.stream_completion, attempt {}", attempt);
 
+
             let (mut events, mut error) = match model.stream_completion(request, cx).await {
-                Ok(events) => (events.fuse(), None),
-                Err(err) => (stream::empty().boxed().fuse(), Some(err)),
+                Ok(events) => (language_model::extract_thinking_from_stream(events).fuse(), None),
+                Err(err) => (futures::stream::empty().boxed().fuse(), Some(err)),
             };
+
             let mut tool_results: FuturesUnordered<Task<LanguageModelToolResult>> =
                 FuturesUnordered::new();
             let mut early_tool_results: Vec<LanguageModelToolResult> = Vec::new();
@@ -2587,7 +2589,7 @@ impl Thread {
         let task = cx
             .spawn(async move |this, cx| {
                 let mut summary = String::new();
-                let mut messages = model.stream_completion(request, cx).await.log_err()?;
+                let mut messages = language_model::extract_thinking_from_stream(model.stream_completion(request, cx).await.log_err()?);
                 while let Some(event) = messages.next().await {
                     let event = event.log_err()?;
                     let text = match event {
@@ -2645,7 +2647,7 @@ impl Thread {
             let mut title = String::new();
 
             let generate = async {
-                let mut messages = model.stream_completion(request, cx).await?;
+                let mut messages = language_model::extract_thinking_from_stream(model.stream_completion(request, cx).await?);
                 while let Some(event) = messages.next().await {
                     let event = event?;
                     let text = match event {

--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -104,6 +104,8 @@ struct ModelCapabilityToggles {
     pub supports_parallel_tool_calls: ToggleState,
     pub supports_prompt_cache_key: ToggleState,
     pub supports_chat_completions: ToggleState,
+    pub parse_reasoning_tags: ToggleState,
+    pub drop_reasoning_blocks: ToggleState,
 }
 
 struct ModelInput {
@@ -170,6 +172,8 @@ impl ModelInput {
                 supports_parallel_tool_calls: parallel_tool_calls.into(),
                 supports_prompt_cache_key: prompt_cache_key.into(),
                 supports_chat_completions: chat_completions.into(),
+                parse_reasoning_tags: false.into(),
+                drop_reasoning_blocks: false.into(),
             },
         }
     }
@@ -180,6 +184,8 @@ impl ModelInput {
             return Err(SharedString::from("Model Name cannot be empty"));
         }
         Ok(AvailableModel {
+            parse_reasoning_tags: self.capabilities.parse_reasoning_tags.selected(),
+            drop_reasoning_blocks: self.capabilities.drop_reasoning_blocks.selected(),
             name,
             display_name: None,
             max_completion_tokens: Some(
@@ -442,6 +448,34 @@ impl AddLlmProviderModal {
                         .on_click(cx.listener(
                             move |this, checked, _window, cx| {
                                 this.input.models[ix].capabilities.supports_chat_completions =
+                                    *checked;
+                                cx.notify();
+                            },
+                        )),
+                    )
+                    .child(
+                        Checkbox::new(
+                            ("parse-reasoning-tags", ix),
+                            model.capabilities.parse_reasoning_tags,
+                        )
+                        .label("Parse streaming reasoning tags (for providers that stream thoughts)")
+                        .on_click(cx.listener(
+                            move |this, checked, _window, cx| {
+                                this.input.models[ix].capabilities.parse_reasoning_tags =
+                                    *checked;
+                                cx.notify();
+                            },
+                        )),
+                    )
+                    .child(
+                        Checkbox::new(
+                            ("drop-reasoning-blocks", ix),
+                            model.capabilities.drop_reasoning_blocks,
+                        )
+                        .label("Drop past reasoning blocks to save context window")
+                        .on_click(cx.listener(
+                            move |this, checked, _window, cx| {
+                                this.input.models[ix].capabilities.drop_reasoning_blocks =
                                     *checked;
                                 cx.notify();
                             },

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -426,7 +426,7 @@ impl CodegenAlternative {
             let request = self.build_request(&model, user_prompt, context_task, cx)?;
             let completion_events = cx.spawn({
                 let model = model.clone();
-                async move |_, cx| model.stream_completion(request.await, cx).await
+                async move |_, cx| Ok(language_model::extract_thinking_from_stream(model.stream_completion(request.await, cx).await?))
             });
             self.generation = self.handle_completion(model, completion_events, cx);
         } else {

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -357,7 +357,15 @@ mod tests {
             vec![
                 LanguageModelCompletionEvent::Text("Hello ".to_string()),
                 LanguageModelCompletionEvent::Thinking {
-                    text: "Wait, I am thinking".to_string(),
+                    text: "Wait, ".to_string(),
+                    signature: None,
+                },
+                LanguageModelCompletionEvent::Thinking {
+                    text: "I am ".to_string(),
+                    signature: None,
+                },
+                LanguageModelCompletionEvent::Thinking {
+                    text: "thinking".to_string(),
                     signature: None,
                 },
                 LanguageModelCompletionEvent::Text("World!".to_string()),

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -325,6 +325,47 @@ pub trait LanguageModelProviderState: 'static {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{StreamExt, stream};
+
+    #[gpui::test]
+    async fn test_extract_thinking_from_stream() {
+        let events = vec![
+            Ok(LanguageModelCompletionEvent::Text("Hello ".to_string())),
+            Ok(LanguageModelCompletionEvent::Text("<thi".to_string())),
+            Ok(LanguageModelCompletionEvent::Text(
+                "nking>Wait, ".to_string(),
+            )),
+            Ok(LanguageModelCompletionEvent::Text("I am ".to_string())),
+            Ok(LanguageModelCompletionEvent::Text("thinking</".to_string())),
+            Ok(LanguageModelCompletionEvent::Text("thinking>".to_string())),
+            Ok(LanguageModelCompletionEvent::Text("World!".to_string())),
+        ];
+
+        let stream = stream::iter(events).boxed();
+        let mut extracted = extract_thinking_from_stream(stream);
+
+        let mut results = Vec::new();
+        while let Some(event) = extracted.next().await {
+            results.push(event.unwrap());
+        }
+
+        assert_eq!(
+            results,
+            vec![
+                LanguageModelCompletionEvent::Text("Hello ".to_string()),
+                LanguageModelCompletionEvent::Thinking {
+                    text: "Wait, I am thinking".to_string(),
+                    signature: None,
+                },
+                LanguageModelCompletionEvent::Text("World!".to_string()),
+            ]
+        );
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum LanguageModelCostInfo {
     /// Cost per 1,000 input and output tokens
@@ -361,4 +402,162 @@ impl LanguageModelCostInfo {
             SharedString::from(format!("{:.2}", cost))
         }
     }
+}
+
+pub fn extract_thinking_from_stream(
+    stream: futures::stream::BoxStream<
+        'static,
+        Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+    >,
+) -> futures::stream::BoxStream<
+    'static,
+    Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+> {
+    struct State {
+        stream: futures::stream::BoxStream<
+            'static,
+            Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+        >,
+        buffer: String,
+        in_thinking_tag: Option<&'static str>,
+        pending_events: std::collections::VecDeque<LanguageModelCompletionEvent>,
+    }
+
+    futures::stream::unfold(
+        State {
+            stream,
+            buffer: String::new(),
+            in_thinking_tag: None,
+            pending_events: std::collections::VecDeque::new(),
+        },
+        |mut state| async move {
+            use futures::StreamExt;
+            loop {
+                if let Some(event) = state.pending_events.pop_front() {
+                    return Some((Ok(event), state));
+                }
+
+                match state.stream.next().await {
+                    Some(Ok(LanguageModelCompletionEvent::Text(text))) => {
+                        state.buffer.push_str(&text);
+
+                        loop {
+                            if let Some(closing_tag) = state.in_thinking_tag {
+                                if let Some(end_idx) = state.buffer.find(closing_tag) {
+                                    if end_idx > 0 {
+                                        state.pending_events.push_back(
+                                            LanguageModelCompletionEvent::Thinking {
+                                                text: state.buffer[..end_idx].to_string(),
+                                                signature: None,
+                                            },
+                                        );
+                                    }
+                                    state.buffer.drain(..end_idx + closing_tag.len());
+                                    state.in_thinking_tag = None;
+                                } else {
+                                    let mut safe_len = state.buffer.len();
+                                    for i in 1..=closing_tag.len() {
+                                        if state.buffer.ends_with(&closing_tag[..i]) {
+                                            safe_len = state.buffer.len() - i;
+                                            break;
+                                        }
+                                    }
+                                    if safe_len > 0 {
+                                        state.pending_events.push_back(
+                                            LanguageModelCompletionEvent::Thinking {
+                                                text: state.buffer[..safe_len].to_string(),
+                                                signature: None,
+                                            },
+                                        );
+                                        state.buffer.drain(..safe_len);
+                                    }
+                                    break;
+                                }
+                            } else {
+                                let mut first_start: Option<usize> = None;
+                                let mut matched_tag: Option<(&'static str, &'static str)> = None;
+
+                                let tags = [
+                                    ("<think>", "</think>"),
+                                    ("<thinking>", "</thinking>"),
+                                    ("<thoughts>", "</thoughts>"),
+                                ];
+
+                                for (open, close) in tags {
+                                    if let Some(idx) = state.buffer.find(open) {
+                                        if first_start.map_or(true, |first| idx < first) {
+                                            first_start = Some(idx);
+                                            matched_tag = Some((open, close));
+                                        }
+                                    }
+                                }
+
+                                if let Some(start_idx) = first_start {
+                                    let (open_tag, close_tag) = matched_tag.unwrap();
+                                    if start_idx > 0 {
+                                        state.pending_events.push_back(
+                                            LanguageModelCompletionEvent::Text(
+                                                state.buffer[..start_idx].to_string(),
+                                            ),
+                                        );
+                                    }
+                                    state.buffer.drain(..start_idx + open_tag.len());
+                                    state.in_thinking_tag = Some(close_tag);
+                                } else {
+                                    let mut safe_len = state.buffer.len();
+                                    for (open, _) in tags {
+                                        for i in 1..=open.len() {
+                                            if state.buffer.ends_with(&open[..i]) {
+                                                if state.buffer.len() - i < safe_len {
+                                                    safe_len = state.buffer.len() - i;
+                                                }
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    if safe_len > 0 {
+                                        state.pending_events.push_back(
+                                            LanguageModelCompletionEvent::Text(
+                                                state.buffer[..safe_len].to_string(),
+                                            ),
+                                        );
+                                        state.buffer.drain(..safe_len);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Some(Ok(other)) => {
+                        state.pending_events.push_back(other);
+                    }
+                    Some(Err(err)) => {
+                        return Some((Err(err), state));
+                    }
+                    None => {
+                        if !state.buffer.is_empty() {
+                            if state.in_thinking_tag.is_some() {
+                                state.pending_events.push_back(
+                                    LanguageModelCompletionEvent::Thinking {
+                                        text: state.buffer.clone(),
+                                        signature: None,
+                                    },
+                                );
+                            } else {
+                                state
+                                    .pending_events
+                                    .push_back(LanguageModelCompletionEvent::Text(
+                                        state.buffer.clone(),
+                                    ));
+                            }
+                            state.buffer.clear();
+                            continue;
+                        }
+                        return None;
+                    }
+                }
+            }
+        },
+    )
+    .boxed()
 }

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -401,6 +401,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.supports_prompt_cache_key(),
                 self.max_output_tokens(),
                 self.model.reasoning_effort(),
+                false,
             );
             let completions = self.stream_completion(request, cx);
             async move {
@@ -416,6 +417,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.supports_prompt_cache_key(),
                 self.max_output_tokens(),
                 self.model.reasoning_effort(),
+                false,
             );
             let completions = self.stream_response(request, cx);
             async move {

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -403,11 +403,18 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 self.model.capabilities.prompt_cache_key,
                 self.max_output_tokens(),
                 self.model.reasoning_effort,
+                self.model.drop_reasoning_blocks,
             );
             let completions = self.stream_completion(request, cx);
+            let parse_reasoning_tags = self.model.parse_reasoning_tags;
             async move {
                 let mapper = OpenAiEventMapper::new();
-                Ok(mapper.map_stream(completions.await?).boxed())
+                let mapped_stream = mapper.map_stream(completions.await?).boxed();
+                if parse_reasoning_tags {
+                    Ok(language_model::extract_thinking_from_stream(mapped_stream).boxed())
+                } else {
+                    Ok(mapped_stream)
+                }
             }
             .boxed()
         } else {
@@ -418,11 +425,18 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 self.model.capabilities.prompt_cache_key,
                 self.max_output_tokens(),
                 self.model.reasoning_effort,
+                self.model.drop_reasoning_blocks,
             );
             let completions = self.stream_response(request, cx);
+            let parse_reasoning_tags = self.model.parse_reasoning_tags;
             async move {
                 let mapper = OpenAiResponseEventMapper::new();
-                Ok(mapper.map_stream(completions.await?).boxed())
+                let mapped_stream = mapper.map_stream(completions.await?).boxed();
+                if parse_reasoning_tags {
+                    Ok(language_model::extract_thinking_from_stream(mapped_stream).boxed())
+                } else {
+                    Ok(mapped_stream)
+                }
             }
             .boxed()
         }

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -490,6 +490,7 @@ impl LanguageModel for OpenCodeLanguageModel {
                     false,
                     self.model.max_output_tokens(),
                     None,
+                    false,
                 );
                 let stream = self.stream_openai_chat(openai_request, cx);
                 async move {
@@ -506,6 +507,7 @@ impl LanguageModel for OpenCodeLanguageModel {
                     false,
                     self.model.max_output_tokens(),
                     None,
+                    false,
                 );
                 let stream = self.stream_openai_response(response_request, cx);
                 async move {

--- a/crates/language_models/src/provider/vercel.rs
+++ b/crates/language_models/src/provider/vercel.rs
@@ -324,6 +324,7 @@ impl LanguageModel for VercelLanguageModel {
             self.model.supports_prompt_cache_key(),
             self.max_output_tokens(),
             None,
+            false,
         );
         let completions = self.stream_completion(request, cx);
         async move {

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -461,6 +461,7 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
             self.model.capabilities.prompt_cache_key,
             self.max_output_tokens(),
             None,
+            false,
         );
         let completions = self.stream_open_ai(request, cx);
         async move {

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -347,6 +347,7 @@ impl LanguageModel for XAiLanguageModel {
             self.model.supports_prompt_cache_key(),
             self.max_output_tokens(),
             None,
+            false,
         );
         let completions = self.stream_completion(request, cx);
         async move {

--- a/crates/language_models_cloud/src/language_models_cloud.rs
+++ b/crates/language_models_cloud/src/language_models_cloud.rs
@@ -547,6 +547,7 @@ impl<TP: CloudLlmTokenProvider + 'static> LanguageModel for CloudLanguageModel<T
                     true,
                     None,
                     None,
+                    false,
                 );
 
                 if enable_thinking && let Some(effort) = effort {
@@ -596,6 +597,7 @@ impl<TP: CloudLlmTokenProvider + 'static> LanguageModel for CloudLanguageModel<T
                     false,
                     None,
                     None,
+                    false,
                 );
                 let auth_context = token_provider.auth_context(cx);
                 let future = self.request_limiter.stream(async move {

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -29,6 +29,7 @@ pub fn into_open_ai(
     supports_prompt_cache_key: bool,
     max_output_tokens: Option<u64>,
     reasoning_effort: Option<ReasoningEffort>,
+    drop_reasoning_blocks: bool,
 ) -> crate::Request {
     let stream = !model_id.starts_with("o1-");
 
@@ -36,7 +37,16 @@ pub fn into_open_ai(
     for message in request.messages {
         for content in message.content {
             match content {
-                MessageContent::Text(text) | MessageContent::Thinking { text, .. } => {
+                MessageContent::Thinking { text, .. } => {
+                    if !drop_reasoning_blocks {
+                        add_message_content_part(
+                            MessagePart::Text { text },
+                            message.role,
+                            &mut messages,
+                        );
+                    }
+                }
+                MessageContent::Text(text) => {
                     let should_add = if message.role == Role::User {
                         // Including whitespace-only user messages can cause error with OpenAI compatible APIs
                         // See https://github.com/zed-industries/zed/issues/40097
@@ -163,6 +173,7 @@ pub fn into_open_ai_response(
     supports_prompt_cache_key: bool,
     max_output_tokens: Option<u64>,
     reasoning_effort: Option<ReasoningEffort>,
+    drop_reasoning_blocks: bool,
 ) -> ResponseRequest {
     let stream = !model_id.starts_with("o1-");
 
@@ -182,7 +193,7 @@ pub fn into_open_ai_response(
 
     let mut input_items = Vec::new();
     for (index, message) in messages.into_iter().enumerate() {
-        append_message_to_response_items(message, index, &mut input_items);
+        append_message_to_response_items(message, index, &mut input_items, drop_reasoning_blocks);
     }
 
     let tools: Vec<_> = tools
@@ -229,6 +240,7 @@ fn append_message_to_response_items(
     message: LanguageModelRequestMessage,
     index: usize,
     input_items: &mut Vec<ResponseInputItem>,
+    drop_reasoning_blocks: bool,
 ) {
     let mut content_parts: Vec<ResponseInputContent> = Vec::new();
 
@@ -238,7 +250,9 @@ fn append_message_to_response_items(
                 push_response_text_part(&message.role, text, &mut content_parts);
             }
             MessageContent::Thinking { text, .. } => {
-                push_response_text_part(&message.role, text, &mut content_parts);
+                if !drop_reasoning_blocks {
+                    push_response_text_part(&message.role, text, &mut content_parts);
+                }
             }
             MessageContent::RedactedThinking(_) => {}
             MessageContent::Image(image) => {

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -278,6 +278,10 @@ pub struct OpenAiCompatibleAvailableModel {
     pub reasoning_effort: Option<OpenAiReasoningEffort>,
     #[serde(default)]
     pub capabilities: OpenAiCompatibleModelCapabilities,
+    #[serde(default)]
+    pub parse_reasoning_tags: bool,
+    #[serde(default)]
+    pub drop_reasoning_blocks: bool,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
### Description
This PR adds native support for parsing tags like `<think>`, `<thinking>`, and `<thoughts>` directly from streaming LLM responses. This allows custom proxy providers and locally hosted models (e.g., DeepSeek-R1 via OpenAI-compatible endpoints) to seamlessly render their reasoning process inside Zed's native `Thinking` UI blocks, preventing the reasoning from mixing with code or normal text.


### Changes
1. Added `parse_reasoning_tags` and `drop_reasoning_blocks` toggles to the Add Custom Provider UI and `OpenAiCompatibleAvailableModel` settings.
2. Implemented a robust `extract_thinking_from_stream` parser in `language_model.rs` that works across network chunk boundaries without breaking normal text blocks.
3. Updated `open_ai_compatible` provider to apply the stream mapping conditionally.
4. Dropped `MessageContent::Thinking` from the outgoing context history when `drop_reasoning_blocks` is enabled, saving massive amounts of context window tokens.
5. Added unit tests for the stream parser.

### Motivation
With reasoning models becoming the industry standard, many users rely on proxy APIs (like Gemini-2.5-pro or DeepSeek-R1) which return thoughts directly in the stream text. This PR ensures that Zed's native thinking UI works universally for any OpenAI-compatible endpoint that emits reasoning tags, without hardcoding this behavior for all models globally.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added `parse_reasoning_tags` and `drop_reasoning_blocks` options for OpenAI-compatible providers, enabling native thinking UI support for streaming reasoning tags.