### PR TITLE
Fix rendering error of the selection box when text is fully selected by mouse events in Markdown

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -872,6 +872,10 @@ impl Selection {
     fn tail(&self) -> usize {
         if self.reversed { self.end } else { self.start }
     }
+
+    fn contains(&self, source_index: usize) -> bool {
+        self.start <= self.end && (self.start..self.end).contains(&source_index)
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1335,6 +1339,14 @@ impl MarkdownElement {
                                     cx.notify();
                                     return;
                                 }
+                            }
+                            // If the location of a single-click event falls within the existing selection from the previous frame,
+                            // the selection should not be reset.
+                            if event.click_count == 1 && markdown.selection.contains(source_index) {
+                                window.focus(&markdown.focus_handle, cx);
+                                window.prevent_default();
+                                cx.notify();
+                                return;
                             }
                             let (range, mode) = match event.click_count {
                                 1 => {


### PR DESCRIPTION
In Markdown, four or more consecutive left-clicks cause Zed to select all rendered text. Yet, despite the text being fully selected (copyable via Command+C), the visual selection highlight fails to render highlight.

<img width="958" height="287" alt="图片" src="https://github.com/user-attachments/assets/61da287a-3901-4389-b631-c74c3af8ce4d" />

As illustrated above, when all rendered text in the floating Markdown window is selected, Command+C copies it successfully, yet the selection highlight fails to render. The fixed version is shown below.         

<img width="655" height="471" alt="图片" src="https://github.com/user-attachments/assets/d2a001b4-dea8-4ac6-9a33-7a2ed9ca1699" />

Self-Review Checklist:

- [ x ] I've reviewed my own diff for quality, security, and reliability
- [ x ] Unsafe blocks (if any) have justifying comments
- [ x ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ x ] Tests cover the new/changed behavior
- [ x ] Performance impact has been considered and is acceptable

Release Notes:

- Fixed markdown all selection highlight render error