### PR TITLE
compliance: Temporarily fix the wrong compliance reports

### DIFF
--- a/tooling/compliance/src/checks.rs
+++ b/tooling/compliance/src/checks.rs
@@ -6,7 +6,7 @@ use crate::{
     git::{CommitDetails, CommitList},
     github::{
         CommitAuthor, GithubApiClient, GithubLogin, PullRequestComment, PullRequestData,
-        PullRequestReview, Repository, ReviewState,
+        PullRequestReview, Repository, ReviewState, ZED_ZIPPY_AUTHOR,
     },
     report::Report,
 };
@@ -115,6 +115,10 @@ impl Reporter {
         commit: &CommitDetails,
     ) -> Result<ReviewSuccess, ReviewFailure> {
         let Some(pr_number) = commit.pr_number() else {
+            if commit.author().name().contains("Zed Zippy") && commit.title().starts_with("Bump to")
+            {
+                return Ok(ReviewSuccess::CoAuthored(vec![ZED_ZIPPY_AUTHOR.clone()]));
+            }
             return Err(ReviewFailure::NoPullRequestFound);
         };
 

--- a/tooling/compliance/src/git.rs
+++ b/tooling/compliance/src/git.rs
@@ -163,6 +163,10 @@ impl Committer {
             email: email.to_owned(),
         }
     }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 impl fmt::Display for Committer {

--- a/tooling/compliance/src/github.rs
+++ b/tooling/compliance/src/github.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, fmt, ops::Not};
+use std::{borrow::Cow, collections::HashMap, fmt, ops::Not, sync::LazyLock};
 
 use anyhow::Result;
 use derive_more::Deref;
@@ -72,6 +72,14 @@ pub struct CommitAuthor {
     email: String,
     user: Option<GithubLogin>,
 }
+
+pub(crate) const ZED_ZIPPY_AUTHOR: LazyLock<CommitAuthor> = LazyLock::new(|| CommitAuthor {
+    name: "Zed Zippy".to_string(),
+    email: "234243425+zed-zippy[bot]@users.noreply.github.com".to_string(),
+    user: Some(GithubLogin {
+        login: "zed-zippy[bot]".to_string(),
+    }),
+});
 
 impl CommitAuthor {
     pub(crate) fn user(&self) -> Option<&GithubLogin> {

--- a/tooling/compliance/src/github.rs
+++ b/tooling/compliance/src/github.rs
@@ -73,7 +73,7 @@ pub struct CommitAuthor {
     user: Option<GithubLogin>,
 }
 
-pub(crate) const ZED_ZIPPY_AUTHOR: LazyLock<CommitAuthor> = LazyLock::new(|| CommitAuthor {
+pub(crate) static ZED_ZIPPY_AUTHOR: LazyLock<CommitAuthor> = LazyLock::new(|| CommitAuthor {
     name: "Zed Zippy".to_string(),
     email: "234243425+zed-zippy[bot]@users.noreply.github.com".to_string(),
     user: Some(GithubLogin {


### PR DESCRIPTION
This will be fully replaced by https://github.com/zed-industries/zed/pull/54342 - however, this will not help for the next week on the stable branch, since we have plenty of non-signed commits on that branch currently.

Thus, adding this temporary check here to fix this and which is a cherry-pickable change. This **will** be fully replaced by the linked PR, however, I cannot cherry pick that since we would otherwise need to force-push the branches to remove the bad commits.

Release Notes:

- N/A
