### PR TITLE
Add new settings to improve split-pane behavior

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -15,6 +15,7 @@ use std::{ops::Range, sync::LazyLock};
 use text::OffsetRangeExt;
 use theme::ActiveTheme as _;
 use util::{ResultExt, TryFutureExt as _, maybe};
+use workspace::WorkspaceSettings;
 
 #[derive(Debug)]
 pub struct HoveredLinkState {
@@ -216,6 +217,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) -> Task<anyhow::Result<Navigated>> {
+        let split = Self::is_alt_pressed(&modifiers, cx)
+            ^ WorkspaceSettings::get_global(cx).new_tab_on_gotos;
+
         if let Some(hovered_link_state) = self.hovered_link_state.take() {
             self.hide_hovered_link(cx);
             if !hovered_link_state.links.is_empty() {
@@ -254,7 +258,6 @@ impl Editor {
                     })
                     .collect();
                 let nav_entry = self.navigation_entry(mb_anchor, cx);
-                let split = Self::is_alt_pressed(&modifiers, cx);
                 let navigate_task =
                     self.navigate_to_hover_links(None, links, nav_entry, split, window, cx);
                 self.select(SelectPhase::End, window, cx);
@@ -275,7 +278,6 @@ impl Editor {
         );
 
         let navigate_task = if point.as_valid().is_some() {
-            let split = Self::is_alt_pressed(&modifiers, cx);
             match (modifiers.shift, split) {
                 (true, true) => {
                     self.go_to_type_definition_split(&GoToTypeDefinitionSplit, window, cx)

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1016,6 +1016,9 @@ impl VsCodeSettings {
             }),
             zoomed_padding: None,
             focus_follows_mouse: None,
+            new_tab_on_gotos: self.read_bool("workspace.editor.new_tab_on_gotos.enabled"),
+            prefer_left_pane_to_new_panes: self
+                .read_bool("workspace.editor.prefer_left_pane_to_new_panes"),
         }
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -130,6 +130,16 @@ pub struct WorkspaceSettingsContent {
     /// Whether the focused panel follows the mouse location
     /// Default: false
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
+    /// Whether Go-To-Definition/Find-References prefers the use of a new tab or not.
+    /// When enabled, `Ctrl+Click` and `Ctrl+Alt+Click` behaviours are swapped.
+    ///
+    /// Default: false
+    pub new_tab_on_gotos: Option<bool>,
+    /// Whether actions that would open in an adjacent pane should look for a left pane to use
+    /// before opening a new pane on the right or not.
+    ///
+    /// Default: false
+    pub prefer_left_pane_to_new_panes: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5453,10 +5453,15 @@ impl Workspace {
     }
 
     pub fn adjacent_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Entity<Pane> {
-        self.find_pane_in_direction(SplitDirection::Right, cx)
-            .unwrap_or_else(|| {
-                self.split_pane(self.active_pane.clone(), SplitDirection::Right, window, cx)
-            })
+        if WorkspaceSettings::get_global(cx).prefer_left_pane_to_new_panes {
+            self.find_pane_in_direction(SplitDirection::Left, cx)
+        } else {
+            None
+        }
+        .or_else(|| self.find_pane_in_direction(SplitDirection::Right, cx))
+        .unwrap_or_else(|| {
+            self.split_pane(self.active_pane.clone(), SplitDirection::Right, window, cx)
+        })
     }
 
     pub fn pane_for(&self, handle: &dyn ItemHandle) -> Option<Entity<Pane>> {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -37,6 +37,8 @@ pub struct WorkspaceSettings {
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
     pub focus_follows_mouse: FocusFollowsMouse,
+    pub new_tab_on_gotos: bool,
+    pub prefer_left_pane_to_new_panes: bool,
 }
 
 #[derive(Copy, Clone, Deserialize)]
@@ -136,6 +138,8 @@ impl Settings for WorkspaceSettings {
                         .unwrap_or(250),
                 ),
             },
+            new_tab_on_gotos: workspace.new_tab_on_gotos.unwrap_or(false),
+            prefer_left_pane_to_new_panes: workspace.prefer_left_pane_to_new_panes.unwrap_or(false),
         }
     }
 }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Added a `new_tab_on_gotos` option that swaps behavior between `Ctrl+Click` and `Ctrl+Alt+Click`, allowing users to use split-pane behavior by default when performing lookups.
- Added a `prefer_left_pane_to_new_panes` option which, when set to true, makes Zed prefer swapping to a pane on the left rather than create a new pane on the right when a request for an adjacent pane is made; making the navigation experience more consistent and avoiding pane cascades.


# Author comments

Hi there!

This is my first PR to Zed, so I tried to keep the embedded model above as intact as possible.
Here's some more details on what I did and why.

This PR just proposes additional settings that tweak behavior slightly, and are off-by-default to avoid disrupting other users. I'll highlight caveats when relevant.

## `new_tab_on_gotos`

This one is kinda self-explanatory, I like to use `Ctrl+Click` in other editors to peek at code and dislike how doing so in Zed hides the current editor entirely behind the referenced one.

While I'd love to come with a PR that adds VSCode's Peek Editors to Zed eventually, the most straight-forward path to me was to at least solve the "steals focus" issue, which I feel allowing users to chose to open definitions in an adjacent tab with the default lookup action does for cheap.

Caveats:
- I'd like this to also work for reference search, but it doesn't yet. I simply haven't pushed my luck further yet, but I might edit this PR (or create a new one) to add support for this.
- The option might be a bit restrictive, especially if other `Ctrl+Click` behaviors (such as Peek Editors) eventually turn up. Maybe a better name for the option would be `"go_to_symbols": "in_current_pane"|"in_adjacent_pane"` which could then be expanded with `"in_peek_editor"` in the future.

## `prefer_left_pane_to_new_panes`

This setting tweaks the `adjacent_pane` function behavior so that it looks for a pane on the left first before trying to create a new pane.

This makes adjacent-pane-tied behavior much neater, as it behaves more consistently between tabs and avoids the cascade effect that this workflow leads to with current Zed.

If anything, I feel like this behavior would be a sound default, but I still left it to default to `false` to avoid breaking unsuspecting users' workflows.