### PR TITLE
git: Revert skipping of events for the `.git` directory itself (#54443) (cherry-pick to stable)

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -7,9 +7,7 @@ use chardetng::EncodingDetector;
 use clock::ReplicaId;
 use collections::{HashMap, HashSet, VecDeque};
 use encoding_rs::Encoding;
-use fs::{
-    Fs, MTime, PathEvent, PathEventKind, RemoveOptions, Watcher, copy_recursive, read_dir_items,
-};
+use fs::{Fs, MTime, PathEvent, RemoveOptions, Watcher, copy_recursive, read_dir_items};
 use futures::{
     FutureExt as _, Stream, StreamExt,
     channel::{
@@ -4231,24 +4229,11 @@ impl BackgroundScanner {
                 }
 
                 if let Some((dot_git_abs_path, path_in_git_dir)) = dot_git_paths {
-                    // We ignore `""` as well, as that is going to be the
-                    // `.git` folder itself. WE do not care about it, if
-                    // there are changes within we will see them, we need
-                    // this ignore to prevent us from accidentally observing
-                    // the ignored created file due to the events not being
-                    // empty after filtering.
-
-                    let is_dot_git_changed = {
-                        path_in_git_dir == Path::new("")
-                            && event.kind == Some(PathEventKind::Changed)
-                            && self.fs.is_dir(abs_path.as_path()).await
-                    };
                     let condition = skipped_files_in_dot_git.iter().any(|skipped| {
                         OsStr::new(skipped) == path_in_git_dir.as_path().as_os_str()
                     }) || skipped_dirs_in_dot_git
                         .iter()
-                        .any(|skipped_git_subdir| path_in_git_dir.starts_with(skipped_git_subdir))
-                        || is_dot_git_changed;
+                        .any(|skipped_git_subdir| path_in_git_dir.starts_with(skipped_git_subdir));
                     if condition {
                         log::debug!(
                             "ignoring event {abs_path:?} as it's in the .git directory among skipped files or directories"


### PR DESCRIPTION
This reverts #54329 and the part of #52499 that was an earlier attempt at the same thing, which caused us to incorrectly miss git state updates on Windows. cc @Veykril it seems like we need to find a different way to fix the problem of `.git` scanning cycles.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a bug causing stale git state on Windows.