### PR TITLE
git_ui: Show renamed files in git panel

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -738,6 +738,7 @@ fn db_status_to_proto(
         }),
         diff_stat_added: entry.lines_added.map(|v| v as u32),
         diff_stat_deleted: entry.lines_deleted.map(|v| v as u32),
+        original_path: None,
     })
 }
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -457,7 +457,7 @@ impl GitRepository for FakeGitRepository {
                         worktree_status: StatusCode::Unmodified,
                     })
                 {
-                    entries.push((path.clone(), status));
+                    entries.push((path.clone(), status, None));
                 }
             }
             entries.sort_by(|a, b| a.0.cmp(&b.0));

--- a/crates/git/src/commit.rs
+++ b/crates/git/src/commit.rs
@@ -106,7 +106,19 @@ pub fn parse_git_diff_name_status(content: &str) -> impl Iterator<Item = (&str, 
     std::iter::from_fn(move || {
         loop {
             let status_str = parts.next()?;
+            if status_str.is_empty() {
+                continue;
+            }
             let path = parts.next()?;
+
+            if status_str.starts_with('R') {
+                let new_path = parts.next()?;
+                return Some((new_path, StatusCode::Renamed));
+            } else if status_str.starts_with('C') {
+                let new_path = parts.next()?;
+                return Some((new_path, StatusCode::Copied));
+            }
+
             let status = match status_str {
                 "M" => StatusCode::Modified,
                 "A" => StatusCode::Added,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1,6 +1,6 @@
 use crate::commit::parse_git_diff_name_status;
 use crate::stash::GitStash;
-use crate::status::{DiffTreeType, GitStatus, StatusCode, TreeDiff};
+use crate::status::{DiffTreeType, FileStatus, GitStatus, StatusCode, TrackedStatus, TreeDiff};
 use crate::{Oid, RunHook, SHORT_SHA_LENGTH};
 use anyhow::{Context as _, Result, anyhow, bail};
 use collections::HashMap;
@@ -1251,7 +1251,6 @@ impl GitRepository for RealGitRepository {
                     "show",
                     "--format=",
                     "-z",
-                    "--no-renames",
                     "--name-status",
                     "--first-parent",
                 ])
@@ -1287,7 +1286,7 @@ impl GitRepository for RealGitRepository {
                 };
 
                 match status_code {
-                    StatusCode::Modified => {
+                    StatusCode::Modified | StatusCode::Renamed | StatusCode::Copied => {
                         stdin.write_all(commit.as_bytes()).await?;
                         stdin.write_all(b":").await?;
                         stdin.write_all(path.as_bytes()).await?;
@@ -1333,7 +1332,7 @@ impl GitRepository for RealGitRepository {
                 };
 
                 match status_code {
-                    StatusCode::Modified => {
+                    StatusCode::Modified | StatusCode::Renamed | StatusCode::Copied => {
                         info_line.clear();
                         stdout.read_line(&mut info_line).await?;
                         let len = info_line.trim_end().parse().with_context(|| {
@@ -1635,11 +1634,15 @@ impl GitRepository for RealGitRepository {
         };
         let args = git_status_args(path_prefixes);
         log::debug!("Checking for git status in {path_prefixes:?}");
+        let repository = self.repository.clone();
         self.executor.spawn(async move {
             let output = git.build_command(&args).output().await?;
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                stdout.parse()
+                let mut status: GitStatus = stdout.parse()?;
+                let repository = repository.lock();
+                infer_unstaged_renames(&repository, &git.working_directory, &mut status);
+                Ok(status)
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 anyhow::bail!("git status failed: {stderr}");
@@ -1657,7 +1660,6 @@ impl GitRepository for RealGitRepository {
             OsString::from("diff-tree"),
             OsString::from("-r"),
             OsString::from("-z"),
-            OsString::from("--no-renames"),
         ];
         match request {
             DiffTreeType::MergeBase { base, head } => {
@@ -2126,7 +2128,7 @@ impl GitRepository for RealGitRepository {
                 let mut args: Vec<String> = vec![
                     "diff".into(),
                     "--numstat".into(),
-                    "--no-renames".into(),
+                    "-z".into(),
                     "HEAD".into(),
                 ];
                 if !path_prefixes.is_empty() {
@@ -3185,6 +3187,101 @@ async fn read_single_commit_response<R: smol::io::AsyncBufRead + Unpin>(
         .ok_or_else(|| anyhow!("failed to parse commit {}", sha))
 }
 
+fn infer_unstaged_renames(
+    repository: &git2::Repository,
+    working_directory: &Path,
+    status: &mut GitStatus,
+) {
+    let mut deleted_entries = Vec::new();
+    let mut untracked_entries = Vec::new();
+
+    for (index, (repo_path, file_status, _)) in status.entries.iter().enumerate() {
+        match *file_status {
+            FileStatus::Tracked(TrackedStatus {
+                index_status: StatusCode::Unmodified,
+                worktree_status: StatusCode::Deleted,
+            }) => deleted_entries.push((index, repo_path.clone())),
+            FileStatus::Untracked => untracked_entries.push((index, repo_path.clone())),
+            _ => {}
+        }
+    }
+
+    if deleted_entries.is_empty() || untracked_entries.is_empty() {
+        return;
+    }
+
+    let head_tree = match repository.head().and_then(|head| head.peel_to_tree()) {
+        Ok(tree) => tree,
+        Err(_) => return,
+    };
+
+    let mut matched_untracked: HashSet<usize> = HashSet::default();
+    let mut renames = Vec::new();
+
+    for (deleted_index, deleted_path) in deleted_entries {
+        let deleted_entry = match head_tree.get_path(deleted_path.as_std_path()) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        if deleted_entry.filemode() == i32::from(git2::FileMode::Link) {
+            continue;
+        }
+
+        let deleted_blob = match repository.find_blob(deleted_entry.id()) {
+            Ok(blob) => blob,
+            Err(_) => continue,
+        };
+
+        let mut rename_target = None;
+        for (untracked_index, untracked_path) in &untracked_entries {
+            if matched_untracked.contains(untracked_index) {
+                continue;
+            }
+
+            let candidate_path = working_directory.join(untracked_path.as_std_path());
+            let candidate_bytes = match std::fs::read(&candidate_path) {
+                Ok(bytes) => bytes,
+                Err(_) => continue,
+            };
+
+            if candidate_bytes == deleted_blob.content() {
+                rename_target = Some((*untracked_index, untracked_path.clone()));
+                break;
+            }
+        }
+
+        if let Some((untracked_index, untracked_path)) = rename_target {
+            matched_untracked.insert(untracked_index);
+            renames.push((deleted_index, untracked_index, deleted_path, untracked_path));
+        }
+    }
+
+    if renames.is_empty() {
+        return;
+    }
+
+    let mut entries = status.entries.iter().cloned().collect::<Vec<_>>();
+    let mut removed_indexes: HashSet<usize> = HashSet::default();
+
+    for (deleted_index, untracked_index, old_path, new_path) in renames {
+        removed_indexes.insert(deleted_index);
+        removed_indexes.insert(untracked_index);
+        entries.push((
+            new_path,
+            FileStatus::worktree(StatusCode::Renamed),
+            Some(old_path),
+        ));
+    }
+
+    entries = entries
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, entry)| (!removed_indexes.contains(&index)).then_some(entry))
+        .collect();
+    entries.sort_unstable_by(|(a, _, _), (b, _, _)| a.cmp(b));
+    status.entries = entries.into();
+}
+
 fn parse_initial_graph_output<'a>(
     lines: impl Iterator<Item = &'a str>,
 ) -> Vec<Arc<InitialGraphCommitData>> {
@@ -3225,7 +3322,6 @@ fn git_status_args(path_prefixes: &[RepoPath]) -> Vec<OsString> {
         OsString::from("status"),
         OsString::from("--porcelain=v1"),
         OsString::from("--untracked-files=all"),
-        OsString::from("--no-renames"),
         OsString::from("-z"),
         OsString::from("--"),
     ];
@@ -4493,6 +4589,158 @@ mod tests {
             moved_worktree.path.canonicalize().unwrap(),
             new_path.canonicalize().unwrap()
         );
+    }
+
+    #[gpui::test]
+    async fn test_status_infers_unstaged_rename(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(repo_dir.path()).unwrap();
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        smol::fs::write(repo_dir.path().join("old_name.rs"), "fn renamed() {}\n")
+            .await
+            .unwrap();
+        repo.stage_paths(vec![repo_path("old_name.rs")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+        repo.commit(
+            "Initial commit".into(),
+            None,
+            CommitOptions::default(),
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(checkpoint_author_envs()),
+        )
+        .await
+        .unwrap();
+
+        smol::fs::rename(
+            repo_dir.path().join("old_name.rs"),
+            repo_dir.path().join("new_name.rs"),
+        )
+        .await
+        .unwrap();
+
+        let root = RepoPath::from_rel_path(RelPath::new(Path::new(""), PathStyle::local()).unwrap().as_ref());
+        let status = repo.status(&[root]).await.unwrap();
+        assert_eq!(status.entries.len(), 1);
+
+        let (path, file_status, original_path) = &status.entries[0];
+        assert_eq!(path, &repo_path("new_name.rs"));
+        assert_eq!(*file_status, FileStatus::worktree(StatusCode::Renamed));
+        assert_eq!(original_path.as_ref(), Some(&repo_path("old_name.rs")));
+    }
+
+    #[gpui::test]
+    async fn test_status_does_not_infer_rename_when_content_changes(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(repo_dir.path()).unwrap();
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        smol::fs::write(repo_dir.path().join("old_name.rs"), "fn renamed() {}\n")
+            .await
+            .unwrap();
+        repo.stage_paths(vec![repo_path("old_name.rs")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+        repo.commit(
+            "Initial commit".into(),
+            None,
+            CommitOptions::default(),
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(checkpoint_author_envs()),
+        )
+        .await
+        .unwrap();
+
+        smol::fs::rename(
+            repo_dir.path().join("old_name.rs"),
+            repo_dir.path().join("new_name.rs"),
+        )
+        .await
+        .unwrap();
+        smol::fs::write(repo_dir.path().join("new_name.rs"), "fn changed() {}\n")
+            .await
+            .unwrap();
+
+        let root = RepoPath::from_rel_path(RelPath::new(Path::new(""), PathStyle::local()).unwrap().as_ref());
+        let status = repo.status(&[root]).await.unwrap();
+        assert_eq!(status.entries.len(), 2);
+        assert_eq!(status.entries[0].0, repo_path("new_name.rs"));
+        assert_eq!(status.entries[0].1, FileStatus::Untracked);
+        assert_eq!(status.entries[1].0, repo_path("old_name.rs"));
+        assert_eq!(status.entries[1].1, FileStatus::worktree(StatusCode::Deleted));
+    }
+
+    #[gpui::test]
+    async fn test_status_preserves_staged_rename(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(repo_dir.path()).unwrap();
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        smol::fs::write(repo_dir.path().join("old_name.rs"), "fn renamed() {}\n")
+            .await
+            .unwrap();
+        repo.stage_paths(vec![repo_path("old_name.rs")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+        repo.commit(
+            "Initial commit".into(),
+            None,
+            CommitOptions::default(),
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(checkpoint_author_envs()),
+        )
+        .await
+        .unwrap();
+
+        smol::fs::rename(
+            repo_dir.path().join("old_name.rs"),
+            repo_dir.path().join("new_name.rs"),
+        )
+        .await
+        .unwrap();
+        repo.stage_paths(vec![repo_path("old_name.rs"), repo_path("new_name.rs")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
+
+        let root = RepoPath::from_rel_path(RelPath::new(Path::new(""), PathStyle::local()).unwrap().as_ref());
+        let status = repo.status(&[root]).await.unwrap();
+        assert_eq!(status.entries.len(), 1);
+
+        let (path, file_status, original_path) = &status.entries[0];
+        assert_eq!(path, &repo_path("new_name.rs"));
+        assert!(file_status.is_renamed());
+        assert_eq!(original_path.as_ref(), Some(&repo_path("old_name.rs")));
     }
 
     #[test]

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -166,6 +166,7 @@ impl FileStatus {
         self.is_modified()
             || self.is_created()
             || self.is_deleted()
+            || self.is_renamed()
             || self.is_untracked()
             || self.is_conflicted()
     }
@@ -197,6 +198,16 @@ impl FileStatus {
         };
         tracked.index_status == StatusCode::Deleted && tracked.worktree_status != StatusCode::Added
             || tracked.worktree_status == StatusCode::Deleted
+    }
+
+    pub fn is_renamed(self) -> bool {
+        match self {
+            FileStatus::Tracked(tracked) => matches!(
+                (tracked.index_status, tracked.worktree_status),
+                (StatusCode::Renamed, _) | (_, StatusCode::Renamed)
+            ),
+            _ => false,
+        }
     }
 
     pub fn is_untracked(self) -> bool {
@@ -250,7 +261,11 @@ impl StatusCode {
                 deleted: 1,
                 ..TrackedSummary::UNCHANGED
             },
-            StatusCode::Renamed | StatusCode::Copied | StatusCode::Unmodified => {
+            StatusCode::Renamed => TrackedSummary {
+                modified: 1,
+                ..TrackedSummary::UNCHANGED
+            },
+            StatusCode::Copied | StatusCode::Unmodified => {
                 TrackedSummary::UNCHANGED
             }
         }
@@ -429,40 +444,62 @@ impl std::ops::Sub for GitSummary {
 
 #[derive(Clone, Debug)]
 pub struct GitStatus {
-    pub entries: Arc<[(RepoPath, FileStatus)]>,
+    pub entries: Arc<[(RepoPath, FileStatus, Option<RepoPath>)]>,
 }
 
 impl FromStr for GitStatus {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let mut entries = s
-            .split('\0')
-            .filter_map(|entry| {
-                let sep = entry.get(2..3)?;
-                if sep != " " {
-                    return None;
+        let mut parts = s.split('\0');
+        let mut entries = Vec::new();
+
+        while let Some(entry) = parts.next() {
+            let sep = match entry.get(2..3) {
+                Some(" ") => {}
+                _ => continue,
+            };
+            let _ = sep;
+            let path_str = &entry[3..];
+            if path_str.ends_with('/') {
+                continue;
+            }
+
+            let status_bytes: [u8; 2] = entry.as_bytes()[0..2].try_into().unwrap();
+            let status = match FileStatus::from_bytes(status_bytes).log_err() {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let is_rename_or_copy = matches!(status_bytes[0], b'R' | b'C')
+                || matches!(status_bytes[1], b'R' | b'C');
+
+            if is_rename_or_copy {
+                // Porcelain v1 with -z: rename produces `XY new_path\0old_path\0`
+                let original_path_str = match parts.next() {
+                    Some(s) if !s.is_empty() => s,
+                    _ => continue,
                 };
-                let path = &entry[3..];
-                // The git status output includes untracked directories as well as untracked files.
-                // We do our own processing to compute the "summary" status of each directory,
-                // so just skip any directories in the output, since they'll otherwise interfere
-                // with our handling of nested repositories.
-                if path.ends_with('/') {
-                    return None;
-                }
-                let status = entry.as_bytes()[0..2].try_into().unwrap();
-                let status = FileStatus::from_bytes(status).log_err()?;
-                // git-status outputs `/`-delimited repo paths, even on Windows.
-                let path = RepoPath::from_rel_path(RelPath::unix(path).log_err()?);
-                Some((path, status))
-            })
-            .collect::<Vec<_>>();
-        entries.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
-        // When a file exists in HEAD, is deleted in the index, and exists again in the working copy,
-        // git produces two lines for it, one reading `D ` (deleted in index, unmodified in working copy)
-        // and the other reading `??` (untracked). Merge these two into the equivalent of `DA`.
-        entries.dedup_by(|(a, a_status), (b, b_status)| {
+                let new_path = match RelPath::unix(path_str).log_err() {
+                    Some(r) => RepoPath::from_rel_path(r),
+                    None => continue,
+                };
+                let orig_path = match RelPath::unix(original_path_str).log_err() {
+                    Some(r) => RepoPath::from_rel_path(r),
+                    None => continue,
+                };
+                entries.push((new_path, status, Some(orig_path)));
+            } else {
+                let path = match RelPath::unix(path_str).log_err() {
+                    Some(r) => RepoPath::from_rel_path(r),
+                    None => continue,
+                };
+                entries.push((path, status, None));
+            }
+        }
+
+        entries.sort_unstable_by(|(a, _, _), (b, _, _)| a.cmp(b));
+        entries.dedup_by(|(a, a_status, _), (b, b_status, _)| {
             const INDEX_DELETED: FileStatus = FileStatus::index(StatusCode::Deleted);
             if a.ne(&b) {
                 return false;
@@ -535,6 +572,7 @@ pub enum TreeDiffStatus {
     Added,
     Modified { old: Oid },
     Deleted { old: Oid },
+    Renamed { old: Oid },
 }
 
 impl FromStr for TreeDiff {
@@ -543,37 +581,45 @@ impl FromStr for TreeDiff {
     fn from_str(s: &str) -> Result<Self> {
         let mut fields = s.split('\0');
         let mut parsed = HashMap::default();
-        while let Some((status, path)) = fields.next().zip(fields.next()) {
-            let path = RepoPath::from_rel_path(RelPath::unix(path)?);
-
-            let mut fields = status.split(" ").skip(2);
-            let old_sha = fields
+        while let Some((status_field, path)) = fields.next().zip(fields.next()) {
+            let mut status_parts = status_field.split(" ").skip(2);
+            let old_sha = status_parts
                 .next()
                 .ok_or_else(|| anyhow!("expected to find old_sha"))?
                 .to_owned()
                 .parse()?;
-            let _new_sha = fields
+            let _new_sha = status_parts
                 .next()
                 .ok_or_else(|| anyhow!("expected to find new_sha"))?;
-            let status = fields
+            let status_str = status_parts
                 .next()
-                .and_then(|s| {
-                    if s.len() == 1 {
-                        s.as_bytes().first()
-                    } else {
-                        None
-                    }
-                })
                 .ok_or_else(|| anyhow!("expected to find status"))?;
 
-            let result = match StatusCode::from_byte(*status)? {
-                StatusCode::Modified => TreeDiffStatus::Modified { old: old_sha },
-                StatusCode::Added => TreeDiffStatus::Added,
-                StatusCode::Deleted => TreeDiffStatus::Deleted { old: old_sha },
-                _status => continue,
+            let status_byte = match status_str.as_bytes().first() {
+                Some(b) => *b,
+                None => continue,
             };
 
-            parsed.insert(path, result);
+            let is_rename = status_byte == b'R' || status_byte == b'C';
+            let (final_path, result) = if is_rename {
+                let new_path_str = match fields.next() {
+                    Some(s) if !s.is_empty() => s,
+                    _ => continue,
+                };
+                let new_path = RepoPath::from_rel_path(RelPath::unix(new_path_str)?);
+                (new_path, TreeDiffStatus::Renamed { old: old_sha })
+            } else {
+                let path = RepoPath::from_rel_path(RelPath::unix(path)?);
+                let result = match StatusCode::from_byte(status_byte)? {
+                    StatusCode::Modified => TreeDiffStatus::Modified { old: old_sha },
+                    StatusCode::Added => TreeDiffStatus::Added,
+                    StatusCode::Deleted => TreeDiffStatus::Deleted { old: old_sha },
+                    _status => continue,
+                };
+                (path, result)
+            };
+
+            parsed.insert(final_path, result);
         }
 
         Ok(Self { entries: parsed })
@@ -591,31 +637,43 @@ pub struct GitDiffStat {
     pub entries: Arc<[(RepoPath, DiffStat)]>,
 }
 
-/// Parses the output of `git diff --numstat` where output looks like:
+/// Parses the output of `git diff --numstat -z` where output is NUL-separated.
 ///
-/// ```text
-/// 24   12   dir/file.txt
-/// ```
+/// Normal entries: `added\tdeleted\tpath\0`
+/// Rename entries: `added\tdeleted\t\0old_path\0new_path\0`
 pub fn parse_numstat(output: &str) -> GitDiffStat {
     let mut entries = Vec::new();
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() {
+    let mut parts = output.split('\0');
+
+    while let Some(line) = parts.next() {
+        if !line.contains('\t') {
             continue;
         }
-        let mut parts = line.splitn(3, '\t');
+        let mut fields = line.splitn(3, '\t');
         let (Some(added_str), Some(deleted_str), Some(path_str)) =
-            (parts.next(), parts.next(), parts.next())
+            (fields.next(), fields.next(), fields.next())
         else {
             continue;
         };
-        let Ok(added) = added_str.parse::<u32>() else {
+        let Ok(added) = added_str.trim().parse::<u32>() else {
             continue;
         };
         let Ok(deleted) = deleted_str.parse::<u32>() else {
             continue;
         };
-        let Ok(path) = RepoPath::new(path_str) else {
+
+        let path = if path_str.is_empty() {
+            let _old_path = parts.next().unwrap_or("");
+            let new_path = parts.next().unwrap_or("");
+            new_path
+        } else {
+            path_str
+        };
+
+        if path.is_empty() {
+            continue;
+        }
+        let Ok(path) = RepoPath::new(path) else {
             continue;
         };
         entries.push((path, DiffStat { added, deleted }));
@@ -645,7 +703,7 @@ mod tests {
 
     #[test]
     fn test_parse_numstat_normal() {
-        let input = "10\t5\tsrc/main.rs\n3\t1\tREADME.md\n";
+        let input = "10\t5\tsrc/main.rs\03\t1\tREADME.md\0";
         let result = parse_numstat(input);
         assert_eq!(result.entries.len(), 2);
         assert_eq!(
@@ -667,7 +725,7 @@ mod tests {
     #[test]
     fn test_parse_numstat_binary_files_skipped() {
         // git diff --numstat outputs "-\t-\tpath" for binary files
-        let input = "-\t-\timage.png\n5\t2\tsrc/lib.rs\n";
+        let input = "-\t-\timage.png\05\t2\tsrc/lib.rs\0";
         let result = parse_numstat(input);
         assert_eq!(result.entries.len(), 1);
         assert!(lookup(&result.entries, "image.png").is_none());
@@ -683,13 +741,12 @@ mod tests {
     #[test]
     fn test_parse_numstat_empty_input() {
         assert!(parse_numstat("").entries.is_empty());
-        assert!(parse_numstat("\n\n").entries.is_empty());
-        assert!(parse_numstat("   \n  \n").entries.is_empty());
+        assert!(parse_numstat("\0\0").entries.is_empty());
     }
 
     #[test]
     fn test_parse_numstat_malformed_lines_skipped() {
-        let input = "not_a_number\t5\tfile.rs\n10\t5\tvalid.rs\n";
+        let input = "not_a_number\t5\tfile.rs\010\t5\tvalid.rs\0";
         let result = parse_numstat(input);
         assert_eq!(result.entries.len(), 1);
         assert_eq!(
@@ -703,8 +760,7 @@ mod tests {
 
     #[test]
     fn test_parse_numstat_incomplete_lines_skipped() {
-        // Lines with fewer than 3 tab-separated fields are skipped
-        let input = "10\t5\n7\t3\tok.rs\n";
+        let input = "10\t5\07\t3\tok.rs\0";
         let result = parse_numstat(input);
         assert_eq!(result.entries.len(), 1);
         assert_eq!(
@@ -718,7 +774,7 @@ mod tests {
 
     #[test]
     fn test_parse_numstat_zero_stats() {
-        let input = "0\t0\tunchanged_but_present.rs\n";
+        let input = "0\t0\tunchanged_but_present.rs\0";
         let result = parse_numstat(input);
         assert_eq!(
             lookup(&result.entries, "unchanged_but_present.rs"),
@@ -727,6 +783,38 @@ mod tests {
                 deleted: 0
             })
         );
+    }
+
+    #[test]
+    fn test_parse_numstat_renamed_file() {
+        // With -z, renamed entries have format: "added\tdeleted\t\0old_path\0new_path\0"
+        let input = "3\t1\t\0old_name.rs\0new_name.rs\0";
+        let result = parse_numstat(input);
+        assert_eq!(result.entries.len(), 1);
+        assert_eq!(
+            lookup(&result.entries, "new_name.rs"),
+            Some(&DiffStat {
+                added: 3,
+                deleted: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_git_status_renamed() {
+        // Porcelain v1 with -z: rename produces "R  new_path\0old_path\0"
+        let input = "R  new_file.rs\0old_file.rs\0M  modified.rs\0";
+        let result: GitStatus = input.parse().unwrap();
+        assert_eq!(result.entries.len(), 2);
+        let (path, status, original) = &result.entries[1];
+        assert_eq!(path, &RepoPath::new("new_file.rs").unwrap());
+        assert!(status.is_renamed());
+        assert_eq!(original.as_ref().unwrap(), &RepoPath::new("old_file.rs").unwrap());
+
+        let (path, status, original) = &result.entries[0];
+        assert_eq!(path, &RepoPath::new("modified.rs").unwrap());
+        assert!(status.is_modified());
+        assert!(original.is_none());
     }
 
     #[test]

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -103,6 +103,42 @@ pub fn create_embedded(
     BranchList::new_embedded(workspace, repository, width, window, cx)
 }
 
+/// Creates an embedded branch list that only selects (does not checkout).
+/// The `on_select` callback is called with the selected branch ref_name.
+pub fn create_select_only(
+    workspace: WeakEntity<Workspace>,
+    repository: Option<Entity<Repository>>,
+    on_select: Arc<dyn Fn(SharedString, &mut App) + Send + Sync>,
+    width: Rems,
+    window: &mut Window,
+    cx: &mut Context<BranchList>,
+) -> BranchList {
+    let list = BranchList::new_embedded(workspace, repository, width, window, cx);
+    list.picker.update(cx, |picker, _| {
+        picker.delegate.on_select = Some(on_select);
+    });
+    list
+}
+
+/// Creates a modal branch list that only selects (does not checkout).
+/// Shows as a modal dialog with custom placeholder text.
+pub fn create_modal_select_only(
+    workspace: WeakEntity<Workspace>,
+    repository: Option<Entity<Repository>>,
+    on_select: Arc<dyn Fn(SharedString, &mut App) + Send + Sync>,
+    placeholder: Arc<str>,
+    width: Rems,
+    window: &mut Window,
+    cx: &mut Context<BranchList>,
+) -> BranchList {
+    let list = BranchList::new(workspace, repository, BranchListStyle::Modal, width, window, cx);
+    list.picker.update(cx, |picker, _| {
+        picker.delegate.on_select = Some(on_select);
+        picker.delegate.custom_placeholder = Some(placeholder);
+    });
+    list
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum BranchListStyle {
     Modal,
@@ -386,6 +422,8 @@ pub struct BranchListDelegate {
     state: PickerState,
     focus_handle: FocusHandle,
     restore_selected_branch: Option<SharedString>,
+    on_select: Option<Arc<dyn Fn(SharedString, &mut App) + Send + Sync>>,
+    custom_placeholder: Option<Arc<str>>,
 }
 
 #[derive(Debug)]
@@ -452,6 +490,8 @@ impl BranchListDelegate {
             state: PickerState::List,
             focus_handle: cx.focus_handle(),
             restore_selected_branch: None,
+            on_select: None,
+            custom_placeholder: None,
         }
     }
 
@@ -590,6 +630,9 @@ impl PickerDelegate for BranchListDelegate {
     type ListItem = ListItem;
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        if let Some(placeholder) = &self.custom_placeholder {
+            return placeholder.clone();
+        }
         match self.state {
             PickerState::List | PickerState::NewRemote | PickerState::NewBranch => {
                 match self.branch_filter {
@@ -664,6 +707,25 @@ impl PickerDelegate for BranchListDelegate {
                 self.editor_position() == PickerEditorPosition::Start,
                 |this| this.child(Divider::horizontal()),
             )
+    }
+
+    fn render_header(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<AnyElement> {
+        let placeholder = self.custom_placeholder.as_ref()?;
+        Some(
+            h_flex()
+                .px_2p5()
+                .py_1()
+                .child(
+                    Label::new(placeholder.to_string())
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .into_any_element(),
+        )
     }
 
     fn editor_position(&self) -> PickerEditorPosition {
@@ -823,6 +885,14 @@ impl PickerDelegate for BranchListDelegate {
 
         match entry {
             Entry::Branch { branch, .. } => {
+                // If on_select callback is set, just call it without checking out
+                if let Some(on_select) = &self.on_select {
+                    let branch_name: SharedString = branch.ref_name.clone();
+                    on_select(branch_name, cx);
+                    cx.emit(DismissEvent);
+                    return;
+                }
+
                 let current_branch = self.repo.as_ref().map(|repo| {
                     repo.read_with(cx, |repo, _| {
                         repo.branch.as_ref().map(|branch| branch.ref_name.clone())

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -535,14 +535,26 @@ pub struct GitStatusEntry {
     pub(crate) status: FileStatus,
     pub(crate) staging: StageStatus,
     pub(crate) diff_stat: Option<DiffStat>,
+    pub(crate) original_path: Option<RepoPath>,
 }
 
 impl GitStatusEntry {
     fn display_name(&self, path_style: PathStyle) -> String {
-        self.repo_path
+        let name = self
+            .repo_path
             .file_name()
             .map(|name| name.to_owned())
-            .unwrap_or_else(|| self.repo_path.display(path_style).to_string())
+            .unwrap_or_else(|| self.repo_path.display(path_style).to_string());
+
+        if let Some(orig) = &self.original_path {
+            let orig_name = orig
+                .file_name()
+                .map(|name| name.to_owned())
+                .unwrap_or_else(|| orig.display(path_style).to_string());
+            format!("{name} \u{2190} {orig_name}")
+        } else {
+            name
+        }
     }
 
     fn parent_dir(&self, path_style: PathStyle) -> Option<String> {
@@ -2505,6 +2517,8 @@ impl GitPanel {
             Some("Delete")
         } else if git_status_entry.status.is_created() {
             Some("Create")
+        } else if git_status_entry.status.is_renamed() {
+            Some("Rename")
         } else if git_status_entry.status.is_modified() {
             Some("Update")
         } else {
@@ -3577,6 +3591,7 @@ impl GitPanel {
                 status: entry.status,
                 staging,
                 diff_stat: entry.diff_stat,
+                original_path: entry.original_path.clone(),
             };
 
             if staging.has_staged() {
@@ -3614,6 +3629,7 @@ impl GitPanel {
                             status: status.status,
                             staging: StageStatus::Staged,
                             diff_stat: status.diff_stat,
+                            original_path: status.original_path,
                         });
             }
         }
@@ -5088,12 +5104,15 @@ impl GitPanel {
         let is_modified = status.is_modified();
         let is_deleted = status.is_deleted();
         let is_created = status.is_created();
+        let is_renamed = status.is_renamed();
 
         let label_color = if status_style == StatusStyle::LabelColor {
             if has_conflict {
                 Color::VersionControlConflict
             } else if is_created {
                 Color::VersionControlAdded
+            } else if is_renamed {
+                Color::VersionControlRenamed
             } else if is_modified {
                 Color::VersionControlModified
             } else if is_deleted {
@@ -6674,6 +6693,7 @@ mod tests {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 }),
                 GitListEntry::Status(GitStatusEntry {
                     repo_path: repo_path("crates/util/util.rs"),
@@ -6683,6 +6703,7 @@ mod tests {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },),
             ],
         );
@@ -6707,6 +6728,7 @@ mod tests {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 }),
                 GitListEntry::Status(GitStatusEntry {
                     repo_path: repo_path("crates/util/util.rs"),
@@ -6716,6 +6738,7 @@ mod tests {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },),
             ],
         );

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -730,6 +730,11 @@ impl RenderOnce for GitStatusIcon {
                 IconName::SquareMinus,
                 cx.theme().colors().version_control_deleted,
             )
+        } else if status.is_renamed() {
+            (
+                IconName::ArrowRight,
+                cx.theme().colors().version_control_renamed,
+            )
         } else if status.is_modified() {
             (
                 IconName::SquareDot,

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -94,6 +94,7 @@ impl ProjectDiff {
     pub(crate) fn register(workspace: &mut Workspace, cx: &mut Context<Workspace>) {
         workspace.register_action(Self::deploy);
         workspace.register_action(Self::deploy_branch_diff);
+        workspace.register_action(Self::deploy_branch_compare);
         workspace.register_action(|workspace, _: &Add, window, cx| {
             Self::deploy(workspace, &Diff, window, cx);
         });
@@ -144,10 +145,136 @@ impl ProjectDiff {
             .detach_and_notify_err(workspace_weak, window, cx);
     }
 
+    pub fn deploy_branch_compare(
+        workspace: &mut Workspace,
+        _: &zed_actions::git::BranchCompare,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        telemetry::event!("Git Branch Compare Opened");
+        let project = workspace.project().clone();
+        let repository = project.read(cx).active_repository(cx);
+        let workspace_handle = cx.entity();
+        let workspace_weak = workspace_handle.downgrade();
+
+        let (compare_sender, compare_receiver) = smol::channel::bounded::<SharedString>(1);
+        let (base_sender, base_receiver) = smol::channel::bounded::<SharedString>(1);
+
+        // Step 1: Show picker for compare branch
+        let on_compare_selected: Arc<dyn Fn(SharedString, &mut App) + Send + Sync> =
+            Arc::new(move |branch_name: SharedString, _cx: &mut App| {
+                compare_sender.try_send(branch_name).log_err();
+            });
+
+        workspace.toggle_modal(window, cx, |window, cx| {
+            crate::branch_picker::create_modal_select_only(
+                workspace_weak.clone(),
+                repository.clone(),
+                on_compare_selected,
+                "Select compare branch…".into(),
+                rems(34.),
+                window,
+                cx,
+            )
+        });
+
+        // Async task: wait for compare selection, then open base picker, then open tab
+        let repository_clone = repository.clone();
+        window
+            .spawn(cx, {
+                let workspace = workspace_handle.clone();
+                let workspace_weak = workspace_weak.clone();
+                async move |cx| {
+                    let Ok(compare_ref) = compare_receiver.recv().await else {
+                        return;
+                    };
+
+                    // Step 2: Show picker for base branch
+                    let on_base_selected: Arc<dyn Fn(SharedString, &mut App) + Send + Sync> =
+                        Arc::new(move |branch_name: SharedString, _cx: &mut App| {
+                            base_sender.try_send(branch_name).log_err();
+                        });
+
+                    if workspace
+                        .update_in(cx, |workspace, window, cx| {
+                            workspace.toggle_modal(window, cx, |window, cx| {
+                                crate::branch_picker::create_modal_select_only(
+                                    workspace_weak.clone(),
+                                    repository_clone,
+                                    on_base_selected,
+                                    "Select base branch…".into(),
+                                    rems(34.),
+                                    window,
+                                    cx,
+                                )
+                            });
+                        })
+                        .is_err()
+                    {
+                        return;
+                    }
+
+                    let Ok(base_ref) = base_receiver.recv().await else {
+                        return;
+                    };
+
+                    // Step 3: Open the compare tab
+                    workspace
+                        .update_in(cx, |workspace, window, cx| {
+                            // Deduplicate
+                            let existing = workspace.items_of_type::<Self>(cx).find(|item| {
+                                matches!(
+                                    item.read(cx).diff_base(cx),
+                                    DiffBase::Compare { base_ref: b, compare_ref: c }
+                                        if *b == base_ref && *c == compare_ref
+                                )
+                            });
+                            if let Some(existing) = existing {
+                                workspace.activate_item(&existing, true, true, window, cx);
+                                return;
+                            }
+
+                            let workspace_handle = cx.entity();
+                            let branch_diff = cx.new(|cx| {
+                                branch_diff::BranchDiff::new(
+                                    DiffBase::Compare {
+                                        base_ref,
+                                        compare_ref,
+                                    },
+                                    project.clone(),
+                                    window,
+                                    cx,
+                                )
+                            });
+                            let project_diff = cx.new(|cx| {
+                                Self::new_impl(
+                                    branch_diff,
+                                    project,
+                                    workspace_handle,
+                                    window,
+                                    cx,
+                                )
+                            });
+                            workspace.add_item_to_active_pane(
+                                Box::new(project_diff),
+                                None,
+                                true,
+                                window,
+                                cx,
+                            );
+                        })
+                        .log_err();
+                }
+            })
+            .detach();
+    }
+
     fn review_diff(&mut self, _: &ReviewDiff, window: &mut Window, cx: &mut Context<Self>) {
         let diff_base = self.diff_base(cx).clone();
-        let DiffBase::Merge { base_ref } = diff_base else {
-            return;
+        let base_ref = match &diff_base {
+            DiffBase::Merge { base_ref } => base_ref.clone(),
+            DiffBase::Compare { base_ref, .. } => base_ref.clone(),
+            DiffBase::Head => return,
         };
 
         let Some(repo) = self.branch_diff.read(cx).repo().cloned() else {
@@ -359,10 +486,11 @@ impl ProjectDiff {
             );
             match branch_diff.read(cx).diff_base() {
                 DiffBase::Head => {}
-                DiffBase::Merge { .. } => diff_display_editor.set_render_diff_hunk_controls(
-                    Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
-                    cx,
-                ),
+                DiffBase::Merge { .. } | DiffBase::Compare { .. } => diff_display_editor
+                    .set_render_diff_hunk_controls(
+                        Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
+                        cx,
+                    ),
             }
             diff_display_editor.rhs_editor().update(cx, |editor, cx| {
                 editor.disable_diagnostics(cx);
@@ -374,7 +502,7 @@ impl ProjectDiff {
                             workspace: workspace.downgrade(),
                         });
                     }
-                    DiffBase::Merge { .. } => {
+                    DiffBase::Merge { .. } | DiffBase::Compare { .. } => {
                         editor.register_addon(BranchDiffAddon {
                             branch_diff: branch_diff.clone(),
                         });
@@ -960,6 +1088,9 @@ impl Item for ProjectDiff {
         match self.diff_base(cx) {
             DiffBase::Head => Some("Project Diff".into()),
             DiffBase::Merge { .. } => Some("Branch Diff".into()),
+            DiffBase::Compare { base_ref, compare_ref } => {
+                Some(format!("Compare: {}..{}", base_ref, compare_ref).into())
+            }
         }
     }
 
@@ -977,6 +1108,9 @@ impl Item for ProjectDiff {
         match self.branch_diff.read(cx).diff_base() {
             DiffBase::Head => "Uncommitted Changes".into(),
             DiffBase::Merge { base_ref } => format!("Changes since {}", base_ref).into(),
+            DiffBase::Compare { base_ref, compare_ref } => {
+                format!("{}..{}", base_ref, compare_ref).into()
+            }
         }
     }
 
@@ -1115,7 +1249,16 @@ impl Item for ProjectDiff {
 impl Render for ProjectDiff {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let is_empty = self.multibuffer.read(cx).is_empty();
-        let is_branch_diff_view = matches!(self.diff_base(cx), DiffBase::Merge { .. });
+        let diff_base = self.diff_base(cx).clone();
+        let is_branch_diff_view = matches!(diff_base, DiffBase::Merge { .. } | DiffBase::Compare { .. });
+
+        let empty_message = match &diff_base {
+            DiffBase::Head => "No uncommitted changes".to_string(),
+            DiffBase::Merge { base_ref } => format!("No changes since {}", base_ref),
+            DiffBase::Compare { base_ref, compare_ref } => {
+                format!("No differences between {} and {}", base_ref, compare_ref)
+            }
+        };
 
         div()
             .track_focus(&self.focus_handle)
@@ -1129,12 +1272,11 @@ impl Render for ProjectDiff {
             .justify_center()
             .size_full()
             .when(is_empty, |el| {
-                let remote_button = if let Some(panel) = self
-                    .workspace
-                    .upgrade()
-                    .and_then(|workspace| workspace.read(cx).panel::<GitPanel>(cx))
-                {
-                    panel.update(cx, |panel, cx| panel.render_remote_button(cx))
+                let remote_button = if matches!(diff_base, DiffBase::Head) {
+                    self.workspace
+                        .upgrade()
+                        .and_then(|workspace| workspace.read(cx).panel::<GitPanel>(cx))
+                        .and_then(|panel| panel.update(cx, |panel, cx| panel.render_remote_button(cx)))
                 } else {
                     None
                 };
@@ -1145,7 +1287,7 @@ impl Render for ProjectDiff {
                         .child(
                             h_flex()
                                 .justify_around()
-                                .child(Label::new("No uncommitted changes")),
+                                .child(Label::new(empty_message)),
                         )
                         .map(|el| match remote_button {
                             Some(button) => el.child(h_flex().justify_around().child(button)),
@@ -1158,7 +1300,6 @@ impl Render for ProjectDiff {
                         .child(
                             h_flex().justify_around().mt_1().child(
                                 Button::new("project-diff-close-button", "Close")
-                                    // .style(ButtonStyle::Transparent)
                                     .key_binding(KeyBinding::for_action_in(
                                         &CloseActiveItem::default(),
                                         &keybinding_focus_handle,
@@ -1622,7 +1763,7 @@ impl ToolbarItemView for BranchDiffToolbar {
     ) -> ToolbarItemLocation {
         self.project_diff = active_pane_item
             .and_then(|item| item.act_as::<ProjectDiff>(cx))
-            .filter(|item| matches!(item.read(cx).diff_base(cx), DiffBase::Merge { .. }))
+            .filter(|item| matches!(item.read(cx).diff_base(cx), DiffBase::Merge { .. } | DiffBase::Compare { .. }))
             .map(|entity| entity.downgrade());
         if self.project_diff.is_some() {
             ToolbarItemLocation::PrimaryRight

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -196,6 +196,7 @@ pub struct StatusEntry {
     pub repo_path: RepoPath,
     pub status: FileStatus,
     pub diff_stat: Option<DiffStat>,
+    pub original_path: Option<RepoPath>,
 }
 
 impl StatusEntry {
@@ -219,6 +220,7 @@ impl StatusEntry {
             status: Some(status_to_proto(self.status)),
             diff_stat_added: self.diff_stat.map(|ds| ds.added),
             diff_stat_deleted: self.diff_stat.map(|ds| ds.deleted),
+            original_path: self.original_path.as_ref().map(|p| p.to_proto()),
         }
     }
 }
@@ -233,10 +235,18 @@ impl TryFrom<proto::StatusEntry> for StatusEntry {
             (Some(added), Some(deleted)) => Some(DiffStat { added, deleted }),
             _ => None,
         };
+        let original_path = value
+            .original_path
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(RepoPath::from_proto)
+            .transpose()
+            .context("invalid original path")?;
         Ok(Self {
             repo_path,
             status,
             diff_stat,
+            original_path,
         })
     }
 }
@@ -3110,7 +3120,7 @@ impl GitStore {
                     path: path.as_ref().to_proto(),
                     status: match status {
                         TreeDiffStatus::Added {} => proto::tree_diff_status::Status::Added.into(),
-                        TreeDiffStatus::Modified { .. } => {
+                        TreeDiffStatus::Modified { .. } | TreeDiffStatus::Renamed { .. } => {
                             proto::tree_diff_status::Status::Modified.into()
                         }
                         TreeDiffStatus::Deleted { .. } => {
@@ -3118,9 +3128,9 @@ impl GitStore {
                         }
                     },
                     oid: match status {
-                        TreeDiffStatus::Deleted { old } | TreeDiffStatus::Modified { old } => {
-                            Some(old.to_string())
-                        }
+                        TreeDiffStatus::Deleted { old }
+                        | TreeDiffStatus::Modified { old }
+                        | TreeDiffStatus::Renamed { old } => Some(old.to_string()),
                         TreeDiffStatus::Added => None,
                     },
                 })
@@ -3913,6 +3923,7 @@ impl RepositorySnapshot {
                         Ordering::Equal => {
                             if new_entry.status != old_entry.status
                                 || new_entry.diff_stat != old_entry.diff_stat
+                                || new_entry.original_path != old_entry.original_path
                             {
                                 updated_statuses.push(new_entry.to_proto());
                             }
@@ -7140,13 +7151,15 @@ impl Repository {
                         let prev_statuses = prev_snapshot.statuses_by_path.clone();
                         let mut cursor = prev_statuses.cursor::<PathProgress>(());
 
-                        for (repo_path, status) in &*statuses.entries {
+                        for (repo_path, status, original_path) in &*statuses.entries {
                             let current_diff_stat = diff_stats.get(repo_path).copied();
 
                             changed_paths.remove(repo_path);
                             if cursor.seek_forward(&PathTarget::Path(repo_path), Bias::Left)
                                 && cursor.item().is_some_and(|entry| {
-                                    entry.status == *status && entry.diff_stat == current_diff_stat
+                                    entry.status == *status
+                                        && entry.diff_stat == current_diff_stat
+                                        && entry.original_path.as_ref() == original_path.as_ref()
                                 })
                             {
                                 continue;
@@ -7156,6 +7169,7 @@ impl Repository {
                                 repo_path: repo_path.clone(),
                                 status: *status,
                                 diff_stat: current_diff_stat,
+                                original_path: original_path.clone(),
                             }));
                         }
                         let mut cursor = prev_statuses.cursor::<PathProgress>(());
@@ -7755,7 +7769,7 @@ async fn compute_snapshot(
         diff_stats.entries.iter().map(|(p, s)| (p, *s)).collect();
     let mut conflicted_paths = Vec::new();
     let statuses_by_path = SumTree::from_iter(
-        statuses.entries.iter().map(|(repo_path, status)| {
+        statuses.entries.iter().map(|(repo_path, status, original_path)| {
             if status.is_conflicted() {
                 conflicted_paths.push(repo_path.clone());
             }
@@ -7763,6 +7777,7 @@ async fn compute_snapshot(
                 repo_path: repo_path.clone(),
                 status: *status,
                 diff_stat: diff_stat_map.get(repo_path).copied(),
+                original_path: original_path.clone(),
             }
         }),
         (),

--- a/crates/project/src/git_store/branch_diff.rs
+++ b/crates/project/src/git_store/branch_diff.rs
@@ -25,11 +25,12 @@ use crate::{
 pub enum DiffBase {
     Head,
     Merge { base_ref: SharedString },
+    Compare { base_ref: SharedString, compare_ref: SharedString },
 }
 
 impl DiffBase {
     pub fn is_merge_base(&self) -> bool {
-        matches!(self, DiffBase::Merge { .. })
+        matches!(self, DiffBase::Merge { .. } | DiffBase::Compare { .. })
     }
 }
 
@@ -119,6 +120,19 @@ impl BranchDiff {
         *self.update_needed.borrow_mut() = ();
     }
 
+    pub fn set_diff_base(&mut self, diff_base: DiffBase, cx: &mut Context<Self>) {
+        self.diff_base = diff_base;
+        self.tree_diff = None;
+        self.base_commit = None;
+        self.head_commit = None;
+        cx.emit(BranchDiffEvent::FileListChanged);
+        *self.update_needed.borrow_mut() = ();
+    }
+
+    pub fn tree_diff(&self) -> Option<&TreeDiff> {
+        self.tree_diff.as_ref()
+    }
+
     pub async fn handle_status_updates(
         this: WeakEntity<Self>,
         mut recv: postage::watch::Receiver<()>,
@@ -142,14 +156,22 @@ impl BranchDiff {
                     }
                 } else if let Some(repo) = this.repo.as_ref() {
                     repo.update(cx, |repo, _| {
-                        if let Some(branch) = &repo.branch
-                            && let DiffBase::Merge { base_ref } = &this.diff_base
-                            && let Some(commit) = branch.most_recent_commit.as_ref()
-                            && &branch.ref_name == base_ref
-                            && this.base_commit.as_ref() != Some(&commit.sha)
-                        {
-                            this.base_commit = Some(commit.sha.clone());
-                            needs_update = true;
+                        match &this.diff_base {
+                            DiffBase::Merge { base_ref } => {
+                                if let Some(branch) = &repo.branch
+                                    && let Some(commit) = branch.most_recent_commit.as_ref()
+                                    && &branch.ref_name == base_ref
+                                    && this.base_commit.as_ref() != Some(&commit.sha)
+                                {
+                                    this.base_commit = Some(commit.sha.clone());
+                                    needs_update = true;
+                                }
+                            }
+                            DiffBase::Compare { .. } => {
+                                // For Compare mode, always update on head changes
+                                needs_update = true;
+                            }
+                            DiffBase::Head => {}
                         }
 
                         if repo.head_commit.as_ref().map(|c| &c.sha) != this.head_commit.as_ref() {
@@ -249,21 +271,23 @@ impl BranchDiff {
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
         let task = this.update(cx, |this, cx| {
-            let DiffBase::Merge { base_ref } = this.diff_base.clone() else {
-                return None;
+            let diff_tree_type = match this.diff_base.clone() {
+                DiffBase::Merge { base_ref } => DiffTreeType::MergeBase {
+                    base: base_ref,
+                    head: "HEAD".into(),
+                },
+                DiffBase::Compare { base_ref, compare_ref } => DiffTreeType::MergeBase {
+                    base: base_ref,
+                    head: compare_ref,
+                },
+                DiffBase::Head => return None,
             };
             let Some(repo) = this.repo.as_ref() else {
                 this.tree_diff.take();
                 return None;
             };
             repo.update(cx, |repo, cx| {
-                Some(repo.diff_tree(
-                    DiffTreeType::MergeBase {
-                        base: base_ref,
-                        head: "HEAD".into(),
-                    },
-                    cx,
-                ))
+                Some(repo.diff_tree(diff_tree_type, cx))
             })
         })?;
         let Some(task) = task else { return Ok(()) };
@@ -290,33 +314,37 @@ impl BranchDiff {
         self.project.update(cx, |_project, cx| {
             let mut seen = HashSet::default();
 
-            for item in repo.read(cx).cached_status() {
-                seen.insert(item.repo_path.clone());
-                let branch_diff = self
-                    .tree_diff
-                    .as_ref()
-                    .and_then(|t| t.entries.get(&item.repo_path))
-                    .cloned();
-                let Some(status) = self.merge_statuses(Some(item.status), branch_diff.as_ref())
-                else {
-                    continue;
-                };
-                if !status.has_changes() {
-                    continue;
+            // For Compare mode, skip working tree status — only show tree diff entries
+            if !matches!(self.diff_base, DiffBase::Compare { .. }) {
+                for item in repo.read(cx).cached_status() {
+                    seen.insert(item.repo_path.clone());
+                    let branch_diff = self
+                        .tree_diff
+                        .as_ref()
+                        .and_then(|t| t.entries.get(&item.repo_path))
+                        .cloned();
+                    let Some(status) =
+                        self.merge_statuses(Some(item.status), branch_diff.as_ref())
+                    else {
+                        continue;
+                    };
+                    if !status.has_changes() {
+                        continue;
+                    }
+
+                    let Some(project_path) =
+                        repo.read(cx).repo_path_to_project_path(&item.repo_path, cx)
+                    else {
+                        continue;
+                    };
+                    let task = Self::load_buffer(branch_diff, project_path, repo.clone(), cx);
+
+                    output.push(DiffBuffer {
+                        repo_path: item.repo_path.clone(),
+                        load: task,
+                        file_status: item.status,
+                    });
                 }
-
-                let Some(project_path) =
-                    repo.read(cx).repo_path_to_project_path(&item.repo_path, cx)
-                else {
-                    continue;
-                };
-                let task = Self::load_buffer(branch_diff, project_path, repo.clone(), cx);
-
-                output.push(DiffBuffer {
-                    repo_path: item.repo_path.clone(),
-                    load: task,
-                    file_status: item.status,
-                });
             }
             let Some(tree_diff) = self.tree_diff.as_ref() else {
                 return;

--- a/crates/project/src/git_store/branch_diff.rs
+++ b/crates/project/src/git_store/branch_diff.rs
@@ -389,7 +389,8 @@ impl BranchDiff {
                 let oid = match entry {
                     git::status::TreeDiffStatus::Added { .. } => None,
                     git::status::TreeDiffStatus::Modified { old, .. }
-                    | git::status::TreeDiffStatus::Deleted { old } => Some(old),
+                    | git::status::TreeDiffStatus::Deleted { old }
+                    | git::status::TreeDiffStatus::Renamed { old } => Some(old),
                 };
                 project
                     .update(cx, |project, cx| {
@@ -424,6 +425,10 @@ fn diff_status_to_file_status(branch_diff: &git::status::TreeDiffStatus) -> File
         git::status::TreeDiffStatus::Deleted { .. } => FileStatus::Tracked(TrackedStatus {
             index_status: StatusCode::Deleted,
             worktree_status: StatusCode::Deleted,
+        }),
+        git::status::TreeDiffStatus::Renamed { .. } => FileStatus::Tracked(TrackedStatus {
+            index_status: StatusCode::Renamed,
+            worktree_status: StatusCode::Unmodified,
         }),
     };
     file_status

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -9907,11 +9907,13 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
                     diff_stat: None,
+                    original_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("d.txt"),
@@ -9920,6 +9922,7 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                         added: 0,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },
             ]
         );
@@ -9945,11 +9948,13 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
                     diff_stat: None,
+                    original_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("c.txt"),
@@ -9958,6 +9963,7 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                         added: 1,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("d.txt"),
@@ -9966,6 +9972,7 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                         added: 0,
                         deleted: 1,
                     }),
+                    original_path: None,
                 },
             ]
         );
@@ -10003,6 +10010,7 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                     added: 0,
                     deleted: 1,
                 }),
+                original_path: None,
             }]
         );
     });
@@ -10068,6 +10076,7 @@ async fn test_git_status_postprocessing(cx: &mut gpui::TestAppContext) {
                 }
                 .into(),
                 diff_stat: None,
+                original_path: None,
             }]
         )
     });
@@ -10274,6 +10283,7 @@ async fn test_repository_pending_ops_staging(
                     added: 1,
                     deleted: 0,
                 }),
+                original_path: None,
             }]
         );
     });
@@ -10384,6 +10394,7 @@ async fn test_repository_pending_ops_long_running_staging(
                     added: 1,
                     deleted: 0,
                 }),
+                original_path: None,
             }]
         );
     });
@@ -10509,11 +10520,13 @@ async fn test_repository_pending_ops_stage_all(
                     repo_path: repo_path("a.txt"),
                     status: FileStatus::Untracked,
                     diff_stat: None,
+                    original_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
                     diff_stat: None,
+                    original_path: None,
                 },
             ]
         );

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -341,6 +341,7 @@ message StatusEntry {
   GitFileStatus status = 3;
   optional uint32 diff_stat_added = 4;
   optional uint32 diff_stat_deleted = 5;
+  optional string original_path = 6;
 }
 
 message StashEntry {

--- a/crates/ui/src/styles/color.rs
+++ b/crates/ui/src/styles/color.rs
@@ -81,6 +81,8 @@ pub enum Color {
     VersionControlIgnored,
     /// A version control color used to indicate modified files or content in version control.
     VersionControlModified,
+    /// A version control color used to indicate renamed files in version control.
+    VersionControlRenamed,
     /// A color used to indicate a warning condition.
     Warning,
 }
@@ -112,6 +114,7 @@ impl Color {
             Color::VersionControlDeleted => cx.theme().colors().version_control_deleted,
             Color::VersionControlIgnored => cx.theme().colors().version_control_ignored,
             Color::VersionControlModified => cx.theme().colors().version_control_modified,
+            Color::VersionControlRenamed => cx.theme().colors().version_control_renamed,
             Color::Warning => cx.theme().status().warning,
             Color::Custom(color) => *color,
         }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -275,7 +275,9 @@ pub mod git {
             /// Opens the git worktree selector.
             Worktree,
             /// Creates a pull request for the current branch.
-            CreatePullRequest
+            CreatePullRequest,
+            /// Opens the branch compare panel.
+            BranchCompare
         ]
     );
 }


### PR DESCRIPTION
## Summary
- detect renamed files in git status and thread the original path through project and UI state
- infer unstaged renames when git reports them as deleted plus untracked so the panel shows a single renamed entry
- render renamed files with dedicated label text, icon, color, and coverage in git tests

## Test plan
- [x] cargo check -p git -p project -p git_ui
- [x] cargo test -p git
- [x] cargo test -p git_ui
- [x] manually renamed a tracked file without staging and verified the git panel showed a single renamed entry

Release Notes:

- Fixed the git panel to show renamed files as a single renamed entry instead of separate deleted and untracked rows.