### PR TITLE
project: Fix staleness occuring during external git operations

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1437,18 +1437,19 @@ impl GitStore {
                     );
                     return;
                 }
+                let updates_tx = downstream
+                    .as_ref()
+                    .map(|downstream| downstream.updates_tx.clone());
                 self.update_repositories_from_worktree(
                     *worktree_id,
                     project_environment.clone(),
                     next_repository_id.clone(),
-                    downstream
-                        .as_ref()
-                        .map(|downstream| downstream.updates_tx.clone()),
+                    updates_tx.clone(),
                     changed_repos.clone(),
                     fs.clone(),
                     cx,
                 );
-                self.local_worktree_git_repos_changed(worktree, changed_repos, cx);
+                self.local_worktree_git_repos_changed(worktree, changed_repos, updates_tx, cx);
             }
             WorktreeStoreEvent::WorktreeRemoved(_entity_id, worktree_id) => {
                 let repos_without_worktree: Vec<RepositoryId> = self
@@ -1825,9 +1826,12 @@ impl GitStore {
         &mut self,
         worktree: Entity<Worktree>,
         changed_repos: &UpdatedGitRepositoriesSet,
+        updates_tx: Option<mpsc::UnboundedSender<DownstreamUpdate>>,
         cx: &mut Context<Self>,
     ) {
-        log::debug!("local worktree repos changed");
+        log::debug!(
+            "local worktree repos changed; refreshing diff bases and scheduling status scan"
+        );
         debug_assert!(worktree.read(cx).is_local());
 
         for repository in self.repositories.values() {
@@ -1838,6 +1842,7 @@ impl GitStore {
                         || update.new_work_directory_abs_path.as_ref() == Some(repo_abs_path)
                 }) {
                     repository.reload_buffer_diff_bases(cx);
+                    repository.schedule_scan(updates_tx.clone(), cx);
                 }
             });
         }

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1777,7 +1777,16 @@ mod worktree_git_repo_update_tests {
 
         let output = Command::new("git")
             .current_dir(&work_dir)
-            .args(["commit", "--allow-empty", "-m", "empty"])
+            .args([
+                "-c",
+                "user.email=test@zed.dev",
+                "-c",
+                "user.name=test",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "empty",
+            ])
             .output()
             .await
             .expect("git commit");

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1715,3 +1715,93 @@ mod resolve_worktree_tests {
         }
     }
 }
+
+/// External git operations that change `.git` metadata without necessarily updating worktree entries
+/// should still refresh repository state (see `GitStore::local_worktree_git_repos_changed`).
+#[cfg(not(windows))]
+mod worktree_git_repo_update_tests {
+    use std::sync::{Arc, Mutex};
+
+    use crate::Project;
+
+    use fs::RealFs;
+    use gpui::TestAppContext;
+    use project::git_store::{GitStoreEvent, RepositoryEvent};
+    use serde_json::json;
+    use smol::process::Command;
+    use util::test::TempTree;
+    use worktree::WorktreeModelHandle as _;
+
+    #[gpui::test]
+    async fn external_empty_commit_emits_head_changed(cx: &mut TestAppContext) {
+        crate::init_test(cx);
+        cx.executor().allow_parking();
+
+        let root = TempTree::new(json!({
+            "project": {
+                "tracked.txt": "content",
+            }
+        }));
+
+        let work_dir = root.path().join("project");
+        let repo = crate::git_init(work_dir.as_path());
+        crate::git_add("tracked.txt", &repo);
+        crate::git_commit("Initial commit", &repo);
+
+        let head_before = repo.head().unwrap().target().unwrap().to_string();
+
+        let project = Project::test(
+            Arc::new(RealFs::new(None, cx.executor())),
+            [root.path()],
+            cx,
+        )
+        .await;
+
+        let repository_updates = Arc::new(Mutex::new(Vec::new()));
+        project.update(cx, |project, cx| {
+            let repo_events = repository_updates.clone();
+            cx.subscribe(project.git_store(), move |_, _, event, _| {
+                if let GitStoreEvent::RepositoryUpdated(_, event, _) = event {
+                    repo_events.lock().unwrap().push(event.clone());
+                }
+            })
+            .detach();
+        });
+
+        let tree = project.read_with(cx, |project, cx| project.worktrees(cx).next().unwrap());
+        tree.flush_fs_events(cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.executor().run_until_parked();
+
+        let output = Command::new("git")
+            .current_dir(&work_dir)
+            .args(["commit", "--allow-empty", "-m", "empty"])
+            .output()
+            .await
+            .expect("git commit");
+        assert!(
+            output.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        tree.flush_fs_events(cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.executor().run_until_parked();
+
+        let head_after = repo.head().unwrap().target().unwrap().to_string();
+        assert_ne!(head_before, head_after, "git commit should advance HEAD");
+
+        let events = repository_updates.lock().unwrap().clone();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, RepositoryEvent::HeadChanged)),
+            "expected HeadChanged after external git metadata change; got {events:?}"
+        );
+    }
+}


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #51398

Release Notes:

- Fixed stale git status in the panel and project after external git commands that only updated repository metadata (for example commits or checkouts from another terminal).
