### PR TITLE
cli: Make `zed --wait --diff` not wait until window close

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -642,14 +642,6 @@ fn main() -> Result<()> {
         }
     }
 
-    // When only diff paths are provided (no regular paths), add the current
-    // working directory so the workspace opens with the right context.
-    if paths.is_empty() && urls.is_empty() && !diff_paths.is_empty() {
-        if let Ok(cwd) = env::current_dir() {
-            paths.push(cwd.to_string_lossy().into_owned());
-        }
-    }
-
     anyhow::ensure!(
         args.dev_server_token.is_none(),
         "Dev servers were removed in v0.157.x please upgrade to SSH remoting: https://zed.dev/docs/remote-development"

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -783,7 +783,7 @@ async fn open_workspaces(
 }
 
 async fn open_local_workspace(
-    workspace_paths: Vec<String>,
+    mut workspace_paths: Vec<String>,
     diff_paths: Vec<[String; 2]>,
     diff_all: bool,
     open_options: workspace::OpenOptions,
@@ -791,6 +791,16 @@ async fn open_local_workspace(
     app_state: &Arc<AppState>,
     cx: &mut AsyncApp,
 ) -> bool {
+    let user_provided_paths = !workspace_paths.is_empty();
+
+    // When only diff paths are provided (no regular paths), add the current
+    // working directory so the workspace opens with the right context.
+    if !user_provided_paths && !diff_paths.is_empty() {
+        if let Ok(cwd) = std::env::current_dir() {
+            workspace_paths.push(cwd.to_string_lossy().into_owned());
+        }
+    }
+
     let paths_with_position =
         derive_paths_with_position(app_state.fs.as_ref(), workspace_paths).await;
 
@@ -822,10 +832,12 @@ async fn open_local_workspace(
     // the entire workspace is closed.
     if open_options.wait {
         let mut wait_for_window_close = paths_with_position.is_empty() && diff_paths.is_empty();
-        for path_with_position in &paths_with_position {
-            if app_state.fs.is_dir(&path_with_position.path).await {
-                wait_for_window_close = true;
-                break;
+        if user_provided_paths {
+            for path_with_position in &paths_with_position {
+                if app_state.fs.is_dir(&path_with_position.path).await {
+                    wait_for_window_close = true;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
`zed --wait --diff <left> <right>` currently waits for the entire window to close instead of just the diff itself, due to the combination of
- `zed --diff` adds the cwd to the paths to open (see #45131), and
- passing a directory to `zed --wait` blocks until the Zed window is closed (see #44936), which doesn't distinguish between explicit paths and the one `zed --diff` adds

Fixed by only running the `zed --wait <dir>` logic to block until the window is closed in case the user actually passed any non-diff paths.

I've confirmed locally that it works, though I wasn't really sure how to write a good test for this.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- `zed --wait --diff <left> <right>` now blocks until the diff is closed, and not until the entire window is closed.