### PR TITLE
Handle git push when there is no remote

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3109,6 +3109,14 @@ impl GitPanel {
             let remote = match remote.await {
                 Ok(Some(remote)) => remote,
                 Ok(None) => {
+                    this.update(cx, |this, cx| {
+                        this.show_error_toast(
+                            "push",
+                            anyhow::anyhow!("No remote available to push to. Add a remote to be able to publish changes."),
+                            cx,
+                        )
+                    })
+                    .ok();
                     return Ok(());
                 }
                 Err(e) => {


### PR DESCRIPTION
Previously hitting `Publish` in the git panel would silently fail with no error message if the git repo was new or didn't have a remote.

Now, when hitting `Publish` or attempting to push when there is no remote using keyboard shortcuts, or using `Push To` or force push options, an error message will be displayed.

<img width="1135" height="522" alt="Screenshot 2026-04-22 at 10 02 26 AM" src="https://github.com/user-attachments/assets/93c5e7ee-371e-4c2c-961b-42501cbd7119" />

<img width="1135" height="522" alt="Screenshot 2026-04-22 at 10 02 36 AM" src="https://github.com/user-attachments/assets/a923e5f2-4099-45b5-8fe2-eb78f4fc9f10" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed handling of `git push` when there is no remote available to push to
