### PR TITLE
gpui: Narrow profiler location borrow to static

### DIFF
--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -70,8 +70,8 @@ pub struct SerializedLocation {
     pub column: u32,
 }
 
-impl From<&core::panic::Location<'static>> for SerializedLocation {
-    fn from(value: &core::panic::Location<'static>) -> Self {
+impl From<&'static core::panic::Location<'static>> for SerializedLocation {
+    fn from(value: &'static core::panic::Location<'static>) -> Self {
         SerializedLocation {
             file: value.file().into(),
             line: value.line(),


### PR DESCRIPTION
## Summary

- narrow `SerializedLocation`'s `From` impl to accept `&'static core::panic::Location<'static>`
- match the actual `TaskTiming.location` type and keep the `SharedString` file conversion on the borrowed path

## Why

- `TaskTiming.location` already stores `&'static core::panic::Location<'static>`
- the broader `&core::panic::Location<'static>` signature weakens the outer borrow, which makes `value.file().into()` depend on a shorter borrow than the target `SharedString`
- narrowing the impl expresses the real invariant and avoids the lifetime escape seen on stable toolchains

## Validation

- `CARGO_HOME=/tmp/zed-pr-profiler-static-ref/.cargo-home CARGO_TARGET_DIR=/tmp/zed-pr-profiler-static-ref/target cargo check -p gpui --lib`
- this currently fails on untouched upstream code in `crates/gpui/src/text_system/line_wrapper.rs:202` with `error[E0658]: use of unstable library feature 'round_char_boundary'`

Release Notes:

- N/A
