### PR TITLE
vim: Add noremap support to SendKeystrokes

### DIFF
--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -449,16 +449,20 @@ impl DispatchTree {
         &self,
         input: &[Keystroke],
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
+        skip_send_keystrokes_remap: bool,
     ) -> (SmallVec<[KeyBinding; 1]>, bool, Vec<KeyContext>) {
         let context_stack: Vec<KeyContext> = dispatch_path
             .iter()
             .filter_map(|node_id| self.node(*node_id).context.clone())
             .collect();
 
-        let (bindings, partial) = self
-            .keymap
-            .borrow()
-            .bindings_for_input(input, &context_stack);
+        let (bindings, partial) =
+            self.keymap
+                .borrow()
+                .bindings_for_input_filtered(input, &context_stack, |binding| {
+                    skip_send_keystrokes_remap
+                        && binding.action().name() == "workspace::SendKeystrokes"
+                });
         (bindings, partial, context_stack)
     }
 
@@ -485,9 +489,11 @@ impl DispatchTree {
         mut input: SmallVec<[Keystroke; 1]>,
         keystroke: Keystroke,
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
+        skip_send_keystrokes_remap: bool,
     ) -> DispatchResult {
         input.push(keystroke.clone());
-        let (bindings, pending, context_stack) = self.bindings_for_input(&input, dispatch_path);
+        let (bindings, pending, context_stack) =
+            self.bindings_for_input(&input, dispatch_path, skip_send_keystrokes_remap);
 
         if pending {
             return DispatchResult {
@@ -510,9 +516,11 @@ impl DispatchTree {
         }
         input.pop();
 
-        let (suffix, mut to_replay) = self.replay_prefix(input, dispatch_path);
+        let (suffix, mut to_replay) =
+            self.replay_prefix(input, dispatch_path, skip_send_keystrokes_remap);
 
-        let mut result = self.dispatch_key(suffix, keystroke, dispatch_path);
+        let mut result =
+            self.dispatch_key(suffix, keystroke, dispatch_path, skip_send_keystrokes_remap);
         to_replay.extend(result.to_replay);
         result.to_replay = to_replay;
         result
@@ -524,11 +532,13 @@ impl DispatchTree {
         &mut self,
         input: SmallVec<[Keystroke; 1]>,
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
+        skip_send_keystrokes_remap: bool,
     ) -> SmallVec<[Replay; 1]> {
-        let (suffix, mut to_replay) = self.replay_prefix(input, dispatch_path);
+        let (suffix, mut to_replay) =
+            self.replay_prefix(input, dispatch_path, skip_send_keystrokes_remap);
 
         if !suffix.is_empty() {
-            to_replay.extend(self.flush_dispatch(suffix, dispatch_path))
+            to_replay.extend(self.flush_dispatch(suffix, dispatch_path, skip_send_keystrokes_remap))
         }
 
         to_replay
@@ -539,10 +549,15 @@ impl DispatchTree {
         &self,
         mut input: SmallVec<[Keystroke; 1]>,
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
+        skip_send_keystrokes_remap: bool,
     ) -> (SmallVec<[Keystroke; 1]>, SmallVec<[Replay; 1]>) {
         let mut to_replay: SmallVec<[Replay; 1]> = Default::default();
         for last in (0..input.len()).rev() {
-            let (bindings, _, _) = self.bindings_for_input(&input[0..=last], dispatch_path);
+            let (bindings, _, _) = self.bindings_for_input(
+                &input[0..=last],
+                dispatch_path,
+                skip_send_keystrokes_remap,
+            );
             if !bindings.is_empty() {
                 to_replay.push(Replay {
                     keystroke: input.drain(0..=last).next_back().unwrap(),
@@ -740,7 +755,7 @@ mod tests {
             key: &str,
             path: &DispatchPath,
         ) -> DispatchResult {
-            tree.dispatch_key(pending, Keystroke::parse(key).unwrap(), path)
+            tree.dispatch_key(pending, Keystroke::parse(key).unwrap(), path, false)
         }
 
         let dispatch_path: DispatchPath = SmallVec::new();

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -167,10 +167,27 @@ impl Keymap {
         input: &[impl AsKeystroke],
         context_stack: &[KeyContext],
     ) -> (SmallVec<[KeyBinding; 1]>, bool) {
+        self.bindings_for_input_filtered(input, context_stack, |_| false)
+    }
+
+    /// Returns bindings for the given input while allowing callers to skip matching bindings.
+    pub fn bindings_for_input_filtered<T, F>(
+        &self,
+        input: &[T],
+        context_stack: &[KeyContext],
+        should_skip: F,
+    ) -> (SmallVec<[KeyBinding; 1]>, bool)
+    where
+        T: AsKeystroke,
+        F: Fn(&KeyBinding) -> bool,
+    {
         let mut matched_bindings = SmallVec::<[(usize, BindingIndex, &KeyBinding); 1]>::new();
         let mut pending_bindings = SmallVec::<[(BindingIndex, &KeyBinding); 1]>::new();
 
         for (ix, binding) in self.bindings().enumerate().rev() {
+            if should_skip(binding) {
+                continue;
+            }
             let Some(depth) = self.binding_enabled(binding, context_stack) else {
                 continue;
             };

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -991,6 +991,7 @@ pub struct Window {
     focus_enabled: bool,
     pending_input: Option<PendingInput>,
     pending_modifier: ModifierState,
+    skip_send_keystrokes_remap: bool,
     pub(crate) pending_input_observers: SubscriberSet<(), AnyObserver>,
     prompt: Option<RenderablePromptHandle>,
     pub(crate) client_inset: Option<Pixels>,
@@ -1148,6 +1149,7 @@ struct PendingInput {
     focus: Option<FocusId>,
     timer: Option<Task<()>>,
     needs_timeout: bool,
+    skip_send_keystrokes_remap: bool,
 }
 
 pub(crate) struct ElementStateBox {
@@ -1599,6 +1601,7 @@ impl Window {
             focus_enabled: true,
             pending_input: None,
             pending_modifier: ModifierState::default(),
+            skip_send_keystrokes_remap: false,
             pending_input_observers: SubscriberSet::new(),
             prompt: None,
             client_inset: None,
@@ -4219,6 +4222,15 @@ impl Window {
         false
     }
 
+    /// Dispatch a given keystroke as though the user had typed it, without expanding
+    /// `workspace::SendKeystrokes` bindings.
+    pub fn dispatch_keystroke_no_remap(&mut self, keystroke: Keystroke, cx: &mut App) -> bool {
+        self.skip_send_keystrokes_remap = true;
+        let handled = self.dispatch_keystroke(keystroke, cx);
+        self.skip_send_keystrokes_remap = false;
+        handled
+    }
+
     /// Return a key binding string for an action, to display in the UI. Uses the highest precedence
     /// binding for the action (last binding added to the keymap).
     pub fn keystroke_text_for(&self, action: &dyn Action) -> String {
@@ -4483,14 +4495,18 @@ impl Window {
             currently_pending = PendingInput::default();
         }
 
+        let skip_send_keystrokes_remap =
+            currently_pending.skip_send_keystrokes_remap || self.skip_send_keystrokes_remap;
+
         let match_result = self.rendered_frame.dispatch_tree.dispatch_key(
             currently_pending.keystrokes,
             keystroke,
             &dispatch_path,
+            skip_send_keystrokes_remap,
         );
 
         if !match_result.to_replay.is_empty() {
-            self.replay_pending_input(match_result.to_replay, cx);
+            self.replay_pending_input(match_result.to_replay, skip_send_keystrokes_remap, cx);
             cx.propagate_event = true;
         }
 
@@ -4498,6 +4514,7 @@ impl Window {
             currently_pending.timer.take();
             currently_pending.keystrokes = match_result.pending;
             currently_pending.focus = self.focus;
+            currently_pending.skip_send_keystrokes_remap = skip_send_keystrokes_remap;
 
             let text_input_requires_timeout = event
                 .downcast_ref::<KeyDownEvent>()
@@ -4528,13 +4545,18 @@ impl Window {
                         let dispatch_path =
                             window.rendered_frame.dispatch_tree.dispatch_path(node_id);
 
-                        let to_replay = window
-                            .rendered_frame
-                            .dispatch_tree
-                            .flush_dispatch(currently_pending.keystrokes, &dispatch_path);
+                        let to_replay = window.rendered_frame.dispatch_tree.flush_dispatch(
+                            currently_pending.keystrokes,
+                            &dispatch_path,
+                            currently_pending.skip_send_keystrokes_remap,
+                        );
 
                         window.pending_input_changed(cx);
-                        window.replay_pending_input(to_replay, cx)
+                        window.replay_pending_input(
+                            to_replay,
+                            currently_pending.skip_send_keystrokes_remap,
+                            cx,
+                        )
                     })
                     .log_err();
                 }));
@@ -4676,7 +4698,12 @@ impl Window {
             .map(|pending_input| pending_input.keystrokes.as_slice())
     }
 
-    fn replay_pending_input(&mut self, replays: SmallVec<[Replay; 1]>, cx: &mut App) {
+    fn replay_pending_input(
+        &mut self,
+        replays: SmallVec<[Replay; 1]>,
+        skip_send_keystrokes_remap: bool,
+        cx: &mut App,
+    ) {
         let node_id = self.focus_node_id_in_rendered_frame(self.focus);
         let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
 
@@ -4689,6 +4716,11 @@ impl Window {
 
             cx.propagate_event = true;
             for binding in replay.bindings {
+                if skip_send_keystrokes_remap
+                    && binding.action().name() == "workspace::SendKeystrokes"
+                {
+                    continue;
+                }
                 self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
                 if !cx.propagate_event {
                     self.dispatch_keystroke_observers(

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -819,7 +819,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
             return;
         };
         let task = workspace.update(cx, |workspace, cx| {
-            workspace.send_keystrokes_impl(keystrokes, window, cx)
+            workspace.send_keystrokes_impl(keystrokes, false, window, cx)
         });
         let had_range = action.range.is_some();
         let had_override = action.override_rows.is_some();

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1287,7 +1287,7 @@ async fn test_remap(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g z",
-            workspace::SendKeystrokes("l l l l".to_string()),
+            workspace::SendKeystrokes::new("l l l l"),
             None,
         )])
     });
@@ -1299,7 +1299,7 @@ async fn test_remap(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g y",
-            workspace::SendKeystrokes("i f o o escape l".to_string()),
+            workspace::SendKeystrokes::new("i f o o escape l"),
             None,
         )])
     });
@@ -1311,7 +1311,7 @@ async fn test_remap(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g x",
-            workspace::SendKeystrokes("g z g y".to_string()),
+            workspace::SendKeystrokes::new("g z g y"),
             None,
         )])
     });
@@ -1323,7 +1323,7 @@ async fn test_remap(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g w",
-            workspace::SendKeystrokes(": j enter".to_string()),
+            workspace::SendKeystrokes::new(": j enter"),
             None,
         )])
     });
@@ -1335,7 +1335,7 @@ async fn test_remap(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g u",
-            workspace::SendKeystrokes("g w g z".to_string()),
+            workspace::SendKeystrokes::new("g w g z"),
             None,
         )])
     });
@@ -1347,7 +1347,7 @@ async fn test_remap(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g t",
-            workspace::SendKeystrokes("i space escape".to_string()),
+            workspace::SendKeystrokes::new("i space escape"),
             None,
         )])
     });
@@ -1944,12 +1944,12 @@ async fn test_remap_adjacent_dog_cat(cx: &mut gpui::TestAppContext) {
         cx.bind_keys([
             KeyBinding::new(
                 "d o g",
-                workspace::SendKeystrokes("🐶".to_string()),
+                workspace::SendKeystrokes::new("🐶"),
                 Some("vim_mode == insert"),
             ),
             KeyBinding::new(
                 "c a t",
-                workspace::SendKeystrokes("🐱".to_string()),
+                workspace::SendKeystrokes::new("🐱"),
                 Some("vim_mode == insert"),
             ),
         ])
@@ -1978,17 +1978,17 @@ async fn test_remap_nested_pineapple(cx: &mut gpui::TestAppContext) {
         cx.bind_keys([
             KeyBinding::new(
                 "p i n",
-                workspace::SendKeystrokes("📌".to_string()),
+                workspace::SendKeystrokes::new("📌"),
                 Some("vim_mode == insert"),
             ),
             KeyBinding::new(
                 "p i n e",
-                workspace::SendKeystrokes("🌲".to_string()),
+                workspace::SendKeystrokes::new("🌲"),
                 Some("vim_mode == insert"),
             ),
             KeyBinding::new(
                 "p i n e a p p l e",
-                workspace::SendKeystrokes("🍍".to_string()),
+                workspace::SendKeystrokes::new("🍍"),
                 Some("vim_mode == insert"),
             ),
         ])
@@ -2021,12 +2021,12 @@ async fn test_remap_recursion(cx: &mut gpui::TestAppContext) {
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "x",
-            workspace::SendKeystrokes("\" _ x".to_string()),
+            workspace::SendKeystrokes::new("\" _ x"),
             Some("VimControl"),
         )]);
         cx.bind_keys([KeyBinding::new(
             "y",
-            workspace::SendKeystrokes("2 x".to_string()),
+            workspace::SendKeystrokes::new("2 x"),
             Some("VimControl"),
         )])
     });
@@ -2039,6 +2039,72 @@ async fn test_remap_recursion(cx: &mut gpui::TestAppContext) {
     cx.simulate_shared_keystrokes("y").await;
     cx.shared_clipboard().await.assert_eq("h");
     cx.shared_state().await.assert_eq("ˇlo");
+}
+
+#[perf]
+#[gpui::test]
+async fn test_send_keystrokes_noremap(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+    cx.update(|_, cx| {
+        cx.bind_keys([KeyBinding::new(
+            "x",
+            workspace::SendKeystrokes::new("\" _ x"),
+            Some("VimControl"),
+        )]);
+        cx.bind_keys([KeyBinding::new(
+            "y",
+            workspace::SendKeystrokes::Options(workspace::SendKeystrokesOptions {
+                keystrokes: "2 x".to_string(),
+                noremap: true,
+            }),
+            Some("VimControl"),
+        )])
+    });
+
+    cx.set_state("ˇhello", Mode::Normal);
+    cx.simulate_keystrokes("d l");
+    cx.shared_clipboard().assert_eq("h");
+    cx.simulate_keystrokes("y");
+    cx.run_until_parked();
+    cx.shared_clipboard().assert_eq("el");
+    cx.assert_state("ˇlo", Mode::Normal);
+}
+
+#[perf]
+#[gpui::test]
+async fn test_send_keystrokes_noremap_preserved_when_queued(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+    cx.update(|_, cx| {
+        cx.bind_keys([KeyBinding::new(
+            "x",
+            workspace::SendKeystrokes::new("\" _ x"),
+            Some("VimControl"),
+        )]);
+        cx.bind_keys([KeyBinding::new(
+            "y",
+            workspace::SendKeystrokes::Options(workspace::SendKeystrokesOptions {
+                keystrokes: "2 x".to_string(),
+                noremap: true,
+            }),
+            Some("VimControl"),
+        )]);
+        cx.bind_keys([KeyBinding::new(
+            "z",
+            workspace::SendKeystrokes::new("escape"),
+            Some("VimControl"),
+        )])
+    });
+
+    cx.set_state("ˇhello", Mode::Normal);
+    cx.simulate_keystrokes("d l");
+    cx.shared_clipboard().assert_eq("h");
+
+    cx.simulate_keystrokes("z");
+    cx.simulate_keystrokes("y");
+    cx.run_until_parked();
+
+    cx.shared_clipboard().assert_eq("el");
+    cx.assert_state("ˇlo", Mode::Normal);
 }
 
 #[perf]
@@ -2804,7 +2870,7 @@ async fn test_send_keystrokes_underscore_is_literal_46509(cx: &mut gpui::TestApp
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g x",
-            workspace::SendKeystrokes("\" _ x".to_string()),
+            workspace::SendKeystrokes::new("\" _ x"),
             Some("VimControl"),
         )])
     });
@@ -2878,7 +2944,7 @@ async fn test_send_keystrokes_no_key_equivalent_mapping_46509(cx: &mut gpui::Tes
     cx.update(|_, cx| {
         cx.bind_keys([KeyBinding::new(
             "g p",
-            workspace::SendKeystrokes("{".to_string()),
+            workspace::SendKeystrokes::new("{"),
             Some("vim_mode == normal"),
         )])
     });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -451,7 +451,41 @@ pub struct CloseItemInAllPanes {
 /// Sends a sequence of keystrokes to the active element.
 #[derive(Clone, Deserialize, PartialEq, JsonSchema, Action)]
 #[action(namespace = workspace)]
-pub struct SendKeystrokes(pub String);
+#[serde(untagged)]
+pub enum SendKeystrokes {
+    Keystrokes(String),
+    Options(SendKeystrokesOptions),
+}
+
+impl SendKeystrokes {
+    pub fn new(keystrokes: impl Into<String>) -> Self {
+        Self::Keystrokes(keystrokes.into())
+    }
+
+    fn keystrokes(&self) -> &str {
+        match self {
+            Self::Keystrokes(keystrokes) => keystrokes,
+            Self::Options(options) => &options.keystrokes,
+        }
+    }
+
+    fn noremap(&self) -> bool {
+        match self {
+            Self::Keystrokes(_) => false,
+            Self::Options(options) => options.noremap,
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, PartialEq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SendKeystrokesOptions {
+    /// The space-separated keystrokes to dispatch.
+    pub keystrokes: String,
+    /// If true, dispatch the keystrokes without expanding other `SendKeystrokes` remaps.
+    #[serde(default)]
+    pub noremap: bool,
+}
 
 actions!(
     project_symbols,
@@ -1311,9 +1345,15 @@ type PromptForOpenPath = Box<
 
 #[derive(Default)]
 struct DispatchingKeystrokes {
-    dispatched: HashSet<Vec<Keystroke>>,
-    queue: VecDeque<Keystroke>,
+    dispatched: HashSet<Vec<QueuedKeystroke>>,
+    queue: VecDeque<QueuedKeystroke>,
     task: Option<Shared<Task<()>>>,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+struct QueuedKeystroke {
+    keystroke: Keystroke,
+    noremap: bool,
 }
 
 /// Collects everything project-related for a certain window opened.
@@ -3243,7 +3283,7 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         let keystrokes: Vec<Keystroke> = action
-            .0
+            .keystrokes()
             .split(' ')
             .flat_map(|k| Keystroke::parse(k).log_err())
             .map(|k| {
@@ -3253,22 +3293,27 @@ impl Workspace {
                     .clone()
             })
             .collect();
-        let _ = self.send_keystrokes_impl(keystrokes, window, cx);
+        let _ = self.send_keystrokes_impl(keystrokes, action.noremap(), window, cx);
     }
 
     pub fn send_keystrokes_impl(
         &mut self,
         keystrokes: Vec<Keystroke>,
+        noremap: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Shared<Task<()>> {
+        let queued_keystrokes = keystrokes
+            .into_iter()
+            .map(|keystroke| QueuedKeystroke { keystroke, noremap })
+            .collect::<Vec<_>>();
         let mut state = self.dispatching_keystrokes.borrow_mut();
-        if !state.dispatched.insert(keystrokes.clone()) {
+        if !state.dispatched.insert(queued_keystrokes.clone()) {
             cx.propagate();
             return state.task.clone().unwrap();
         }
 
-        state.queue.extend(keystrokes);
+        state.queue.extend(queued_keystrokes);
 
         let keystrokes = self.dispatching_keystrokes.clone();
         if state.task.is_none() {
@@ -3277,18 +3322,26 @@ impl Workspace {
                     .spawn(cx, async move |cx| {
                         // limit to 100 keystrokes to avoid infinite recursion.
                         for _ in 0..100 {
-                            let keystroke = {
+                            let queued_keystroke = {
                                 let mut state = keystrokes.borrow_mut();
-                                let Some(keystroke) = state.queue.pop_front() else {
+                                let Some(queued_keystroke) = state.queue.pop_front() else {
                                     state.dispatched.clear();
                                     state.task.take();
                                     return;
                                 };
-                                keystroke
+                                queued_keystroke
                             };
                             cx.update(|window, cx| {
                                 let focused = window.focused(cx);
-                                window.dispatch_keystroke(keystroke.clone(), cx);
+                                if queued_keystroke.noremap {
+                                    window.dispatch_keystroke_no_remap(
+                                        queued_keystroke.keystroke.clone(),
+                                        cx,
+                                    );
+                                } else {
+                                    window
+                                        .dispatch_keystroke(queued_keystroke.keystroke.clone(), cx);
+                                }
                                 if window.focused(cx) != focused {
                                     // dispatch_keystroke may cause the focus to change.
                                     // draw's side effect is to schedule the FocusChanged events in the current flush effect cycle

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -285,6 +285,24 @@ The argument to `SendKeystrokes` is a space-separated list of keystrokes (using 
 
 If the argument to `SendKeystrokes` contains the binding used to trigger it, it will use the next-highest-precedence definition of that binding. This allows you to extend the default behavior of a key binding.
 
+If you need Vim-style `noremap` behavior, pass an object instead of a string:
+
+```json [keymap]
+[
+  {
+    "context": "VimControl",
+    "bindings": {
+      "y": [
+        "workspace::SendKeystrokes",
+        { "keystrokes": "2 x", "noremap": true }
+      ]
+    }
+  }
+]
+```
+
+`noremap` defaults to `false`, which preserves the current behavior.
+
 ### Forward keys to terminal
 
 If you're on Linux or Windows, you might find yourself wanting to forward key combinations to the built-in terminal instead of them being handled by Zed.


### PR DESCRIPTION
This feature is for people like me, coming from Neovim.

In Neovim/Vim, there is an option for keymaps being recursive or not.  
This is called noremap in Vim and was required for bringing my keymaps I am used to on Neovim to Zed.
Since I am not alone with this problem, I implemented it.

In my case, I wanted to change the clipboard behavior. `d` for deleting without writing to clipboard. `x` for cutting to clipboard. etc. This requires a non-recursive keymap. Zed's keymaps being recursive, makes this impossible.

For your information, I am inexperienced in Rust.

What changed:
- SendKeystrokes changed from a plain string action to an enum that accepts either:
  - a string, preserving old behavior
  - an object with keystrokes and noremap
- dispatch logic now respects noremap per queued synthetic keystroke
- tests and docs were added for the new behavior

Why:
- allow Vim-style non-recursive remaps
- keep existing keymaps working unchanged
- avoid queued keystrokes accidentally inheriting wrong remap mode