### PR TITLE
title_bar: Fix worktree label showing `main` when opening a worktree directly

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -190,14 +190,20 @@ impl Render for TitleBar {
                 .root_name()
                 .file_name()
                 .map(|name| SharedString::from(name.to_string()));
-            linked_worktree_name = repository.as_ref().and_then(|repo| {
+            if let Some(repo) = &repository {
                 let repo = repo.read(cx);
-                linked_worktree_short_name(
+                linked_worktree_name = linked_worktree_short_name(
                     repo.original_repo_abs_path.as_ref(),
                     repo.work_directory_abs_path.as_ref(),
-                )
-                .filter(|name| Some(name) != project_name.as_ref())
-            });
+                );
+                if let Some(name) = repo
+                    .original_repo_abs_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                {
+                    project_name = Some(SharedString::from(name.to_string()));
+                }
+            }
         }
 
         children.push(


### PR DESCRIPTION
This PR fixes an issue where we'd show incorrect worktree labels when opening a linked worktree directly. The linked worktree name would be displayed in the project button but the dedicated worktree button would be displaying "main", which is incorrect. 

Now that we have a dedicated worktree button in the title bar, we can make the project button always show the root repository name, effectively matching the threads sidebar. 

Release Notes:

- Fixed the title bar worktree button showing "main" when opening a linked git worktree directly.
