### PR TITLE
bedrock: Fix max_token_count for extended context models when allow_extended_context is enabled

### DIFF
--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -423,10 +423,15 @@ impl BedrockLanguageModelProvider {
         }
     }
 
-    fn create_language_model(&self, model: bedrock::Model) -> Arc<dyn LanguageModel> {
+    fn create_language_model(
+        &self,
+        model: bedrock::Model,
+        allow_extended_context: bool,
+    ) -> Arc<dyn LanguageModel> {
         Arc::new(BedrockModel {
             id: LanguageModelId::from(model.id().to_string()),
             model,
+            allow_extended_context,
             http_client: self.http_client.clone(),
             handle: self.handle.clone(),
             state: self.state.clone(),
@@ -449,13 +454,18 @@ impl LanguageModelProvider for BedrockLanguageModelProvider {
         IconOrSvg::Icon(IconName::AiBedrock)
     }
 
-    fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
-        Some(self.create_language_model(bedrock::Model::default()))
+    fn default_model(&self, cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        let allow_extended_context = self.state.read(cx).get_allow_extended_context();
+        Some(self.create_language_model(bedrock::Model::default(), allow_extended_context))
     }
 
     fn default_fast_model(&self, cx: &App) -> Option<Arc<dyn LanguageModel>> {
         let region = self.state.read(cx).get_region();
-        Some(self.create_language_model(bedrock::Model::default_fast(region.as_str())))
+        let allow_extended_context = self.state.read(cx).get_allow_extended_context();
+        Some(self.create_language_model(
+            bedrock::Model::default_fast(region.as_str()),
+            allow_extended_context,
+        ))
     }
 
     fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
@@ -491,9 +501,10 @@ impl LanguageModelProvider for BedrockLanguageModelProvider {
             );
         }
 
+        let allow_extended_context = self.state.read(cx).get_allow_extended_context();
         models
             .into_values()
-            .map(|model| self.create_language_model(model))
+            .map(|model| self.create_language_model(model, allow_extended_context))
             .collect()
     }
 
@@ -531,6 +542,7 @@ impl LanguageModelProviderState for BedrockLanguageModelProvider {
 struct BedrockModel {
     id: LanguageModelId,
     model: Model,
+    allow_extended_context: bool,
     http_client: AwsHttpClient,
     handle: tokio::runtime::Handle,
     client: OnceCell<BedrockClient>,
@@ -699,7 +711,11 @@ impl LanguageModel for BedrockModel {
     }
 
     fn max_token_count(&self) -> u64 {
-        self.model.max_token_count()
+        if self.allow_extended_context && self.model.supports_extended_context() {
+            1_000_000
+        } else {
+            self.model.max_token_count()
+        }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {


### PR DESCRIPTION
## Summary

Fixes #54390

When `allow_extended_context: true` is set in Bedrock settings, the actual API requests correctly include the `anthropic_beta: context-1m-2025-08-07` header — but `max_token_count()` on `BedrockModel` was still returning `200_000`. This caused Zed's context window tracking to prompt the user to start a new context at ~144K tokens, even though the model supports up to 1M tokens.

## Root Cause

`BedrockModel::max_token_count()` unconditionally delegated to `Model::max_tokens()`, which hard-codes `200_000` for Claude Opus 4.6, Opus 4.7, and Sonnet 4.6. The `allow_extended_context` setting was only consulted at request-dispatch time (to set the beta header), never at token-count-reporting time.

## Fix

- Added `allow_extended_context: bool` field to `BedrockModel`, captured from settin- Added `allow_extendede
- Updated `create_language_model()` to accept and store the flag
- Updated all call sites (`default_model`, `default_fast_model`, `provided_models`) to read the setting and pass it through
- `max_token_count()` now returns `1_000_000` when `allow_extended_context` is true and the model supports extended context (Opus 4.6, Opus 4.7, Sonnet 4.6 — gated by the existing `supports_extended_context()` predicate)

The direct Anthropic API provider is unaffected (it already returns `1_000_000` for these models). The Copilot Chat provider is also unaffected (it reads context window sizes from the live API response).

Release Notes:

- Fixed Bedrock Claude Opus 4.7 (and Opus 4.6, Sonnet 4.6) reporting a 200K context window in Zed when `allow_extended_context` is enabled — the full 1M token limit is now reflected correctly