### PR TITLE
editor: Fix 'seperate' typo in rewrap test comments

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7586,7 +7586,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test that change in comment prefix (e.g., `//` to `///`) trigger seperate rewraps
+    // Test that change in comment prefix (e.g., `//` to `///`) trigger separate rewraps
     assert_rewrap(
         indoc! {"
             «// A regular long long comment to be wrapped.
@@ -7602,7 +7602,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test that change in indentation level trigger seperate rewraps
+    // Test that change in indentation level trigger separate rewraps
     assert_rewrap(
         indoc! {"
             fn foo() {


### PR DESCRIPTION

**Repo:** zed-industries/zed (⭐ 49000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Corrects two occurrences of the misspelling "seperate" → "separate" in comments
within the rewrap test cases in `crates/editor/src/editor_tests.rs`.

## Why
Small spelling fix in test documentation. Improves readability of the test
intent for anyone touching the rewrap behavior. The repo uses `typos` in CI
(see `typos.toml`), and these comments are not in the excluded paths, so
fixing them keeps the codebase clean.

## Testing
Comment-only change in test code; no behavior is affected. No build/test run
needed beyond what CI does.

## Risk
Low — comment-only edits inside test functions.
