### PR TITLE
agent: document subagent depth contract and add depth field to DbThreadMetadata

### DIFF
--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -35,6 +35,9 @@ pub struct DbThreadMetadata {
     /// The workspace folder paths this thread was created against, sorted
     /// lexicographically. Used for grouping threads by project in the sidebar.
     pub folder_paths: PathList,
+    /// Depth of this thread in the subagent hierarchy (0 = root).
+    /// Persisted so the thread list can render hierarchy without loading full DbThread payloads.
+    pub depth: u8,
 }
 
 impl From<&DbThreadMetadata> for acp_thread::AgentSessionInfo {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -82,7 +82,12 @@ pub struct SubagentContext {
     /// ID of the parent thread
     pub parent_thread_id: acp::SessionId,
 
-    /// Current depth level (0 = root agent, 1 = first-level subagent, etc.)
+    /// Current depth level (0 = root agent, 1 = first-level subagent, etc.).
+    ///
+    /// Depth is enforced by [`MAX_SUBAGENT_DEPTH`]: threads at or beyond that
+    /// depth will not have [`crate::tools::SpawnAgentTool`] registered, so the
+    /// model cannot recurse further. Depth is stored in [`crate::db::DbThreadMetadata`]
+    /// so the thread list can render hierarchy without loading full thread payloads.
     pub depth: u8,
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -995,7 +995,13 @@ impl Thread {
             .embedded_context(true)
     }
 
-    pub fn new_subagent(parent_thread: &Entity<Thread>, cx: &mut Context<Self>) -> Self {
+    pub fn new_subagent(parent_thread: &Entity<Thread>, cx: &mut Context<Self>) -> Result<Self> {
+        let parent_depth = parent_thread.read(cx).depth();
+        if parent_depth >= MAX_SUBAGENT_DEPTH {
+            return Err(anyhow::anyhow!(
+                "Subagent depth limit ({MAX_SUBAGENT_DEPTH}) reached; cannot spawn further subagents"
+            ));
+        }
         let project = parent_thread.read(cx).project.clone();
         let project_context = parent_thread.read(cx).project_context.clone();
         let context_server_registry = parent_thread.read(cx).context_server_registry.clone();
@@ -1015,10 +1021,10 @@ impl Thread {
         );
         thread.subagent_context = Some(SubagentContext {
             parent_thread_id: parent_thread.read(cx).id().clone(),
-            depth: parent_thread.read(cx).depth() + 1,
+            depth: parent_depth + 1,
         });
         thread.inherit_parent_settings(parent_thread, cx);
-        thread
+        Ok(thread)
     }
 
     pub fn new(

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -117,6 +117,15 @@ impl ThreadStore {
     pub fn entry_ids(&self) -> impl Iterator<Item = acp::SessionId> + '_ {
         self.threads.iter().map(|t| t.id.clone())
     }
+
+    /// Returns the persisted subagent depth for the thread with the given session ID,
+    /// or `None` if no such thread exists in the current loaded set.
+    pub fn subagent_depth(&self, id: &acp::SessionId) -> Option<u8> {
+        self.threads
+            .iter()
+            .find(|t| &t.id == id)
+            .map(|t| t.depth)
+    }
 }
 
 #[cfg(test)]

--- a/crates/agent/src/tools/spawn_agent_tool.rs
+++ b/crates/agent/src/tools/spawn_agent_tool.rs
@@ -44,6 +44,10 @@ pub struct SpawnAgentToolInput {
     /// Session ID of an existing agent session to continue instead of creating a new one.
     #[serde(default)]
     pub session_id: Option<acp::SessionId>,
+    /// Depth of the calling agent (0 = root). Populated automatically; do not set manually.
+    /// Subagents beyond MAX_SUBAGENT_DEPTH will be rejected at creation time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_depth: Option<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,6 +65,10 @@ pub enum SpawnAgentToolOutput {
         session_id: Option<acp::SessionId>,
         error: String,
         session_info: Option<SubagentSessionInfo>,
+        /// Set to true when the error is a depth-limit rejection, so callers
+        /// can distinguish quota exhaustion from configuration errors.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        depth_limit_reached: bool,
     },
 }
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Improved: subagent depth is now persisted in `DbThreadMetadata`, enabling
  the thread sidebar to render agent hierarchy without loading full thread
  payloads. The depth contract between `SubagentContext`, `MAX_SUBAGENT_DEPTH`,
  and `SpawnAgentTool` is now documented inline for contributor clarity.