### PR TITLE
Update v0.233.x Stable Release Channel

### DIFF
--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-preview
+stable


### PR DESCRIPTION
Update `crates/zed/RELEASE_CHANNEL` from `preview` to `stable` for the v0.233.x release.