### PR TITLE
terminal: Add setting to show terminal title in tabs

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1944,6 +1944,10 @@
     // Timeout for hover and Cmd-click path hyperlink discovery in milliseconds. Specifying a
     // timeout of `0` will disable path hyperlinking in terminal.
     "path_hyperlink_timeout_ms": 1,
+    // Whether to show the shell-driven terminal title in the tab.
+    //
+    // When enabled, terminal breadcrumbs are hidden and terminal tab rename is disabled.
+    "show_title_in_tab": false,
     // Whether to show a badge on the terminal panel icon with the count of open terminals.
     "show_count_badge": false,
     // Whether to invoke the OS-specific alert sound when the terminal bell (BEL character) is printed.

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -919,6 +919,7 @@ impl VsCodeSettings {
             scrollbar: None,
             scroll_multiplier: None,
             toolbar: None,
+            show_title_in_tab: None,
             show_count_badge: None,
             flexible: None,
         })

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -175,6 +175,12 @@ pub struct TerminalSettingsContent {
     /// Default: 45
     #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
     pub minimum_contrast: Option<f32>,
+    /// Whether to show the shell-driven terminal title in the tab.
+    ///
+    /// When enabled, terminal breadcrumbs are hidden and terminal tab rename is disabled.
+    ///
+    /// Default: false
+    pub show_title_in_tab: Option<bool>,
     /// Whether to show a badge on the terminal panel icon with the count of open terminals.
     ///
     /// Default: false

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5154,7 +5154,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn terminal_panel_section() -> [SettingsPageItem; 4] {
+    fn terminal_panel_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("Terminal Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5200,6 +5200,28 @@ fn panels_page() -> SettingsPage {
                             .terminal
                             .get_or_insert_default()
                             .show_count_badge = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Show Title in Tab",
+                description: "Show the terminal title in the tab, hide terminal breadcrumbs, and disable terminal tab renaming.",
+                field: Box::new(SettingField {
+                    json_path: Some("terminal.show_title_in_tab"),
+                    pick: |settings_content| {
+                        settings_content
+                            .terminal
+                            .as_ref()?
+                            .show_title_in_tab
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .terminal
+                            .get_or_insert_default()
+                            .show_title_in_tab = value;
                     },
                 }),
                 metadata: None,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -774,6 +774,7 @@ impl TerminalBuilder {
 
         Ok(String::from_utf16(&buf[..size as usize])?)
     }
+
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -933,6 +934,17 @@ impl TaskStatus {
 const FIND_HYPERLINK_THROTTLE_PX: Pixels = px(5.0);
 
 impl Terminal {
+    #[cfg(windows)]
+    fn strip_windows_verbatim_prefix(path: &str) -> std::borrow::Cow<'_, str> {
+        if let Some(path) = path.strip_prefix(r"\\?\UNC\") {
+            std::borrow::Cow::Owned(format!(r"\\{path}"))
+        } else if let Some(path) = path.strip_prefix(r"\\?\") {
+            std::borrow::Cow::Borrowed(path)
+        } else {
+            std::borrow::Cow::Borrowed(path)
+        }
+    }
+
     fn process_event(&mut self, event: AlacTermEvent, cx: &mut Context<Self>) {
         match event {
             AlacTermEvent::Title(title) => {
@@ -940,12 +952,15 @@ impl Terminal {
                 // and it would end up showing the shell executable path in breadcrumbs
                 #[cfg(windows)]
                 {
-                    if self
+                    let ignore_shell_program_title = self
                         .shell_program
                         .as_ref()
-                        .map(|e| *e == title)
-                        .unwrap_or(false)
-                    {
+                        .map(|shell_program| {
+                            Self::strip_windows_verbatim_prefix(shell_program)
+                                == Self::strip_windows_verbatim_prefix(&title)
+                        })
+                        .unwrap_or(false);
+                    if ignore_shell_program_title {
                         return;
                     }
                 }
@@ -3496,6 +3511,38 @@ mod tests {
                     );
                 }
             }
+        }
+
+        #[cfg(windows)]
+        #[gpui::test]
+        fn test_ignores_windows_shell_title_with_verbatim_prefix(cx: &mut TestAppContext) {
+            let terminal = cx.new(|cx| {
+                TerminalBuilder::new_display_only(
+                    CursorShape::default(),
+                    AlternateScroll::On,
+                    None,
+                    0,
+                    cx.background_executor(),
+                    PathStyle::local(),
+                )
+                .unwrap()
+                .subscribe(cx)
+            });
+
+            terminal.update(cx, |terminal, cx| {
+                terminal.shell_program =
+                    Some(r"\\?\C:\Program Files\PowerShell\7\pwsh.exe".to_string());
+
+                terminal.process_event(
+                    AlacTermEvent::Title(r"C:\Program Files\PowerShell\7\pwsh.exe".to_string()),
+                    cx,
+                );
+
+                assert!(
+                    terminal.breadcrumb_text.is_empty(),
+                    "default shell title should be ignored even when shell_program uses the \\\\?\\ prefix"
+                );
+            });
         }
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -51,6 +51,7 @@ pub struct TerminalSettings {
     pub minimum_contrast: f32,
     pub path_hyperlink_regexes: Vec<String>,
     pub path_hyperlink_timeout_ms: u64,
+    pub show_title_in_tab: bool,
     pub show_count_badge: bool,
     pub bell: TerminalBell,
 }
@@ -133,6 +134,7 @@ impl settings::Settings for TerminalSettings {
                 })
                 .collect(),
             path_hyperlink_timeout_ms: project_content.path_hyperlink_timeout_ms.unwrap(),
+            show_title_in_tab: user_content.show_title_in_tab.unwrap(),
             show_count_badge: user_content.show_count_badge.unwrap(),
             bell: user_content.bell.unwrap(),
         }
@@ -181,5 +183,59 @@ impl From<CursorShape> for AlacCursorStyle {
             shape: value.into(),
             blinking: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TerminalSettings;
+    use gpui::TestAppContext;
+    use settings::{
+        default_settings, LocalSettingsKind, LocalSettingsPath, Settings, SettingsLocation,
+        SettingsStore, WorktreeId,
+    };
+    use util::rel_path::RelPath;
+
+    #[gpui::test]
+    fn test_show_title_in_tab_comes_from_user_settings_while_project_shell_override_applies(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let mut store = SettingsStore::new(cx, &default_settings());
+            store.register_setting::<TerminalSettings>();
+            store.set_default_settings(&default_settings(), cx).unwrap();
+            store
+                .set_user_settings(r#"{ "terminal": { "show_title_in_tab": true } }"#, cx)
+                .unwrap();
+            store
+                .set_local_settings(
+                    WorktreeId::from_usize(1),
+                    LocalSettingsPath::InWorktree(RelPath::empty().into_arc()),
+                    LocalSettingsKind::Settings,
+                    Some(r#"{ "terminal": { "shell": { "program": "/bin/project-shell" } } }"#),
+                    cx,
+                )
+                .unwrap();
+
+            cx.set_global(store);
+
+            let settings_location = SettingsLocation {
+                worktree_id: WorktreeId::from_usize(1),
+                path: RelPath::empty(),
+            };
+
+            assert!(TerminalSettings::get(Some(settings_location), cx).show_title_in_tab);
+            assert_eq!(
+                TerminalSettings::get(
+                    Some(SettingsLocation {
+                        worktree_id: WorktreeId::from_usize(1),
+                        path: RelPath::empty(),
+                    }),
+                    cx,
+                )
+                .shell,
+                task::Shell::Program("/bin/project-shell".to_owned())
+            );
+        });
     }
 }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -138,6 +138,7 @@ pub struct TerminalView {
     hover_tooltip_update: Task<()>,
     workspace_id: Option<WorkspaceId>,
     show_breadcrumbs: bool,
+    show_title_in_tab: bool,
     block_below_cursor: Option<Rc<BlockProperties>>,
     scroll_top: Pixels,
     scroll_handle: TerminalScrollHandle,
@@ -282,6 +283,7 @@ impl TerminalView {
             mode: TerminalMode::Standalone,
             workspace_id,
             show_breadcrumbs: TerminalSettings::get_global(cx).toolbar.breadcrumbs,
+            show_title_in_tab: TerminalSettings::get_global(cx).show_title_in_tab,
             block_below_cursor: None,
             scroll_top: Pixels::ZERO,
             scroll_handle,
@@ -435,13 +437,18 @@ impl TerminalView {
         self.focus_handle.focus(window, cx);
     }
 
+    fn cancel_renaming(&mut self) {
+        self.rename_editor = None;
+        self.rename_editor_subscription = None;
+    }
+
     pub fn rename_terminal(
         &mut self,
         _: &RenameTerminal,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.terminal.read(cx).task().is_some() {
+        if self.show_title_in_tab || self.terminal.read(cx).task().is_some() {
             return;
         }
 
@@ -479,6 +486,35 @@ impl TerminalView {
             editor.focus_handle(cx).focus(window, cx);
         });
         cx.notify();
+    }
+
+    fn terminal_dynamic_title(&self, cx: &App) -> Option<String> {
+        let title = self.terminal().read(cx).breadcrumb_text.trim().to_owned();
+        (!title.is_empty()).then_some(title)
+    }
+
+    fn terminal_default_tab_title(&self, detail: usize, cx: &App) -> SharedString {
+        self.terminal().read(cx).title(detail == 0).into()
+    }
+
+    fn terminal_tab_title(&self, detail: usize, cx: &App) -> SharedString {
+        if self.show_title_in_tab
+            && let Some(dynamic_title) = self.terminal_dynamic_title(cx)
+        {
+            return dynamic_title.into();
+        }
+
+        if !self.show_title_in_tab {
+            if let Some(custom_title) = self
+                .custom_title
+                .as_ref()
+                .filter(|title| !title.trim().is_empty())
+            {
+                return custom_title.clone().into();
+            }
+        }
+
+        self.terminal_default_tab_title(detail, cx)
     }
 
     pub fn clear_bell(&mut self, cx: &mut Context<TerminalView>) {
@@ -554,7 +590,9 @@ impl TerminalView {
     fn settings_changed(&mut self, cx: &mut Context<Self>) {
         let settings = TerminalSettings::get_global(cx);
         let breadcrumb_visibility_changed = self.show_breadcrumbs != settings.toolbar.breadcrumbs;
+        let title_mode_changed = self.show_title_in_tab != settings.show_title_in_tab;
         self.show_breadcrumbs = settings.toolbar.breadcrumbs;
+        self.show_title_in_tab = settings.show_title_in_tab;
 
         let should_blink = match settings.blinking {
             TerminalBlink::Off => false,
@@ -581,6 +619,13 @@ impl TerminalView {
 
         if breadcrumb_visibility_changed {
             cx.emit(ItemEvent::UpdateBreadcrumbs);
+        }
+        if title_mode_changed {
+            if self.show_title_in_tab {
+                self.cancel_renaming();
+            }
+            cx.emit(ItemEvent::UpdateBreadcrumbs);
+            cx.emit(ItemEvent::UpdateTab);
         }
         cx.notify();
     }
@@ -1104,7 +1149,10 @@ fn subscribe_for_terminal_events(
                         cx,
                     ),
                 },
-                Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
+                Event::BreadcrumbsChanged => {
+                    cx.emit(ItemEvent::UpdateBreadcrumbs);
+                    cx.emit(ItemEvent::UpdateTab);
+                }
                 Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
                 Event::SelectionsChanged => {
                     window.invalidate_character_coordinates();
@@ -1327,12 +1375,7 @@ impl Item for TerminalView {
 
     fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
         let terminal = self.terminal().read(cx);
-        let title = self
-            .custom_title
-            .as_ref()
-            .filter(|title| !title.trim().is_empty())
-            .cloned()
-            .unwrap_or_else(|| terminal.title(true));
+        let title = self.terminal_tab_title(params.detail.unwrap_or_default(), cx);
 
         let (icon, icon_color, rerun_button) = match terminal.task() {
             Some(terminal_task) => match &terminal_task.status {
@@ -1429,11 +1472,7 @@ impl Item for TerminalView {
     }
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
-        if let Some(custom_title) = self.custom_title.as_ref().filter(|l| !l.trim().is_empty()) {
-            return custom_title.clone().into();
-        }
-        let terminal = self.terminal().read(cx);
-        terminal.title(detail == 0).into()
+        self.terminal_tab_title(detail, cx)
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {
@@ -1594,7 +1633,7 @@ impl Item for TerminalView {
         cx: &mut Context<Self>,
     ) -> Vec<(SharedString, Box<dyn gpui::Action>)> {
         let terminal = self.terminal.read(cx);
-        if terminal.task().is_none() {
+        if terminal.task().is_none() && !self.show_title_in_tab {
             vec![("Rename".into(), Box::new(RenameTerminal))]
         } else {
             Vec::new()
@@ -1665,7 +1704,10 @@ impl Item for TerminalView {
     }
 
     fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
-        if self.show_breadcrumbs && !self.terminal().read(cx).breadcrumb_text.trim().is_empty() {
+        if self.show_breadcrumbs
+            && !self.show_title_in_tab
+            && !self.terminal().read(cx).breadcrumb_text.trim().is_empty()
+        {
             ToolbarItemLocation::PrimaryLeft
         } else {
             ToolbarItemLocation::Hidden
@@ -2034,8 +2076,9 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::TestAppContext;
+    use gpui::{TestAppContext, UpdateGlobal};
     use project::{Entry, Project, ProjectPath, Worktree};
+    use std::cell::RefCell;
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
     use util::paths::PathStyle;
@@ -2761,6 +2804,432 @@ mod tests {
             let text = view.tab_content_text(0, cx);
             assert_ne!(text.as_ref(), "my-server");
         });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_prefers_dynamic_terminal_title(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text = "server: api-01".to_owned();
+        });
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        terminal_view.update(cx, |view, cx| {
+            view.set_custom_title(Some("manual-name".to_owned()), cx);
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), "server: api-01");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_falls_back_to_default_tab_title(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        let expected_default_title = terminal.read_with(cx, |terminal, _| terminal.title(true));
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text.clear();
+        });
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        terminal_view.update(cx, |view, cx| {
+            view.set_custom_title(Some("manual-name".to_owned()), cx);
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), expected_default_title);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_restores_custom_title_after_disabling(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text = "shell-owned-title".to_owned();
+        });
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        terminal_view.update(cx, |view, cx| {
+            view.set_custom_title(Some("manual-name".to_owned()), cx);
+        });
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        terminal_view.update(cx, |view, cx| {
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), "shell-owned-title");
+        });
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(false);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        terminal_view.update(cx, |view, cx| {
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), "manual-name");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_toggle_emits_update_tab_and_breadcrumbs(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(false);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        let events: Rc<RefCell<Vec<ItemEvent>>> = Rc::default();
+        cx.update({
+            let events = events.clone();
+            |cx| {
+                cx.subscribe(&terminal_view, move |_, event, _| {
+                    events.borrow_mut().push(*event);
+                })
+            }
+        })
+        .detach();
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        let events = events.borrow();
+        assert!(events.contains(&ItemEvent::UpdateTab));
+        assert!(events.contains(&ItemEvent::UpdateBreadcrumbs));
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_hides_terminal_breadcrumbs(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.toolbar.get_or_insert_default().breadcrumbs = Some(true);
+                    terminal.show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text = "server: api-01".to_owned();
+        });
+
+        cx.add_window(|window, cx| {
+            let view = TerminalView::new(
+                terminal.clone(),
+                workspace.downgrade(),
+                None,
+                project.downgrade(),
+                window,
+                cx,
+            );
+            assert_eq!(view.breadcrumb_location(cx), ToolbarItemLocation::Hidden);
+            view
+        })
+        .root(cx)
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_removes_rename_from_tab_menu(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+
+        cx.add_window(|window, cx| {
+            let view = TerminalView::new(
+                terminal.clone(),
+                workspace.downgrade(),
+                None,
+                project.downgrade(),
+                window,
+                cx,
+            );
+            let actions = view.tab_extra_context_menu_actions(window, cx);
+            assert!(!actions.iter().any(|(label, _)| label.as_ref() == "Rename"));
+            view
+        })
+        .root(cx)
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_makes_rename_action_a_no_op(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+
+        cx.add_window(|window, cx| {
+            let mut view = TerminalView::new(
+                terminal.clone(),
+                workspace.downgrade(),
+                None,
+                project.downgrade(),
+                window,
+                cx,
+            );
+            view.rename_terminal(&RenameTerminal, window, cx);
+            assert!(view.rename_editor.is_none());
+            view
+        })
+        .root(cx)
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_toggle_cancels_pending_rename(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.show_title_in_tab = Some(false);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text = "server: api-01".to_owned();
+        });
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                let mut view = TerminalView::new(
+                    terminal.clone(),
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                );
+                view.rename_terminal(&RenameTerminal, window, cx);
+                assert!(view.rename_editor.is_some());
+                assert!(view.rename_editor_subscription.is_some());
+                view
+            })
+            .root(cx)
+            .unwrap();
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        terminal_view.update(cx, |view, cx| {
+            assert!(view.rename_editor.is_none());
+            assert!(view.rename_editor_subscription.is_none());
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), "server: api-01");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_breadcrumbs_changed_emits_update_tab_when_show_title_in_tab(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal.clone(),
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        let events: Rc<RefCell<Vec<ItemEvent>>> = Rc::default();
+        cx.update({
+            let events = events.clone();
+            |cx| {
+                cx.subscribe(&terminal_view, move |_, event, _| {
+                    events.borrow_mut().push(*event);
+                })
+            }
+        })
+        .detach();
+
+        terminal.update(cx, |terminal, cx| {
+            terminal.breadcrumb_text = "server: api-01".to_owned();
+            cx.emit(Event::BreadcrumbsChanged);
+        });
+        cx.run_until_parked();
+
+        let events = events.borrow();
+        assert!(events.contains(&ItemEvent::UpdateBreadcrumbs));
+        assert!(events.contains(&ItemEvent::UpdateTab));
     }
 
     #[gpui::test]

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4032,6 +4032,7 @@ List of `integer` column numbers
     "toolbar": {
       "breadcrumbs": false
     },
+    "show_title_in_tab": false,
     "working_directory": "current_project_directory",
     "scrollbar": {
       "show": null
@@ -4483,9 +4484,34 @@ At the moment, only the `breadcrumbs` option is available, it controls displayin
 
 If the terminal title is empty, the breadcrumbs won't be shown.
 
+If `show_title_in_tab` is enabled, Zed hides terminal breadcrumbs even
+when `breadcrumbs` is `true`.
+
 The shell running in the terminal needs to be configured to emit the title.
 
 Example command to set the title: `echo -e "\e]2;New Title\007";`
+
+### Terminal: Show Title In Tab
+
+- Description: Whether to show the shell-driven terminal title in the tab.
+- Setting: `show_title_in_tab`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
+When enabled, Zed hides terminal breadcrumbs and disables terminal tab
+renaming. If the shell does not set a title, Zed falls back to the
+default terminal tab label.
+
+```json [settings]
+{
+  "terminal": {
+    "show_title_in_tab": true
+  }
+}
+```
 
 ### Terminal: Button
 

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -335,6 +335,27 @@ Show the terminal title in a breadcrumb toolbar:
 
 The title can be set by your shell using the escape sequence `\e]2;Title\007`.
 
+If `terminal.show_title_in_tab` is enabled, Zed hides terminal
+breadcrumbs even when `terminal.toolbar.breadcrumbs` is `true`.
+
+### Tab Titles
+
+If your shell sets a terminal title, you can show that title in the tab
+instead of the terminal toolbar:
+
+```json [settings]
+{
+  "terminal": {
+    "show_title_in_tab": true
+  }
+}
+```
+
+When enabled, Zed uses the shell-driven terminal title for the tab,
+hides terminal breadcrumbs, and disables terminal tab renaming. If the
+shell does not set a title, the tab falls back to Zed's default terminal
+label.
+
 ## Integration with Tasks
 
 The terminal integrates with Zed's [task system](./tasks.md). When you run a task, it executes in the terminal. Rerun the last task from a terminal with:


### PR DESCRIPTION
## Context

This adds a `terminal.show_title_in_tab` setting so terminal tabs can show
the current terminal title instead of only the default tab label.

When enabled, the terminal title takes ownership of the tab title and the
terminal breadcrumbs are hidden to avoid showing the same information twice.
Terminal rename is also disabled while the setting is on, but any existing
custom title is preserved and becomes visible again once the setting is
turned off.

This also fixes a Windows-specific issue where shell title events could show
the full shell path in tabs when the incoming title and the resolved shell
path differed only by the `\\?\` verbatim-path prefix.

## How to Review

- Review the new setting wiring in terminal settings, default settings,
  settings UI content, and VS Code import.
- Review the terminal tab title priority changes in `terminal_view`:
  terminal title when enabled, fallback to the existing default title when
  empty, and temporary suppression of custom rename titles while enabled.
- Review the rename gating in terminal tabs and context menus when
  `terminal.show_title_in_tab` is enabled.
- Review the Windows shell-title comparison in `terminal.rs`.
- Review the new tests covering dynamic-title precedence, fallback to the
  default tab title, breadcrumbs hiding, rename disabling, and the Windows
  path regression.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added `terminal.show_title_in_tab` to display terminal titles in tabs,
  hide duplicate terminal breadcrumbs, and disable terminal rename while the
  terminal title owns the tab title.
- Fixed Windows terminal tabs showing full shell paths when shell title
  events differed from the resolved shell path only by the `\\?\` prefix.