### PR TITLE
Fix Claude Opus 4.7 ID on AWS Bedrock

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -289,7 +289,7 @@ impl Model {
             Self::ClaudeOpus4_1 => "anthropic.claude-opus-4-1-20250805-v1:0",
             Self::ClaudeOpus4_5 => "anthropic.claude-opus-4-5-20251101-v1:0",
             Self::ClaudeOpus4_6 => "anthropic.claude-opus-4-6-v1",
-            Self::ClaudeOpus4_7 => "anthropic.claude-opus-4-7-v1",
+            Self::ClaudeOpus4_7 => "anthropic.claude-opus-4-7",
             Self::ClaudeSonnet4_6 => "anthropic.claude-sonnet-4-6",
             Self::Llama4Scout17B => "meta.llama4-scout-17b-instruct-v1:0",
             Self::Llama4Maverick17B => "meta.llama4-maverick-17b-instruct-v1:0",
@@ -817,7 +817,7 @@ mod tests {
         );
         assert_eq!(
             Model::ClaudeOpus4_7.cross_region_inference_id("eu-west-1", false)?,
-            "eu.anthropic.claude-opus-4-7-v1"
+            "eu.anthropic.claude-opus-4-7"
         );
         Ok(())
     }
@@ -851,7 +851,7 @@ mod tests {
         );
         assert_eq!(
             Model::ClaudeOpus4_7.cross_region_inference_id("ap-southeast-2", false)?,
-            "au.anthropic.claude-opus-4-7-v1"
+            "au.anthropic.claude-opus-4-7"
         );
         Ok(())
     }
@@ -915,7 +915,7 @@ mod tests {
         );
         assert_eq!(
             Model::ClaudeOpus4_7.cross_region_inference_id("us-east-1", true)?,
-            "global.anthropic.claude-opus-4-7-v1"
+            "global.anthropic.claude-opus-4-7"
         );
         assert_eq!(
             Model::Nova2Lite.cross_region_inference_id("us-east-1", true)?,


### PR DESCRIPTION
AWS Bedrock now has claude opus 4.7 name without `v1` postfix

<img width="295" height="223" alt="Screenshot 2026-04-22 at 5 01 59 PM" src="https://github.com/user-attachments/assets/fcc3dd7d-74c9-4c57-8dd6-8bc6c219f6a3" />

<img width="291" height="129" alt="Screenshot 2026-04-22 at 5 01 41 PM" src="https://github.com/user-attachments/assets/2596e496-d93a-412b-b3d8-3bb676b41c88" />
