### PR TITLE
editor: Add coverage gutter UI

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -847,6 +847,8 @@ actions!(
         ToggleDiagnostics,
         /// Toggles indent guides display.
         ToggleIndentGuides,
+        /// Toggles code coverage gutter display.
+        ToggleCoverageGutter,
         /// Toggles inlay hints display.
         ToggleInlayHints,
         /// Toggles semantic highlights display.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1188,6 +1188,8 @@ pub struct Editor {
     show_line_numbers: Option<bool>,
     use_relative_line_numbers: Option<bool>,
     show_git_diff_gutter: Option<bool>,
+    show_coverage_gutter: bool,
+    coverage_data: HashMap<MultiBufferRow, CoverageStatus>,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
     show_bookmarks: Option<bool>,
@@ -1403,6 +1405,7 @@ pub struct EditorSnapshot {
     show_line_numbers: Option<bool>,
     number_deleted_lines: bool,
     show_git_diff_gutter: Option<bool>,
+    show_coverage_gutter: bool,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
     show_breakpoints: Option<bool>,
@@ -1416,6 +1419,13 @@ pub struct EditorSnapshot {
     current_line_highlight: CurrentLineHighlight,
     gutter_hovered: bool,
     semantic_tokens_enabled: bool,
+}
+
+/// Represents the code coverage status of a line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageStatus {
+    Covered,
+    Uncovered,
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -2448,6 +2458,8 @@ impl Editor {
             enable_runnables: full_mode,
             enable_mouse_wheel_zoom: full_mode,
             show_git_diff_gutter: None,
+            show_coverage_gutter: false,
+            coverage_data: HashMap::default(),
             show_code_actions: None,
             show_runnables: None,
             show_bookmarks: None,
@@ -3330,6 +3342,7 @@ impl Editor {
             show_line_numbers: self.show_line_numbers,
             number_deleted_lines: self.number_deleted_lines,
             show_git_diff_gutter: self.show_git_diff_gutter,
+            show_coverage_gutter: self.show_coverage_gutter,
             semantic_tokens_enabled: self.semantic_token_state.enabled(),
             show_code_actions: self.show_code_actions,
             show_runnables: self.show_runnables,
@@ -22218,6 +22231,51 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn set_show_coverage_gutter(&mut self, show: bool, cx: &mut Context<Self>) {
+        self.show_coverage_gutter = show;
+        cx.notify();
+    }
+
+    pub fn set_coverage_data(
+        &mut self,
+        data: HashMap<MultiBufferRow, CoverageStatus>,
+        cx: &mut Context<Self>,
+    ) {
+        self.coverage_data = data;
+        self.show_coverage_gutter = true;
+        cx.notify();
+    }
+
+    pub fn coverage_data(&self) -> &HashMap<MultiBufferRow, CoverageStatus> {
+        &self.coverage_data
+    }
+
+    pub fn toggle_coverage_gutter(
+        &mut self,
+        _: &ToggleCoverageGutter,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.show_coverage_gutter {
+            self.show_coverage_gutter = false;
+            self.coverage_data.clear();
+        } else {
+            let max_row = self.buffer.read(cx).read(cx).max_point().row;
+            let mut data = HashMap::default();
+            for row in 0..=max_row {
+                let status = if row % 7 == 0 || row % 13 == 0 {
+                    CoverageStatus::Uncovered
+                } else {
+                    CoverageStatus::Covered
+                };
+                data.insert(MultiBufferRow(row), status);
+            }
+            self.coverage_data = data;
+            self.show_coverage_gutter = true;
+        }
+        cx.notify();
+    }
+
     pub fn set_show_code_actions(&mut self, show_code_actions: bool, cx: &mut Context<Self>) {
         self.show_code_actions = Some(show_code_actions);
         cx.notify();
@@ -28471,7 +28529,7 @@ impl EditorSnapshot {
 
             let is_singleton = self.buffer_snapshot().is_singleton();
 
-            let left_padding = git_blame_entries_width.unwrap_or(Pixels::ZERO)
+            let mut left_padding = git_blame_entries_width.unwrap_or(Pixels::ZERO)
                 + if !is_singleton {
                     ch_width * 4.0
                 // runnables, breakpoints and bookmarks are shown in the same place
@@ -28485,6 +28543,10 @@ impl EditorSnapshot {
                 } else {
                     px(0.)
                 };
+
+            if self.show_coverage_gutter {
+                left_padding += ch_width;
+            }
 
             let shows_folds = is_singleton && gutter_settings.folds;
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1,15 +1,15 @@
 use crate::{
     ActiveDiagnostic, BUFFER_HEADER_PADDING, BlockId, CURSORS_VISIBLE_FOR, ChunkRendererContext,
     ChunkReplacement, CodeActionSource, ColumnarMode, ConflictsOurs, ConflictsOursMarker,
-    ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker, ContextMenuPlacement, CursorShape,
-    CustomBlockId, DisplayDiffHunk, DisplayPoint, DisplayRow, EditDisplayMode, EditPrediction,
-    Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle, FILE_HEADER_HEIGHT,
-    FocusedBlock, GutterDimensions, GutterHoverButton, HalfPageDown, HalfPageUp, HandleInput,
-    HoveredCursor, InlayHintRefreshReason, JumpData, LineDown, LineHighlight, LineUp, MAX_LINE_LEN,
-    MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown, PageUp,
-    PhantomDiffReviewIndicator, Point, RowExt, RowRangeExt, SelectPhase, Selection,
-    SelectionDragState, SelectionEffects, SizingBehavior, SoftWrap, StickyHeaderExcerpt, ToPoint,
-    ToggleFold, ToggleFoldAll,
+    ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker, ContextMenuPlacement, CoverageStatus,
+    CursorShape, CustomBlockId, DisplayDiffHunk, DisplayPoint, DisplayRow, EditDisplayMode,
+    EditPrediction, Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle,
+    FILE_HEADER_HEIGHT, FocusedBlock, GutterDimensions, GutterHoverButton, HalfPageDown,
+    HalfPageUp, HandleInput, HoveredCursor, InlayHintRefreshReason, JumpData, LineDown,
+    LineHighlight, LineUp, MAX_LINE_LEN, MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+    OpenExcerpts, PageDown, PageUp, PhantomDiffReviewIndicator, Point, RowExt, RowRangeExt,
+    SelectPhase, Selection, SelectionDragState, SelectionEffects, SizingBehavior, SoftWrap,
+    StickyHeaderExcerpt, ToPoint, ToggleFold, ToggleFoldAll,
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     column_pixels,
     display_map::{
@@ -47,8 +47,8 @@ use gpui::{
     MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels,
     PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Size,
     StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyleRefinement,
-    WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop, linear_gradient, outline,
-    pattern_slash, point, px, quad, relative, size, solid_background, transparent_black,
+    WeakEntity, Window, anchored, deferred, div, fill, hsla, linear_color_stop, linear_gradient,
+    outline, pattern_slash, point, px, quad, relative, size, solid_background, transparent_black,
 };
 use itertools::Itertools;
 use language::{
@@ -526,6 +526,7 @@ impl EditorElement {
         register_action(editor, window, Editor::toggle_git_blame);
         register_action(editor, window, Editor::toggle_git_blame_inline);
         register_action(editor, window, Editor::open_git_blame_commit);
+        register_action(editor, window, Editor::toggle_coverage_gutter);
         register_action(editor, window, Editor::toggle_selected_diff_hunks);
         register_action(editor, window, Editor::toggle_staged_selected_diff_hunks);
         register_action(editor, window, Editor::stage_and_next);
@@ -3327,10 +3328,12 @@ impl EditorElement {
             .ilog10()
             + 1;
 
-        let git_gutter_width = Self::gutter_strip_width(line_height)
-            + gutter_dimensions
-                .git_blame_entries_width
-                .unwrap_or_default();
+        let show_coverage = self.editor.read(cx).show_coverage_gutter;
+        let git_gutter_width = Self::gutter_left_strips_width(
+            line_height,
+            show_coverage,
+            gutter_dimensions.git_blame_entries_width,
+        );
         let available_width = gutter_dimensions.left_padding - git_gutter_width;
 
         buffer_rows
@@ -3378,7 +3381,7 @@ impl EditorElement {
                     .into_any_element();
 
                 let position = point(
-                    git_gutter_width + px(1.),
+                    git_gutter_width,
                     ix as f32 * line_height
                         - Pixels::from(scroll_top % ScrollPixelOffset::from(line_height))
                         + px(1.),
@@ -6273,8 +6276,59 @@ impl EditorElement {
         });
     }
 
+    fn paint_coverage_gutter(layout: &EditorLayout, window: &mut Window, cx: &mut App) {
+        if layout.coverage_data.is_empty() {
+            return;
+        }
+
+        let line_height = layout.position_map.line_height;
+        let scroll_position = layout.position_map.snapshot.scroll_position();
+        let scroll_top = scroll_position.y * ScrollPixelOffset::from(line_height);
+        let strip_width = Self::coverage_strip_width(line_height);
+        let git_strip_width = Self::gutter_strip_width(line_height);
+        let x_offset = git_strip_width + px(1.);
+
+        window.paint_layer(layout.gutter_hitbox.bounds, |window| {
+            for &(display_row, status) in &layout.coverage_data {
+                let color = match status {
+                    CoverageStatus::Covered => hsla(0.33, 0.8, 0.45, 0.8),
+                    CoverageStatus::Uncovered => hsla(0.0, 0.8, 0.45, 0.8),
+                };
+
+                let start_y = Pixels::from(
+                    display_row.as_f64() * ScrollPixelOffset::from(line_height) - scroll_top,
+                );
+                let end_y = start_y + line_height;
+
+                let origin = layout.gutter_hitbox.bounds.origin + point(x_offset, start_y);
+                let bounds = Bounds::new(origin, size(strip_width, end_y - start_y));
+
+                let flattened_color = cx.theme().colors().editor_background.blend(color);
+
+                window.paint_quad(fill(bounds, flattened_color));
+            }
+        });
+    }
+
     fn gutter_strip_width(line_height: Pixels) -> Pixels {
         (0.275 * line_height).floor()
+    }
+
+    fn coverage_strip_width(line_height: Pixels) -> Pixels {
+        (0.15 * line_height).floor()
+    }
+
+    fn gutter_left_strips_width(
+        line_height: Pixels,
+        show_coverage: bool,
+        git_blame_entries_width: Option<Pixels>,
+    ) -> Pixels {
+        let mut width =
+            Self::gutter_strip_width(line_height) + git_blame_entries_width.unwrap_or_default();
+        if show_coverage {
+            width += Self::coverage_strip_width(line_height) + px(1.);
+        }
+        width
     }
 
     fn diff_hunk_bounds(
@@ -6423,6 +6477,8 @@ impl EditorElement {
         if show_git_gutter {
             Self::paint_gutter_diff_hunks(layout, self.split_side, window, cx)
         }
+
+        Self::paint_coverage_gutter(layout, window, cx);
 
         let highlight_width = 0.275 * layout.position_map.line_height;
         let highlight_corner_radii = Corners::all(0.05 * layout.position_map.line_height);
@@ -7984,8 +8040,11 @@ impl Gutter<'_> {
             AvailableSpace::Definite(self.line_height),
         );
         let indicator_size = button.layout_as_root(available_space, window, cx);
-        let git_gutter_width = EditorElement::gutter_strip_width(self.line_height)
-            + self.dimensions.git_blame_entries_width.unwrap_or_default();
+        let git_gutter_width = EditorElement::gutter_left_strips_width(
+            self.line_height,
+            self.snapshot.show_coverage_gutter,
+            self.dimensions.git_blame_entries_width,
+        );
 
         let x = git_gutter_width + px(2.);
 
@@ -10799,10 +10858,11 @@ impl Element for EditorElement {
                         );
                     }
 
-                    let git_gutter_width = Self::gutter_strip_width(line_height)
-                        + gutter_dimensions
-                            .git_blame_entries_width
-                            .unwrap_or_default();
+                    let git_gutter_width = Self::gutter_left_strips_width(
+                        line_height,
+                        snapshot.show_coverage_gutter,
+                        gutter_dimensions.git_blame_entries_width,
+                    );
                     let available_width = gutter_dimensions.left_padding - git_gutter_width;
 
                     let max_line_number_length = self
@@ -11045,6 +11105,24 @@ impl Element for EditorElement {
                         editor.last_position_map = Some(position_map.clone())
                     });
 
+                    let coverage_data = {
+                        let editor = self.editor.read(cx);
+                        let coverage = editor.coverage_data();
+                        if position_map.snapshot.show_coverage_gutter && !coverage.is_empty() {
+                            row_infos
+                                .iter()
+                                .enumerate()
+                                .filter_map(|(ix, row_info)| {
+                                    let multibuffer_row = row_info.multibuffer_row?;
+                                    let status = coverage.get(&multibuffer_row)?;
+                                    Some((DisplayRow(start_row.0 + ix as u32), *status))
+                                })
+                                .collect()
+                        } else {
+                            Vec::new()
+                        }
+                    };
+
                     EditorLayout {
                         mode,
                         position_map,
@@ -11088,6 +11166,7 @@ impl Element for EditorElement {
                         sticky_buffer_header,
                         sticky_headers,
                         expand_toggles,
+                        coverage_data,
                         text_align: self.style.text.text_align,
                         content_width: text_hitbox.size.width,
                     }
@@ -11281,6 +11360,7 @@ pub struct EditorLayout {
     sticky_buffer_header: Option<AnyElement>,
     sticky_headers: Option<StickyHeaders>,
     document_colors: Option<(DocumentColorsRenderMode, Vec<(Range<DisplayPoint>, Hsla)>)>,
+    coverage_data: Vec<(DisplayRow, CoverageStatus)>,
     text_align: TextAlign,
     content_width: Pixels,
 }


### PR DESCRIPTION
Hello, I am working on source code coverage similar to vscode coverage-gutters, I wonder if these UI changes are acceptable. If so, then I will move on to read the lcov data and display the gutters appropriately.

Please make any comments and considerations.

Thank you

-Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added initial UI support for source code coverage gutters