### PR TITLE
vim: Ensure vgl does not select newline in helix mode

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -157,6 +157,26 @@ impl Vim {
                     }
 
                     let (new_head, goal) = match motion {
+                        // EndOfLine positions after the last character, but in
+                        // helix visual mode we want the selection to end ON the
+                        // last character. Adjust left here so the subsequent
+                        // right-expansion (below) includes the last char without
+                        // spilling into the newline.
+                        Motion::EndOfLine { .. } => {
+                            let (point, _goal) = motion
+                                .move_point(
+                                    map,
+                                    current_head,
+                                    selection.goal,
+                                    times,
+                                    &text_layout_details,
+                                )
+                                .unwrap_or((current_head, selection.goal));
+                            (
+                                movement::saturating_left(map, point),
+                                SelectionGoal::None,
+                            )
+                        }
                         // Going to next word start is special cased
                         // since Vim differs from Helix in that motion
                         // Vim: `w` goes to the first character of a word
@@ -1989,6 +2009,23 @@ mod test {
         cx.set_state("ˇhello", Mode::HelixNormal);
         cx.simulate_keystrokes("l v l l");
         cx.assert_state("h«ellˇ»o", Mode::HelixSelect);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_end_of_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // v g l d should delete to end of line without consuming the newline
+        cx.set_state("ˇThe quick brown\nfox jumps over", Mode::HelixNormal);
+        cx.simulate_keystrokes("v g l d");
+        cx.assert_state("ˇ\nfox jumps over", Mode::HelixNormal);
+
+        // same from the middle of a line — cursor lands on the last
+        // remaining character (the space) after delete
+        cx.set_state("The ˇquick brown\nfox jumps over", Mode::HelixNormal);
+        cx.simulate_keystrokes("v g l d");
+        cx.assert_state("Theˇ \nfox jumps over", Mode::HelixNormal);
     }
 
     #[gpui::test]

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -163,7 +163,7 @@ impl Vim {
                         // right-expansion (below) includes the last char without
                         // spilling into the newline.
                         Motion::EndOfLine { .. } => {
-                            let (point, _goal) = motion
+                            let (point, goal) = motion
                                 .move_point(
                                     map,
                                     current_head,
@@ -172,10 +172,7 @@ impl Vim {
                                     &text_layout_details,
                                 )
                                 .unwrap_or((current_head, selection.goal));
-                            (
-                                movement::saturating_left(map, point),
-                                SelectionGoal::None,
-                            )
+                            (movement::saturating_left(map, point), goal)
                         }
                         // Going to next word start is special cased
                         // since Vim differs from Helix in that motion


### PR DESCRIPTION
### Ensure that vgl does not select the newline instead of last character.

EndOfLine positions after the last character, but in helix visual mode we want the selection to end ON the last character. Adjust left so the subsequent
right-expansion includes the last char without
spilling into the newline.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments (N/A, no unsafe used)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes: [54195](https://github.com/zed-industries/zed/issues/54195)

Release Notes:

- ***Fixed:*** _Helix vgl now correctly selects to end of line without including the newline character in the selection._
