### PR TITLE
agent: Expose task_priority field and priority-aware delegation guidance to `update_plan_tool`

### DIFF
--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -36,6 +36,7 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 - When work is in progress, prefer having exactly one step marked as `in_progress`.
 - You can mark multiple completed steps in a single `update_plan` call.
 - If the task changes midway through, update the plan so it reflects the new approach.
+- Use `priority: high` for steps that are blocking — i.e., nothing else can proceed until they complete. Use `priority: low` for optional or exploratory steps. Leave `priority` unset (or use `medium`) for everything else. Do not mark every step `high`; reserve it for genuine blockers.
 
 Use a plan when:
 
@@ -185,6 +186,8 @@ Sub-agents can help you move faster on large tasks when you use them thoughtfull
 * Running tests or config commands that can output a large amount of logs when you want a concise summary. Because you only receive the subagent's final message, ask it to include the relevant failing lines or diagnostics in its response.
 
 When you delegate work, focus on coordinating and synthesizing results instead of duplicating the same work yourself. If multiple agents might edit files, assign them disjoint write scopes.
+
+When spawning multiple agents in parallel, set `task_priority: high` on delegations whose result you must have before any further planning can proceed. Set `task_priority: low` on speculative or exploratory delegations whose result you could proceed without if necessary. Omit `task_priority` (or use `medium`) for standard parallel work.
 
 This feature must be used wisely. For simple or straightforward tasks, prefer doing the work directly instead of spawning a new agent.
 

--- a/crates/agent/src/tools/spawn_agent_tool.rs
+++ b/crates/agent/src/tools/spawn_agent_tool.rs
@@ -44,6 +44,11 @@ pub struct SpawnAgentToolInput {
     /// Session ID of an existing agent session to continue instead of creating a new one.
     #[serde(default)]
     pub session_id: Option<acp::SessionId>,
+    /// Hint to the orchestrator about the urgency of this subtask relative to
+    /// other parallel delegations. Use `high` for blocking work, `low` for
+    /// optional or exploratory tasks. Omit (or use `medium`) for standard tasks.
+    #[serde(default)]
+    pub task_priority: crate::tools::update_plan_tool::PlanEntryPriority,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/agent/src/tools/update_plan_tool.rs
+++ b/crates/agent/src/tools/update_plan_tool.rs
@@ -28,18 +28,49 @@ impl From<PlanEntryStatus> for acp::PlanEntryStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[schemars(inline)]
+pub enum PlanEntryPriority {
+    /// A background or optional task; does not block progress.
+    Low,
+    /// Standard priority — the default for most steps.
+    Medium,
+    /// Blocking or time-sensitive; should be addressed before lower-priority steps.
+    High,
+}
+
+impl Default for PlanEntryPriority {
+    fn default() -> Self {
+        PlanEntryPriority::Medium
+    }
+}
+
+impl From<PlanEntryPriority> for acp::PlanEntryPriority {
+    fn from(value: PlanEntryPriority) -> Self {
+        match value {
+            PlanEntryPriority::Low => acp::PlanEntryPriority::Low,
+            PlanEntryPriority::Medium => acp::PlanEntryPriority::Medium,
+            PlanEntryPriority::High => acp::PlanEntryPriority::High,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct PlanItem {
     /// Human-readable description of what this task aims to accomplish.
     pub step: String,
     /// The current status of this task.
     pub status: PlanEntryStatus,
+    /// The priority of this task. Defaults to `medium` when omitted.
+    #[serde(default)]
+    pub priority: PlanEntryPriority,
 }
 
 impl From<PlanItem> for acp::PlanEntry {
     fn from(value: PlanItem) -> Self {
         acp::PlanEntry::new(
             value.step,
-            acp::PlanEntryPriority::Medium,
+            value.priority.into(),
             value.status.into(),
         )
     }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:
- Improved: `update_plan` tool now accepts a `priority` field (`low` / `medium` / `high`) per plan step, surfacing the already-present `PlanEntryPriority` field in the ACP protocol that was previously hardcoded to `medium`.
- Improved: `spawn_agent` tool now accepts a `task_priority` hint so the orchestrating model can signal urgency across parallel delegations.
- Improved: System prompt planning and multi-agent delegation sections updated with guidance on when to use each priority level.