### PR TITLE
agent: Respect favorite model settings and sync UI changes back to settings

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1432,11 +1432,12 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             })
             .cloned();
 
-        let agent_settings::ModelPreferences {
+        let LanguageModelSelection {
             enable_thinking,
             effort,
             speed,
-        } = agent_settings::resolve_model_preferences(&model, favorite.as_ref());
+            ..
+        } = agent_settings::language_model_to_selection(&model, favorite.as_ref());
 
         thread.update(cx, |thread, cx| {
             thread.set_model(model.clone(), cx);

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -47,7 +47,7 @@ use prompt_store::{
     WorktreeContext,
 };
 use serde::{Deserialize, Serialize};
-use settings::{LanguageModelSelection, update_settings_file};
+use settings::{LanguageModelSelection, Settings as _, update_settings_file};
 use std::any::Any;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -1423,16 +1423,49 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             return Task::ready(Err(anyhow!("Invalid model ID {}", model_id)));
         };
 
-        // We want to reset the effort level when switching models, as the currently-selected effort level may
-        // not be compatible.
-        let effort = model
-            .default_effort_level()
-            .map(|effort_level| effort_level.value.to_string());
+        let favorite = agent_settings::AgentSettings::get_global(cx)
+            .favorite_models
+            .iter()
+            .find(|favorite| {
+                favorite.provider.0 == model.provider_id().0.as_ref()
+                    && favorite.model == model.id().0.as_ref()
+            })
+            .cloned();
+
+        let effort = match favorite
+            .as_ref()
+            .and_then(|favorite| favorite.effort.as_ref())
+        {
+            Some(favorite_effort)
+                if model
+                    .supported_effort_levels()
+                    .iter()
+                    .any(|level| level.value.as_ref() == favorite_effort.as_str()) =>
+            {
+                Some(favorite_effort.clone())
+            }
+            _ => model
+                .default_effort_level()
+                .map(|effort_level| effort_level.value.to_string()),
+        };
+
+        let enable_thinking = match favorite.as_ref() {
+            Some(favorite) => favorite.enable_thinking && model.supports_thinking(),
+            None => model.supports_thinking(),
+        };
+
+        let speed = favorite
+            .as_ref()
+            .and_then(|favorite| favorite.speed)
+            .filter(|_| model.supports_fast_mode());
 
         thread.update(cx, |thread, cx| {
             thread.set_model(model.clone(), cx);
             thread.set_thinking_effort(effort.clone(), cx);
-            thread.set_thinking_enabled(model.supports_thinking(), cx);
+            thread.set_thinking_enabled(enable_thinking, cx);
+            if let Some(speed) = speed {
+                thread.set_speed(speed, cx);
+            }
         });
 
         update_settings_file(

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1432,32 +1432,11 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             })
             .cloned();
 
-        let effort = match favorite
-            .as_ref()
-            .and_then(|favorite| favorite.effort.as_ref())
-        {
-            Some(favorite_effort)
-                if model
-                    .supported_effort_levels()
-                    .iter()
-                    .any(|level| level.value.as_ref() == favorite_effort.as_str()) =>
-            {
-                Some(favorite_effort.clone())
-            }
-            _ => model
-                .default_effort_level()
-                .map(|effort_level| effort_level.value.to_string()),
-        };
-
-        let enable_thinking = match favorite.as_ref() {
-            Some(favorite) => favorite.enable_thinking && model.supports_thinking(),
-            None => model.supports_thinking(),
-        };
-
-        let speed = favorite
-            .as_ref()
-            .and_then(|favorite| favorite.speed)
-            .filter(|_| model.supports_fast_mode());
+        let agent_settings::ModelPreferences {
+            enable_thinking,
+            effort,
+            speed,
+        } = agent_settings::resolve_model_preferences(&model, favorite.as_ref());
 
         thread.update(cx, |thread, cx| {
             thread.set_model(model.clone(), cx);

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -2,7 +2,7 @@ use std::{any::Any, rc::Rc, sync::Arc};
 
 use agent_client_protocol as acp;
 use agent_servers::{AgentServer, AgentServerDelegate};
-use agent_settings::AgentSettings;
+use agent_settings::{AgentSettings, favorite_selection_for_model};
 use anyhow::Result;
 use collections::HashSet;
 use fs::Fs;
@@ -105,46 +105,15 @@ fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSele
                 .find(|m| m.id() == model_id_typed)
         });
 
-    let live = AgentSettings::get_global(cx)
-        .default_model
-        .as_ref()
-        .filter(|selection| selection.provider.0 == provider && selection.model == model);
-
-    let (enable_thinking, effort, speed) = match (resolved.as_ref(), live) {
-        (Some(model), Some(current)) => (
-            current.enable_thinking && model.supports_thinking(),
-            current
-                .effort
-                .clone()
-                .filter(|value| {
-                    model
-                        .supported_effort_levels()
-                        .iter()
-                        .any(|level| level.value.as_ref() == value.as_str())
-                })
-                .or_else(|| {
-                    model
-                        .default_effort_level()
-                        .map(|effort| effort.value.to_string())
-                }),
-            current.speed.filter(|_| model.supports_fast_mode()),
-        ),
-        (Some(model), None) => (
-            model.supports_thinking(),
-            model
-                .default_effort_level()
-                .map(|effort| effort.value.to_string()),
-            None,
-        ),
-        (None, _) => (false, None, None),
-    };
-
-    LanguageModelSelection {
-        provider: provider.to_owned().into(),
-        model: model.to_owned(),
-        enable_thinking,
-        effort,
-        speed,
+    match resolved {
+        Some(model) => favorite_selection_for_model(&model, cx),
+        None => LanguageModelSelection {
+            provider: provider.to_owned().into(),
+            model: model.to_owned(),
+            enable_thinking: false,
+            effort: None,
+            speed: None,
+        },
     }
 }
 

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use collections::HashSet;
 use fs::Fs;
 use gpui::{App, Entity, Task};
+use language_model::{LanguageModelId, LanguageModelProviderId, LanguageModelRegistry};
 use project::{AgentId, Project};
 use prompt_store::PromptStore;
 use settings::{LanguageModelSelection, Settings as _, update_settings_file};
@@ -76,7 +77,7 @@ impl AgentServer for NativeAgentServer {
         fs: Arc<dyn Fs>,
         cx: &App,
     ) {
-        let selection = model_id_to_selection(&model_id);
+        let selection = model_id_to_selection(&model_id, cx);
         update_settings_file(fs, cx, move |settings, _| {
             let agent = settings.agent.get_or_insert_default();
             if should_be_favorite {
@@ -89,15 +90,61 @@ impl AgentServer for NativeAgentServer {
 }
 
 /// Convert a ModelId (e.g. "anthropic/claude-3-5-sonnet") to a LanguageModelSelection.
-fn model_id_to_selection(model_id: &acp::ModelId) -> LanguageModelSelection {
+fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSelection {
     let id = model_id.0.as_ref();
     let (provider, model) = id.split_once('/').unwrap_or(("", id));
+
+    let provider_id = LanguageModelProviderId(provider.to_string().into());
+    let model_id_typed = LanguageModelId(model.to_string().into());
+    let resolved = LanguageModelRegistry::global(cx)
+        .read(cx)
+        .provider(&provider_id)
+        .and_then(|p| {
+            p.provided_models(cx)
+                .into_iter()
+                .find(|m| m.id() == model_id_typed)
+        });
+
+    let live = AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| selection.provider.0 == provider && selection.model == model);
+
+    let (enable_thinking, effort, speed) = match (resolved.as_ref(), live) {
+        (Some(model), Some(current)) => (
+            current.enable_thinking && model.supports_thinking(),
+            current
+                .effort
+                .clone()
+                .filter(|value| {
+                    model
+                        .supported_effort_levels()
+                        .iter()
+                        .any(|level| level.value.as_ref() == value.as_str())
+                })
+                .or_else(|| {
+                    model
+                        .default_effort_level()
+                        .map(|effort| effort.value.to_string())
+                }),
+            current.speed.filter(|_| model.supports_fast_mode()),
+        ),
+        (Some(model), None) => (
+            model.supports_thinking(),
+            model
+                .default_effort_level()
+                .map(|effort| effort.value.to_string()),
+            None,
+        ),
+        (None, _) => (false, None, None),
+    };
+
     LanguageModelSelection {
         provider: provider.to_owned().into(),
         model: model.to_owned(),
-        enable_thinking: false,
-        effort: None,
-        speed: None,
+        enable_thinking,
+        effort,
+        speed,
     }
 }
 

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -105,25 +105,26 @@ fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSele
                 .find(|m| m.id() == model_id_typed)
         });
 
-    let current_user_selection =
-        AgentSettings::get_global(cx)
-            .default_model
-            .as_ref()
-            .filter(|selection| {
-                selection.provider.0 == model.provider_id().0.as_ref()
-                    && selection.model == model.id().0.as_ref()
-            });
-
-    match resolved {
-        Some(model) => language_model_to_selection(&model, cx),
-        None => LanguageModelSelection {
+    let Some(resolved) = resolved else {
+        return LanguageModelSelection {
             provider: provider.to_owned().into(),
             model: model.to_owned(),
             enable_thinking: false,
             effort: None,
             speed: None,
-        },
-    }
+        };
+    };
+
+    let current_user_selection = AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| {
+            selection.provider.0 == resolved.provider_id().0.as_ref()
+                && selection.model == resolved.id().0.as_ref()
+        })
+        .cloned();
+
+    language_model_to_selection(&resolved, current_user_selection.as_ref())
 }
 
 #[cfg(test)]

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -2,7 +2,7 @@ use std::{any::Any, rc::Rc, sync::Arc};
 
 use agent_client_protocol as acp;
 use agent_servers::{AgentServer, AgentServerDelegate};
-use agent_settings::{AgentSettings, favorite_selection_for_model};
+use agent_settings::{AgentSettings, language_model_to_selection};
 use anyhow::Result;
 use collections::HashSet;
 use fs::Fs;
@@ -106,7 +106,7 @@ fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSele
         });
 
     match resolved {
-        Some(model) => favorite_selection_for_model(&model, cx),
+        Some(model) => language_model_to_selection(&model, cx),
         None => LanguageModelSelection {
             provider: provider.to_owned().into(),
             model: model.to_owned(),

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -105,6 +105,15 @@ fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSele
                 .find(|m| m.id() == model_id_typed)
         });
 
+    let current_user_selection =
+        AgentSettings::get_global(cx)
+            .default_model
+            .as_ref()
+            .filter(|selection| {
+                selection.provider.0 == model.provider_id().0.as_ref()
+                    && selection.model == model.id().0.as_ref()
+            });
+
     match resolved {
         Some(model) => language_model_to_selection(&model, cx),
         None => LanguageModelSelection {

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -210,7 +210,58 @@ impl AgentSettings {
             .map(|sel| ModelId::new(format!("{}/{}", sel.provider.0, sel.model)))
             .collect()
     }
+}
 
+pub fn favorite_selection_for_model(
+    model: &Arc<dyn LanguageModel>,
+    cx: &App,
+) -> LanguageModelSelection {
+    let provider_id = model.provider_id().0.to_string();
+    let model_id = model.id().0.to_string();
+
+    let current_selection = AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| selection.provider.0 == provider_id && selection.model == model_id);
+
+    let (enable_thinking, effort, speed) = match current_selection {
+        Some(current) => (
+            current.enable_thinking && model.supports_thinking(),
+            current
+                .effort
+                .clone()
+                .filter(|value| {
+                    model
+                        .supported_effort_levels()
+                        .iter()
+                        .any(|level| level.value.as_ref() == value.as_str())
+                })
+                .or_else(|| {
+                    model
+                        .default_effort_level()
+                        .map(|effort| effort.value.to_string())
+                }),
+            current.speed.filter(|_| model.supports_fast_mode()),
+        ),
+        None => (
+            model.supports_thinking(),
+            model
+                .default_effort_level()
+                .map(|effort| effort.value.to_string()),
+            None,
+        ),
+    };
+
+    LanguageModelSelection {
+        provider: provider_id.into(),
+        model: model_id,
+        enable_thinking,
+        effort,
+        speed,
+    }
+}
+
+impl AgentSettings {
     pub fn get_layout(cx: &App) -> WindowLayout {
         let store = cx.global::<SettingsStore>();
         let merged = store.merged_settings();

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -8,7 +8,7 @@ use collections::{HashSet, IndexMap};
 use fs::Fs;
 use futures::channel::oneshot;
 use gpui::{App, Pixels, px};
-use language_model::{LanguageModel, Speed};
+use language_model::LanguageModel;
 use project::DisableAiSettings;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -212,19 +212,16 @@ impl AgentSettings {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct ModelPreferences {
-    pub enable_thinking: bool,
-    pub effort: Option<String>,
-    pub speed: Option<Speed>,
-}
-
-pub fn resolve_model_preferences(
+pub fn language_model_to_selection(
     model: &Arc<dyn LanguageModel>,
     override_selection: Option<&LanguageModelSelection>,
-) -> ModelPreferences {
+) -> LanguageModelSelection {
+    let provider = model.provider_id().0.to_string().into();
+    let model_name = model.id().0.to_string();
     match override_selection {
-        Some(current) => ModelPreferences {
+        Some(current) => LanguageModelSelection {
+            provider,
+            model: model_name,
             enable_thinking: current.enable_thinking && model.supports_thinking(),
             effort: current
                 .effort
@@ -242,40 +239,15 @@ pub fn resolve_model_preferences(
                 }),
             speed: current.speed.filter(|_| model.supports_fast_mode()),
         },
-        None => ModelPreferences {
+        None => LanguageModelSelection {
+            provider,
+            model: model_name,
             enable_thinking: model.supports_thinking(),
             effort: model
                 .default_effort_level()
                 .map(|effort| effort.value.to_string()),
             speed: None,
         },
-    }
-}
-
-pub fn language_model_to_selection(
-    model: &Arc<dyn LanguageModel>,
-    cx: &App,
-) -> LanguageModelSelection {
-    let provider_id = model.provider_id().0.to_string();
-    let model_id = model.id().0.to_string();
-
-    let current_user_selection = AgentSettings::get_global(cx)
-        .default_model
-        .as_ref()
-        .filter(|selection| selection.provider.0 == provider_id && selection.model == model_id);
-
-    let ModelPreferences {
-        enable_thinking,
-        effort,
-        speed,
-    } = resolve_model_preferences(model, current_user_selection);
-
-    LanguageModelSelection {
-        provider: provider_id.into(),
-        model: model_id,
-        enable_thinking,
-        effort,
-        speed,
     }
 }
 

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -8,7 +8,7 @@ use collections::{HashSet, IndexMap};
 use fs::Fs;
 use futures::channel::oneshot;
 use gpui::{App, Pixels, px};
-use language_model::LanguageModel;
+use language_model::{LanguageModel, Speed};
 use project::DisableAiSettings;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -212,22 +212,21 @@ impl AgentSettings {
     }
 }
 
-pub fn favorite_selection_for_model(
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelPreferences {
+    pub enable_thinking: bool,
+    pub effort: Option<String>,
+    pub speed: Option<Speed>,
+}
+
+pub fn resolve_model_preferences(
     model: &Arc<dyn LanguageModel>,
-    cx: &App,
-) -> LanguageModelSelection {
-    let provider_id = model.provider_id().0.to_string();
-    let model_id = model.id().0.to_string();
-
-    let current_selection = AgentSettings::get_global(cx)
-        .default_model
-        .as_ref()
-        .filter(|selection| selection.provider.0 == provider_id && selection.model == model_id);
-
-    let (enable_thinking, effort, speed) = match current_selection {
-        Some(current) => (
-            current.enable_thinking && model.supports_thinking(),
-            current
+    override_selection: Option<&LanguageModelSelection>,
+) -> ModelPreferences {
+    match override_selection {
+        Some(current) => ModelPreferences {
+            enable_thinking: current.enable_thinking && model.supports_thinking(),
+            effort: current
                 .effort
                 .clone()
                 .filter(|value| {
@@ -241,16 +240,35 @@ pub fn favorite_selection_for_model(
                         .default_effort_level()
                         .map(|effort| effort.value.to_string())
                 }),
-            current.speed.filter(|_| model.supports_fast_mode()),
-        ),
-        None => (
-            model.supports_thinking(),
-            model
+            speed: current.speed.filter(|_| model.supports_fast_mode()),
+        },
+        None => ModelPreferences {
+            enable_thinking: model.supports_thinking(),
+            effort: model
                 .default_effort_level()
                 .map(|effort| effort.value.to_string()),
-            None,
-        ),
-    };
+            speed: None,
+        },
+    }
+}
+
+pub fn favorite_selection_for_model(
+    model: &Arc<dyn LanguageModel>,
+    cx: &App,
+) -> LanguageModelSelection {
+    let provider_id = model.provider_id().0.to_string();
+    let model_id = model.id().0.to_string();
+
+    let current_user_selection = AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| selection.provider.0 == provider_id && selection.model == model_id);
+
+    let ModelPreferences {
+        enable_thinking,
+        effort,
+        speed,
+    } = resolve_model_preferences(model, current_user_selection);
 
     LanguageModelSelection {
         provider: provider_id.into(),

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -252,7 +252,7 @@ pub fn resolve_model_preferences(
     }
 }
 
-pub fn favorite_selection_for_model(
+pub fn language_model_to_selection(
     model: &Arc<dyn LanguageModel>,
     cx: &App,
 ) -> LanguageModelSelection {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3837,12 +3837,20 @@ impl ThreadView {
                         let enable_thinking = !thread.thinking_enabled();
                         thread.set_thinking_enabled(enable_thinking, cx);
 
+                        let Some(model) = thread.model() else {
+                            return;
+                        };
+                        let provider_id = model.provider_id().0.to_string();
+                        let model_id = model.id().0.to_string();
                         let fs = thread.project().read(cx).fs().clone();
                         update_settings_file(fs, cx, move |settings, _| {
-                            if let Some(agent) = settings.agent.as_mut()
-                                && let Some(default_model) = agent.default_model.as_mut()
-                            {
-                                default_model.enable_thinking = enable_thinking;
+                            if let Some(agent) = settings.agent.as_mut() {
+                                if let Some(default_model) = agent.default_model.as_mut() {
+                                    default_model.enable_thinking = enable_thinking;
+                                }
+                                agent.update_favorite_model(&provider_id, &model_id, |favorite| {
+                                    favorite.enable_thinking = enable_thinking
+                                });
                             }
                         });
                     });
@@ -3973,14 +3981,28 @@ impl ThreadView {
                                                     cx,
                                                 );
 
+                                                let Some(model) = thread.model() else {
+                                                    return;
+                                                };
+                                                let provider_id = model.provider_id().0.to_string();
+                                                let model_id = model.id().0.to_string();
                                                 let fs = thread.project().read(cx).fs().clone();
                                                 update_settings_file(fs, cx, move |settings, _| {
-                                                    if let Some(agent) = settings.agent.as_mut()
-                                                        && let Some(default_model) =
+                                                    if let Some(agent) = settings.agent.as_mut() {
+                                                        if let Some(default_model) =
                                                             agent.default_model.as_mut()
-                                                    {
-                                                        default_model.effort =
-                                                            Some(effort.to_string());
+                                                        {
+                                                            default_model.effort =
+                                                                Some(effort.to_string());
+                                                        }
+                                                        agent.update_favorite_model(
+                                                            &provider_id,
+                                                            &model_id,
+                                                            |favorite| {
+                                                                favorite.effort =
+                                                                    Some(effort.to_string())
+                                                            },
+                                                        );
                                                     }
                                                 });
                                             });
@@ -8876,12 +8898,20 @@ impl ThreadView {
                 .unwrap_or(Speed::Fast);
             thread.set_speed(new_speed, cx);
 
+            let Some(model) = thread.model() else {
+                return;
+            };
+            let provider_id = model.provider_id().0.to_string();
+            let model_id = model.id().0.to_string();
             let fs = thread.project().read(cx).fs().clone();
             update_settings_file(fs, cx, move |settings, _| {
-                if let Some(agent) = settings.agent.as_mut()
-                    && let Some(default_model) = agent.default_model.as_mut()
-                {
-                    default_model.speed = Some(new_speed);
+                if let Some(agent) = settings.agent.as_mut() {
+                    if let Some(default_model) = agent.default_model.as_mut() {
+                        default_model.speed = Some(new_speed);
+                    }
+                    agent.update_favorite_model(&provider_id, &model_id, |favorite| {
+                        favorite.speed = Some(new_speed)
+                    });
                 }
             });
         });
@@ -8922,12 +8952,20 @@ impl ThreadView {
         thread.update(cx, |thread, cx| {
             thread.set_thinking_effort(Some(next_effort.clone()), cx);
 
+            let Some(model) = thread.model() else {
+                return;
+            };
+            let provider_id = model.provider_id().0.to_string();
+            let model_id = model.id().0.to_string();
             let fs = thread.project().read(cx).fs().clone();
             update_settings_file(fs, cx, move |settings, _| {
-                if let Some(agent) = settings.agent.as_mut()
-                    && let Some(default_model) = agent.default_model.as_mut()
-                {
-                    default_model.effort = Some(next_effort);
+                if let Some(agent) = settings.agent.as_mut() {
+                    if let Some(default_model) = agent.default_model.as_mut() {
+                        default_model.effort = Some(next_effort.clone());
+                    }
+                    agent.update_favorite_model(&provider_id, &model_id, |favorite| {
+                        favorite.effort = Some(next_effort)
+                    });
                 }
             });
         });

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3837,20 +3837,22 @@ impl ThreadView {
                         let enable_thinking = !thread.thinking_enabled();
                         thread.set_thinking_enabled(enable_thinking, cx);
 
-                        let Some(model) = thread.model() else {
-                            return;
-                        };
-                        let provider_id = model.provider_id().0.to_string();
-                        let model_id = model.id().0.to_string();
+                        let favorite_key = thread.model().map(|model| {
+                            (model.provider_id().0.to_string(), model.id().0.to_string())
+                        });
                         let fs = thread.project().read(cx).fs().clone();
                         update_settings_file(fs, cx, move |settings, _| {
                             if let Some(agent) = settings.agent.as_mut() {
                                 if let Some(default_model) = agent.default_model.as_mut() {
                                     default_model.enable_thinking = enable_thinking;
                                 }
-                                agent.update_favorite_model(&provider_id, &model_id, |favorite| {
-                                    favorite.enable_thinking = enable_thinking
-                                });
+                                if let Some((provider_id, model_id)) = &favorite_key {
+                                    agent.update_favorite_model(
+                                        provider_id,
+                                        model_id,
+                                        |favorite| favorite.enable_thinking = enable_thinking,
+                                    );
+                                }
                             }
                         });
                     });
@@ -3981,11 +3983,12 @@ impl ThreadView {
                                                     cx,
                                                 );
 
-                                                let Some(model) = thread.model() else {
-                                                    return;
-                                                };
-                                                let provider_id = model.provider_id().0.to_string();
-                                                let model_id = model.id().0.to_string();
+                                                let favorite_key = thread.model().map(|model| {
+                                                    (
+                                                        model.provider_id().0.to_string(),
+                                                        model.id().0.to_string(),
+                                                    )
+                                                });
                                                 let fs = thread.project().read(cx).fs().clone();
                                                 update_settings_file(fs, cx, move |settings, _| {
                                                     if let Some(agent) = settings.agent.as_mut() {
@@ -3995,14 +3998,18 @@ impl ThreadView {
                                                             default_model.effort =
                                                                 Some(effort.to_string());
                                                         }
-                                                        agent.update_favorite_model(
-                                                            &provider_id,
-                                                            &model_id,
-                                                            |favorite| {
-                                                                favorite.effort =
-                                                                    Some(effort.to_string())
-                                                            },
-                                                        );
+                                                        if let Some((provider_id, model_id)) =
+                                                            &favorite_key
+                                                        {
+                                                            agent.update_favorite_model(
+                                                                provider_id,
+                                                                model_id,
+                                                                |favorite| {
+                                                                    favorite.effort =
+                                                                        Some(effort.to_string())
+                                                                },
+                                                            );
+                                                        }
                                                     }
                                                 });
                                             });
@@ -8898,20 +8905,20 @@ impl ThreadView {
                 .unwrap_or(Speed::Fast);
             thread.set_speed(new_speed, cx);
 
-            let Some(model) = thread.model() else {
-                return;
-            };
-            let provider_id = model.provider_id().0.to_string();
-            let model_id = model.id().0.to_string();
+            let favorite_key = thread
+                .model()
+                .map(|model| (model.provider_id().0.to_string(), model.id().0.to_string()));
             let fs = thread.project().read(cx).fs().clone();
             update_settings_file(fs, cx, move |settings, _| {
                 if let Some(agent) = settings.agent.as_mut() {
                     if let Some(default_model) = agent.default_model.as_mut() {
                         default_model.speed = Some(new_speed);
                     }
-                    agent.update_favorite_model(&provider_id, &model_id, |favorite| {
-                        favorite.speed = Some(new_speed)
-                    });
+                    if let Some((provider_id, model_id)) = &favorite_key {
+                        agent.update_favorite_model(provider_id, model_id, |favorite| {
+                            favorite.speed = Some(new_speed)
+                        });
+                    }
                 }
             });
         });
@@ -8952,20 +8959,20 @@ impl ThreadView {
         thread.update(cx, |thread, cx| {
             thread.set_thinking_effort(Some(next_effort.clone()), cx);
 
-            let Some(model) = thread.model() else {
-                return;
-            };
-            let provider_id = model.provider_id().0.to_string();
-            let model_id = model.id().0.to_string();
+            let favorite_key = thread
+                .model()
+                .map(|model| (model.provider_id().0.to_string(), model.id().0.to_string()));
             let fs = thread.project().read(cx).fs().clone();
             update_settings_file(fs, cx, move |settings, _| {
                 if let Some(agent) = settings.agent.as_mut() {
                     if let Some(default_model) = agent.default_model.as_mut() {
                         default_model.effort = Some(next_effort.clone());
                     }
-                    agent.update_favorite_model(&provider_id, &model_id, |favorite| {
-                        favorite.effort = Some(next_effort)
-                    });
+                    if let Some((provider_id, model_id)) = &favorite_key {
+                        agent.update_favorite_model(provider_id, model_id, |favorite| {
+                            favorite.effort = Some(next_effort)
+                        });
+                    }
                 }
             });
         });

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use agent_settings::favorite_selection_for_model;
+use agent_settings::language_model_to_selection;
 use fs::Fs;
 use language_model::LanguageModel;
 use settings::update_settings_file;
@@ -12,7 +12,7 @@ pub fn toggle_in_settings(
     fs: Arc<dyn Fs>,
     cx: &mut App,
 ) {
-    let selection = favorite_selection_for_model(&model, cx);
+    let selection = language_model_to_selection(&model, cx);
     update_settings_file(fs, cx, move |settings, _| {
         let agent = settings.agent.get_or_insert_default();
         if should_be_favorite {

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -12,6 +12,15 @@ pub fn toggle_in_settings(
     fs: Arc<dyn Fs>,
     cx: &mut App,
 ) {
+    let current_user_selection =
+        AgentSettings::get_global(cx)
+            .default_model
+            .as_ref()
+            .filter(|selection| {
+                selection.provider.0 == model.provider_id().0.as_ref()
+                    && selection.model == model.id().0.as_ref()
+            });
+
     let selection = language_model_to_selection(&model, cx);
     update_settings_file(fs, cx, move |settings, _| {
         let agent = settings.agent.get_or_insert_default();

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -1,56 +1,10 @@
 use std::sync::Arc;
 
-use agent_settings::AgentSettings;
+use agent_settings::favorite_selection_for_model;
 use fs::Fs;
 use language_model::LanguageModel;
-use settings::{LanguageModelSelection, Settings as _, update_settings_file};
+use settings::update_settings_file;
 use ui::App;
-
-fn language_model_to_selection(model: &Arc<dyn LanguageModel>, cx: &App) -> LanguageModelSelection {
-    let provider_id = model.provider_id().0.to_string();
-    let model_id = model.id().0.to_string();
-
-    let user_current_model = AgentSettings::get_global(cx)
-        .default_model
-        .as_ref()
-        .filter(|selection| selection.provider.0 == provider_id && selection.model == model_id);
-
-    let (enable_thinking, effort, speed) = match user_current_model {
-        Some(current) => (
-            current.enable_thinking && model.supports_thinking(),
-            current
-                .effort
-                .clone()
-                .filter(|value| {
-                    model
-                        .supported_effort_levels()
-                        .iter()
-                        .any(|level| level.value.as_ref() == value.as_str())
-                })
-                .or_else(|| {
-                    model
-                        .default_effort_level()
-                        .map(|effort| effort.value.to_string())
-                }),
-            current.speed.filter(|_| model.supports_fast_mode()),
-        ),
-        None => (
-            model.supports_thinking(),
-            model
-                .default_effort_level()
-                .map(|effort| effort.value.to_string()),
-            None,
-        ),
-    };
-
-    LanguageModelSelection {
-        provider: provider_id.into(),
-        model: model_id,
-        enable_thinking,
-        effort,
-        speed,
-    }
-}
 
 pub fn toggle_in_settings(
     model: Arc<dyn LanguageModel>,
@@ -58,7 +12,7 @@ pub fn toggle_in_settings(
     fs: Arc<dyn Fs>,
     cx: &mut App,
 ) {
-    let selection = language_model_to_selection(&model, cx);
+    let selection = favorite_selection_for_model(&model, cx);
     update_settings_file(fs, cx, move |settings, _| {
         let agent = settings.agent.get_or_insert_default();
         if should_be_favorite {

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -1,17 +1,54 @@
 use std::sync::Arc;
 
+use agent_settings::AgentSettings;
 use fs::Fs;
 use language_model::LanguageModel;
-use settings::{LanguageModelSelection, update_settings_file};
+use settings::{LanguageModelSelection, Settings as _, update_settings_file};
 use ui::App;
 
-fn language_model_to_selection(model: &Arc<dyn LanguageModel>) -> LanguageModelSelection {
+fn language_model_to_selection(model: &Arc<dyn LanguageModel>, cx: &App) -> LanguageModelSelection {
+    let provider_id = model.provider_id().0.to_string();
+    let model_id = model.id().0.to_string();
+
+    let user_current_model = AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| selection.provider.0 == provider_id && selection.model == model_id);
+
+    let (enable_thinking, effort, speed) = match user_current_model {
+        Some(current) => (
+            current.enable_thinking && model.supports_thinking(),
+            current
+                .effort
+                .clone()
+                .filter(|value| {
+                    model
+                        .supported_effort_levels()
+                        .iter()
+                        .any(|level| level.value.as_ref() == value.as_str())
+                })
+                .or_else(|| {
+                    model
+                        .default_effort_level()
+                        .map(|effort| effort.value.to_string())
+                }),
+            current.speed.filter(|_| model.supports_fast_mode()),
+        ),
+        None => (
+            model.supports_thinking(),
+            model
+                .default_effort_level()
+                .map(|effort| effort.value.to_string()),
+            None,
+        ),
+    };
+
     LanguageModelSelection {
-        provider: model.provider_id().to_string().into(),
-        model: model.id().0.to_string(),
-        enable_thinking: false,
-        effort: None,
-        speed: None,
+        provider: provider_id.into(),
+        model: model_id,
+        enable_thinking,
+        effort,
+        speed,
     }
 }
 
@@ -21,7 +58,7 @@ pub fn toggle_in_settings(
     fs: Arc<dyn Fs>,
     cx: &mut App,
 ) {
-    let selection = language_model_to_selection(&model);
+    let selection = language_model_to_selection(&model, cx);
     update_settings_file(fs, cx, move |settings, _| {
         let agent = settings.agent.get_or_insert_default();
         if should_be_favorite {

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use agent_settings::language_model_to_selection;
+use agent_settings::{AgentSettings, language_model_to_selection};
 use fs::Fs;
 use language_model::LanguageModel;
-use settings::update_settings_file;
+use settings::{Settings as _, update_settings_file};
 use ui::App;
 
 pub fn toggle_in_settings(
@@ -12,16 +12,16 @@ pub fn toggle_in_settings(
     fs: Arc<dyn Fs>,
     cx: &mut App,
 ) {
-    let current_user_selection =
-        AgentSettings::get_global(cx)
-            .default_model
-            .as_ref()
-            .filter(|selection| {
-                selection.provider.0 == model.provider_id().0.as_ref()
-                    && selection.model == model.id().0.as_ref()
-            });
+    let current_user_selection = AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| {
+            selection.provider.0 == model.provider_id().0.as_ref()
+                && selection.model == model.id().0.as_ref()
+        })
+        .cloned();
 
-    let selection = language_model_to_selection(&model, cx);
+    let selection = language_model_to_selection(&model, current_user_selection.as_ref());
     update_settings_file(fs, cx, move |settings, _| {
         let agent = settings.agent.get_or_insert_default();
         if should_be_favorite {

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -275,13 +275,34 @@ impl AgentSettingsContent {
     }
 
     pub fn add_favorite_model(&mut self, model: LanguageModelSelection) {
-        if !self.favorite_models.contains(&model) {
+        // Note: this is intentional to not compare using `PartialEq`here.
+        // Full equality would treat entries that differ just in thinking/effort/speed
+        // as distinct and silently produce duplicates.
+        if !self
+            .favorite_models
+            .iter()
+            .any(|m| m.provider == model.provider && m.model == model.model)
+        {
             self.favorite_models.push(model);
         }
     }
 
     pub fn remove_favorite_model(&mut self, model: &LanguageModelSelection) {
-        self.favorite_models.retain(|m| m != model);
+        self.favorite_models
+            .retain(|m| !(m.provider == model.provider && m.model == model.model));
+    }
+
+    pub fn update_favorite_model<F>(&mut self, provider: &str, model: &str, f: F)
+    where
+        F: FnOnce(&mut LanguageModelSelection),
+    {
+        if let Some(entry) = self
+            .favorite_models
+            .iter_mut()
+            .find(|m| m.provider.0 == provider && m.model == model)
+        {
+            f(entry);
+        }
     }
 
     pub fn set_tool_default_permission(&mut self, tool_id: &str, mode: ToolPermissionMode) {


### PR DESCRIPTION
Closes #54313

**Before:**
- Favoriting a model only stored `provider`, `model`, and hardcoded `enable_thinking` to `false`.
- Selecting a favorited model would not restore your preferred `enable_thinking`, `effort`, or `speed` settings.

This means that if you'd like to use, say, GPT 5.4 your favorite model on `xhigh` effort every single time, switching to it would set effort to `medium` (the default for the model) instead.

**After:**
- Favoriting a model captures your current `enable_thinking`, `effort`, and `speed` when it matches the currently-selected model. Otherwise, it falls back to the model's own defaults, i.e. thinking-capable models are no longer favorited with `enable_thinking` forced to `false`.
- Selecting a favorited model applies its stored thinking / effort / speed.
- Toggling thinking, changing effort, or toggling fast mode on a favorited model updates the favorite entry in settings (along with the existing `default_model` setting), so the preference doesn't drift.

Release Notes:

- Agent favorite models now remember and restore per-model thinking, effort level, and fast mode preferences.