### PR TITLE
markdown: Fix rendering error of the selection box when text is fully selected by mouse events in Markdown

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2848,15 +2848,17 @@ impl RenderedText {
         for line in self.lines.iter() {
             let line_source_start = line.source_mappings.first().unwrap().source_index;
             if source_index < line_source_start {
-                break;
-            } else if source_index > line.source_end {
-                continue;
-            } else {
                 let line_height = line.layout.line_height();
-                let rendered_index_within_line = line.rendered_index_for_source_index(source_index);
-                let position = line.layout.position_for_index(rendered_index_within_line)?;
+                let position = line.layout.position_for_index(0)?;
                 return Some((position, line_height));
             }
+            if source_index > line.source_end {
+                continue;
+            }
+            let line_height = line.layout.line_height();
+            let rendered_index_within_line = line.rendered_index_for_source_index(source_index);
+            let position = line.layout.position_for_index(rendered_index_within_line)?;
+            return Some((position, line_height));
         }
         None
     }


### PR DESCRIPTION
In Markdown, four or more consecutive left-clicks cause Zed to select all rendered text. Yet, despite the text being fully selected (copyable via Command+C), the visual selection highlight fails to render highlight.

<img width="958" height="287" alt="图片" src="https://github.com/user-attachments/assets/61da287a-3901-4389-b631-c74c3af8ce4d" />

As illustrated above, when all rendered text in the floating Markdown window is selected, Command+C copies it successfully, yet the selection highlight fails to render. The fixed version is shown below.         

<img width="655" height="471" alt="图片" src="https://github.com/user-attachments/assets/d2a001b4-dea8-4ac6-9a33-7a2ed9ca1699" />

Self-Review Checklist:

- [ x ] I've reviewed my own diff for quality, security, and reliability
- [ x ] Unsafe blocks (if any) have justifying comments
- [ x ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ x ] Tests cover the new/changed behavior
- [ x ] Performance impact has been considered and is acceptable

Release Notes:

- Fixed markdown all selection highlight render error