### PR TITLE
git: Only show header staging checkboxes when hovering the header itself

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4961,6 +4961,7 @@ impl GitPanel {
     ) -> AnyElement {
         let id: ElementId = ElementId::Name(format!("header_{}", ix).into());
         let checkbox_id: ElementId = ElementId::Name(format!("header_{}_checkbox", ix).into());
+        let group_name: SharedString = format!("header_{}", ix).into();
         let toggle_state = self.header_state(header.header);
         let section = header.header;
         let weak = cx.weak_entity();
@@ -4968,6 +4969,7 @@ impl GitPanel {
 
         h_flex()
             .id(id)
+            .group(group_name.clone())
             .h(self.list_item_height())
             .w_full()
             .items_center()
@@ -5011,7 +5013,7 @@ impl GitPanel {
                             }),
                     )
                     .when(!show_checkbox_persistently, |this| {
-                        this.visible_on_hover("entries")
+                        this.visible_on_hover(group_name)
                     }),
             )
             .into_any_element()


### PR DESCRIPTION
Previously, we would show these checkboxes whenever hovering anywhere in the `entries` group, which covers all headers and status entries. This seems excessive, and also has a problem that the header checkboxes disappear when the mouse moves over a non-header (status entry) checkbox, presumably because those have `stop_propagation`. Now, we only show the checkbox for a header when that specific header is hovered.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A