### PR TITLE
lsp: Resolve code lenses before surfacing them as code actions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -27691,22 +27691,33 @@ impl CodeActionProvider for Entity<Project> {
         _window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<Vec<CodeAction>>> {
-        self.update(cx, |project, cx| {
-            let code_lens_actions = project.code_lens_actions(buffer, range.clone(), cx);
-            let code_actions = project.code_actions(buffer, range, None, cx);
-            cx.background_spawn(async move {
+        let project = self.clone();
+        let buffer = buffer.clone();
+        self.update(cx, |p, cx| {
+            let code_lens_actions = p.code_lens_actions(&buffer, range.clone(), cx);
+            let code_actions = p.code_actions(&buffer, range, None, cx);
+            cx.spawn(async move |_, cx| {
                 let (code_lens_actions, code_actions) = join(code_lens_actions, code_actions).await;
-                Ok(code_lens_actions
+                let lens_actions = code_lens_actions
                     .context("code lens fetch")?
-                    .into_iter()
-                    .flatten()
-                    .chain(
-                        code_actions
-                            .context("code action fetch")?
-                            .into_iter()
-                            .flatten(),
-                    )
-                    .collect())
+                    .unwrap_or_default();
+                let other_actions = code_actions
+                    .context("code action fetch")?
+                    .unwrap_or_default();
+
+                // Resolve lazy code lens items so the menu displays real
+                // titles (e.g. rust-analyzer's "N implementations") rather
+                // than "Unknown command".
+                let mut resolved_lens = Vec::with_capacity(lens_actions.len());
+                for action in lens_actions {
+                    let resolve_task = project.update(cx, |project, cx| {
+                        project.resolve_code_action(buffer.clone(), action.clone(), cx)
+                    });
+                    let resolved = resolve_task.await.unwrap_or(action);
+                    resolved_lens.push(resolved);
+                }
+
+                Ok(resolved_lens.into_iter().chain(other_actions).collect())
             })
         })
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -28548,6 +28548,134 @@ async fn test_apply_code_lens_actions_with_commands(cx: &mut gpui::TestAppContex
 }
 
 #[gpui::test]
+async fn test_code_lens_resolved_before_reaching_code_action_menu(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "a.ts": "a",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(Arc::new(Language::new(
+        LanguageConfig {
+            name: "TypeScript".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["ts".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+    )));
+    let mut fake_language_servers = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                code_lens_provider: Some(lsp::CodeLensOptions {
+                    resolve_provider: Some(true),
+                }),
+                execute_command_provider: Some(lsp::ExecuteCommandOptions {
+                    commands: vec!["the_command".to_string()],
+                    ..lsp::ExecuteCommandOptions::default()
+                }),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let editor = workspace
+        .update_in(cx, |workspace, window, cx| {
+            workspace.open_abs_path(
+                PathBuf::from(path!("/dir/a.ts")),
+                OpenOptions::default(),
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap()
+        .downcast::<Editor>()
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    let fake_server = fake_language_servers.next().await.unwrap();
+
+    let buffer = editor.update(cx, |editor, cx| {
+        editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("have opened a single file by path")
+    });
+
+    let buffer_snapshot = buffer.update(cx, |buffer, _| buffer.snapshot());
+    let anchor = buffer_snapshot.anchor_at(0, text::Bias::Left);
+    drop(buffer_snapshot);
+
+    let actions = cx
+        .update_window(*window, |_, window, cx| {
+            project.code_actions(&buffer, anchor..anchor, window, cx)
+        })
+        .unwrap();
+
+    // Server returns a lazy code lens: no `command`, only `data`. A proper
+    // `codeLens/resolve` is required before the menu can display it.
+    fake_server
+        .set_request_handler::<lsp::request::CodeLensRequest, _, _>(|_, _| async move {
+            Ok(Some(vec![lsp::CodeLens {
+                range: lsp::Range::default(),
+                command: None,
+                data: Some(json!({"id": "lens_1"})),
+            }]))
+        })
+        .next()
+        .await;
+
+    fake_server
+        .set_request_handler::<lsp::request::CodeLensResolve, _, _>(|lens, _| async move {
+            Ok(lsp::CodeLens {
+                command: Some(lsp::Command {
+                    title: "Resolved title".to_owned(),
+                    command: "the_command".to_owned(),
+                    arguments: None,
+                }),
+                ..lens
+            })
+        })
+        .next()
+        .await;
+
+    let actions = actions.await.unwrap();
+    assert_eq!(
+        actions.len(),
+        1,
+        "Expected a single lens action, got: {actions:#?}"
+    );
+    let action = &actions[0];
+    assert_eq!(
+        action.lsp_action.title(),
+        "Resolved title",
+        "Lazy lens must be resolved before being surfaced as a code action, \
+         otherwise the menu would display \"Unknown command\" and client-side \
+         dispatch of commands like `rust-analyzer.showReferences` would miss."
+    );
+    assert!(action.resolved, "Action should be marked as resolved");
+}
+
+#[gpui::test]
 async fn test_editor_restore_data_different_in_panes(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5501,6 +5501,37 @@ impl LspStore {
         }
     }
 
+    /// Resolves the `command`/`edit` fields of a lazily-returned code action
+    /// or code lens. `apply_code_action` resolves at apply time, but UI paths
+    /// that need to display the action's label before applying (e.g. the code
+    /// action menu) must resolve up front.
+    pub fn resolve_code_action(
+        &self,
+        buffer_handle: Entity<Buffer>,
+        mut action: CodeAction,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<CodeAction>> {
+        if action.resolved || self.upstream_client().is_some() || !self.mode.is_local() {
+            return Task::ready(Ok(action));
+        }
+        let Some((_, lang_server, request_timeout)) = buffer_handle.update(cx, |buffer, cx| {
+            let request_timeout = ProjectSettings::get_global(cx)
+                .global_lsp_settings
+                .get_request_timeout();
+            self.language_server_for_local_buffer(buffer, action.server_id, cx)
+                .map(|(adapter, server)| (adapter.clone(), server.clone(), request_timeout))
+        }) else {
+            return Task::ready(Ok(action));
+        };
+
+        cx.background_spawn(async move {
+            LocalLspStore::try_resolve_code_action(&lang_server, &mut action, request_timeout)
+                .await
+                .context("resolving a code action")?;
+            Ok(action)
+        })
+    }
+
     pub fn apply_code_action(
         &self,
         buffer_handle: Entity<Buffer>,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4424,6 +4424,17 @@ impl Project {
         })
     }
 
+    pub fn resolve_code_action(
+        &self,
+        buffer_handle: Entity<Buffer>,
+        action: CodeAction,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<CodeAction>> {
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.resolve_code_action(buffer_handle, action, cx)
+        })
+    }
+
     pub fn apply_code_action(
         &self,
         buffer_handle: Entity<Buffer>,


### PR DESCRIPTION
Code lens items are currently exposed through the code action menu. When a language server returns lenses lazily (rust-analyzer's `N implementations` etc.), they arrive with no `command` field until `codeLens/resolve` fills it in.
This caused two user-visible issues in the menu:
1. The item's label displayed as "Unknown command" instead of the real title.
2. Clicking the item dispatched to `workspace/executeCommand` instead of the intended client-side handler (references panel, runnable scheduler). `try_handle_client_command` runs before `apply_code_action`, so it saw `command = None`, returned false, and the action fell through to the generic apply path — by which point resolving the action was too late to redirect.

Resolve lazy lenses inline in `Entity<Project>::code_actions` so that by the time the menu renders (and by the time the user clicks), the `command` field is populated. `refresh_code_actions` is already 250ms debounced, and already-resolved actions short-circuit the new `Project::resolve_code_action` / `LspStore::resolve_code_action`, so the extra request only fires once the user has parked their cursor.

Notes on scope:
In this PR, `codeLens/resolve` fires whenever `refresh_code_actions` runs i.e. on every cursor row change (250 ms debounced), regardless of whether the user actually opens the code action menu. So that can produce unnecessary resolve requests.

The ideal would be to resolve lazily when the menu is opened, but this PR keeps the scope narrow to the correctness fix (lazy lenses showing "Unknown command" in the menu, and client-side command dispatch missing) so it's easy to review in isolation.

Separately: now that the inline code lens UI landed in #54100, it may be worth considering whether surfacing code lenses through the code action menu is still justified. Removing that feature would eliminate the eager-resolve overhead entirely, and the inline UI already covers the functionality. Happy to follow up on either of these in separate changes.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed code lens entries in the code action menu showing as "Unknown command" and failing to dispatch when clicked

