### PR TITLE
copilot_chat: Respect prompt token limits

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1691,7 +1691,9 @@ impl Thread {
         let usage = self.latest_request_token_usage()?;
         let model = self.model.clone()?;
         Some(acp_thread::TokenUsage {
-            max_tokens: model.max_token_count(),
+            max_tokens: model
+                .max_prompt_token_count()
+                .unwrap_or_else(|| model.max_token_count()),
             max_output_tokens: model.max_output_tokens(),
             used_tokens: usage.total_tokens(),
             input_tokens: usage.input_tokens,

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -1269,11 +1269,13 @@ mod tests {
 
         let schema: ModelSchema = serde_json::from_str(json).unwrap();
 
-        // max_token_count() should return context window (200000), not prompt tokens (90000)
+        // max_token_count() should return the context window (200000), while
+        // max_prompt_token_count() should return the prompt/input limit (90000).
         assert_eq!(schema.data[0].max_token_count(), 200000);
         assert_eq!(schema.data[0].max_prompt_token_count(), Some(90000));
 
-        // GPT-4o should return 128000 (context window), not 110000 (prompt tokens)
+        // GPT-4o should return 128000 as the context window, while
+        // max_prompt_token_count() should return the prompt/input limit (110000).
         assert_eq!(schema.data[1].max_token_count(), 128000);
         assert_eq!(schema.data[1].max_prompt_token_count(), Some(110000));
     }

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -264,6 +264,15 @@ impl Model {
         self.capabilities.limits.max_context_window_tokens as u64
     }
 
+    pub fn max_prompt_token_count(&self) -> Option<u64> {
+        let max_prompt_tokens = self.capabilities.limits.max_prompt_tokens;
+        if max_prompt_tokens == 0 {
+            None
+        } else {
+            Some(max_prompt_tokens)
+        }
+    }
+
     pub fn max_output_tokens(&self) -> usize {
         self.capabilities.limits.max_output_tokens
     }
@@ -1262,9 +1271,11 @@ mod tests {
 
         // max_token_count() should return context window (200000), not prompt tokens (90000)
         assert_eq!(schema.data[0].max_token_count(), 200000);
+        assert_eq!(schema.data[0].max_prompt_token_count(), Some(90000));
 
         // GPT-4o should return 128000 (context window), not 110000 (prompt tokens)
         assert_eq!(schema.data[1].max_token_count(), 128000);
+        assert_eq!(schema.data[1].max_prompt_token_count(), Some(110000));
     }
 
     #[test]

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -117,6 +117,9 @@ pub trait LanguageModel: Send + Sync {
     }
 
     fn max_token_count(&self) -> u64;
+    fn max_prompt_token_count(&self) -> Option<u64> {
+        None
+    }
     fn max_output_tokens(&self) -> Option<u64> {
         None
     }

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -262,52 +262,26 @@ impl LanguageModel for CopilotChatLanguageModel {
 
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
         let levels = self.model.reasoning_effort_levels();
-        if !levels.is_empty() {
-            return levels
-                .iter()
-                .map(|level| {
-                    let name = match level.as_str() {
-                        "low" => "Low".into(),
-                        "medium" => "Medium".into(),
-                        "high" => "High".into(),
-                        "xhigh" => "Extra High".into(),
-                        _ => language_model::SharedString::from(level.clone()),
-                    };
-                    LanguageModelEffortLevel {
-                        name,
-                        value: language_model::SharedString::from(level.clone()),
-                        is_default: level == "high",
-                    }
-                })
-                .collect();
+        if levels.is_empty() {
+            return vec![];
         }
-
-        if self.model.supports_adaptive_thinking() {
-            vec![
+        levels
+            .iter()
+            .map(|level| {
+                let name = match level.as_str() {
+                    "low" => "Low".into(),
+                    "medium" => "Medium".into(),
+                    "high" => "High".into(),
+                    "xhigh" => "Extra High".into(),
+                    _ => language_model::SharedString::from(level.clone()),
+                };
                 LanguageModelEffortLevel {
-                    name: "Low".into(),
-                    value: "low".into(),
-                    is_default: false,
-                },
-                LanguageModelEffortLevel {
-                    name: "Medium".into(),
-                    value: "medium".into(),
-                    is_default: false,
-                },
-                LanguageModelEffortLevel {
-                    name: "High".into(),
-                    value: "high".into(),
-                    is_default: true,
-                },
-                LanguageModelEffortLevel {
-                    name: "Max".into(),
-                    value: "max".into(),
-                    is_default: false,
-                },
-            ]
-        } else {
-            vec![]
-        }
+                    name,
+                    value: language_model::SharedString::from(level.clone()),
+                    is_default: level == "high",
+                }
+            })
+            .collect()
     }
 
     fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -262,26 +262,52 @@ impl LanguageModel for CopilotChatLanguageModel {
 
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
         let levels = self.model.reasoning_effort_levels();
-        if levels.is_empty() {
-            return vec![];
+        if !levels.is_empty() {
+            return levels
+                .iter()
+                .map(|level| {
+                    let name = match level.as_str() {
+                        "low" => "Low".into(),
+                        "medium" => "Medium".into(),
+                        "high" => "High".into(),
+                        "xhigh" => "Extra High".into(),
+                        _ => language_model::SharedString::from(level.clone()),
+                    };
+                    LanguageModelEffortLevel {
+                        name,
+                        value: language_model::SharedString::from(level.clone()),
+                        is_default: level == "high",
+                    }
+                })
+                .collect();
         }
-        levels
-            .iter()
-            .map(|level| {
-                let name = match level.as_str() {
-                    "low" => "Low".into(),
-                    "medium" => "Medium".into(),
-                    "high" => "High".into(),
-                    "xhigh" => "Extra High".into(),
-                    _ => language_model::SharedString::from(level.clone()),
-                };
+
+        if self.model.supports_adaptive_thinking() {
+            vec![
                 LanguageModelEffortLevel {
-                    name,
-                    value: language_model::SharedString::from(level.clone()),
-                    is_default: level == "high",
-                }
-            })
-            .collect()
+                    name: "Low".into(),
+                    value: "low".into(),
+                    is_default: false,
+                },
+                LanguageModelEffortLevel {
+                    name: "Medium".into(),
+                    value: "medium".into(),
+                    is_default: false,
+                },
+                LanguageModelEffortLevel {
+                    name: "High".into(),
+                    value: "high".into(),
+                    is_default: true,
+                },
+                LanguageModelEffortLevel {
+                    name: "Max".into(),
+                    value: "max".into(),
+                    is_default: false,
+                },
+            ]
+        } else {
+            vec![]
+        }
     }
 
     fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {
@@ -316,6 +342,10 @@ impl LanguageModel for CopilotChatLanguageModel {
 
     fn max_token_count(&self) -> u64 {
         self.model.max_token_count()
+    }
+
+    fn max_prompt_token_count(&self) -> Option<u64> {
+        self.model.max_prompt_token_count()
     }
 
     fn count_tokens(


### PR DESCRIPTION
## Summary

Fix Copilot-backed thread token budgeting to use the provider's prompt token limit instead of the larger context window when available.

This keeps Zed's token usage UI and warning thresholds aligned with the effective backend request cap for Copilot models that expose `max_prompt_tokens`.

## Changes

- add `max_prompt_token_count()` to the `LanguageModel` trait with a default `None`
- expose `max_prompt_tokens` from Copilot model metadata
- wire the Copilot prompt token limit through the Copilot language model provider
- update thread token usage to prefer `max_prompt_token_count()` over `max_token_count()`
- extend Copilot model tests to verify both context window and prompt token limits are preserved separately

## Why

Copilot model metadata includes both:

- `max_context_window_tokens`
- `max_prompt_tokens`

Zed was using the context window as the thread token budget, which can overestimate the amount of prompt that the Copilot backend will actually accept. This leads to misleading token-limit UI and avoidable `model_max_prompt_tokens_exceeded` failures.

This change keeps `max_token_count()` as the context window and introduces a separate prompt-limit accessor so budgeting can use the more accurate value without changing the meaning of the existing API.

Release Notes:

- Fixed Copilot-backed agent threads using the model context window instead of the prompt token limit for token budgeting and limit warnings.