### PR TITLE
Cleanup open thread connections on close

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2162,7 +2162,7 @@ impl AgentPanel {
         self.cleanup_retained_threads(cx);
     }
 
-    fn cleanup_retained_threads(&mut self, cx: &App) {
+    fn cleanup_retained_threads(&mut self, cx: &mut App) {
         let mut potential_removals = self
             .retained_threads
             .iter()
@@ -2185,7 +2185,61 @@ impl AgentPanel {
             .take(n)
             .collect::<Vec<_>>();
         for id in to_remove {
-            self.retained_threads.remove(&id);
+            let Some(conversation_view) = self.retained_threads.remove(&id) else {
+                continue;
+            };
+            Self::close_conversation_view_session(&conversation_view, cx);
+        }
+    }
+
+    fn close_conversation_view_session(
+        conversation_view: &Entity<ConversationView>,
+        cx: &mut App,
+    ) {
+        let Some(thread_view) = conversation_view.read(cx).root_thread_view() else {
+            return;
+        };
+        let thread_entity = thread_view.read(cx).thread.clone();
+        let (connection, session_id) = {
+            let thread = thread_entity.read(cx);
+            if !thread.connection().supports_close_session() {
+                return;
+            }
+            (thread.connection().clone(), thread.session_id().clone())
+        };
+        connection
+            .close_session(&session_id, cx)
+            .detach_and_log_err(cx);
+    }
+
+    /// Drop all in-memory state for a thread and ask the agent to close the
+    /// session. Used by `Archive Thread` when the user holds the secondary
+    /// modifier to force a hard close. Reopen must go through `load_session`.
+    pub fn force_close_thread(
+        &mut self,
+        thread_id: ThreadId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(conversation_view) = self.retained_threads.remove(&thread_id) {
+            Self::close_conversation_view_session(&conversation_view, cx);
+        }
+
+        let base_matches = matches!(
+            &self.base_view,
+            BaseView::AgentThread { conversation_view }
+                if conversation_view.read(cx).thread_id == thread_id
+        );
+        if base_matches {
+            let old_view = std::mem::replace(&mut self.base_view, BaseView::Uninitialized);
+            if let BaseView::AgentThread { conversation_view } = old_view {
+                Self::close_conversation_view_session(&conversation_view, cx);
+            }
+            self.clear_overlay_state();
+            self.activate_draft(false, window, cx);
+            self.serialize(cx);
+            cx.emit(AgentPanelEvent::ActiveViewChanged);
+            cx.notify();
         }
     }
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2994,6 +2994,7 @@ impl Sidebar {
     fn archive_thread(
         &mut self,
         session_id: &acp::SessionId,
+        force_close: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -3017,6 +3018,22 @@ impl Sidebar {
                     .as_ref()
                     .map(|workspace| PathList::new(&workspace.read(cx).root_paths(cx)))
             });
+
+        if force_close {
+            if let Some(thread_id) = thread_id {
+                if let Some(multi_workspace) = self.multi_workspace.upgrade() {
+                    let workspaces: Vec<_> =
+                        multi_workspace.read(cx).workspaces().cloned().collect();
+                    for workspace in workspaces {
+                        if let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
+                            panel.update(cx, |panel, cx| {
+                                panel.force_close_thread(thread_id, window, cx);
+                            });
+                        }
+                    }
+                }
+            }
+        }
 
         // Compute which linked worktree roots should be archived from disk if
         // this thread is archived. This must happen before we remove any
@@ -3549,7 +3566,7 @@ impl Sidebar {
                     AgentThreadStatus::Completed | AgentThreadStatus::Error => {}
                 }
                 if let Some(session_id) = thread.metadata.session_id.clone() {
-                    self.archive_thread(&session_id, window, cx);
+                    self.archive_thread(&session_id, false, window, cx);
                 }
             }
             _ => {}
@@ -3924,9 +3941,10 @@ impl Sidebar {
                         .tooltip({
                             let focus_handle = focus_handle.clone();
                             move |_window, cx| {
-                                Tooltip::for_action_in(
+                                Tooltip::with_meta_in(
                                     "Archive Thread",
-                                    &RemoveSelectedThread,
+                                    Some(&RemoveSelectedThread),
+                                    "⌘-click to force close connection",
                                     &focus_handle,
                                     cx,
                                 )
@@ -3934,9 +3952,10 @@ impl Sidebar {
                         })
                         .on_click({
                             let session_id = session_id_for_delete.clone();
-                            cx.listener(move |this, _, window, cx| {
+                            cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
                                 if let Some(ref session_id) = session_id {
-                                    this.archive_thread(session_id, window, cx);
+                                    let force_close = event.modifiers().secondary();
+                                    this.archive_thread(session_id, force_close, window, cx);
                                 }
                             })
                         }),

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -4626,7 +4626,7 @@ async fn test_archive_thread_uses_next_threads_own_workspace(cx: &mut TestAppCon
 
     // Archive thread 2.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&thread2_session_id, window, cx);
+        sidebar.archive_thread(&thread2_session_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -4763,7 +4763,7 @@ async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppCon
 
     // Archive the worktree thread (the only thread for /wt-feature-a).
     sidebar.update_in(cx, |sidebar: &mut Sidebar, window, cx| {
-        sidebar.archive_thread(&wt_thread_id, window, cx);
+        sidebar.archive_thread(&wt_thread_id, false, window, cx);
     });
 
     // archive_thread spawns a multi-layered chain of tasks (workspace
@@ -5421,7 +5421,7 @@ async fn test_archive_last_worktree_thread_not_blocked_by_remote_thread_at_same_
 
     // Archive the local worktree thread.
     sidebar.update_in(cx, |sidebar: &mut Sidebar, window, cx| {
-        sidebar.archive_thread(&wt_thread_id, window, cx);
+        sidebar.archive_thread(&wt_thread_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -5920,6 +5920,7 @@ async fn test_archive_thread_keeps_metadata_but_hides_from_sidebar(cx: &mut Test
     sidebar.update_in(cx, |sidebar, window, cx| {
         sidebar.archive_thread(
             &acp::SessionId::new(Arc::from("thread-to-archive")),
+            false,
             window,
             cx,
         );
@@ -5998,7 +5999,7 @@ async fn test_archive_thread_active_entry_management(cx: &mut TestAppContext) {
     cx.run_until_parked();
 
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&thread_a, window, cx);
+        sidebar.archive_thread(&thread_a, false, window, cx);
     });
     cx.run_until_parked();
 
@@ -6033,7 +6034,7 @@ async fn test_archive_thread_active_entry_management(cx: &mut TestAppContext) {
     });
 
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&thread_b, window, cx);
+        sidebar.archive_thread(&thread_b, false, window, cx);
     });
     cx.run_until_parked();
 
@@ -6072,7 +6073,7 @@ async fn test_unarchive_only_shows_restored_thread(cx: &mut TestAppContext) {
 
     // Archive it.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&session_id, window, cx);
+        sidebar.archive_thread(&session_id, false, window, cx);
     });
     cx.run_until_parked();
 
@@ -6391,7 +6392,7 @@ async fn test_unarchive_into_existing_workspace_replaces_draft(cx: &mut TestAppC
 
     // Archive the thread — the group is left empty (no draft created).
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&session_id, window, cx);
+        sidebar.archive_thread(&session_id, false, window, cx);
     });
     cx.run_until_parked();
 
@@ -6600,7 +6601,7 @@ async fn test_unarchive_after_removing_parent_project_group_restores_real_thread
     cx.run_until_parked();
 
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&session_id, window, cx);
+        sidebar.archive_thread(&session_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -6739,7 +6740,7 @@ async fn test_unarchive_does_not_create_duplicate_real_thread_metadata(cx: &mut 
     });
 
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&session_id, window, cx);
+        sidebar.archive_thread(&session_id, false, window, cx);
     });
     cx.run_until_parked();
 
@@ -6843,7 +6844,7 @@ async fn test_switch_to_workspace_with_archived_thread_shows_no_active_entry(
 
     // Archive it while project-b is active.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&thread_a, window, cx);
+        sidebar.archive_thread(&thread_a, false, window, cx);
     });
     cx.run_until_parked();
 
@@ -7087,7 +7088,7 @@ async fn test_archive_last_thread_on_linked_worktree_does_not_create_new_thread_
 
     // Archive the worktree thread — it's the only thread using ochre-drift.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&worktree_thread_id, window, cx);
+        sidebar.archive_thread(&worktree_thread_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -7217,7 +7218,7 @@ async fn test_archive_last_thread_on_linked_worktree_with_no_siblings_leaves_gro
 
     // Archive it — there are no other threads in the group.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&worktree_thread_id, window, cx);
+        sidebar.archive_thread(&worktree_thread_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -7539,7 +7540,7 @@ async fn test_archive_thread_on_linked_worktree_selects_sibling_thread(cx: &mut 
 
     // Archive the worktree thread.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&worktree_thread_id, window, cx);
+        sidebar.archive_thread(&worktree_thread_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -9113,7 +9114,7 @@ mod property_test {
             Operation::ArchiveThread { index } => {
                 let session_id = state.saved_thread_ids[index].clone();
                 sidebar.update_in(cx, |sidebar: &mut Sidebar, window, cx| {
-                    sidebar.archive_thread(&session_id, window, cx);
+                    sidebar.archive_thread(&session_id, false, window, cx);
                 });
                 cx.run_until_parked();
                 state.saved_thread_ids.remove(index);
@@ -10160,7 +10161,7 @@ async fn test_archive_removes_worktree_even_when_workspace_paths_diverge(cx: &mu
 
     // Archive the worktree thread.
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&wt_thread_id, window, cx);
+        sidebar.archive_thread(&wt_thread_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -10381,7 +10382,7 @@ async fn test_archive_mixed_workspace_closes_only_archived_worktree_items(cx: &m
     // Archive the feature-b thread.
     let fb_session_id = acp::SessionId::new(Arc::from("feature-b-thread"));
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&fb_session_id, window, cx);
+        sidebar.archive_thread(&fb_session_id, false, window, cx);
     });
 
     cx.run_until_parked();
@@ -10629,7 +10630,7 @@ async fn test_remote_archive_thread_with_active_connection(
     );
 
     sidebar.update_in(cx, |sidebar: &mut Sidebar, window, cx| {
-        sidebar.archive_thread(&wt_thread_id, window, cx);
+        sidebar.archive_thread(&wt_thread_id, false, window, cx);
     });
     cx.run_until_parked();
     server_cx.run_until_parked();
@@ -10748,7 +10749,7 @@ async fn test_remote_archive_thread_with_disconnected_remote(
     });
 
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.archive_thread(&thread_id, window, cx);
+        sidebar.archive_thread(&thread_id, false, window, cx);
     });
     cx.run_until_parked();
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks - None present
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #NA

Release Notes:

- Added cleanup logic for open thread connections using `session/close`

<img width="560" height="88" alt="image" src="https://github.com/user-attachments/assets/48146781-b4b3-43e1-8efa-4b0ed3450181" />
