### PR TITLE
Fix thinking block handling for OpenAI-compatible providers

### DIFF
--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -1250,6 +1250,10 @@ impl CodegenAlternative {
                             let mut lock = total_text.lock();
                             lock.push_str(&text);
                         }
+                        Ok(LanguageModelCompletionEvent::Thinking { .. }) => {}
+                        Ok(LanguageModelCompletionEvent::RedactedThinking { .. }) => {}
+                        Ok(LanguageModelCompletionEvent::ReasoningDetails(_)) => {}
+                        Ok(LanguageModelCompletionEvent::Stop(_)) => {}
                         Ok(e) => {
                             log::warn!("Unexpected event: {:?}", e);
                             break;
@@ -1303,6 +1307,9 @@ impl CodegenAlternative {
                                 lock.push_str(&text);
                                 None
                             }
+                            Ok(LanguageModelCompletionEvent::Thinking { .. }) => None
+                            Ok(LanguageModelCompletionEvent::RedactedThinking { .. }) => None
+                            Ok(LanguageModelCompletionEvent::ReasoningDetails(_)) => None
                             Ok(LanguageModelCompletionEvent::Stop(_reason)) => None,
                             e => {
                                 log::error!("UNEXPECTED EVENT {:?}", e);

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -373,12 +373,16 @@ fn add_message_content_part(
 
 pub struct OpenAiEventMapper {
     tool_calls_by_index: HashMap<usize, RawToolCall>,
+    in_thinking: bool,
+    pending_text: String,
 }
 
 impl OpenAiEventMapper {
     pub fn new() -> Self {
         Self {
             tool_calls_by_index: HashMap::default(),
+            in_thinking: false,
+            pending_text: String::new(),
         }
     }
 
@@ -424,7 +428,47 @@ impl OpenAiEventMapper {
             }
             if let Some(content) = delta.content.clone() {
                 if !content.is_empty() {
-                    events.push(Ok(LanguageModelCompletionEvent::Text(content)));
+                    let mut text = content.to_string();
+                    self.pending_text.push_str(&text);
+                    if self.in_thinking {
+                        if let Some(end) = self.pending_text.find("</think>") {
+                            if end + 8 < self.pending_text.len() {
+                                text = self.pending_text[end + 8..].to_string();
+                                text = text.trim_start().to_string();
+                            } else {
+                                text = String::new();
+                            }
+                            self.in_thinking = false;
+                            self.pending_text.clear();
+                            if !text.is_empty() {
+                                events.push(Ok(LanguageModelCompletionEvent::Text(text)));
+                            }
+                        }
+                    } else {
+                        if let Some(start) = self.pending_text.find("<think>") {
+                            if let Some(end) = self.pending_text.find("</think>") {
+                                if start > 0 {
+                                    text = self.pending_text[..start].to_string();
+                                    text = text.trim_start().to_string();
+                                } else if end + 8 < self.pending_text.len() {
+                                    text = self.pending_text[end + 8..].to_string();
+                                    text = text.trim_start().to_string();
+                                } else {
+                                    text = String::new();
+                                }
+                                self.pending_text.clear();
+                                if !text.is_empty() {
+                                    events.push(Ok(LanguageModelCompletionEvent::Text(text)));
+                                }
+                            } else {
+                                self.in_thinking = true;
+                                self.pending_text.clear();
+                            }
+                        } else {
+                            events.push(Ok(LanguageModelCompletionEvent::Text(text)));
+                            self.pending_text.clear();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
- Handle Thinking, RedactedThinking, ReasoningDetails events in buffer_codegen
- Strip <thinking> blocks from content for providers like MiniMax that send thinking in content field instead of reasoning_content field
- Use pending text buffer to properly track thinking across chunks

This fixes models that send thinking as plain text in the content field (e.g., minimaxai/minimax-m2.*) appearing in the output.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #47559, #53135

Release Notes:

- N/A or Added/Fixed/Improved ...
