### PR TITLE
Fix deduplicate tool use requests to prevent multiple authorizations

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -948,6 +948,76 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_duplicate_tool_use_requests_authorization_once(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let mut events = thread
+        .update(cx, |thread, cx| {
+            thread.add_tool(ToolRequiringPermission);
+            thread.send(UserMessageId::new(), ["abc"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    let duplicate_tool_use = LanguageModelToolUse {
+        id: "duplicate_tool_id".into(),
+        name: ToolRequiringPermission::NAME.into(),
+        raw_input: "{}".into(),
+        input: json!({}),
+        is_input_complete: true,
+        thought_signature: None,
+    };
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        duplicate_tool_use.clone(),
+    ));
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        duplicate_tool_use,
+    ));
+    fake_model.end_last_completion_stream();
+
+    let tool_call_auth = next_tool_call_authorization(&mut events).await;
+    assert_eq!(
+        tool_call_auth.tool_call.tool_call_id,
+        acp::ToolCallId::new("duplicate_tool_id")
+    );
+
+    cx.run_until_parked();
+
+    let mut extra_authorizations = 0;
+    while let Some(Some(event)) = events.next().now_or_never() {
+        if matches!(event, Ok(ThreadEvent::ToolCallAuthorization(_))) {
+            extra_authorizations += 1;
+        }
+    }
+    assert_eq!(extra_authorizations, 0);
+
+    tool_call_auth
+        .response
+        .send(acp_thread::SelectedPermissionOutcome::new(
+            acp::PermissionOptionId::new("allow"),
+            acp::PermissionOptionKind::AllowOnce,
+        ))
+        .unwrap();
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let message = completion.messages.last().unwrap();
+    assert_eq!(
+        message.content,
+        vec![language_model::MessageContent::ToolResult(
+            LanguageModelToolResult {
+                tool_use_id: "duplicate_tool_id".into(),
+                tool_name: ToolRequiringPermission::NAME.into(),
+                is_error: false,
+                content: "Allowed".into(),
+                output: Some("Allowed".into())
+            }
+        )]
+    );
+}
+
+#[gpui::test]
 async fn test_tool_hallucination(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1855,6 +1855,7 @@ impl Thread {
             tools: self.enabled_tools(cx),
             cancellation_tx,
             streaming_tool_inputs: HashMap::default(),
+            started_tool_uses: HashSet::default(),
             _task: cx.spawn(async move |this, cx| {
                 log::debug!("Starting agent turn execution");
 
@@ -2130,6 +2131,11 @@ impl Thread {
             None,
         );
         this.update(cx, |this, _cx| {
+            if let Some(running_turn) = this.running_turn.as_mut() {
+                running_turn
+                    .started_tool_uses
+                    .remove(&tool_result.tool_use_id);
+            }
             this.pending_message()
                 .tool_results
                 .insert(tool_result.tool_use_id.clone(), tool_result)
@@ -2348,6 +2354,10 @@ impl Thread {
 
                 let (mut sender, tool_input) = ToolInputSender::channel();
                 sender.send_partial(tool_use.input);
+                if !running_turn.started_tool_uses.insert(tool_use.id.clone()) {
+                    log::debug!("Ignoring duplicate streaming tool use {}", tool_use.id);
+                    return None;
+                }
                 running_turn
                     .streaming_tool_inputs
                     .insert(tool_use.id.clone(), sender);
@@ -2377,6 +2387,20 @@ impl Thread {
             sender.send_full(tool_use.input);
             return None;
         }
+
+        if self
+            .running_turn
+            .as_ref()
+            .is_some_and(|turn| turn.started_tool_uses.contains(&tool_use.id))
+        {
+            log::debug!("Ignoring duplicate tool use {}", tool_use.id);
+            return None;
+        }
+
+        self.running_turn
+            .as_mut()?
+            .started_tool_uses
+            .insert(tool_use.id.clone());
 
         log::debug!("Running tool {}", tool_use.name);
         let tool_input = ToolInput::ready(tool_use.input);
@@ -3163,6 +3187,7 @@ struct RunningTurn {
     /// Senders for tools that support input streaming and have already been
     /// started but are still receiving input from the LLM.
     streaming_tool_inputs: HashMap<LanguageModelToolUseId, ToolInputSender>,
+    started_tool_uses: HashSet<LanguageModelToolUseId>,
 }
 
 impl RunningTurn {

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anthropic::AnthropicModelMode;
 use anyhow::{Result, anyhow};
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use copilot::{GlobalCopilotAuth, Status};
 use copilot_chat::responses as copilot_responses;
 use copilot_chat::{
@@ -694,12 +694,14 @@ pub fn map_to_language_model_completion_events(
 
 pub struct CopilotResponsesEventMapper {
     pending_stop_reason: Option<StopReason>,
+    seen_tool_call_ids: HashSet<String>,
 }
 
 impl CopilotResponsesEventMapper {
     pub fn new() -> Self {
         Self {
             pending_stop_reason: None,
+            seen_tool_call_ids: HashSet::default(),
         }
     }
 
@@ -747,6 +749,10 @@ impl CopilotResponsesEventMapper {
                     thought_signature,
                     ..
                 } => {
+                    if !self.seen_tool_call_ids.insert(call_id.clone()) {
+                        return Vec::new();
+                    }
+
                     let mut events = Vec::new();
                     match parse_tool_arguments(&arguments) {
                         Ok(input) => events.push(Ok(LanguageModelCompletionEvent::ToolUse(
@@ -1518,6 +1524,42 @@ mod tests {
         }
         assert_eq!(stop_count, 1, "should emit exactly one Stop event");
         assert!(saw_tool_use_stop, "Stop reason should be ToolUse");
+    }
+
+    #[test]
+    fn responses_stream_ignores_duplicate_tool_calls() {
+        let function_call = responses::ResponseOutputItem::FunctionCall {
+            id: Some("fn_1".into()),
+            call_id: "call_1".into(),
+            name: "do_it".into(),
+            arguments: "{}".into(),
+            status: None,
+            thought_signature: None,
+        };
+        let events = vec![
+            responses::StreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: function_call.clone(),
+            },
+            responses::StreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: function_call,
+            },
+        ];
+
+        let mapped = map_events(events);
+
+        assert_eq!(mapped.len(), 2);
+        assert!(matches!(
+            mapped[0],
+            LanguageModelCompletionEvent::ToolUse(ref use_) if use_.id.to_string() == "call_1"
+        ));
+        assert!(matches!(
+            mapped[1],
+            LanguageModelCompletionEvent::Stop(StopReason::ToolUse)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53095
Now: 

https://github.com/user-attachments/assets/d92592ea-8b8d-4abe-a2e8-f12abf7d2c3b



Release Notes:

- Fixed duplicate tool use requests triggering multiple authorization prompts

Prevents duplicate tool use requests from triggering multiple permission authorizations. When the LLM sends duplicate tool use events (same tool_call_id), only the first one is processed subsequent duplicates are now silently ignored.