### PR TITLE
recent_projects: Fix unaligned keybinding labels in quick-switch menu

### DIFF
--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -417,22 +417,40 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                         create_new_window: false,
                     };
 
-                    Button::new("open_local_folder", "Add Local Folders")
-                        .key_binding(KeyBinding::for_action_in(&open_action, &focus_handle, cx))
+                    ListItem::new("open_local_folder")
+                        .inset(true)
+                        .spacing(ListItemSpacing::Sparse)
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .justify_between()
+                                .items_center()
+                                .child(Label::new("Add Local Folders"))
+                                .child(KeyBinding::for_action_in(&open_action, &focus_handle, cx)),
+                        )
                         .on_click(cx.listener(move |_, _, window, cx| {
                             window.dispatch_action(open_action.boxed_clone(), cx);
                             cx.emit(DismissEvent);
                         }))
                 })
                 .child(
-                    Button::new("open_remote_folder", "Add Remote Folder")
-                        .key_binding(KeyBinding::for_action(
-                            &OpenRemote {
-                                from_existing_connection: false,
-                                create_new_window: false,
-                            },
-                            cx,
-                        ))
+                    ListItem::new("open_remote_folder")
+                        .inset(true)
+                        .spacing(ListItemSpacing::Sparse)
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .justify_between()
+                                .items_center()
+                                .child(Label::new("Add Remote Folder"))
+                                .child(KeyBinding::for_action(
+                                    &OpenRemote {
+                                        from_existing_connection: false,
+                                        create_new_window: false,
+                                    },
+                                    cx,
+                                )),
+                        )
                         .on_click(cx.listener(|_, _, window, cx| {
                             window.dispatch_action(
                                 OpenRemote {

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -12,7 +12,7 @@ use picker::{
 };
 use remote::RemoteConnectionOptions;
 use settings::Settings;
-use ui::{KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*};
+use ui::{ButtonLike, KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*};
 use ui_input::ErasedEditor;
 use util::{ResultExt, paths::PathExt};
 use workspace::{
@@ -417,12 +417,11 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                         create_new_window: false,
                     };
 
-                    ListItem::new("open_local_folder")
-                        .inset(true)
-                        .spacing(ListItemSpacing::Sparse)
+                    ButtonLike::new("open_local_folder")
                         .child(
                             h_flex()
                                 .w_full()
+                                .gap_1()
                                 .justify_between()
                                 .items_center()
                                 .child(Label::new("Add Local Folders"))
@@ -434,12 +433,11 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                         }))
                 })
                 .child(
-                    ListItem::new("open_remote_folder")
-                        .inset(true)
-                        .spacing(ListItemSpacing::Sparse)
+                    ButtonLike::new("open_remote_folder")
                         .child(
                             h_flex()
                                 .w_full()
+                                .gap_1()
                                 .justify_between()
                                 .items_center()
                                 .child(Label::new("Add Remote Folder"))

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -423,7 +423,6 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                                 .w_full()
                                 .gap_1()
                                 .justify_between()
-                                .items_center()
                                 .child(Label::new("Add Local Folders"))
                                 .child(KeyBinding::for_action_in(&open_action, &focus_handle, cx)),
                         )
@@ -439,7 +438,6 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                                 .w_full()
                                 .gap_1()
                                 .justify_between()
-                                .items_center()
                                 .child(Label::new("Add Remote Folder"))
                                 .child(KeyBinding::for_action(
                                     &OpenRemote {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54324 

Release Notes:

- Fixed shortcut label alignment in the Recent Projects quick-switch footer by rendering action rows with a consistent two-column layout (label left, keybinding right) for “Add Local Folders” and “Add Remote Folder”.
