### PR TITLE
Load shell environment synchronously before app initialization

### DIFF
--- a/crates/edit_prediction_cli/src/headless.rs
+++ b/crates/edit_prediction_cli/src/headless.rs
@@ -103,7 +103,7 @@ pub fn init(cx: &mut App) -> EpAppState {
         tx.send(Some(options)).log_err();
     })
     .detach();
-    let node_runtime = NodeRuntime::new(client.http_client(), None, rx);
+    let node_runtime = NodeRuntime::new(client.http_client(), rx);
 
     let extension_host_proxy = ExtensionHostProxy::global(cx);
 

--- a/crates/eval_cli/src/headless.rs
+++ b/crates/eval_cli/src/headless.rs
@@ -103,7 +103,7 @@ pub fn init(cx: &mut App) -> Arc<AgentCliAppState> {
         node_options_tx.send(Some(options)).log_err();
     })
     .detach();
-    let node_runtime = NodeRuntime::new(client.http_client(), None, node_options_rx);
+    let node_runtime = NodeRuntime::new(client.http_client(), node_options_rx);
 
     let extension_host_proxy = ExtensionHostProxy::global(cx);
     debug_adapter_extension::init(extension_host_proxy.clone(), cx);

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, anyhow, bail};
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
-use futures::{AsyncReadExt, FutureExt as _, channel::oneshot, future::Shared};
+use futures::AsyncReadExt;
 use http_client::{Host, HttpClient, Url};
 use log::Level;
 use semver::Version;
@@ -55,13 +55,11 @@ struct NodeRuntimeState {
     instance: Option<Box<dyn NodeRuntimeTrait>>,
     last_options: Option<NodeBinaryOptions>,
     options: watch::Receiver<Option<NodeBinaryOptions>>,
-    shell_env_loaded: Shared<oneshot::Receiver<()>>,
 }
 
 impl NodeRuntime {
     pub fn new(
         http: Arc<dyn HttpClient>,
-        shell_env_loaded: Option<oneshot::Receiver<()>>,
         options: watch::Receiver<Option<NodeBinaryOptions>>,
     ) -> Self {
         NodeRuntime(Arc::new(Mutex::new(NodeRuntimeState {
@@ -69,7 +67,6 @@ impl NodeRuntime {
             instance: None,
             last_options: None,
             options,
-            shell_env_loaded: shell_env_loaded.unwrap_or(oneshot::channel().1).shared(),
         })))
     }
 
@@ -79,7 +76,6 @@ impl NodeRuntime {
             instance: None,
             last_options: None,
             options: watch::channel(Some(NodeBinaryOptions::default())).1,
-            shell_env_loaded: oneshot::channel().1.shared(),
         })))
     }
 
@@ -132,7 +128,6 @@ impl NodeRuntime {
         }
 
         let system_node_error = if options.allow_path_lookup {
-            state.shell_env_loaded.clone().await.ok();
             match SystemNodeRuntime::detect().await {
                 Ok(instance) => {
                     log::info!("using Node.js found on PATH: {:?}", instance);

--- a/crates/project_benchmarks/src/main.rs
+++ b/crates/project_benchmarks/src/main.rs
@@ -131,7 +131,7 @@ fn main() -> Result<(), anyhow::Error> {
         let client = Client::production(cx);
         let http_client = FakeHttpClient::with_200_response();
         let (_, rx) = watch::channel(None);
-        let node = NodeRuntime::new(http_client, None, rx);
+        let node = NodeRuntime::new(http_client, rx);
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
         let registry = Arc::new(LanguageRegistry::new(cx.background_executor().clone()));
         let fs = Arc::new(RealFs::new(None, cx.background_executor().clone()));

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -15,9 +15,7 @@ use collections::HashMap;
 use extension::ExtensionHostProxy;
 use fs::{Fs, RealFs};
 use futures::{
-    AsyncRead, AsyncWrite, AsyncWriteExt, FutureExt, SinkExt,
-    channel::{mpsc, oneshot},
-    select, select_biased,
+    AsyncRead, AsyncWrite, AsyncWriteExt, FutureExt, SinkExt, channel::mpsc, select, select_biased,
 };
 use git::GitHostingProviderRegistry;
 use gpui::{App, AppContext as _, Context, Entity, UpdateGlobal as _};
@@ -497,18 +495,19 @@ pub fn execute_run(
         .unwrap();
 
     #[cfg(unix)]
-    let shell_env_loaded_rx = {
-        let (shell_env_loaded_tx, shell_env_loaded_rx) = oneshot::channel();
-        app.background_executor()
-            .spawn(async {
-                util::load_login_shell_environment().await.log_err();
-                shell_env_loaded_tx.send(()).ok();
-            })
-            .detach();
-        Some(shell_env_loaded_rx)
-    };
-    #[cfg(windows)]
-    let shell_env_loaded_rx: Option<oneshot::Receiver<()>> = None;
+    {
+        use std::time::Duration;
+
+        let shell_env_timeout = Duration::from_secs(3);
+        if !util::load_login_shell_environment_sync(shell_env_timeout) {
+            log::error!(
+                "loading login shell environment timed out after {:?}; \
+                 environment variables from shell config may be missing. \
+                 Check your shell startup files for issues that could cause hangs.",
+                shell_env_timeout,
+            );
+        }
+    }
 
     let git_hosting_provider_registry = Arc::new(GitHostingProviderRegistry::new());
     let run = move |cx: &mut _| {
@@ -566,8 +565,7 @@ pub fn execute_run(
                 )
             };
 
-            let node_runtime =
-                NodeRuntime::new(http_client.clone(), shell_env_loaded_rx, node_settings_rx);
+            let node_runtime = NodeRuntime::new(http_client.clone(), node_settings_rx);
 
             let mut languages = LanguageRegistry::new(cx.background_executor().clone());
             languages.set_language_server_download_dir(paths::languages_dir().clone());

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -382,6 +382,30 @@ pub async fn load_login_shell_environment() -> Result<()> {
     Ok(())
 }
 
+/// Load the login shell environment synchronously, with a timeout.
+///
+/// Returns `true` if the environment was loaded successfully within the timeout,
+/// `false` if it timed out or failed.
+#[cfg(unix)]
+pub fn load_login_shell_environment_sync(timeout: std::time::Duration) -> bool {
+    use std::sync::mpsc;
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = smol::block_on(load_login_shell_environment());
+        tx.send(result).ok();
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(result) => {
+            result.log_err();
+            true
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => false,
+        Err(mpsc::RecvTimeoutError::Disconnected) => false,
+    }
+}
+
 /// Configures the process to start a new session, to prevent interactive shells from taking control
 /// of the terminal.
 ///

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -18,7 +18,7 @@ use db::kvp::{GlobalKeyValueStore, KeyValueStore};
 use editor::Editor;
 use extension::ExtensionHostProxy;
 use fs::{Fs, RealFs};
-use futures::{StreamExt, channel::oneshot, future};
+use futures::{StreamExt, future};
 use git::GitHostingProviderRegistry;
 use git_ui::clone::clone_and_open;
 use gpui::{App, AppContext, Application, AsyncApp, Focusable as _, QuitMode, UpdateGlobal as _};
@@ -406,17 +406,32 @@ fn main() {
         paths::keymap_file().clone(),
     );
 
-    let (shell_env_loaded_tx, shell_env_loaded_rx) = oneshot::channel();
     if !stdout_is_a_pty() {
-        app.background_executor()
-            .spawn(async {
-                #[cfg(unix)]
-                util::load_login_shell_environment().await.log_err();
-                shell_env_loaded_tx.send(()).ok();
-            })
-            .detach()
-    } else {
-        drop(shell_env_loaded_tx)
+        #[cfg(unix)]
+        {
+            use std::time::Duration;
+
+            // Load the login shell environment synchronously before app initialization.
+            //
+            // On macOS, apps launched from the Dock/Spotlight are started by launchd,
+            // and on Linux, apps launched from .desktop files are started by the
+            // desktop environment -- neither inherits shell environment variables.
+            // Zed compensates by spawning the user's login shell to capture its
+            // environment. This must complete before app.run() because environment
+            // variables are read via LazyLock statics (env_var! macro) that capture
+            // values on first access and never re-read. If loaded asynchronously,
+            // those statics race with initialization and permanently miss env vars
+            // like API keys.
+            let shell_env_timeout = Duration::from_secs(3);
+            if !util::load_login_shell_environment_sync(shell_env_timeout) {
+                log::error!(
+                    "loading login shell environment timed out after {:?}; \
+                     environment variables from shell config may be missing. \
+                     Check your shell startup files for issues that could cause hangs.",
+                    shell_env_timeout,
+                );
+            }
+        }
     }
 
     app.on_open_urls({
@@ -522,7 +537,7 @@ fn main() {
         .detach();
         ui::on_new_scrollbars::<SettingsStore>(cx);
 
-        let node_runtime = NodeRuntime::new(client.http_client(), Some(shell_env_loaded_rx), rx);
+        let node_runtime = NodeRuntime::new(client.http_client(), rx);
 
         debug_adapter_extension::init(extension_host_proxy.clone(), cx);
         languages::init(languages.clone(), fs.clone(), node_runtime.clone(), cx);


### PR DESCRIPTION
## Summary

- Fix race condition where environment variables from shell config files (API keys, `ZED_*` settings) were permanently missed when launching Zed from macOS Dock/Spotlight or Linux `.desktop` files
- Add `load_login_shell_environment_sync()` helper that blocks with a 3-second timeout, used by both main app and remote server before initialization
- Remove the now-unnecessary `shell_env_loaded` channel from `NodeRuntime`

## Background

On macOS, apps launched from the Dock are started by `launchd`, and on Linux, apps from `.desktop` files are started by the desktop environment -- neither inherits shell environment variables. Zed has a workaround that spawns a login shell to capture the environment, but it ran asynchronously.

In Dec 2025, `0283bfb049` ("Enable configuring edit prediction providers through the settings UI") introduced `ApiKeyState` with `EnvVar`/`LazyLock`, which reads env vars once on first access and never retries. Since edit predictions initialize at startup, the `LazyLock` gets triggered before the async shell env loading completes, permanently capturing `None` for all API keys.

This affects **all** `env_var!` statics: every LLM provider API key (Anthropic, OpenAI, Mistral, DeepSeek, xAI, OpenRouter, Codestral, etc.), AWS/Bedrock credentials, Mercury tokens, and `ZED_*` configuration variables. Related: #46506.

Before the `LazyLock<EnvVar>` refactor, API keys were read with `std::env::var()` on demand (e.g. when a user triggered an LLM request), so by the time the read happened the async env loading had long since completed. The switch to eager `LazyLock` capture at startup created the race.

## Approach

- `util::load_login_shell_environment_sync(timeout)` spawns the async env loader on a dedicated thread and blocks the caller with `recv_timeout`. No `smol::Timer` usage (respects clippy `disallowed_methods`).
- Both `crates/zed/src/main.rs` and `crates/remote_server/src/server.rs` call this synchronously before `app.run()`.
- `NodeRuntime` no longer carries a `shell_env_loaded` channel -- the environment is guaranteed loaded before it's constructed.
- On timeout, an `error!` log is emitted with actionable guidance about checking shell startup files.

## Tradeoff

Startup when launched from Dock/`.desktop` blocks for the time it takes to spawn a login shell (~100-500ms typically), with a 3-second timeout as a safety net for broken shell configs. This latency was already present but previously hidden on a background thread.

Release Notes:

- Fixed environment variables from shell configuration not being available when launching Zed from macOS Dock/Spotlight or Linux desktop launchers