### PR TITLE
Show added line counts for untracked files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7271,7 +7271,6 @@ dependencies = [
  "futures 0.3.32",
  "git2",
  "gpui",
- "heapless",
  "http_client",
  "itertools 0.14.0",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7271,6 +7271,7 @@ dependencies = [
  "futures 0.3.32",
  "git2",
  "gpui",
+ "heapless",
  "http_client",
  "itertools 0.14.0",
  "log",
@@ -7292,6 +7293,7 @@ dependencies = [
  "url",
  "urlencoding",
  "util",
+ "util_macros",
  "uuid",
  "ztracing",
 ]

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -28,6 +28,7 @@ use parking_lot::Mutex;
 use rope::Rope;
 use std::{path::PathBuf, sync::Arc, sync::atomic::AtomicBool};
 use text::LineEnding;
+use util::TakeUntilExt;
 use util::{paths::PathStyle, rel_path::RelPath};
 
 #[derive(Clone)]
@@ -1111,32 +1112,34 @@ impl GitRepository for FakeGitRepository {
             })
         }
 
+        fn strip_drive_prefix(path: &Path) -> PathBuf {
+            path.components()
+                .filter(|c| !matches!(c, std::path::Component::Prefix(_)))
+                .collect()
+        }
+
         let path_prefixes = path_prefixes.to_vec();
 
         let workdir_path = self.dot_git_path.parent().unwrap().to_path_buf();
-        eprintln!("dbg!: workdir_path: {workdir_path:?}");
         let worktree_files: HashMap<RepoPath, String> = self
             .fs
             .files()
             .iter()
             .filter_map(|path| {
-                eprintln!("dbg!: path: {path:?}");
-                eprintln!("dbg!: workdir_path: {workdir_path:?}");
+                let path = strip_drive_prefix(path);
                 let repo_path = path.strip_prefix(&workdir_path).ok()?;
                 if repo_path.starts_with(".git") {
                     return None;
                 }
-                eprintln!("dbg!: repo_path: {repo_path:?}");
                 let content = self
                     .fs
-                    .read_file_sync(path)
+                    .read_file_sync(&path)
                     .ok()
                     .and_then(|bytes| String::from_utf8(bytes).ok())?;
                 let repo_path = RelPath::new(repo_path, PathStyle::local()).ok()?;
                 Some((RepoPath::from_rel_path(&repo_path), content))
             })
             .collect();
-        eprintln!("dbg!: worktree_files: {worktree_files:?}");
 
         self.with_state_async(false, move |state| {
             let mut entries = Vec::new();
@@ -1146,10 +1149,7 @@ impl GitRepository for FakeGitRepository {
                 .chain(worktree_files.keys())
                 .collect();
             for path in all_paths {
-                eprintln!("dbg!: path: {path:?}");
-                eprintln!("dbg!: path_prefixes: {path_prefixes:?}");
                 if !matches_prefixes(path, &path_prefixes) {
-                    eprintln!("dbg!: continuing");
                     continue;
                 }
                 let head = state.head_contents.get(path);

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -1098,14 +1098,6 @@ impl GitRepository for FakeGitRepository {
         &self,
         path_prefixes: &[RepoPath],
     ) -> BoxFuture<'_, Result<git::status::GitDiffStat>> {
-        fn count_lines(s: &str) -> u32 {
-            if s.is_empty() {
-                0
-            } else {
-                s.lines().count() as u32
-            }
-        }
-
         fn matches_prefixes(path: &RepoPath, prefixes: &[RepoPath]) -> bool {
             if prefixes.is_empty() {
                 return true;
@@ -1146,11 +1138,7 @@ impl GitRepository for FakeGitRepository {
             let all_paths: HashSet<&RepoPath> = state
                 .head_contents
                 .keys()
-                .chain(
-                    worktree_files
-                        .keys()
-                        .filter(|p| state.index_contents.contains_key(*p)),
-                )
+                .chain(worktree_files.keys())
                 .collect();
             for path in all_paths {
                 if !matches_prefixes(path, &path_prefixes) {
@@ -1163,8 +1151,8 @@ impl GitRepository for FakeGitRepository {
                         entries.push((
                             path.clone(),
                             git::status::DiffStat {
-                                added: count_lines(new),
-                                deleted: count_lines(old),
+                                added: new.lines().count() as u32,
+                                deleted: old.lines().count() as u32,
                             },
                         ));
                     }
@@ -1173,7 +1161,7 @@ impl GitRepository for FakeGitRepository {
                             path.clone(),
                             git::status::DiffStat {
                                 added: 0,
-                                deleted: count_lines(old),
+                                deleted: old.lines().count() as u32,
                             },
                         ));
                     }
@@ -1181,7 +1169,7 @@ impl GitRepository for FakeGitRepository {
                         entries.push((
                             path.clone(),
                             git::status::DiffStat {
-                                added: count_lines(new),
+                                added: new.lines().count() as u32,
                                 deleted: 0,
                             },
                         ));

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -1114,15 +1114,19 @@ impl GitRepository for FakeGitRepository {
         let path_prefixes = path_prefixes.to_vec();
 
         let workdir_path = self.dot_git_path.parent().unwrap().to_path_buf();
+        eprintln!("dbg!: workdir_path: {workdir_path:?}");
         let worktree_files: HashMap<RepoPath, String> = self
             .fs
             .files()
             .iter()
             .filter_map(|path| {
+                eprintln!("dbg!: path: {path:?}");
+                eprintln!("dbg!: workdir_path: {workdir_path:?}");
                 let repo_path = path.strip_prefix(&workdir_path).ok()?;
                 if repo_path.starts_with(".git") {
                     return None;
                 }
+                eprintln!("dbg!: repo_path: {repo_path:?}");
                 let content = self
                     .fs
                     .read_file_sync(path)
@@ -1132,6 +1136,7 @@ impl GitRepository for FakeGitRepository {
                 Some((RepoPath::from_rel_path(&repo_path), content))
             })
             .collect();
+        eprintln!("dbg!: worktree_files: {worktree_files:?}");
 
         self.with_state_async(false, move |state| {
             let mut entries = Vec::new();
@@ -1141,7 +1146,10 @@ impl GitRepository for FakeGitRepository {
                 .chain(worktree_files.keys())
                 .collect();
             for path in all_paths {
+                eprintln!("dbg!: path: {path:?}");
+                eprintln!("dbg!: path_prefixes: {path_prefixes:?}");
                 if !matches_prefixes(path, &path_prefixes) {
+                    eprintln!("dbg!: continuing");
                     continue;
                 }
                 let head = state.head_contents.get(path);

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -28,7 +28,6 @@ use parking_lot::Mutex;
 use rope::Rope;
 use std::{path::PathBuf, sync::Arc, sync::atomic::AtomicBool};
 use text::LineEnding;
-use util::TakeUntilExt;
 use util::{paths::PathStyle, rel_path::RelPath};
 
 #[derive(Clone)]

--- a/crates/fs/tests/integration/fake_git_repo.rs
+++ b/crates/fs/tests/integration/fake_git_repo.rs
@@ -1,8 +1,5 @@
 use fs::{FakeFs, Fs};
-use git::{
-    repository::RepoPath,
-    status::DiffStat,
-};
+use git::{repository::RepoPath, status::DiffStat};
 use gpui::{BackgroundExecutor, TestAppContext};
 use serde_json::json;
 use std::path::{Path, PathBuf};

--- a/crates/fs/tests/integration/fake_git_repo.rs
+++ b/crates/fs/tests/integration/fake_git_repo.rs
@@ -1,4 +1,8 @@
 use fs::{FakeFs, Fs};
+use git::{
+    repository::RepoPath,
+    status::DiffStat,
+};
 use gpui::{BackgroundExecutor, TestAppContext};
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -193,4 +197,38 @@ async fn test_checkpoints(executor: BackgroundExecutor) {
         .unwrap();
     assert!(diff.contains("b"), "diff should mention changed file 'b'");
     assert!(diff.contains("c"), "diff should mention added file 'c'");
+}
+
+#[gpui::test]
+async fn test_untracked_files(executor: BackgroundExecutor) {
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/"),
+        json!({
+            "foo": {
+                ".git": {},
+                "a": "lorem",
+            },
+        }),
+    )
+    .await;
+
+    let repository = fs
+        .open_repo(Path::new("/foo/.git"), Some("git".as_ref()))
+        .unwrap();
+
+    let stats = repository
+        .diff_stat(&[RepoPath::new("").unwrap()])
+        .await
+        .unwrap();
+    assert_eq!(
+        stats.entries.to_vec(),
+        vec![(
+            RepoPath::new("a").unwrap(),
+            DiffStat {
+                added: 1,
+                deleted: 0
+            }
+        )]
+    );
 }

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -23,7 +23,6 @@ derive_more.workspace = true
 git2.workspace = true
 gpui.workspace = true
 http_client.workspace = true
-heapless.workspace = true
 itertools.workspace = true
 log.workspace = true
 parking_lot.workspace = true

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -23,6 +23,7 @@ derive_more.workspace = true
 git2.workspace = true
 gpui.workspace = true
 http_client.workspace = true
+heapless.workspace = true
 itertools.workspace = true
 log.workspace = true
 parking_lot.workspace = true
@@ -48,6 +49,7 @@ ztracing.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 serde_json.workspace = true
+util_macros.workspace = true
 text = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -43,6 +43,20 @@ pub use askpass::{AskPassDelegate, AskPassResult, AskPassSession};
 
 pub const REMOTE_CANCELLED_BY_USER: &str = "Operation cancelled by user";
 
+fn line_count_for_diff_stat(contents: &[u8]) -> u32 {
+    if contents.is_empty() {
+        return 0;
+    }
+
+    let trailing_line = if contents.last() == Some(&b'\n') {
+        0
+    } else {
+        1
+    };
+    let line_count = contents.iter().filter(|byte| **byte == b'\n').count() + trailing_line;
+    u32::try_from(line_count).unwrap_or(u32::MAX)
+}
+
 /// Format string used in graph log to get initial data for the git graph
 /// %H - Full commit hash
 /// %P - Parent hashes
@@ -2117,7 +2131,60 @@ impl GitRepository for RealGitRepository {
                     );
                 }
                 let output = git_binary.run(&args).await?;
-                Ok(crate::status::parse_numstat(&output))
+                let mut diff_stat = crate::status::parse_numstat(&output);
+                let mut entries = diff_stat.entries.to_vec();
+                let mut paths_with_stats = entries
+                    .iter()
+                    .map(|(path, _)| path.clone())
+                    .collect::<HashSet<_>>();
+
+                let mut untracked_args: Vec<OsString> = vec![
+                    "ls-files".into(),
+                    "--others".into(),
+                    "--exclude-standard".into(),
+                    "-z".into(),
+                ];
+                if !path_prefixes.is_empty() {
+                    untracked_args.push("--".into());
+                    untracked_args.extend(
+                        path_prefixes
+                            .iter()
+                            .map(|p| p.as_std_path().as_os_str().to_os_string()),
+                    );
+                }
+                let untracked_output = git_binary.run_raw(&untracked_args).await?;
+
+                for path_str in untracked_output.split_terminator('\0') {
+                    let Ok(path) = RepoPath::new(path_str) else {
+                        continue;
+                    };
+                    if paths_with_stats.contains(&path) {
+                        continue;
+                    }
+
+                    let full_path = git_binary.working_directory.join(path.as_std_path());
+                    match smol::fs::read(&full_path).await {
+                        Ok(contents) => {
+                            entries.push((
+                                path.clone(),
+                                crate::status::DiffStat {
+                                    added: line_count_for_diff_stat(&contents),
+                                    deleted: 0,
+                                },
+                            ));
+                            paths_with_stats.insert(path);
+                        }
+                        Err(err) => {
+                            log::debug!("failed to read untracked file {full_path:?}: {err}");
+                        }
+                    }
+                }
+
+                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                entries.dedup_by(|(a, _), (b, _)| a == b);
+                diff_stat.entries = entries.into();
+
+                Ok(diff_stat)
             })
             .boxed()
     }
@@ -3672,6 +3739,15 @@ mod tests {
             std::env::set_var("GIT_CONFIG_GLOBAL", "");
             std::env::set_var("GIT_CONFIG_SYSTEM", "");
         }
+    }
+
+    #[test]
+    fn test_line_count_for_diff_stat() {
+        assert_eq!(line_count_for_diff_stat(b""), 0);
+        assert_eq!(line_count_for_diff_stat(b"one"), 1);
+        assert_eq!(line_count_for_diff_stat(b"one\n"), 1);
+        assert_eq!(line_count_for_diff_stat(b"one\ntwo"), 2);
+        assert_eq!(line_count_for_diff_stat(b"one\ntwo\n"), 2);
     }
 
     #[gpui::test]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -15,12 +15,13 @@ use futures::{AsyncReadExt, AsyncWriteExt, FutureExt as _, select_biased};
 use git2::{BranchType, ErrorCode};
 use gpui::{AppContext as _, AsyncApp, BackgroundExecutor, SharedString, Task};
 use itertools::Itertools;
+use log::warn;
 use parking_lot::Mutex;
 use rope::Rope;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use smallvec::SmallVec;
-use smol::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use smol::io::{AsyncBufReadExt, BufReader};
 use smol::Timer;
 use text::LineEnding;
 
@@ -2103,14 +2104,13 @@ impl GitRepository for RealGitRepository {
         path_prefixes: &[RepoPath],
     ) -> BoxFuture<'_, Result<crate::status::GitDiffStat>> {
         // if we import this in module scope we have to fully qualify `.boxed()` everywhere
-        use smol::future::FutureExt as _; 
+        use smol::future::FutureExt as _;
 
         let path_prefixes: Vec<_> = path_prefixes
             .iter()
             .map(|p| p.as_std_path().as_os_str().to_os_string())
             .collect();
         let git_binary = self.git_binary();
-        let repo_path = self.path();
         let fut = async move {
             let git_binary = git_binary?;
 
@@ -2122,15 +2122,15 @@ impl GitRepository for RealGitRepository {
                 .into();
 
             let untracked =
-                count_untracked_lines(&git_binary, path_prefixes, &paths_with_stats, repo_path)
-                    .await?;
+                count_untracked_lines(&git_binary, path_prefixes, &paths_with_stats).await?;
 
             let timeout = async {
                 Timer::after(Duration::from_secs(1)).await;
+                warn!("Timed out counting lines in untracked file paths");
                 BTreeMap::<RepoPath, DiffStat>::new()
             };
 
-            // streams are lazy, until this point we have not done file access here we
+            // streams are lazy, until this point we have not done file access. Here we
             // concurrently stat all files in any order.
             use futures::StreamExt;
             let total: std::collections::BTreeMap<_, _> = untracked
@@ -3823,6 +3823,8 @@ mod tests {
         );
     }
 
+    // TODO!(yara) test worktrees (both symlink behaviour and basic untracked)
+
     #[gpui::test]
     async fn test_diff_stat_includes_untracked_files(cx: &mut TestAppContext) {
         disable_git_global_config();
@@ -3857,53 +3859,72 @@ mod tests {
         .await
         .unwrap();
 
-        smol::fs::write(repo_dir.path().join("empty.txt"), "")
+        smol::fs::write(repo_dir.path().join("a"), "lorem")
             .await
             .unwrap();
-        smol::fs::write(repo_dir.path().join("new.txt"), "one\ntwo\n")
-            .await
-            .unwrap();
-        smol::fs::write(repo_dir.path().join("no_newline.txt"), "one")
-            .await
-            .unwrap();
-        #[cfg(unix)]
-        std::os::unix::fs::symlink("tracked.txt", repo_dir.path().join("link.txt")).unwrap();
 
-        let diff_stat = repo.diff_stat(&[]).await.unwrap();
-        let mut expected_entries = vec![
-            (
-                repo_path("empty.txt"),
-                crate::status::DiffStat {
-                    added: 0,
-                    deleted: 0,
-                },
-            ),
-            (
-                repo_path("new.txt"),
-                crate::status::DiffStat {
-                    added: 2,
-                    deleted: 0,
-                },
-            ),
-            (
-                repo_path("no_newline.txt"),
-                crate::status::DiffStat {
+        let stats = repo.diff_stat(&[RepoPath::new("").unwrap()]).await.unwrap();
+        assert_eq!(
+            stats.entries.to_vec(),
+            vec![(
+                RepoPath::new("a").unwrap(),
+                DiffStat {
                     added: 1,
-                    deleted: 0,
-                },
-            ),
-        ];
-        #[cfg(unix)]
-        expected_entries.push((
-            repo_path("link.txt"),
-            crate::status::DiffStat {
-                added: 1,
-                deleted: 0,
-            },
-        ));
-        expected_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    deleted: 0
+                }
+            )]
+        );
+    }
 
-        assert_eq!(diff_stat.entries.as_ref(), expected_entries.as_slice());
+    #[gpui::test]
+    async fn test_diff_stat_includes_untracked_symlinks(cx: &mut TestAppContext) {
+        disable_git_global_config();
+
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(repo_dir.path()).unwrap();
+
+        smol::fs::write(repo_dir.path().join("tracked.txt"), "tracked\n")
+            .await
+            .unwrap();
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        repo.stage_paths(vec![repo_path("tracked.txt")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+        repo.commit(
+            "Initial commit".into(),
+            None,
+            CommitOptions::default(),
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(checkpoint_author_envs()),
+        )
+        .await
+        .unwrap();
+
+        smol::fs::write(repo_dir.path().join("a"), "lorem")
+            .await
+            .unwrap();
+
+        let stats = repo.diff_stat(&[RepoPath::new("").unwrap()]).await.unwrap();
+        assert_eq!(
+            stats.entries.to_vec(),
+            vec![(
+                RepoPath::new("a").unwrap(),
+                DiffStat {
+                    added: 1,
+                    deleted: 0
+                }
+            )]
+        );
     }
 
     #[gpui::test]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1,7 +1,7 @@
 use crate::commit::parse_git_diff_name_status;
 use crate::stash::GitStash;
 use crate::status::{
-    DiffTreeType, GitDiffStat, GitStatus, StatusCode, TreeDiff, count_untracked_lines,
+    DiffStat, DiffTreeType, GitDiffStat, GitStatus, StatusCode, TreeDiff, count_untracked_lines,
     tracked_lines,
 };
 use crate::{Oid, RunHook, SHORT_SHA_LENGTH};
@@ -21,14 +21,16 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use smallvec::SmallVec;
 use smol::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use smol::Timer;
 use text::LineEnding;
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::sync::atomic::AtomicBool;
 
 use std::process::ExitStatus;
 use std::str::FromStr;
+use std::time::Duration;
 use std::{
     cmp::Ordering,
     future,
@@ -2100,39 +2102,49 @@ impl GitRepository for RealGitRepository {
         &self,
         path_prefixes: &[RepoPath],
     ) -> BoxFuture<'_, Result<crate::status::GitDiffStat>> {
+        // if we import this in module scope we have to fully qualify `.boxed()` everywhere
+        use smol::future::FutureExt as _; 
+
         let path_prefixes: Vec<_> = path_prefixes
             .iter()
             .map(|p| p.as_std_path().as_os_str().to_os_string())
             .collect();
         let git_binary = self.git_binary();
+        let repo_path = self.path();
+        let fut = async move {
+            let git_binary = git_binary?;
 
-        self.executor
-            .spawn(async move {
-                let git_binary = git_binary?;
+            let tracked = tracked_lines(&git_binary, &path_prefixes).await?;
+            let paths_with_stats: Mutex<_> = tracked
+                .iter()
+                .map(|(path, _)| path.clone())
+                .collect::<collections::HashSet<_>>()
+                .into();
 
-                let tracked = tracked_lines(&git_binary, &path_prefixes).await?;
-                let paths_with_stats: Mutex<_> = tracked
-                    .iter()
-                    .map(|(path, _)| path.clone())
-                    .collect::<collections::HashSet<_>>()
-                    .into();
+            let untracked =
+                count_untracked_lines(&git_binary, path_prefixes, &paths_with_stats, repo_path)
+                    .await?;
 
-                let untracked =
-                    count_untracked_lines(&git_binary, path_prefixes, &paths_with_stats).await?;
-                // streams are lazy, until this point we have not done file access here we
-                // concurrently stat all files in any order.
-                use futures::StreamExt;
-                let total: std::collections::BTreeMap<_, _> = untracked
-                    .filter_map(|s| std::future::ready(s)) // this is flatten
-                    .chain(futures::stream::iter(tracked))
-                    .collect() // StreamExt::collect
-                    .await;
+            let timeout = async {
+                Timer::after(Duration::from_secs(1)).await;
+                BTreeMap::<RepoPath, DiffStat>::new()
+            };
 
-                Ok(GitDiffStat {
-                    entries: total.into_iter().collect_vec().into(),
-                })
+            // streams are lazy, until this point we have not done file access here we
+            // concurrently stat all files in any order.
+            use futures::StreamExt;
+            let total: std::collections::BTreeMap<_, _> = untracked
+                .filter_map(|s| std::future::ready(s)) // this is flatten
+                .chain(futures::stream::iter(tracked))
+                .collect() // StreamExt::collect
+                .or(timeout)
+                .await;
+
+            Ok(GitDiffStat {
+                entries: total.into_iter().collect_vec().into(),
             })
-            .boxed()
+        };
+        futures::FutureExt::boxed(fut)
     }
 
     fn stage_paths(
@@ -3677,6 +3689,8 @@ fn checkpoint_author_envs() -> HashMap<String, String> {
 mod tests {
     use std::fs;
 
+    use crate::status::DiffStat;
+
     use super::*;
     use gpui::TestAppContext;
 
@@ -3817,6 +3831,7 @@ mod tests {
 
         let repo_dir = tempfile::tempdir().unwrap();
         git2::Repository::init(repo_dir.path()).unwrap();
+
         smol::fs::write(repo_dir.path().join("tracked.txt"), "tracked\n")
             .await
             .unwrap();

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -57,6 +57,38 @@ fn line_count_for_diff_stat(contents: &[u8]) -> u32 {
     u32::try_from(line_count).unwrap_or(u32::MAX)
 }
 
+async fn line_count_for_diff_stat_file(path: &Path) -> Result<u32> {
+    let file = smol::fs::File::open(path).await?;
+    let mut reader = BufReader::new(file);
+    let mut line_count = 0u32;
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line).await? == 0 {
+            break;
+        }
+        line_count = line_count.saturating_add(1);
+    }
+
+    Ok(line_count)
+}
+
+async fn untracked_path_diff_stat(full_path: &Path) -> Result<Option<crate::status::DiffStat>> {
+    let metadata = smol::fs::symlink_metadata(full_path).await?;
+    let file_type = metadata.file_type();
+    let added = if file_type.is_file() {
+        line_count_for_diff_stat_file(full_path).await?
+    } else if file_type.is_symlink() {
+        let target = smol::fs::read_link(full_path).await?;
+        line_count_for_diff_stat(target.to_string_lossy().as_bytes())
+    } else {
+        return Ok(None);
+    };
+
+    Ok(Some(crate::status::DiffStat { added, deleted: 0 }))
+}
+
 async fn untracked_diff_stat_entries(
     git_binary: &GitBinary,
     path_prefixes: &[RepoPath],
@@ -88,19 +120,14 @@ async fn untracked_diff_stat_entries(
         }
 
         let full_path = git_binary.working_directory.join(path.as_std_path());
-        match smol::fs::read(&full_path).await {
-            Ok(contents) => {
-                entries.push((
-                    path.clone(),
-                    crate::status::DiffStat {
-                        added: line_count_for_diff_stat(&contents),
-                        deleted: 0,
-                    },
-                ));
+        match untracked_path_diff_stat(&full_path).await {
+            Ok(Some(diff_stat)) => {
+                entries.push((path.clone(), diff_stat));
                 paths_with_stats.insert(path);
             }
+            Ok(None) => {}
             Err(err) => {
-                log::debug!("failed to read untracked file {full_path:?}: {err}");
+                log::debug!("failed to stat untracked file {full_path:?}: {err}");
             }
         }
     }
@@ -3910,21 +3937,53 @@ mod tests {
         .await
         .unwrap();
 
+        smol::fs::write(repo_dir.path().join("empty.txt"), "")
+            .await
+            .unwrap();
         smol::fs::write(repo_dir.path().join("new.txt"), "one\ntwo\n")
             .await
             .unwrap();
+        smol::fs::write(repo_dir.path().join("no_newline.txt"), "one")
+            .await
+            .unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("tracked.txt", repo_dir.path().join("link.txt")).unwrap();
 
         let diff_stat = repo.diff_stat(&[]).await.unwrap();
-        assert_eq!(
-            diff_stat.entries.as_ref(),
-            &[(
+        let mut expected_entries = vec![
+            (
+                repo_path("empty.txt"),
+                crate::status::DiffStat {
+                    added: 0,
+                    deleted: 0,
+                },
+            ),
+            (
                 repo_path("new.txt"),
                 crate::status::DiffStat {
                     added: 2,
-                    deleted: 0
-                }
-            )]
-        );
+                    deleted: 0,
+                },
+            ),
+            (
+                repo_path("no_newline.txt"),
+                crate::status::DiffStat {
+                    added: 1,
+                    deleted: 0,
+                },
+            ),
+        ];
+        #[cfg(unix)]
+        expected_entries.push((
+            repo_path("link.txt"),
+            crate::status::DiffStat {
+                added: 1,
+                deleted: 0,
+            },
+        ));
+        expected_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        assert_eq!(diff_stat.entries.as_ref(), expected_entries.as_slice());
     }
 
     #[gpui::test]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1,6 +1,9 @@
 use crate::commit::parse_git_diff_name_status;
 use crate::stash::GitStash;
-use crate::status::{DiffTreeType, GitStatus, StatusCode, TreeDiff};
+use crate::status::{
+    DiffTreeType, GitDiffStat, GitStatus, StatusCode, TreeDiff, count_untracked_lines,
+    tracked_lines,
+};
 use crate::{Oid, RunHook, SHORT_SHA_LENGTH};
 use anyhow::{Context as _, Result, anyhow, bail};
 use async_channel::Sender;
@@ -8,9 +11,10 @@ use collections::HashMap;
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use futures::io::BufWriter;
-use futures::{AsyncWriteExt, FutureExt as _, select_biased};
+use futures::{AsyncReadExt, AsyncWriteExt, FutureExt as _, select_biased};
 use git2::{BranchType, ErrorCode};
 use gpui::{AppContext as _, AsyncApp, BackgroundExecutor, SharedString, Task};
+use itertools::Itertools;
 use parking_lot::Mutex;
 use rope::Rope;
 use schemars::JsonSchema;
@@ -42,98 +46,6 @@ use uuid::Uuid;
 pub use askpass::{AskPassDelegate, AskPassResult, AskPassSession};
 
 pub const REMOTE_CANCELLED_BY_USER: &str = "Operation cancelled by user";
-
-fn line_count_for_diff_stat(contents: &[u8]) -> u32 {
-    if contents.is_empty() {
-        return 0;
-    }
-
-    let trailing_line = if contents.last() == Some(&b'\n') {
-        0
-    } else {
-        1
-    };
-    let line_count = contents.iter().filter(|byte| **byte == b'\n').count() + trailing_line;
-    u32::try_from(line_count).unwrap_or(u32::MAX)
-}
-
-async fn line_count_for_diff_stat_file(path: &Path) -> Result<u32> {
-    let file = smol::fs::File::open(path).await?;
-    let mut reader = BufReader::new(file);
-    let mut line_count = 0u32;
-    let mut line = Vec::new();
-
-    loop {
-        line.clear();
-        if reader.read_until(b'\n', &mut line).await? == 0 {
-            break;
-        }
-        line_count = line_count.saturating_add(1);
-    }
-
-    Ok(line_count)
-}
-
-async fn untracked_path_diff_stat(full_path: &Path) -> Result<Option<crate::status::DiffStat>> {
-    let metadata = smol::fs::symlink_metadata(full_path).await?;
-    let file_type = metadata.file_type();
-    let added = if file_type.is_file() {
-        line_count_for_diff_stat_file(full_path).await?
-    } else if file_type.is_symlink() {
-        let target = smol::fs::read_link(full_path).await?;
-        line_count_for_diff_stat(target.to_string_lossy().as_bytes())
-    } else {
-        return Ok(None);
-    };
-
-    Ok(Some(crate::status::DiffStat { added, deleted: 0 }))
-}
-
-async fn untracked_diff_stat_entries(
-    git_binary: &GitBinary,
-    path_prefixes: &[RepoPath],
-    paths_with_stats: &mut HashSet<RepoPath>,
-) -> Result<Vec<(RepoPath, crate::status::DiffStat)>> {
-    let mut args: Vec<OsString> = vec![
-        "ls-files".into(),
-        "--others".into(),
-        "--exclude-standard".into(),
-        "-z".into(),
-    ];
-    if !path_prefixes.is_empty() {
-        args.push("--".into());
-        args.extend(
-            path_prefixes
-                .iter()
-                .map(|p| p.as_std_path().as_os_str().to_os_string()),
-        );
-    }
-    let output = git_binary.run_raw(&args).await?;
-    let mut entries = Vec::new();
-
-    for path_str in output.split_terminator('\0') {
-        let Ok(path) = RepoPath::new(path_str) else {
-            continue;
-        };
-        if paths_with_stats.contains(&path) {
-            continue;
-        }
-
-        let full_path = git_binary.working_directory.join(path.as_std_path());
-        match untracked_path_diff_stat(&full_path).await {
-            Ok(Some(diff_stat)) => {
-                entries.push((path.clone(), diff_stat));
-                paths_with_stats.insert(path);
-            }
-            Ok(None) => {}
-            Err(err) => {
-                log::debug!("failed to stat untracked file {full_path:?}: {err}");
-            }
-        }
-    }
-
-    Ok(entries)
-}
 
 /// Format string used in graph log to get initial data for the git graph
 /// %H - Full commit hash
@@ -2188,44 +2100,37 @@ impl GitRepository for RealGitRepository {
         &self,
         path_prefixes: &[RepoPath],
     ) -> BoxFuture<'_, Result<crate::status::GitDiffStat>> {
-        let path_prefixes = path_prefixes.to_vec();
+        let path_prefixes: Vec<_> = path_prefixes
+            .iter()
+            .map(|p| p.as_std_path().as_os_str().to_os_string())
+            .collect();
         let git_binary = self.git_binary();
 
         self.executor
             .spawn(async move {
                 let git_binary = git_binary?;
-                let mut args: Vec<String> = vec![
-                    "diff".into(),
-                    "--numstat".into(),
-                    "--no-renames".into(),
-                    "HEAD".into(),
-                ];
-                if !path_prefixes.is_empty() {
-                    args.push("--".into());
-                    args.extend(
-                        path_prefixes
-                            .iter()
-                            .map(|p| p.as_std_path().to_string_lossy().into_owned()),
-                    );
-                }
-                let output = git_binary.run(&args).await?;
-                let mut diff_stat = crate::status::parse_numstat(&output);
-                let mut entries = diff_stat.entries.to_vec();
-                let mut paths_with_stats = entries
+
+                let tracked = tracked_lines(&git_binary, &path_prefixes).await?;
+                let paths_with_stats: Mutex<_> = tracked
                     .iter()
                     .map(|(path, _)| path.clone())
-                    .collect::<HashSet<_>>();
+                    .collect::<collections::HashSet<_>>()
+                    .into();
 
-                entries.extend(
-                    untracked_diff_stat_entries(&git_binary, &path_prefixes, &mut paths_with_stats)
-                        .await?,
-                );
+                let untracked =
+                    count_untracked_lines(&git_binary, path_prefixes, &paths_with_stats).await?;
+                // streams are lazy, until this point we have not done file access here we
+                // concurrently stat all files in any order.
+                use futures::StreamExt;
+                let total: std::collections::BTreeMap<_, _> = untracked
+                    .filter_map(|s| std::future::ready(s)) // this is flatten
+                    .chain(futures::stream::iter(tracked))
+                    .collect() // StreamExt::collect
+                    .await;
 
-                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-                entries.dedup_by(|(a, _), (b, _)| a == b);
-                diff_stat.entries = entries.into();
-
-                Ok(diff_stat)
+                Ok(GitDiffStat {
+                    entries: total.into_iter().collect_vec().into(),
+                })
             })
             .boxed()
     }
@@ -3376,7 +3281,7 @@ async fn exclude_files(git: &GitBinary) -> Result<GitExcludeOverride> {
 
 pub(crate) struct GitBinary {
     git_binary_path: PathBuf,
-    working_directory: PathBuf,
+    pub working_directory: PathBuf,
     git_directory: PathBuf,
     executor: BackgroundExecutor,
     index_file_path: Option<PathBuf>,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -57,6 +57,57 @@ fn line_count_for_diff_stat(contents: &[u8]) -> u32 {
     u32::try_from(line_count).unwrap_or(u32::MAX)
 }
 
+async fn untracked_diff_stat_entries(
+    git_binary: &GitBinary,
+    path_prefixes: &[RepoPath],
+    paths_with_stats: &mut HashSet<RepoPath>,
+) -> Result<Vec<(RepoPath, crate::status::DiffStat)>> {
+    let mut args: Vec<OsString> = vec![
+        "ls-files".into(),
+        "--others".into(),
+        "--exclude-standard".into(),
+        "-z".into(),
+    ];
+    if !path_prefixes.is_empty() {
+        args.push("--".into());
+        args.extend(
+            path_prefixes
+                .iter()
+                .map(|p| p.as_std_path().as_os_str().to_os_string()),
+        );
+    }
+    let output = git_binary.run_raw(&args).await?;
+    let mut entries = Vec::new();
+
+    for path_str in output.split_terminator('\0') {
+        let Ok(path) = RepoPath::new(path_str) else {
+            continue;
+        };
+        if paths_with_stats.contains(&path) {
+            continue;
+        }
+
+        let full_path = git_binary.working_directory.join(path.as_std_path());
+        match smol::fs::read(&full_path).await {
+            Ok(contents) => {
+                entries.push((
+                    path.clone(),
+                    crate::status::DiffStat {
+                        added: line_count_for_diff_stat(&contents),
+                        deleted: 0,
+                    },
+                ));
+                paths_with_stats.insert(path);
+            }
+            Err(err) => {
+                log::debug!("failed to read untracked file {full_path:?}: {err}");
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
 /// Format string used in graph log to get initial data for the git graph
 /// %H - Full commit hash
 /// %P - Parent hashes
@@ -2138,47 +2189,10 @@ impl GitRepository for RealGitRepository {
                     .map(|(path, _)| path.clone())
                     .collect::<HashSet<_>>();
 
-                let mut untracked_args: Vec<OsString> = vec![
-                    "ls-files".into(),
-                    "--others".into(),
-                    "--exclude-standard".into(),
-                    "-z".into(),
-                ];
-                if !path_prefixes.is_empty() {
-                    untracked_args.push("--".into());
-                    untracked_args.extend(
-                        path_prefixes
-                            .iter()
-                            .map(|p| p.as_std_path().as_os_str().to_os_string()),
-                    );
-                }
-                let untracked_output = git_binary.run_raw(&untracked_args).await?;
-
-                for path_str in untracked_output.split_terminator('\0') {
-                    let Ok(path) = RepoPath::new(path_str) else {
-                        continue;
-                    };
-                    if paths_with_stats.contains(&path) {
-                        continue;
-                    }
-
-                    let full_path = git_binary.working_directory.join(path.as_std_path());
-                    match smol::fs::read(&full_path).await {
-                        Ok(contents) => {
-                            entries.push((
-                                path.clone(),
-                                crate::status::DiffStat {
-                                    added: line_count_for_diff_stat(&contents),
-                                    deleted: 0,
-                                },
-                            ));
-                            paths_with_stats.insert(path);
-                        }
-                        Err(err) => {
-                            log::debug!("failed to read untracked file {full_path:?}: {err}");
-                        }
-                    }
-                }
+                entries.extend(
+                    untracked_diff_stat_entries(&git_binary, &path_prefixes, &mut paths_with_stats)
+                        .await?,
+                );
 
                 entries.sort_by(|(a, _), (b, _)| a.cmp(b));
                 entries.dedup_by(|(a, _), (b, _)| a == b);
@@ -3741,15 +3755,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_line_count_for_diff_stat() {
-        assert_eq!(line_count_for_diff_stat(b""), 0);
-        assert_eq!(line_count_for_diff_stat(b"one"), 1);
-        assert_eq!(line_count_for_diff_stat(b"one\n"), 1);
-        assert_eq!(line_count_for_diff_stat(b"one\ntwo"), 2);
-        assert_eq!(line_count_for_diff_stat(b"one\ntwo\n"), 2);
-    }
-
     #[gpui::test]
     async fn test_build_command_untrusted_includes_both_safety_args(cx: &mut TestAppContext) {
         cx.executor().allow_parking();
@@ -3869,6 +3874,56 @@ mod tests {
         assert_eq!(
             path,
             git_directory.join(format!("index-{}.tmp", Uuid::nil()))
+        );
+    }
+
+    #[gpui::test]
+    async fn test_diff_stat_includes_untracked_files(cx: &mut TestAppContext) {
+        disable_git_global_config();
+
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(repo_dir.path()).unwrap();
+        smol::fs::write(repo_dir.path().join("tracked.txt"), "tracked\n")
+            .await
+            .unwrap();
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        repo.stage_paths(vec![repo_path("tracked.txt")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+        repo.commit(
+            "Initial commit".into(),
+            None,
+            CommitOptions::default(),
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(checkpoint_author_envs()),
+        )
+        .await
+        .unwrap();
+
+        smol::fs::write(repo_dir.path().join("new.txt"), "one\ntwo\n")
+            .await
+            .unwrap();
+
+        let diff_stat = repo.diff_stat(&[]).await.unwrap();
+        assert_eq!(
+            diff_stat.entries.as_ref(),
+            &[(
+                repo_path("new.txt"),
+                crate::status::DiffStat {
+                    added: 2,
+                    deleted: 0
+                }
+            )]
         );
     }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -2114,7 +2114,11 @@ impl GitRepository for RealGitRepository {
         let fut = async move {
             let git_binary = git_binary?;
 
-            let tracked = tracked_lines(&git_binary, &path_prefixes).await?;
+            // `git diff --numstat HEAD` fails when there are no commits yet,
+            // so treat errors as "no tracked changes" rather than propagating.
+            let tracked = tracked_lines(&git_binary, &path_prefixes)
+                .await
+                .unwrap_or_default();
             let paths_with_stats: Mutex<_> = tracked
                 .iter()
                 .map(|(path, _)| path.clone())
@@ -2145,7 +2149,6 @@ impl GitRepository for RealGitRepository {
                 .or(timeout)
                 .await;
 
-            dbg!(&total);
             Ok(GitDiffStat {
                 entries: total.into_iter().collect_vec().into(),
             })
@@ -3828,8 +3831,6 @@ mod tests {
             git_directory.join(format!("index-{}.tmp", Uuid::nil()))
         );
     }
-
-    // TODO!(yara) test worktrees (both symlink behaviour and basic untracked)
 
     #[gpui::test]
     async fn test_diff_stat_includes_untracked_files(cx: &mut TestAppContext) {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -21,8 +21,8 @@ use rope::Rope;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use smallvec::SmallVec;
-use smol::io::{AsyncBufReadExt, BufReader};
 use smol::Timer;
+use smol::io::{AsyncBufReadExt, BufReader};
 use text::LineEnding;
 
 use std::collections::{BTreeMap, HashSet};
@@ -2125,6 +2125,11 @@ impl GitRepository for RealGitRepository {
                 count_untracked_lines(&git_binary, path_prefixes, &paths_with_stats).await?;
 
             let timeout = async {
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "This will not cause non-determinism since the tests \
+                    should complete well before 2s"
+                )]
                 Timer::after(Duration::from_secs(1)).await;
                 warn!("Timed out counting lines in untracked file paths");
                 BTreeMap::<RepoPath, DiffStat>::new()
@@ -2140,6 +2145,7 @@ impl GitRepository for RealGitRepository {
                 .or(timeout)
                 .await;
 
+            dbg!(&total);
             Ok(GitDiffStat {
                 entries: total.into_iter().collect_vec().into(),
             })

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -669,18 +669,15 @@ pub(crate) async fn count_untracked_lines(
     let stream = output // TODO!(Yara) check if this is not regressing pref (use chromium)
         .split_terminator('\0')
         .filter_map(|path_str| {
-            dbg!(&path_str);
             let Ok(path) = RepoPath::new(path_str) else {
                 return None;
             };
             if paths_with_stats.lock().contains(&path) {
                 return None;
             }
-            dbg!(&path_str);
 
             let absolute_path: Arc<Path> =
                 git_binary.working_directory.join(path.as_std_path()).into();
-            dbg!(&absolute_path);
             untracked_path_diff_stat(Arc::clone(&absolute_path), Arc::clone(&repo_path))
                 .map(move |res| match res {
                     Ok(Some(diff_stat)) => {
@@ -705,9 +702,7 @@ async fn untracked_path_diff_stat(
 ) -> Result<Option<crate::status::DiffStat>> {
     const ONE_MEGABYTE: u64 = 1024 * 1024;
 
-    dbg!();
     let file = smol::fs::symlink_metadata(&absolute_path).await?;
-    dbg!();
     if file.len() > ONE_MEGABYTE {
         return Ok(None);
     }
@@ -718,11 +713,9 @@ async fn untracked_path_diff_stat(
         absolute_path
     };
 
-    dbg!(&absolute_path, &repo_path);
     if file.is_symlink() && absolute_path.strip_prefix(repo_path).is_err() {
         return Ok(None); // symlink to file outside repository
     }
-    dbg!();
 
     if smol::fs::metadata(&absolute_path).await?.is_dir() {
         return Ok(None);
@@ -779,7 +772,7 @@ async fn utf8_line_count(reader: impl smol::io::AsyncRead) -> Result<u32, LineCo
 
     // will be wrong if the buffer
     let has_trailing_chars = last_read.last().is_some_and(|b| *b != b'\n');
-    Ok(count + dbg!(has_trailing_chars) as u32)
+    Ok(count + has_trailing_chars as u32)
 }
 
 fn trim_broken_utf8(s: &[u8]) -> &[u8] {

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -666,7 +666,7 @@ pub(crate) async fn count_untracked_lines(
     let output = git_binary.run_raw(&args).await?;
     let repo_path: Arc<Path> = git_binary.working_directory.clone().into();
 
-    let stream = output // TODO!(Yara) check if this is not regressing pref (use chromium)
+    let stream = output 
         .split_terminator('\0')
         .filter_map(|path_str| {
             let Ok(path) = RepoPath::new(path_str) else {

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -1,15 +1,16 @@
 use crate::repository::GitBinary;
 use crate::{Oid, repository::RepoPath};
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use collections::{HashMap, HashSet};
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, Stream};
 use gpui::SharedString;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use smol::io::{AsyncBufReadExt, BufReader};
+use smol::io::{AsyncReadExt, BufReader};
+use smol::stream::StreamExt;
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{str::FromStr, sync::Arc};
 use util::{ResultExt, rel_path::RelPath};
 
@@ -653,6 +654,7 @@ pub(crate) async fn count_untracked_lines(
     git_binary: &GitBinary,
     mut path_prefixes: Vec<OsString>,
     paths_with_stats: &Mutex<HashSet<RepoPath>>,
+    repo_path: PathBuf,
 ) -> Result<impl Stream<Item = Option<(RepoPath, DiffStat)>>> {
     let mut args: Vec<OsString> = vec![
         "ls-files".into(),
@@ -665,8 +667,9 @@ pub(crate) async fn count_untracked_lines(
         args.append(&mut path_prefixes);
     }
     let output = git_binary.run_raw(&args).await?;
+    let repo_path: Arc<Path> = repo_path.into();
 
-    let stream = output
+    let stream = output // TODO!(Yara) check if this is not regressing pref (use chromium)
         .split_terminator('\0')
         .filter_map(|path_str| {
             let Ok(path) = RepoPath::new(path_str) else {
@@ -677,7 +680,7 @@ pub(crate) async fn count_untracked_lines(
             }
 
             let full_path: Arc<Path> = git_binary.working_directory.join(path.as_std_path()).into();
-            untracked_path_diff_stat(Arc::clone(&full_path))
+            untracked_path_diff_stat(Arc::clone(&full_path), Arc::clone(&repo_path))
                 .map(move |res| match res {
                     Ok(Some(diff_stat)) => {
                         paths_with_stats.lock().insert(path.clone());
@@ -695,50 +698,86 @@ pub(crate) async fn count_untracked_lines(
     Ok(stream)
 }
 
-async fn untracked_path_diff_stat(full_path: Arc<Path>) -> Result<Option<crate::status::DiffStat>> {
-    let metadata = smol::fs::symlink_metadata(&full_path).await?;
-    let file_type = metadata.file_type();
-    let added = if file_type.is_file() {
-        line_count_for_diff_stat_file(&full_path).await?
-    } else if file_type.is_symlink() {
-        let target = smol::fs::read_link(&full_path).await?;
-        line_count_for_diff_stat(target.to_string_lossy().as_bytes())
-    } else {
+async fn untracked_path_diff_stat(
+    full_path: Arc<Path>,
+    repo_path: Arc<Path>,
+) -> Result<Option<crate::status::DiffStat>> {
+    const ONE_MEGABYTE: u64 = 1024 * 1024;
+
+    let file = smol::fs::symlink_metadata(&full_path).await?;
+    if file.len() > ONE_MEGABYTE {
         return Ok(None);
-    };
-
-    Ok(Some(crate::status::DiffStat { added, deleted: 0 }))
-}
-
-async fn line_count_for_diff_stat_file(path: &Path) -> Result<u32> {
-    let file = smol::fs::File::open(path).await?;
-    let mut reader = BufReader::new(file);
-    let mut line_count = 0u32;
-    let mut line = Vec::new();
-
-    loop {
-        line.clear();
-        if reader.read_until(b'\n', &mut line).await? == 0 {
-            break;
-        }
-        line_count = line_count.saturating_add(1);
     }
 
-    Ok(line_count)
-}
-
-fn line_count_for_diff_stat(contents: &[u8]) -> u32 {
-    if contents.is_empty() {
-        return 0;
-    }
-
-    let trailing_line = if contents.last() == Some(&b'\n') {
-        0
+    let path = if file.is_symlink() {
+        smol::fs::read_link(&full_path).await?.into()
     } else {
-        1
+        full_path
     };
-    let line_count = contents.iter().filter(|byte| **byte == b'\n').count() + trailing_line;
-    u32::try_from(line_count).unwrap_or(u32::MAX)
+
+    if file.is_symlink() && path.strip_prefix(repo_path).is_err() {
+        return Ok(None); // symlink to file outside repository
+    }
+
+    if !file.is_file() {
+        return Ok(None);
+    }
+
+    match utf8_line_count_for_file(&path).await {
+        Ok(count) => Ok(Some(DiffStat {
+            added: count,
+            deleted: 0,
+        })),
+        Err(LineCountErr::NotUtf8) => Ok(None),
+        Err(LineCountErr::ReadError(e)) => Err(e)
+            .context("Count not count lines for untracked diff file")
+            .with_context(|| format!("path: {}", path.display())),
+    }
+}
+
+enum LineCountErr {
+    NotUtf8,
+    ReadError(std::io::Error),
+}
+
+async fn utf8_line_count_for_file(path: &Path) -> Result<u32, LineCountErr> {
+    fn is_validate_utf8(bytes: &[u8]) -> bool {
+        fn are_cnt_bytes<const N: usize>(bytes: [u8; N]) -> bool {
+            bytes.iter().all(|b| b & 0b1000_0000 != 0)
+        }
+
+        match bytes {
+            [b1] => b1 & 0b1000_0000 != 0,
+            [b1, b2] => b1 & 0b1100_0000 != 0 && are_cnt_bytes([*b2]),
+            [b1, b2, b3] => b1 & 0b1110_0000 != 0 && are_cnt_bytes([*b2, *b3]),
+            [b1, b2, b3, b4] => b1 & 0b1111_0000 != 0 && are_cnt_bytes([*b2, *b3, *b4]),
+            _ => unreachable!("only slices of length 1 to 4 are passed in"),
+        }
+    }
+    fn is_linefeed(bytes: &[u8]) -> bool {
+        matches!(bytes, [b'\r', b'\n', ..] | [b'\n', ..])
+    }
+
+    let file = smol::fs::File::open(path)
+        .await
+        .map_err(LineCountErr::ReadError)?;
+    let mut bytes = BufReader::new(file).bytes();
+
+    let mut count = 0;
+    let mut maybe_utf8 = heapless::Vec::<u8, 4>::new();
+    while let Some(byte) = bytes.next().await {
+        let byte = byte.map_err(LineCountErr::ReadError)?;
+        maybe_utf8.push(byte).expect("cleared before out of space");
+        if is_validate_utf8(&maybe_utf8) {
+            count += is_linefeed(&maybe_utf8) as u32;
+            maybe_utf8.clear();
+        }
+        if maybe_utf8.is_full() {
+            return Err(LineCountErr::NotUtf8);
+        }
+    }
+
+    Ok(count)
 }
 
 #[cfg(test)]

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -1,8 +1,15 @@
+use crate::repository::GitBinary;
 use crate::{Oid, repository::RepoPath};
 use anyhow::{Result, anyhow};
-use collections::HashMap;
+use collections::{HashMap, HashSet};
+use futures::stream::FuturesUnordered;
+use futures::{FutureExt, Stream};
 use gpui::SharedString;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use smol::io::{AsyncBufReadExt, BufReader};
+use std::ffi::OsString;
+use std::path::Path;
 use std::{str::FromStr, sync::Arc};
 use util::{ResultExt, rel_path::RelPath};
 
@@ -596,36 +603,142 @@ pub struct GitDiffStat {
 /// ```text
 /// 24   12   dir/file.txt
 /// ```
-pub fn parse_numstat(output: &str) -> GitDiffStat {
-    let mut entries = Vec::new();
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let mut parts = line.splitn(3, '\t');
-        let (Some(added_str), Some(deleted_str), Some(path_str)) =
-            (parts.next(), parts.next(), parts.next())
-        else {
-            continue;
-        };
-        let Ok(added) = added_str.parse::<u32>() else {
-            continue;
-        };
-        let Ok(deleted) = deleted_str.parse::<u32>() else {
-            continue;
-        };
-        let Ok(path) = RepoPath::new(path_str) else {
-            continue;
-        };
-        entries.push((path, DiffStat { added, deleted }));
-    }
-    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-    entries.dedup_by(|(a, _), (b, _)| a == b);
+pub fn parse_numstat(output: &str) -> Vec<(RepoPath, DiffStat)> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            let mut parts = line.splitn(3, '\t');
+            let (Some(added_str), Some(deleted_str), Some(path_str)) =
+                (parts.next(), parts.next(), parts.next())
+            else {
+                return None;
+            };
+            let Ok(added) = added_str.parse::<u32>() else {
+                return None;
+            };
+            let Ok(deleted) = deleted_str.parse::<u32>() else {
+                return None;
+            };
+            let Ok(path) = RepoPath::new(path_str) else {
+                return None;
+            };
+            Some((path, DiffStat { added, deleted }))
+        })
+        .collect()
+}
 
-    GitDiffStat {
-        entries: entries.into(),
+pub(crate) async fn tracked_lines(
+    git_binary: &GitBinary,
+    path_prefixes: &[OsString],
+) -> Result<Vec<(RepoPath, crate::status::DiffStat)>> {
+    let mut args: Vec<OsString> = vec![
+        "diff".into(),
+        "--numstat".into(),
+        "--no-renames".into(),
+        "HEAD".into(),
+    ];
+    if !path_prefixes.is_empty() {
+        args.push("--".into());
+        args.extend(path_prefixes.iter().cloned());
     }
+    let output = git_binary.run(&args).await?;
+    Ok(crate::status::parse_numstat(&output))
+}
+
+pub(crate) async fn count_untracked_lines(
+    git_binary: &GitBinary,
+    mut path_prefixes: Vec<OsString>,
+    paths_with_stats: &Mutex<HashSet<RepoPath>>,
+) -> Result<impl Stream<Item = Option<(RepoPath, DiffStat)>>> {
+    let mut args: Vec<OsString> = vec![
+        "ls-files".into(),
+        "--others".into(),
+        "--exclude-standard".into(),
+        "-z".into(),
+    ];
+    if !path_prefixes.is_empty() {
+        args.push("--".into());
+        args.append(&mut path_prefixes);
+    }
+    let output = git_binary.run_raw(&args).await?;
+
+    let stream = output
+        .split_terminator('\0')
+        .filter_map(|path_str| {
+            let Ok(path) = RepoPath::new(path_str) else {
+                return None;
+            };
+            if paths_with_stats.lock().contains(&path) {
+                return None;
+            }
+
+            let full_path: Arc<Path> = git_binary.working_directory.join(path.as_std_path()).into();
+            untracked_path_diff_stat(Arc::clone(&full_path))
+                .map(move |res| match res {
+                    Ok(Some(diff_stat)) => {
+                        paths_with_stats.lock().insert(path.clone());
+                        Some((path, diff_stat))
+                    }
+                    Ok(None) => None,
+                    Err(err) => {
+                        log::debug!("failed to stat untracked file {full_path:?}: {err}");
+                        None
+                    }
+                })
+                .into() // Some
+        })
+        .collect::<FuturesUnordered<_>>();
+    Ok(stream)
+}
+
+async fn untracked_path_diff_stat(full_path: Arc<Path>) -> Result<Option<crate::status::DiffStat>> {
+    let metadata = smol::fs::symlink_metadata(&full_path).await?;
+    let file_type = metadata.file_type();
+    let added = if file_type.is_file() {
+        line_count_for_diff_stat_file(&full_path).await?
+    } else if file_type.is_symlink() {
+        let target = smol::fs::read_link(&full_path).await?;
+        line_count_for_diff_stat(target.to_string_lossy().as_bytes())
+    } else {
+        return Ok(None);
+    };
+
+    Ok(Some(crate::status::DiffStat { added, deleted: 0 }))
+}
+
+async fn line_count_for_diff_stat_file(path: &Path) -> Result<u32> {
+    let file = smol::fs::File::open(path).await?;
+    let mut reader = BufReader::new(file);
+    let mut line_count = 0u32;
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line).await? == 0 {
+            break;
+        }
+        line_count = line_count.saturating_add(1);
+    }
+
+    Ok(line_count)
+}
+
+fn line_count_for_diff_stat(contents: &[u8]) -> u32 {
+    if contents.is_empty() {
+        return 0;
+    }
+
+    let trailing_line = if contents.last() == Some(&b'\n') {
+        0
+    } else {
+        1
+    };
+    let line_count = contents.iter().filter(|byte| **byte == b'\n').count() + trailing_line;
+    u32::try_from(line_count).unwrap_or(u32::MAX)
 }
 
 #[cfg(test)]
@@ -647,16 +760,16 @@ mod tests {
     fn test_parse_numstat_normal() {
         let input = "10\t5\tsrc/main.rs\n3\t1\tREADME.md\n";
         let result = parse_numstat(input);
-        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.len(), 2);
         assert_eq!(
-            lookup(&result.entries, "src/main.rs"),
+            lookup(&result, "src/main.rs"),
             Some(&DiffStat {
                 added: 10,
                 deleted: 5
             })
         );
         assert_eq!(
-            lookup(&result.entries, "README.md"),
+            lookup(&result, "README.md"),
             Some(&DiffStat {
                 added: 3,
                 deleted: 1
@@ -669,10 +782,10 @@ mod tests {
         // git diff --numstat outputs "-\t-\tpath" for binary files
         let input = "-\t-\timage.png\n5\t2\tsrc/lib.rs\n";
         let result = parse_numstat(input);
-        assert_eq!(result.entries.len(), 1);
-        assert!(lookup(&result.entries, "image.png").is_none());
+        assert_eq!(result.len(), 1);
+        assert!(lookup(&result, "image.png").is_none());
         assert_eq!(
-            lookup(&result.entries, "src/lib.rs"),
+            lookup(&result, "src/lib.rs"),
             Some(&DiffStat {
                 added: 5,
                 deleted: 2
@@ -682,18 +795,18 @@ mod tests {
 
     #[test]
     fn test_parse_numstat_empty_input() {
-        assert!(parse_numstat("").entries.is_empty());
-        assert!(parse_numstat("\n\n").entries.is_empty());
-        assert!(parse_numstat("   \n  \n").entries.is_empty());
+        assert!(parse_numstat("").is_empty());
+        assert!(parse_numstat("\n\n").is_empty());
+        assert!(parse_numstat("   \n  \n").is_empty());
     }
 
     #[test]
     fn test_parse_numstat_malformed_lines_skipped() {
         let input = "not_a_number\t5\tfile.rs\n10\t5\tvalid.rs\n";
         let result = parse_numstat(input);
-        assert_eq!(result.entries.len(), 1);
+        assert_eq!(result.len(), 1);
         assert_eq!(
-            lookup(&result.entries, "valid.rs"),
+            lookup(&result, "valid.rs"),
             Some(&DiffStat {
                 added: 10,
                 deleted: 5
@@ -706,9 +819,9 @@ mod tests {
         // Lines with fewer than 3 tab-separated fields are skipped
         let input = "10\t5\n7\t3\tok.rs\n";
         let result = parse_numstat(input);
-        assert_eq!(result.entries.len(), 1);
+        assert_eq!(result.len(), 1);
         assert_eq!(
-            lookup(&result.entries, "ok.rs"),
+            lookup(&result, "ok.rs"),
             Some(&DiffStat {
                 added: 7,
                 deleted: 3
@@ -721,7 +834,7 @@ mod tests {
         let input = "0\t0\tunchanged_but_present.rs\n";
         let result = parse_numstat(input);
         assert_eq!(
-            lookup(&result.entries, "unchanged_but_present.rs"),
+            lookup(&result, "unchanged_but_present.rs"),
             Some(&DiffStat {
                 added: 0,
                 deleted: 0

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -666,7 +666,7 @@ pub(crate) async fn count_untracked_lines(
     let output = git_binary.run_raw(&args).await?;
     let repo_path: Arc<Path> = git_binary.working_directory.clone().into();
 
-    let stream = output 
+    let stream = output
         .split_terminator('\0')
         .filter_map(|path_str| {
             let Ok(path) = RepoPath::new(path_str) else {

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -7,8 +7,6 @@ use futures::{FutureExt, Stream, pin_mut};
 use gpui::SharedString;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use smol::io::{AsyncReadExt, BufReader};
-use smol::stream::StreamExt;
 use std::ffi::OsString;
 use std::path::Path;
 use std::{str::FromStr, sync::Arc};
@@ -730,9 +728,9 @@ async fn untracked_path_diff_stat(
         return Ok(None);
     }
 
-    let file = smol::fs::File::open(&absolute_path).await?;
-    let bytes = BufReader::new(file).bytes();
-    match dbg!(utf8_line_count_for_stream(bytes).await) {
+    let reader = smol::fs::File::open(&absolute_path).await?;
+    let reader = smol::io::BufReader::new(reader);
+    match utf8_line_count(reader).await {
         Ok(count) => Ok(Some(DiffStat {
             added: count,
             deleted: 0,
@@ -750,59 +748,86 @@ enum LineCountErr {
     ReadError(std::io::Error),
 }
 
-async fn utf8_line_count_for_stream(
-    bytes: impl Stream<Item = Result<u8, std::io::Error>>,
-) -> Result<u32, LineCountErr> {
-    fn is_utf8(bytes: &[u8]) -> bool {
-        fn are_cnt_bytes<const N: usize>(bytes: [u8; N]) -> bool {
-            bytes.iter().all(|b| b & 0b1100_0000 == 0b1000_0000)
-        }
-
-        match bytes {
-            [b1] => b1 & 0b1000_0000 == 0b0000_0000,
-            [b1, b2] => {
-                std::hint::cold_path();
-                b1 & 0b1110_0000 == 0b1100_0000 && are_cnt_bytes([*b2])
-            }
-            [b1, b2, b3] => {
-                std::hint::cold_path();
-                b1 & 0b1111_0000 == 0b1110_0000 && are_cnt_bytes([*b2, *b3])
-            }
-            [b1, b2, b3, b4] => {
-                std::hint::cold_path();
-                b1 & 0b1111_1000 == 0b1111_0000 && are_cnt_bytes([*b2, *b3, *b4])
-            }
-            _ => unreachable!("only slices of length 1 to 4 are passed in"),
-        }
-    }
-    fn is_linefeed(bytes: &[u8]) -> bool {
-        matches!(bytes, [b'\r', b'\n', ..] | [b'\n', ..])
-    }
-
+// Line feeds are not multi byte utf8 characters so we can safely ignore those.
+// We also do not need to be sure the text is valid utf8, a high probability is
+// enough. We use this to speed things up by ignoring characters split between
+// buffers instead (we strip the first and last bytes that match the utf8
+// continuation pattern instead).
+async fn utf8_line_count(reader: impl smol::io::AsyncRead) -> Result<u32, LineCountErr> {
+    use smol::io::AsyncReadExt;
+    let mut buff = [0u8; 20_000];
+    let mut prev_n_read = 0;
     let mut count = 0;
-    let mut has_trailing_characters = false;
-    let mut maybe_utf8 = heapless::Vec::<u8, 4>::new();
 
-    pin_mut!(bytes);
-    while let Some(byte) = bytes.next().await {
-        let byte = byte.map_err(LineCountErr::ReadError)?;
-        maybe_utf8.push(byte).expect("cleared before out of space");
-        if is_utf8(&maybe_utf8) {
-            if is_linefeed(&maybe_utf8) {
-                count += 1;
-                has_trailing_characters = false;
-            } else {
-                has_trailing_characters = true;
-            }
-            maybe_utf8.clear();
+    pin_mut!(reader);
+    let last_read = loop {
+        let n_read = reader
+            .read(&mut buff)
+            .await
+            .map_err(LineCountErr::ReadError)?;
+        if n_read == 0 {
+            break &buff[..prev_n_read];
         }
-        dbg!(&maybe_utf8);
-        if maybe_utf8.is_full() {
-            return Err(LineCountErr::NotUtf8);
-        }
+
+        prev_n_read = n_read;
+        let read = &buff[..n_read];
+        let read = trim_broken_utf8(&read);
+
+        str::from_utf8(read).map_err(|_| LineCountErr::NotUtf8)?;
+        count += buff.iter().filter(|b| **b == b'\n').count() as u32;
+    };
+
+    // will be wrong if the buffer
+    let has_trailing_chars = last_read.last().is_some_and(|b| *b != b'\n');
+    Ok(count + dbg!(has_trailing_chars) as u32)
+}
+
+fn trim_broken_utf8(s: &[u8]) -> &[u8] {
+    #[inline(always)]
+    fn all_utf8_cnt<const N: usize>(bytes: [u8; N]) -> bool {
+        bytes.iter().all(|b| b & 0b1100_0000 == 0b1000_0000)
+    }
+    #[inline(always)]
+    fn utf8_len1_start(byte: u8) -> bool {
+        byte & 0b1000_0000 == 0b0000_0000
+    }
+    #[inline(always)]
+    fn utf8_len2_start(byte: u8) -> bool {
+        byte & 0b1110_0000 == 0b1100_0000
+    }
+    #[inline(always)]
+    fn utf8_len3_start(byte: u8) -> bool {
+        byte & 0b1111_0000 == 0b1110_0000
     }
 
-    Ok(count + has_trailing_characters as u32)
+    let s = match s {
+        [b1, b2, b3, ..] if all_utf8_cnt([*b1, *b2, *b3]) => &s[3..],
+        [b1, b2, ..] if all_utf8_cnt([*b1, *b2]) => &s[2..],
+        [b1, ..] if all_utf8_cnt([*b1]) => &s[1..],
+        _ => s,
+    };
+
+    let s = match s {
+        [.., b0, b1, b2, b3] if all_utf8_cnt([*b1, *b2, *b3]) => s,
+        [.., b0, b1, b2] if all_utf8_cnt([*b1, *b2]) => {
+            if utf8_len3_start(*b0) {
+                s
+            } else {
+                &s[..s.len() - 3]
+            }
+        }
+        [.., b0, b1] if all_utf8_cnt([*b1]) => {
+            if utf8_len2_start(*b0) {
+                s
+            } else {
+                &s[..s.len() - 2]
+            }
+        }
+        [.., b0] if !utf8_len1_start(*b0) => &s[..s.len() - 1],
+        [..] => s,
+    };
+
+    s
 }
 
 #[cfg(test)]
@@ -951,14 +976,13 @@ mod tests {
     }
 
     #[test]
-    fn test_utf8_line_count_for_stream() {
-        use super::utf8_line_count_for_stream;
-        use futures::stream;
+    fn test_utf8_line_count() {
+        use super::utf8_line_count;
 
         #[track_caller]
-        fn assert_utf8_line_count(input: &str, expected: u32) {
-            let byte_stream = stream::iter(input.bytes().map(Ok::<u8, std::io::Error>));
-            let count = smol::block_on(utf8_line_count_for_stream(byte_stream)).unwrap();
+        fn assert_count(input: &str, expected: u32) {
+            let cursor = smol::io::Cursor::new(input.as_bytes().to_vec());
+            let count = smol::block_on(utf8_line_count(cursor)).unwrap();
             assert_eq!(count, expected, "input: {input:?}");
         }
 
@@ -972,52 +996,25 @@ mod tests {
         assert_eq!('🦀'.len_utf8(), 4);
         assert_eq!('🌈'.len_utf8(), 4);
 
-        assert_utf8_line_count("A\n¢\r\n❤😀\n🦀☃\n", 4);
-        assert_utf8_line_count("A\n¢\r\n❤😀\n🦀☃\nñ🌈", 5);
-        assert_utf8_line_count("", 0);
-        assert_utf8_line_count("❤🦀😀☃¢ñ🌈", 1);
-        assert_utf8_line_count("🦀\n\n\n😀", 4);
-        assert_utf8_line_count("🌈\r\n☃", 2);
-    }
+        assert_count("A\n¢\r\n❤😀\n🦀☃\n", 4);
+        assert_count("A\n¢\r\n❤😀\n🦀☃\nñ🌈", 5);
+        assert_count("", 0);
+        assert_count("❤🦀😀☃¢ñ🌈", 1);
+        assert_count("🦀\n\n\n😀", 4);
+        assert_count("🌈\r\n☃", 2);
 
-    mod perf {
-        use super::super::utf8_line_count_for_stream;
-        use futures::stream;
-        use util_macros::perf;
+        // 3-byte characters (e.g. em-dash U+2014) mixed with other widths
+        assert_eq!('—'.len_utf8(), 3);
+        assert_count("hello — world\n", 1);
+        assert_count("—\n—\n—", 3);
+        assert_count("ñoño — ❤🌈\n", 1);
 
-        fn make_test_input(line_count: usize) -> String {
-            let line = "The quick brown 🦀 jumps over the lazy ☃ — ñoño! ❤🌈\n";
-            line.repeat(line_count)
-        }
-
-        #[perf]
-        fn bench_utf8_line_count_for_stream_small() {
-            let input = make_test_input(100);
-            let byte_stream = stream::iter(input.bytes().map(Ok::<u8, std::io::Error>));
-            let count = smol::block_on(utf8_line_count_for_stream(byte_stream)).unwrap();
-            assert_eq!(count, 100);
-        }
-
-        #[perf]
-        fn bench_utf8_line_count_for_stream_large() {
-            let input = make_test_input(10_000);
-            let byte_stream = stream::iter(input.bytes().map(Ok::<u8, std::io::Error>));
-            let count = smol::block_on(utf8_line_count_for_stream(byte_stream)).unwrap();
-            assert_eq!(count, 10_000);
-        }
-
-        #[perf]
-        fn bench_lines_count_small() {
-            let input = make_test_input(100);
-            let count = input.lines().count();
-            assert_eq!(count, 100);
-        }
-
-        #[perf]
-        fn bench_lines_count_large() {
-            let input = make_test_input(10_000);
-            let count = input.lines().count();
-            assert_eq!(count, 10_000);
-        }
+        // Invalid UTF-8 should return an error
+        let invalid: Vec<u8> = vec![0xFF, 0xFE, 0xFD, 0xFC];
+        let cursor = smol::io::Cursor::new(invalid);
+        assert!(
+            smol::block_on(utf8_line_count(cursor)).is_err(),
+            "expected error on invalid UTF-8"
+        );
     }
 }

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -3,14 +3,14 @@ use crate::{Oid, repository::RepoPath};
 use anyhow::{Context, Result, anyhow};
 use collections::{HashMap, HashSet};
 use futures::stream::FuturesUnordered;
-use futures::{FutureExt, Stream};
+use futures::{FutureExt, Stream, pin_mut};
 use gpui::SharedString;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use smol::io::{AsyncReadExt, BufReader};
 use smol::stream::StreamExt;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::{str::FromStr, sync::Arc};
 use util::{ResultExt, rel_path::RelPath};
 
@@ -654,7 +654,6 @@ pub(crate) async fn count_untracked_lines(
     git_binary: &GitBinary,
     mut path_prefixes: Vec<OsString>,
     paths_with_stats: &Mutex<HashSet<RepoPath>>,
-    repo_path: PathBuf,
 ) -> Result<impl Stream<Item = Option<(RepoPath, DiffStat)>>> {
     let mut args: Vec<OsString> = vec![
         "ls-files".into(),
@@ -667,20 +666,24 @@ pub(crate) async fn count_untracked_lines(
         args.append(&mut path_prefixes);
     }
     let output = git_binary.run_raw(&args).await?;
-    let repo_path: Arc<Path> = repo_path.into();
+    let repo_path: Arc<Path> = git_binary.working_directory.clone().into();
 
     let stream = output // TODO!(Yara) check if this is not regressing pref (use chromium)
         .split_terminator('\0')
         .filter_map(|path_str| {
+            dbg!(&path_str);
             let Ok(path) = RepoPath::new(path_str) else {
                 return None;
             };
             if paths_with_stats.lock().contains(&path) {
                 return None;
             }
+            dbg!(&path_str);
 
-            let full_path: Arc<Path> = git_binary.working_directory.join(path.as_std_path()).into();
-            untracked_path_diff_stat(Arc::clone(&full_path), Arc::clone(&repo_path))
+            let absolute_path: Arc<Path> =
+                git_binary.working_directory.join(path.as_std_path()).into();
+            dbg!(&absolute_path);
+            untracked_path_diff_stat(Arc::clone(&absolute_path), Arc::clone(&repo_path))
                 .map(move |res| match res {
                     Ok(Some(diff_stat)) => {
                         paths_with_stats.lock().insert(path.clone());
@@ -688,7 +691,7 @@ pub(crate) async fn count_untracked_lines(
                     }
                     Ok(None) => None,
                     Err(err) => {
-                        log::debug!("failed to stat untracked file {full_path:?}: {err}");
+                        log::debug!("failed to stat untracked file {absolute_path:?}: {err}");
                         None
                     }
                 })
@@ -699,31 +702,37 @@ pub(crate) async fn count_untracked_lines(
 }
 
 async fn untracked_path_diff_stat(
-    full_path: Arc<Path>,
+    absolute_path: Arc<Path>,
     repo_path: Arc<Path>,
 ) -> Result<Option<crate::status::DiffStat>> {
     const ONE_MEGABYTE: u64 = 1024 * 1024;
 
-    let file = smol::fs::symlink_metadata(&full_path).await?;
+    dbg!();
+    let file = smol::fs::symlink_metadata(&absolute_path).await?;
+    dbg!();
     if file.len() > ONE_MEGABYTE {
         return Ok(None);
     }
 
-    let path = if file.is_symlink() {
-        smol::fs::read_link(&full_path).await?.into()
+    let absolute_path = if file.is_symlink() {
+        smol::fs::read_link(&absolute_path).await?.into()
     } else {
-        full_path
+        absolute_path
     };
 
-    if file.is_symlink() && path.strip_prefix(repo_path).is_err() {
+    dbg!(&absolute_path, &repo_path);
+    if file.is_symlink() && absolute_path.strip_prefix(repo_path).is_err() {
         return Ok(None); // symlink to file outside repository
     }
+    dbg!();
 
-    if !file.is_file() {
+    if smol::fs::metadata(&absolute_path).await?.is_dir() {
         return Ok(None);
     }
 
-    match utf8_line_count_for_file(&path).await {
+    let file = smol::fs::File::open(&absolute_path).await?;
+    let bytes = BufReader::new(file).bytes();
+    match dbg!(utf8_line_count_for_stream(bytes).await) {
         Ok(count) => Ok(Some(DiffStat {
             added: count,
             deleted: 0,
@@ -731,26 +740,38 @@ async fn untracked_path_diff_stat(
         Err(LineCountErr::NotUtf8) => Ok(None),
         Err(LineCountErr::ReadError(e)) => Err(e)
             .context("Count not count lines for untracked diff file")
-            .with_context(|| format!("path: {}", path.display())),
+            .with_context(|| format!("path: {}", absolute_path.display())),
     }
 }
 
+#[derive(Debug)]
 enum LineCountErr {
     NotUtf8,
     ReadError(std::io::Error),
 }
 
-async fn utf8_line_count_for_file(path: &Path) -> Result<u32, LineCountErr> {
-    fn is_validate_utf8(bytes: &[u8]) -> bool {
+async fn utf8_line_count_for_stream(
+    bytes: impl Stream<Item = Result<u8, std::io::Error>>,
+) -> Result<u32, LineCountErr> {
+    fn is_utf8(bytes: &[u8]) -> bool {
         fn are_cnt_bytes<const N: usize>(bytes: [u8; N]) -> bool {
-            bytes.iter().all(|b| b & 0b1000_0000 != 0)
+            bytes.iter().all(|b| b & 0b1100_0000 == 0b1000_0000)
         }
 
         match bytes {
-            [b1] => b1 & 0b1000_0000 != 0,
-            [b1, b2] => b1 & 0b1100_0000 != 0 && are_cnt_bytes([*b2]),
-            [b1, b2, b3] => b1 & 0b1110_0000 != 0 && are_cnt_bytes([*b2, *b3]),
-            [b1, b2, b3, b4] => b1 & 0b1111_0000 != 0 && are_cnt_bytes([*b2, *b3, *b4]),
+            [b1] => b1 & 0b1000_0000 == 0b0000_0000,
+            [b1, b2] => {
+                std::hint::cold_path();
+                b1 & 0b1110_0000 == 0b1100_0000 && are_cnt_bytes([*b2])
+            }
+            [b1, b2, b3] => {
+                std::hint::cold_path();
+                b1 & 0b1111_0000 == 0b1110_0000 && are_cnt_bytes([*b2, *b3])
+            }
+            [b1, b2, b3, b4] => {
+                std::hint::cold_path();
+                b1 & 0b1111_1000 == 0b1111_0000 && are_cnt_bytes([*b2, *b3, *b4])
+            }
             _ => unreachable!("only slices of length 1 to 4 are passed in"),
         }
     }
@@ -758,26 +779,30 @@ async fn utf8_line_count_for_file(path: &Path) -> Result<u32, LineCountErr> {
         matches!(bytes, [b'\r', b'\n', ..] | [b'\n', ..])
     }
 
-    let file = smol::fs::File::open(path)
-        .await
-        .map_err(LineCountErr::ReadError)?;
-    let mut bytes = BufReader::new(file).bytes();
-
     let mut count = 0;
+    let mut has_trailing_characters = false;
     let mut maybe_utf8 = heapless::Vec::<u8, 4>::new();
+
+    pin_mut!(bytes);
     while let Some(byte) = bytes.next().await {
         let byte = byte.map_err(LineCountErr::ReadError)?;
         maybe_utf8.push(byte).expect("cleared before out of space");
-        if is_validate_utf8(&maybe_utf8) {
-            count += is_linefeed(&maybe_utf8) as u32;
+        if is_utf8(&maybe_utf8) {
+            if is_linefeed(&maybe_utf8) {
+                count += 1;
+                has_trailing_characters = false;
+            } else {
+                has_trailing_characters = true;
+            }
             maybe_utf8.clear();
         }
+        dbg!(&maybe_utf8);
         if maybe_utf8.is_full() {
             return Err(LineCountErr::NotUtf8);
         }
     }
 
-    Ok(count)
+    Ok(count + has_trailing_characters as u32)
 }
 
 #[cfg(test)]
@@ -923,5 +948,76 @@ mod tests {
                 .collect()
             }
         )
+    }
+
+    #[test]
+    fn test_utf8_line_count_for_stream() {
+        use super::utf8_line_count_for_stream;
+        use futures::stream;
+
+        #[track_caller]
+        fn assert_utf8_line_count(input: &str, expected: u32) {
+            let byte_stream = stream::iter(input.bytes().map(Ok::<u8, std::io::Error>));
+            let count = smol::block_on(utf8_line_count_for_stream(byte_stream)).unwrap();
+            assert_eq!(count, expected, "input: {input:?}");
+        }
+
+        // Verify UTF-8 widths: 1, 2, 3, and 4-byte characters
+        assert_eq!('A'.len_utf8(), 1);
+        assert_eq!('¢'.len_utf8(), 2);
+        assert_eq!('ñ'.len_utf8(), 2);
+        assert_eq!('❤'.len_utf8(), 3);
+        assert_eq!('☃'.len_utf8(), 3);
+        assert_eq!('😀'.len_utf8(), 4);
+        assert_eq!('🦀'.len_utf8(), 4);
+        assert_eq!('🌈'.len_utf8(), 4);
+
+        assert_utf8_line_count("A\n¢\r\n❤😀\n🦀☃\n", 4);
+        assert_utf8_line_count("A\n¢\r\n❤😀\n🦀☃\nñ🌈", 5);
+        assert_utf8_line_count("", 0);
+        assert_utf8_line_count("❤🦀😀☃¢ñ🌈", 1);
+        assert_utf8_line_count("🦀\n\n\n😀", 4);
+        assert_utf8_line_count("🌈\r\n☃", 2);
+    }
+
+    mod perf {
+        use super::super::utf8_line_count_for_stream;
+        use futures::stream;
+        use util_macros::perf;
+
+        fn make_test_input(line_count: usize) -> String {
+            let line = "The quick brown 🦀 jumps over the lazy ☃ — ñoño! ❤🌈\n";
+            line.repeat(line_count)
+        }
+
+        #[perf]
+        fn bench_utf8_line_count_for_stream_small() {
+            let input = make_test_input(100);
+            let byte_stream = stream::iter(input.bytes().map(Ok::<u8, std::io::Error>));
+            let count = smol::block_on(utf8_line_count_for_stream(byte_stream)).unwrap();
+            assert_eq!(count, 100);
+        }
+
+        #[perf]
+        fn bench_utf8_line_count_for_stream_large() {
+            let input = make_test_input(10_000);
+            let byte_stream = stream::iter(input.bytes().map(Ok::<u8, std::io::Error>));
+            let count = smol::block_on(utf8_line_count_for_stream(byte_stream)).unwrap();
+            assert_eq!(count, 10_000);
+        }
+
+        #[perf]
+        fn bench_lines_count_small() {
+            let input = make_test_input(100);
+            let count = input.lines().count();
+            assert_eq!(count, 100);
+        }
+
+        #[perf]
+        fn bench_lines_count_large() {
+            let input = make_test_input(10_000);
+            let count = input.lines().count();
+            assert_eq!(count, 10_000);
+        }
     }
 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -7576,8 +7576,6 @@ impl Repository {
                     return Ok(());
                 }
 
-                let has_head = prev_snapshot.head_commit.is_some();
-
                 let stash_entries = backend.stash_entries().await?;
                 let changed_path_statuses = cx
                     .background_spawn(async move {
@@ -7586,14 +7584,7 @@ impl Repository {
                         let changed_paths_vec = changed_paths.iter().cloned().collect::<Vec<_>>();
 
                         let status_task = backend.status(&changed_paths_vec);
-                        let diff_stat_future = if has_head {
-                            backend.diff_stat(&changed_paths_vec)
-                        } else {
-                            future::ready(Ok(status::GitDiffStat {
-                                entries: Arc::default(),
-                            }))
-                            .boxed()
-                        };
+                        let diff_stat_future = backend.diff_stat(&changed_paths_vec);
 
                         let (statuses, diff_stats) =
                             futures::future::try_join(status_task, diff_stat_future).await?;
@@ -8627,17 +8618,8 @@ async fn compute_snapshot(
     let (statuses, diff_stats, stash_entries) = cx
         .background_spawn({
             let backend = backend.clone();
-            let snapshot = snapshot.clone();
             async move {
-                let diff_stat_future: BoxFuture<'_, Result<status::GitDiffStat>> =
-                    if snapshot.head_commit.is_some() {
-                        backend.diff_stat(&[])
-                    } else {
-                        future::ready(Ok(status::GitDiffStat {
-                            entries: Arc::default(),
-                        }))
-                        .boxed()
-                    };
+                let diff_stat_future = backend.diff_stat(&[]);
                 futures::future::try_join3(
                     backend.status(&[RepoPath::from_rel_path(
                         &RelPath::new(".".as_ref(), PathStyle::local()).unwrap(),

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -41,7 +41,7 @@ use git::{
     },
     stash::{GitStash, StashEntry},
     status::{
-        self, DiffStat, DiffTreeType, FileStatus, GitSummary, StatusCode, TrackedStatus, TreeDiff,
+        DiffStat, DiffTreeType, FileStatus, GitSummary, StatusCode, TrackedStatus, TreeDiff,
         TreeDiffStatus, UnmergedStatus, UnmergedStatusCode,
     },
 };

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -10325,12 +10325,10 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
-                    diff_stat: Some(
-                        DiffStat {
-                            added: 1,
-                            deleted: 0,
-                        },
-                    ),
+                    diff_stat: Some(DiffStat {
+                        added: 1,
+                        deleted: 0,
+                    },),
                 },
                 StatusEntry {
                     repo_path: repo_path("d.txt"),

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -10325,7 +10325,12 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
-                    diff_stat: None,
+                    diff_stat: Some(
+                        DiffStat {
+                            added: 1,
+                            deleted: 0,
+                        },
+                    ),
                 },
                 StatusEntry {
                     repo_path: repo_path("d.txt"),

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -10366,7 +10366,10 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
-                    diff_stat: None,
+                    diff_stat: Some(DiffStat {
+                        added: 1,
+                        deleted: 0,
+                    }),
                 },
                 StatusEntry {
                     repo_path: repo_path("c.txt"),
@@ -10925,12 +10928,18 @@ async fn test_repository_pending_ops_stage_all(
                 StatusEntry {
                     repo_path: repo_path("a.txt"),
                     status: FileStatus::Untracked,
-                    diff_stat: None,
+                    diff_stat: Some(DiffStat {
+                        added: 1,
+                        deleted: 0
+                    }),
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
-                    diff_stat: None,
+                    diff_stat: Some(DiffStat {
+                        added: 1,
+                        deleted: 0
+                    }),
                 },
             ]
         );

--- a/crates/util_macros/src/util_macros.rs
+++ b/crates/util_macros/src/util_macros.rs
@@ -180,6 +180,8 @@ impl PerfArgs {
 ///     // Test goes here.
 /// }
 /// ```
+///
+/// Run with: cargo perf-test
 #[proc_macro_attribute]
 #[warn(clippy::all, clippy::pedantic)]
 pub fn perf(our_attr: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
Fixes #54266

Summary:
- Includes untracked files when building git diff stats.
- Counts untracked file lines so new files can show +N in git UI instead of a blank stat.

Release Notes:

- Fixed new files missing added-line counts in git change lists.