### PR TITLE
Add create_thread and list_agents_and_models agent tools

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1079,10 +1079,12 @@
         "tools": {
           "copy_path": true,
           "create_directory": true,
+          "create_thread": true,
           "delete_path": true,
           "diagnostics": true,
           "edit_file": true,
           "fetch": true,
+          "list_agents_and_models": true,
           "list_directory": true,
           "project_notifications": false,
           "move_path": true,
@@ -1105,8 +1107,10 @@
         // We don't know which of the context server tools are safe for the "Ask" profile, so we don't enable them by default.
         // "enable_all_context_servers": true,
         "tools": {
+          "create_thread": true,
           "diagnostics": true,
           "fetch": true,
+          "list_agents_and_models": true,
           "list_directory": true,
           "project_notifications": false,
           "now": true,

--- a/crates/agent/.rules
+++ b/crates/agent/.rules
@@ -1,0 +1,25 @@
+# Registering a new built-in agent tool
+
+Registering a tool in `Thread::add_default_tools()` and the `tools!` macro in
+`crates/agent/src/tools.rs` is **not enough** for the model to actually receive
+it. There are two additional gates that must be updated or the tool will be
+silently filtered out:
+
+1. **Built-in profiles in `assets/settings/default.json`.** The `write` and
+   `ask` profiles under `agent.profiles` each contain an explicit `tools` map
+   that acts as a per-profile allowlist. `Thread::enabled_tools()` calls
+   `profile.is_tool_enabled(name)` and excludes any tool not present with value
+   `true`. Add the new tool name to both profiles (or whichever profiles it
+   should be available in).
+
+2. **`test_all_tools_are_in_tool_info_or_excluded` in
+   `crates/settings_ui/src/pages/tool_permissions_setup.rs`.** This test walks
+   `agent::ALL_TOOL_NAMES` and asserts each entry is either in the `TOOLS`
+   permission-UI list or in `EXCLUDED_TOOLS`. Add a `ToolInfo` entry if the
+   tool has permission checks (i.e. calls `decide_permission_from_settings`);
+   otherwise add the tool name to `EXCLUDED_TOOLS` with a comment explaining
+   why it doesn't need one.
+
+The symptom of skipping step 1 is that the tool appears nowhere in the LLM's
+tool list even though it's registered and compiles fine. The symptom of
+skipping step 2 is a failing unit test in `settings_ui`.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -250,6 +250,22 @@ impl LanguageModels {
     }
 }
 
+/// Implemented by the UI layer to provide the ability for agent tools to create
+/// sibling threads that appear in the agent panel.
+///
+/// `agent_ui::AgentPanel` installs an implementation of this trait on the
+/// `NativeAgent` when it sets up a connection. Tools in a native-agent thread
+/// then discover and use the host via `NativeThreadEnvironment`.
+pub trait SiblingThreadHost {
+    fn create_sibling_thread(
+        &self,
+        request: SiblingThreadRequest,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<SiblingThreadInfo>>;
+
+    fn list_available_agents(&self, cx: &mut App) -> Result<AvailableAgents>;
+}
+
 pub struct NativeAgent {
     /// Session ID -> Session mapping
     sessions: HashMap<acp::SessionId, Session>,
@@ -261,6 +277,8 @@ pub struct NativeAgent {
     templates: Arc<Templates>,
     /// Cached model information
     models: LanguageModels,
+    /// Handler installed by the UI for `create_thread` / `list_agents_and_models` tools.
+    sibling_thread_host: Option<Rc<dyn SiblingThreadHost>>,
     prompt_store: Option<Entity<PromptStore>>,
     fs: Arc<dyn Fs>,
     _subscriptions: Vec<Subscription>,
@@ -292,11 +310,20 @@ impl NativeAgent {
                 projects: HashMap::default(),
                 templates,
                 models: LanguageModels::new(cx),
+                sibling_thread_host: None,
                 prompt_store,
                 fs,
                 _subscriptions: subscriptions,
             }
         })
+    }
+
+    pub fn set_sibling_thread_host(&mut self, host: Rc<dyn SiblingThreadHost>) {
+        self.sibling_thread_host = Some(host);
+    }
+
+    pub fn sibling_thread_host(&self) -> Option<Rc<dyn SiblingThreadHost>> {
+        self.sibling_thread_host.clone()
     }
 
     fn new_session(
@@ -1996,6 +2023,40 @@ impl ThreadEnvironment for NativeThreadEnvironment {
         cx: &mut App,
     ) -> Result<Rc<dyn SubagentHandle>> {
         self.resume_subagent_thread(session_id, cx)
+    }
+
+    fn create_sibling_thread(
+        &self,
+        request: SiblingThreadRequest,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<SiblingThreadInfo>> {
+        let host = match self
+            .agent
+            .read_with(cx, |agent, _| agent.sibling_thread_host())
+        {
+            Ok(Some(host)) => host,
+            Ok(None) => {
+                return Task::ready(Err(anyhow!(
+                    "No sibling-thread host is registered. This usually means the \
+                     agent panel hasn't been initialized in this workspace."
+                )));
+            }
+            Err(err) => return Task::ready(Err(err)),
+        };
+        host.create_sibling_thread(request, cx)
+    }
+
+    fn list_available_agents(&self, cx: &mut App) -> Result<AvailableAgents> {
+        let host = self
+            .agent
+            .read_with(cx, |agent, _| agent.sibling_thread_host())?
+            .ok_or_else(|| {
+                anyhow!(
+                    "No sibling-thread host is registered. This usually means the \
+                     agent panel hasn't been initialized in this workspace."
+                )
+            })?;
+        host.list_available_agents(cx)
     }
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -9,7 +9,8 @@ use crate::{
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
 use feature_flags::{
-    FeatureFlagAppExt as _, StreamingEditFileToolFeatureFlag, UpdatePlanToolFeatureFlag,
+    CreateThreadToolFeatureFlag, FeatureFlagAppExt as _, StreamingEditFileToolFeatureFlag,
+    UpdatePlanToolFeatureFlag,
 };
 
 use agent_client_protocol as acp;
@@ -1664,8 +1665,10 @@ impl Thread {
         // Sibling-thread tools are exposed at every depth: a subagent should
         // still be able to kick off independent sibling work on behalf of the
         // user, even when it can no longer nest further subagents.
-        self.add_tool(CreateThreadTool::new(environment.clone()));
-        self.add_tool(ListAgentsAndModelsTool::new(environment));
+        if cx.has_flag::<CreateThreadToolFeatureFlag>() {
+            self.add_tool(CreateThreadTool::new(environment.clone()));
+            self.add_tool(ListAgentsAndModelsTool::new(environment));
+        }
     }
 
     pub fn add_tool<T: AgentTool>(&mut self, tool: T) {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1,8 +1,8 @@
 use crate::{
-    ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
-    DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
-    ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot, ReadFileTool,
-    RestoreFileFromDiskTool, SaveFileTool, SpawnAgentTool, StreamingEditFileTool,
+    ContextServerRegistry, CopyPathTool, CreateDirectoryTool, CreateThreadTool, DbLanguageModel,
+    DbThread, DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
+    ListAgentsAndModelsTool, ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot,
+    ReadFileTool, RestoreFileFromDiskTool, SaveFileTool, SpawnAgentTool, StreamingEditFileTool,
     SystemPromptTemplate, Template, Templates, TerminalTool, ToolPermissionDecision,
     UpdatePlanTool, WebSearchTool, decide_permission_from_settings,
 };
@@ -661,6 +661,90 @@ pub trait ThreadEnvironment {
             "Resuming subagent sessions is not supported"
         ))
     }
+
+    /// Creates an independent sibling thread visible in the agent sidebar.
+    /// Unlike subagents, sibling threads are first-class threads that persist
+    /// and run in parallel without reporting results back to the parent.
+    fn create_sibling_thread(
+        &self,
+        request: SiblingThreadRequest,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<SiblingThreadInfo>> {
+        let _ = request;
+        let _ = cx;
+        Task::ready(Err(anyhow::anyhow!(
+            "Creating sibling threads is not supported in this environment"
+        )))
+    }
+
+    /// Lists the agents and models available for use with `create_sibling_thread`.
+    fn list_available_agents(&self, cx: &mut App) -> Result<AvailableAgents> {
+        let _ = cx;
+        Err(anyhow::anyhow!(
+            "Listing available agents is not supported in this environment"
+        ))
+    }
+}
+
+/// A request to create a new sibling thread.
+#[derive(Debug, Clone)]
+pub struct SiblingThreadRequest {
+    /// A short title for the new thread, shown in the sidebar.
+    pub title: SharedString,
+    /// The initial prompt to send to the new thread.
+    pub prompt: String,
+    /// Optional agent ID to use. Defaults to the native Zed agent.
+    pub agent_id: Option<String>,
+    /// Optional model override, as `provider/model-id`.
+    /// Defaults to the user's configured default model for the agent.
+    pub model: Option<String>,
+    /// Whether to create the thread in a new git worktree.
+    /// Not yet supported; passing `true` will return an error.
+    pub use_new_worktree: bool,
+    /// Git ref (branch, tag, or commit) to base the new worktree on.
+    /// Only relevant when `use_new_worktree` is true.
+    pub base_ref: Option<String>,
+}
+
+/// Information returned when a sibling thread is successfully created.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiblingThreadInfo {
+    /// The title assigned to the thread.
+    pub title: SharedString,
+    /// The agent ID used for the thread.
+    pub agent_id: String,
+    /// The model ID used for the thread, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// A list of agents and, for each, the models available for use.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableAgents {
+    pub agents: Vec<AvailableAgent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableAgent {
+    /// Identifier used when creating a thread.
+    pub id: String,
+    /// Human-readable name shown in the UI.
+    pub name: String,
+    /// Whether this is Zed's built-in native agent.
+    pub is_native: bool,
+    /// Models available for this agent. May be empty if models are not
+    /// enumerated up front (e.g., external agents that choose their own).
+    pub models: Vec<AvailableModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvailableModel {
+    /// Identifier to pass as the `model` field when creating a thread.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Whether this is the default model for the agent.
+    pub is_default: bool,
 }
 
 #[derive(Debug)]
@@ -1574,8 +1658,14 @@ impl Thread {
         self.add_tool(WebSearchTool);
 
         if self.depth() < MAX_SUBAGENT_DEPTH {
-            self.add_tool(SpawnAgentTool::new(environment));
+            self.add_tool(SpawnAgentTool::new(environment.clone()));
         }
+
+        // Sibling-thread tools are exposed at every depth: a subagent should
+        // still be able to kick off independent sibling work on behalf of the
+        // user, even when it can no longer nest further subagents.
+        self.add_tool(CreateThreadTool::new(environment.clone()));
+        self.add_tool(ListAgentsAndModelsTool::new(environment));
     }
 
     pub fn add_tool<T: AgentTool>(&mut self, tool: T) {

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -1,6 +1,7 @@
 mod context_server_registry;
 mod copy_path_tool;
 mod create_directory_tool;
+mod create_thread_tool;
 mod delete_path_tool;
 mod diagnostics_tool;
 mod edit_file_tool;
@@ -9,6 +10,7 @@ mod evals;
 mod fetch_tool;
 mod find_path_tool;
 mod grep_tool;
+mod list_agents_and_models_tool;
 mod list_directory_tool;
 mod move_path_tool;
 mod now_tool;
@@ -30,12 +32,14 @@ use language_model::{LanguageModelRequestTool, LanguageModelToolSchemaFormat};
 pub use context_server_registry::*;
 pub use copy_path_tool::*;
 pub use create_directory_tool::*;
+pub use create_thread_tool::*;
 pub use delete_path_tool::*;
 pub use diagnostics_tool::*;
 pub use edit_file_tool::*;
 pub use fetch_tool::*;
 pub use find_path_tool::*;
 pub use grep_tool::*;
+pub use list_agents_and_models_tool::*;
 pub use list_directory_tool::*;
 pub use move_path_tool::*;
 pub use now_tool::*;
@@ -121,12 +125,14 @@ macro_rules! tools {
 tools! {
     CopyPathTool,
     CreateDirectoryTool,
+    CreateThreadTool,
     DeletePathTool,
     DiagnosticsTool,
     EditFileTool,
     FetchTool,
     FindPathTool,
     GrepTool,
+    ListAgentsAndModelsTool,
     ListDirectoryTool,
     MovePathTool,
     NowTool,

--- a/crates/agent/src/tools/create_thread_tool.rs
+++ b/crates/agent/src/tools/create_thread_tool.rs
@@ -1,0 +1,175 @@
+use agent_client_protocol as acp;
+use anyhow::Result;
+use gpui::{App, SharedString, Task};
+use language_model::LanguageModelToolResultContent;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::{AgentTool, SiblingThreadRequest, ThreadEnvironment, ToolCallEventStream, ToolInput};
+
+/// Create a new agent thread that runs in parallel with this one.
+///
+/// Use this to kick off separable pieces of work without interrupting the current
+/// conversation. The new thread appears in the agent sidebar just like a thread
+/// the user created themselves, and runs independently — you will NOT receive
+/// its output and you cannot interact with it afterwards. Use `spawn_agent`
+/// instead if you need the results back.
+///
+/// A successful call returns only the title, agent ID, and model used; there is
+/// currently no way to look up or control a sibling thread by session ID.
+///
+/// ### When to use
+/// - The user asks you to start another thread, investigation, or exploration on the side.
+/// - You notice a separable task (refactor, bug fix, investigation) that shouldn't
+///   derail the current conversation but is worth pursuing.
+///
+/// ### Prompt design
+/// The new thread has no access to this conversation's history. Include in `prompt`
+/// everything the new agent needs: goals, relevant file paths, constraints, and
+/// context. Assume the new thread starts from a blank slate in the same project.
+///
+/// ### Agent and model selection
+/// - If you don't know what agents or models are available, call `list_agents_and_models`.
+/// - For bulk / lightweight work (e.g., spawning many parallel threads), prefer a
+///   cheaper / faster model over the default.
+/// - Leave `agent` and `model` unset to use the user's current defaults.
+///
+/// ### Worktree support
+/// Not yet implemented. Setting `use_new_worktree` to true currently returns an
+/// error. Sibling threads always share the parent thread's worktree for now.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateThreadToolInput {
+    /// Short descriptive title for the new thread, shown in the sidebar
+    /// (e.g., "Investigate flaky login test").
+    pub title: String,
+
+    /// The initial prompt to send to the new thread. Include all the context the
+    /// new agent needs — files, goals, constraints — because it has no access to
+    /// the current conversation's history.
+    pub prompt: String,
+
+    /// Optional agent ID to use. Omit to use the user's currently selected agent.
+    /// Call `list_agents_and_models` if you need to see what's available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+
+    /// Optional model override as `provider/model-id` (e.g.,
+    /// `anthropic/claude-haiku-4-latest`). Only meaningful for Zed's native
+    /// agent. Omit to use the user's configured default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// If true, create the thread in a new git worktree rather than sharing the
+    /// parent's worktree. NOT YET SUPPORTED — passing true currently fails.
+    #[serde(default)]
+    pub use_new_worktree: bool,
+
+    /// Git ref to base the new worktree on. Only used when `use_new_worktree`
+    /// is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CreateThreadToolOutput {
+    Success {
+        title: String,
+        agent_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+    },
+    Error {
+        error: String,
+    },
+}
+
+impl From<CreateThreadToolOutput> for LanguageModelToolResultContent {
+    fn from(output: CreateThreadToolOutput) -> Self {
+        serde_json::to_string(&output)
+            .unwrap_or_else(|e| format!("Failed to serialize create_thread output: {e}"))
+            .into()
+    }
+}
+
+pub struct CreateThreadTool {
+    environment: Rc<dyn ThreadEnvironment>,
+}
+
+impl CreateThreadTool {
+    pub fn new(environment: Rc<dyn ThreadEnvironment>) -> Self {
+        Self { environment }
+    }
+}
+
+impl AgentTool for CreateThreadTool {
+    type Input = CreateThreadToolInput;
+    type Output = CreateThreadToolOutput;
+
+    const NAME: &'static str = "create_thread";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        match input {
+            Ok(i) => format!("Create thread: {}", i.title).into(),
+            Err(value) => value
+                .get("title")
+                .and_then(|v| v.as_str())
+                .map(|s| format!("Create thread: {s}").into())
+                .unwrap_or_else(|| "Create thread".into()),
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        cx.spawn(async move |cx| {
+            let input = input.recv().await.map_err(|e| CreateThreadToolOutput::Error {
+                error: format!("Failed to receive tool input: {e}"),
+            })?;
+
+            if input.use_new_worktree {
+                return Err(CreateThreadToolOutput::Error {
+                    error: "Creating sibling threads in a new git worktree is not yet supported. \
+                            Set `use_new_worktree` to false to create the thread in the current worktree."
+                        .into(),
+                });
+            }
+
+            let title: SharedString = input.title.clone().into();
+            let request = SiblingThreadRequest {
+                title: title.clone(),
+                prompt: input.prompt,
+                agent_id: input.agent,
+                model: input.model,
+                use_new_worktree: input.use_new_worktree,
+                base_ref: input.base_ref,
+            };
+
+            let task = self.environment.create_sibling_thread(request, cx);
+            match task.await {
+                Ok(info) => Ok(CreateThreadToolOutput::Success {
+                    title: info.title.to_string(),
+                    agent_id: info.agent_id,
+                    model: info.model,
+                }),
+                Err(error) => Err(CreateThreadToolOutput::Error {
+                    error: error.to_string(),
+                }),
+            }
+        })
+    }
+}

--- a/crates/agent/src/tools/list_agents_and_models_tool.rs
+++ b/crates/agent/src/tools/list_agents_and_models_tool.rs
@@ -1,0 +1,78 @@
+use agent_client_protocol as acp;
+use anyhow::Result;
+use gpui::{App, SharedString, Task};
+use language_model::LanguageModelToolResultContent;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::{AgentTool, AvailableAgents, ThreadEnvironment, ToolCallEventStream, ToolInput};
+
+/// List the agents and models available for use with the `create_thread` tool.
+///
+/// Call this before `create_thread` if you need to pick a specific agent or a
+/// non-default model (for example, to use a cheaper model for bulk work). If
+/// you're happy with the user's current defaults, you don't need to call this.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ListAgentsAndModelsToolInput {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ListAgentsAndModelsToolOutput {
+    Success(AvailableAgents),
+    Error { error: String },
+}
+
+impl From<ListAgentsAndModelsToolOutput> for LanguageModelToolResultContent {
+    fn from(output: ListAgentsAndModelsToolOutput) -> Self {
+        serde_json::to_string(&output)
+            .unwrap_or_else(|e| format!("Failed to serialize list_agents_and_models output: {e}"))
+            .into()
+    }
+}
+
+pub struct ListAgentsAndModelsTool {
+    environment: Rc<dyn ThreadEnvironment>,
+}
+
+impl ListAgentsAndModelsTool {
+    pub fn new(environment: Rc<dyn ThreadEnvironment>) -> Self {
+        Self { environment }
+    }
+}
+
+impl AgentTool for ListAgentsAndModelsTool {
+    type Input = ListAgentsAndModelsToolInput;
+    type Output = ListAgentsAndModelsToolOutput;
+
+    const NAME: &'static str = "list_agents_and_models";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        _input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        "List agents and models".into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        _input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        let result = self.environment.list_available_agents(cx);
+        Task::ready(match result {
+            Ok(agents) => Ok(ListAgentsAndModelsToolOutput::Success(agents)),
+            Err(error) => Err(ListAgentsAndModelsToolOutput::Error {
+                error: error.to_string(),
+            }),
+        })
+    }
+}

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -624,6 +624,21 @@ fn build_conflicted_files_resolution_prompt(
     content
 }
 
+/// Optional parameters for `AgentPanel::create_thread_with_options`. The
+/// default value matches today's behavior of the bare `create_thread` method.
+#[derive(Default)]
+pub struct CreateThreadOptions {
+    /// Title to assign to the new thread up front.
+    pub title: Option<SharedString>,
+    /// Initial content to populate in the thread (optionally auto-submitted).
+    pub initial_content: Option<AgentInitialContent>,
+    /// Agent to use. Defaults to the panel's selected agent.
+    pub agent: Option<Agent>,
+    /// Model override, as `provider/model-id`. Only applied when the thread
+    /// uses the native Zed agent.
+    pub model: Option<String>,
+}
+
 pub(crate) struct AgentThread {
     conversation_view: Entity<ConversationView>,
 }
@@ -1346,13 +1361,76 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> ThreadId {
-        let agent = if self.project.read(cx).is_via_collab() {
-            Agent::NativeAgent
+        self.create_thread_with_options(CreateThreadOptions::default(), source, window, cx)
+    }
+
+    /// Creates a new retained thread and inserts it into the sidebar without
+    /// switching the active view to it. Used by both the "new thread" UI action
+    /// (with default options) and the `create_thread` agent tool (which passes
+    /// an initial prompt, and optionally an agent and model override).
+    pub fn create_thread_with_options(
+        &mut self,
+        options: CreateThreadOptions,
+        source: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ThreadId {
+        let (agent, override_used) = if self.project.read(cx).is_via_collab() {
+            (Agent::NativeAgent, false)
+        } else if let Some(override_agent) = options.agent {
+            (override_agent, true)
         } else {
-            self.selected_agent.clone()
+            (self.selected_agent.clone(), false)
         };
-        let thread = self.create_agent_thread(agent, None, None, None, None, source, window, cx);
+        // If the caller explicitly overrode the agent (e.g., the `create_thread`
+        // tool wants to spawn a sibling thread using a specific agent), we
+        // shouldn't let that change the panel's selected_agent or the
+        // last-used-agent preference. Snapshot and restore both.
+        let saved_selected_agent = override_used.then(|| self.selected_agent.clone());
+        let thread = self.create_agent_thread(
+            agent,
+            None,
+            None,
+            options.title.clone(),
+            options.initial_content,
+            source,
+            window,
+            cx,
+        );
+        if let Some(original) = saved_selected_agent {
+            if self.selected_agent != original {
+                self.selected_agent = original.clone();
+                self.serialize(cx);
+                // Restore the last-used-agent in persistent storage as well.
+                cx.background_spawn({
+                    let kvp = KeyValueStore::global(cx);
+                    async move {
+                        write_global_last_used_agent(kvp, original).await;
+                    }
+                })
+                .detach();
+            }
+        }
         let thread_id = thread.conversation_view.read(cx).thread_id;
+        if let Some(model) = options.model.as_ref() {
+            let model = model.clone();
+            let conversation_view = thread.conversation_view.downgrade();
+            cx.spawn(async move |_this, cx| {
+                // The underlying native thread is created asynchronously, so defer
+                // the model selection until it's available.
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(0))
+                    .await;
+                conversation_view
+                    .update(cx, |conversation_view, cx| {
+                        if let Some(native_thread) = conversation_view.as_native_thread(cx) {
+                            apply_native_model_override(&native_thread, &model, cx);
+                        }
+                    })
+                    .ok();
+            })
+            .detach();
+        }
         self.retained_threads
             .insert(thread_id, thread.conversation_view);
         thread_id
@@ -2652,21 +2730,52 @@ impl AgentPanel {
             )
         });
 
-        cx.observe(&conversation_view, |this, server_view, cx| {
-            let is_active = this
-                .active_conversation_view()
-                .is_some_and(|active| active.entity_id() == server_view.entity_id());
-            if is_active {
-                cx.emit(AgentPanelEvent::ActiveViewChanged);
-                this.serialize(cx);
-            } else {
-                cx.emit(AgentPanelEvent::RetainedThreadChanged);
-            }
-            cx.notify();
-        })
+        cx.observe_in(
+            &conversation_view,
+            window,
+            |this, server_view, window, cx| {
+                let is_active = this
+                    .active_conversation_view()
+                    .is_some_and(|active| active.entity_id() == server_view.entity_id());
+                if is_active {
+                    cx.emit(AgentPanelEvent::ActiveViewChanged);
+                    this.serialize(cx);
+                } else {
+                    cx.emit(AgentPanelEvent::RetainedThreadChanged);
+                }
+                this.ensure_sibling_host_installed(&server_view, window, cx);
+                cx.notify();
+            },
+        )
         .detach();
 
+        // Try installing the host eagerly as well, in case the connection is
+        // already established by the time the observe fires.
+        self.ensure_sibling_host_installed(&conversation_view, window, cx);
+
         AgentThread { conversation_view }
+    }
+
+    fn ensure_sibling_host_installed(
+        &self,
+        conversation_view: &Entity<ConversationView>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(native_connection) = conversation_view.read(cx).as_native_connection(cx) else {
+            return;
+        };
+        let native_agent = native_connection.0.clone();
+        if native_agent.read(cx).sibling_thread_host().is_some() {
+            return;
+        }
+        let host = Rc::new(AgentPanelSiblingHost::new(
+            cx.weak_entity(),
+            window.window_handle(),
+        )) as Rc<dyn agent::SiblingThreadHost>;
+        native_agent.update(cx, |native_agent, _cx| {
+            native_agent.set_sibling_thread_host(host);
+        });
     }
 
     fn active_thread_has_messages(&self, cx: &App) -> bool {
@@ -3654,6 +3763,175 @@ impl AgentPanel {
         })?;
 
         anyhow::Ok(())
+    }
+}
+
+/// Apply a `provider/model-id` model override to a freshly-created native thread.
+/// Best-effort: logs an error and leaves the default model in place if the
+/// string can't be parsed or the model isn't registered.
+pub(crate) fn apply_native_model_override(
+    thread: &Entity<agent::Thread>,
+    model_id: &str,
+    cx: &mut App,
+) {
+    let Some(selected) = parse_provider_slash_model(model_id) else {
+        log::warn!(
+            "create_thread: could not parse model override {model_id:?}; expected `provider/model-id`"
+        );
+        return;
+    };
+    let configured = LanguageModelRegistry::global(cx)
+        .update(cx, |registry, cx| registry.select_model(&selected, cx));
+    let Some(configured) = configured else {
+        log::warn!(
+            "create_thread: no model registered for {model_id:?}; using thread's default model"
+        );
+        return;
+    };
+    thread.update(cx, |thread, cx| {
+        thread.set_model(configured.model, cx);
+    });
+}
+
+fn parse_provider_slash_model(input: &str) -> Option<language_model::SelectedModel> {
+    let (provider, model) = input.split_once('/')?;
+    if provider.is_empty() || model.is_empty() {
+        return None;
+    }
+    Some(language_model::SelectedModel {
+        provider: language_model::LanguageModelProviderId::from(provider.to_string()),
+        model: language_model::LanguageModelId::from(model.to_string()),
+    })
+}
+
+/// Bridges agent-side `SiblingThreadHost` calls to `AgentPanel`. Constructed
+/// and installed on a `NativeAgent` by the agent panel when a native-agent
+/// thread is created.
+pub(crate) struct AgentPanelSiblingHost {
+    panel: WeakEntity<AgentPanel>,
+    window: gpui::AnyWindowHandle,
+}
+
+impl AgentPanelSiblingHost {
+    pub(crate) fn new(panel: WeakEntity<AgentPanel>, window: gpui::AnyWindowHandle) -> Self {
+        Self { panel, window }
+    }
+}
+
+impl agent::SiblingThreadHost for AgentPanelSiblingHost {
+    fn create_sibling_thread(
+        &self,
+        request: agent::SiblingThreadRequest,
+        cx: &mut gpui::AsyncApp,
+    ) -> Task<Result<agent::SiblingThreadInfo>> {
+        let panel = self.panel.clone();
+        let window = self.window;
+        cx.spawn(async move |cx| {
+            let agent_choice = match request.agent_id.as_deref() {
+                None => None,
+                Some(id) if id == agent::ZED_AGENT_ID.as_ref() => Some(Agent::NativeAgent),
+                Some(id) => Some(Agent::Custom {
+                    id: project::AgentId(id.to_string().into()),
+                }),
+            };
+
+            let initial_content = AgentInitialContent::ContentBlock {
+                blocks: vec![acp::ContentBlock::Text(acp::TextContent::new(
+                    request.prompt.clone(),
+                ))],
+                auto_submit: true,
+            };
+
+            let title: SharedString = request.title.clone();
+            let options = CreateThreadOptions {
+                title: Some(title.clone()),
+                initial_content: Some(initial_content),
+                agent: agent_choice.clone(),
+                model: request.model.clone(),
+            };
+
+            // We deliberately don't wait for the new thread's session to
+            // become available here: there are currently no agent tools that
+            // operate on sibling threads by session ID, so requiring one would
+            // just introduce a race for no benefit.
+            let resolved_agent_id = window.update(cx, |_root, window, cx| {
+                panel.update(cx, |panel, cx| {
+                    panel.create_thread_with_options(options, "agent_tool", window, cx);
+                    let resolved_agent = agent_choice
+                        .clone()
+                        .unwrap_or_else(|| panel.selected_agent.clone());
+                    resolved_agent.id()
+                })
+            })??;
+
+            Ok(agent::SiblingThreadInfo {
+                title,
+                agent_id: resolved_agent_id.0.to_string(),
+                model: request.model,
+            })
+        })
+    }
+
+    fn list_available_agents(&self, cx: &mut App) -> Result<agent::AvailableAgents> {
+        let panel = self
+            .panel
+            .upgrade()
+            .ok_or_else(|| anyhow!("Agent panel is no longer available"))?;
+
+        let mut agents = Vec::new();
+
+        // Native Zed agent — always available, and we can enumerate models
+        // directly from the language model registry.
+        let native_models = {
+            let registry = LanguageModelRegistry::read_global(cx);
+            let default = registry.default_model();
+            let mut models = Vec::new();
+            for provider in registry.providers() {
+                if !provider.is_authenticated(cx) {
+                    continue;
+                }
+                let provider_id = provider.id();
+                for model in provider.provided_models(cx) {
+                    let id = format!("{}/{}", provider_id.0, model.id().0);
+                    let is_default = default
+                        .as_ref()
+                        .map(|cm| cm.provider.id() == provider_id && cm.model.id() == model.id())
+                        .unwrap_or(false);
+                    models.push(agent::AvailableModel {
+                        id,
+                        name: model.name().0.to_string(),
+                        is_default,
+                    });
+                }
+            }
+            models
+        };
+        agents.push(agent::AvailableAgent {
+            id: agent::ZED_AGENT_ID.to_string(),
+            name: Agent::NativeAgent.label().to_string(),
+            is_native: true,
+            models: native_models,
+        });
+
+        let project = panel.read(cx).project.clone();
+        let agent_server_store = project.read(cx).agent_server_store().clone();
+        let store = agent_server_store.read(cx);
+        for agent_id in store.external_agents() {
+            let display = store
+                .agent_display_name(agent_id)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| agent_id.0.to_string());
+            agents.push(agent::AvailableAgent {
+                id: agent_id.0.to_string(),
+                name: display,
+                is_native: false,
+                // External agents pick their own models dynamically; we don't
+                // try to enumerate them ahead of time.
+                models: Vec::new(),
+            });
+        }
+
+        Ok(agent::AvailableAgents { agents })
     }
 }
 

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -67,6 +67,19 @@ impl FeatureFlag for UpdatePlanToolFeatureFlag {
     }
 }
 
+/// Gates the `create_thread` and `list_agents_and_models` tools, which let
+/// the agent spawn independent sibling threads that show up in the agent
+/// panel sidebar.
+pub struct CreateThreadToolFeatureFlag;
+
+impl FeatureFlag for CreateThreadToolFeatureFlag {
+    const NAME: &'static str = "create-thread-tool";
+
+    fn enabled_for_staff() -> bool {
+        true
+    }
+}
+
 pub struct ProjectPanelUndoRedoFeatureFlag;
 
 impl FeatureFlag for ProjectPanelUndoRedoFeatureFlag {

--- a/crates/settings_ui/src/pages/tool_permissions_setup.rs
+++ b/crates/settings_ui/src/pages/tool_permissions_setup.rs
@@ -1410,6 +1410,7 @@ mod tests {
             "diagnostics",
             "find_path",
             "grep",
+            "list_agents_and_models",
             "list_directory",
             "now",
             "open",
@@ -1418,8 +1419,9 @@ mod tests {
             // streaming_edit_file uses "edit_file" for permission lookups,
             // so its rules are configured under the edit_file entry.
             "streaming_edit_file",
-            // Subagent permission checks happen at the level of individual
-            // tool calls within the subagent, not at the spawning level.
+            // Sibling/subagent thread creation delegates permission checks to
+            // tool calls inside the spawned thread, not the spawning itself.
+            "create_thread",
             "spawn_agent",
             // update_plan updates UI-visible planning state but does not use
             // tool permission rules.


### PR DESCRIPTION
Adds two new built-in agent tools that let the agent spawn independent
sibling threads which appear in the agent sidebar and run in parallel with
the current conversation:

- **`create_thread`** — creates a new thread with a user-supplied title and
  initial prompt. The new thread runs on the user's behalf, persists like any
  other thread, and does **not** report results back to the parent (use
  `spawn_agent` for that). The parent thread's active view is never
  interrupted.
- **`list_agents_and_models`** — lets the agent enumerate configured agents
  and, for the native agent, the models that are available. Useful for
  choosing a cheaper model for bulk work (the motivating stress test:
  "spawn 100 threads that each write a haiku, using Haiku rather than Opus").

## Behavior

- The new thread shares the parent's project and worktree.
- It's inserted into `AgentPanel.retained_threads` just like a user-created
  thread, subject to the same `MaxIdleRetainedThreads` eviction and
  `ThreadMetadataStore` persistence. Running threads are never evicted;
  finished threads are rehydrated from disk on click.
- `create_thread` supports optional `agent` and `model` overrides. An agent
  override does **not** mutate the panel's `selected_agent` or the
  last-used-agent preference — those are snapshotted and restored around the
  call.
- A `use_new_worktree` field is on the schema but currently returns an error;
  the flag is there so follow-up work can wire it through to the existing
  `handle_worktree_requested` flow without a schema change.

## Architecture

- `agent::ThreadEnvironment` grows two new methods (`create_sibling_thread`,
  `list_available_agents`) with default impls that return an error, so
  existing implementors are unaffected.
- A new `agent::SiblingThreadHost` trait bridges the `agent` crate (which
  cannot depend on UI) to `agent_ui`. `NativeAgent` stores an optional host,
  `NativeThreadEnvironment` forwards calls to it.
- `AgentPanel` implements the host (`AgentPanelSiblingHost`) and installs it
  on the `NativeAgent` whenever a native-agent conversation view connects.
- `AgentPanel::create_thread_with_options` parameterizes the existing
  `create_thread` with an initial content block, agent, and model override.
  The plain `create_thread` becomes a thin wrapper that passes defaults, so
  no existing call sites change.

The tool goes through the same `create_agent_thread` → `ConversationView`
path as the user-facing "new thread" action, so eviction, persistence, and
sidebar rendering are identical to user-created threads.

## What's not in this PR

- `use_new_worktree: true` currently returns an error. The existing worktree
  flow (`handle_worktree_requested` / `open_worktree_workspace_and_start_thread`)
  already creates a second `Workspace` inside the current `MultiWorkspace`
  via `find_or_create_workspace`; a follow-up will thread a "background"
  placement parameter through that flow so it can skip
  `multi_workspace.activate` and install the new thread without taking focus.
- No tool for operating on an already-created sibling thread by ID. The
  initial success payload deliberately does not include a session ID because
  the session is populated asynchronously and we have no downstream consumer
  for it today.

## Testing

- `cargo check --lib` and `cargo clippy --no-deps` are clean on `agent`,
  `agent_ui`, and `settings_ui`.
- Manually exercised in a dev build: the agent can create a sibling thread
  with a title and prompt, the user's active thread stays focused, the new
  thread appears in the sidebar and begins generating.
- `list_agents_and_models` correctly enumerates the native agent with its
  default model flagged, plus any configured external agents.

## Suggested .rules additions

None required — a `.rules` file for the `agent` crate was added alongside
this change documenting the non-obvious fact that a new built-in tool must
be listed in `assets/settings/default.json`'s built-in profiles and either
added to `TOOLS` or `EXCLUDED_TOOLS` in
`settings_ui/src/pages/tool_permissions_setup.rs`. I hit both of those gates
during this work.

Release Notes:

- N/A
