### PR TITLE
Fix env-var API keys not loading when launched from Dock/Spotlight

### DIFF
--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -388,7 +388,7 @@ impl AgentServer for CustomAgentServer {
 
 fn api_key_for_gemini_cli(cx: &mut App) -> Task<Result<String>> {
     let env_var = EnvVar::new("GEMINI_API_KEY".into()).or(EnvVar::new("GOOGLE_AI_API_KEY".into()));
-    if let Some(key) = env_var.value {
+    if let Some(key) = env_var.value() {
         return Task::ready(Ok(key));
     }
     let credentials_provider = zed_credentials_provider::global(cx);

--- a/crates/codestral/src/codestral.rs
+++ b/crates/codestral/src/codestral.rs
@@ -226,6 +226,10 @@ impl EditPredictionDelegate for CodestralEditPredictionDelegate {
     ) {
         log::debug!("Codestral: Refresh called (debounce: {})", debounce);
 
+        // Re-trigger key loading in case the env var became available after
+        // the initial (possibly too-early) attempt at startup.
+        load_codestral_api_key(cx).detach();
+
         let Some(api_key) = codestral_api_key(cx) else {
             log::warn!("Codestral: No API key configured, skipping refresh");
             return;

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -552,6 +552,14 @@ impl EditPredictionButton {
 
         CodestralEditPredictionDelegate::ensure_api_key_loaded(cx);
 
+        let codestral_api_key_state = codestral::codestral_api_key_state(cx);
+        cx.observe(&codestral_api_key_state, |_, _, cx| cx.notify())
+            .detach();
+
+        let mercury_api_token = edit_prediction::mercury::mercury_api_token(cx);
+        cx.observe(&mercury_api_token, |_, _, cx| cx.notify())
+            .detach();
+
         Self {
             editor_subscription: None,
             editor_enabled: None,

--- a/crates/env_var/src/env_var.rs
+++ b/crates/env_var/src/env_var.rs
@@ -1,24 +1,34 @@
 use gpui_shared_string::SharedString;
 
+/// A reference to an environment variable that reads its value from the process
+/// environment on each access.
+///
+/// This avoids caching stale values when the process environment is updated
+/// after construction (e.g., when shell environment variables are loaded
+/// asynchronously at startup).
 #[derive(Clone)]
 pub struct EnvVar {
     pub name: SharedString,
-    /// Value of the environment variable. Also `None` when set to an empty string.
-    pub value: Option<String>,
 }
 
 impl EnvVar {
     pub fn new(name: SharedString) -> Self {
-        let value = std::env::var(name.as_str()).ok();
+        Self { name }
+    }
+
+    /// Read the current value of the environment variable.
+    /// Returns `None` if the variable is unset or empty.
+    pub fn value(&self) -> Option<String> {
+        let value = std::env::var(self.name.as_str()).ok();
         if value.as_ref().is_some_and(|v| v.is_empty()) {
-            Self { name, value: None }
+            None
         } else {
-            Self { name, value }
+            value
         }
     }
 
     pub fn or(self, other: EnvVar) -> EnvVar {
-        if self.value.is_some() { self } else { other }
+        if self.value().is_some() { self } else { other }
     }
 }
 
@@ -32,9 +42,11 @@ macro_rules! env_var {
 
 /// Generates a `LazyLock<bool>` expression for use in a `static` declaration. Checks if the
 /// environment variable exists and is non-empty.
+///
+/// Note: Unlike `env_var!`, this captures the value once at first access and does not re-read.
 #[macro_export]
 macro_rules! bool_env_var {
     ($name:expr) => {
-        ::std::sync::LazyLock::new(|| $crate::EnvVar::new(($name).into()).value.is_some())
+        ::std::sync::LazyLock::new(|| $crate::EnvVar::new(($name).into()).value().is_some())
     };
 }

--- a/crates/language_model/src/api_key.rs
+++ b/crates/language_model/src/api_key.rs
@@ -170,10 +170,10 @@ impl ApiKeyState {
             return Task::ready(Ok(()));
         }
 
-        if let Some(key) = &self.env_var.value
+        if let Some(key) = self.env_var.value()
             && !key.is_empty()
         {
-            let api_key = ApiKey::from_env(self.env_var.name.clone(), key);
+            let api_key = ApiKey::from_env(self.env_var.name.clone(), &key);
             self.url = url;
             self.load_status = LoadStatus::Loaded(api_key);
             self.load_task = None;

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -11,7 +11,7 @@ pub use language_model_core::*;
 use anyhow::Result;
 use futures::FutureExt;
 use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
-use gpui::{AnyView, App, AsyncApp, Task, Window};
+use gpui::{AnyView, App, AsyncApp, Global, Task, Window};
 use icons::IconName;
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -21,6 +21,17 @@ pub use crate::model::*;
 pub use crate::registry::*;
 pub use crate::request::{LanguageModelImageExt, gpui_size_to_image_size, image_size_to_gpui};
 pub use env_var::{EnvVar, env_var};
+
+/// Marker global set after the login shell environment has been loaded.
+///
+/// On macOS, apps launched from Dock/Spotlight don't inherit shell environment
+/// variables (including API keys). Zed loads them asynchronously via a login
+/// shell. Subsystems that depend on environment variables (LLM providers, edit
+/// prediction providers) can `cx.observe_global::<ShellEnvLoaded>()` to retry
+/// authentication once the environment is available.
+pub struct ShellEnvLoaded;
+
+impl Global for ShellEnvLoaded {}
 
 pub fn init(cx: &mut App) {
     registry::init(cx);

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -6,7 +6,8 @@ use collections::HashSet;
 use credentials_provider::CredentialsProvider;
 use gpui::{App, Context, Entity};
 use language_model::{
-    ConfiguredModel, LanguageModelProviderId, LanguageModelRegistry, ZED_CLOUD_PROVIDER_ID,
+    ConfiguredModel, LanguageModelProviderId, LanguageModelRegistry, ShellEnvLoaded,
+    ZED_CLOUD_PROVIDER_ID,
 };
 use provider::deepseek::DeepSeekLanguageModelProvider;
 
@@ -154,6 +155,24 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
                 );
             });
             openai_compatible_providers = openai_compatible_providers_new;
+        }
+    })
+    .detach();
+
+    // After the login shell environment has been loaded, re-authenticate all
+    // providers. On macOS, apps launched from Dock/Spotlight don't inherit
+    // shell env vars (including API keys), so the initial authentication
+    // attempt at startup may have found nothing.
+    let registry = LanguageModelRegistry::global(cx).downgrade();
+    cx.observe_global::<ShellEnvLoaded>(move |cx| {
+        let Some(registry) = registry.upgrade() else {
+            return;
+        };
+        let providers = registry.read(cx).providers();
+        for provider in providers {
+            if !provider.is_authenticated(cx) {
+                provider.authenticate(cx).detach();
+            }
         }
     })
     .detach();

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -291,29 +291,28 @@ impl State {
         let credentials_provider = self.credentials_provider.clone();
         cx.spawn(async move |this, cx| {
             // Try environment variables first
-            let (auth, from_env) = if let Some(bearer_token) = &ZED_BEDROCK_BEARER_TOKEN_VAR.value {
+            let (auth, from_env) = if let Some(bearer_token) = ZED_BEDROCK_BEARER_TOKEN_VAR.value()
+            {
                 if !bearer_token.is_empty() {
                     (
                         Some(BedrockAuth::ApiKey {
-                            api_key: bearer_token.to_string(),
+                            api_key: bearer_token,
                         }),
                         true,
                     )
                 } else {
                     (None, false)
                 }
-            } else if let Some(access_key_id) = &ZED_BEDROCK_ACCESS_KEY_ID_VAR.value {
-                if let Some(secret_access_key) = &ZED_BEDROCK_SECRET_ACCESS_KEY_VAR.value {
+            } else if let Some(access_key_id) = ZED_BEDROCK_ACCESS_KEY_ID_VAR.value() {
+                if let Some(secret_access_key) = ZED_BEDROCK_SECRET_ACCESS_KEY_VAR.value() {
                     if !access_key_id.is_empty() && !secret_access_key.is_empty() {
                         let session_token = ZED_BEDROCK_SESSION_TOKEN_VAR
-                            .value
-                            .as_deref()
-                            .filter(|s| !s.is_empty())
-                            .map(|s| s.to_string());
+                            .value()
+                            .filter(|s| !s.is_empty());
                         (
                             Some(BedrockAuth::IamCredentials {
-                                access_key_id: access_key_id.to_string(),
-                                secret_access_key: secret_access_key.to_string(),
+                                access_key_id,
+                                secret_access_key,
                                 session_token,
                             }),
                             true,
@@ -367,9 +366,9 @@ impl State {
     /// Get the resolved region. Checks env var, then settings, then defaults to us-east-1.
     fn get_region(&self) -> String {
         // Priority: env var > settings > default
-        if let Some(region) = ZED_BEDROCK_REGION_VAR.value.as_deref() {
+        if let Some(region) = ZED_BEDROCK_REGION_VAR.value() {
             if !region.is_empty() {
-                return region.to_string();
+                return region;
             }
         }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -407,16 +407,19 @@ fn main() {
     );
 
     let (shell_env_loaded_tx, shell_env_loaded_rx) = oneshot::channel();
+    let (shell_env_global_tx, shell_env_global_rx) = oneshot::channel::<()>();
     if !stdout_is_a_pty() {
         app.background_executor()
             .spawn(async {
                 #[cfg(unix)]
                 util::load_login_shell_environment().await.log_err();
                 shell_env_loaded_tx.send(()).ok();
+                shell_env_global_tx.send(()).ok();
             })
-            .detach()
+            .detach();
     } else {
-        drop(shell_env_loaded_tx)
+        drop(shell_env_loaded_tx);
+        drop(shell_env_global_tx);
     }
 
     app.on_open_urls({
@@ -662,6 +665,17 @@ fn main() {
         web_search_providers::init(app_state.client.clone(), app_state.user_store.clone(), cx);
         snippet_provider::init(cx);
         edit_prediction_registry::init(app_state.client.clone(), app_state.user_store.clone(), cx);
+
+        // After the login shell environment has been loaded, set a global so
+        // subsystems can re-check environment-variable-based API keys.
+        cx.spawn(async move |cx| {
+            shell_env_global_rx.await.ok();
+            cx.update(|cx| {
+                cx.set_global(language_model::ShellEnvLoaded);
+            });
+        })
+        .detach();
+
         let prompt_builder = PromptBuilder::load(app_state.fs.clone(), stdout_is_a_pty(), cx);
         project::AgentRegistryStore::init_global(
             cx,

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -6,6 +6,7 @@ use edit_prediction::{EditPredictionModel, ZedEditPredictionDelegate};
 use editor::Editor;
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{EditPredictionProvider, all_language_settings};
+use language_model::ShellEnvLoaded;
 
 use settings::{EditPredictionPromptFormat, SettingsStore};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
@@ -100,6 +101,23 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
                     cx,
                 );
             }
+        }
+    })
+    .detach();
+
+    // After the login shell environment has been loaded, re-trigger API key
+    // loading for providers that use environment variables. On macOS, apps
+    // launched from Dock/Spotlight don't inherit shell env vars, so the
+    // initial key load at startup may have found nothing.
+    cx.observe_global::<ShellEnvLoaded>(move |cx| {
+        let provider_config = edit_prediction_provider_config_for_settings(cx);
+        if provider_config == Some(EditPredictionProviderConfig::Codestral) {
+            load_codestral_api_key(cx).detach();
+        }
+        if let Some(EditPredictionProviderConfig::Zed(EditPredictionModel::Mercury)) =
+            provider_config
+        {
+            edit_prediction::mercury::load_mercury_api_token(cx).detach();
         }
     })
     .detach();


### PR DESCRIPTION
## Summary

- Fix race condition where environment variables (API keys for LLM providers, `ZED_*` settings) are not available when Zed is launched from macOS Dock/Spotlight or Linux `.desktop` files
- Affects all env-var-based API keys: Anthropic, OpenAI, Mistral, DeepSeek, xAI, OpenRouter, Codestral, Mercury, Bedrock, and more
- Related: #46506

## Background

On macOS, apps launched from the Dock are started by `launchd`, which does not inherit shell environment variables. Zed compensates by spawning the user's login shell asynchronously to capture its environment. However, API key loading runs at startup before this async shell env loading completes, so keys are permanently missed.

There are two root causes:

**1. `EnvVar` cached stale values.** In Dec 2025, `0283bfb049` introduced `ApiKeyState` with `EnvVar`/`LazyLock`, which read env vars once at construction time and cached the result. Since `LazyLock` statics are initialized during app startup — before async shell env loading completes — they permanently cached `None`.

**2. Nothing retried key loading after shell env loaded.** The `shell_env_loaded` signal only gated `NodeRuntime`. LLM providers and edit prediction providers (Codestral, Mercury) loaded keys once at startup, found nothing, and never retried.

## Approach

### Commit 1: `EnvVar` live reads

`EnvVar` no longer caches the value. The `LazyLock` now only stores the variable name; `.value()` calls `std::env::var()` on each access. This means any code that calls `load_if_needed` after shell env has loaded will find the env var.

### Commit 2: `ShellEnvLoaded` global + retry

Introduce a `ShellEnvLoaded` marker global (set via `cx.set_global` after login shell env loading completes). Subsystems observe it to retry authentication:

- **LLM providers** (`language_models::init`): `observe_global::<ShellEnvLoaded>` iterates over all registered providers and calls `authenticate()` on any that aren't yet authenticated. The existing notification chain (`provider.cx.notify()` → registry `ProviderStateChanged` → agent panel re-render) handles UI updates.

- **Edit prediction providers** (`edit_prediction_registry::init`): `observe_global::<ShellEnvLoaded>` re-triggers `load_codestral_api_key` and `load_mercury_api_token` depending on the active provider.

- **Status bar button** (`edit_prediction_button.rs`): Observes the Codestral and Mercury `ApiKeyState` entities so it re-renders when keys load (removing the red "missing key" indicator).

- **Codestral `refresh()`**: Belt-and-suspenders — also retries `load_codestral_api_key` on each prediction request, ensuring the key is picked up even if the global signal was missed.

This approach avoids blocking startup, doesn't change the async shell env loading strategy, and works for all providers uniformly.

## Files changed

| File | Change |
|---|---|
| `crates/env_var/src/env_var.rs` | `EnvVar.value`: cached field → live `std::env::var()` method |
| `crates/language_model/src/api_key.rs` | `.value` → `.value()` call sites |
| `crates/language_model/src/language_model.rs` | Define `ShellEnvLoaded` marker global |
| `crates/language_models/src/language_models.rs` | Re-authenticate all LLM providers on `ShellEnvLoaded` |
| `crates/language_models/src/provider/bedrock.rs` | `.value` → `.value()` call sites |
| `crates/agent_servers/src/custom.rs` | `.value` → `.value()` call sites |
| `crates/zed/src/main.rs` | Set `ShellEnvLoaded` global after shell env loads |
| `crates/zed/src/zed/edit_prediction_registry.rs` | Retry Codestral/Mercury key loading on `ShellEnvLoaded` |
| `crates/codestral/src/codestral.rs` | Retry key loading in `refresh()` |
| `crates/edit_prediction_ui/src/edit_prediction_button.rs` | Observe Codestral/Mercury key entities for re-render |

Release Notes:

- Fixed environment variables from shell configuration (API keys, etc.) not being available when launching Zed from macOS Dock/Spotlight or Linux desktop launchers