### PR TITLE
git_graph: Fix pluralization of "Changed Files" in commit details

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1872,12 +1872,6 @@ impl GitGraph {
             .map(|diff| diff.files.len())
             .unwrap_or(0);
 
-        let changed_files_heading = if changed_files_count == 1 {
-            "1 Changed File".to_string()
-        } else {
-            format!("{changed_files_count} Changed Files")
-        };
-
         let (total_lines_added, total_lines_removed) =
             self.selected_commit_diff_stats.unwrap_or((0, 0));
 
@@ -2106,9 +2100,17 @@ impl GitGraph {
                             .w_full()
                             .justify_between()
                             .child(
-                                Label::new(changed_files_heading)
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
+                                Label::new(format!(
+                                    "{} Changed {}",
+                                    changed_files_count,
+                                    if changed_files_count == 1 {
+                                        "File"
+                                    } else {
+                                        "Files"
+                                    }
+                                ))
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
                             )
                             .child(DiffStat::new(
                                 "commit-diff-stat",

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1872,6 +1872,12 @@ impl GitGraph {
             .map(|diff| diff.files.len())
             .unwrap_or(0);
 
+        let changed_files_heading = if changed_files_count == 1 {
+            "1 Changed File".to_string()
+        } else {
+            format!("{changed_files_count} Changed Files")
+        };
+
         let (total_lines_added, total_lines_removed) =
             self.selected_commit_diff_stats.unwrap_or((0, 0));
 
@@ -2100,7 +2106,7 @@ impl GitGraph {
                             .w_full()
                             .justify_between()
                             .child(
-                                Label::new(format!("{} Changed Files", changed_files_count))
+                                Label::new(changed_files_heading)
                                     .size(LabelSize::Small)
                                     .color(Color::Muted),
                             )


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54283 

Release Notes:

- Fixed: Git graph commit detail header now uses “1 Changed File” when exactly one file changed, and “N Changed Files” otherwise, instead of always saying “Changed Files”.
