### PR TITLE
Update v0.234.x Preview Release Channel

### DIFF
--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-dev
+preview


### PR DESCRIPTION
Updates `crates/zed/RELEASE_CHANNEL` from `dev` to `preview` for the v0.234.x release branch.