### PR TITLE
onboarding: Ensure scrollbar is shown at the proper edge

### DIFF
--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -288,70 +288,62 @@ impl Render for Onboarding {
                 window.focus_prev(cx);
                 cx.notify();
             }))
+            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
             .child(
                 div()
+                    .id("page-content")
                     .size_full()
+                    .overflow_y_scroll()
                     .child(
-                        div().max_w(Rems(48.0)).size_full().mx_auto().child(
-                            v_flex()
-                                .id("page-content")
-                                .m_auto()
-                                .p_12()
-                                .size_full()
-                                .max_w_full()
-                                .min_w_0()
-                                .gap_6()
-                                .overflow_y_scroll()
-                                .child(
-                                    h_flex()
-                                        .w_full()
-                                        .gap_4()
-                                        .justify_between()
-                                        .child(
-                                            h_flex()
-                                                .gap_4()
-                                                .child(Vector::square(
-                                                    VectorName::ZedLogo,
-                                                    rems(2.5),
-                                                ))
-                                                .child(
-                                                    v_flex()
-                                                        .child(
-                                                            Headline::new("Welcome to Zed")
-                                                                .size(HeadlineSize::Small),
-                                                        )
-                                                        .child(
-                                                            Label::new(
-                                                                "The editor for what's next",
-                                                            )
+                        v_flex()
+                            .min_w_0()
+                            .max_w(rems_from_px(780.))
+                            .w_full()
+                            .mx_auto()
+                            .p_12()
+                            .gap_6()
+                            .child(
+                                h_flex()
+                                    .w_full()
+                                    .gap_4()
+                                    .justify_between()
+                                    .child(
+                                        h_flex()
+                                            .gap_4()
+                                            .child(Vector::square(VectorName::ZedLogo, rems(2.5)))
+                                            .child(
+                                                v_flex()
+                                                    .child(
+                                                        Headline::new("Welcome to Zed")
+                                                            .size(HeadlineSize::Small),
+                                                    )
+                                                    .child(
+                                                        Label::new("The editor for what's next")
                                                             .color(Color::Muted)
                                                             .size(LabelSize::Small)
                                                             .italic(),
-                                                        ),
-                                                ),
-                                        )
-                                        .child({
-                                            Button::new("finish_setup", "Finish Setup")
-                                                .style(ButtonStyle::Filled)
-                                                .size(ButtonSize::Medium)
-                                                .width(rems_from_px(200.))
-                                                .key_binding(KeyBinding::for_action_in(
-                                                    &Finish,
-                                                    &self.focus_handle,
-                                                    cx,
-                                                ))
-                                                .on_click(|_, window, cx| {
-                                                    window
-                                                        .dispatch_action(Finish.boxed_clone(), cx);
-                                                })
-                                        }),
-                                )
-                                .child(Divider::horizontal().color(ui::DividerColor::BorderVariant))
-                                .child(self.render_page(cx))
-                                .track_scroll(&self.scroll_handle),
-                        ),
+                                                    ),
+                                            ),
+                                    )
+                                    .child({
+                                        Button::new("finish_setup", "Finish Setup")
+                                            .style(ButtonStyle::Filled)
+                                            .size(ButtonSize::Medium)
+                                            .width(rems_from_px(200.))
+                                            .key_binding(KeyBinding::for_action_in(
+                                                &Finish,
+                                                &self.focus_handle,
+                                                cx,
+                                            ))
+                                            .on_click(|_, window, cx| {
+                                                window.dispatch_action(Finish.boxed_clone(), cx);
+                                            })
+                                    }),
+                            )
+                            .child(Divider::horizontal().color(ui::DividerColor::BorderVariant))
+                            .child(self.render_page(cx)),
                     )
-                    .vertical_scrollbar_for(&self.scroll_handle, window, cx),
+                    .track_scroll(&self.scroll_handle),
             )
     }
 }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -292,62 +292,64 @@ impl Render for Onboarding {
                 div()
                     .size_full()
                     .child(
-                        div()
-                            .max_w(Rems(48.0))
-                            .size_full()
-                            .mx_auto()
-                            .child(
-                                v_flex()
-                                    .id("page-content")
-                                    .m_auto()
-                                    .p_12()
-                                    .size_full()
-                                    .max_w_full()
-                                    .min_w_0()
-                                    .gap_6()
-                                    .overflow_y_scroll()
-                                    .child(
-                                        h_flex()
-                                            .w_full()
-                                            .gap_4()
-                                            .justify_between()
-                                            .child(
-                                                h_flex()
-                                                    .gap_4()
-                                                    .child(Vector::square(VectorName::ZedLogo, rems(2.5)))
-                                                    .child(
-                                                        v_flex()
-                                                            .child(
-                                                                Headline::new("Welcome to Zed")
-                                                                    .size(HeadlineSize::Small),
+                        div().max_w(Rems(48.0)).size_full().mx_auto().child(
+                            v_flex()
+                                .id("page-content")
+                                .m_auto()
+                                .p_12()
+                                .size_full()
+                                .max_w_full()
+                                .min_w_0()
+                                .gap_6()
+                                .overflow_y_scroll()
+                                .child(
+                                    h_flex()
+                                        .w_full()
+                                        .gap_4()
+                                        .justify_between()
+                                        .child(
+                                            h_flex()
+                                                .gap_4()
+                                                .child(Vector::square(
+                                                    VectorName::ZedLogo,
+                                                    rems(2.5),
+                                                ))
+                                                .child(
+                                                    v_flex()
+                                                        .child(
+                                                            Headline::new("Welcome to Zed")
+                                                                .size(HeadlineSize::Small),
+                                                        )
+                                                        .child(
+                                                            Label::new(
+                                                                "The editor for what's next",
                                                             )
-                                                            .child(
-                                                                Label::new("The editor for what's next")
-                                                                    .color(Color::Muted)
-                                                                    .size(LabelSize::Small)
-                                                                    .italic(),
-                                                            ),
-                                                    ),
-                                            )
-                                            .child({
-                                                Button::new("finish_setup", "Finish Setup")
-                                                    .style(ButtonStyle::Filled)
-                                                    .size(ButtonSize::Medium)
-                                                    .width(rems_from_px(200.))
-                                                    .key_binding(KeyBinding::for_action_in(
-                                                        &Finish,
-                                                        &self.focus_handle,
-                                                        cx,
-                                                    ))
-                                                    .on_click(|_, window, cx| {
-                                                        window.dispatch_action(Finish.boxed_clone(), cx);
-                                                    })
-                                            }),
-                                    )
-                                    .child(Divider::horizontal().color(ui::DividerColor::BorderVariant))
-                                    .child(self.render_page(cx))
-                                    .track_scroll(&self.scroll_handle),
-                            ),
+                                                            .color(Color::Muted)
+                                                            .size(LabelSize::Small)
+                                                            .italic(),
+                                                        ),
+                                                ),
+                                        )
+                                        .child({
+                                            Button::new("finish_setup", "Finish Setup")
+                                                .style(ButtonStyle::Filled)
+                                                .size(ButtonSize::Medium)
+                                                .width(rems_from_px(200.))
+                                                .key_binding(KeyBinding::for_action_in(
+                                                    &Finish,
+                                                    &self.focus_handle,
+                                                    cx,
+                                                ))
+                                                .on_click(|_, window, cx| {
+                                                    window
+                                                        .dispatch_action(Finish.boxed_clone(), cx);
+                                                })
+                                        }),
+                                )
+                                .child(Divider::horizontal().color(ui::DividerColor::BorderVariant))
+                                .child(self.render_page(cx))
+                                .track_scroll(&self.scroll_handle),
+                        ),
                     )
                     .vertical_scrollbar_for(&self.scroll_handle, window, cx),
             )

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -290,60 +290,64 @@ impl Render for Onboarding {
             }))
             .child(
                 div()
-                    .max_w(Rems(48.0))
                     .size_full()
-                    .mx_auto()
                     .child(
-                        v_flex()
-                            .id("page-content")
-                            .m_auto()
-                            .p_12()
+                        div()
+                            .max_w(Rems(48.0))
                             .size_full()
-                            .max_w_full()
-                            .min_w_0()
-                            .gap_6()
-                            .overflow_y_scroll()
+                            .mx_auto()
                             .child(
-                                h_flex()
-                                    .w_full()
-                                    .gap_4()
-                                    .justify_between()
+                                v_flex()
+                                    .id("page-content")
+                                    .m_auto()
+                                    .p_12()
+                                    .size_full()
+                                    .max_w_full()
+                                    .min_w_0()
+                                    .gap_6()
+                                    .overflow_y_scroll()
                                     .child(
                                         h_flex()
+                                            .w_full()
                                             .gap_4()
-                                            .child(Vector::square(VectorName::ZedLogo, rems(2.5)))
+                                            .justify_between()
                                             .child(
-                                                v_flex()
+                                                h_flex()
+                                                    .gap_4()
+                                                    .child(Vector::square(VectorName::ZedLogo, rems(2.5)))
                                                     .child(
-                                                        Headline::new("Welcome to Zed")
-                                                            .size(HeadlineSize::Small),
-                                                    )
-                                                    .child(
-                                                        Label::new("The editor for what's next")
-                                                            .color(Color::Muted)
-                                                            .size(LabelSize::Small)
-                                                            .italic(),
+                                                        v_flex()
+                                                            .child(
+                                                                Headline::new("Welcome to Zed")
+                                                                    .size(HeadlineSize::Small),
+                                                            )
+                                                            .child(
+                                                                Label::new("The editor for what's next")
+                                                                    .color(Color::Muted)
+                                                                    .size(LabelSize::Small)
+                                                                    .italic(),
+                                                            ),
                                                     ),
-                                            ),
+                                            )
+                                            .child({
+                                                Button::new("finish_setup", "Finish Setup")
+                                                    .style(ButtonStyle::Filled)
+                                                    .size(ButtonSize::Medium)
+                                                    .width(rems_from_px(200.))
+                                                    .key_binding(KeyBinding::for_action_in(
+                                                        &Finish,
+                                                        &self.focus_handle,
+                                                        cx,
+                                                    ))
+                                                    .on_click(|_, window, cx| {
+                                                        window.dispatch_action(Finish.boxed_clone(), cx);
+                                                    })
+                                            }),
                                     )
-                                    .child({
-                                        Button::new("finish_setup", "Finish Setup")
-                                            .style(ButtonStyle::Filled)
-                                            .size(ButtonSize::Medium)
-                                            .width(rems_from_px(200.))
-                                            .key_binding(KeyBinding::for_action_in(
-                                                &Finish,
-                                                &self.focus_handle,
-                                                cx,
-                                            ))
-                                            .on_click(|_, window, cx| {
-                                                window.dispatch_action(Finish.boxed_clone(), cx);
-                                            })
-                                    }),
-                            )
-                            .child(Divider::horizontal().color(ui::DividerColor::BorderVariant))
-                            .child(self.render_page(cx))
-                            .track_scroll(&self.scroll_handle),
+                                    .child(Divider::horizontal().color(ui::DividerColor::BorderVariant))
+                                    .child(self.render_page(cx))
+                                    .track_scroll(&self.scroll_handle),
+                            ),
                     )
                     .vertical_scrollbar_for(&self.scroll_handle, window, cx),
             )


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54391

Release Notes:

- Fixed onboarding UI scrollbar placement so the vertical scrollbar now appears at the right edge of the onboarding pane, while keeping onboarding content centered.
