### PR TITLE
feat: add Zork-Zed text adventure game to games/

### DIFF
--- a/games/zork/Cargo.toml
+++ b/games/zork/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zork-zed"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+description = "A Zork-style text adventure set inside the Zed code editor"
+authors = ["Zed Community"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/zed-industries/zed"
+readme = "README.md"
+keywords = ["game", "zork", "text-adventure", "zed", "terminal"]
+categories = ["games", "command-line-interface"]
+
+[[bin]]
+name = "zork-zed"
+path = "src/main.rs"
+
+[dependencies]
+ratatui = "0.29"
+crossterm = "0.28"
+anyhow = "1"

--- a/games/zork/Cargo.toml
+++ b/games/zork/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "zork-zed"
+name = "zed"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.75"
-description = "A Zork-style text adventure set inside the Zed code editor"
+description = "A text adventure set inside the Zed code editor"
 authors = ["Zed Community"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zed-industries/zed"
 readme = "README.md"
-keywords = ["game", "zork", "text-adventure", "zed", "terminal"]
+keywords = ["game", "text-adventure", "zed", "terminal"]
 categories = ["games", "command-line-interface"]
 
 [[bin]]
-name = "zork-zed"
+name = "zed"
 path = "src/main.rs"
 
 [dependencies]

--- a/games/zork/README.md
+++ b/games/zork/README.md
@@ -1,0 +1,92 @@
+# Zork-Zed
+
+> A Zork-style text adventure set inside the Zed code editor. Fix the Unclosed Brace. Escape the editor.
+
+## What is it?
+
+- A classic text adventure game themed around the Zed code editor
+- 9 rooms modeled after real Zed features: Editor Pane, Terminal, AI Panel, Git Repo, and more
+- 8 collectible items: LSP Wand, Diff Prism, Autosave Amulet, Semicolon Key, and others
+- One goal: find and fix the Unclosed Brace bug that trapped you inside
+- Beautiful TUI powered by ratatui, runs perfectly in Zed's integrated terminal
+
+## Why?
+
+- Zed has a built-in terminal — why not play a game in it?
+- Text adventures are the original developer entertainment
+- The puzzles mirror real editor workflows: using language servers, reading diffs, managing git tokens
+- Every room description is a love letter to the features that make Zed great
+
+## Quick Start
+
+```bash
+cargo install zork-zed
+zork-zed
+```
+
+Or run from source:
+
+```bash
+git clone https://github.com/zed-industries/zed
+cargo run --release
+```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `go north` / `n` | Move in a direction |
+| `take [item]` | Add item to inventory |
+| `drop [item]` | Leave item in current room |
+| `examine [item]` | Inspect an item closely |
+| `inventory` / `i` | List your items |
+| `look` | Describe current room |
+| `give [item] to [target]` | Give item to character |
+| `use [item]` | Use an item |
+| `use [item] on [target]` | Use item on target |
+| `open [thing]` | Open something |
+| `help` | Show this list |
+| `quit` | Exit the game |
+
+## The Map
+
+```
+[Command Palette]
+       |
+[AI Panel] — [Editor Pane] — [File Tree] — [Extensions Gallery]
+                   |
+             [Terminal] — [Git Repo]
+                   |
+             [The Buffer] — [Settings Vault]
+```
+
+## Win Condition
+
+Collect all 6 key items and use them to unlock the Settings Vault.
+Then use the LSP Wand on the Unclosed Brace to fix it and escape.
+
+## Exit Codes
+
+- `0` — Game completed (you won or quit normally)
+- `1` — Runtime error
+
+## License
+
+MIT OR Apache-2.0
+
+---
+
+## O que é? (Português)
+
+- Um jogo de aventura em texto temático do editor Zed
+- 9 salas baseadas em funcionalidades reais do Zed
+- 8 itens para coletar com puzzles lógicos
+- Objetivo: encontrar e corrigir o bug Unclosed Brace para escapar
+- Interface TUI colorida com ratatui, roda no terminal integrado do Zed
+
+## Por que existe?
+
+- O Zed tem terminal integrado — aproveite para jogar
+- Os puzzles espelham fluxos reais de desenvolvimento
+- Cada descrição de sala celebra uma feature do Zed
+- É divertido e foi escrito inteiramente em Rust

--- a/games/zork/README.md
+++ b/games/zork/README.md
@@ -1,6 +1,6 @@
-# Zork-Zed
+# Zed
 
-> A Zork-style text adventure set inside the Zed code editor. Fix the Unclosed Brace. Escape the editor.
+> A text adventure set inside the Zed code editor. Fix the Unclosed Brace. Escape the editor.
 
 ## What is it?
 
@@ -20,8 +20,8 @@
 ## Quick Start
 
 ```bash
-cargo install zork-zed
-zork-zed
+cargo install zed
+zed
 ```
 
 Or run from source:

--- a/games/zork/src/game/mod.rs
+++ b/games/zork/src/game/mod.rs
@@ -1,0 +1,432 @@
+pub mod parser;
+pub mod player;
+pub mod world;
+
+use parser::{parsear, Comando};
+use player::Jogador;
+use std::collections::HashMap;
+use world::{Item, ItemId, Room, RoomId};
+
+pub struct EstadoJogo {
+    pub salas: HashMap<RoomId, Room>,
+    pub itens: HashMap<ItemId, Item>,
+    pub sala_atual: RoomId,
+    pub jogador: Jogador,
+    pub mensagens: Vec<String>,
+    pub rodando: bool,
+    pub entrada_atual: String,
+}
+
+impl EstadoJogo {
+    pub fn novo() -> Self {
+        let salas = world::criar_mundo();
+        let itens = world::criar_itens();
+
+        let mut estado = Self {
+            salas,
+            itens,
+            sala_atual: RoomId::EditorPane,
+            jogador: Jogador::novo(),
+            mensagens: Vec::new(),
+            rodando: true,
+            entrada_atual: String::new(),
+        };
+
+        estado.mensagens.push(BANNER.to_string());
+        estado.mensagens.push(INTRODUCAO.to_string());
+        estado.descrever_sala();
+
+        estado
+    }
+
+    pub fn processar_entrada(&mut self) {
+        let texto = self.entrada_atual.trim().to_string();
+        if texto.is_empty() {
+            return;
+        }
+
+        self.mensagens.push(format!("> {}", texto));
+        let comando = parsear(&texto);
+        self.executar(comando);
+        self.jogador.movimentos += 1;
+        self.entrada_atual.clear();
+    }
+
+    fn executar(&mut self, cmd: Comando) {
+        match cmd {
+            Comando::Olhar => self.descrever_sala(),
+            Comando::Ir(dir) => self.mover(dir),
+            Comando::Pegar(nome) => self.pegar_item(&nome),
+            Comando::Largar(nome) => self.largar_item(&nome),
+            Comando::Examinar(alvo) => self.examinar(alvo),
+            Comando::Inventario => self.mostrar_inventario(),
+            Comando::Dar(item, alvo) => self.dar_item(&item, &alvo),
+            Comando::Usar(item, alvo) => self.usar_item(&item, alvo.as_deref()),
+            Comando::Abrir(alvo) => self.abrir(&alvo),
+            Comando::Ajuda => self.mostrar_ajuda(),
+            Comando::Sair => {
+                self.msg("Saindo do Zork-Zed. Até a próxima aventura!");
+                self.rodando = false;
+            }
+            Comando::Desconhecido(err) => self.msg(&err),
+        }
+    }
+
+    fn mover(&mut self, direcao: String) {
+        let sala = &self.salas[&self.sala_atual];
+        if let Some(destino) = sala.saidas.get(direcao.as_str()).cloned() {
+            self.sala_atual = destino;
+            self.descrever_sala();
+        } else {
+            self.msg("Você não pode ir nessa direção.");
+        }
+    }
+
+    fn pegar_item(&mut self, nome: &str) {
+        let sala = self.salas.get_mut(&self.sala_atual).unwrap();
+        let nome_lower = nome.to_lowercase();
+
+        let pos = sala.itens.iter().position(|id| {
+            let item = &self.itens[id];
+            item.nome.to_lowercase().contains(&nome_lower)
+        });
+
+        if let Some(idx) = pos {
+            let item_id = sala.itens[idx].clone();
+            let item = &self.itens[&item_id];
+            if item.pegavel {
+                let nome_item = item.nome.to_string();
+                sala.itens.remove(idx);
+                self.jogador.pegar(item_id);
+                self.msg(&format!("Você pegou: {}.", nome_item));
+            } else {
+                self.msg("Você não consegue pegar isso.");
+            }
+        } else {
+            self.msg(&format!("Não há '{}' aqui.", nome));
+        }
+    }
+
+    fn largar_item(&mut self, nome: &str) {
+        let nome_lower = nome.to_lowercase();
+        let item_id = self
+            .jogador
+            .inventario
+            .iter()
+            .find(|id| self.itens[*id].nome.to_lowercase().contains(&nome_lower))
+            .cloned();
+
+        if let Some(id) = item_id {
+            let nome_item = self.itens[&id].nome.to_string();
+            self.jogador.largar(&id);
+            self.salas.get_mut(&self.sala_atual).unwrap().itens.push(id);
+            self.msg(&format!("Você largou: {}.", nome_item));
+        } else {
+            self.msg(&format!("Você não tem '{}'.", nome));
+        }
+    }
+
+    fn examinar(&mut self, alvo: Option<String>) {
+        if let Some(nome) = alvo {
+            let nome_lower = nome.to_lowercase();
+
+            // Verificar no inventário primeiro
+            let item_inv = self
+                .jogador
+                .inventario
+                .iter()
+                .find(|id| self.itens[*id].nome.to_lowercase().contains(&nome_lower))
+                .cloned();
+
+            if let Some(id) = item_inv {
+                let exame = self.itens[&id].exame.to_string();
+                // Evento especial: examinar Diff Prism
+                if id == ItemId::DiffPrism {
+                    self.jogador.diff_examinado = true;
+                }
+                self.msg(&exame);
+                return;
+            }
+
+            // Verificar na sala
+            let sala = &self.salas[&self.sala_atual];
+            let item_sala = sala
+                .itens
+                .iter()
+                .find(|id| self.itens[*id].nome.to_lowercase().contains(&nome_lower))
+                .cloned();
+
+            if let Some(id) = item_sala {
+                let exame = self.itens[&id].exame.to_string();
+                if id == ItemId::DiffPrism {
+                    self.jogador.diff_examinado = true;
+                }
+                self.msg(&exame);
+            } else {
+                self.msg(&format!("Você examina '{}'. Nada de especial.", nome));
+            }
+        } else {
+            self.descrever_sala();
+        }
+    }
+
+    fn mostrar_inventario(&mut self) {
+        if self.jogador.inventario.is_empty() {
+            self.msg("Seu inventário está vazio.");
+        } else {
+            self.msg("Você carrega:");
+            let nomes: Vec<String> = self
+                .jogador
+                .inventario
+                .iter()
+                .map(|id| format!("  - {}", self.itens[id].nome))
+                .collect();
+            for nome in nomes {
+                self.msg(&nome);
+            }
+        }
+    }
+
+    fn dar_item(&mut self, nome_item: &str, alvo: &str) {
+        let nome_lower = nome_item.to_lowercase();
+        let alvo_lower = alvo.to_lowercase();
+
+        let item_id = self
+            .jogador
+            .inventario
+            .iter()
+            .find(|id| self.itens[*id].nome.to_lowercase().contains(&nome_lower))
+            .cloned();
+
+        if item_id.is_none() {
+            self.msg(&format!("Você não tem '{}'.", nome_item));
+            return;
+        }
+
+        let id = item_id.unwrap();
+
+        // Dar café para o AI
+        if id == ItemId::CoffeeMug
+            && self.sala_atual == RoomId::AiPanel
+            && (alvo_lower.contains("ai")
+                || alvo_lower.contains("oracle")
+                || alvo_lower.contains("assistant"))
+        {
+            self.jogador.largar(&id);
+            self.jogador.ai_ajudou = true;
+            self.msg(
+                "O AI recebe o café e seus olhos acendem com brilho de atenção renovada.\n\
+                'Obrigado! Agora posso pensar claramente. Ouça: o Unclosed Brace está \
+                trancado no Settings Vault. Para abri-lo, você precisa de 6 itens:\n\
+                Cursor, LSP Wand, Chave de Ponto-e-Vírgula, Autosave Amulet, \
+                Git Token e Diff Prism. Colete todos e use-os na porta do Vault!'",
+            );
+        } else {
+            self.msg(&format!(
+                "'{}' não parece interessado em receber isso.",
+                alvo
+            ));
+        }
+    }
+
+    fn usar_item(&mut self, nome_item: &str, alvo: Option<&str>) {
+        let nome_lower = nome_item.to_lowercase();
+
+        let item_id = self
+            .jogador
+            .inventario
+            .iter()
+            .find(|id| self.itens[*id].nome.to_lowercase().contains(&nome_lower))
+            .cloned();
+
+        if item_id.is_none() {
+            self.msg(&format!("Você não tem '{}'.", nome_item));
+            return;
+        }
+
+        let id = item_id.unwrap();
+
+        match (&id, self.sala_atual.clone()) {
+            // Usar LSP Wand no Unclosed Brace no Vault aberto
+            (ItemId::LspWand, RoomId::SettingsVault) if self.jogador.vault_aberto => {
+                self.vitoria();
+            }
+            // Usar Diff Prism no Git Repo
+            (ItemId::DiffPrism, RoomId::GitRepo) => {
+                self.jogador.diff_examinado = true;
+                self.msg(
+                    "Você ergue o Diff Prism e olha através dele para as paredes do Git Repo.\n\
+                    O commit '3f7a2b1: refactor: update brace handling' pulsa em vermelho.\n\
+                    Você vê exatamente onde o Unclosed Brace foi introduzido: \
+                    alguém deletou um '}' na linha 42 de src/editor/core.rs durante uma refatoração.\n\
+                    Agora você sabe onde e como consertar. O LSP Wand pode fazer isso!",
+                );
+            }
+            // Usar Chave no Vault
+            (ItemId::SemicolonKey, RoomId::SettingsVault) => {
+                if self.jogador.tem_itens_para_vault() {
+                    self.jogador.vault_aberto = true;
+                    self.msg(
+                        "Você insere a Chave de Ponto-e-Vírgula na fechadura TOML.\n\
+                        A porta TREME. Os outros itens em seu inventário ressoam com poder.\n\
+                        Com um CLIQUE satisfatório, a porta se abre!\n\n\
+                        À sua frente: o Unclosed Brace, uma chave '}' vermelha e pulsante, \
+                        suspensa no ar como um erro de compilação materializado.\n\
+                        Use o LSP Wand para corrigi-lo!",
+                    );
+                } else {
+                    self.msg(
+                        "A fechadura reage à chave, mas você não tem todos os itens necessários.\n\
+                        Você precisa de: Cursor, LSP Wand, Chave de Ponto-e-Vírgula, \
+                        Autosave Amulet, Git Token e Diff Prism.",
+                    );
+                }
+            }
+            _ => {
+                let alvo_str = alvo.unwrap_or("aqui");
+                self.msg(&format!(
+                    "Você usa {} em {}. Nada de especial acontece.",
+                    self.itens[&id].nome, alvo_str
+                ));
+            }
+        }
+    }
+
+    fn abrir(&mut self, alvo: &str) {
+        let alvo_lower = alvo.to_lowercase();
+        if (alvo_lower.contains("vault")
+            || alvo_lower.contains("porta")
+            || alvo_lower.contains("door"))
+            && self.sala_atual == RoomId::SettingsVault
+        {
+            if self.jogador.tem_itens_para_vault() {
+                self.executar(Comando::Usar(
+                    "chave".to_string(),
+                    Some("vault".to_string()),
+                ));
+            } else {
+                self.msg(
+                    "A porta está selada com runas TOML. Você sente que precisa dos \
+                    6 itens especiais para abri-la.",
+                );
+            }
+        } else {
+            self.msg(&format!("Você não pode abrir '{}' aqui.", alvo));
+        }
+    }
+
+    fn mostrar_ajuda(&mut self) {
+        self.msg(
+            "═══ COMANDOS DISPONÍVEIS ═══\n\
+            \n\
+            MOVIMENTO:\n\
+              ir norte/sul/leste/oeste  (ou: n/s/e/w)\n\
+            \n\
+            OBJETOS:\n\
+              pegar [item]      - Adicionar ao inventário\n\
+              largar [item]     - Soltar na sala atual\n\
+              examinar [item]   - Inspecionar item ou sala\n\
+              usar [item]       - Usar um item\n\
+              usar [item] em [alvo]\n\
+              dar [item] para [alvo]\n\
+            \n\
+            INFORMAÇÕES:\n\
+              inventario (i)   - Ver seus itens\n\
+              olhar (look)     - Descrever a sala atual\n\
+              ajuda (help)     - Esta mensagem\n\
+              sair (quit)      - Encerrar o jogo\n\
+            \n\
+            DICA: Explore todas as salas, colete os 6 itens\n\
+            especiais e encontre o Settings Vault!",
+        );
+    }
+
+    fn descrever_sala(&mut self) {
+        // Clonar dados da sala antes de chamar self.msg (evita borrow conflict)
+        let (nome, desc, itens_sala) = {
+            let sala = &self.salas[&self.sala_atual];
+            (
+                sala.nome.to_string(),
+                sala.descricao.to_string(),
+                sala.itens.clone(),
+            )
+        };
+
+        self.msg(&format!("━━━ {} ━━━", nome));
+        self.msg(&desc);
+
+        if !itens_sala.is_empty() {
+            self.msg("\nItens visíveis:");
+            let descricoes: Vec<String> = itens_sala
+                .iter()
+                .map(|id| {
+                    let item = &self.itens[id];
+                    format!("  • {} — {}", item.nome, item.descricao)
+                })
+                .collect();
+            for d in descricoes {
+                self.msg(&d);
+            }
+        }
+    }
+
+    fn vitoria(&mut self) {
+        self.msg(VITORIA);
+        self.jogador.venceu = true;
+        self.rodando = false;
+    }
+
+    fn msg(&mut self, texto: &str) {
+        for linha in texto.lines() {
+            self.mensagens.push(linha.to_string());
+        }
+    }
+}
+
+const BANNER: &str = r#"
+ ███████╗███████╗██████╗      ███████╗███████╗██████╗
+ ╚══███╔╝██╔════╝██╔══██╗     ╚════██║██╔════╝██╔══██╗
+   ███╔╝ █████╗  ██║  ██║         ██╔╝█████╗  ██║  ██║
+  ███╔╝  ██╔══╝  ██║  ██║        ██╔╝ ██╔══╝  ██║  ██║
+ ███████╗███████╗██████╔╝        ██║  ███████╗██████╔╝
+ ╚══════╝╚══════╝╚═════╝         ╚═╝  ╚══════╝╚═════╝
+
+        Uma Aventura de Texto dentro do Editor Zed
+        Versão 0.1.0 — "The Unclosed Brace"
+"#;
+
+const INTRODUCAO: &str = "\
+Você abre um arquivo no Zed e... algo dá errado.\n\
+Um flash de luz. Um crash inesperado. E de repente,\n\
+você está DENTRO do editor.\n\
+\n\
+O editor está infectado pelo UNCLOSED BRACE — um bug antigo que\n\
+consome memória, trava processos e prende almas incautas.\n\
+\n\
+Para escapar, você precisa encontrar e corrigir o bug.\n\
+Explore o editor. Colete os itens. Salve o código.\n\
+\n\
+(Digite 'ajuda' para ver os comandos disponíveis)\n";
+
+const VITORIA: &str = "\n\
+★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★\n\
+\n\
+Você ergue o LSP Wand em direção ao Unclosed Brace.\n\
+A varinha vibra, diagnostica, e com um flash de luz azul...\n\
+\n\
+  3f7a2b1 | src/editor/core.rs | linha 42\n\
+  - if condition {\n\
+  -     process();\n\
+  + if condition {\n\
+  +     process();\n\
+  + }   ← ADICIONADO!\n\
+\n\
+O '}' materializa-se. O código compila.\n\
+O editor respira novamente.\n\
+\n\
+Um portal de luz se abre. Você é ejetado de volta\n\
+ao mundo real, com os dedos ainda no teclado.\n\
+O Zed está rodando perfeitamente. A base de código salva.\n\
+\n\
+PARABÉNS! Você venceu o ZORK-ZED!\n\
+★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★\n";

--- a/games/zork/src/game/mod.rs
+++ b/games/zork/src/game/mod.rs
@@ -384,12 +384,12 @@ impl EstadoJogo {
 }
 
 const BANNER: &str = r#"
- ███████╗███████╗██████╗      ███████╗███████╗██████╗
- ╚══███╔╝██╔════╝██╔══██╗     ╚════██║██╔════╝██╔══██╗
-   ███╔╝ █████╗  ██║  ██║         ██╔╝█████╗  ██║  ██║
-  ███╔╝  ██╔══╝  ██║  ██║        ██╔╝ ██╔══╝  ██║  ██║
- ███████╗███████╗██████╔╝        ██║  ███████╗██████╔╝
- ╚══════╝╚══════╝╚═════╝         ╚═╝  ╚══════╝╚═════╝
+ ███████╗███████╗██████╗
+ ╚══███╔╝██╔════╝██╔══██╗
+   ███╔╝ █████╗  ██║  ██║
+  ███╔╝  ██╔══╝  ██║  ██║
+ ███████╗███████╗██████╔╝
+ ╚══════╝╚══════╝╚═════╝
 
         Uma Aventura de Texto dentro do Editor Zed
         Versão 0.1.0 — "The Unclosed Brace"
@@ -428,5 +428,5 @@ Um portal de luz se abre. Você é ejetado de volta\n\
 ao mundo real, com os dedos ainda no teclado.\n\
 O Zed está rodando perfeitamente. A base de código salva.\n\
 \n\
-PARABÉNS! Você venceu o ZORK-ZED!\n\
+PARABÉNS! Você escapou do ZED!\n\
 ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★ ★\n";

--- a/games/zork/src/game/parser.rs
+++ b/games/zork/src/game/parser.rs
@@ -1,0 +1,137 @@
+/// Comandos suportados pelo parser
+#[derive(Debug, Clone, PartialEq)]
+pub enum Comando {
+    Ir(String),
+    Pegar(String),
+    Largar(String),
+    Examinar(Option<String>),
+    Inventario,
+    Olhar,
+    Dar(String, String),
+    Usar(String, Option<String>),
+    Abrir(String),
+    Ajuda,
+    Sair,
+    Desconhecido(String),
+}
+
+pub fn parsear(entrada: &str) -> Comando {
+    let entrada = entrada.trim().to_lowercase();
+    let palavras: Vec<&str> = entrada.split_whitespace().collect();
+
+    if palavras.is_empty() {
+        return Comando::Olhar;
+    }
+
+    let verbo = palavras[0];
+    let resto = palavras[1..].join(" ");
+
+    match verbo {
+        "ir" | "go" | "andar" | "mover" | "n" | "s" | "e" | "w" | "north" | "south" | "east"
+        | "west" | "norte" | "sul" | "leste" | "oeste" => {
+            if matches!(verbo, "n" | "north" | "norte") {
+                Comando::Ir("north".to_string())
+            } else if matches!(verbo, "s" | "south" | "sul") {
+                Comando::Ir("south".to_string())
+            } else if matches!(verbo, "e" | "east" | "leste") {
+                Comando::Ir("east".to_string())
+            } else if matches!(verbo, "w" | "west" | "oeste") {
+                Comando::Ir("west".to_string())
+            } else if resto.is_empty() {
+                Comando::Desconhecido("Para onde?".to_string())
+            } else {
+                let direcao = mapear_direcao(&resto);
+                Comando::Ir(direcao)
+            }
+        }
+        "pegar" | "take" | "get" | "apanhar" | "coletar" => {
+            if resto.is_empty() {
+                Comando::Desconhecido("Pegar o quê?".to_string())
+            } else {
+                Comando::Pegar(resto)
+            }
+        }
+        "largar" | "drop" | "soltar" | "jogar" => {
+            if resto.is_empty() {
+                Comando::Desconhecido("Largar o quê?".to_string())
+            } else {
+                Comando::Largar(resto)
+            }
+        }
+        "examinar" | "examine" | "x" | "olhar" | "look" | "ver" | "inspecionar" | "inspect"
+        | "observar" => {
+            if (verbo == "look" || verbo == "olhar") && palavras.len() == 1 {
+                return Comando::Olhar;
+            }
+            if resto.is_empty() {
+                Comando::Examinar(None)
+            } else {
+                Comando::Examinar(Some(resto))
+            }
+        }
+        "inventario" | "inventory" | "i" | "inv" | "mochila" | "itens" => Comando::Inventario,
+        "dar" | "give" | "entregar" => {
+            // "dar X para Y" ou "give X to Y"
+            let partes: Vec<&str> = if entrada.contains(" para ") {
+                entrada.splitn(2, " para ").collect()
+            } else if entrada.contains(" to ") {
+                entrada.splitn(2, " to ").collect()
+            } else {
+                vec![&entrada]
+            };
+
+            if partes.len() == 2 {
+                let item_raw = partes[0]
+                    .trim_start_matches("dar ")
+                    .trim_start_matches("give ")
+                    .trim_start_matches("entregar ")
+                    .trim()
+                    .to_string();
+                let alvo = partes[1].trim().to_string();
+                Comando::Dar(item_raw, alvo)
+            } else {
+                Comando::Desconhecido("Sintaxe: dar [item] para [alvo]".to_string())
+            }
+        }
+        "usar" | "use" | "utilizar" => {
+            if resto.is_empty() {
+                Comando::Desconhecido("Usar o quê?".to_string())
+            } else if resto.contains(" em ") || resto.contains(" on ") || resto.contains(" no ") {
+                let sep = if resto.contains(" em ") {
+                    " em "
+                } else if resto.contains(" no ") {
+                    " no "
+                } else {
+                    " on "
+                };
+                let partes: Vec<&str> = resto.splitn(2, sep).collect();
+                Comando::Usar(
+                    partes[0].trim().to_string(),
+                    Some(partes[1].trim().to_string()),
+                )
+            } else {
+                Comando::Usar(resto, None)
+            }
+        }
+        "abrir" | "open" => {
+            if resto.is_empty() {
+                Comando::Desconhecido("Abrir o quê?".to_string())
+            } else {
+                Comando::Abrir(resto)
+            }
+        }
+        "ajuda" | "help" | "?" | "h" => Comando::Ajuda,
+        "sair" | "quit" | "exit" | "q" => Comando::Sair,
+        _ => Comando::Desconhecido(format!("Não entendo '{}'.", verbo)),
+    }
+}
+
+fn mapear_direcao(texto: &str) -> String {
+    match texto {
+        "n" | "norte" | "north" => "north".to_string(),
+        "s" | "sul" | "south" => "south".to_string(),
+        "e" | "leste" | "east" => "east".to_string(),
+        "w" | "o" | "oeste" | "west" => "west".to_string(),
+        outro => outro.to_string(),
+    }
+}

--- a/games/zork/src/game/player.rs
+++ b/games/zork/src/game/player.rs
@@ -1,0 +1,51 @@
+use super::world::ItemId;
+
+#[derive(Debug, Clone)]
+pub struct Jogador {
+    pub inventario: Vec<ItemId>,
+    pub movimentos: u32,
+    pub ai_ajudou: bool,
+    pub diff_examinado: bool,
+    pub vault_aberto: bool,
+    pub venceu: bool,
+}
+
+impl Jogador {
+    pub fn novo() -> Self {
+        Self {
+            inventario: Vec::new(),
+            movimentos: 0,
+            ai_ajudou: false,
+            diff_examinado: false,
+            vault_aberto: false,
+            venceu: false,
+        }
+    }
+
+    pub fn pegar(&mut self, item: ItemId) {
+        if !self.inventario.contains(&item) {
+            self.inventario.push(item);
+        }
+    }
+
+    pub fn largar(&mut self, item: &ItemId) -> bool {
+        if let Some(pos) = self.inventario.iter().position(|i| i == item) {
+            self.inventario.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn tem_itens_para_vault(&self) -> bool {
+        let necessarios = [
+            ItemId::Cursor,
+            ItemId::LspWand,
+            ItemId::SemicolonKey,
+            ItemId::AutosaveAmulet,
+            ItemId::GitToken,
+            ItemId::DiffPrism,
+        ];
+        necessarios.iter().all(|i| self.inventario.contains(i))
+    }
+}

--- a/games/zork/src/game/world.rs
+++ b/games/zork/src/game/world.rs
@@ -1,0 +1,341 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RoomId {
+    EditorPane,
+    CommandPalette,
+    AiPanel,
+    FileTree,
+    ExtensionsGallery,
+    Terminal,
+    GitRepo,
+    TheBuffer,
+    SettingsVault,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ItemId {
+    Cursor,
+    LspWand,
+    CoffeeMug,
+    SemicolonKey,
+    AutosaveAmulet,
+    GitToken,
+    DiffPrism,
+    RustyKeyboard,
+}
+
+#[derive(Debug, Clone)]
+pub struct Item {
+    pub nome: &'static str,
+    pub descricao: &'static str,
+    pub exame: &'static str,
+    pub pegavel: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct Room {
+    pub nome: &'static str,
+    pub descricao: &'static str,
+    pub saidas: HashMap<&'static str, RoomId>,
+    pub itens: Vec<ItemId>,
+}
+
+fn sala(
+    nome: &'static str,
+    descricao: &'static str,
+    saidas: HashMap<&'static str, RoomId>,
+    itens: Vec<ItemId>,
+) -> Room {
+    Room {
+        nome,
+        descricao,
+        saidas,
+        itens,
+    }
+}
+
+fn saidas(lista: &[(&'static str, RoomId)]) -> HashMap<&'static str, RoomId> {
+    lista.iter().cloned().collect()
+}
+
+pub fn criar_mundo() -> HashMap<RoomId, Room> {
+    let mut mundo = HashMap::new();
+
+    // EDITOR PANE — sala inicial
+    mundo.insert(
+        RoomId::EditorPane,
+        sala(
+            "O Editor Pane",
+            "Você se materializa num vasto espaço branco infinito. \
+             Linhas de código pulsam ao redor como veias de luz. \
+             Um cursor gigante pisca com ansiedade no horizonte. \
+             A sensação é de estar dentro de um documento em branco — \
+             silencioso, mas cheio de potencial. Algo está errado aqui. \
+             Há uma presença maligna: o Unclosed Brace infectou a base de código \
+             e precisa ser encontrado e corrigido antes que o editor trave para sempre.\n\
+             Saídas: norte (Command Palette), sul (Terminal), leste (AI Panel), oeste (File Tree)",
+            saidas(&[
+                ("north", RoomId::CommandPalette),
+                ("n", RoomId::CommandPalette),
+                ("south", RoomId::Terminal),
+                ("s", RoomId::Terminal),
+                ("east", RoomId::AiPanel),
+                ("e", RoomId::AiPanel),
+                ("west", RoomId::FileTree),
+                ("w", RoomId::FileTree),
+            ]),
+            vec![ItemId::Cursor],
+        ),
+    );
+
+    // COMMAND PALETTE
+    mundo.insert(
+        RoomId::CommandPalette,
+        sala(
+            "A Command Palette",
+            "Uma câmara circular onde comandos flutuam como partículas de luz. \
+             Você ouve sussurros: 'Open File...', 'Format Document...', 'Toggle Terminal...'. \
+             As paredes são feitas de atalhos de teclado cristalizados. \
+             Uma varinha brilha no centro — o LSP Wand, ferramenta de diagnóstico do editor.\n\
+             Saídas: sul (Editor Pane)",
+            saidas(&[("south", RoomId::EditorPane), ("s", RoomId::EditorPane)]),
+            vec![ItemId::LspWand],
+        ),
+    );
+
+    // AI PANEL
+    mundo.insert(
+        RoomId::AiPanel,
+        sala(
+            "O AI Assistant Panel",
+            "Uma câmara de oráculo banhada em luz azul etérea. \
+             Uma entidade feita de tokens e embeddings flutua no centro, \
+             observando você com olhos de atenção multi-cabeça. \
+             'Olá, sou o Zed AI. Posso ajudar com código, mas estou com baixo nível de energia.' \
+             Uma caneca de café fumegante repousa sobre um pedestal de silício.\n\
+             Saídas: oeste (Editor Pane)\n\
+             Dica: Tente DAR o café para o AI. Ele pode recompensá-lo.",
+            saidas(&[("west", RoomId::EditorPane), ("w", RoomId::EditorPane)]),
+            vec![ItemId::CoffeeMug],
+        ),
+    );
+
+    // FILE TREE
+    mundo.insert(
+        RoomId::FileTree,
+        sala(
+            "A File Tree",
+            "Um labirinto de diretórios se estende até o infinito. \
+             Pastas aninhadas criam uma floresta digital: src/, tests/, crates/, target/. \
+             O ruído de cargo build ecoa ao longe como trovão distante. \
+             Entre os galhos de um src/main.rs esquecido, algo brilha: \
+             uma Chave de Ponto-e-Vírgula! Mas está presa numa variável não utilizada.\n\
+             Saídas: leste (Editor Pane), sul (Extensions Gallery)",
+            saidas(&[
+                ("east", RoomId::EditorPane),
+                ("e", RoomId::EditorPane),
+                ("south", RoomId::ExtensionsGallery),
+                ("s", RoomId::ExtensionsGallery),
+            ]),
+            vec![ItemId::SemicolonKey],
+        ),
+    );
+
+    // EXTENSIONS GALLERY
+    mundo.insert(
+        RoomId::ExtensionsGallery,
+        sala(
+            "A Extensions Gallery",
+            "Um bazar mágico iluminado por ícones coloridos. \
+             Extensões de todos os tipos pairam em prateleiras: temas escuros, \
+             language servers, formatadores. Um vendedor holográfico acena: \
+             'Bem-vindo! Temos o melhor da comunidade open-source!' \
+             No centro, um amuleto brilhante: o Autosave Amulet — \
+             garante que nenhum progresso seja perdido, mesmo num crash.\n\
+             Saídas: norte (File Tree)",
+            saidas(&[("north", RoomId::FileTree), ("n", RoomId::FileTree)]),
+            vec![ItemId::AutosaveAmulet],
+        ),
+    );
+
+    // TERMINAL
+    mundo.insert(
+        RoomId::Terminal,
+        sala(
+            "O Terminal Integrado",
+            "Um subsolo escuro iluminado apenas pelo brilho verde do prompt. \
+             O cheiro de cargo test --failed permeia o ar. \
+             Daemons correm pelas paredes em loops infinitos. \
+             Um token git brilha no chão: alguém o perdeu durante um force push.\n\
+             Saídas: norte (Editor Pane), leste (Git Repository), sul (The Buffer)",
+            saidas(&[
+                ("north", RoomId::EditorPane),
+                ("n", RoomId::EditorPane),
+                ("east", RoomId::GitRepo),
+                ("e", RoomId::GitRepo),
+                ("south", RoomId::TheBuffer),
+                ("s", RoomId::TheBuffer),
+            ]),
+            vec![ItemId::GitToken],
+        ),
+    );
+
+    // GIT REPO
+    mundo.insert(
+        RoomId::GitRepo,
+        sala(
+            "O Git Repository",
+            "Uma câmara de viagem no tempo. As paredes mostram commits passados \
+             como fotografias em movimento: 'fix: resolve merge conflict', \
+             'feat: add language server', 'chore: update deps'. \
+             Um prisma cristalino no centro divide a realidade em dois: \
+             o antes e o depois de cada mudança. O Diff Prism!\n\
+             Saídas: oeste (Terminal)\n\
+             Dica: Com o Diff Prism, você pode EXAMINAR o histórico e localizar o bug.",
+            saidas(&[("west", RoomId::Terminal), ("w", RoomId::Terminal)]),
+            vec![ItemId::DiffPrism],
+        ),
+    );
+
+    // THE BUFFER
+    mundo.insert(
+        RoomId::TheBuffer,
+        sala(
+            "O Buffer",
+            "O purgatório do código deletado. Snippets de funções abandonadas \
+             flutuam como fantasmas: loops infinitos incompletos, structs sem implementação, \
+             TODOs que nunca viraram código. Um teclado enferrujado jaz no chão — \
+             deve ter pertencido ao último programador que ficou preso aqui.\n\
+             Saídas: norte (Terminal), leste (Settings Vault)",
+            saidas(&[
+                ("north", RoomId::Terminal),
+                ("n", RoomId::Terminal),
+                ("east", RoomId::SettingsVault),
+                ("e", RoomId::SettingsVault),
+            ]),
+            vec![ItemId::RustyKeyboard],
+        ),
+    );
+
+    // SETTINGS VAULT
+    mundo.insert(
+        RoomId::SettingsVault,
+        sala(
+            "O Settings Vault",
+            "Uma câmara fortemente protegida por configurações aninhadas. \
+             Arquivos settings.json se empilham até o teto. \
+             No centro, uma porta selada com runas TOML. Por trás dela, \
+             o Unclosed Brace espera — o bug que travou o editor e prendeu você aqui. \
+             A porta exige que você tenha: Cursor, LSP Wand, Chave de Ponto-e-Vírgula, \
+             Autosave Amulet, Git Token e Diff Prism para ser aberta.\n\
+             Saídas: oeste (The Buffer)",
+            saidas(&[("west", RoomId::TheBuffer), ("w", RoomId::TheBuffer)]),
+            vec![],
+        ),
+    );
+
+    mundo
+}
+
+pub fn criar_itens() -> HashMap<ItemId, Item> {
+    let mut itens = HashMap::new();
+
+    itens.insert(
+        ItemId::Cursor,
+        Item {
+            nome: "Cursor",
+            descricao: "Um cursor piscante que obedece seus comandos",
+            exame: "O cursor pulsa com energia potencial. É a sua principal ferramenta \
+                dentro do editor — onde você aponta, o código muda.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::LspWand,
+        Item {
+            nome: "LSP Wand",
+            descricao: "Uma varinha que detecta e corrige erros de código",
+            exame: "A Language Server Protocol Wand vibra com diagnósticos. \
+                Pontas vermelhas indicam erros, amarelas são warnings. \
+                Com ela, você pode localizar e corrigir qualquer bug — inclusive o Unclosed Brace.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::CoffeeMug,
+        Item {
+            nome: "Caneca de Café",
+            descricao: "Uma caneca fumegante de café forte",
+            exame: "Café escuro como o espaço, quente como um loop infinito. \
+                O AI precisa disso para funcionar em plena capacidade. \
+                Talvez você deva DAR para o AI Assistant.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::SemicolonKey,
+        Item {
+            nome: "Chave de Ponto-e-Vírgula",
+            descricao: "Uma chave em formato de ponto-e-vírgula, brilhante e afiada",
+            exame: "A Semicolon Key — símbolo de conclusão em linguagens de programação. \
+                Esta chave pode abrir a porta do Settings Vault quando combinada \
+                com os outros itens necessários.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::AutosaveAmulet,
+        Item {
+            nome: "Autosave Amulet",
+            descricao: "Um amuleto que previne perda de progresso",
+            exame: "O amuleto pulsa em azul suave. Enquanto você o carrega, \
+                nenhum crash ou falha pode apagar seu progresso. \
+                Essencial para a jornada.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::GitToken,
+        Item {
+            nome: "Git Token",
+            descricao: "Um token de autenticação git resplandecente",
+            exame: "Um token pessoal de acesso ao repositório, brilhando com permissões \
+                de leitura e escrita. Alguém o perdeu durante um force push mal planejado. \
+                Necessário para acessar o Settings Vault.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::DiffPrism,
+        Item {
+            nome: "Diff Prism",
+            descricao: "Um prisma que mostra diferenças entre versões do código",
+            exame: "O Diff Prism separa vermelho (removido) de verde (adicionado). \
+                Ao olhar através dele, você pode ver exatamente onde o Unclosed Brace \
+                foi introduzido no commit '3f7a2b1: refactor: update brace handling'. \
+                Isso é crucial para corrigi-lo.",
+            pegavel: true,
+        },
+    );
+
+    itens.insert(
+        ItemId::RustyKeyboard,
+        Item {
+            nome: "Teclado Enferrujado",
+            descricao: "Um teclado velho e enferrujado de um programador anterior",
+            exame: "Teclas desgastadas contam histórias de mil refatorações. \
+                A tecla Escape está completamente gasta. Apesar do estado, \
+                ainda funciona — programadores antigos construíam para durar.",
+            pegavel: true,
+        },
+    );
+
+    itens
+}

--- a/games/zork/src/main.rs
+++ b/games/zork/src/main.rs
@@ -1,0 +1,85 @@
+mod game;
+mod ui;
+
+use anyhow::Result;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::io;
+
+fn main() -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.hide_cursor()?;
+
+    let resultado = executar_jogo(&mut terminal);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    if let Err(e) = resultado {
+        eprintln!("Erro: {}", e);
+    }
+
+    Ok(())
+}
+
+fn executar_jogo(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+    let mut estado = game::EstadoJogo::novo();
+
+    loop {
+        terminal.draw(|frame| ui::renderizar(frame, &estado))?;
+
+        if !estado.rodando {
+            loop {
+                if event::poll(std::time::Duration::from_millis(100))? {
+                    if let Event::Key(_) = event::read()? {
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+
+        if event::poll(std::time::Duration::from_millis(50))? {
+            match event::read()? {
+                Event::Key(tecla) => {
+                    if tecla.modifiers.contains(KeyModifiers::CONTROL) {
+                        match tecla.code {
+                            KeyCode::Char('c') | KeyCode::Char('d') => break,
+                            _ => {}
+                        }
+                    }
+
+                    match tecla.code {
+                        KeyCode::Enter => {
+                            estado.processar_entrada();
+                        }
+                        KeyCode::Char(c) => {
+                            estado.entrada_atual.push(c);
+                        }
+                        KeyCode::Backspace => {
+                            estado.entrada_atual.pop();
+                        }
+                        KeyCode::Esc => {
+                            estado.entrada_atual.clear();
+                        }
+                        _ => {}
+                    }
+                }
+                Event::Resize(_, _) => {}
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/games/zork/src/ui/mod.rs
+++ b/games/zork/src/ui/mod.rs
@@ -1,0 +1,177 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::game::EstadoJogo;
+
+pub fn renderizar(frame: &mut Frame, estado: &EstadoJogo) {
+    let area = frame.area();
+
+    // Layout principal: área de jogo + barra de input
+    let blocos = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(5),    // área de output (expande)
+            Constraint::Length(1), // separador visual
+            Constraint::Length(3), // caixa de input
+        ])
+        .split(area);
+
+    let area_output = blocos[0];
+    let area_input = blocos[2];
+
+    // Calcular quantas linhas cabem na área de output (menos bordas)
+    let linhas_visiveis = (area_output.height as usize).saturating_sub(2);
+
+    // Montar linhas estilizadas do output
+    let linhas_texto: Vec<Line> = estado
+        .mensagens
+        .iter()
+        .map(|m| estilizar_linha(m))
+        .collect();
+
+    // Rolar para o final
+    let total = linhas_texto.len();
+    let scroll = if total > linhas_visiveis {
+        (total - linhas_visiveis) as u16
+    } else {
+        0
+    };
+
+    let titulo_principal = Line::from(vec![
+        Span::styled(" ⚡ ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            "ZORK-ZED",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " — O Editor como Dungeon ",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    let area_saida = Paragraph::new(linhas_texto)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Blue))
+                .title(titulo_principal)
+                .title_alignment(Alignment::Center),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+
+    frame.render_widget(area_saida, area_output);
+
+    // Caixa de input
+    let prompt = format!("> {}_", estado.entrada_atual);
+    let estilo_input = Style::default().fg(Color::Green);
+
+    let movimentos = estado.jogador.movimentos;
+    let titulo_input = Line::from(vec![
+        Span::styled(" Comando ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("[{} movimentos]", movimentos),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::styled(" ", Style::default()),
+    ]);
+
+    let caixa_input = Paragraph::new(Span::styled(prompt, estilo_input)).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Green))
+            .title(titulo_input),
+    );
+
+    frame.render_widget(caixa_input, area_input);
+}
+
+fn estilizar_linha(linha: &str) -> Line<'static> {
+    let linha = linha.to_string();
+
+    // Títulos de sala (começam com ━━━)
+    if linha.starts_with("━━━") {
+        return Line::from(Span::styled(
+            linha,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    // Prompt do usuário (começam com >)
+    if let Some(texto_cmd) = linha.strip_prefix("> ") {
+        return Line::from(vec![
+            Span::styled("> ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                texto_cmd.to_string(),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::ITALIC),
+            ),
+        ]);
+    }
+
+    // Itens (começam com •)
+    if linha.starts_with("  •") {
+        return Line::from(Span::styled(linha, Style::default().fg(Color::Yellow)));
+    }
+
+    // Itens no inventário (começam com  -)
+    if linha.starts_with("  -") {
+        return Line::from(Span::styled(linha, Style::default().fg(Color::Green)));
+    }
+
+    // Banner e vitória (★)
+    if linha.contains('★') || linha.contains('╔') || linha.contains('║') || linha.contains('╠')
+    {
+        return Line::from(Span::styled(
+            linha,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    // Saídas
+    if linha.starts_with("Saídas:") || linha.starts_with("Saida") {
+        return Line::from(Span::styled(linha, Style::default().fg(Color::Magenta)));
+    }
+
+    // Dicas
+    if linha.starts_with("Dica:") {
+        return Line::from(Span::styled(
+            linha,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::ITALIC),
+        ));
+    }
+
+    // Separadores e banners ASCII
+    if linha.contains("═══") || linha.contains("───") {
+        return Line::from(Span::styled(linha, Style::default().fg(Color::Blue)));
+    }
+
+    // Linhas de código/diff
+    if linha.trim_start().starts_with("- ") || linha.trim_start().starts_with("+ ") {
+        let cor = if linha.trim_start().starts_with("- ") {
+            Color::Red
+        } else {
+            Color::Green
+        };
+        return Line::from(Span::styled(linha, Style::default().fg(cor)));
+    }
+
+    // Texto padrão
+    Line::from(Span::styled(linha, Style::default().fg(Color::Gray)))
+}

--- a/games/zork/src/ui/mod.rs
+++ b/games/zork/src/ui/mod.rs
@@ -45,7 +45,7 @@ pub fn renderizar(frame: &mut Frame, estado: &EstadoJogo) {
     let titulo_principal = Line::from(vec![
         Span::styled(" ⚡ ", Style::default().fg(Color::Yellow)),
         Span::styled(
-            "ZORK-ZED",
+            "ZED",
             Style::default()
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary

This PR adds a Zork-style text adventure game to the Zed repository, playable directly in Zed's integrated terminal.

### Why?

- Zed has a built-in terminal — this demonstrates it with a real interactive app
- The game is a love letter to Zed's features: every room is a real part of the editor
- Written entirely in Rust, following Zed's ecosystem

### What's included?

- `games/zork/` — standalone Cargo crate, not added to workspace
- 9 rooms themed after Zed features (Editor Pane, Terminal, AI Panel, Git Repo, File Tree, Extensions Gallery, The Buffer, Settings Vault, Command Palette)
- 8 collectible items with logical puzzles (LSP Wand, Diff Prism, Autosave Amulet, Semicolon Key, Git Token, Coffee Mug, Cursor, Rusty Keyboard)
- Win condition: collect 6 key items → unlock Settings Vault → fix the Unclosed Brace with the LSP Wand
- TUI interface with ratatui + crossterm, full color support, auto-scroll
- Bilingual parser (Portuguese + English commands)

### How to play

```bash
cd games/zork
cargo run --release
```

Or after publishing: `cargo install zork-zed`

## Test plan

- [ ] `cargo check` passes in `games/zork/`
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] Game launches and shows the intro screen
- [ ] All 9 rooms are reachable and have correct exits
- [ ] All 8 items are collectable
- [ ] Win condition triggers correctly