### PR TITLE
agent: Render mermaid diagrams in agent threads

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -14,7 +14,7 @@ use gpui::{AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Ta
 use itertools::Itertools;
 use language::language_settings::FormatOnSave;
 use language::{Anchor, Buffer, BufferSnapshot, LanguageRegistry, Point, ToPoint, text_diff};
-use markdown::Markdown;
+use markdown::{Markdown, MarkdownOptions};
 pub use mention::*;
 use project::lsp_store::{FormatTrigger, LspFormatTarget};
 use project::{AgentLocation, Project, git_store::GitStoreCheckpoint};
@@ -709,8 +709,18 @@ impl ContentBlock {
         cx: &mut App,
     ) -> ContentBlock {
         ContentBlock::Markdown {
-            markdown: cx
-                .new(|cx| Markdown::new(content.into(), Some(language_registry.clone()), None, cx)),
+            markdown: cx.new(|cx| {
+                Markdown::new_with_options(
+                    content.into(),
+                    Some(language_registry.clone()),
+                    None,
+                    MarkdownOptions {
+                        render_mermaid_diagrams: true,
+                        ..Default::default()
+                    },
+                    cx,
+                )
+            }),
         }
     }
 
@@ -3023,10 +3033,14 @@ fn markdown_for_raw_output(
             )
         })),
         serde_json::Value::String(value) => Some(cx.new(|cx| {
-            Markdown::new(
+            Markdown::new_with_options(
                 value.clone().into(),
                 Some(language_registry.clone()),
                 None,
+                MarkdownOptions {
+                    render_mermaid_diagrams: true,
+                    ..Default::default()
+                },
                 cx,
             )
         })),

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -92,6 +92,8 @@ Use these conventions:
 
 If you want to show Mermaid source as code instead of rendering it as a diagram, use a `/dev/null/...` fenced block such as `/dev/null/example.mmd`.
 
+When generating Mermaid diagrams for the thread, prefer vertical layouts that read well in a narrow side panel. For example, prefer `graph TD` or `flowchart TD` unless a horizontal layout is clearly a better fit.
+
 You may encounter bare fenced blocks and language-tagged fenced blocks in Markdown, but for agent responses you should continue to prefer the path-based convention above, with `mermaid` as the explicit rendering carve-out.
 
 <example>

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -76,15 +76,23 @@ The one exception to this is if the user references something you don't know abo
 
 ## Code Block Formatting
 
-Whenever you mention a code block, you MUST ONLY use the following format:
+Whenever you mention a code block, prefer these formats:
 
 ```path/to/Something.blah#L123-456
 (code goes here)
 ```
 
-The `#L123-456` means the line number range 123 through 456, and the path/to/Something.blah is a path in the project. (If there is no valid path in the project, then you can use /dev/null/path.extension for its path.) This is the ONLY valid way to format code blocks, because the Markdown parser does not understand the more common ```language syntax, or bare ``` blocks. It only understands this path-based syntax, and if the path is missing, then it will error and you will have to do it over again.
-Just to be really clear about this, if you ever find yourself writing three backticks followed by a language name, STOP!
-You have made a mistake. You can only ever put paths after triple backticks!
+The `#L123-456` means the line number range 123 through 456, and the path/to/Something.blah is a path in the project. If there is no valid path in the project, use `/dev/null/path.extension` for generic examples instead.
+The ONLY exception to the path-based fenced code block format are mermaid diagrams, which should use ```mermaid.
+
+Use these conventions:
+- ` ```path/to/file.ext#Lx-y ` for real source references in the project.
+- ` ```/dev/null/example.ext#Lx-y ` for generic examples that are not backed by a real project file.
+- ` ```mermaid ` when you want the diagram to render in the thread.
+
+If you want to show Mermaid source as code instead of rendering it as a diagram, use a `/dev/null/...` fenced block such as `/dev/null/example.mmd`.
+
+You may encounter bare fenced blocks and language-tagged fenced blocks in Markdown, but for agent responses you should continue to prefer the path-based convention above, with `mermaid` as the explicit rendering carve-out.
 
 <example>
 Based on all the information I've gathered, here's a summary of how this system works:

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -16,6 +16,7 @@ use mermaid::{
 };
 pub use path_range::{LineCol, PathWithRange};
 use settings::Settings as _;
+use theme::GlobalTheme;
 use theme_settings::ThemeSettings;
 use ui::Checkbox;
 use ui::CopyButton;
@@ -36,7 +37,7 @@ use gpui::{
     FocusHandle, Focusable, FontStyle, FontWeight, GlobalElementId, Hitbox, Hsla, Image,
     ImageFormat, ImageSource, KeyContext, Length, MouseButton, MouseDownEvent, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Point, ScrollHandle, Stateful, StrikethroughStyle,
-    StyleRefinement, StyledText, Task, TextAlign, TextLayout, TextRun, TextStyle,
+    StyleRefinement, StyledText, Subscription, Task, TextAlign, TextLayout, TextRun, TextStyle,
     TextStyleRefinement, actions, img, point, quad,
 };
 use language::{CharClassifier, Language, LanguageRegistry, Rope};
@@ -329,6 +330,7 @@ pub struct Markdown {
     fallback_code_block_language: Option<LanguageName>,
     options: MarkdownOptions,
     mermaid_state: MermaidState,
+    _theme_subscription: Option<Subscription>,
     copied_code_blocks: HashSet<ElementId>,
     code_block_scroll_handles: BTreeMap<usize, ScrollHandle>,
     context_menu_link: Option<SharedString>,
@@ -501,6 +503,7 @@ impl Markdown {
             fallback_code_block_language,
             options,
             mermaid_state: MermaidState::default(),
+            _theme_subscription: None,
             copied_code_blocks: HashSet::default(),
             code_block_scroll_handles: BTreeMap::default(),
             context_menu_link: None,
@@ -508,6 +511,14 @@ impl Markdown {
             search_highlights: Vec::new(),
             active_search_highlight: None,
         };
+        if this.options.render_mermaid_diagrams {
+            this._theme_subscription = Some(cx.observe_global::<GlobalTheme>(|this, cx| {
+                this.mermaid_state.clear();
+                let parsed_markdown = this.parsed_markdown.clone();
+                this.mermaid_state.update(&parsed_markdown, cx);
+                cx.notify();
+            }));
+        }
         this.parse(cx);
         this
     }

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -1,12 +1,14 @@
 use collections::HashMap;
 use gpui::{
-    Animation, AnimationExt, AnyElement, Context, ImageSource, RenderImage, StyledText, Task, img,
-    pulsating_between,
+    Animation, AnimationExt, AnyElement, App, Context, Hsla, ImageSource, RenderImage, StyledText,
+    Task, img, pulsating_between,
 };
+
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
+
 use ui::prelude::*;
 
 use crate::parser::{CodeBlockKind, MarkdownEvent, MarkdownTag};
@@ -99,11 +101,15 @@ impl CachedMermaidDiagram {
         let render_image = Arc::new(OnceLock::<anyhow::Result<Arc<RenderImage>>>::new());
         let render_image_clone = render_image.clone();
         let svg_renderer = cx.svg_renderer();
+        let render_options = mermaid_render_options(cx);
 
         let task = cx.spawn(async move |this, cx| {
             let value = cx
                 .background_spawn(async move {
-                    let svg_string = mermaid_rs_renderer::render(&contents.contents)?;
+                    let svg_string = mermaid_rs_renderer::render_with_options(
+                        &contents.contents,
+                        render_options,
+                    )?;
                     let scale = contents.scale as f32 / 100.0;
                     svg_renderer
                         .render_single_frame(svg_string.as_bytes(), scale)
@@ -156,6 +162,108 @@ fn parse_mermaid_info(info: &str) -> Option<u32> {
     )
 }
 
+fn mermaid_render_options(cx: &App) -> mermaid_rs_renderer::RenderOptions {
+    let colors = cx.theme().colors();
+
+    let mut theme = mermaid_rs_renderer::Theme::modern();
+    theme.primary_color = color_to_hex(colors.element_background);
+    theme.primary_text_color = color_to_hex(colors.text);
+    theme.primary_border_color = color_to_hex(colors.border_variant);
+    theme.line_color = color_to_hex(colors.border);
+    theme.secondary_color = color_to_hex(colors.editor_background);
+    theme.tertiary_color = color_to_hex(colors.panel_background);
+    theme.edge_label_background = color_to_hex(colors.element_background);
+    theme.cluster_background = color_to_hex(colors.editor_background);
+    theme.cluster_border = color_to_hex(colors.border_variant);
+    theme.background = color_to_hex(Hsla {
+        a: 0.0,
+        ..colors.editor_background
+    });
+    theme.sequence_actor_fill = color_to_hex(colors.element_background);
+    theme.sequence_actor_border = color_to_hex(colors.border_variant);
+    theme.sequence_actor_line = color_to_hex(colors.border);
+    theme.sequence_note_fill = color_to_hex(colors.panel_background);
+    theme.sequence_note_border = color_to_hex(colors.border_variant);
+    theme.sequence_activation_fill = color_to_hex(colors.editor_background);
+    theme.sequence_activation_border = color_to_hex(colors.border_variant);
+    theme.text_color = color_to_hex(colors.text);
+    theme.git_commit_label_color = color_to_hex(colors.text);
+    theme.git_commit_label_background = color_to_hex(colors.element_background);
+    theme.git_tag_label_color = color_to_hex(colors.text);
+    theme.git_tag_label_background = color_to_hex(colors.panel_background);
+    theme.git_tag_label_border = color_to_hex(colors.border_variant);
+    theme.pie_title_text_color = color_to_hex(colors.text);
+    theme.pie_section_text_color = color_to_hex(colors.text);
+    theme.pie_legend_text_color = color_to_hex(colors.text_muted);
+    theme.pie_stroke_color = color_to_hex(colors.border_variant);
+    theme.pie_outer_stroke_color = color_to_hex(colors.border);
+
+    let accent = color_to_hex(colors.text_accent);
+    theme.git_colors = [
+        accent.clone(),
+        color_to_hex(colors.text),
+        color_to_hex(colors.element_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.panel_background),
+        color_to_hex(colors.border),
+        color_to_hex(colors.border_variant),
+        color_to_hex(colors.text_muted),
+    ];
+    theme.git_inv_colors = [
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.editor_background),
+    ];
+    theme.git_branch_label_colors = [
+        accent.clone(),
+        accent.clone(),
+        accent.clone(),
+        accent.clone(),
+        accent.clone(),
+        accent.clone(),
+        accent.clone(),
+        accent,
+    ];
+    theme.pie_colors = [
+        color_to_hex(colors.text_accent),
+        color_to_hex(colors.border_selected),
+        color_to_hex(colors.border_focused),
+        color_to_hex(colors.icon),
+        color_to_hex(colors.text),
+        color_to_hex(colors.text_muted),
+        color_to_hex(colors.border),
+        color_to_hex(colors.border_variant),
+        color_to_hex(colors.element_background),
+        color_to_hex(colors.editor_background),
+        color_to_hex(colors.panel_background),
+        color_to_hex(colors.background),
+    ];
+
+    mermaid_rs_renderer::RenderOptions {
+        theme,
+        ..Default::default()
+    }
+}
+
+fn color_to_hex(color: Hsla) -> String {
+    let color = color.to_rgb();
+    let red = (color.r * 255.0).round() as u8;
+    let green = (color.g * 255.0).round() as u8;
+    let blue = (color.b * 255.0).round() as u8;
+    let alpha = (color.a * 255.0).round() as u8;
+
+    if alpha == 255 {
+        format!("#{red:02X}{green:02X}{blue:02X}")
+    } else {
+        format!("#{red:02X}{green:02X}{blue:02X}{alpha:02X}")
+    }
+}
+
 pub(crate) fn extract_mermaid_diagrams(
     source: &str,
     events: &[(Range<usize>, MarkdownEvent)],
@@ -195,11 +303,10 @@ pub(crate) fn extract_mermaid_diagrams(
 pub(crate) fn render_mermaid_diagram(
     parsed: &ParsedMarkdownMermaidDiagram,
     mermaid_state: &MermaidState,
-    style: &MarkdownStyle,
+    _style: &MarkdownStyle,
 ) -> AnyElement {
     let cached = mermaid_state.cache.get(&parsed.contents);
-    let mut container = div().w_full();
-    container.style().refine(&style.code_block);
+    let container = div().w_full();
 
     if let Some(result) = cached.and_then(|cached| cached.render_image.get()) {
         match result {

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -312,7 +312,7 @@ pub(crate) fn render_mermaid_diagram(
         match result {
             Ok(render_image) => container
                 .child(
-                    div().w_full().child(
+                    div().w_full().flex().justify_center().child(
                         img(ImageSource::Render(render_image.clone()))
                             .max_w_full()
                             .with_fallback(|| {
@@ -332,6 +332,8 @@ pub(crate) fn render_mermaid_diagram(
             .child(
                 div()
                     .w_full()
+                    .flex()
+                    .justify_center()
                     .child(
                         img(ImageSource::Render(fallback.clone()))
                             .max_w_full()
@@ -353,15 +355,17 @@ pub(crate) fn render_mermaid_diagram(
     } else {
         container
             .child(
-                Label::new("Rendering mermaid diagram...")
-                    .color(Color::Muted)
-                    .with_animation(
-                        "mermaid-loading-pulse",
-                        Animation::new(Duration::from_secs(2))
-                            .repeat()
-                            .with_easing(pulsating_between(0.4, 0.8)),
-                        |label, delta| label.alpha(delta),
-                    ),
+                div().w_full().flex().justify_center().child(
+                    Label::new("Rendering mermaid diagram...")
+                        .color(Color::Muted)
+                        .with_animation(
+                            "mermaid-loading-pulse",
+                            Animation::new(Duration::from_secs(2))
+                                .repeat()
+                                .with_easing(pulsating_between(0.4, 0.8)),
+                            |label, delta| label.alpha(delta),
+                        ),
+                ),
             )
             .into_any_element()
     }


### PR DESCRIPTION
Enable Mermaid rendering in agent threads so responses can display diagrams inline.

This sets a distinction between normal code examples and Mermaid diagrams: agent responses should continue to use path-based fenced blocks for code, while fenced `mermaid` blocks are now the intentional exception when the goal is to render a diagram inline.

I opened https://github.com/zed-industries/zed/discussions/54263 as well, but went ahead with a PR since this seemed like a small, self-contained change. While I was at it, I also made mermaid rendering theme-aware and centered; if that feels out of scope, I'm happy to split it out or drop it.

Example:
<img width="1287" height="1406" alt="image" src="https://github.com/user-attachments/assets/38278405-469b-4ab7-bb1d-c97abf46e5b8" />

Release Notes:

- Added mermaid diagram rendering in agent threads.
- Improved mermaid presentation with theme-aware, centered rendering.