### PR TITLE
project: Fix infinite search loop for literal queries with non-ASCII and regex-specific characters

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -115,7 +115,13 @@ impl SearchQuery {
                 files_to_exclude,
                 false,
                 buffers,
-            );
+            )
+            .map(|mut search_query| {
+                if let Self::Regex { ref mut inner, .. } = search_query {
+                    inner.query = Arc::from(query.as_str());
+                }
+                search_query
+            });
         }
         let search = AhoCorasickBuilder::new()
             .ascii_case_insensitive(!case_sensitive)

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -5466,4 +5466,71 @@ pub mod tests {
         );
         cx.background_executor.run_until_parked();
     }
+
+    #[gpui::test]
+    async fn test_project_search_replace_all_with_unicode_and_regex_chars(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                "file.rs": "😀#12345\n😀#12345\n",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let search = cx.new(|cx| ProjectSearch::new(project.clone(), cx));
+        let search_view = cx.add_window(|window, cx| {
+            ProjectSearchView::new(workspace.downgrade(), search.clone(), window, cx, None)
+        });
+
+        // text with non-ASCII and regex special characters
+        let query_text = "😀#123";
+        search_view
+            .update(cx, |search_view, window, cx| {
+                search_view
+                    .search_options
+                    .remove(SearchOptions::CASE_SENSITIVE);
+                search_view.query_editor.update(cx, |query_editor, cx| {
+                    query_editor.set_text(query_text, window, cx)
+                });
+                search_view
+                    .replacement_editor
+                    .update(cx, |replacement_editor, cx| {
+                        replacement_editor.set_text("REPLACED", window, cx)
+                    });
+                search_view.search(cx);
+            })
+            .unwrap();
+
+        cx.background_executor.run_until_parked();
+
+        search_view
+            .update(cx, |search_view, window, cx| {
+                search_view.replace_all(&ReplaceAll, window, cx);
+            })
+            .unwrap();
+
+        // Before, the replace would get stuck in an infinite loop
+        // The executor never gets parked
+        cx.background_executor.run_until_parked();
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/file.rs"), cx)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            buffer.update(cx, |buffer, _| buffer.text()),
+            "REPLACED45\nREPLACED45\n"
+        );
+    }
 }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54331

In #28752, in order to get case-insensitive search for non-ASCII queries, we introduced a regex fallback:
https://github.com/zed-industries/zed/blob/cfebe3a85af0fab9688c275ecf22aa30c3501cc6/crates/project/src/search.rs#L103-L118

Inside the `regex()` build method, we store the passed query in the `SearchInputs` as `initial_query`, which is intended to represent the exact user input. However, when these two parts are combined during the Unicode fallback, this logic breaks.

If a user input a "# 😀", the code detects non-ASCII characters and passes the query to the regex constructor. To ensure it still behaves like a literal search, we call `regex::escape()`, passing "\\# 😀" instead of the raw input. This causes the internal identity of the search to become the escaped string.

The "Replace All" logic in project search then performs a staleness check to see if the query has been updated:
https://github.com/zed-industries/zed/blob/cfebe3a85af0fab9688c275ecf22aa30c3501cc6/crates/search/src/project_search.rs#L839-L849
It compares the raw text in the editor ("# 😀") against the last search query text ("\\# 😀"). Because they never match, Zed assumes the query has changed and  triggers a refresh search to update the results. This leads to an endless cycle of mismatches and retries.

This PR ensures that the original, non-escaped query is stored correctly in the search identity, even when the logic requires an escaped regex fallback. It's also worth noting that the regression test included here won't produce a standard error on the current main branch; instead, it will run endlessly, which is the exact behavior being fixed.

Release Notes:

- Fixed an infinite loop in Project Search & Replace when using non-ASCII characters and regex-specific symbols with Case Sensitivity disabled.
