### PR TITLE
Revert "markdown: Apply theme syntax color to inline code in rendered markdown"

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -196,11 +196,6 @@ impl MarkdownStyle {
                 font_size: Some(buffer_font_size.into()),
                 font_weight: Some(buffer_font_weight),
                 background_color: Some(colors.editor_foreground.opacity(0.08)),
-                color: cx
-                    .theme()
-                    .syntax()
-                    .style_for_name("text.literal")
-                    .and_then(|style| style.color),
                 ..Default::default()
             },
             link: TextStyleRefinement {


### PR DESCRIPTION
Reverts zed-industries/zed#54475

This causes inline code blocks to look strange in some themes

<img width="361" height="103" alt="image" src="https://github.com/user-attachments/assets/1deb77c7-644a-4019-bd79-ad9e53934ce9" />

Release Notes:

- N/A