### PR TITLE
fs: Polling backend support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6438,6 +6438,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol",
+ "telemetry",
  "tempfile",
  "text",
  "time",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -35,6 +35,7 @@ proto.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smol.workspace = true
+telemetry.workspace = true
 tempfile.workspace = true
 text.workspace = true
 time.workspace = true

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -73,6 +73,118 @@ pub trait Watcher: Send + Sync {
     fn remove(&self, path: &Path) -> Result<()>;
 }
 
+/// Detect whether a path requires polling instead of native file watching.
+///
+/// Returns `true` for filesystem types where inotify/FSEvents/ReadDirectoryChanges
+/// silently fail to deliver events: 9P (WSL drvfs), NFS, CIFS/SMB, FUSE (sshfs), etc.
+///
+/// Can be overridden with the `ZED_FILE_WATCHER_MODE` environment variable:
+/// - `native` — always use native OS watcher
+/// - `poll` — always use polling
+/// - `auto` (default) — auto-detect based on filesystem type
+pub fn requires_poll_watcher(path: &Path) -> bool {
+    match std::env::var("ZED_FILE_WATCHER_MODE")
+        .as_deref()
+        .unwrap_or("auto")
+    {
+        "native" => return false,
+        "poll" => return true,
+        _ => {}
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return detect_requires_poll_watcher_linux(path);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = path;
+        false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn detect_requires_poll_watcher_linux(path: &Path) -> bool {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    // Check filesystem type via statfs
+    let c_path = match CString::new(path.as_os_str().as_bytes()) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(c_path.as_ptr(), &mut stat) } != 0 {
+        return false;
+    }
+
+    // Filesystem magic numbers where inotify does not deliver events.
+    // These are defined in linux/magic.h and statfs(2).
+    const V9FS_MAGIC: i64 = 0x01021997; // Plan 9 / WSL2 interop (drvfs)
+    const NFS_SUPER_MAGIC: i64 = 0x6969;
+    const CIFS_MAGIC: i64 = 0xFF534D42u32 as i64; // CIFS/SMB
+    const SMB_SUPER_MAGIC: i64 = 0x517B;
+    const SMB2_MAGIC: i64 = 0xFE534D42u32 as i64;
+    const FUSE_SUPER_MAGIC: i64 = 0x65735546; // FUSE (includes sshfs)
+
+    let fs_type = stat.f_type;
+    if fs_type == V9FS_MAGIC
+        || fs_type == NFS_SUPER_MAGIC
+        || fs_type == CIFS_MAGIC
+        || fs_type == SMB_SUPER_MAGIC
+        || fs_type == SMB2_MAGIC
+        || fs_type == FUSE_SUPER_MAGIC
+    {
+        log::info!(
+            "Detected network/virtual filesystem (type 0x{:x}) at {}, using poll watcher",
+            fs_type,
+            path.display()
+        );
+        return true;
+    }
+
+    // Also check for WSL + /mnt/<drive>/ pattern as a fallback
+    // in case statfs returns an unexpected type for drvfs
+    if is_wsl_drvfs_path(path) {
+        log::info!(
+            "Detected WSL drvfs mount at {}, using poll watcher",
+            path.display()
+        );
+        return true;
+    }
+
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl_drvfs_path(path: &Path) -> bool {
+    // Only relevant inside WSL
+    if std::env::var_os("WSL_DISTRO_NAME").is_none() {
+        if let Ok(version) = std::fs::read_to_string("/proc/version") {
+            let v = version.to_lowercase();
+            if !v.contains("microsoft") && !v.contains("wsl") {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    // Windows drives are mounted at /mnt/c, /mnt/d, etc.
+    let path_str = match path.to_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    if !path_str.starts_with("/mnt/") || path_str.len() < 6 {
+        return false;
+    }
+    let after_mnt = &path_str[5..];
+    after_mnt.starts_with(|c: char| c.is_ascii_alphabetic())
+        && (after_mnt.len() == 1 || after_mnt.as_bytes()[1] == b'/')
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum PathEventKind {
     Removed,
@@ -1059,9 +1171,44 @@ impl Fs for RealFs {
         use util::{ResultExt as _, paths::SanitizedPath};
         let executor = self.executor.clone();
 
+        let use_poll = requires_poll_watcher(path);
+
         let (tx, rx) = smol::channel::unbounded();
         let pending_paths: Arc<Mutex<Vec<PathEvent>>> = Default::default();
-        let watcher = Arc::new(fs_watcher::FsWatcher::new(tx, pending_paths.clone()));
+
+        let watcher: Arc<dyn Watcher> = if use_poll {
+            // Default poll interval: 2 seconds. Override with ZED_FILE_WATCHER_POLL_MS.
+            let poll_ms: u64 = std::env::var("ZED_FILE_WATCHER_POLL_MS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(2000)
+                .clamp(500, 30000);
+            let poll_interval = Duration::from_millis(poll_ms);
+
+            match fs_watcher::PollFsWatcher::new(
+                tx.clone(),
+                pending_paths.clone(),
+                poll_interval,
+            ) {
+                Ok(pw) => {
+                    log::info!(
+                        "Using poll watcher ({}ms interval) for {}",
+                        poll_ms,
+                        path.display()
+                    );
+                    Arc::new(pw)
+                }
+                Err(e) => {
+                    log::error!(
+                        "Failed to create poll watcher for {}, falling back to native: {e}",
+                        path.display()
+                    );
+                    Arc::new(fs_watcher::FsWatcher::new(tx.clone(), pending_paths.clone()))
+                }
+            }
+        } else {
+            Arc::new(fs_watcher::FsWatcher::new(tx.clone(), pending_paths.clone()))
+        };
 
         // If the path doesn't exist yet (e.g. settings.json), watch the parent dir to learn when it's created.
         if let Err(e) = watcher.add(path)

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -92,10 +92,9 @@ pub fn requires_poll_watcher(path: &Path) -> bool {
         _ => {}
     }
 
-    let path = effective_watch_path(path);
-
     #[cfg(target_os = "linux")]
     {
+        let path = effective_watch_path(path);
         return detect_requires_poll_watcher_linux(&path);
     }
 
@@ -1199,6 +1198,7 @@ impl Fs for RealFs {
                 fs_watcher::poll_interval().as_millis(),
                 path.display()
             );
+            telemetry::event!("fs_watcher_poll", path = path.display().to_string());
             fs_watcher::WatcherMode::Poll
         } else {
             fs_watcher::WatcherMode::Native

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1193,24 +1193,21 @@ impl Fs for RealFs {
         let (tx, rx) = smol::channel::unbounded();
         let pending_paths: Arc<Mutex<Vec<PathEvent>>> = Default::default();
 
-        let watcher: Arc<dyn Watcher> = if use_poll {
+        let mode = if use_poll {
             log::info!(
                 "Using poll watcher ({}ms interval) for {}",
                 fs_watcher::poll_interval().as_millis(),
                 path.display()
             );
-            Arc::new(fs_watcher::FsWatcher::new(
-                tx.clone(),
-                pending_paths.clone(),
-                fs_watcher::WatcherMode::Poll,
-            ))
+            fs_watcher::WatcherMode::Poll
         } else {
-            Arc::new(fs_watcher::FsWatcher::new(
-                tx.clone(),
-                pending_paths.clone(),
-                fs_watcher::WatcherMode::Native,
-            ))
+            fs_watcher::WatcherMode::Native
         };
+        let watcher: Arc<dyn Watcher> = Arc::new(fs_watcher::FsWatcher::new(
+            tx.clone(),
+            pending_paths.clone(),
+            mode,
+        ));
 
         if let Err(e) = watcher.add(&watch_path) {
             log::warn!(

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1202,30 +1202,23 @@ impl Fs for RealFs {
                 .clamp(500, 30000);
             let poll_interval = Duration::from_millis(poll_ms);
 
-            match fs_watcher::PollFsWatcher::new(tx.clone(), pending_paths.clone(), poll_interval) {
-                Ok(pw) => {
-                    log::info!(
-                        "Using poll watcher ({}ms interval) for {}",
-                        poll_ms,
-                        path.display()
-                    );
-                    Arc::new(pw)
-                }
-                Err(e) => {
-                    log::error!(
-                        "Failed to create poll watcher for {}, falling back to native: {e}",
-                        path.display()
-                    );
-                    Arc::new(fs_watcher::FsWatcher::new(
-                        tx.clone(),
-                        pending_paths.clone(),
-                    ))
-                }
-            }
+            log::info!(
+                "Using poll watcher ({}ms interval) for {}",
+                poll_ms,
+                path.display()
+            );
+            Arc::new(fs_watcher::FsWatcher::new(
+                tx.clone(),
+                pending_paths.clone(),
+                fs_watcher::WatcherMode::Poll,
+                Some(poll_interval),
+            ))
         } else {
             Arc::new(fs_watcher::FsWatcher::new(
                 tx.clone(),
                 pending_paths.clone(),
+                fs_watcher::WatcherMode::Native,
+                None,
             ))
         };
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -92,9 +92,11 @@ pub fn requires_poll_watcher(path: &Path) -> bool {
         _ => {}
     }
 
+    let path = effective_watch_path(path);
+
     #[cfg(target_os = "linux")]
     {
-        return detect_requires_poll_watcher_linux(path);
+        return detect_requires_poll_watcher_linux(&path);
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -102,6 +104,20 @@ pub fn requires_poll_watcher(path: &Path) -> bool {
         let _ = path;
         false
     }
+}
+
+pub fn effective_watch_path(path: &Path) -> PathBuf {
+    if path.exists() {
+        return path.to_path_buf();
+    }
+
+    for ancestor in path.ancestors() {
+        if ancestor.exists() {
+            return ancestor.to_path_buf();
+        }
+    }
+
+    path.to_path_buf()
 }
 
 #[cfg(target_os = "linux")]
@@ -1172,6 +1188,7 @@ impl Fs for RealFs {
         let executor = self.executor.clone();
 
         let use_poll = requires_poll_watcher(path);
+        let watch_path = effective_watch_path(path);
 
         let (tx, rx) = smol::channel::unbounded();
         let pending_paths: Arc<Mutex<Vec<PathEvent>>> = Default::default();
@@ -1185,11 +1202,7 @@ impl Fs for RealFs {
                 .clamp(500, 30000);
             let poll_interval = Duration::from_millis(poll_ms);
 
-            match fs_watcher::PollFsWatcher::new(
-                tx.clone(),
-                pending_paths.clone(),
-                poll_interval,
-            ) {
+            match fs_watcher::PollFsWatcher::new(tx.clone(), pending_paths.clone(), poll_interval) {
                 Ok(pw) => {
                     log::info!(
                         "Using poll watcher ({}ms interval) for {}",
@@ -1203,22 +1216,24 @@ impl Fs for RealFs {
                         "Failed to create poll watcher for {}, falling back to native: {e}",
                         path.display()
                     );
-                    Arc::new(fs_watcher::FsWatcher::new(tx.clone(), pending_paths.clone()))
+                    Arc::new(fs_watcher::FsWatcher::new(
+                        tx.clone(),
+                        pending_paths.clone(),
+                    ))
                 }
             }
         } else {
-            Arc::new(fs_watcher::FsWatcher::new(tx.clone(), pending_paths.clone()))
+            Arc::new(fs_watcher::FsWatcher::new(
+                tx.clone(),
+                pending_paths.clone(),
+            ))
         };
 
-        // If the path doesn't exist yet (e.g. settings.json), watch the parent dir to learn when it's created.
-        if let Err(e) = watcher.add(path)
-            && let Some(parent) = path.parent()
-            && let Err(parent_e) = watcher.add(parent)
-        {
+        if let Err(e) = watcher.add(&watch_path) {
             log::warn!(
-                "Failed to watch {} and its parent directory {}:\n{e}\n{parent_e}",
+                "Failed to watch {} using {}:\n{e}",
                 path.display(),
-                parent.display()
+                watch_path.display()
             );
         }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1194,31 +1194,21 @@ impl Fs for RealFs {
         let pending_paths: Arc<Mutex<Vec<PathEvent>>> = Default::default();
 
         let watcher: Arc<dyn Watcher> = if use_poll {
-            // Default poll interval: 2 seconds. Override with ZED_FILE_WATCHER_POLL_MS.
-            let poll_ms: u64 = std::env::var("ZED_FILE_WATCHER_POLL_MS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(2000)
-                .clamp(500, 30000);
-            let poll_interval = Duration::from_millis(poll_ms);
-
             log::info!(
                 "Using poll watcher ({}ms interval) for {}",
-                poll_ms,
+                fs_watcher::poll_interval().as_millis(),
                 path.display()
             );
             Arc::new(fs_watcher::FsWatcher::new(
                 tx.clone(),
                 pending_paths.clone(),
                 fs_watcher::WatcherMode::Poll,
-                Some(poll_interval),
             ))
         } else {
             Arc::new(fs_watcher::FsWatcher::new(
                 tx.clone(),
                 pending_paths.clone(),
                 fs_watcher::WatcherMode::Native,
-                None,
             ))
         };
 

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -5,10 +5,23 @@ use std::{
     ops::DerefMut,
     path::Path,
     sync::{Arc, OnceLock},
+    time::Duration,
 };
 use util::{ResultExt, paths::SanitizedPath};
 
 use crate::{PathEvent, PathEventKind, Watcher};
+
+/// Determines how file changes are detected.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WatcherMode {
+    /// Use the OS-native file watcher (inotify on Linux, FSEvents on macOS,
+    /// ReadDirectoryChanges on Windows). Most efficient but doesn't work on
+    /// network filesystems, WSL drvfs mounts, or FUSE mounts.
+    #[default]
+    Native,
+    /// Use polling to detect file changes. Works on all filesystems but uses more CPU.
+    Poll,
+}
 
 pub struct FsWatcher {
     tx: smol::channel::Sender<()>,
@@ -209,6 +222,103 @@ fn coalesce_pending_rescans(pending_paths: &mut Vec<PathEvent>, path_events: &mu
 
 fn is_covered_rescan(kind: Option<PathEventKind>, path: &Path, ancestor: &Path) -> bool {
     kind == Some(PathEventKind::Rescan) && path != ancestor && path.starts_with(ancestor)
+}
+
+/// A polling-based file watcher that works on any filesystem.
+///
+/// Unlike [`FsWatcher`] (which uses OS-native inotify/FSEvents/ReadDirectoryChanges),
+/// this periodically polls the filesystem for changes. Use this for network filesystems,
+/// WSL drvfs mounts, FUSE mounts, or other situations where native watchers silently
+/// fail to deliver events.
+pub struct PollFsWatcher {
+    watcher: Mutex<notify::PollWatcher>,
+    watched_paths: Mutex<Vec<Arc<std::path::Path>>>,
+}
+
+impl PollFsWatcher {
+    pub fn new(
+        tx: smol::channel::Sender<()>,
+        pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
+        poll_interval: Duration,
+    ) -> anyhow::Result<Self> {
+        let config = notify::Config::default().with_poll_interval(poll_interval);
+
+        let watcher = notify::PollWatcher::new(
+            move |event: Result<notify::Event, notify::Error>| {
+                let Some(event) = event
+                    .map_err(|e| log::warn!("poll watcher error: {e}"))
+                    .ok()
+                    .filter(|event| !matches!(event.kind, EventKind::Access(_)))
+                else {
+                    return;
+                };
+
+                let kind = match event.kind {
+                    EventKind::Create(_) => Some(PathEventKind::Created),
+                    EventKind::Modify(_) => Some(PathEventKind::Changed),
+                    EventKind::Remove(_) => Some(PathEventKind::Removed),
+                    _ => None,
+                };
+
+                let mut path_events = event
+                    .paths
+                    .iter()
+                    .map(|event_path| PathEvent {
+                        path: event_path.to_path_buf(),
+                        kind,
+                    })
+                    .collect::<Vec<_>>();
+
+                if !path_events.is_empty() {
+                    path_events.sort();
+                    let mut pending_paths = pending_path_events.lock();
+                    if pending_paths.is_empty() {
+                        tx.try_send(()).ok();
+                    }
+                    util::extend_sorted(&mut *pending_paths, path_events, usize::MAX, |a, b| {
+                        a.path.cmp(&b.path)
+                    });
+                }
+            },
+            config,
+        )?;
+
+        Ok(Self {
+            watcher: Mutex::new(watcher),
+            watched_paths: Mutex::new(Vec::new()),
+        })
+    }
+}
+
+impl Watcher for PollFsWatcher {
+    fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        use notify::Watcher as _;
+        log::trace!("poll watcher add: {path:?}");
+
+        {
+            let watched = self.watched_paths.lock();
+            if watched.iter().any(|p| path.starts_with(p.as_ref())) {
+                log::trace!("poll watcher: path already covered: {path:?}");
+                return Ok(());
+            }
+        }
+
+        self.watcher
+            .lock()
+            .watch(path, notify::RecursiveMode::Recursive)?;
+
+        self.watched_paths.lock().push(path.into());
+        Ok(())
+    }
+
+    fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        use notify::Watcher as _;
+        log::trace!("poll watcher remove: {path:?}");
+
+        self.watched_paths.lock().retain(|p| p.as_ref() != path);
+        self.watcher.lock().unwatch(path)?;
+        Ok(())
+    }
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -29,6 +29,64 @@ pub struct FsWatcher {
     registrations: Mutex<BTreeMap<Arc<std::path::Path>, WatcherRegistrationId>>,
 }
 
+fn enqueue_path_events(
+    tx: &smol::channel::Sender<()>,
+    pending_path_events: &Arc<Mutex<Vec<PathEvent>>>,
+    mut path_events: Vec<PathEvent>,
+) {
+    if path_events.is_empty() {
+        return;
+    }
+
+    path_events.sort();
+    let mut pending_paths = pending_path_events.lock();
+    if pending_paths.is_empty() {
+        tx.try_send(()).ok();
+    }
+    coalesce_pending_rescans(&mut pending_paths, &mut path_events);
+    util::extend_sorted(&mut *pending_paths, path_events, usize::MAX, |a, b| {
+        a.path.cmp(&b.path)
+    });
+}
+
+fn push_notify_event(
+    tx: &smol::channel::Sender<()>,
+    pending_path_events: &Arc<Mutex<Vec<PathEvent>>>,
+    watched_root: &Path,
+    event: &notify::Event,
+) {
+    let kind = match &event.kind {
+        // `need_rescan` is handled below, so unknown event kinds can still trigger recovery.
+        EventKind::Create(_) => Some(PathEventKind::Created),
+        EventKind::Modify(_) => Some(PathEventKind::Changed),
+        EventKind::Remove(_) => Some(PathEventKind::Removed),
+        _ => None,
+    };
+    let root_path = SanitizedPath::new_arc(watched_root);
+    let mut path_events = event
+        .paths
+        .iter()
+        .filter_map(|event_path| {
+            let event_path = SanitizedPath::new(event_path);
+            event_path.starts_with(&root_path).then(|| PathEvent {
+                path: event_path.as_path().to_path_buf(),
+                kind,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if event.need_rescan() {
+        log::warn!("filesystem watcher lost sync for {watched_root:?}; scheduling rescan");
+        path_events.retain(|path_event| path_event.path != watched_root);
+        path_events.push(PathEvent {
+            path: watched_root.to_path_buf(),
+            kind: Some(PathEventKind::Rescan),
+        });
+    }
+
+    enqueue_path_events(tx, pending_path_events, path_events);
+}
+
 impl FsWatcher {
     pub fn new(
         tx: smol::channel::Sender<()>,
@@ -92,7 +150,6 @@ impl Watcher for FsWatcher {
             }
         }
 
-        let root_path = SanitizedPath::new_arc(path);
         let path: Arc<std::path::Path> = path.into();
 
         #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -107,52 +164,7 @@ impl Watcher for FsWatcher {
             |g| {
                 g.add(watch_path, mode, move |event: &notify::Event| {
                     log::trace!("watcher received event: {event:?}");
-                    let kind = match event.kind {
-                        EventKind::Create(_) => Some(PathEventKind::Created),
-                        EventKind::Modify(_) => Some(PathEventKind::Changed),
-                        EventKind::Remove(_) => Some(PathEventKind::Removed),
-                        _ => None,
-                    };
-                    let mut path_events = event
-                        .paths
-                        .iter()
-                        .filter_map(|event_path| {
-                            let event_path = SanitizedPath::new(event_path);
-                            event_path.starts_with(&root_path).then(|| PathEvent {
-                                path: event_path.as_path().to_path_buf(),
-                                kind,
-                            })
-                        })
-                        .collect::<Vec<_>>();
-
-                    let is_rescan_event = event.need_rescan();
-                    if is_rescan_event {
-                        log::warn!(
-                            "filesystem watcher lost sync for {callback_path:?}; scheduling rescan"
-                        );
-                        // we only keep the first event per path below, this ensures it will be the rescan event
-                        // we'll remove any existing pending events for the same reason once we have the lock below
-                        path_events.retain(|p| &p.path != callback_path.as_ref());
-                        path_events.push(PathEvent {
-                            path: callback_path.to_path_buf(),
-                            kind: Some(PathEventKind::Rescan),
-                        });
-                    }
-
-                    if !path_events.is_empty() {
-                        path_events.sort();
-                        let mut pending_paths = pending_paths.lock();
-                        if pending_paths.is_empty() {
-                            tx.try_send(()).ok();
-                        }
-                        coalesce_pending_rescans(&mut pending_paths, &mut path_events);
-                        util::extend_sorted(
-                            &mut *pending_paths,
-                            path_events,
-                            usize::MAX,
-                            |a, b| a.path.cmp(&b.path),
-                        );
-                    }
+                    push_notify_event(&tx, &pending_paths, callback_path.as_ref(), event);
                 })
             }
         })??;
@@ -232,7 +244,7 @@ fn is_covered_rescan(kind: Option<PathEventKind>, path: &Path, ancestor: &Path) 
 /// fail to deliver events.
 pub struct PollFsWatcher {
     watcher: Mutex<notify::PollWatcher>,
-    watched_paths: Mutex<Vec<Arc<std::path::Path>>>,
+    watched_paths: Arc<Mutex<BTreeMap<Arc<std::path::Path>, usize>>>,
 }
 
 impl PollFsWatcher {
@@ -243,41 +255,38 @@ impl PollFsWatcher {
     ) -> anyhow::Result<Self> {
         let config = notify::Config::default().with_poll_interval(poll_interval);
 
+        let watched_paths = Arc::new(Mutex::new(BTreeMap::<Arc<std::path::Path>, usize>::new()));
+        let callback_paths = watched_paths.clone();
         let watcher = notify::PollWatcher::new(
-            move |event: Result<notify::Event, notify::Error>| {
-                let Some(event) = event
-                    .map_err(|e| log::warn!("poll watcher error: {e}"))
-                    .ok()
-                    .filter(|event| !matches!(event.kind, EventKind::Access(_)))
-                else {
-                    return;
-                };
-
-                let kind = match event.kind {
-                    EventKind::Create(_) => Some(PathEventKind::Created),
-                    EventKind::Modify(_) => Some(PathEventKind::Changed),
-                    EventKind::Remove(_) => Some(PathEventKind::Removed),
-                    _ => None,
-                };
-
-                let mut path_events = event
-                    .paths
-                    .iter()
-                    .map(|event_path| PathEvent {
-                        path: event_path.to_path_buf(),
-                        kind,
-                    })
-                    .collect::<Vec<_>>();
-
-                if !path_events.is_empty() {
-                    path_events.sort();
-                    let mut pending_paths = pending_path_events.lock();
-                    if pending_paths.is_empty() {
-                        tx.try_send(()).ok();
+            move |result: Result<notify::Event, notify::Error>| {
+                let watched_roots = callback_paths.lock().keys().cloned().collect::<Vec<_>>();
+                match result {
+                    Ok(event) => {
+                        if matches!(event.kind, EventKind::Access(_)) {
+                            return;
+                        }
+                        for watched_root in watched_roots {
+                            push_notify_event(
+                                &tx,
+                                &pending_path_events,
+                                watched_root.as_ref(),
+                                &event,
+                            );
+                        }
                     }
-                    util::extend_sorted(&mut *pending_paths, path_events, usize::MAX, |a, b| {
-                        a.path.cmp(&b.path)
-                    });
+                    Err(error) => {
+                        for watched_root in watched_roots {
+                            log::warn!("watcher error for {watched_root:?}: {error}");
+                            enqueue_path_events(
+                                &tx,
+                                &pending_path_events,
+                                vec![PathEvent {
+                                    path: watched_root.to_path_buf(),
+                                    kind: Some(PathEventKind::Rescan),
+                                }],
+                            );
+                        }
+                    }
                 }
             },
             config,
@@ -285,38 +294,59 @@ impl PollFsWatcher {
 
         Ok(Self {
             watcher: Mutex::new(watcher),
-            watched_paths: Mutex::new(Vec::new()),
+            watched_paths,
         })
     }
 }
 
 impl Watcher for PollFsWatcher {
     fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        use notify::Watcher as _;
         log::trace!("poll watcher add: {path:?}");
 
-        {
-            let watched = self.watched_paths.lock();
-            if watched.iter().any(|p| path.starts_with(p.as_ref())) {
-                log::trace!("poll watcher: path already covered: {path:?}");
-                return Ok(());
-            }
+        let path: Arc<std::path::Path> = path.into();
+        let mut path_counts = self.watched_paths.lock();
+        let path_already_covered = path_counts
+            .keys()
+            .any(|watched_path| path.starts_with(watched_path.as_ref()) && path != *watched_path);
+
+        if !path_already_covered && !path_counts.contains_key(&path) {
+            drop(path_counts);
+            use notify::Watcher as _;
+            self.watcher
+                .lock()
+                .watch(&path, notify::RecursiveMode::Recursive)?;
+            path_counts = self.watched_paths.lock();
         }
 
-        self.watcher
-            .lock()
-            .watch(path, notify::RecursiveMode::Recursive)?;
-
-        self.watched_paths.lock().push(path.into());
+        *path_counts.entry(path).or_insert(0) += 1;
         Ok(())
     }
 
     fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        use notify::Watcher as _;
         log::trace!("poll watcher remove: {path:?}");
 
-        self.watched_paths.lock().retain(|p| p.as_ref() != path);
-        self.watcher.lock().unwatch(path)?;
+        let path: Arc<std::path::Path> = path.into();
+        let mut path_counts = self.watched_paths.lock();
+        let Some(count) = path_counts.get_mut(&path) else {
+            return Ok(());
+        };
+
+        *count -= 1;
+        if *count > 0 {
+            return Ok(());
+        }
+
+        path_counts.remove(&path);
+        let path_is_still_covered = path_counts.keys().any(|watched_path| {
+            path.starts_with(watched_path.as_ref()) && path.as_ref() != watched_path.as_ref()
+        });
+        if path_is_still_covered {
+            return Ok(());
+        }
+
+        drop(path_counts);
+        use notify::Watcher as _;
+        self.watcher.lock().unwatch(&path)?;
         Ok(())
     }
 }

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -1,59 +1,38 @@
+use anyhow::anyhow;
 use notify::EventKind;
 use parking_lot::Mutex;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
+    ops::DerefMut,
     path::Path,
     sync::{Arc, OnceLock},
     time::Duration,
 };
-use util::paths::SanitizedPath;
+use util::{ResultExt, paths::SanitizedPath};
 
 use crate::{PathEvent, PathEventKind, Watcher};
 
-/// Determines how file changes are detected.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum WatcherMode {
-    /// Use the OS-native file watcher (inotify on Linux, FSEvents on macOS,
-    /// ReadDirectoryChanges on Windows). Most efficient but doesn't work on
-    /// network filesystems, WSL drvfs mounts, or FUSE mounts.
     #[default]
     Native,
-    /// Use polling to detect file changes. Works on all filesystems but uses more CPU.
     Poll,
 }
 
-enum WatchBackend {
-    Native(notify::RecommendedWatcher),
-    Poll(notify::PollWatcher),
-}
+type WatcherCallback = dyn for<'a> Fn(Result<&'a notify::Event, &'a notify::Error>) + Send + Sync;
 
-impl WatchBackend {
-    fn watch(&mut self, path: &Path, recursive_mode: notify::RecursiveMode) -> notify::Result<()> {
-        use notify::Watcher as _;
-
-        match self {
-            Self::Native(watcher) => watcher.watch(path, recursive_mode),
-            Self::Poll(watcher) => watcher.watch(path, recursive_mode),
-        }
-    }
-
-    fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
-        use notify::Watcher as _;
-
-        match self {
-            Self::Native(watcher) => watcher.unwatch(path),
-            Self::Poll(watcher) => watcher.unwatch(path),
-        }
-    }
+enum BackendSlot<T> {
+    Uninitialized,
+    Ready(T),
+    Failed(String),
 }
 
 pub struct FsWatcher {
-    backend: Mutex<Option<WatchBackend>>,
-    mode: WatcherMode,
-    poll_interval: Option<Duration>,
     tx: smol::channel::Sender<()>,
     pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
-    watched_paths: Arc<Mutex<BTreeMap<Arc<std::path::Path>, usize>>>,
+    registrations: Mutex<BTreeMap<Arc<std::path::Path>, WatcherRegistrationId>>,
+    mode: WatcherMode,
+    poll_interval: Option<Duration>,
 }
 
 fn enqueue_path_events(
@@ -138,133 +117,89 @@ impl FsWatcher {
         poll_interval: Option<Duration>,
     ) -> Self {
         Self {
-            backend: Mutex::new(None),
-            mode,
-            poll_interval,
             tx,
             pending_path_events,
-            watched_paths: Arc::new(Mutex::new(BTreeMap::new())),
+            registrations: Default::default(),
+            mode,
+            poll_interval,
         }
-    }
-
-    fn recursive_mode(&self) -> notify::RecursiveMode {
-        match self.mode {
-            WatcherMode::Native => native_recursive_mode(),
-            WatcherMode::Poll => notify::RecursiveMode::Recursive,
-        }
-    }
-
-    fn ensure_backend(&self) -> anyhow::Result<()> {
-        let mut backend = self.backend.lock();
-        if backend.is_some() {
-            return Ok(());
-        }
-
-        let callback_paths = self.watched_paths.clone();
-        let callback_tx = self.tx.clone();
-        let callback_pending_path_events = self.pending_path_events.clone();
-        let callback = move |result: Result<notify::Event, notify::Error>| {
-            let watched_roots = callback_paths.lock().keys().cloned().collect::<Vec<_>>();
-            match result {
-                Ok(event) => {
-                    if matches!(event.kind, EventKind::Access(_)) {
-                        return;
-                    }
-                    for watched_root in watched_roots {
-                        push_notify_event(
-                            &callback_tx,
-                            &callback_pending_path_events,
-                            watched_root.as_ref(),
-                            &event,
-                        );
-                    }
-                }
-                Err(error) => {
-                    for watched_root in watched_roots {
-                        push_notify_error(
-                            &callback_tx,
-                            &callback_pending_path_events,
-                            watched_root.as_ref(),
-                            &error,
-                        );
-                    }
-                }
-            }
-        };
-
-        *backend = Some(match self.mode {
-            WatcherMode::Native => WatchBackend::Native(notify::recommended_watcher(callback)?),
-            WatcherMode::Poll => {
-                let config = notify::Config::default()
-                    .with_poll_interval(self.poll_interval.unwrap_or(Duration::from_secs(2)));
-                WatchBackend::Poll(notify::PollWatcher::new(callback, config)?)
-            }
-        });
-        Ok(())
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
-fn native_recursive_mode() -> notify::RecursiveMode {
-    notify::RecursiveMode::Recursive
-}
+impl Drop for FsWatcher {
+    fn drop(&mut self) {
+        let mut registrations = BTreeMap::new();
+        {
+            let old = &mut self.registrations.lock();
+            std::mem::swap(old.deref_mut(), &mut registrations);
+        }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn native_recursive_mode() -> notify::RecursiveMode {
-    notify::RecursiveMode::NonRecursive
+        let global_watcher = global_watcher();
+        for (_, registration) in registrations {
+            global_watcher.remove(registration);
+        }
+    }
 }
 
 impl Watcher for FsWatcher {
     fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
         log::trace!("watcher add: {path:?}");
 
-        let path: Arc<std::path::Path> = path.into();
-        let mut path_counts = self.watched_paths.lock();
-        let path_already_covered = path_counts
-            .keys()
-            .any(|watched_path| path.starts_with(watched_path.as_ref()) && path != *watched_path);
-
-        if !path_already_covered && !path_counts.contains_key(&path) {
-            drop(path_counts);
-            self.ensure_backend()?;
-            self.backend
+        if (self.mode == WatcherMode::Poll
+            || native_recursive_mode() == notify::RecursiveMode::Recursive)
+            && let Some((watched_path, _)) = self
+                .registrations
                 .lock()
-                .as_mut()
-                .expect("backend initialized")
-                .watch(&path, self.recursive_mode())?;
-            path_counts = self.watched_paths.lock();
+                .range::<std::path::Path, _>((
+                    std::ops::Bound::Unbounded,
+                    std::ops::Bound::Included(path),
+                ))
+                .next_back()
+            && watched_path.as_ref() != path
+            && path.starts_with(watched_path.as_ref())
+        {
+            log::trace!(
+                "path to watch is covered by existing registration: {path:?}, {watched_path:?}"
+            );
+            return Ok(());
         }
 
-        *path_counts.entry(path).or_insert(0) += 1;
+        if self.registrations.lock().contains_key(path) {
+            log::trace!("path to watch is already registered: {path:?}");
+            return Ok(());
+        }
+
+        let tx = self.tx.clone();
+        let pending_path_events = self.pending_path_events.clone();
+        let watched_root: Arc<std::path::Path> = path.into();
+        let callback_root = watched_root.clone();
+        let registration_id = global_watcher().add(
+            watched_root.clone(),
+            self.mode,
+            self.poll_interval,
+            move |result| match result {
+                Ok(event) => {
+                    push_notify_event(&tx, &pending_path_events, callback_root.as_ref(), event)
+                }
+                Err(error) => {
+                    push_notify_error(&tx, &pending_path_events, callback_root.as_ref(), error)
+                }
+            },
+        )?;
+
+        self.registrations
+            .lock()
+            .insert(watched_root, registration_id);
         Ok(())
     }
 
     fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
         log::trace!("remove watched path: {path:?}");
-
-        let path: Arc<std::path::Path> = path.into();
-        let mut path_counts = self.watched_paths.lock();
-        let Some(count) = path_counts.get_mut(&path) else {
+        let Some(registration) = self.registrations.lock().remove(path) else {
             return Ok(());
         };
 
-        *count -= 1;
-        if *count > 0 {
-            return Ok(());
-        }
-
-        path_counts.remove(&path);
-        let path_is_still_covered = path_counts.keys().any(|watched_path| {
-            path.starts_with(watched_path.as_ref()) && path.as_ref() != watched_path.as_ref()
-        });
-        if path_is_still_covered {
-            return Ok(());
-        }
-
-        drop(path_counts);
-        if let Some(backend) = self.backend.lock().as_mut() {
-            backend.unwatch(&path)?;
-        }
+        global_watcher().remove(registration);
         Ok(())
     }
 }
@@ -319,10 +254,310 @@ fn is_covered_rescan(kind: Option<PathEventKind>, path: &Path, ancestor: &Path) 
     kind == Some(PathEventKind::Rescan) && path != ancestor && path.starts_with(ancestor)
 }
 
-pub struct NativeWatcherAvailability;
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct WatcherRegistrationId(u32);
 
-static FS_WATCHER_INSTANCE: OnceLock<anyhow::Result<NativeWatcherAvailability, notify::Error>> =
-    OnceLock::new();
+struct WatcherRegistrationState {
+    callback: Arc<WatcherCallback>,
+    path: Arc<std::path::Path>,
+    mode: WatcherMode,
+}
+
+struct WatcherState {
+    watchers: HashMap<WatcherRegistrationId, WatcherRegistrationState>,
+    native_path_registrations: HashMap<Arc<std::path::Path>, u32>,
+    poll_path_registrations: HashMap<Arc<std::path::Path>, u32>,
+    last_registration: WatcherRegistrationId,
+}
+
+pub struct GlobalWatcher {
+    state: Mutex<WatcherState>,
+
+    // DANGER: never keep state lock while holding backend watcher lock.
+    // Calling watch can synchronously trigger an event callback that needs state.
+    native_watcher: Mutex<BackendSlot<notify::RecommendedWatcher>>,
+    poll_watcher: Mutex<BackendSlot<notify::PollWatcher>>,
+}
+
+impl GlobalWatcher {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(WatcherState {
+                watchers: Default::default(),
+                native_path_registrations: Default::default(),
+                poll_path_registrations: Default::default(),
+                last_registration: Default::default(),
+            }),
+            native_watcher: Mutex::new(BackendSlot::Uninitialized),
+            poll_watcher: Mutex::new(BackendSlot::Uninitialized),
+        }
+    }
+
+    #[must_use]
+    fn add(
+        &self,
+        path: Arc<std::path::Path>,
+        mode: WatcherMode,
+        poll_interval: Option<Duration>,
+        cb: impl for<'a> Fn(Result<&'a notify::Event, &'a notify::Error>) + Send + Sync + 'static,
+    ) -> anyhow::Result<WatcherRegistrationId> {
+        let mut state = self.state.lock();
+        let path_registrations = Self::path_registrations_mut(&mut state, mode);
+
+        let path_already_covered =
+            Self::path_already_covered(path.as_ref(), path_registrations, mode);
+        if !path_already_covered && !path_registrations.contains_key(&path) {
+            drop(state);
+            self.watch_path(path.as_ref(), mode, poll_interval)?;
+            state = self.state.lock();
+        }
+
+        let id = state.last_registration;
+        state.last_registration = WatcherRegistrationId(id.0 + 1);
+        state.watchers.insert(
+            id,
+            WatcherRegistrationState {
+                callback: Arc::new(cb),
+                path: path.clone(),
+                mode,
+            },
+        );
+        *Self::path_registrations_mut(&mut state, mode)
+            .entry(path)
+            .or_insert(0) += 1;
+
+        Ok(id)
+    }
+
+    pub fn remove(&self, id: WatcherRegistrationId) {
+        let mut state = self.state.lock();
+        let Some(registration_state) = state.watchers.remove(&id) else {
+            return;
+        };
+
+        let path_registrations = Self::path_registrations_mut(&mut state, registration_state.mode);
+        let Some(count) = path_registrations.get_mut(&registration_state.path) else {
+            return;
+        };
+        *count -= 1;
+        if *count > 0 {
+            return;
+        }
+
+        path_registrations.remove(&registration_state.path);
+        let path_is_still_covered = Self::path_already_covered(
+            registration_state.path.as_ref(),
+            path_registrations,
+            registration_state.mode,
+        );
+        if path_is_still_covered {
+            return;
+        }
+
+        drop(state);
+        self.unwatch_path(registration_state.path.as_ref(), registration_state.mode)
+            .log_err();
+    }
+
+    fn handle_notify_result(
+        &self,
+        mode: WatcherMode,
+        result: Result<notify::Event, notify::Error>,
+    ) {
+        log::trace!("global handle event for {mode:?}: {result:?}");
+
+        let callbacks = {
+            let state = self.state.lock();
+            state
+                .watchers
+                .values()
+                .filter(|registration| registration.mode == mode)
+                .map(|registration| registration.callback.clone())
+                .collect::<Vec<_>>()
+        };
+
+        match result {
+            Ok(event) => {
+                if matches!(event.kind, EventKind::Access(_)) {
+                    return;
+                }
+                for callback in callbacks {
+                    callback(Ok(&event));
+                }
+            }
+            Err(error) => {
+                for callback in callbacks {
+                    callback(Err(&error));
+                }
+            }
+        }
+    }
+
+    fn ensure_native_watcher(&self) -> anyhow::Result<()> {
+        let mut watcher = self.native_watcher.lock();
+        match &mut *watcher {
+            BackendSlot::Ready(_) => Ok(()),
+            BackendSlot::Failed(error) => Err(anyhow!(error.clone())),
+            BackendSlot::Uninitialized => {
+                match notify::recommended_watcher(|result| {
+                    global_watcher().handle_notify_result(WatcherMode::Native, result)
+                }) {
+                    Ok(file_watcher) => {
+                        *watcher = BackendSlot::Ready(file_watcher);
+                        Ok(())
+                    }
+                    Err(error) => {
+                        let error = error.to_string();
+                        *watcher = BackendSlot::Failed(error.clone());
+                        Err(anyhow!(error))
+                    }
+                }
+            }
+        }
+    }
+
+    fn ensure_poll_watcher(&self, poll_interval: Option<Duration>) -> anyhow::Result<()> {
+        let mut watcher = self.poll_watcher.lock();
+        match &mut *watcher {
+            BackendSlot::Ready(_) => Ok(()),
+            BackendSlot::Failed(error) => Err(anyhow!(error.clone())),
+            BackendSlot::Uninitialized => {
+                let poll_interval = poll_interval.unwrap_or(Duration::from_secs(2));
+                let config = notify::Config::default().with_poll_interval(poll_interval);
+                match notify::PollWatcher::new(
+                    |result| global_watcher().handle_notify_result(WatcherMode::Poll, result),
+                    config,
+                ) {
+                    Ok(file_watcher) => {
+                        *watcher = BackendSlot::Ready(file_watcher);
+                        Ok(())
+                    }
+                    Err(error) => {
+                        let error = error.to_string();
+                        *watcher = BackendSlot::Failed(error.clone());
+                        Err(anyhow!(error))
+                    }
+                }
+            }
+        }
+    }
+
+    fn watch_path(
+        &self,
+        path: &Path,
+        mode: WatcherMode,
+        poll_interval: Option<Duration>,
+    ) -> anyhow::Result<()> {
+        use notify::Watcher as _;
+
+        match mode {
+            WatcherMode::Native => {
+                self.ensure_native_watcher()?;
+                let mut watcher = self.native_watcher.lock();
+                match &mut *watcher {
+                    BackendSlot::Ready(watcher) => watcher.watch(path, native_recursive_mode())?,
+                    BackendSlot::Failed(error) => return Err(anyhow!(error.clone())),
+                    BackendSlot::Uninitialized => {
+                        return Err(anyhow!("native watcher not initialized"));
+                    }
+                }
+            }
+            WatcherMode::Poll => {
+                self.ensure_poll_watcher(poll_interval)?;
+                let mut watcher = self.poll_watcher.lock();
+                match &mut *watcher {
+                    BackendSlot::Ready(watcher) => {
+                        watcher.watch(path, notify::RecursiveMode::Recursive)?
+                    }
+                    BackendSlot::Failed(error) => return Err(anyhow!(error.clone())),
+                    BackendSlot::Uninitialized => {
+                        return Err(anyhow!("poll watcher not initialized"));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn unwatch_path(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
+        use notify::Watcher as _;
+
+        match mode {
+            WatcherMode::Native => {
+                let mut watcher = self.native_watcher.lock();
+                if let BackendSlot::Ready(watcher) = &mut *watcher {
+                    watcher.unwatch(path)?;
+                }
+            }
+            WatcherMode::Poll => {
+                let mut watcher = self.poll_watcher.lock();
+                if let BackendSlot::Ready(watcher) = &mut *watcher {
+                    watcher.unwatch(path)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn path_registrations_mut(
+        state: &mut WatcherState,
+        mode: WatcherMode,
+    ) -> &mut HashMap<Arc<std::path::Path>, u32> {
+        match mode {
+            WatcherMode::Native => &mut state.native_path_registrations,
+            WatcherMode::Poll => &mut state.poll_path_registrations,
+        }
+    }
+
+    fn path_already_covered(
+        path: &Path,
+        path_registrations: &HashMap<Arc<std::path::Path>, u32>,
+        mode: WatcherMode,
+    ) -> bool {
+        match mode {
+            WatcherMode::Native => native_path_already_covered(path, path_registrations),
+            WatcherMode::Poll => path_registrations
+                .keys()
+                .any(|existing| existing.as_ref() != path && path.starts_with(existing.as_ref())),
+        }
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn native_recursive_mode() -> notify::RecursiveMode {
+    notify::RecursiveMode::Recursive
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn native_recursive_mode() -> notify::RecursiveMode {
+    notify::RecursiveMode::NonRecursive
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn native_path_already_covered(
+    path: &Path,
+    path_registrations: &HashMap<Arc<std::path::Path>, u32>,
+) -> bool {
+    path_registrations
+        .keys()
+        .any(|existing| existing.as_ref() != path && path.starts_with(existing.as_ref()))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn native_path_already_covered(
+    _path: &Path,
+    _path_registrations: &HashMap<Arc<std::path::Path>, u32>,
+) -> bool {
+    false
+}
+
+static FS_WATCHER_INSTANCE: OnceLock<GlobalWatcher> = OnceLock::new();
+
+fn global_watcher() -> &'static GlobalWatcher {
+    FS_WATCHER_INSTANCE.get_or_init(GlobalWatcher::new)
+}
 
 #[cfg(test)]
 mod tests {
@@ -415,13 +650,8 @@ mod tests {
     }
 }
 
-pub fn global<T>(f: impl FnOnce(&NativeWatcherAvailability) -> T) -> anyhow::Result<T> {
-    let result = FS_WATCHER_INSTANCE.get_or_init(|| {
-        notify::recommended_watcher(|_: Result<notify::Event, notify::Error>| {})
-            .map(|_| NativeWatcherAvailability)
-    });
-    match result {
-        Ok(availability) => Ok(f(availability)),
-        Err(error) => Err(anyhow::anyhow!("{error}")),
-    }
+pub fn global<T>(f: impl FnOnce(&GlobalWatcher) -> T) -> anyhow::Result<T> {
+    let global_watcher = global_watcher();
+    global_watcher.ensure_native_watcher()?;
+    Ok(f(global_watcher))
 }

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -1,13 +1,12 @@
 use notify::EventKind;
 use parking_lot::Mutex;
 use std::{
-    collections::{BTreeMap, HashMap},
-    ops::DerefMut,
+    collections::BTreeMap,
     path::Path,
     sync::{Arc, OnceLock},
     time::Duration,
 };
-use util::{ResultExt, paths::SanitizedPath};
+use util::paths::SanitizedPath;
 
 use crate::{PathEvent, PathEventKind, Watcher};
 
@@ -23,10 +22,38 @@ pub enum WatcherMode {
     Poll,
 }
 
+enum WatchBackend {
+    Native(notify::RecommendedWatcher),
+    Poll(notify::PollWatcher),
+}
+
+impl WatchBackend {
+    fn watch(&mut self, path: &Path, recursive_mode: notify::RecursiveMode) -> notify::Result<()> {
+        use notify::Watcher as _;
+
+        match self {
+            Self::Native(watcher) => watcher.watch(path, recursive_mode),
+            Self::Poll(watcher) => watcher.watch(path, recursive_mode),
+        }
+    }
+
+    fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+        use notify::Watcher as _;
+
+        match self {
+            Self::Native(watcher) => watcher.unwatch(path),
+            Self::Poll(watcher) => watcher.unwatch(path),
+        }
+    }
+}
+
 pub struct FsWatcher {
+    backend: Mutex<Option<WatchBackend>>,
+    mode: WatcherMode,
+    poll_interval: Option<Duration>,
     tx: smol::channel::Sender<()>,
     pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
-    registrations: Mutex<BTreeMap<Arc<std::path::Path>, WatcherRegistrationId>>,
+    watched_paths: Arc<Mutex<BTreeMap<Arc<std::path::Path>, usize>>>,
 }
 
 fn enqueue_path_events(
@@ -56,7 +83,6 @@ fn push_notify_event(
     event: &notify::Event,
 ) {
     let kind = match &event.kind {
-        // `need_rescan` is handled below, so unknown event kinds can still trigger recovery.
         EventKind::Create(_) => Some(PathEventKind::Created),
         EventKind::Modify(_) => Some(PathEventKind::Changed),
         EventKind::Remove(_) => Some(PathEventKind::Removed),
@@ -87,102 +113,159 @@ fn push_notify_event(
     enqueue_path_events(tx, pending_path_events, path_events);
 }
 
+fn push_notify_error(
+    tx: &smol::channel::Sender<()>,
+    pending_path_events: &Arc<Mutex<Vec<PathEvent>>>,
+    watched_root: &Path,
+    error: &notify::Error,
+) {
+    log::warn!("watcher error for {watched_root:?}: {error}");
+    enqueue_path_events(
+        tx,
+        pending_path_events,
+        vec![PathEvent {
+            path: watched_root.to_path_buf(),
+            kind: Some(PathEventKind::Rescan),
+        }],
+    );
+}
+
 impl FsWatcher {
     pub fn new(
         tx: smol::channel::Sender<()>,
         pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
+        mode: WatcherMode,
+        poll_interval: Option<Duration>,
     ) -> Self {
         Self {
+            backend: Mutex::new(None),
+            mode,
+            poll_interval,
             tx,
             pending_path_events,
-            registrations: Default::default(),
+            watched_paths: Arc::new(Mutex::new(BTreeMap::new())),
         }
+    }
+
+    fn recursive_mode(&self) -> notify::RecursiveMode {
+        match self.mode {
+            WatcherMode::Native => native_recursive_mode(),
+            WatcherMode::Poll => notify::RecursiveMode::Recursive,
+        }
+    }
+
+    fn ensure_backend(&self) -> anyhow::Result<()> {
+        let mut backend = self.backend.lock();
+        if backend.is_some() {
+            return Ok(());
+        }
+
+        let callback_paths = self.watched_paths.clone();
+        let callback_tx = self.tx.clone();
+        let callback_pending_path_events = self.pending_path_events.clone();
+        let callback = move |result: Result<notify::Event, notify::Error>| {
+            let watched_roots = callback_paths.lock().keys().cloned().collect::<Vec<_>>();
+            match result {
+                Ok(event) => {
+                    if matches!(event.kind, EventKind::Access(_)) {
+                        return;
+                    }
+                    for watched_root in watched_roots {
+                        push_notify_event(
+                            &callback_tx,
+                            &callback_pending_path_events,
+                            watched_root.as_ref(),
+                            &event,
+                        );
+                    }
+                }
+                Err(error) => {
+                    for watched_root in watched_roots {
+                        push_notify_error(
+                            &callback_tx,
+                            &callback_pending_path_events,
+                            watched_root.as_ref(),
+                            &error,
+                        );
+                    }
+                }
+            }
+        };
+
+        *backend = Some(match self.mode {
+            WatcherMode::Native => WatchBackend::Native(notify::recommended_watcher(callback)?),
+            WatcherMode::Poll => {
+                let config = notify::Config::default()
+                    .with_poll_interval(self.poll_interval.unwrap_or(Duration::from_secs(2)));
+                WatchBackend::Poll(notify::PollWatcher::new(callback, config)?)
+            }
+        });
+        Ok(())
     }
 }
 
-impl Drop for FsWatcher {
-    fn drop(&mut self) {
-        let mut registrations = BTreeMap::new();
-        {
-            let old = &mut self.registrations.lock();
-            std::mem::swap(old.deref_mut(), &mut registrations);
-        }
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn native_recursive_mode() -> notify::RecursiveMode {
+    notify::RecursiveMode::Recursive
+}
 
-        let _ = global(|g| {
-            for (_, registration) in registrations {
-                g.remove(registration);
-            }
-        });
-    }
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn native_recursive_mode() -> notify::RecursiveMode {
+    notify::RecursiveMode::NonRecursive
 }
 
 impl Watcher for FsWatcher {
     fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
         log::trace!("watcher add: {path:?}");
-        let tx = self.tx.clone();
-        let pending_paths = self.pending_path_events.clone();
-
-        #[cfg(any(target_os = "windows", target_os = "macos"))]
-        {
-            // Return early if an ancestor of this path was already being watched.
-            // saves a huge amount of memory
-            if let Some((watched_path, _)) = self
-                .registrations
-                .lock()
-                .range::<std::path::Path, _>((
-                    std::ops::Bound::Unbounded,
-                    std::ops::Bound::Included(path),
-                ))
-                .next_back()
-                && path.starts_with(watched_path.as_ref())
-            {
-                log::trace!(
-                    "path to watch is covered by existing registration: {path:?}, {watched_path:?}"
-                );
-                return Ok(());
-            }
-        }
-        #[cfg(target_os = "linux")]
-        {
-            if self.registrations.lock().contains_key(path) {
-                log::trace!("path to watch is already watched: {path:?}");
-                return Ok(());
-            }
-        }
 
         let path: Arc<std::path::Path> = path.into();
+        let mut path_counts = self.watched_paths.lock();
+        let path_already_covered = path_counts
+            .keys()
+            .any(|watched_path| path.starts_with(watched_path.as_ref()) && path != *watched_path);
 
-        #[cfg(any(target_os = "windows", target_os = "macos"))]
-        let mode = notify::RecursiveMode::Recursive;
-        #[cfg(target_os = "linux")]
-        let mode = notify::RecursiveMode::NonRecursive;
+        if !path_already_covered && !path_counts.contains_key(&path) {
+            drop(path_counts);
+            self.ensure_backend()?;
+            self.backend
+                .lock()
+                .as_mut()
+                .expect("backend initialized")
+                .watch(&path, self.recursive_mode())?;
+            path_counts = self.watched_paths.lock();
+        }
 
-        let registration_path = path.clone();
-        let registration_id = global({
-            let watch_path = path.clone();
-            let callback_path = path;
-            |g| {
-                g.add(watch_path, mode, move |event: &notify::Event| {
-                    log::trace!("watcher received event: {event:?}");
-                    push_notify_event(&tx, &pending_paths, callback_path.as_ref(), event);
-                })
-            }
-        })??;
-
-        self.registrations
-            .lock()
-            .insert(registration_path, registration_id);
-
+        *path_counts.entry(path).or_insert(0) += 1;
         Ok(())
     }
 
     fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
         log::trace!("remove watched path: {path:?}");
-        let Some(registration) = self.registrations.lock().remove(path) else {
+
+        let path: Arc<std::path::Path> = path.into();
+        let mut path_counts = self.watched_paths.lock();
+        let Some(count) = path_counts.get_mut(&path) else {
             return Ok(());
         };
 
-        global(|w| w.remove(registration))
+        *count -= 1;
+        if *count > 0 {
+            return Ok(());
+        }
+
+        path_counts.remove(&path);
+        let path_is_still_covered = path_counts.keys().any(|watched_path| {
+            path.starts_with(watched_path.as_ref()) && path.as_ref() != watched_path.as_ref()
+        });
+        if path_is_still_covered {
+            return Ok(());
+        }
+
+        drop(path_counts);
+        if let Some(backend) = self.backend.lock().as_mut() {
+            backend.unwatch(&path)?;
+        }
+        Ok(())
     }
 }
 
@@ -236,216 +319,9 @@ fn is_covered_rescan(kind: Option<PathEventKind>, path: &Path, ancestor: &Path) 
     kind == Some(PathEventKind::Rescan) && path != ancestor && path.starts_with(ancestor)
 }
 
-/// A polling-based file watcher that works on any filesystem.
-///
-/// Unlike [`FsWatcher`] (which uses OS-native inotify/FSEvents/ReadDirectoryChanges),
-/// this periodically polls the filesystem for changes. Use this for network filesystems,
-/// WSL drvfs mounts, FUSE mounts, or other situations where native watchers silently
-/// fail to deliver events.
-pub struct PollFsWatcher {
-    watcher: Mutex<notify::PollWatcher>,
-    watched_paths: Arc<Mutex<BTreeMap<Arc<std::path::Path>, usize>>>,
-}
+pub struct NativeWatcherAvailability;
 
-impl PollFsWatcher {
-    pub fn new(
-        tx: smol::channel::Sender<()>,
-        pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
-        poll_interval: Duration,
-    ) -> anyhow::Result<Self> {
-        let config = notify::Config::default().with_poll_interval(poll_interval);
-
-        let watched_paths = Arc::new(Mutex::new(BTreeMap::<Arc<std::path::Path>, usize>::new()));
-        let callback_paths = watched_paths.clone();
-        let watcher = notify::PollWatcher::new(
-            move |result: Result<notify::Event, notify::Error>| {
-                let watched_roots = callback_paths.lock().keys().cloned().collect::<Vec<_>>();
-                match result {
-                    Ok(event) => {
-                        if matches!(event.kind, EventKind::Access(_)) {
-                            return;
-                        }
-                        for watched_root in watched_roots {
-                            push_notify_event(
-                                &tx,
-                                &pending_path_events,
-                                watched_root.as_ref(),
-                                &event,
-                            );
-                        }
-                    }
-                    Err(error) => {
-                        for watched_root in watched_roots {
-                            log::warn!("watcher error for {watched_root:?}: {error}");
-                            enqueue_path_events(
-                                &tx,
-                                &pending_path_events,
-                                vec![PathEvent {
-                                    path: watched_root.to_path_buf(),
-                                    kind: Some(PathEventKind::Rescan),
-                                }],
-                            );
-                        }
-                    }
-                }
-            },
-            config,
-        )?;
-
-        Ok(Self {
-            watcher: Mutex::new(watcher),
-            watched_paths,
-        })
-    }
-}
-
-impl Watcher for PollFsWatcher {
-    fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        log::trace!("poll watcher add: {path:?}");
-
-        let path: Arc<std::path::Path> = path.into();
-        let mut path_counts = self.watched_paths.lock();
-        let path_already_covered = path_counts
-            .keys()
-            .any(|watched_path| path.starts_with(watched_path.as_ref()) && path != *watched_path);
-
-        if !path_already_covered && !path_counts.contains_key(&path) {
-            drop(path_counts);
-            use notify::Watcher as _;
-            self.watcher
-                .lock()
-                .watch(&path, notify::RecursiveMode::Recursive)?;
-            path_counts = self.watched_paths.lock();
-        }
-
-        *path_counts.entry(path).or_insert(0) += 1;
-        Ok(())
-    }
-
-    fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        log::trace!("poll watcher remove: {path:?}");
-
-        let path: Arc<std::path::Path> = path.into();
-        let mut path_counts = self.watched_paths.lock();
-        let Some(count) = path_counts.get_mut(&path) else {
-            return Ok(());
-        };
-
-        *count -= 1;
-        if *count > 0 {
-            return Ok(());
-        }
-
-        path_counts.remove(&path);
-        let path_is_still_covered = path_counts.keys().any(|watched_path| {
-            path.starts_with(watched_path.as_ref()) && path.as_ref() != watched_path.as_ref()
-        });
-        if path_is_still_covered {
-            return Ok(());
-        }
-
-        drop(path_counts);
-        use notify::Watcher as _;
-        self.watcher.lock().unwatch(&path)?;
-        Ok(())
-    }
-}
-
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct WatcherRegistrationId(u32);
-
-struct WatcherRegistrationState {
-    callback: Arc<dyn Fn(&notify::Event) + Send + Sync>,
-    path: Arc<std::path::Path>,
-}
-
-struct WatcherState {
-    watchers: HashMap<WatcherRegistrationId, WatcherRegistrationState>,
-    path_registrations: HashMap<Arc<std::path::Path>, u32>,
-    last_registration: WatcherRegistrationId,
-}
-
-pub struct GlobalWatcher {
-    state: Mutex<WatcherState>,
-
-    // DANGER: never keep the state lock while holding the watcher lock
-    // two mutexes because calling watcher.add triggers an watcher.event, which needs watchers.
-    #[cfg(target_os = "linux")]
-    watcher: Mutex<notify::INotifyWatcher>,
-    #[cfg(target_os = "freebsd")]
-    watcher: Mutex<notify::KqueueWatcher>,
-    #[cfg(target_os = "windows")]
-    watcher: Mutex<notify::ReadDirectoryChangesWatcher>,
-    #[cfg(target_os = "macos")]
-    watcher: Mutex<notify::FsEventWatcher>,
-}
-
-impl GlobalWatcher {
-    #[must_use]
-    fn add(
-        &self,
-        path: Arc<std::path::Path>,
-        mode: notify::RecursiveMode,
-        cb: impl Fn(&notify::Event) + Send + Sync + 'static,
-    ) -> anyhow::Result<WatcherRegistrationId> {
-        use notify::Watcher;
-
-        let mut state = self.state.lock();
-
-        // Check if this path is already covered by an existing watched ancestor path.
-        // On macOS and Windows, watching is recursive, so we don't need to watch
-        // child paths if an ancestor is already being watched.
-        #[cfg(any(target_os = "windows", target_os = "macos"))]
-        let path_already_covered = state.path_registrations.keys().any(|existing| {
-            path.starts_with(existing.as_ref()) && path.as_ref() != existing.as_ref()
-        });
-
-        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-        let path_already_covered = false;
-
-        if !path_already_covered && !state.path_registrations.contains_key(&path) {
-            drop(state);
-            self.watcher.lock().watch(&path, mode)?;
-            state = self.state.lock();
-        }
-
-        let id = state.last_registration;
-        state.last_registration = WatcherRegistrationId(id.0 + 1);
-
-        let registration_state = WatcherRegistrationState {
-            callback: Arc::new(cb),
-            path: path.clone(),
-        };
-        state.watchers.insert(id, registration_state);
-        *state.path_registrations.entry(path).or_insert(0) += 1;
-
-        Ok(id)
-    }
-
-    pub fn remove(&self, id: WatcherRegistrationId) {
-        use notify::Watcher;
-        let mut state = self.state.lock();
-        let Some(registration_state) = state.watchers.remove(&id) else {
-            return;
-        };
-
-        let Some(count) = state.path_registrations.get_mut(&registration_state.path) else {
-            return;
-        };
-        *count -= 1;
-        if *count == 0 {
-            state.path_registrations.remove(&registration_state.path);
-
-            drop(state);
-            self.watcher
-                .lock()
-                .unwatch(&registration_state.path)
-                .log_err();
-        }
-    }
-}
-
-static FS_WATCHER_INSTANCE: OnceLock<anyhow::Result<GlobalWatcher, notify::Error>> =
+static FS_WATCHER_INSTANCE: OnceLock<anyhow::Result<NativeWatcherAvailability, notify::Error>> =
     OnceLock::new();
 
 #[cfg(test)]
@@ -539,45 +415,13 @@ mod tests {
     }
 }
 
-fn handle_event(event: Result<notify::Event, notify::Error>) {
-    log::trace!("global handle event: {event:?}");
-    // Filter out access events, which could lead to a weird bug on Linux after upgrading notify
-    // https://github.com/zed-industries/zed/actions/runs/14085230504/job/39449448832
-    let Some(event) = event
-        .log_err()
-        .filter(|event| !matches!(event.kind, EventKind::Access(_)))
-    else {
-        return;
-    };
-    global::<()>(move |watcher| {
-        let callbacks = {
-            let state = watcher.state.lock();
-            state
-                .watchers
-                .values()
-                .map(|r| r.callback.clone())
-                .collect::<Vec<_>>()
-        };
-        for callback in callbacks {
-            callback(&event);
-        }
-    })
-    .log_err();
-}
-
-pub fn global<T>(f: impl FnOnce(&GlobalWatcher) -> T) -> anyhow::Result<T> {
+pub fn global<T>(f: impl FnOnce(&NativeWatcherAvailability) -> T) -> anyhow::Result<T> {
     let result = FS_WATCHER_INSTANCE.get_or_init(|| {
-        notify::recommended_watcher(handle_event).map(|file_watcher| GlobalWatcher {
-            state: Mutex::new(WatcherState {
-                watchers: Default::default(),
-                path_registrations: Default::default(),
-                last_registration: Default::default(),
-            }),
-            watcher: Mutex::new(file_watcher),
-        })
+        notify::recommended_watcher(|_: Result<notify::Event, notify::Error>| {})
+            .map(|_| NativeWatcherAvailability)
     });
     match result {
-        Ok(g) => Ok(f(g)),
-        Err(e) => Err(anyhow::anyhow!("{e}")),
+        Ok(availability) => Ok(f(availability)),
+        Err(error) => Err(anyhow::anyhow!("{error}")),
     }
 }

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -1,11 +1,10 @@
-use anyhow::anyhow;
 use notify::EventKind;
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, HashMap},
     ops::DerefMut,
     path::Path,
-    sync::{Arc, OnceLock},
+    sync::{Arc, LazyLock, OnceLock},
     time::Duration,
 };
 use util::{ResultExt, paths::SanitizedPath};
@@ -19,20 +18,105 @@ pub enum WatcherMode {
     Poll,
 }
 
-type WatcherCallback = dyn for<'a> Fn(Result<&'a notify::Event, &'a notify::Error>) + Send + Sync;
-
-enum BackendSlot<T> {
-    Uninitialized,
-    Ready(T),
-    Failed(String),
-}
-
 pub struct FsWatcher {
     tx: smol::channel::Sender<()>,
     pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
     registrations: Mutex<BTreeMap<Arc<std::path::Path>, WatcherRegistrationId>>,
     mode: WatcherMode,
-    poll_interval: Option<Duration>,
+}
+
+impl FsWatcher {
+    pub fn new(
+        tx: smol::channel::Sender<()>,
+        pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
+        mode: WatcherMode,
+    ) -> Self {
+        Self {
+            tx,
+            pending_path_events,
+            registrations: Default::default(),
+            mode,
+        }
+    }
+}
+
+impl Drop for FsWatcher {
+    fn drop(&mut self) {
+        let mut registrations = BTreeMap::new();
+        {
+            let old = &mut self.registrations.lock();
+            std::mem::swap(old.deref_mut(), &mut registrations);
+        }
+
+        let global_watcher = global_watcher();
+        for (_, registration) in registrations {
+            global_watcher.remove(registration);
+        }
+    }
+}
+
+impl Watcher for FsWatcher {
+    fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        log::trace!("watcher add: {path:?}");
+        let tx = self.tx.clone();
+        let pending_path_events = self.pending_path_events.clone();
+
+        if (self.mode == WatcherMode::Poll || cfg!(any(target_os = "windows", target_os = "macos")))
+            && let Some((watched_path, _)) = self
+                .registrations
+                .lock()
+                .range::<std::path::Path, _>((
+                    std::ops::Bound::Unbounded,
+                    std::ops::Bound::Included(path),
+                ))
+                .next_back()
+            && path.starts_with(watched_path.as_ref())
+        {
+            log::trace!(
+                "path to watch is covered by existing registration: {path:?}, {watched_path:?}"
+            );
+            return Ok(());
+        }
+
+        if self.registrations.lock().contains_key(path) {
+            log::trace!("path to watch is already watched: {path:?}");
+            return Ok(());
+        }
+
+        let root_path = SanitizedPath::new_arc(path);
+        let path: Arc<std::path::Path> = path.into();
+
+        let registration_path = path.clone();
+        let registration_id = global_watcher().add(
+            path.clone(),
+            self.mode,
+            move |result: Result<&notify::Event, &notify::Error>| match result {
+                Ok(event) => {
+                    log::trace!("watcher received event: {event:?}");
+                    push_notify_event(&tx, &pending_path_events, &root_path, path.as_ref(), event);
+                }
+                Err(error) => {
+                    push_notify_error(&tx, &pending_path_events, path.as_ref(), error);
+                }
+            },
+        )?;
+
+        self.registrations
+            .lock()
+            .insert(registration_path, registration_id);
+
+        Ok(())
+    }
+
+    fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        log::trace!("remove watched path: {path:?}");
+        let Some(registration) = self.registrations.lock().remove(path) else {
+            return Ok(());
+        };
+
+        global_watcher().remove(registration);
+        Ok(())
+    }
 }
 
 fn enqueue_path_events(
@@ -58,22 +142,22 @@ fn enqueue_path_events(
 fn push_notify_event(
     tx: &smol::channel::Sender<()>,
     pending_path_events: &Arc<Mutex<Vec<PathEvent>>>,
+    root_path: &SanitizedPath,
     watched_root: &Path,
     event: &notify::Event,
 ) {
-    let kind = match &event.kind {
+    let kind = match event.kind {
         EventKind::Create(_) => Some(PathEventKind::Created),
         EventKind::Modify(_) => Some(PathEventKind::Changed),
         EventKind::Remove(_) => Some(PathEventKind::Removed),
         _ => None,
     };
-    let root_path = SanitizedPath::new_arc(watched_root);
     let mut path_events = event
         .paths
         .iter()
         .filter_map(|event_path| {
             let event_path = SanitizedPath::new(event_path);
-            event_path.starts_with(&root_path).then(|| PathEvent {
+            event_path.starts_with(root_path).then(|| PathEvent {
                 path: event_path.as_path().to_path_buf(),
                 kind,
             })
@@ -107,101 +191,6 @@ fn push_notify_error(
             kind: Some(PathEventKind::Rescan),
         }],
     );
-}
-
-impl FsWatcher {
-    pub fn new(
-        tx: smol::channel::Sender<()>,
-        pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
-        mode: WatcherMode,
-        poll_interval: Option<Duration>,
-    ) -> Self {
-        Self {
-            tx,
-            pending_path_events,
-            registrations: Default::default(),
-            mode,
-            poll_interval,
-        }
-    }
-}
-
-impl Drop for FsWatcher {
-    fn drop(&mut self) {
-        let mut registrations = BTreeMap::new();
-        {
-            let old = &mut self.registrations.lock();
-            std::mem::swap(old.deref_mut(), &mut registrations);
-        }
-
-        let global_watcher = global_watcher();
-        for (_, registration) in registrations {
-            global_watcher.remove(registration);
-        }
-    }
-}
-
-impl Watcher for FsWatcher {
-    fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        log::trace!("watcher add: {path:?}");
-
-        if (self.mode == WatcherMode::Poll
-            || native_recursive_mode() == notify::RecursiveMode::Recursive)
-            && let Some((watched_path, _)) = self
-                .registrations
-                .lock()
-                .range::<std::path::Path, _>((
-                    std::ops::Bound::Unbounded,
-                    std::ops::Bound::Included(path),
-                ))
-                .next_back()
-            && watched_path.as_ref() != path
-            && path.starts_with(watched_path.as_ref())
-        {
-            log::trace!(
-                "path to watch is covered by existing registration: {path:?}, {watched_path:?}"
-            );
-            return Ok(());
-        }
-
-        if self.registrations.lock().contains_key(path) {
-            log::trace!("path to watch is already registered: {path:?}");
-            return Ok(());
-        }
-
-        let tx = self.tx.clone();
-        let pending_path_events = self.pending_path_events.clone();
-        let watched_root: Arc<std::path::Path> = path.into();
-        let callback_root = watched_root.clone();
-        let registration_id = global_watcher().add(
-            watched_root.clone(),
-            self.mode,
-            self.poll_interval,
-            move |result| match result {
-                Ok(event) => {
-                    push_notify_event(&tx, &pending_path_events, callback_root.as_ref(), event)
-                }
-                Err(error) => {
-                    push_notify_error(&tx, &pending_path_events, callback_root.as_ref(), error)
-                }
-            },
-        )?;
-
-        self.registrations
-            .lock()
-            .insert(watched_root, registration_id);
-        Ok(())
-    }
-
-    fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        log::trace!("remove watched path: {path:?}");
-        let Some(registration) = self.registrations.lock().remove(path) else {
-            return Ok(());
-        };
-
-        global_watcher().remove(registration);
-        Ok(())
-    }
 }
 
 fn coalesce_pending_rescans(pending_paths: &mut Vec<PathEvent>, path_events: &mut Vec<PathEvent>) {
@@ -258,7 +247,7 @@ fn is_covered_rescan(kind: Option<PathEventKind>, path: &Path, ancestor: &Path) 
 pub struct WatcherRegistrationId(u32);
 
 struct WatcherRegistrationState {
-    callback: Arc<WatcherCallback>,
+    callback: Arc<dyn for<'a> Fn(Result<&'a notify::Event, &'a notify::Error>) + Send + Sync>,
     path: Arc<std::path::Path>,
     mode: WatcherMode,
 }
@@ -270,61 +259,53 @@ struct WatcherState {
     last_registration: WatcherRegistrationId,
 }
 
+impl WatcherState {
+    fn path_registrations(&mut self, mode: WatcherMode) -> &mut HashMap<Arc<std::path::Path>, u32> {
+        match mode {
+            WatcherMode::Native => &mut self.native_path_registrations,
+            WatcherMode::Poll => &mut self.poll_path_registrations,
+        }
+    }
+}
+
 pub struct GlobalWatcher {
     state: Mutex<WatcherState>,
 
-    // DANGER: never keep state lock while holding backend watcher lock.
-    // Calling watch can synchronously trigger an event callback that needs state.
-    native_watcher: Mutex<BackendSlot<notify::RecommendedWatcher>>,
-    poll_watcher: Mutex<BackendSlot<notify::PollWatcher>>,
+    // DANGER: never keep state lock while holding watcher lock
+    // two mutexes because calling watcher.add triggers watcher.event, which needs watchers.
+    native_watcher: Mutex<Option<notify::RecommendedWatcher>>,
+    poll_watcher: Mutex<Option<notify::PollWatcher>>,
 }
 
 impl GlobalWatcher {
-    fn new() -> Self {
-        Self {
-            state: Mutex::new(WatcherState {
-                watchers: Default::default(),
-                native_path_registrations: Default::default(),
-                poll_path_registrations: Default::default(),
-                last_registration: Default::default(),
-            }),
-            native_watcher: Mutex::new(BackendSlot::Uninitialized),
-            poll_watcher: Mutex::new(BackendSlot::Uninitialized),
-        }
-    }
-
     #[must_use]
     fn add(
         &self,
         path: Arc<std::path::Path>,
         mode: WatcherMode,
-        poll_interval: Option<Duration>,
         cb: impl for<'a> Fn(Result<&'a notify::Event, &'a notify::Error>) + Send + Sync + 'static,
     ) -> anyhow::Result<WatcherRegistrationId> {
         let mut state = self.state.lock();
-        let path_registrations = Self::path_registrations_mut(&mut state, mode);
-
+        let registrations_for_mode = state.path_registrations(mode);
         let path_already_covered =
-            Self::path_already_covered(path.as_ref(), path_registrations, mode);
-        if !path_already_covered && !path_registrations.contains_key(&path) {
+            path_already_covered(path.as_ref(), registrations_for_mode, mode);
+
+        if !path_already_covered && !registrations_for_mode.contains_key(&path) {
             drop(state);
-            self.watch_path(path.as_ref(), mode, poll_interval)?;
+            self.watch(&path, mode)?;
             state = self.state.lock();
         }
 
         let id = state.last_registration;
         state.last_registration = WatcherRegistrationId(id.0 + 1);
-        state.watchers.insert(
-            id,
-            WatcherRegistrationState {
-                callback: Arc::new(cb),
-                path: path.clone(),
-                mode,
-            },
-        );
-        *Self::path_registrations_mut(&mut state, mode)
-            .entry(path)
-            .or_insert(0) += 1;
+
+        let registration_state = WatcherRegistrationState {
+            callback: Arc::new(cb),
+            path: path.clone(),
+            mode,
+        };
+        state.watchers.insert(id, registration_state);
+        *state.path_registrations(mode).entry(path).or_insert(0) += 1;
 
         Ok(id)
     }
@@ -335,164 +316,70 @@ impl GlobalWatcher {
             return;
         };
 
-        let path_registrations = Self::path_registrations_mut(&mut state, registration_state.mode);
+        let path_registrations = state.path_registrations(registration_state.mode);
         let Some(count) = path_registrations.get_mut(&registration_state.path) else {
             return;
         };
         *count -= 1;
-        if *count > 0 {
-            return;
-        }
+        if *count == 0 {
+            path_registrations.remove(&registration_state.path);
+            let path_still_covered = path_already_covered(
+                registration_state.path.as_ref(),
+                path_registrations,
+                registration_state.mode,
+            );
 
-        path_registrations.remove(&registration_state.path);
-        let path_is_still_covered = Self::path_already_covered(
-            registration_state.path.as_ref(),
-            path_registrations,
-            registration_state.mode,
-        );
-        if path_is_still_covered {
-            return;
-        }
-
-        drop(state);
-        self.unwatch_path(registration_state.path.as_ref(), registration_state.mode)
-            .log_err();
-    }
-
-    fn handle_notify_result(
-        &self,
-        mode: WatcherMode,
-        result: Result<notify::Event, notify::Error>,
-    ) {
-        log::trace!("global handle event for {mode:?}: {result:?}");
-
-        let callbacks = {
-            let state = self.state.lock();
-            state
-                .watchers
-                .values()
-                .filter(|registration| registration.mode == mode)
-                .map(|registration| registration.callback.clone())
-                .collect::<Vec<_>>()
-        };
-
-        match result {
-            Ok(event) => {
-                if matches!(event.kind, EventKind::Access(_)) {
-                    return;
-                }
-                for callback in callbacks {
-                    callback(Ok(&event));
-                }
-            }
-            Err(error) => {
-                for callback in callbacks {
-                    callback(Err(&error));
-                }
+            if !path_still_covered {
+                drop(state);
+                self.unwatch(&registration_state.path, registration_state.mode)
+                    .log_err();
             }
         }
     }
 
-    fn ensure_native_watcher(&self) -> anyhow::Result<()> {
-        let mut watcher = self.native_watcher.lock();
-        match &mut *watcher {
-            BackendSlot::Ready(_) => Ok(()),
-            BackendSlot::Failed(error) => Err(anyhow!(error.clone())),
-            BackendSlot::Uninitialized => {
-                match notify::recommended_watcher(|result| {
-                    global_watcher().handle_notify_result(WatcherMode::Native, result)
-                }) {
-                    Ok(file_watcher) => {
-                        *watcher = BackendSlot::Ready(file_watcher);
-                        Ok(())
-                    }
-                    Err(error) => {
-                        let error = error.to_string();
-                        *watcher = BackendSlot::Failed(error.clone());
-                        Err(anyhow!(error))
-                    }
-                }
-            }
-        }
-    }
-
-    fn ensure_poll_watcher(&self, poll_interval: Option<Duration>) -> anyhow::Result<()> {
-        let mut watcher = self.poll_watcher.lock();
-        match &mut *watcher {
-            BackendSlot::Ready(_) => Ok(()),
-            BackendSlot::Failed(error) => Err(anyhow!(error.clone())),
-            BackendSlot::Uninitialized => {
-                let poll_interval = poll_interval.unwrap_or(Duration::from_secs(2));
-                let config = notify::Config::default().with_poll_interval(poll_interval);
-                match notify::PollWatcher::new(
-                    |result| global_watcher().handle_notify_result(WatcherMode::Poll, result),
-                    config,
-                ) {
-                    Ok(file_watcher) => {
-                        *watcher = BackendSlot::Ready(file_watcher);
-                        Ok(())
-                    }
-                    Err(error) => {
-                        let error = error.to_string();
-                        *watcher = BackendSlot::Failed(error.clone());
-                        Err(anyhow!(error))
-                    }
-                }
-            }
-        }
-    }
-
-    fn watch_path(
-        &self,
-        path: &Path,
-        mode: WatcherMode,
-        poll_interval: Option<Duration>,
-    ) -> anyhow::Result<()> {
-        use notify::Watcher as _;
+    fn watch(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
+        use notify::Watcher;
 
         match mode {
             WatcherMode::Native => {
                 self.ensure_native_watcher()?;
-                let mut watcher = self.native_watcher.lock();
-                match &mut *watcher {
-                    BackendSlot::Ready(watcher) => watcher.watch(path, native_recursive_mode())?,
-                    BackendSlot::Failed(error) => return Err(anyhow!(error.clone())),
-                    BackendSlot::Uninitialized => {
-                        return Err(anyhow!("native watcher not initialized"));
-                    }
-                }
+                self.native_watcher
+                    .lock()
+                    .as_mut()
+                    .expect("native watcher initialized")
+                    .watch(
+                        path,
+                        if cfg!(any(target_os = "windows", target_os = "macos")) {
+                            notify::RecursiveMode::Recursive
+                        } else {
+                            notify::RecursiveMode::NonRecursive
+                        },
+                    )?;
             }
             WatcherMode::Poll => {
-                self.ensure_poll_watcher(poll_interval)?;
-                let mut watcher = self.poll_watcher.lock();
-                match &mut *watcher {
-                    BackendSlot::Ready(watcher) => {
-                        watcher.watch(path, notify::RecursiveMode::Recursive)?
-                    }
-                    BackendSlot::Failed(error) => return Err(anyhow!(error.clone())),
-                    BackendSlot::Uninitialized => {
-                        return Err(anyhow!("poll watcher not initialized"));
-                    }
-                }
+                self.ensure_poll_watcher()?;
+                self.poll_watcher
+                    .lock()
+                    .as_mut()
+                    .expect("poll watcher initialized")
+                    .watch(path, notify::RecursiveMode::Recursive)?;
             }
         }
 
         Ok(())
     }
 
-    fn unwatch_path(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
-        use notify::Watcher as _;
+    fn unwatch(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
+        use notify::Watcher;
 
         match mode {
             WatcherMode::Native => {
-                let mut watcher = self.native_watcher.lock();
-                if let BackendSlot::Ready(watcher) = &mut *watcher {
+                if let Some(watcher) = self.native_watcher.lock().as_mut() {
                     watcher.unwatch(path)?;
                 }
             }
             WatcherMode::Poll => {
-                let mut watcher = self.poll_watcher.lock();
-                if let BackendSlot::Ready(watcher) = &mut *watcher {
+                if let Some(watcher) = self.poll_watcher.lock().as_mut() {
                     watcher.unwatch(path)?;
                 }
             }
@@ -501,62 +388,103 @@ impl GlobalWatcher {
         Ok(())
     }
 
-    fn path_registrations_mut(
-        state: &mut WatcherState,
-        mode: WatcherMode,
-    ) -> &mut HashMap<Arc<std::path::Path>, u32> {
-        match mode {
-            WatcherMode::Native => &mut state.native_path_registrations,
-            WatcherMode::Poll => &mut state.poll_path_registrations,
+    fn ensure_native_watcher(&self) -> anyhow::Result<()> {
+        if self.native_watcher.lock().is_some() {
+            return Ok(());
         }
+
+        let watcher = notify::recommended_watcher(handle_native_event)?;
+        *self.native_watcher.lock() = Some(watcher);
+        Ok(())
     }
 
-    fn path_already_covered(
-        path: &Path,
-        path_registrations: &HashMap<Arc<std::path::Path>, u32>,
-        mode: WatcherMode,
-    ) -> bool {
-        match mode {
-            WatcherMode::Native => native_path_already_covered(path, path_registrations),
-            WatcherMode::Poll => path_registrations
-                .keys()
-                .any(|existing| existing.as_ref() != path && path.starts_with(existing.as_ref())),
+    fn ensure_poll_watcher(&self) -> anyhow::Result<()> {
+        if self.poll_watcher.lock().is_some() {
+            return Ok(());
         }
+
+        let config = notify::Config::default().with_poll_interval(*POLL_INTERVAL);
+        let watcher = notify::PollWatcher::new(handle_poll_event, config)?;
+        *self.poll_watcher.lock() = Some(watcher);
+        Ok(())
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
-fn native_recursive_mode() -> notify::RecursiveMode {
-    notify::RecursiveMode::Recursive
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn native_recursive_mode() -> notify::RecursiveMode {
-    notify::RecursiveMode::NonRecursive
-}
-
-#[cfg(any(target_os = "windows", target_os = "macos"))]
-fn native_path_already_covered(
+fn path_already_covered(
     path: &Path,
     path_registrations: &HashMap<Arc<std::path::Path>, u32>,
+    mode: WatcherMode,
 ) -> bool {
-    path_registrations
-        .keys()
-        .any(|existing| existing.as_ref() != path && path.starts_with(existing.as_ref()))
+    (mode == WatcherMode::Poll || cfg!(any(target_os = "windows", target_os = "macos")))
+        && path_registrations
+            .keys()
+            .any(|existing| path.starts_with(existing.as_ref()) && path != existing.as_ref())
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn native_path_already_covered(
-    _path: &Path,
-    _path_registrations: &HashMap<Arc<std::path::Path>, u32>,
-) -> bool {
-    false
+static POLL_INTERVAL: LazyLock<Duration> = LazyLock::new(|| {
+    let poll_ms: u64 = std::env::var("ZED_FILE_WATCHER_POLL_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(2000)
+        .clamp(500, 30000);
+    Duration::from_millis(poll_ms)
+});
+
+pub fn poll_interval() -> Duration {
+    *POLL_INTERVAL
 }
 
 static FS_WATCHER_INSTANCE: OnceLock<GlobalWatcher> = OnceLock::new();
 
 fn global_watcher() -> &'static GlobalWatcher {
-    FS_WATCHER_INSTANCE.get_or_init(GlobalWatcher::new)
+    FS_WATCHER_INSTANCE.get_or_init(|| GlobalWatcher {
+        state: Mutex::new(WatcherState {
+            watchers: Default::default(),
+            native_path_registrations: Default::default(),
+            poll_path_registrations: Default::default(),
+            last_registration: Default::default(),
+        }),
+        native_watcher: Mutex::new(None),
+        poll_watcher: Mutex::new(None),
+    })
+}
+
+fn handle_native_event(event: Result<notify::Event, notify::Error>) {
+    handle_event(WatcherMode::Native, event);
+}
+
+fn handle_poll_event(event: Result<notify::Event, notify::Error>) {
+    handle_event(WatcherMode::Poll, event);
+}
+
+fn handle_event(mode: WatcherMode, event: Result<notify::Event, notify::Error>) {
+    log::trace!("global handle event for {mode:?}: {event:?}");
+
+    let callbacks = {
+        let state = global_watcher().state.lock();
+        state
+            .watchers
+            .values()
+            .filter(|registration| registration.mode == mode)
+            .map(|registration| registration.callback.clone())
+            .collect::<Vec<_>>()
+    };
+
+    match event {
+        Ok(event) => {
+            if matches!(event.kind, EventKind::Access(_)) {
+                return;
+            }
+            for callback in callbacks {
+                callback(Ok(&event));
+            }
+        }
+        Err(error) => {
+            for callback in callbacks {
+                callback(Err(&error));
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #51340
Release Notes:

- Linux/WSL: Added polling filesystem watching support in order to support file watching on file systems that do emit events through `inotify`, for example `/mnt/c` in WSL, network filesystems, and FUSE mounts. Polling should be automatically chosen over `inotify` when necessary, however it can be manually chosen by setting the `ZED_FILE_WATCHER_MODE=poll` env var 