### PR TITLE
Fix tsgo LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.95.1"
-source = "git+https://github.com/zed-industries/lsp-types?rev=9bceaf7d06bd9394dc6ed002e27d306348d5b83d#9bceaf7d06bd9394dc6ed002e27d306348d5b83d"
+source = "git+https://github.com/zed-industries/lsp-types?rev=f4dfa89a21ca35cd929b70354b1583fabae325f8#f4dfa89a21ca35cd929b70354b1583fabae325f8"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -611,7 +611,7 @@ linkify = "0.10.0"
 libwebrtc = "0.3.26"
 livekit = { version = "0.7.32", features = ["tokio", "rustls-tls-native-roots"] }
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
-lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "9bceaf7d06bd9394dc6ed002e27d306348d5b83d" }
+lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "f4dfa89a21ca35cd929b70354b1583fabae325f8" }
 mach2 = "0.5"
 markup5ever_rcdom = "0.3.0"
 metal = "0.33"


### PR DESCRIPTION
Bumps the `lsp-types` rev which contains patch for breaking change introduced by upstream `typescript-go` repo 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
- Fixed tsgo LSP
