### PR TITLE
Add 'protobuf' to path_suffixes for proto

### DIFF
--- a/extensions/proto/languages/proto/config.toml
+++ b/extensions/proto/languages/proto/config.toml
@@ -1,6 +1,6 @@
 name = "Proto"
 grammar = "proto"
-path_suffixes = ["proto"]
+path_suffixes = ["proto", "protobuf"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
I have encountered markdown files that fence protobuf source blocks with a `protobuf` tag instead of `proto`. [GitHub accepts both](https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml#L6042).

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

~Closes #ISSUE~ (no issue)

Release Notes:

- `protobuf` accepted as markdown code fence tag for Protocol Buffers
