### PR TITLE
Do not play join sound in large meetings

### DIFF
--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -893,7 +893,8 @@ impl Room {
                             if this.created.elapsed() > Duration::from_millis(100) {
                                 if let proto::ChannelRole::Guest = role {
                                     Audio::play_sound(Sound::GuestJoined, cx);
-                                } else {
+                                // Do not play join sound in large meetings
+                                } else if this.remote_participants().len() < 10 {
                                     Audio::play_sound(Sound::Joined, cx);
                                 }
                             }


### PR DESCRIPTION
The join sounds get annoying in large meetings, let's not play it anymore when the meeting get's really big. The guest joined sound is plays regardless of group size so participants get a heads-up when someone external joins.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Improved join sound no longer plays in large meetings
