### PR TITLE
git_graph: fix the misalignment between the canvas and table

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -927,10 +927,13 @@ impl GitGraph {
         cx.notify();
     }
 
-    fn row_height(cx: &App) -> Pixels {
+    fn row_height(window: &Window, cx: &App) -> Pixels {
         let settings = ThemeSettings::get_global(cx);
         let font_size = settings.buffer_font_size(cx);
-        font_size + px(12.0)
+        let raw = font_size + px(12.0);
+        let scale = window.scale_factor();
+
+        (raw * scale).round() / scale
     }
 
     fn graph_canvas_content_width(&self) -> Pixels {
@@ -1035,10 +1038,10 @@ impl GitGraph {
                 ],
             )
         });
-        let mut row_height = Self::row_height(cx);
+        let mut row_height = Self::row_height(window, cx);
 
-        cx.observe_global_in::<settings::SettingsStore>(window, move |this, _window, cx| {
-            let new_row_height = Self::row_height(cx);
+        cx.observe_global_in::<settings::SettingsStore>(window, move |this, window, cx| {
+            let new_row_height = Self::row_height(window, cx);
             if new_row_height != row_height {
                 this.row_height = new_row_height;
                 this.table_interaction_state.update(cx, |state, _cx| {
@@ -3081,12 +3084,12 @@ mod tests {
     use fs::FakeFs;
     use git::Oid;
     use git::repository::InitialGraphCommitData;
-    use gpui::TestAppContext;
+    use gpui::{TestAppContext, UpdateGlobal};
     use project::Project;
     use project::git_store::{GitStoreEvent, RepositoryEvent};
     use rand::prelude::*;
     use serde_json::json;
-    use settings::SettingsStore;
+    use settings::{SettingsStore, ThemeSettingsContent};
     use smallvec::{SmallVec, smallvec};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
@@ -4178,6 +4181,95 @@ mod tests {
                 absolute_calc_row,
                 Some(1),
                 "Row calculation should yield absolute row exactly"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_row_height_matches_uniform_list_item_height(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.theme = Box::new(ThemeSettingsContent {
+                        ui_font_size: Some(12.7.into()),
+                        buffer_font_size: Some(13.7.into()),
+                        ..Default::default()
+                    })
+                });
+            })
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            serde_json::json!({
+                ".git": {},
+                "file.txt": "content",
+            }),
+        )
+        .await;
+
+        let mut rng = StdRng::seed_from_u64(99);
+        let commits = generate_random_commit_dag(&mut rng, 20, false);
+        fs.set_graph_commits(Path::new("/project/.git"), commits);
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        cx.run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("should have a repository")
+        });
+
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+
+        let workspace_weak =
+            multi_workspace.read_with(&*cx, |multi, _| multi.workspace().downgrade());
+
+        let git_graph = cx.new_window_entity(|window, cx| {
+            GitGraph::new(
+                repository.read(cx).id,
+                project.read(cx).git_store().clone(),
+                workspace_weak,
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        cx.draw(
+            point(px(0.), px(0.)),
+            gpui::size(px(1200.), px(800.)),
+            |_, _| git_graph.clone().into_any_element(),
+        );
+        cx.run_until_parked();
+
+        git_graph.read_with(&*cx, |graph, cx| {
+            let commit_count = graph.graph_data.commits.len();
+            assert!(
+                commit_count > 0,
+                "need at least one commit to measure item height"
+            );
+
+            let table_state = graph.table_interaction_state.read(cx);
+            let item_size = table_state.scroll_handle.0.borrow().last_item_size.expect(
+                "uniform_list should have populated last_item_size after draw(); \
+                     the table has not been laid out",
+            );
+
+            let measured_item_height = item_size.contents.height / commit_count as f32;
+
+            assert_eq!(
+                graph.row_height, measured_item_height,
+                "GitGraph::row_height ({}) must exactly match the height that \
+                 uniform_list measured for each table row ({}). \
+                 A mismatch means the canvas and table rows will drift when scrolling.",
+                graph.row_height, measured_item_height,
             );
         });
     }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53469

The git graph panel consists of two separate components: the graph canvas and the commit info table. While they are rendered using different methods, their vertical layout both depend on the `row_height` property.

https://github.com/zed-industries/zed/blob/ec9be5c332f79986b046a2985e003766591ec82f/crates/git_graph/src/git_graph.rs#L930-L934

The discrepancy arises because the canvas rendering adopts the floating-point `row_height` directly, whereas the commit info table is implemented via GPUI's `uniform_list`. The underlying layout engine for the table intrinsically snaps elements to physical device pixels. When `display_scale * buffer_font_size` results in a fractional logical pixel value, the table's snapped row height slightly differs from the raw float used by the canvas. Over many rows, this compounding subpixel difference creates a noticeable visual mismatch.

This change fixes the issue by explicitly snapping the computed `row_height` property to the nearest physical pixel boundary beforehand. Because both the canvas math and the table's layout engine now operate on the exact same rounded device-pixel height, they remain perfectly aligned regardless of fractional font scaling.

Release Notes:

- Fixed an issue where the git graph lines would become vertically misaligned with the commit list alongside it when `buffer_font_size` set to non-integer.