### PR TITLE
Use buffer line numbers when copying file locations

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23918,38 +23918,46 @@ impl Editor {
 
         let multi_buffer = self.buffer().read(cx);
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
-        let buffer_ranges = multi_buffer_snapshot
-            .range_to_buffer_ranges(selection_range.start..selection_range.end);
-        let selected_buffer_range = if selection.reversed {
-            buffer_ranges.first()
-        } else {
-            buffer_ranges.last()
+        let format_location = |buffer_snapshot, buffer_range: Range<Point>| {
+            let start_line = buffer_range.start.row + 1;
+            let end_line = buffer_range.end.row + 1;
+
+            let end_line = if buffer_range.end.column == 0 && end_line > start_line {
+                end_line - 1
+            } else {
+                end_line
+            };
+
+            let project = self.project()?.read(cx);
+            let file = buffer_snapshot.file()?;
+            let path = file.path().display(project.path_style(cx));
+
+            let location = if start_line == end_line {
+                format!("{path}:{start_line}")
+            } else {
+                format!("{path}:{start_line}-{end_line}")
+            };
+            Some(location)
         };
 
-        if let Some(file_location) =
+        let file_location = if selection_range.start == selection_range.end {
+            multi_buffer_snapshot
+                .point_to_buffer_point(selection.head())
+                .and_then(|(buffer_snapshot, point)| format_location(buffer_snapshot, point..point))
+        } else {
+            let buffer_ranges = multi_buffer_snapshot
+                .range_to_buffer_ranges(selection_range.start..selection_range.end);
+            let selected_buffer_range = if selection.reversed {
+                buffer_ranges.first()
+            } else {
+                buffer_ranges.last()
+            };
             selected_buffer_range.and_then(|(buffer_snapshot, range, _)| {
-                let buffer_range = range.to_point(buffer_snapshot);
-                let start_line = buffer_range.start.row + 1;
-                let end_line = buffer_range.end.row + 1;
-
-                let end_line = if buffer_range.end.column == 0 && end_line > start_line {
-                    end_line - 1
-                } else {
-                    end_line
-                };
-
-                let project = self.project()?.read(cx);
-                let file = buffer_snapshot.file()?;
-                let path = file.path().display(project.path_style(cx));
-
-                let location = if start_line == end_line {
-                    format!("{path}:{start_line}")
-                } else {
-                    format!("{path}:{start_line}-{end_line}")
-                };
-                Some(location)
+                format_location(buffer_snapshot, range.to_point(buffer_snapshot))
             })
-        {
+        };
+
+        if let Some(file_location) = file_location {
             cx.write_to_clipboard(ClipboardItem::new_string(file_location));
         }
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23914,28 +23914,42 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         let selection = self.selections.newest::<Point>(&self.display_snapshot(cx));
+        let selection_range = selection.range();
 
-        let start_line = selection.start.row + 1;
-        let end_line = selection.end.row + 1;
-
-        let end_line = if selection.end.column == 0 && end_line > start_line {
-            end_line - 1
+        let multi_buffer = self.buffer().read(cx);
+        let multi_buffer_snapshot = multi_buffer.snapshot(cx);
+        let buffer_ranges = multi_buffer_snapshot
+            .range_to_buffer_ranges(selection_range.start..selection_range.end);
+        let selected_buffer_range = if selection.reversed {
+            buffer_ranges.first()
         } else {
-            end_line
+            buffer_ranges.last()
         };
 
-        if let Some(file_location) = self.active_buffer(cx).and_then(|buffer| {
-            let project = self.project()?.read(cx);
-            let file = buffer.read(cx).file()?;
-            let path = file.path().display(project.path_style(cx));
+        if let Some(file_location) =
+            selected_buffer_range.and_then(|(buffer_snapshot, range, _)| {
+                let buffer_range = range.to_point(buffer_snapshot);
+                let start_line = buffer_range.start.row + 1;
+                let end_line = buffer_range.end.row + 1;
 
-            let location = if start_line == end_line {
-                format!("{path}:{start_line}")
-            } else {
-                format!("{path}:{start_line}-{end_line}")
-            };
-            Some(location)
-        }) {
+                let end_line = if buffer_range.end.column == 0 && end_line > start_line {
+                    end_line - 1
+                } else {
+                    end_line
+                };
+
+                let project = self.project()?.read(cx);
+                let file = buffer_snapshot.file()?;
+                let path = file.path().display(project.path_style(cx));
+
+                let location = if start_line == end_line {
+                    format!("{path}:{start_line}")
+                } else {
+                    format!("{path}:{start_line}-{end_line}")
+                };
+                Some(location)
+            })
+        {
             cx.write_to_clipboard(ClipboardItem::new_string(file_location));
         }
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23919,54 +23919,48 @@ impl Editor {
         let multi_buffer = self.buffer().read(cx);
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
 
-        let file_location = if let Some(buffer) = self.active_buffer(cx) {
-            let result = if selection_range.start == selection_range.end {
-                multi_buffer_snapshot
-                    .point_to_buffer_point(selection.head())
-                    .and_then(|(_, point)| {
-                        let start_line = point.row + 1;
+        let format_location = |buffer_snapshot: &BufferSnapshot, buffer_range: Range<Point>| {
+            let start_line = buffer_range.start.row + 1;
+            let end_line = buffer_range.end.row + 1;
 
-                        let project = self.project()?.read(cx);
-                        let file = buffer.read(cx).file()?;
-                        let path = file.path().display(project.path_style(cx));
-
-                        let location = format!("{path}:{start_line}");
-                        Some(location)
-                    })
+            let end_line = if buffer_range.end.column == 0 && end_line > start_line {
+                end_line - 1
             } else {
-                let buffer_ranges = multi_buffer_snapshot
-                    .range_to_buffer_ranges(selection_range.start..selection_range.end);
-                let selected_buffer_range = if selection.reversed {
-                    buffer_ranges.first()
-                } else {
-                    buffer_ranges.last()
-                };
-                selected_buffer_range.and_then(|(_, range, _)| {
-                    let buffer_range = range.to_point(&buffer.read(cx));
-                    let start_line = buffer_range.start.row + 1;
-                    let end_line = buffer_range.end.row + 1;
-
-                    let end_line = if buffer_range.end.column == 0 && end_line > start_line {
-                        end_line - 1
-                    } else {
-                        end_line
-                    };
-
-                    let project = self.project()?.read(cx);
-                    let file = buffer.read(cx).file()?;
-                    let path = file.path().display(project.path_style(cx));
-
-                    let location = if start_line == end_line {
-                        format!("{path}:{start_line}")
-                    } else {
-                        format!("{path}:{start_line}-{end_line}")
-                    };
-                    Some(location)
-                })
+                end_line
             };
-            result
+
+            let project = self.project()?.read(cx);
+            let file = buffer_snapshot.file()?;
+            let path = file.path().display(project.path_style(cx)).to_string();
+            let path = if path.is_empty() {
+                file.file_name(cx).to_string()
+            } else {
+                path
+            };
+
+            let location = if start_line == end_line {
+                format!("{path}:{start_line}")
+            } else {
+                format!("{path}:{start_line}-{end_line}")
+            };
+            Some(location)
+        };
+
+        let file_location = if selection_range.start == selection_range.end {
+            multi_buffer_snapshot
+                .point_to_buffer_point(selection.head())
+                .and_then(|(buffer_snapshot, point)| format_location(buffer_snapshot, point..point))
         } else {
-            None
+            let buffer_ranges = multi_buffer_snapshot
+                .range_to_buffer_ranges(selection_range.start..selection_range.end);
+            let selected_buffer_range = if selection.reversed {
+                buffer_ranges.first()
+            } else {
+                buffer_ranges.last()
+            };
+            selected_buffer_range.and_then(|(buffer_snapshot, range, _)| {
+                format_location(buffer_snapshot, range.to_point(buffer_snapshot))
+            })
         };
 
         if let Some(file_location) = file_location {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23918,43 +23918,55 @@ impl Editor {
 
         let multi_buffer = self.buffer().read(cx);
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
-        let format_location = |buffer_snapshot, buffer_range: Range<Point>| {
-            let start_line = buffer_range.start.row + 1;
-            let end_line = buffer_range.end.row + 1;
 
-            let end_line = if buffer_range.end.column == 0 && end_line > start_line {
-                end_line - 1
+        let file_location = if let Some(buffer) = self.active_buffer(cx) {
+            let result = if selection_range.start == selection_range.end {
+                multi_buffer_snapshot
+                    .point_to_buffer_point(selection.head())
+                    .and_then(|(_, point)| {
+                        let start_line = point.row + 1;
+
+                        let project = self.project()?.read(cx);
+                        let file = buffer.read(cx).file()?;
+                        let path = file.path().display(project.path_style(cx));
+
+                        let location = format!("{path}:{start_line}");
+                        Some(location)
+                    })
             } else {
-                end_line
+                let buffer_ranges = multi_buffer_snapshot
+                    .range_to_buffer_ranges(selection_range.start..selection_range.end);
+                let selected_buffer_range = if selection.reversed {
+                    buffer_ranges.first()
+                } else {
+                    buffer_ranges.last()
+                };
+                selected_buffer_range.and_then(|(_, range, _)| {
+                    let buffer_range = range.to_point(&buffer.read(cx));
+                    let start_line = buffer_range.start.row + 1;
+                    let end_line = buffer_range.end.row + 1;
+
+                    let end_line = if buffer_range.end.column == 0 && end_line > start_line {
+                        end_line - 1
+                    } else {
+                        end_line
+                    };
+
+                    let project = self.project()?.read(cx);
+                    let file = buffer.read(cx).file()?;
+                    let path = file.path().display(project.path_style(cx));
+
+                    let location = if start_line == end_line {
+                        format!("{path}:{start_line}")
+                    } else {
+                        format!("{path}:{start_line}-{end_line}")
+                    };
+                    Some(location)
+                })
             };
-
-            let project = self.project()?.read(cx);
-            let file = buffer_snapshot.file()?;
-            let path = file.path().display(project.path_style(cx));
-
-            let location = if start_line == end_line {
-                format!("{path}:{start_line}")
-            } else {
-                format!("{path}:{start_line}-{end_line}")
-            };
-            Some(location)
-        };
-
-        let file_location = if selection_range.start == selection_range.end {
-            multi_buffer_snapshot
-                .point_to_buffer_point(selection.head())
-                .and_then(|(buffer_snapshot, point)| format_location(buffer_snapshot, point..point))
+            result
         } else {
-            let buffer_ranges = multi_buffer_snapshot
-                .range_to_buffer_ranges(selection_range.start..selection_range.end);
-            let selected_buffer_range = if selection.reversed {
-                buffer_ranges.first()
-            } else {
-                buffer_ranges.last()
-            };
-            selected_buffer_range.and_then(|(buffer_snapshot, range, _)| {
-                format_location(buffer_snapshot, range.to_point(buffer_snapshot))
-            })
+            None
         };
 
         if let Some(file_location) = file_location {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8758,6 +8758,54 @@ async fn test_clipboard_line_numbers_from_multibuffer(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_copy_file_location_uses_buffer_lines_in_multibuffer(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(
+        path!("/file.txt"),
+        "first line\nsecond line\nthird line\nfourth line\nfifth line\n".into(),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/file.txt").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.txt"), cx)
+        })
+        .await
+        .unwrap();
+
+    let multibuffer = cx.new(|cx| {
+        let mut multibuffer = MultiBuffer::new(ReadWrite);
+        multibuffer.set_excerpts_for_path(
+            PathKey::sorted(0),
+            buffer,
+            [Point::new(2, 0)..Point::new(5, 0)],
+            0,
+            cx,
+        );
+        multibuffer
+    });
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), multibuffer, window, cx)
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(Default::default(), window, cx, |selections| {
+            selections.select_ranges([Point::new(0, 0)..Point::new(0, 0)]);
+        });
+        editor.copy_file_location(&CopyFileLocation, window, cx);
+    });
+
+    assert_eq!(
+        cx.read_from_clipboard().and_then(|item| item.text()),
+        Some("file.txt:3".to_string())
+    );
+}
+
+#[gpui::test]
 async fn test_paste_multiline(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3554,6 +3554,81 @@ fn test_newline(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_newline_trailing_whitespace(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent);
+    });
+
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("    hello\n    world\n", cx));
+    let editor = cx.add_window(|window, cx| build_editor(buffer.clone(), window, cx));
+
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_display_ranges([
+                    DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9)
+                ])
+            });
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hello\n    \n    world\n");
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hello\n\n    \n    world\n");
+        })
+        .unwrap();
+
+    buffer.update(cx, |buffer, cx| {
+        let start = MultiBufferOffset(0);
+        let end = buffer.len(cx);
+        buffer.edit([(start..end, "    hello\n    world\n")], None, cx);
+    });
+
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_display_ranges([
+                    DisplayPoint::new(DisplayRow(0), 7)..DisplayPoint::new(DisplayRow(0), 7)
+                ])
+            });
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hel\n    lo\n    world\n");
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "    hel\n\n    lo\n    world\n");
+        })
+        .unwrap();
+
+    update_test_language_settings(cx, &|settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    buffer.update(cx, |buffer, cx| {
+        let start = MultiBufferOffset(0);
+        let end = buffer.len(cx);
+        buffer.edit([(start..end, "\thello\n\tworld\n")], None, cx);
+    });
+
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_display_ranges([
+                    DisplayPoint::new(DisplayRow(0), 9)..DisplayPoint::new(DisplayRow(0), 9)
+                ])
+            });
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "\thello\n\t\n\tworld\n");
+
+            editor.newline(&Newline, window, cx);
+            assert_eq!(editor.text(cx), "\thello\n\n\t\n\tworld\n");
+        })
+        .unwrap();
+}
+
+#[gpui::test]
 async fn test_newline_yaml(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
@@ -8754,54 +8829,6 @@ async fn test_clipboard_line_numbers_from_multibuffer(cx: &mut TestAppContext) {
         selection.line_range,
         Some(2..=5),
         "line range should be from original file (rows 2-5), not multibuffer rows (0-2)"
-    );
-}
-
-#[gpui::test]
-async fn test_copy_file_location_uses_buffer_lines_in_multibuffer(cx: &mut TestAppContext) {
-    init_test(cx, |_| {});
-
-    let fs = FakeFs::new(cx.executor());
-    fs.insert_file(
-        path!("/file.txt"),
-        "first line\nsecond line\nthird line\nfourth line\nfifth line\n".into(),
-    )
-    .await;
-
-    let project = Project::test(fs, [path!("/file.txt").as_ref()], cx).await;
-    let buffer = project
-        .update(cx, |project, cx| {
-            project.open_local_buffer(path!("/file.txt"), cx)
-        })
-        .await
-        .unwrap();
-
-    let multibuffer = cx.new(|cx| {
-        let mut multibuffer = MultiBuffer::new(ReadWrite);
-        multibuffer.set_excerpts_for_path(
-            PathKey::sorted(0),
-            buffer,
-            [Point::new(2, 0)..Point::new(5, 0)],
-            0,
-            cx,
-        );
-        multibuffer
-    });
-
-    let (editor, cx) = cx.add_window_view(|window, cx| {
-        build_editor_with_project(project.clone(), multibuffer, window, cx)
-    });
-
-    editor.update_in(cx, |editor, window, cx| {
-        editor.change_selections(Default::default(), window, cx, |selections| {
-            selections.select_ranges([Point::new(0, 0)..Point::new(0, 0)]);
-        });
-        editor.copy_file_location(&CopyFileLocation, window, cx);
-    });
-
-    assert_eq!(
-        cx.read_from_clipboard().and_then(|item| item.text()),
-        Some("file.txt:3".to_string())
     );
 }
 
@@ -28984,29 +29011,36 @@ println!("5");
     });
 }
 
-#[gpui::test]
-async fn test_hide_mouse_context_menu_on_modal_opened(cx: &mut TestAppContext) {
-    struct EmptyModalView {
-        focus_handle: gpui::FocusHandle,
+struct EmptyModalView {
+    focus_handle: gpui::FocusHandle,
+}
+
+impl EventEmitter<DismissEvent> for EmptyModalView {}
+
+impl Render for EmptyModalView {
+    fn render(&mut self, _: &mut Window, _: &mut Context<'_, Self>) -> impl IntoElement {
+        div()
     }
-    impl EventEmitter<DismissEvent> for EmptyModalView {}
-    impl Render for EmptyModalView {
-        fn render(&mut self, _: &mut Window, _: &mut Context<'_, Self>) -> impl IntoElement {
-            div()
-        }
+}
+
+impl Focusable for EmptyModalView {
+    fn focus_handle(&self, _cx: &App) -> gpui::FocusHandle {
+        self.focus_handle.clone()
     }
-    impl Focusable for EmptyModalView {
-        fn focus_handle(&self, _cx: &App) -> gpui::FocusHandle {
-            self.focus_handle.clone()
-        }
-    }
-    impl workspace::ModalView for EmptyModalView {}
-    fn new_empty_modal_view(cx: &App) -> EmptyModalView {
-        EmptyModalView {
+}
+
+impl workspace::ModalView for EmptyModalView {}
+
+impl EmptyModalView {
+    fn new(cx: &App) -> Self {
+        Self {
             focus_handle: cx.focus_handle(),
         }
     }
+}
 
+#[gpui::test]
+async fn test_hide_mouse_context_menu_on_modal_opened(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let fs = FakeFs::new(cx.executor());
@@ -29035,11 +29069,77 @@ async fn test_hide_mouse_context_menu_on_modal_opened(cx: &mut TestAppContext) {
         assert!(editor.mouse_context_menu.is_some());
     });
     workspace.update_in(cx, |workspace, window, cx| {
-        workspace.toggle_modal(window, cx, |_, cx| new_empty_modal_view(cx));
+        workspace.toggle_modal(window, cx, |_, cx| EmptyModalView::new(cx));
     });
 
     cx.read(|cx| {
         assert!(editor.read(cx).mouse_context_menu.is_none());
+    });
+}
+
+#[gpui::test]
+async fn test_hide_pending_blame_popover_when_modal_opens(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+        .unwrap();
+    let multi_buffer = cx.update(|cx| MultiBuffer::build_simple("Buffer Contents!", cx));
+    let buffer_id = multi_buffer.read_with(cx, |multi_buffer, cx| {
+        multi_buffer
+            .all_buffers_iter()
+            .next()
+            .expect("Should have at least one buffer")
+            .read(cx)
+            .remote_id()
+    });
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            multi_buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, _, cx| {
+        editor.blame = Some(
+            cx.new(|cx| GitBlame::new(editor.buffer.clone(), project.clone(), false, true, cx)),
+        );
+        editor.show_blame_popover(
+            buffer_id,
+            &::git::blame::BlameEntry {
+                sha: "1b1b1b".parse().unwrap(),
+                range: 0..1,
+                ..Default::default()
+            },
+            gpui::point(gpui::px(0.), gpui::px(0.)),
+            false,
+            cx,
+        );
+
+        assert!(editor.inline_blame_popover_show_task.is_some());
+        assert!(editor.inline_blame_popover.is_none());
+    });
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.toggle_modal(window, cx, |_, cx| EmptyModalView::new(cx));
+    });
+
+    // Toggling a modal while the blame popover task is still pending should
+    // clear both the task and any rendered popover.
+    editor.update_in(cx, |editor, _, _| {
+        assert!(editor.inline_blame_popover.is_none());
+        assert!(editor.inline_blame_popover_show_task.is_none());
     });
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -36507,3 +36507,51 @@ fn setup_syntax_highlighting(
 
     syntax
 }
+
+#[gpui::test]
+async fn test_copy_file_location_uses_buffer_lines_in_multibuffer(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(
+        path!("/file.txt"),
+        "first line\nsecond line\nthird line\nfourth line\nfifth line\n".into(),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/file.txt").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.txt"), cx)
+        })
+        .await
+        .unwrap();
+
+    let multibuffer = cx.new(|cx| {
+        let mut multibuffer = MultiBuffer::new(ReadWrite);
+        multibuffer.set_excerpts_for_path(
+            PathKey::sorted(0),
+            buffer,
+            [Point::new(2, 0)..Point::new(5, 0)],
+            0,
+            cx,
+        );
+        multibuffer
+    });
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), multibuffer, window, cx)
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(Default::default(), window, cx, |selections| {
+            selections.select_ranges([Point::new(0, 0)..Point::new(0, 0)]);
+        });
+        editor.copy_file_location(&CopyFileLocation, window, cx);
+    });
+
+    assert_eq!(
+        cx.read_from_clipboard().and_then(|item| item.text()),
+        Some("file.txt:3".to_string())
+    );
+}


### PR DESCRIPTION
Fixes #54250

Summary:
- Converts copied file-location selections through the underlying buffer range before formatting line numbers.
- Adds regression coverage for copying a location from a multibuffer excerpt.

Release Notes:

- Fixed copy file location from multibuffer excerpts reporting multibuffer-relative lines.