### PR TITLE
eslint: Fix `workspaceFolder.uri` sent as raw path instead of `file:/…

### DIFF
--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -254,7 +254,9 @@ impl LspAdapter for EsLintLspAdapter {
                 "mode": "auto"
             },
             "workspaceFolder": {
-                "uri": worktree_root,
+                "uri": Uri::from_file_path(worktree_root)
+                    .map(|uri| uri.as_str().to_owned())
+                    .unwrap_or_default(),
                 "name": worktree_root.file_name()
                     .unwrap_or(worktree_root.as_os_str())
                     .to_string_lossy(),


### PR DESCRIPTION
…/` URI

The ESLint adapter was sending `workspaceFolder.uri` as a raw filesystem path (e.g. `/Users/foo/project`) instead of a proper `file://` URI (e.g. `file:///Users/foo/project`).

This caused the vscode-eslint server's `workingDirectory: { mode: "auto" }` to fail when resolving the workspace root, falling back to the linted file's directory as the working directory. As a result, `eslint-import-resolver-typescript` could not locate `tsconfig.json`, breaking path alias resolution for rules like `import/order` — producing different lint results compared to VS Code.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- N/A or Added/Fixed/Improved ...
