### PR TITLE
Fix broken `is_maximized` check on Windows

### DIFF
--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -174,7 +174,7 @@ impl WindowsWindowState {
     }
 
     pub(crate) fn is_maximized(&self) -> bool {
-        !self.is_fullscreen()
+        !self.is_fullscreen() && unsafe { IsZoomed(self.hwnd) }.as_bool()
     }
 
     fn bounds(&self) -> Bounds<Pixels> {


### PR DESCRIPTION
Bad change from https://github.com/zed-industries/zed/pull/54321

Fixes https://github.com/zed-industries/zed/issues/54418

Release Notes:

- N/A