### PR TITLE
git_ui: Add branch compare to diff any two branches

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -103,6 +103,42 @@ pub fn create_embedded(
     BranchList::new_embedded(workspace, repository, width, window, cx)
 }
 
+/// Creates an embedded branch list that only selects (does not checkout).
+/// The `on_select` callback is called with the selected branch ref_name.
+pub fn create_select_only(
+    workspace: WeakEntity<Workspace>,
+    repository: Option<Entity<Repository>>,
+    on_select: Arc<dyn Fn(SharedString, &mut App) + Send + Sync>,
+    width: Rems,
+    window: &mut Window,
+    cx: &mut Context<BranchList>,
+) -> BranchList {
+    let list = BranchList::new_embedded(workspace, repository, width, window, cx);
+    list.picker.update(cx, |picker, _| {
+        picker.delegate.on_select = Some(on_select);
+    });
+    list
+}
+
+/// Creates a modal branch list that only selects (does not checkout).
+/// Shows as a modal dialog with custom placeholder text.
+pub fn create_modal_select_only(
+    workspace: WeakEntity<Workspace>,
+    repository: Option<Entity<Repository>>,
+    on_select: Arc<dyn Fn(SharedString, &mut App) + Send + Sync>,
+    placeholder: Arc<str>,
+    width: Rems,
+    window: &mut Window,
+    cx: &mut Context<BranchList>,
+) -> BranchList {
+    let list = BranchList::new(workspace, repository, BranchListStyle::Modal, width, window, cx);
+    list.picker.update(cx, |picker, _| {
+        picker.delegate.on_select = Some(on_select);
+        picker.delegate.custom_placeholder = Some(placeholder);
+    });
+    list
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum BranchListStyle {
     Modal,
@@ -386,6 +422,8 @@ pub struct BranchListDelegate {
     state: PickerState,
     focus_handle: FocusHandle,
     restore_selected_branch: Option<SharedString>,
+    on_select: Option<Arc<dyn Fn(SharedString, &mut App) + Send + Sync>>,
+    custom_placeholder: Option<Arc<str>>,
 }
 
 #[derive(Debug)]
@@ -452,6 +490,8 @@ impl BranchListDelegate {
             state: PickerState::List,
             focus_handle: cx.focus_handle(),
             restore_selected_branch: None,
+            on_select: None,
+            custom_placeholder: None,
         }
     }
 
@@ -590,6 +630,9 @@ impl PickerDelegate for BranchListDelegate {
     type ListItem = ListItem;
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        if let Some(placeholder) = &self.custom_placeholder {
+            return placeholder.clone();
+        }
         match self.state {
             PickerState::List | PickerState::NewRemote | PickerState::NewBranch => {
                 match self.branch_filter {
@@ -664,6 +707,25 @@ impl PickerDelegate for BranchListDelegate {
                 self.editor_position() == PickerEditorPosition::Start,
                 |this| this.child(Divider::horizontal()),
             )
+    }
+
+    fn render_header(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<AnyElement> {
+        let placeholder = self.custom_placeholder.as_ref()?;
+        Some(
+            h_flex()
+                .px_2p5()
+                .py_1()
+                .child(
+                    Label::new(placeholder.to_string())
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .into_any_element(),
+        )
     }
 
     fn editor_position(&self) -> PickerEditorPosition {
@@ -823,6 +885,14 @@ impl PickerDelegate for BranchListDelegate {
 
         match entry {
             Entry::Branch { branch, .. } => {
+                // If on_select callback is set, just call it without checking out
+                if let Some(on_select) = &self.on_select {
+                    let branch_name: SharedString = branch.ref_name.clone();
+                    on_select(branch_name, cx);
+                    cx.emit(DismissEvent);
+                    return;
+                }
+
                 let current_branch = self.repo.as_ref().map(|repo| {
                     repo.read_with(cx, |repo, _| {
                         repo.branch.as_ref().map(|branch| branch.ref_name.clone())

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -94,6 +94,7 @@ impl ProjectDiff {
     pub(crate) fn register(workspace: &mut Workspace, cx: &mut Context<Workspace>) {
         workspace.register_action(Self::deploy);
         workspace.register_action(Self::deploy_branch_diff);
+        workspace.register_action(Self::deploy_branch_compare);
         workspace.register_action(|workspace, _: &Add, window, cx| {
             Self::deploy(workspace, &Diff, window, cx);
         });
@@ -144,10 +145,136 @@ impl ProjectDiff {
             .detach_and_notify_err(workspace_weak, window, cx);
     }
 
+    pub fn deploy_branch_compare(
+        workspace: &mut Workspace,
+        _: &zed_actions::git::BranchCompare,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        telemetry::event!("Git Branch Compare Opened");
+        let project = workspace.project().clone();
+        let repository = project.read(cx).active_repository(cx);
+        let workspace_handle = cx.entity();
+        let workspace_weak = workspace_handle.downgrade();
+
+        let (compare_sender, compare_receiver) = smol::channel::bounded::<SharedString>(1);
+        let (base_sender, base_receiver) = smol::channel::bounded::<SharedString>(1);
+
+        // Step 1: Show picker for compare branch
+        let on_compare_selected: Arc<dyn Fn(SharedString, &mut App) + Send + Sync> =
+            Arc::new(move |branch_name: SharedString, _cx: &mut App| {
+                compare_sender.try_send(branch_name).log_err();
+            });
+
+        workspace.toggle_modal(window, cx, |window, cx| {
+            crate::branch_picker::create_modal_select_only(
+                workspace_weak.clone(),
+                repository.clone(),
+                on_compare_selected,
+                "Select compare branch…".into(),
+                rems(34.),
+                window,
+                cx,
+            )
+        });
+
+        // Async task: wait for compare selection, then open base picker, then open tab
+        let repository_clone = repository.clone();
+        window
+            .spawn(cx, {
+                let workspace = workspace_handle.clone();
+                let workspace_weak = workspace_weak.clone();
+                async move |cx| {
+                    let Ok(compare_ref) = compare_receiver.recv().await else {
+                        return;
+                    };
+
+                    // Step 2: Show picker for base branch
+                    let on_base_selected: Arc<dyn Fn(SharedString, &mut App) + Send + Sync> =
+                        Arc::new(move |branch_name: SharedString, _cx: &mut App| {
+                            base_sender.try_send(branch_name).log_err();
+                        });
+
+                    if workspace
+                        .update_in(cx, |workspace, window, cx| {
+                            workspace.toggle_modal(window, cx, |window, cx| {
+                                crate::branch_picker::create_modal_select_only(
+                                    workspace_weak.clone(),
+                                    repository_clone,
+                                    on_base_selected,
+                                    "Select base branch…".into(),
+                                    rems(34.),
+                                    window,
+                                    cx,
+                                )
+                            });
+                        })
+                        .is_err()
+                    {
+                        return;
+                    }
+
+                    let Ok(base_ref) = base_receiver.recv().await else {
+                        return;
+                    };
+
+                    // Step 3: Open the compare tab
+                    workspace
+                        .update_in(cx, |workspace, window, cx| {
+                            // Deduplicate
+                            let existing = workspace.items_of_type::<Self>(cx).find(|item| {
+                                matches!(
+                                    item.read(cx).diff_base(cx),
+                                    DiffBase::Compare { base_ref: b, compare_ref: c }
+                                        if *b == base_ref && *c == compare_ref
+                                )
+                            });
+                            if let Some(existing) = existing {
+                                workspace.activate_item(&existing, true, true, window, cx);
+                                return;
+                            }
+
+                            let workspace_handle = cx.entity();
+                            let branch_diff = cx.new(|cx| {
+                                branch_diff::BranchDiff::new(
+                                    DiffBase::Compare {
+                                        base_ref,
+                                        compare_ref,
+                                    },
+                                    project.clone(),
+                                    window,
+                                    cx,
+                                )
+                            });
+                            let project_diff = cx.new(|cx| {
+                                Self::new_impl(
+                                    branch_diff,
+                                    project,
+                                    workspace_handle,
+                                    window,
+                                    cx,
+                                )
+                            });
+                            workspace.add_item_to_active_pane(
+                                Box::new(project_diff),
+                                None,
+                                true,
+                                window,
+                                cx,
+                            );
+                        })
+                        .log_err();
+                }
+            })
+            .detach();
+    }
+
     fn review_diff(&mut self, _: &ReviewDiff, window: &mut Window, cx: &mut Context<Self>) {
         let diff_base = self.diff_base(cx).clone();
-        let DiffBase::Merge { base_ref } = diff_base else {
-            return;
+        let base_ref = match &diff_base {
+            DiffBase::Merge { base_ref } => base_ref.clone(),
+            DiffBase::Compare { base_ref, .. } => base_ref.clone(),
+            DiffBase::Head => return,
         };
 
         let Some(repo) = self.branch_diff.read(cx).repo().cloned() else {
@@ -359,10 +486,11 @@ impl ProjectDiff {
             );
             match branch_diff.read(cx).diff_base() {
                 DiffBase::Head => {}
-                DiffBase::Merge { .. } => diff_display_editor.set_render_diff_hunk_controls(
-                    Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
-                    cx,
-                ),
+                DiffBase::Merge { .. } | DiffBase::Compare { .. } => diff_display_editor
+                    .set_render_diff_hunk_controls(
+                        Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
+                        cx,
+                    ),
             }
             diff_display_editor.rhs_editor().update(cx, |editor, cx| {
                 editor.disable_diagnostics(cx);
@@ -374,7 +502,7 @@ impl ProjectDiff {
                             workspace: workspace.downgrade(),
                         });
                     }
-                    DiffBase::Merge { .. } => {
+                    DiffBase::Merge { .. } | DiffBase::Compare { .. } => {
                         editor.register_addon(BranchDiffAddon {
                             branch_diff: branch_diff.clone(),
                         });
@@ -960,6 +1088,9 @@ impl Item for ProjectDiff {
         match self.diff_base(cx) {
             DiffBase::Head => Some("Project Diff".into()),
             DiffBase::Merge { .. } => Some("Branch Diff".into()),
+            DiffBase::Compare { base_ref, compare_ref } => {
+                Some(format!("Compare: {}..{}", base_ref, compare_ref).into())
+            }
         }
     }
 
@@ -977,6 +1108,9 @@ impl Item for ProjectDiff {
         match self.branch_diff.read(cx).diff_base() {
             DiffBase::Head => "Uncommitted Changes".into(),
             DiffBase::Merge { base_ref } => format!("Changes since {}", base_ref).into(),
+            DiffBase::Compare { base_ref, compare_ref } => {
+                format!("{}..{}", base_ref, compare_ref).into()
+            }
         }
     }
 
@@ -1115,7 +1249,16 @@ impl Item for ProjectDiff {
 impl Render for ProjectDiff {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let is_empty = self.multibuffer.read(cx).is_empty();
-        let is_branch_diff_view = matches!(self.diff_base(cx), DiffBase::Merge { .. });
+        let diff_base = self.diff_base(cx).clone();
+        let is_branch_diff_view = matches!(diff_base, DiffBase::Merge { .. } | DiffBase::Compare { .. });
+
+        let empty_message = match &diff_base {
+            DiffBase::Head => "No uncommitted changes".to_string(),
+            DiffBase::Merge { base_ref } => format!("No changes since {}", base_ref),
+            DiffBase::Compare { base_ref, compare_ref } => {
+                format!("No differences between {} and {}", base_ref, compare_ref)
+            }
+        };
 
         div()
             .track_focus(&self.focus_handle)
@@ -1129,12 +1272,11 @@ impl Render for ProjectDiff {
             .justify_center()
             .size_full()
             .when(is_empty, |el| {
-                let remote_button = if let Some(panel) = self
-                    .workspace
-                    .upgrade()
-                    .and_then(|workspace| workspace.read(cx).panel::<GitPanel>(cx))
-                {
-                    panel.update(cx, |panel, cx| panel.render_remote_button(cx))
+                let remote_button = if matches!(diff_base, DiffBase::Head) {
+                    self.workspace
+                        .upgrade()
+                        .and_then(|workspace| workspace.read(cx).panel::<GitPanel>(cx))
+                        .and_then(|panel| panel.update(cx, |panel, cx| panel.render_remote_button(cx)))
                 } else {
                     None
                 };
@@ -1145,7 +1287,7 @@ impl Render for ProjectDiff {
                         .child(
                             h_flex()
                                 .justify_around()
-                                .child(Label::new("No uncommitted changes")),
+                                .child(Label::new(empty_message)),
                         )
                         .map(|el| match remote_button {
                             Some(button) => el.child(h_flex().justify_around().child(button)),
@@ -1158,7 +1300,6 @@ impl Render for ProjectDiff {
                         .child(
                             h_flex().justify_around().mt_1().child(
                                 Button::new("project-diff-close-button", "Close")
-                                    // .style(ButtonStyle::Transparent)
                                     .key_binding(KeyBinding::for_action_in(
                                         &CloseActiveItem::default(),
                                         &keybinding_focus_handle,
@@ -1622,7 +1763,7 @@ impl ToolbarItemView for BranchDiffToolbar {
     ) -> ToolbarItemLocation {
         self.project_diff = active_pane_item
             .and_then(|item| item.act_as::<ProjectDiff>(cx))
-            .filter(|item| matches!(item.read(cx).diff_base(cx), DiffBase::Merge { .. }))
+            .filter(|item| matches!(item.read(cx).diff_base(cx), DiffBase::Merge { .. } | DiffBase::Compare { .. }))
             .map(|entity| entity.downgrade());
         if self.project_diff.is_some() {
             ToolbarItemLocation::PrimaryRight

--- a/crates/project/src/git_store/branch_diff.rs
+++ b/crates/project/src/git_store/branch_diff.rs
@@ -25,11 +25,12 @@ use crate::{
 pub enum DiffBase {
     Head,
     Merge { base_ref: SharedString },
+    Compare { base_ref: SharedString, compare_ref: SharedString },
 }
 
 impl DiffBase {
     pub fn is_merge_base(&self) -> bool {
-        matches!(self, DiffBase::Merge { .. })
+        matches!(self, DiffBase::Merge { .. } | DiffBase::Compare { .. })
     }
 }
 
@@ -119,6 +120,19 @@ impl BranchDiff {
         *self.update_needed.borrow_mut() = ();
     }
 
+    pub fn set_diff_base(&mut self, diff_base: DiffBase, cx: &mut Context<Self>) {
+        self.diff_base = diff_base;
+        self.tree_diff = None;
+        self.base_commit = None;
+        self.head_commit = None;
+        cx.emit(BranchDiffEvent::FileListChanged);
+        *self.update_needed.borrow_mut() = ();
+    }
+
+    pub fn tree_diff(&self) -> Option<&TreeDiff> {
+        self.tree_diff.as_ref()
+    }
+
     pub async fn handle_status_updates(
         this: WeakEntity<Self>,
         mut recv: postage::watch::Receiver<()>,
@@ -142,14 +156,22 @@ impl BranchDiff {
                     }
                 } else if let Some(repo) = this.repo.as_ref() {
                     repo.update(cx, |repo, _| {
-                        if let Some(branch) = &repo.branch
-                            && let DiffBase::Merge { base_ref } = &this.diff_base
-                            && let Some(commit) = branch.most_recent_commit.as_ref()
-                            && &branch.ref_name == base_ref
-                            && this.base_commit.as_ref() != Some(&commit.sha)
-                        {
-                            this.base_commit = Some(commit.sha.clone());
-                            needs_update = true;
+                        match &this.diff_base {
+                            DiffBase::Merge { base_ref } => {
+                                if let Some(branch) = &repo.branch
+                                    && let Some(commit) = branch.most_recent_commit.as_ref()
+                                    && &branch.ref_name == base_ref
+                                    && this.base_commit.as_ref() != Some(&commit.sha)
+                                {
+                                    this.base_commit = Some(commit.sha.clone());
+                                    needs_update = true;
+                                }
+                            }
+                            DiffBase::Compare { .. } => {
+                                // For Compare mode, always update on head changes
+                                needs_update = true;
+                            }
+                            DiffBase::Head => {}
                         }
 
                         if repo.head_commit.as_ref().map(|c| &c.sha) != this.head_commit.as_ref() {
@@ -249,21 +271,23 @@ impl BranchDiff {
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
         let task = this.update(cx, |this, cx| {
-            let DiffBase::Merge { base_ref } = this.diff_base.clone() else {
-                return None;
+            let diff_tree_type = match this.diff_base.clone() {
+                DiffBase::Merge { base_ref } => DiffTreeType::MergeBase {
+                    base: base_ref,
+                    head: "HEAD".into(),
+                },
+                DiffBase::Compare { base_ref, compare_ref } => DiffTreeType::MergeBase {
+                    base: base_ref,
+                    head: compare_ref,
+                },
+                DiffBase::Head => return None,
             };
             let Some(repo) = this.repo.as_ref() else {
                 this.tree_diff.take();
                 return None;
             };
             repo.update(cx, |repo, cx| {
-                Some(repo.diff_tree(
-                    DiffTreeType::MergeBase {
-                        base: base_ref,
-                        head: "HEAD".into(),
-                    },
-                    cx,
-                ))
+                Some(repo.diff_tree(diff_tree_type, cx))
             })
         })?;
         let Some(task) = task else { return Ok(()) };
@@ -290,33 +314,37 @@ impl BranchDiff {
         self.project.update(cx, |_project, cx| {
             let mut seen = HashSet::default();
 
-            for item in repo.read(cx).cached_status() {
-                seen.insert(item.repo_path.clone());
-                let branch_diff = self
-                    .tree_diff
-                    .as_ref()
-                    .and_then(|t| t.entries.get(&item.repo_path))
-                    .cloned();
-                let Some(status) = self.merge_statuses(Some(item.status), branch_diff.as_ref())
-                else {
-                    continue;
-                };
-                if !status.has_changes() {
-                    continue;
+            // For Compare mode, skip working tree status — only show tree diff entries
+            if !matches!(self.diff_base, DiffBase::Compare { .. }) {
+                for item in repo.read(cx).cached_status() {
+                    seen.insert(item.repo_path.clone());
+                    let branch_diff = self
+                        .tree_diff
+                        .as_ref()
+                        .and_then(|t| t.entries.get(&item.repo_path))
+                        .cloned();
+                    let Some(status) =
+                        self.merge_statuses(Some(item.status), branch_diff.as_ref())
+                    else {
+                        continue;
+                    };
+                    if !status.has_changes() {
+                        continue;
+                    }
+
+                    let Some(project_path) =
+                        repo.read(cx).repo_path_to_project_path(&item.repo_path, cx)
+                    else {
+                        continue;
+                    };
+                    let task = Self::load_buffer(branch_diff, project_path, repo.clone(), cx);
+
+                    output.push(DiffBuffer {
+                        repo_path: item.repo_path.clone(),
+                        load: task,
+                        file_status: item.status,
+                    });
                 }
-
-                let Some(project_path) =
-                    repo.read(cx).repo_path_to_project_path(&item.repo_path, cx)
-                else {
-                    continue;
-                };
-                let task = Self::load_buffer(branch_diff, project_path, repo.clone(), cx);
-
-                output.push(DiffBuffer {
-                    repo_path: item.repo_path.clone(),
-                    load: task,
-                    file_status: item.status,
-                });
             }
             let Some(tree_diff) = self.tree_diff.as_ref() else {
                 return;

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -275,7 +275,9 @@ pub mod git {
             /// Opens the git worktree selector.
             Worktree,
             /// Creates a pull request for the current branch.
-            CreatePullRequest
+            CreatePullRequest,
+            /// Opens the branch compare panel.
+            BranchCompare
         ]
     );
 }


### PR DESCRIPTION
## Summary

- Add a **Branch Compare** command (`git: Branch Compare` in the command palette) that opens a diff tab comparing any two git branches, reusing the existing `ProjectDiff` / `SplittableEditor` infrastructure for inline and side-by-side diff views
- Introduce `DiffBase::Compare { base_ref, compare_ref }` variant to the data layer, with a two-step modal branch picker flow (compare branch first, then base branch) using bounded channels for async communication
- Handle the `Compare` variant across all relevant match arms: hunk controls (disabled), editor addon, tab title/tooltip, empty state message, toolbar visibility, and working tree status filtering

## Details

This adds VSCode-like branch comparison functionality to Zed. The user flow is:

1. Command palette → **git: Branch Compare**
2. First modal picker: "Select compare branch…" (the branch to review)
3. Second modal picker: "Select base branch…" (what to compare against)
4. A new tab opens titled `base..compare` showing the tree-level diff

Key implementation choices:
- **Reuses `ProjectDiff`** entirely — gets `SplittableEditor` (inline/split toggle), multi-buffer diff rendering, search, navigation, and serialization for free
- **`DiffBase::Compare`** uses `DiffTreeType::MergeBase { base, head: compare_ref }` to compute the merge-base diff between two arbitrary refs
- **Working tree status is skipped** in Compare mode since we're comparing two refs, not the working tree
- **Tab deduplication**: selecting the same two branches reuses an existing tab
- **Modal branch picker** with `render_header` showing a label ("Select compare branch…" / "Select base branch…") so the user always knows which step they're on

## Test plan

- [ ] Open a git repo in Zed
- [ ] Command palette → "git: Branch Compare"
- [ ] First picker shows "Select compare branch…" header → select a branch
- [ ] Second picker shows "Select base branch…" header → select another branch
- [ ] Tab opens with `base..compare` title showing file diffs
- [ ] Toggle inline/split view via toolbar — both modes work
- [ ] Press Escape on either picker → gracefully cancels, no error
- [ ] Re-trigger with same two branches → reuses existing tab
- [ ] Select two identical branches → shows "No differences between X and Y"

Release Notes:

- Added a "Branch Compare" command to diff any two git branches in an inline or side-by-side view

🤖 Generated with [Claude Code](https://claude.com/claude-code)