### PR TITLE
Highlight CSS font shorthand line-height values

### DIFF
--- a/crates/grammars/src/css/highlights.scm
+++ b/crates/grammars/src/css/highlights.scm
@@ -96,6 +96,9 @@
   (float_value)
 ] @number
 
+((plain_value) @number
+  (#match? @number "^/[0-9]+(\\.[0-9]+)?[a-zA-Z%]*$"))
+
 (unit) @type.unit
 
 [


### PR DESCRIPTION
Fixes #54235

Summary:
- Highlights slash-prefixed numeric CSS values like /32px as numbers.
- Keeps the query scoped to numeric slash values used by font shorthand line-height syntax.

Release Notes:

- Fixed CSS highlighting for line-height values in font shorthand properties.