### PR TITLE
gpui: Add accessibility annotation API via AccessKit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,39 @@
 version = 4
 
 [[package]]
+name = "accesskit"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534bc3fdc89a64a1db3c46b33c198fde2b7c3c7d094e5809c8c8bf2970c18243"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "acp_thread"
 version = "0.1.0"
 dependencies = [
@@ -1973,7 +2006,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1993,7 +2026,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2100,11 +2133,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -2961,7 +3003,7 @@ dependencies = [
  "http_client_tls",
  "httparse",
  "log",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "paths",
  "postage",
@@ -3893,13 +3935,13 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
- "objc2",
+ "objc2 0.6.3",
  "objc2-audio-toolbox",
  "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4973,9 +5015,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -7575,6 +7617,7 @@ dependencies = [
 name = "gpui"
 version = "0.2.2"
 dependencies = [
+ "accesskit",
  "anyhow",
  "async-channel 2.5.0",
  "async-task",
@@ -7619,8 +7662,8 @@ dependencies = [
  "naga 29.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus",
  "objc",
- "objc2",
- "objc2-metal",
+ "objc2 0.6.3",
+ "objc2-metal 0.3.2",
  "parking",
  "parking_lot",
  "pathfinder_geometry",
@@ -7714,6 +7757,7 @@ dependencies = [
 name = "gpui_macos"
 version = "0.1.0"
 dependencies = [
+ "accesskit_macos",
  "anyhow",
  "async-task",
  "block",
@@ -7740,7 +7784,7 @@ dependencies = [
  "media",
  "metal",
  "objc",
- "objc2-app-kit",
+ "objc2-app-kit 0.3.1",
  "parking_lot",
  "pathfinder_geometry",
  "raw-window-handle",
@@ -8789,7 +8833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -11433,6 +11477,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11443,12 +11503,28 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -11459,11 +11535,11 @@ checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -11472,8 +11548,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -11483,10 +11559,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -11496,7 +11572,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -11506,10 +11594,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -11520,14 +11620,26 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -11543,16 +11655,41 @@ dependencies = [
 
 [[package]]
 name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -11562,10 +11699,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -13643,8 +13780,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.11.1",
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -13677,7 +13814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14208,10 +14345,10 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -16378,7 +16515,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18517,8 +18654,8 @@ dependencies = [
  "chrono",
  "libc",
  "log",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "percent-encoding",
  "scopeguard",
@@ -20433,7 +20570,7 @@ dependencies = [
  "ash",
  "bit-set 0.9.1",
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
@@ -20449,11 +20586,11 @@ dependencies = [
  "log",
  "naga 29.0.0 (git+https://github.com/zed-industries/wgpu.git?branch=v29)",
  "ndk-sys",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float 4.6.0",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7757,6 +7757,7 @@ dependencies = [
 name = "gpui_macos"
 version = "0.1.0"
 dependencies = [
+ "accesskit",
  "accesskit_macos",
  "anyhow",
  "async-task",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -45,6 +45,7 @@ path = "src/gpui.rs"
 doctest = false
 
 [dependencies]
+accesskit = "0.24"
 anyhow.workspace = true
 async-task = "4.7"
 backtrace = { workspace = true, optional = true }
@@ -247,3 +248,7 @@ path = "examples/list_example.rs"
 [[example]]
 name = "mouse_pressure"
 path = "examples/mouse_pressure.rs"
+
+[[example]]
+name = "accessibility"
+path = "examples/accessibility.rs"

--- a/crates/gpui/examples/accessibility.rs
+++ b/crates/gpui/examples/accessibility.rs
@@ -10,8 +10,8 @@
 #![cfg_attr(target_family = "wasm", no_main)]
 
 use gpui::{
-    App, Bounds, Context, FocusHandle, Live, Role, SharedString, Stateful, Window, WindowBounds,
-    WindowOptions, actions, div, prelude::*, px, size,
+    App, Bounds, Context, FocusHandle, KeyDownEvent, Live, Role, SharedString, Stateful, Window,
+    WindowBounds, WindowOptions, actions, div, prelude::*, px, size,
 };
 use gpui_platform::application;
 
@@ -27,6 +27,8 @@ struct AccessibilityExample {
     mute_focus: FocusHandle,
     option_a_focus: FocusHandle,
     option_b_focus: FocusHandle,
+    username: String,
+    username_focus: FocusHandle,
 }
 
 impl AccessibilityExample {
@@ -41,6 +43,28 @@ impl AccessibilityExample {
             mute_focus: cx.focus_handle(),
             option_a_focus: cx.focus_handle(),
             option_b_focus: cx.focus_handle(),
+            username: String::new(),
+            username_focus: cx.focus_handle(),
+        }
+    }
+
+    fn handle_username_keydown(
+        &mut self,
+        event: &KeyDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.keystroke.key == "backspace" {
+            self.username.pop();
+            cx.notify();
+        } else if let Some(ch) = &event.keystroke.key_char {
+            if !event.keystroke.modifiers.platform
+                && !event.keystroke.modifiers.control
+                && ch.chars().all(|c| !c.is_control())
+            {
+                self.username.push_str(ch);
+                cx.notify();
+            }
         }
     }
 
@@ -114,9 +138,29 @@ fn checkbox(id: &'static str, label: &'static str, checked: bool) -> Stateful<gp
 }
 
 fn section_label(text: &'static str) -> gpui::Div {
+    div().text_color(gpui::black().opacity(0.4)).child(text)
+}
+
+fn text_input_label(text: &'static str) -> gpui::Div {
     div()
-        .text_color(gpui::black().opacity(0.4))
+        .text_xs()
+        .text_color(gpui::black().opacity(0.5))
         .child(text)
+}
+
+fn text_input(id: &'static str, value: &str) -> Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .role(Role::TextInput)
+        .px_2()
+        .py_1()
+        .w_full()
+        .border_1()
+        .border_color(gpui::black().opacity(0.3))
+        .rounded_sm()
+        .bg(gpui::white())
+        .cursor_text()
+        .child(SharedString::from(value.to_owned()))
 }
 
 impl Render for AccessibilityExample {
@@ -126,138 +170,184 @@ impl Render for AccessibilityExample {
         div()
             .size_full()
             .flex()
-            .flex_row()
+            .flex_col()
             .bg(gpui::white())
             .text_color(gpui::black())
             .text_sm()
-            // Left panel
+            // Top row: left panel + right panel
             .child(
                 div()
                     .flex()
-                    .flex_col()
-                    .gap_4()
-                    .p_4()
-                    .w(px(240.))
-                    // Buttons section
-                    .child(section_label("BUTTONS"))
+                    .flex_row()
+                    .flex_1()
                     .child(
+                        // Left panel
                         div()
                             .flex()
                             .flex_col()
-                            .gap_2()
-                            // Default
-                            .child(
-                                button("btn-default", "Default")
-                                    .on_click(cx.listener(|this, _, _, cx| {
-                                        this.status = "Default clicked.".into();
-                                        cx.notify();
-                                    })),
-                            )
-                            // Primary (blue)
-                            .child(
-                                button("btn-primary", "Primary")
-                                    .bg(gpui::blue())
-                                    .on_click(cx.listener(|this, _, _, cx| {
-                                        this.status = "Primary clicked.".into();
-                                        cx.notify();
-                                    })),
-                            )
-                            // Danger (red, destructive)
-                            .child(
-                                button("btn-danger", "Danger")
-                                    .bg(gpui::red())
-                                    .on_click(cx.listener(|this, _, _, cx| {
-                                        this.status = "Danger clicked.".into();
-                                        cx.notify();
-                                    })),
-                            )
-                            // Disabled — aria_disabled + no on_click
-                            .child(
-                                button("btn-disabled", "Disabled")
-                                    .aria_disabled(true)
-                                    .bg(gpui::black().opacity(0.25))
-                                    .cursor_not_allowed(),
-                            )
-                            // Toggle (aria_pressed) — press to mute/unmute
-                            .child(
-                                button("btn-mute", if self.muted { "Unmute" } else { "Mute" })
-                                    .aria_pressed(self.muted)
-                                    .track_focus(&self.mute_focus)
-                                    .when(self.muted, |el| el.bg(gpui::blue()))
-                                    .on_click(cx.listener(Self::toggle_mute)),
-                            )
-                            // Counter with increment
+                            .gap_4()
+                            .p_4()
+                            .w(px(240.))
+                            .border_r_1()
+                            .border_color(gpui::black().opacity(0.1))
+                            // Buttons section
+                            .child(section_label("BUTTONS"))
                             .child(
                                 div()
                                     .flex()
-                                    .flex_row()
-                                    .items_center()
+                                    .flex_col()
                                     .gap_2()
+                                    // Default
+                                    .child(button("btn-default", "Button 1").on_click(cx.listener(
+                                        |this, _, _, cx| {
+                                            this.status = "Default clicked.".into();
+                                            cx.notify();
+                                        },
+                                    )))
+                                    // Primary (blue)
+                                    .child(
+                                        button("btn-primary", "OK").bg(gpui::blue()).on_click(
+                                            cx.listener(|this, _, _, cx| {
+                                                this.status = "Primary clicked.".into();
+                                                cx.notify();
+                                            }),
+                                        ),
+                                    )
+                                    // Danger (red, destructive)
+                                    .child(button("btn-danger", "Delete").bg(gpui::red()).on_click(
+                                        cx.listener(|this, _, _, cx| {
+                                            this.status = "Danger clicked.".into();
+                                            cx.notify();
+                                        }),
+                                    ))
+                                    // Disabled — aria_disabled + no on_click
+                                    .child(
+                                        button("btn-disabled", "Upload")
+                                            .aria_disabled(true)
+                                            .bg(gpui::black().opacity(0.25))
+                                            .cursor_not_allowed(),
+                                    )
+                                    // Toggle (aria_pressed) — press to mute/unmute
+                                    .child(
+                                        button(
+                                            "btn-mute",
+                                            if self.muted { "Unmute" } else { "Mute" },
+                                        )
+                                        .aria_pressed(self.muted)
+                                        .track_focus(&self.mute_focus)
+                                        .when(self.muted, |el| el.bg(gpui::blue()))
+                                        .on_click(cx.listener(Self::toggle_mute)),
+                                    )
+                                    // Counter with increment
                                     .child(
                                         div()
-                                            .role(Role::Label)
-                                            .aria_label("Counter value")
-                                            .child(SharedString::from(format!(
-                                                "Count: {}",
-                                                self.count
-                                            ))),
+                                            .flex()
+                                            .flex_row()
+                                            .items_center()
+                                            .gap_2()
+                                            .child(
+                                                div()
+                                                    .role(Role::Label)
+                                                    .aria_label("Counter value")
+                                                    .child(SharedString::from(format!(
+                                                        "Count: {}",
+                                                        self.count
+                                                    ))),
+                                            )
+                                            .child(
+                                                button("btn-increment", "Increment")
+                                                    .track_focus(&self.increment_focus)
+                                                    .on_click(cx.listener(Self::increment)),
+                                            ),
+                                    ),
+                            )
+                            // Checkboxes section
+                            .child(section_label("CHECKBOXES"))
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .gap_2()
+                                    .child(
+                                        checkbox("option-a", "Option A", self.option_a)
+                                            .track_focus(&self.option_a_focus)
+                                            .on_click(cx.listener(Self::toggle_a)),
                                     )
                                     .child(
-                                        button("btn-increment", "Increment")
-                                            .track_focus(&self.increment_focus)
-                                            .on_click(cx.listener(Self::increment)),
+                                        checkbox("option-b", "Option B", self.option_b)
+                                            .track_focus(&self.option_b_focus)
+                                            .on_click(cx.listener(Self::toggle_b)),
                                     ),
-                            ),
-                    )
-                    // Checkboxes section
-                    .child(section_label("CHECKBOXES"))
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap_2()
-                            .child(
-                                checkbox("option-a", "Option A", self.option_a)
-                                    .track_focus(&self.option_a_focus)
-                                    .on_click(cx.listener(Self::toggle_a)),
                             )
+                            // Text inputs section
+                            .child(section_label("TEXT INPUTS"))
                             .child(
-                                checkbox("option-b", "Option B", self.option_b)
-                                    .track_focus(&self.option_b_focus)
-                                    .on_click(cx.listener(Self::toggle_b)),
+                                div().flex().flex_col().gap_3()
+                                    // Editable input — required
+                                    .child(text_input_label("Username (required)"))
+                                    .child(
+                                        text_input(
+                                            "input-username",
+                                            if self.username.is_empty() {
+                                                "Type here…"
+                                            } else {
+                                                &self.username
+                                            },
+                                        )
+                                        .aria_label("Username")
+                                        .aria_required(true)
+                                        .track_focus(&self.username_focus)
+                                        .on_key_down(cx.listener(Self::handle_username_keydown))
+                                        .when(self.username.is_empty(), |el| {
+                                            el.text_color(gpui::black().opacity(0.3))
+                                        }),
+                                    )
+                                    // Read-only input
+                                    .child(text_input_label("Version (read-only)"))
+                                    .child(
+                                        text_input("input-version", "1.0.0")
+                                            .aria_label("Version")
+                                            .aria_readonly(true)
+                                            .text_color(gpui::black().opacity(0.5))
+                                            .bg(gpui::black().opacity(0.05)),
+                                    ),
+                            )
+                            // Live status region
+                            .child(
+                                div()
+                                    .role(Role::Status)
+                                    .aria_live(Live::Polite)
+                                    .text_color(gpui::black().opacity(0.5))
+                                    .child(self.status.clone()),
                             ),
                     )
-                    // Live status region
                     .child(
                         div()
-                            .role(Role::Status)
-                            .aria_live(Live::Polite)
-                            .text_color(gpui::black().opacity(0.5))
-                            .child(self.status.clone()),
-                    )
-                    // Inspector link
-                    .child(
-                        div()
-                            .id("inspector-link")
-                            .mt_2()
-                            .cursor_pointer()
-                            .text_color(gpui::black().opacity(0.4))
-                            .on_click(|_, _, cx| {
-                                cx.open_url("https://developer.apple.com/documentation/accessibility/accessibility-inspector");
-                            })
-                            .child("Open Accessibility Inspector docs ↗"),
+                            .id("inspector-tree")
+                            .flex_1()
+                            .p_3()
+                            .bg(gpui::black().opacity(0.05))
+                            .text_color(gpui::black())
+                            .font_family("monospace")
+                            .overflow_hidden()
+                            .child(tree_text),
                     ),
             )
-            // Right panel: live accessibility tree dump
             .child(
                 div()
-                    .flex_1()
-                    .p_3()
-                    .bg(gpui::black().opacity(0.05))
-                    .text_color(gpui::black())
-                    .font_family("monospace")
-                    .overflow_hidden()
-                    .child(tree_text),
+                    .id("inspector-link")
+                    .py_1()
+                    .px_2()
+                    .border_t_1()
+                    .border_color(gpui::black().opacity(0.1))
+                    .text_color(gpui::black().opacity(0.4))
+                    .cursor_pointer()
+                    .on_click(|_, _, cx| {
+                        cx.open_url(
+                            "https://developer.apple.com/documentation/accessibility/accessibility-inspector",
+                        );
+                    })
+                    .child("Open Accessibility Inspector docs ↗"),
             )
     }
 }
@@ -272,7 +362,10 @@ fn run_example() {
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
-            |window, cx| cx.new(|cx| AccessibilityExample::new(window, cx)),
+            |window, cx| {
+                window.set_window_title("GPUI Accessibility Example");
+                cx.new(|cx| AccessibilityExample::new(window, cx))
+            },
         )
         .unwrap();
 

--- a/crates/gpui/examples/accessibility.rs
+++ b/crates/gpui/examples/accessibility.rs
@@ -1,0 +1,293 @@
+//! Demonstrates GPUI's accessibility annotation API.
+//!
+//! Left panel: interactive UI (buttons + checkboxes + live status region).
+//! Right panel: live text dump of `window.accessibility_tree()`.
+//!
+//! To verify platform accessibility, open **Accessibility Inspector** (ships with
+//! Xcode) and point it at this window. The hierarchy shown there should match
+//! the tree on the right. Click "Open Accessibility Inspector docs" in the UI to
+//! go straight to the Apple developer docs.
+#![cfg_attr(target_family = "wasm", no_main)]
+
+use gpui::{
+    App, Bounds, Context, FocusHandle, Live, Role, SharedString, Stateful, Window, WindowBounds,
+    WindowOptions, actions, div, prelude::*, px, size,
+};
+use gpui_platform::application;
+
+actions!(accessibility_example, [Quit]);
+
+struct AccessibilityExample {
+    count: usize,
+    muted: bool,
+    option_a: bool,
+    option_b: bool,
+    status: SharedString,
+    increment_focus: FocusHandle,
+    mute_focus: FocusHandle,
+    option_a_focus: FocusHandle,
+    option_b_focus: FocusHandle,
+}
+
+impl AccessibilityExample {
+    fn new(_window: &mut Window, cx: &mut Context<Self>) -> Self {
+        Self {
+            count: 0,
+            muted: false,
+            option_a: true,
+            option_b: false,
+            status: SharedString::from("No action yet."),
+            increment_focus: cx.focus_handle(),
+            mute_focus: cx.focus_handle(),
+            option_a_focus: cx.focus_handle(),
+            option_b_focus: cx.focus_handle(),
+        }
+    }
+
+    fn increment(&mut self, _: &gpui::ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        self.count += 1;
+        self.status = SharedString::from(format!("Counter updated to {}.", self.count));
+        cx.notify();
+    }
+
+    fn toggle_mute(&mut self, _: &gpui::ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        self.muted = !self.muted;
+        self.status = SharedString::from(if self.muted { "Muted." } else { "Unmuted." });
+        cx.notify();
+    }
+
+    fn toggle_a(&mut self, _: &gpui::ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        self.option_a = !self.option_a;
+        self.status = SharedString::from(if self.option_a {
+            "Option A enabled."
+        } else {
+            "Option A disabled."
+        });
+        cx.notify();
+    }
+
+    fn toggle_b(&mut self, _: &gpui::ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        self.option_b = !self.option_b;
+        self.status = SharedString::from(if self.option_b {
+            "Option B enabled."
+        } else {
+            "Option B disabled."
+        });
+        cx.notify();
+    }
+}
+
+/// Base button: `bg(black)` + white text. Chain extra methods for variants.
+fn button(id: &'static str, label: &'static str) -> Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .role(Role::Button)
+        .aria_label(label)
+        .px_3()
+        .py_1()
+        .rounded_md()
+        .bg(gpui::black())
+        .text_color(gpui::white())
+        .cursor_pointer()
+        .child(label)
+}
+
+fn checkbox(id: &'static str, label: &'static str, checked: bool) -> Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap_2()
+        .role(Role::CheckBox)
+        .aria_label(label)
+        .aria_checked(checked)
+        .cursor_pointer()
+        .child(
+            div()
+                .size(px(16.))
+                .border_1()
+                .border_color(gpui::black())
+                .when(checked, |el| el.bg(gpui::black())),
+        )
+        .child(label)
+}
+
+fn section_label(text: &'static str) -> gpui::Div {
+    div()
+        .text_color(gpui::black().opacity(0.4))
+        .child(text)
+}
+
+impl Render for AccessibilityExample {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let tree_text = window.accessibility_tree().to_string();
+
+        div()
+            .size_full()
+            .flex()
+            .flex_row()
+            .bg(gpui::white())
+            .text_color(gpui::black())
+            .text_sm()
+            // Left panel
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .p_4()
+                    .w(px(240.))
+                    // Buttons section
+                    .child(section_label("BUTTONS"))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            // Default
+                            .child(
+                                button("btn-default", "Default")
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.status = "Default clicked.".into();
+                                        cx.notify();
+                                    })),
+                            )
+                            // Primary (blue)
+                            .child(
+                                button("btn-primary", "Primary")
+                                    .bg(gpui::blue())
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.status = "Primary clicked.".into();
+                                        cx.notify();
+                                    })),
+                            )
+                            // Danger (red, destructive)
+                            .child(
+                                button("btn-danger", "Danger")
+                                    .bg(gpui::red())
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.status = "Danger clicked.".into();
+                                        cx.notify();
+                                    })),
+                            )
+                            // Disabled — aria_disabled + no on_click
+                            .child(
+                                button("btn-disabled", "Disabled")
+                                    .aria_disabled(true)
+                                    .bg(gpui::black().opacity(0.25))
+                                    .cursor_not_allowed(),
+                            )
+                            // Toggle (aria_pressed) — press to mute/unmute
+                            .child(
+                                button("btn-mute", if self.muted { "Unmute" } else { "Mute" })
+                                    .aria_pressed(self.muted)
+                                    .track_focus(&self.mute_focus)
+                                    .when(self.muted, |el| el.bg(gpui::blue()))
+                                    .on_click(cx.listener(Self::toggle_mute)),
+                            )
+                            // Counter with increment
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .items_center()
+                                    .gap_2()
+                                    .child(
+                                        div()
+                                            .role(Role::Label)
+                                            .aria_label("Counter value")
+                                            .child(SharedString::from(format!(
+                                                "Count: {}",
+                                                self.count
+                                            ))),
+                                    )
+                                    .child(
+                                        button("btn-increment", "Increment")
+                                            .track_focus(&self.increment_focus)
+                                            .on_click(cx.listener(Self::increment)),
+                                    ),
+                            ),
+                    )
+                    // Checkboxes section
+                    .child(section_label("CHECKBOXES"))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(
+                                checkbox("option-a", "Option A", self.option_a)
+                                    .track_focus(&self.option_a_focus)
+                                    .on_click(cx.listener(Self::toggle_a)),
+                            )
+                            .child(
+                                checkbox("option-b", "Option B", self.option_b)
+                                    .track_focus(&self.option_b_focus)
+                                    .on_click(cx.listener(Self::toggle_b)),
+                            ),
+                    )
+                    // Live status region
+                    .child(
+                        div()
+                            .role(Role::Status)
+                            .aria_live(Live::Polite)
+                            .text_color(gpui::black().opacity(0.5))
+                            .child(self.status.clone()),
+                    )
+                    // Inspector link
+                    .child(
+                        div()
+                            .id("inspector-link")
+                            .mt_2()
+                            .cursor_pointer()
+                            .text_color(gpui::black().opacity(0.4))
+                            .on_click(|_, _, cx| {
+                                cx.open_url("https://developer.apple.com/documentation/accessibility/accessibility-inspector");
+                            })
+                            .child("Open Accessibility Inspector docs ↗"),
+                    ),
+            )
+            // Right panel: live accessibility tree dump
+            .child(
+                div()
+                    .flex_1()
+                    .p_3()
+                    .bg(gpui::black().opacity(0.05))
+                    .text_color(gpui::black())
+                    .font_family("monospace")
+                    .overflow_hidden()
+                    .child(tree_text),
+            )
+    }
+}
+
+fn run_example() {
+    application().run(|cx: &mut App| {
+        cx.bind_keys([gpui::KeyBinding::new("cmd-q", Quit, None)]);
+
+        let bounds = Bounds::centered(None, size(px(720.), px(480.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |window, cx| cx.new(|cx| AccessibilityExample::new(window, cx)),
+        )
+        .unwrap();
+
+        cx.activate(true);
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    run_example();
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    gpui_platform::web_init();
+    run_example();
+}

--- a/crates/gpui/src/accessibility.rs
+++ b/crates/gpui/src/accessibility.rs
@@ -1,6 +1,6 @@
 use accesskit::{Live, Node, NodeId, Role, Toggled, TreeUpdate};
 
-use crate::{Bounds, Pixels, SharedString};
+use crate::{Bounds, ScaledPixels, SharedString};
 
 /// Accessibility annotations for a GPUI element.
 ///
@@ -42,7 +42,7 @@ impl Accessibility {
     /// no explicit `aria-label` is set.
     pub(crate) fn to_node(
         &self,
-        bounds: Bounds<Pixels>,
+        bounds: Bounds<ScaledPixels>,
         is_focused: bool,
         child_text: Option<String>,
     ) -> Node {
@@ -220,13 +220,6 @@ fn write_node(
     }
 }
 
-/// Platform trait — each OS backend implements this to push `TreeUpdate` to the AT.
-///
-/// Implementations must ensure internal thread-safety (the adapter may only be
-/// called from the main thread on macOS, so `RefCell` is sufficient).
-pub(crate) trait AccessibilityAdapter {
-    fn update(&mut self, update: TreeUpdate);
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/gpui/src/accessibility.rs
+++ b/crates/gpui/src/accessibility.rs
@@ -1,0 +1,293 @@
+use accesskit::{Live, Node, NodeId, Role, Toggled, TreeUpdate};
+
+use crate::{Bounds, Pixels, SharedString};
+
+/// Accessibility annotations for a GPUI element.
+///
+/// Maps 1:1 to WAI-ARIA 1.1 attributes. Attach to any `div()` via the
+/// builder methods on `InteractiveElement` (e.g. `.role(Role::Button)`).
+#[derive(Default, Clone)]
+pub struct Accessibility {
+    /// `role` — semantic role (e.g. Button, CheckBox, StaticText)
+    pub role: Option<Role>,
+    /// `aria-label` — explicit accessible name
+    pub label: Option<SharedString>,
+    /// `aria-description`
+    pub description: Option<SharedString>,
+    /// `aria-checked` (maps to accesskit Toggled)
+    pub checked: Option<bool>,
+    /// `aria-disabled`
+    pub disabled: Option<bool>,
+    /// `aria-expanded`
+    pub expanded: Option<bool>,
+    /// `aria-hidden` — exclude from the accessibility tree
+    pub hidden: bool,
+    /// `aria-pressed` (maps to accesskit Toggled)
+    pub pressed: Option<bool>,
+    /// `aria-readonly`
+    pub readonly: Option<bool>,
+    /// `aria-required`
+    pub required: Option<bool>,
+    /// `aria-selected`
+    pub selected: Option<bool>,
+    /// `aria-live`
+    pub live: Option<Live>,
+}
+
+impl Accessibility {
+    /// Build an accesskit `Node` from these annotations.
+    ///
+    /// `child_text` is the concatenated text content of descendant StaticText
+    /// nodes, used as the accessible name fallback per ACCNAME 1.2 §4.2 when
+    /// no explicit `aria-label` is set.
+    pub(crate) fn to_node(
+        &self,
+        bounds: Bounds<Pixels>,
+        is_focused: bool,
+        child_text: Option<String>,
+    ) -> Node {
+        let _ = is_focused; // Focused state is conveyed via TreeUpdate::focus, not on the node.
+        let role = self.role.unwrap_or(Role::GenericContainer);
+        let mut node = Node::new(role);
+
+        // Accessible name: explicit label takes priority, then child text fallback (ACCNAME 1.2).
+        if let Some(label) = &self.label {
+            node.set_label(label.as_ref());
+        } else if let Some(text) = child_text {
+            if !text.is_empty() {
+                node.set_label(text);
+            }
+        }
+
+        if let Some(desc) = &self.description {
+            node.set_description(desc.as_ref());
+        }
+
+        node.set_bounds(accesskit::Rect {
+            x0: bounds.origin.x.0 as f64,
+            y0: bounds.origin.y.0 as f64,
+            x1: (bounds.origin.x.0 + bounds.size.width.0) as f64,
+            y1: (bounds.origin.y.0 + bounds.size.height.0) as f64,
+        });
+
+        if let Some(checked) = self.checked {
+            node.set_toggled(if checked {
+                Toggled::True
+            } else {
+                Toggled::False
+            });
+        }
+        if self.disabled.unwrap_or(false) {
+            node.set_disabled();
+        }
+        if let Some(expanded) = self.expanded {
+            node.set_expanded(expanded);
+        }
+        if self.hidden {
+            node.set_hidden();
+        }
+        if let Some(pressed) = self.pressed {
+            node.set_toggled(if pressed {
+                Toggled::True
+            } else {
+                Toggled::False
+            });
+        }
+        if self.readonly.unwrap_or(false) {
+            node.set_read_only();
+        }
+        if self.required.unwrap_or(false) {
+            node.set_required();
+        }
+        if let Some(selected) = self.selected {
+            node.set_selected(selected);
+        }
+        if let Some(live) = self.live {
+            node.set_live(live);
+        }
+
+        node
+    }
+}
+
+/// One accessibility node entry accumulated during `prepaint`.
+#[derive(Clone)]
+pub(crate) struct AccessibilityEntry {
+    pub node_id: NodeId,
+    pub node: Node,
+    pub parent_id: Option<NodeId>,
+}
+
+/// Accumulated accessibility tree for one rendered frame.
+pub(crate) struct AccessibilityFrame {
+    pub entries: Vec<AccessibilityEntry>,
+    pub root_id: Option<NodeId>,
+    pub focus: Option<NodeId>,
+}
+
+impl AccessibilityFrame {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            root_id: None,
+            focus: None,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Convert this frame into an accesskit `TreeUpdate`.
+    pub(crate) fn into_tree_update(self) -> TreeUpdate {
+        // The window root node owns all top-level annotated nodes.
+        let root_id = self.root_id.unwrap_or(NodeId(1));
+
+        // Build parent→children mapping.
+        let mut children_of: std::collections::HashMap<NodeId, Vec<NodeId>> =
+            std::collections::HashMap::new();
+        for entry in &self.entries {
+            let parent = entry.parent_id.unwrap_or(root_id);
+            children_of.entry(parent).or_default().push(entry.node_id);
+        }
+
+        let focus = self
+            .focus
+            .unwrap_or(root_id);
+
+        let mut nodes: Vec<(NodeId, Node)> = self
+            .entries
+            .into_iter()
+            .map(|mut entry| {
+                if let Some(children) = children_of.remove(&entry.node_id) {
+                    entry.node.set_children(children);
+                }
+                (entry.node_id, entry.node)
+            })
+            .collect();
+
+        // Root node: owns all top-level annotated nodes.
+        let mut root_node = Node::new(Role::Window);
+        if let Some(top_level) = children_of.remove(&root_id) {
+            root_node.set_children(top_level);
+        }
+        nodes.push((root_id, root_node));
+
+        TreeUpdate {
+            nodes,
+            tree: Some(accesskit::Tree::new(root_id)),
+            tree_id: accesskit::TreeId::ROOT,
+            focus,
+        }
+    }
+
+    /// Format the tree as indented text for the `accessibility_tree()` debug API.
+    #[cfg(any(feature = "inspector", debug_assertions))]
+    pub(crate) fn format_tree(&self) -> String {
+        // Build parent→children index by entry position.
+        let mut children_of: std::collections::HashMap<Option<NodeId>, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (i, entry) in self.entries.iter().enumerate() {
+            children_of.entry(entry.parent_id).or_default().push(i);
+        }
+
+        let mut out = String::from("[accessibility tree]\n");
+        for &idx in children_of.get(&None).into_iter().flatten() {
+            write_node(&self.entries, &children_of, idx, 1, &mut out);
+        }
+        out
+    }
+}
+
+#[cfg(any(feature = "inspector", debug_assertions))]
+fn write_node(
+    entries: &[AccessibilityEntry],
+    children_of: &std::collections::HashMap<Option<NodeId>, Vec<usize>>,
+    idx: usize,
+    depth: usize,
+    out: &mut String,
+) {
+    use std::fmt::Write;
+
+    let entry = &entries[idx];
+    let indent = "  ".repeat(depth);
+    let role = format!("{:?}", entry.node.role());
+    let label = entry.node.label().unwrap_or("");
+    let _ = writeln!(out, "{}{:<16} {}", indent, role, label);
+    let key = Some(entry.node_id);
+    for &child_idx in children_of.get(&key).into_iter().flatten() {
+        write_node(entries, children_of, child_idx, depth + 1, out);
+    }
+}
+
+/// Platform trait — each OS backend implements this to push `TreeUpdate` to the AT.
+///
+/// Implementations must ensure internal thread-safety (the adapter may only be
+/// called from the main thread on macOS, so `RefCell` is sufficient).
+pub(crate) trait AccessibilityAdapter {
+    fn update(&mut self, update: TreeUpdate);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use accesskit::{Node, NodeId, Role};
+
+    fn entry(id: u64, role: Role, label: &str, parent: Option<u64>) -> AccessibilityEntry {
+        let mut node = Node::new(role);
+        if !label.is_empty() {
+            node.set_label(label);
+        }
+        AccessibilityEntry {
+            node_id: NodeId(id),
+            node,
+            parent_id: parent.map(NodeId),
+        }
+    }
+
+    #[test]
+    fn test_format_tree_empty() {
+        let frame = AccessibilityFrame::new();
+        assert_eq!(frame.format_tree(), "[accessibility tree]\n");
+    }
+
+    #[test]
+    fn test_format_tree_single_node() {
+        let mut frame = AccessibilityFrame::new();
+        frame.entries.push(entry(1, Role::Button, "Increment", None));
+        // Role name left-aligned in 16-char column, then label; depth-1 = 2-space indent.
+        assert_eq!(
+            frame.format_tree(),
+            "[accessibility tree]\n\
+             \x20 Button           Increment\n"
+        );
+    }
+
+    #[test]
+    fn test_format_tree_parent_child() {
+        let mut frame = AccessibilityFrame::new();
+        frame.entries.push(entry(1, Role::Group, "Panel", None));
+        frame.entries.push(entry(2, Role::Button, "OK", Some(1)));
+        frame.entries.push(entry(3, Role::CheckBox, "Opt", Some(1)));
+        // Depth-1 = 2-space indent, depth-2 = 4-space indent.
+        assert_eq!(
+            frame.format_tree(),
+            "[accessibility tree]\n\
+             \x20 Group            Panel\n\
+             \x20   Button           OK\n\
+             \x20   CheckBox         Opt\n"
+        );
+    }
+
+    #[test]
+    fn test_format_tree_no_label() {
+        let mut frame = AccessibilityFrame::new();
+        frame.entries.push(entry(1, Role::GenericContainer, "", None));
+        // "GenericContainer" is exactly 16 chars; trailing space comes from the separator.
+        assert_eq!(
+            frame.format_tree(),
+            "[accessibility tree]\n\
+             \x20 GenericContainer \n"
+        );
+    }
+}

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1967,8 +1967,13 @@ impl Interactivity {
                                         .as_ref()
                                         .map(|h| window.focus == Some(h.id))
                                         .unwrap_or(false);
-                                    let node = props.to_node(bounds, is_focused, None);
+                                    let scaled_bounds =
+                                        bounds.scale(window.scale_factor());
+                                    let node = props.to_node(scaled_bounds, is_focused, None);
                                     window.push_accessibility_node(node_id, node, parent_id);
+                                    if is_focused {
+                                        window.accessibility_frame.focus = Some(node_id);
+                                    }
                                     window.accessibility_node_stack.push(node_id);
                                     true
                                 } else {

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -733,6 +733,78 @@ pub trait InteractiveElement: Sized {
         self
     }
 
+    /// Set the WAI-ARIA role for this element.
+    fn role(mut self, role: crate::Role) -> Self {
+        self.interactivity().accessibility().role = Some(role);
+        self
+    }
+
+    /// Set `aria-label` — the accessible name for this element.
+    fn aria_label(mut self, label: impl Into<crate::SharedString>) -> Self {
+        self.interactivity().accessibility().label = Some(label.into());
+        self
+    }
+
+    /// Set `aria-description`.
+    fn aria_description(mut self, desc: impl Into<crate::SharedString>) -> Self {
+        self.interactivity().accessibility().description = Some(desc.into());
+        self
+    }
+
+    /// Set `aria-checked` (maps to accesskit `Toggled`).
+    fn aria_checked(mut self, checked: bool) -> Self {
+        self.interactivity().accessibility().checked = Some(checked);
+        self
+    }
+
+    /// Set `aria-disabled`.
+    fn aria_disabled(mut self, disabled: bool) -> Self {
+        self.interactivity().accessibility().disabled = Some(disabled);
+        self
+    }
+
+    /// Set `aria-expanded`.
+    fn aria_expanded(mut self, expanded: bool) -> Self {
+        self.interactivity().accessibility().expanded = Some(expanded);
+        self
+    }
+
+    /// Set `aria-hidden` — exclude this element from the accessibility tree.
+    fn aria_hidden(mut self) -> Self {
+        self.interactivity().accessibility().hidden = true;
+        self
+    }
+
+    /// Set `aria-pressed` (maps to accesskit `Toggled`).
+    fn aria_pressed(mut self, pressed: bool) -> Self {
+        self.interactivity().accessibility().pressed = Some(pressed);
+        self
+    }
+
+    /// Set `aria-readonly`.
+    fn aria_readonly(mut self, readonly: bool) -> Self {
+        self.interactivity().accessibility().readonly = Some(readonly);
+        self
+    }
+
+    /// Set `aria-required`.
+    fn aria_required(mut self, required: bool) -> Self {
+        self.interactivity().accessibility().required = Some(required);
+        self
+    }
+
+    /// Set `aria-selected`.
+    fn aria_selected(mut self, selected: bool) -> Self {
+        self.interactivity().accessibility().selected = Some(selected);
+        self
+    }
+
+    /// Set the `aria-live` region behavior.
+    fn aria_live(mut self, live: crate::Live) -> Self {
+        self.interactivity().accessibility().live = Some(live);
+        self
+    }
+
     /// Set the keymap context for this element. This will be used to determine
     /// which action to dispatch from the keymap.
     fn key_context<C, E>(mut self, key_context: C) -> Self
@@ -1718,6 +1790,7 @@ pub struct Interactivity {
     pub(crate) tab_index: Option<isize>,
     pub(crate) tab_group: bool,
     pub(crate) tab_stop: bool,
+    pub(crate) accessibility: Option<Box<crate::Accessibility>>,
 
     #[cfg(any(feature = "inspector", debug_assertions))]
     pub(crate) source_location: Option<&'static core::panic::Location<'static>>,
@@ -1727,6 +1800,10 @@ pub struct Interactivity {
 }
 
 impl Interactivity {
+    fn accessibility(&mut self) -> &mut crate::Accessibility {
+        self.accessibility.get_or_insert_with(Default::default)
+    }
+
     /// Layout this element according to this interactivity state's configured styles
     pub fn request_layout(
         &mut self,
@@ -1879,7 +1956,34 @@ impl Interactivity {
 
                             let scroll_offset =
                                 self.clamp_scroll_position(bounds, &style, window, cx);
+
+                            let pushed_a11y = if let Some(props) = &self.accessibility {
+                                if !props.hidden {
+                                    let node_id = window.next_accessibility_node_id();
+                                    let parent_id =
+                                        window.accessibility_node_stack.last().copied();
+                                    let is_focused = self
+                                        .tracked_focus_handle
+                                        .as_ref()
+                                        .map(|h| window.focus == Some(h.id))
+                                        .unwrap_or(false);
+                                    let node = props.to_node(bounds, is_focused, None);
+                                    window.push_accessibility_node(node_id, node, parent_id);
+                                    window.accessibility_node_stack.push(node_id);
+                                    true
+                                } else {
+                                    false
+                                }
+                            } else {
+                                false
+                            };
+
                             let result = f(&style, scroll_offset, hitbox, window, cx);
+
+                            if pushed_a11y {
+                                window.accessibility_node_stack.pop();
+                            }
+
                             (result, element_state)
                         },
                     )

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -9,6 +9,7 @@ extern crate self as gpui;
 pub static GPUI_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
 #[macro_use]
 mod action;
+mod accessibility;
 mod app;
 
 mod arena;
@@ -86,6 +87,10 @@ pub use ctor::ctor;
 pub use element::*;
 pub use elements::*;
 pub use executor::*;
+pub use accessibility::Accessibility;
+pub use accesskit::{Live, Role};
+#[cfg(any(feature = "inspector", debug_assertions))]
+pub use window::AccessibilityTree;
 pub use geometry::*;
 pub use global::*;
 pub use gpui_macros::{

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -635,6 +635,9 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn on_button_layout_changed(&self, _callback: Box<dyn FnMut()>) {}
+    fn accessibility_adapter(&mut self) -> Option<Box<dyn FnMut(accesskit::TreeUpdate)>> {
+        None
+    }
     fn draw(&self, scene: &Scene);
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -930,6 +930,17 @@ enum InputModality {
     Keyboard,
 }
 
+/// A snapshot of the accessibility tree, returned by [`Window::accessibility_tree`].
+#[cfg(any(feature = "inspector", debug_assertions))]
+pub struct AccessibilityTree(pub String);
+
+#[cfg(any(feature = "inspector", debug_assertions))]
+impl std::fmt::Display for AccessibilityTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Holds the state for a specific window.
 pub struct Window {
     pub(crate) handle: AnyWindowHandle,
@@ -997,6 +1008,13 @@ pub struct Window {
     /// The hitbox that has captured the pointer, if any.
     /// While captured, mouse events route to this hitbox regardless of hit testing.
     captured_hitbox: Option<HitboxId>,
+    pub(crate) accessibility_frame: crate::accessibility::AccessibilityFrame,
+    pub(crate) accessibility_node_stack: Vec<accesskit::NodeId>,
+    pub(crate) accessibility_node_counter: u64,
+    pub(crate) accessibility_adapter:
+        Option<Box<dyn crate::accessibility::AccessibilityAdapter>>,
+    #[cfg(any(feature = "inspector", debug_assertions))]
+    pub(crate) last_accessibility_frame: Option<crate::accessibility::AccessibilityFrame>,
     #[cfg(any(feature = "inspector", debug_assertions))]
     inspector: Option<Entity<Inspector>>,
 }
@@ -1604,6 +1622,12 @@ impl Window {
             client_inset: None,
             image_cache_stack: Vec::new(),
             captured_hitbox: None,
+            accessibility_frame: crate::accessibility::AccessibilityFrame::new(),
+            accessibility_node_stack: Vec::new(),
+            accessibility_node_counter: 1,
+            accessibility_adapter: None,
+            #[cfg(any(feature = "inspector", debug_assertions))]
+            last_accessibility_frame: None,
             #[cfg(any(feature = "inspector", debug_assertions))]
             inspector: None,
         })
@@ -1650,6 +1674,31 @@ impl ContentMask<Pixels> {
 }
 
 impl Window {
+    pub(crate) fn next_accessibility_node_id(&mut self) -> accesskit::NodeId {
+        let id = self.accessibility_node_counter;
+        self.accessibility_node_counter += 1;
+        accesskit::NodeId(id)
+    }
+
+    pub(crate) fn push_accessibility_node(
+        &mut self,
+        node_id: accesskit::NodeId,
+        node: accesskit::Node,
+        parent_id: Option<accesskit::NodeId>,
+    ) {
+        self.accessibility_frame
+            .entries
+            .push(crate::accessibility::AccessibilityEntry { node_id, node, parent_id });
+    }
+
+    fn take_accessibility_frame(&mut self) -> crate::accessibility::AccessibilityFrame {
+        self.accessibility_node_counter = 1;
+        std::mem::replace(
+            &mut self.accessibility_frame,
+            crate::accessibility::AccessibilityFrame::new(),
+        )
+    }
+
     fn mark_view_dirty(&mut self, view_id: EntityId) {
         // Mark ancestor views as dirty. If already in the `dirty_views` set, then all its ancestors
         // should already be dirty.
@@ -2451,7 +2500,30 @@ impl Window {
         self.invalidator.set_phase(DrawPhase::None);
         self.needs_present.set(true);
 
+        self.commit_accessibility_frame();
+
         ArenaClearNeeded::new(&cx.element_arena)
+    }
+
+    fn commit_accessibility_frame(&mut self) {
+        let frame = self.take_accessibility_frame();
+        #[cfg(any(feature = "inspector", debug_assertions))]
+        {
+            self.last_accessibility_frame = if frame.is_empty() {
+                None
+            } else {
+                Some(crate::accessibility::AccessibilityFrame {
+                    entries: frame.entries.clone(),
+                    root_id: frame.root_id,
+                    focus: frame.focus,
+                })
+            };
+        }
+        if let Some(adapter) = &mut self.accessibility_adapter {
+            if !frame.is_empty() {
+                adapter.update(frame.into_tree_update());
+            }
+        }
     }
 
     fn record_entities_accessed(&mut self, cx: &mut App) {
@@ -2483,6 +2555,18 @@ impl Window {
         self.input_latency_tracker.record_frame_presented();
         self.needs_present.set(false);
         profiling::finish_frame!();
+    }
+
+    /// Returns the current accessibility tree as indented text.
+    ///
+    /// Only available in debug builds. Follows Apple's naming convention:
+    /// <https://developer.apple.com/documentation/appkit/nsaccessibility>
+    #[cfg(any(feature = "inspector", debug_assertions))]
+    pub fn accessibility_tree(&self) -> AccessibilityTree {
+        match &self.last_accessibility_frame {
+            Some(frame) => AccessibilityTree(frame.format_tree()),
+            None => AccessibilityTree(String::from("[no accessibility frame]")),
+        }
     }
 
     /// Returns a snapshot of the current input-latency histograms.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1011,8 +1011,7 @@ pub struct Window {
     pub(crate) accessibility_frame: crate::accessibility::AccessibilityFrame,
     pub(crate) accessibility_node_stack: Vec<accesskit::NodeId>,
     pub(crate) accessibility_node_counter: u64,
-    pub(crate) accessibility_adapter:
-        Option<Box<dyn crate::accessibility::AccessibilityAdapter>>,
+    pub(crate) accessibility_adapter: Option<Box<dyn FnMut(accesskit::TreeUpdate)>>,
     #[cfg(any(feature = "inspector", debug_assertions))]
     pub(crate) last_accessibility_frame: Option<crate::accessibility::AccessibilityFrame>,
     #[cfg(any(feature = "inspector", debug_assertions))]
@@ -1562,6 +1561,8 @@ impl Window {
             platform_window.set_app_id(&app_id);
         }
 
+        let accessibility_adapter = platform_window.accessibility_adapter();
+
         platform_window.map_window().unwrap();
 
         Ok(Window {
@@ -1624,8 +1625,8 @@ impl Window {
             captured_hitbox: None,
             accessibility_frame: crate::accessibility::AccessibilityFrame::new(),
             accessibility_node_stack: Vec::new(),
-            accessibility_node_counter: 1,
-            accessibility_adapter: None,
+            accessibility_node_counter: 2,
+            accessibility_adapter,
             #[cfg(any(feature = "inspector", debug_assertions))]
             last_accessibility_frame: None,
             #[cfg(any(feature = "inspector", debug_assertions))]
@@ -1692,7 +1693,7 @@ impl Window {
     }
 
     fn take_accessibility_frame(&mut self) -> crate::accessibility::AccessibilityFrame {
-        self.accessibility_node_counter = 1;
+        self.accessibility_node_counter = 2;
         std::mem::replace(
             &mut self.accessibility_frame,
             crate::accessibility::AccessibilityFrame::new(),
@@ -2521,7 +2522,7 @@ impl Window {
         }
         if let Some(adapter) = &mut self.accessibility_adapter {
             if !frame.is_empty() {
-                adapter.update(frame.into_tree_update());
+                adapter(frame.into_tree_update());
             }
         }
     }

--- a/crates/gpui_macos/Cargo.toml
+++ b/crates/gpui_macos/Cargo.toml
@@ -22,6 +22,7 @@ screen-capture = ["gpui/screen-capture"]
 gpui.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+accesskit_macos = "0.26"
 anyhow.workspace = true
 async-task = "4.7"
 block = "0.1"

--- a/crates/gpui_macos/Cargo.toml
+++ b/crates/gpui_macos/Cargo.toml
@@ -22,6 +22,7 @@ screen-capture = ["gpui/screen-capture"]
 gpui.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+accesskit = "0.24"
 accesskit_macos = "0.26"
 anyhow.workspace = true
 async-task = "4.7"

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -417,6 +417,16 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
             toggle_tab_bar as extern "C" fn(&Object, Sel, id),
         );
 
+        decl.add_method(
+            sel!(accessibilityFocusedUIElement),
+            window_accessibility_focused_ui_element as extern "C" fn(&Object, Sel) -> id,
+        );
+
+        decl.add_method(
+            sel!(accessibilityHitTest:),
+            window_accessibility_hit_test as extern "C" fn(&Object, Sel, NSPoint) -> id,
+        );
+
         decl.register()
     }
 }
@@ -460,6 +470,10 @@ struct MacWindowState {
     closed: Arc<AtomicBool>,
     // The parent window if this window is a sheet (Dialog kind)
     sheet_parent: Option<id>,
+    accessibility_adapter: Option<(
+        accesskit_macos::SubclassingAdapter,
+        Arc<parking_lot::Mutex<Option<accesskit::TreeUpdate>>>,
+    )>,
 }
 
 impl MacWindowState {
@@ -785,6 +799,7 @@ impl MacWindow {
                 activated_least_once: false,
                 closed: Arc::new(AtomicBool::new(false)),
                 sheet_parent: None,
+                accessibility_adapter: None,
             })));
 
             (*native_window).set_ivar(
@@ -926,6 +941,44 @@ impl MacWindow {
                         }
                     }
                 }
+            }
+
+            {
+                // Install the AccessKit subclassing adapter BEFORE the window is first shown.
+                // SubclassingAdapter::for_window dynamically subclasses the window's content view
+                // to intercept accessibilityChildren/accessibilityHitTest/accessibilityFocusedUIElement.
+                // It must be installed before makeKeyAndOrderFront_ / orderFront_ so that the first
+                // accessibility query from the OS (which can happen immediately on show) goes through it.
+                //
+                // The ActivationHandler reads from a shared slot so the first AT query (which normally
+                // produces an empty Placeholder tree) instead returns the last rendered tree. Without
+                // this, the Placeholder's zero-bounds Window node makes the window unselectable in
+                // Accessibility Inspector.
+                let last_tree: Arc<parking_lot::Mutex<Option<accesskit::TreeUpdate>>> =
+                    Arc::new(parking_lot::Mutex::new(None));
+                struct StoredActivationHandler(
+                    Arc<parking_lot::Mutex<Option<accesskit::TreeUpdate>>>,
+                );
+                impl accesskit::ActivationHandler for StoredActivationHandler {
+                    fn request_initial_tree(&mut self) -> Option<accesskit::TreeUpdate> {
+                        let tree = self.0.lock().clone();
+                        eprintln!("[a11y] request_initial_tree: has_tree={}", tree.is_some());
+                        tree
+                    }
+                }
+                struct NullActionHandler;
+                impl accesskit::ActionHandler for NullActionHandler {
+                    fn do_action(&mut self, _request: accesskit::ActionRequest) {}
+                }
+                // Subclass the NSWindow's contentView (the standard AT entry point for the window)
+                // rather than the GPUIView subview, so that the accessibility hierarchy matches
+                // what macOS expects: NSWindow → contentView → accesskit tree.
+                let adapter = accesskit_macos::SubclassingAdapter::for_window(
+                    native_window as *mut std::ffi::c_void,
+                    StoredActivationHandler(last_tree.clone()),
+                    NullActionHandler,
+                );
+                window.0.lock().accessibility_adapter = Some((adapter, last_tree));
             }
 
             if focus && show {
@@ -1428,6 +1481,20 @@ impl PlatformWindow for MacWindow {
         false
     }
 
+    fn accessibility_adapter(&mut self) -> Option<Box<dyn FnMut(accesskit::TreeUpdate)>> {
+        let (mut adapter, last_tree) = self.0.lock().accessibility_adapter.take()?;
+        Some(Box::new(move |update: accesskit::TreeUpdate| {
+            eprintln!("[a11y] commit_frame: {} nodes", update.nodes.len());
+            // Cache the latest tree so StoredActivationHandler can return it when
+            // the AT first connects (avoiding a zero-bounds Placeholder node).
+            *last_tree.lock() = Some(update.clone());
+            if let Some(events) = adapter.update_if_active(|| update) {
+                eprintln!("[a11y] update_if_active returned events → raising");
+                events.raise();
+            }
+        }))
+    }
+
     fn set_edited(&mut self, edited: bool) {
         unsafe {
             let window = self.0.lock().native_window;
@@ -1749,6 +1816,36 @@ extern "C" fn dealloc_window(this: &Object, _: Sel) {
     unsafe {
         drop_window_state(this);
         let _: () = msg_send![super(this, class!(NSWindow)), dealloc];
+    }
+}
+
+// When an accesskit SubclassingAdapter is installed on the contentView, its
+// accessibilityFocusedUIElement returns null when no accesskit node has
+// keyboard focus (e.g. because the root is Role::Window which can't be
+// focused). This causes Accessibility Inspector to see no focused element in
+// the window and refuse to let the user select elements. We fix this by
+// intercepting on the window and falling back to the contentView itself,
+// which still exposes the full accesskit tree via accessibilityChildren.
+extern "C" fn window_accessibility_focused_ui_element(this: &Object, _: Sel) -> id {
+    unsafe {
+        let content_view: id = msg_send![this, contentView];
+        let focused: id = msg_send![content_view, accessibilityFocusedUIElement];
+        if !focused.is_null() {
+            focused
+        } else {
+            content_view
+        }
+    }
+}
+
+// Forward accessibilityHitTest: from the NSWindow to the contentView so that
+// Accessibility Inspector can select individual GPUI elements (not just the window).
+// NSWindow's default implementation does not always delegate into the contentView's
+// accessibilityHitTest:, so we do it explicitly here.
+extern "C" fn window_accessibility_hit_test(this: &Object, _: Sel, point: NSPoint) -> id {
+    unsafe {
+        let content_view: id = msg_send![this, contentView];
+        msg_send![content_view, accessibilityHitTest: point]
     }
 }
 

--- a/docs/src/development/gpui-accessibility.md
+++ b/docs/src/development/gpui-accessibility.md
@@ -288,7 +288,72 @@ fn handle_action_request(request: ActionRequest, window: &mut Window, cx: &mut A
 | `crates/gpui/src/platform/windows/accessibility.rs` | New file: Windows adapter |
 | `crates/gpui/src/platform/linux/accessibility.rs` | New file: Linux adapter |
 | `crates/gpui/src/lib.rs` | Re-export `Role`, `Live` from `accesskit` |
-| `crates/gpui/examples/accessibility.rs` | New example: labeled counter + checkboxes + live region; console tree dump for headless verification |
+| `crates/gpui/examples/accessibility.rs` | New example: labeled counter + checkboxes + live region; live tree text panel showing `accessibility_tree()` output |
+
+## Debug API: Accessibility Tree Dump
+
+Mirrors GPUI's existing inspector pattern — gated on `#[cfg(any(feature = "inspector", debug_assertions))]`, zero overhead in release builds.
+
+### API
+
+```rust
+// crates/gpui/src/window.rs
+
+pub struct AccessibilityTree(String);
+
+impl std::fmt::Display for AccessibilityTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(any(feature = "inspector", debug_assertions))]
+impl Window {
+    /// Returns a snapshot of the current accessibility tree as formatted text.
+    pub fn accessibility_tree(&self) -> AccessibilityTree { ... }
+}
+```
+
+Called from application code or tests at any point after a frame has been drawn:
+
+```rust
+println!("{}", window.accessibility_tree());
+```
+
+### Output format
+
+Indented text tree, one node per line, modeled on how macOS Accessibility Inspector presents its hierarchy:
+
+```
+[accessibility tree]
+  Button          "Increment counter"  enabled=true   (160, 60, 120×32)
+  CheckBox        "Option A"           checked=true   (40, 110, 80×20)
+  CheckBox        "Option B"           checked=false  (140, 110, 80×20)
+  StaticText      "Counter value"      value="3"      (40, 60, 100×32)
+  Status          live=polite                         (40, 150, 400×20)
+    StaticText    "Counter updated to 3"              (40, 150, 400×20)
+```
+
+Each line: `role  label/value  state-flags  (x, y, w×h)`
+
+### Implementation
+
+`Window::accessibility_tree` walks the last built `AccessibilityFrame` and formats each node using `accesskit_consumer::Tree` for traversal order:
+
+```rust
+#[cfg(any(feature = "inspector", debug_assertions))]
+pub fn accessibility_tree(&self) -> String {
+    let Some(frame) = &self.last_accessibility_frame else {
+        return String::from("[no accessibility frame]");
+    };
+    let tree = accesskit_consumer::Tree::new(frame.to_tree_update(), false);
+    let mut out = String::from("[accessibility tree]\n");
+    format_node(&tree, tree.root(), 1, &mut out);
+    out
+}
+```
+
+`Window` stores `last_accessibility_frame: Option<AccessibilityFrame>` only in debug builds (same pattern as `debug_selector` on `Interactivity`).
 
 ## Verification Example
 
@@ -298,17 +363,23 @@ The example renders a small UI with clearly labeled roles and states, then provi
 
 ### What the example renders
 
+The window is split into two panels. The left panel contains interactive UI; the right panel displays the live output of `window.accessibility_tree()`, updated on every state change.
+
 ```
-┌─────────────────────────────────┐
-│  Accessibility Example          │
-│                                 │
-│  [Counter: 3]  [Increment]      │
-│                                 │
-│  ☑ Option A   ☐ Option B        │
-│                                 │
-│  Status: Counter updated to 3   │
-└─────────────────────────────────┘
+┌──────────────────┬─────────────────────────────────────────┐
+│                  │ [accessibility tree]                     │
+│  Counter: 3      │   Button  "Increment counter"            │
+│  [Increment]     │     enabled=true  (160, 60, 120×32)      │
+│                  │   CheckBox  "Option A"                   │
+│  ☑ Option A      │     checked=true  (40, 110, 80×20)       │
+│  ☐ Option B      │   CheckBox  "Option B"                   │
+│                  │     checked=false (140, 110, 80×20)      │
+│                  │   Status  live=polite                    │
+│                  │     "Counter updated to 3"               │
+└──────────────────┴─────────────────────────────────────────┘
 ```
+
+The right panel is simply a `div` rendering `window.accessibility_tree()` as a `SharedString`. No external tool needed — the tree is self-documenting inside the running app.
 
 Elements and their accessibility annotations:
 
@@ -320,35 +391,48 @@ Elements and their accessibility annotations:
 | Checkbox B | `CheckBox` | `"Option B"` | `aria_checked` |
 | Status div | `Status` | — | `aria_live(Live::Polite)` |
 
-### Verification path 1 — macOS Accessibility Inspector
+### Verification
 
-Run the example, open **Xcode → Accessibility Inspector** (or `/Applications/Xcode.app/.../AccessibilityInspector`), point it at the example window. Expected output:
+Interacting with the left panel (click Increment, toggle checkboxes) causes the right panel tree text to update in real time. This proves:
+1. Accessibility annotations are correctly attached to elements
+2. State changes (`checked`, `disabled`, label text) propagate into the tree each frame
+3. `window.accessibility_tree()` is a usable API for inspecting any GPUI window
 
-```
-AXWindow "Accessibility Example"
-  AXStaticText  label="Counter value"   value="3"
-  AXButton      label="Increment counter"  enabled=true
-  AXCheckBox    label="Option A"  value=checked
-  AXCheckBox    label="Option B"  value=unchecked
-  AXGroup       live=polite  label="Status: Counter updated to 3"
-```
+For platform-level validation, open **Xcode Accessibility Inspector** and point it at the example window — the AX hierarchy should match the text panel exactly.
 
-Clicking Increment in the Inspector (via its action panel) should increment the counter — this validates the `ActionRequest::Click` → GPUI event routing.
+## WAI-ARIA Compliance Notes
 
-### Verification path 2 — `cargo run` console output
+### Accessible Name Computation (ACCNAME 1.2)
 
-The example prints its own accessibility tree to stdout on each frame so it can be verified without any external tool:
+Per [ACCNAME 1.2](https://www.w3.org/TR/accname-1.2/), an element's accessible name is determined in this priority order:
 
-```
-[accessibility] frame:
-  NodeId(1)  role=Button       label="Increment counter"  disabled=false  bounds=(160,60,120,32)
-  NodeId(2)  role=CheckBox     label="Option A"            checked=true    bounds=(40,110,80,20)
-  NodeId(3)  role=CheckBox     label="Option B"            checked=false   bounds=(140,110,80,20)
-  NodeId(4)  role=StaticText   label="Counter value"       value="3"       bounds=(40,60,100,32)
-  NodeId(5)  role=Status       live=polite                                  bounds=(40,150,400,20)
+1. `aria-label` (our `label` field) — explicit override, always wins
+2. Text content of child elements — used when no explicit label is set
+
+The paint pipeline **must** implement fallback (2): when `label` is `None`, collect the concatenated text content of all descendant `StaticText` nodes and use it as the AccessKit node's name. Without this, a button with only `.child("Submit")` would have no accessible name — which breaks screen readers.
+
+```rust
+// In Accessibility::to_accesskit_node()
+let name = self.label.clone().or_else(|| collect_child_text(children));
 ```
 
-This dump is written by a `#[cfg(debug_assertions)]` hook in `AccessibilityFrame::into_tree_update`, requiring no platform adapter to produce output.
+### `aria-description` vs `aria-describedby`
+
+The `description` field maps to `aria-description`, which is a WAI-ARIA 1.3 draft attribute. Current AT support is limited. Component authors who need broad AT support today should combine an explicit `aria_label` with a visually hidden companion element. This is a known limitation of the initial implementation; `aria-describedby` (cross-element reference) is out of scope for v1.
+
+### Required Context Roles
+
+WAI-ARIA defines roles that are only meaningful inside a specific parent role:
+
+| Role | Required parent |
+|------|----------------|
+| `ListItem` | `List` |
+| `Option` | `ListBox` |
+| `Tab` | `TabList` |
+| `Row` | `Grid`, `RowGroup`, `Table`, or `TreeGrid` |
+| `TreeItem` | `Tree` or `Group` |
+
+GPUI does not enforce these constraints (nor does AccessKit). Component authors **must** follow them; violations cause AT to ignore or misrepresent the affected nodes. This should be documented in the GPUI accessibility guide.
 
 ## Out of Scope
 

--- a/docs/src/development/gpui-accessibility.md
+++ b/docs/src/development/gpui-accessibility.md
@@ -294,6 +294,8 @@ fn handle_action_request(request: ActionRequest, window: &mut Window, cx: &mut A
 
 Mirrors GPUI's existing inspector pattern — gated on `#[cfg(any(feature = "inspector", debug_assertions))]`, zero overhead in release builds.
 
+The method name `accessibility_tree()` follows Apple's own convention: macOS Accessibility API methods are uniformly prefixed with `accessibility` followed by a noun — `accessibilityChildren()`, `accessibilityParent()`, `accessibilityFrame()`. See [NSAccessibility — Apple Developer Documentation](https://developer.apple.com/documentation/appkit/nsaccessibility).
+
 ### API
 
 ```rust

--- a/docs/superpowers/specs/2026-04-21-gpui-accessibility-design.md
+++ b/docs/superpowers/specs/2026-04-21-gpui-accessibility-design.md
@@ -1,0 +1,301 @@
+# GPUI Accessibility Design
+
+## Overview
+
+Add platform-level accessibility support to `crates/gpui` by integrating the `accesskit` crate ecosystem. This enables assistive technologies (VoiceOver, NVDA, Orca) and AI automation tools to query and interact with GPUI-built UIs.
+
+GPUI is a primitive layer (analogous to HTML/DOM or React). It provides no built-in Button, Input, or other components — those are built by consumers (e.g., Zed's `crates/ui`). Therefore GPUI cannot auto-infer semantic roles; it exposes an annotation API that component authors call explicitly, exactly as HTML exposes `role` and `aria-*` attributes on `<div>`.
+
+## Architecture
+
+```
+Upper layer (Zed ui crate, third-party GPUI users)
+  div().role(Role::Button).aria_label("Submit")
+                    │ annotations
+GPUI Semantic Layer (new)
+  AccessibilityProps on Interactivity
+  prepaint phase builds AccessibilityFrame
+                    │ TreeUpdate
+accesskit (third-party crate)
+  Unified data model: Node, Role, NodeId, TreeUpdate
+       │                 │                │
+accesskit_macos   accesskit_windows   accesskit_unix
+NSAccessibility   UI Automation       AT-SPI (D-Bus)
+       │                 │                │
+VoiceOver / AI    NVDA / AI          Orca / AI
+```
+
+Data flows in two directions:
+1. **Render → platform**: each frame, `AccessibilityFrame` is pushed to the OS via AccessKit
+2. **Platform → GPUI**: `ActionRequest` from AT or AI is routed back into GPUI events (click, focus, set value)
+
+## New Cargo Dependencies
+
+```toml
+# crates/gpui/Cargo.toml
+[dependencies]
+accesskit = "0.18"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+accesskit_macos = "0.17"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+accesskit_windows = "0.24"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+accesskit_unix = "0.11"
+```
+
+## GPUI Semantic Layer
+
+### `AccessibilityProps` struct
+
+New file: `crates/gpui/src/accessibility.rs`
+
+All fields map 1:1 to WAI-ARIA 1.1 attributes. `Role` and `Live` are re-exported from `accesskit` — no custom enums.
+
+```rust
+#[derive(Default, Clone)]
+pub struct AccessibilityProps {
+    pub role: Option<Role>,                // role
+    pub label: Option<SharedString>,       // aria-label
+    pub description: Option<SharedString>, // aria-description
+    pub checked: Option<bool>,             // aria-checked
+    pub disabled: Option<bool>,            // aria-disabled
+    pub expanded: Option<bool>,            // aria-expanded
+    pub hidden: bool,                      // aria-hidden
+    pub pressed: Option<bool>,             // aria-pressed
+    pub readonly: Option<bool>,            // aria-readonly
+    pub required: Option<bool>,            // aria-required
+    pub selected: Option<bool>,            // aria-selected
+    pub live: Option<Live>,                // aria-live: off | polite | assertive
+}
+```
+
+### Changes to `Interactivity`
+
+One new field in `crates/gpui/src/elements/div.rs`:
+
+```rust
+pub struct Interactivity {
+    // ... all existing fields unchanged ...
+    pub(crate) accessibility: Option<Box<AccessibilityProps>>,
+}
+```
+
+`Box` avoids heap allocation for the ~99% of elements with no accessibility annotation.
+
+### Builder Methods on `InteractiveElement`
+
+12 methods, all named after their WAI-ARIA counterparts using snake_case:
+
+```rust
+fn role(self, role: Role) -> Self;
+fn aria_label(self, label: impl Into<SharedString>) -> Self;
+fn aria_description(self, desc: impl Into<SharedString>) -> Self;
+fn aria_checked(self, checked: bool) -> Self;
+fn aria_disabled(self, disabled: bool) -> Self;
+fn aria_expanded(self, expanded: bool) -> Self;
+fn aria_hidden(self) -> Self;           // no argument: sets hidden = true
+fn aria_pressed(self, pressed: bool) -> Self;
+fn aria_readonly(self, readonly: bool) -> Self;
+fn aria_required(self, required: bool) -> Self;
+fn aria_selected(self, selected: bool) -> Self;
+fn aria_live(self, live: Live) -> Self;
+```
+
+Each method lazily initialises `self.interactivity().accessibility` on first call:
+
+```rust
+fn aria_label(mut self, label: impl Into<SharedString>) -> Self {
+    self.interactivity()
+        .accessibility
+        .get_or_insert_with(Default::default)
+        .label = Some(label.into());
+    self
+}
+```
+
+### Usage by upper-layer components
+
+```rust
+// Zed's Button (in crates/ui) — GPUI itself is unchanged
+div()
+    .role(Role::Button)
+    .aria_label(self.label.clone())
+    .aria_disabled(self.disabled)
+    .track_focus(&focus_handle)
+    .on_click(...)
+
+// Progress bar
+div()
+    .role(Role::ProgressBar)
+    .aria_label("Upload progress")
+
+// Live status region
+div()
+    .role(Role::Status)
+    .aria_live(Live::Polite)
+    .child(self.status_message.clone())
+```
+
+## Paint Pipeline
+
+### `AccessibilityFrame`
+
+Built once per frame and discarded after pushing to the platform adapter.
+
+```rust
+pub(crate) struct AccessibilityFrame {
+    pub nodes: Vec<(NodeId, Node)>,
+    pub root_id: NodeId,
+    pub focus: Option<NodeId>,
+}
+```
+
+### `NodeId` assignment
+
+- Elements with a `FocusHandle`: reuse `FocusId` (u64) cast to `NodeId` (NonZeroU128).
+- Elements with accessibility props but no focus handle: allocate from a per-window atomic counter.
+
+```rust
+impl From<FocusId> for NodeId {
+    fn from(id: FocusId) -> NodeId {
+        NodeId(NonZeroU128::new(id.0 as u128).unwrap())
+    }
+}
+```
+
+### Collection during `prepaint`
+
+`Interactivity::prepaint` gains a new block at its end:
+
+```rust
+if let Some(props) = &self.accessibility {
+    let node_id = self.accessibility_node_id(window);
+    let bounds = element_bounds.to_screen_rect(window);
+    let node = props.to_accesskit_node(bounds, is_focused, is_disabled);
+    window.push_accessibility_node(node_id, node, parent_node_id);
+}
+```
+
+### Parent-child tracking
+
+A `accessibility_node_stack: Vec<NodeId>` is maintained on `Window` (parallel to the existing paint depth tracking). Elements without accessibility props are transparent — they do not appear on the stack.
+
+```
+div (role=List)       → NodeId(1)  push
+  div (role=ListItem) → NodeId(2)  push, parent=1
+    div (role=Button) → NodeId(3)  push, parent=2
+    exit              ← pop 3
+  exit                ← pop 2
+exit                  ← pop 1
+```
+
+### Frame commit
+
+At the end of `Window::draw`, after scene submission:
+
+```rust
+let frame = self.take_accessibility_frame();
+if let Some(adapter) = &self.accessibility_adapter {
+    adapter.update(frame.into_tree_update());
+}
+```
+
+## Platform Adapters
+
+### Trait
+
+```rust
+// crates/gpui/src/platform.rs
+pub(crate) trait AccessibilityAdapter {
+    fn update(&self, update: TreeUpdate);
+}
+```
+
+### Per-platform implementation
+
+| Platform | File | Crate |
+|----------|------|-------|
+| macOS | `platform/mac/accessibility.rs` | `accesskit_macos` |
+| Windows | `platform/windows/accessibility.rs` | `accesskit_windows` |
+| Linux | `platform/linux/accessibility.rs` | `accesskit_unix` |
+
+macOS is the highest-priority target. GPUI uses a native Cocoa backend (not winit) on macOS, so `accesskit_macos` is used directly:
+
+```rust
+// platform/mac/accessibility.rs
+use accesskit_macos::Adapter;
+
+pub(crate) struct MacAccessibilityAdapter {
+    inner: Adapter,
+}
+
+impl MacAccessibilityAdapter {
+    pub fn new(ns_view: id, action_handler: impl ActionHandler) -> Self {
+        Self {
+            inner: Adapter::new(ns_view, || initial_tree(), action_handler),
+        }
+    }
+}
+
+impl AccessibilityAdapter for MacAccessibilityAdapter {
+    fn update(&self, update: TreeUpdate) {
+        let events = self.inner.update_if_active(|| update);
+        if let Some(events) = events {
+            events.raise();
+        }
+    }
+}
+```
+
+Windows and Linux use `accesskit_windows` and `accesskit_unix` respectively via a similar thin wrapper.
+
+### `ActionRequest` routing (AT/AI → GPUI events)
+
+When an assistive technology or AI agent sends an action, AccessKit fires a callback. The handler maps it back into GPUI's event system:
+
+```rust
+fn handle_action_request(request: ActionRequest, window: &mut Window, cx: &mut App) {
+    match request.action {
+        Action::Click => window.synthesize_click(request.target, cx),
+        Action::Focus => {
+            if let Some(handle) = window.focus_handle_for_node(request.target) {
+                handle.focus(window);
+            }
+        }
+        Action::SetValue => {
+            if let Some(ActionData::Value(text)) = request.data {
+                window.synthesize_text_input(request.target, text, cx);
+            }
+        }
+        Action::ScrollIntoView => window.scroll_node_into_view(request.target, cx),
+        _ => {}
+    }
+}
+```
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `crates/gpui/Cargo.toml` | Add `accesskit`, `accesskit_macos`, `accesskit_windows`, `accesskit_unix` |
+| `crates/gpui/src/accessibility.rs` | New file: `AccessibilityProps`, `AccessibilityFrame`, `AccessibilityAdapter` trait |
+| `crates/gpui/src/elements/div.rs` | Add `accessibility: Option<Box<AccessibilityProps>>` to `Interactivity`; add 12 builder methods to `InteractiveElement` |
+| `crates/gpui/src/window.rs` | Add `accessibility_adapter`, `accessibility_node_stack`; update `draw` to push `TreeUpdate` |
+| `crates/gpui/src/platform/mac/accessibility.rs` | New file: `MacAccessibilityAdapter` wrapping `accesskit_macos::Adapter` |
+| `crates/gpui/src/platform/windows/accessibility.rs` | New file: Windows adapter |
+| `crates/gpui/src/platform/linux/accessibility.rs` | New file: Linux adapter |
+| `crates/gpui/src/lib.rs` | Re-export `Role`, `Live` from `accesskit` |
+
+## Out of Scope
+
+- Value range attributes (`aria-valuemin/max/now/text`) — add when building slider/progress components
+- `aria-sort`, `aria-haspopup`, `aria-modal`, `aria-orientation` — add per-component need
+- Web/WASM platform — AccessKit has no web backend; browser handles accessibility natively
+- Automatic role inference for built-in components — GPUI has no built-in components
+
+## Release Notes
+
+- N/A (infrastructure only; no user-visible change until upper-layer components annotate themselves)

--- a/docs/superpowers/specs/2026-04-21-gpui-accessibility-design.md
+++ b/docs/superpowers/specs/2026-04-21-gpui-accessibility-design.md
@@ -13,7 +13,7 @@ Upper layer (Zed ui crate, third-party GPUI users)
   div().role(Role::Button).aria_label("Submit")
                     │ annotations
 GPUI Semantic Layer (new)
-  AccessibilityProps on Interactivity
+  Accessibility on Interactivity
   prepaint phase builds AccessibilityFrame
                     │ TreeUpdate
 accesskit (third-party crate)
@@ -34,21 +34,21 @@ Data flows in two directions:
 ```toml
 # crates/gpui/Cargo.toml
 [dependencies]
-accesskit = "0.18"
+accesskit = "0.24"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-accesskit_macos = "0.17"
+accesskit_macos = "0.26"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-accesskit_windows = "0.24"
+accesskit_windows = "0.32"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-accesskit_unix = "0.11"
+accesskit_unix = "0.21"
 ```
 
 ## GPUI Semantic Layer
 
-### `AccessibilityProps` struct
+### `Accessibility` struct
 
 New file: `crates/gpui/src/accessibility.rs`
 
@@ -56,7 +56,7 @@ All fields map 1:1 to WAI-ARIA 1.1 attributes. `Role` and `Live` are re-exported
 
 ```rust
 #[derive(Default, Clone)]
-pub struct AccessibilityProps {
+pub struct Accessibility {
     pub role: Option<Role>,                // role
     pub label: Option<SharedString>,       // aria-label
     pub description: Option<SharedString>, // aria-description
@@ -79,7 +79,7 @@ One new field in `crates/gpui/src/elements/div.rs`:
 ```rust
 pub struct Interactivity {
     // ... all existing fields unchanged ...
-    pub(crate) accessibility: Option<Box<AccessibilityProps>>,
+    pub(crate) accessibility: Option<Box<Accessibility>>,
 }
 ```
 
@@ -281,13 +281,74 @@ fn handle_action_request(request: ActionRequest, window: &mut Window, cx: &mut A
 | File | Change |
 |------|--------|
 | `crates/gpui/Cargo.toml` | Add `accesskit`, `accesskit_macos`, `accesskit_windows`, `accesskit_unix` |
-| `crates/gpui/src/accessibility.rs` | New file: `AccessibilityProps`, `AccessibilityFrame`, `AccessibilityAdapter` trait |
-| `crates/gpui/src/elements/div.rs` | Add `accessibility: Option<Box<AccessibilityProps>>` to `Interactivity`; add 12 builder methods to `InteractiveElement` |
+| `crates/gpui/src/accessibility.rs` | New file: `Accessibility`, `AccessibilityFrame`, `AccessibilityAdapter` trait |
+| `crates/gpui/src/elements/div.rs` | Add `accessibility: Option<Box<Accessibility>>` to `Interactivity`; add 12 builder methods to `InteractiveElement` |
 | `crates/gpui/src/window.rs` | Add `accessibility_adapter`, `accessibility_node_stack`; update `draw` to push `TreeUpdate` |
 | `crates/gpui/src/platform/mac/accessibility.rs` | New file: `MacAccessibilityAdapter` wrapping `accesskit_macos::Adapter` |
 | `crates/gpui/src/platform/windows/accessibility.rs` | New file: Windows adapter |
 | `crates/gpui/src/platform/linux/accessibility.rs` | New file: Linux adapter |
 | `crates/gpui/src/lib.rs` | Re-export `Role`, `Live` from `accesskit` |
+| `crates/gpui/examples/accessibility.rs` | New example: labeled counter + checkboxes + live region; console tree dump for headless verification |
+
+## Verification Example
+
+New file: `crates/gpui/examples/accessibility.rs`
+
+The example renders a small UI with clearly labeled roles and states, then provides two verification paths:
+
+### What the example renders
+
+```
+┌─────────────────────────────────┐
+│  Accessibility Example          │
+│                                 │
+│  [Counter: 3]  [Increment]      │
+│                                 │
+│  ☑ Option A   ☐ Option B        │
+│                                 │
+│  Status: Counter updated to 3   │
+└─────────────────────────────────┘
+```
+
+Elements and their accessibility annotations:
+
+| Element | role | aria_label | other |
+|---------|------|------------|-------|
+| Counter display | `StaticText` | `"Counter value"` | — |
+| Increment button | `Button` | `"Increment counter"` | `aria_disabled` when count ≥ 10 |
+| Checkbox A | `CheckBox` | `"Option A"` | `aria_checked` |
+| Checkbox B | `CheckBox` | `"Option B"` | `aria_checked` |
+| Status div | `Status` | — | `aria_live(Live::Polite)` |
+
+### Verification path 1 — macOS Accessibility Inspector
+
+Run the example, open **Xcode → Accessibility Inspector** (or `/Applications/Xcode.app/.../AccessibilityInspector`), point it at the example window. Expected output:
+
+```
+AXWindow "Accessibility Example"
+  AXStaticText  label="Counter value"   value="3"
+  AXButton      label="Increment counter"  enabled=true
+  AXCheckBox    label="Option A"  value=checked
+  AXCheckBox    label="Option B"  value=unchecked
+  AXGroup       live=polite  label="Status: Counter updated to 3"
+```
+
+Clicking Increment in the Inspector (via its action panel) should increment the counter — this validates the `ActionRequest::Click` → GPUI event routing.
+
+### Verification path 2 — `cargo run` console output
+
+The example prints its own accessibility tree to stdout on each frame so it can be verified without any external tool:
+
+```
+[accessibility] frame:
+  NodeId(1)  role=Button       label="Increment counter"  disabled=false  bounds=(160,60,120,32)
+  NodeId(2)  role=CheckBox     label="Option A"            checked=true    bounds=(40,110,80,20)
+  NodeId(3)  role=CheckBox     label="Option B"            checked=false   bounds=(140,110,80,20)
+  NodeId(4)  role=StaticText   label="Counter value"       value="3"       bounds=(40,60,100,32)
+  NodeId(5)  role=Status       live=polite                                  bounds=(40,150,400,20)
+```
+
+This dump is written by a `#[cfg(debug_assertions)]` hook in `AccessibilityFrame::into_tree_update`, requiring no platform adapter to produce output.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- Integrates `accesskit 0.24` to expose a WAI-ARIA annotation API on GPUI `div` elements, enabling macOS NSAccessibility, Windows UIA, and Linux AT-SPI, as well as AI tooling to query the UI hierarchy
- Adds 12 builder methods on `InteractiveElement` (`role()`, `aria_label()`, `aria_description()`, `aria_checked()`, `aria_disabled()`, `aria_expanded()`, `aria_hidden()`, `aria_pressed()`, `aria_readonly()`, `aria_required()`, `aria_selected()`, `aria_live()`)
- New `AccessibilityFrame` accumulates nodes per render frame and converts to `accesskit::TreeUpdate` via `commit_accessibility_frame()` called at end of `Window::draw()`; bounds are converted from GPUI logical pixels to physical pixels (×`scale_factor`) to match accesskit's coordinate space
- `Window::accessibility_tree()` debug API (debug builds only) returns an indented text dump of the current frame for inspection and testing
- `accesskit_macos` added to `gpui_macos` — installs `SubclassingAdapter` on the window's `contentView` before first show, and overrides `accessibilityFocusedUIElement` and `accessibilityHitTest:` on the `NSWindow` class to ensure Accessibility Inspector can navigate into the accesskit node tree
- Example `crates/gpui/examples/accessibility.rs` demonstrates all common button states (default, primary, danger, disabled, toggle/`aria_pressed`), checkboxes, text inputs, and a live ARIA status region

## Show case

https://github.com/user-attachments/assets/c8ae7c83-b125-4d34-91b8-beccb83c9148

## Test plan

- [ ] Run `cargo test -p gpui accessibility` — 4 unit tests for `AccessibilityFrame::format_tree()` output format
- [ ] Run `cargo check -p gpui --example accessibility` — compiles without errors

### Verifying with macOS Accessibility Inspector

macOS requires a signed `.app` bundle for a process to appear in Accessibility Inspector's target list. Build and wrap the example like this:

```bash
cargo build -p gpui --example accessibility 

mkdir -p /tmp/Accessibility.app/Contents/MacOS
cp target/debug/examples/accessibility /tmp/Accessibility.app/Contents/MacOS/

cat > /tmp/Accessibility.app/Contents/Info.plist <<'PLIST'
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0"><dict>
  <key>CFBundleExecutable</key><string>accessibility</string>
  <key>CFBundleIdentifier</key><string>com.zed.accessibility-example</string>
  <key>CFBundleName</key><string>Accessibility</string>
  <key>CFBundleVersion</key><string>1.0</string>
  <key>CFBundlePackageType</key><string>APPL</string>
  <key>NSPrincipalClass</key><string>NSApplication</string>
  <key>NSHighResolutionCapable</key><true/>
</dict></plist>
PLIST

codesign --sign - --force /tmp/Accessibility.app
open /tmp/Accessibility.app
```

1. Open **Accessibility Inspector** (Xcode → Open Developer Tool → Accessibility Inspector)
2. In Inspector: **Target → choose "Accessibility"** from the process list
3. Use **"point to inspect"** (crosshair icon) and hover over buttons/checkboxes — each element should highlight individually with correct role and label
4. Click elements in the hierarchy view — roles should show as `AXButton`, `AXCheckBox`, `AXTextField`, `AXStaticText`
5. Verify `aria_disabled` on the Disabled button shows `AXEnabled = NO`
6. Click the Mute toggle — `AXValue` (pressed state) should update
7. Click Increment — the Counter label should announce the update via the `AXStatus` live region

Release Notes:

- Added WAI-ARIA accessibility annotation API to GPUI elements, enabling screen readers and AI tools to query the UI hierarchy via accesskit