### PR TITLE
acp_tools: Buffer recent ACP messages so the log pane can show history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "theme_settings",
  "ui",
  "util",
+ "watch",
  "workspace",
 ]
 

--- a/crates/acp_tools/Cargo.toml
+++ b/crates/acp_tools/Cargo.toml
@@ -26,4 +26,5 @@ settings.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
 util.workspace = true
+watch.workspace = true
 workspace.workspace = true

--- a/crates/acp_tools/src/acp_tools.rs
+++ b/crates/acp_tools/src/acp_tools.rs
@@ -1,6 +1,6 @@
 use std::{
-    cell::RefCell,
-    collections::HashSet,
+    cell::{Cell, RefCell},
+    collections::{HashSet, VecDeque},
     fmt::Display,
     rc::{Rc, Weak},
     sync::Arc,
@@ -38,6 +38,122 @@ pub fn init(cx: &mut App) {
     .detach();
 }
 
+/// Maximum number of messages retained in a connection's [`MessageLog`] ring buffer.
+///
+/// Once this cap is hit, the oldest message is dropped as new ones arrive. The
+/// monotonic counter returned by [`MessageLog::snapshot`] still reflects the
+/// true total, so readers can detect when the ring has rolled past unseen
+/// messages.
+const MESSAGE_LOG_CAPACITY: usize = 500;
+
+/// A bounded ring buffer of ACP stream messages for a single connection.
+///
+/// The buffer is populated by a background task owned by the connection itself,
+/// so entries are captured from the moment the connection is created —
+/// independently of whether any UI is observing. Readers open the log on
+/// demand, take a snapshot, then subscribe to the [`watch::Receiver`] returned
+/// by [`Self::subscribe`] to be notified of new entries.
+pub struct MessageLog {
+    messages: RefCell<VecDeque<acp::StreamMessage>>,
+    total_count: Cell<u64>,
+    notifier: RefCell<watch::Sender<u64>>,
+}
+
+/// A point-in-time view of a [`MessageLog`].
+///
+/// `total_count` is the number of messages the log has ever received, including
+/// any that have rolled out of the ring.
+///
+/// `skipped` has two subtly different meanings depending on how the snapshot
+/// was produced:
+///
+/// - From [`MessageLog::snapshot`]: the number of messages that have rolled
+///   out of the ring over the log's entire lifetime (i.e. `total_count -
+///   messages.len()`).
+/// - From [`MessageLog::read_since`]: the number of messages the caller missed
+///   because the ring rolled past their `last_seen_total`. If `last_seen_total`
+///   still lies within the ring, this is `0` even if older messages have
+///   previously been evicted.
+pub struct MessageLogSnapshot {
+    pub messages: Vec<acp::StreamMessage>,
+    pub total_count: u64,
+    pub skipped: u64,
+}
+
+impl MessageLog {
+    pub fn new() -> Rc<Self> {
+        // `watch::channel` takes an initial value; we never observe it because
+        // readers always call `subscribe()` (which syncs to the current
+        // version) and then treat the received value as a wakeup signal.
+        let (tx, _) = watch::channel(0u64);
+        Rc::new(Self {
+            messages: RefCell::new(VecDeque::with_capacity(MESSAGE_LOG_CAPACITY)),
+            total_count: Cell::new(0),
+            notifier: RefCell::new(tx),
+        })
+    }
+
+    pub fn push(&self, message: acp::StreamMessage) {
+        {
+            let mut messages = self.messages.borrow_mut();
+            if messages.len() == MESSAGE_LOG_CAPACITY {
+                messages.pop_front();
+            }
+            messages.push_back(message);
+        }
+        let new_total = self.total_count.get().saturating_add(1);
+        self.total_count.set(new_total);
+        // A dropped receiver is not an error — it just means nobody is watching
+        // right now. The message is still in the ring for the next reader.
+        self.notifier.borrow_mut().send(new_total).ok();
+    }
+
+    pub fn snapshot(&self) -> MessageLogSnapshot {
+        let messages = self.messages.borrow();
+        let total_count = self.total_count.get();
+        let skipped = total_count.saturating_sub(messages.len() as u64);
+        MessageLogSnapshot {
+            messages: messages.iter().cloned().collect(),
+            total_count,
+            skipped,
+        }
+    }
+
+    /// Return every message with a monotonic index `>= last_seen_total`.
+    ///
+    /// If the ring has rolled past `last_seen_total` since the caller's last
+    /// read, the returned snapshot's `skipped` field will be non-zero to
+    /// indicate how many messages were lost.
+    pub fn read_since(&self, last_seen_total: u64) -> MessageLogSnapshot {
+        let messages = self.messages.borrow();
+        let total_count = self.total_count.get();
+        let oldest_index = total_count.saturating_sub(messages.len() as u64);
+
+        let (start_offset, skipped) = if last_seen_total >= oldest_index {
+            ((last_seen_total - oldest_index) as usize, 0)
+        } else {
+            (0, oldest_index - last_seen_total)
+        };
+
+        MessageLogSnapshot {
+            messages: messages.iter().skip(start_offset).cloned().collect(),
+            total_count,
+            skipped,
+        }
+    }
+
+    /// Subscribe for notifications that new messages have been pushed.
+    ///
+    /// The returned receiver is synced to the current version, so the first
+    /// `recv().await` will block until the next `push`. The `u64` carried by
+    /// the channel is the current `total_count` but should be treated as an
+    /// opaque wakeup signal — callers must still use [`Self::read_since`] to
+    /// atomically get the new messages alongside the count.
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.notifier.borrow().receiver()
+    }
+}
+
 struct GlobalAcpConnectionRegistry(Entity<AcpConnectionRegistry>);
 
 impl Global for GlobalAcpConnectionRegistry {}
@@ -49,7 +165,7 @@ pub struct AcpConnectionRegistry {
 
 struct ActiveConnection {
     agent_id: AgentId,
-    connection: Weak<acp::ClientSideConnection>,
+    message_log: Weak<MessageLog>,
 }
 
 impl AcpConnectionRegistry {
@@ -66,12 +182,12 @@ impl AcpConnectionRegistry {
     pub fn set_active_connection(
         &self,
         agent_id: AgentId,
-        connection: &Rc<acp::ClientSideConnection>,
+        message_log: &Rc<MessageLog>,
         cx: &mut Context<Self>,
     ) {
         self.active_connection.replace(Some(ActiveConnection {
             agent_id,
-            connection: Rc::downgrade(connection),
+            message_log: Rc::downgrade(message_log),
         }));
         cx.notify();
     }
@@ -90,7 +206,8 @@ struct WatchedConnection {
     agent_id: AgentId,
     messages: Vec<WatchedConnectionMessage>,
     list_state: ListState,
-    connection: Weak<acp::ClientSideConnection>,
+    message_log: Weak<MessageLog>,
+    last_seen_total: u64,
     incoming_request_methods: HashMap<acp::RequestId, Arc<str>>,
     outgoing_request_methods: HashMap<acp::RequestId, Arc<str>>,
     _task: Task<()>,
@@ -118,40 +235,88 @@ impl AcpTools {
     }
 
     fn update_connection(&mut self, cx: &mut Context<Self>) {
-        let active_connection = self.connection_registry.read(cx).active_connection.borrow();
-        let Some(active_connection) = active_connection.as_ref() else {
+        let (agent_id, log_weak) = {
+            let registry = self.connection_registry.read(cx);
+            let active_connection = registry.active_connection.borrow();
+            let Some(active_connection) = active_connection.as_ref() else {
+                return;
+            };
+
+            if let Some(watched_connection) = self.watched_connection.as_ref() {
+                if Weak::ptr_eq(
+                    &watched_connection.message_log,
+                    &active_connection.message_log,
+                ) {
+                    return;
+                }
+            }
+
+            (
+                active_connection.agent_id.clone(),
+                active_connection.message_log.clone(),
+            )
+        };
+
+        let Some(message_log) = log_weak.upgrade() else {
             return;
         };
 
-        if let Some(watched_connection) = self.watched_connection.as_ref() {
-            if Weak::ptr_eq(
-                &watched_connection.connection,
-                &active_connection.connection,
-            ) {
-                return;
+        let snapshot = message_log.snapshot();
+        let mut log_rx = message_log.subscribe();
+
+        let task = cx.spawn({
+            let log_weak = log_weak.clone();
+            async move |this, cx| {
+                while log_rx.recv().await.is_ok() {
+                    let Some(log) = log_weak.upgrade() else {
+                        break;
+                    };
+                    let Ok(Some(last_seen)) = this.read_with(cx, |this, _| {
+                        this.watched_connection.as_ref().map(|c| c.last_seen_total)
+                    }) else {
+                        break;
+                    };
+                    let new_entries = log.read_since(last_seen);
+                    drop(log);
+                    if this
+                        .update(cx, |this, cx| {
+                            this.ingest_log_snapshot(new_entries, cx);
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
             }
+        });
+
+        self.watched_connection = Some(WatchedConnection {
+            agent_id,
+            messages: Vec::with_capacity(snapshot.messages.len()),
+            list_state: ListState::new(0, ListAlignment::Bottom, px(2048.)),
+            message_log: log_weak,
+            last_seen_total: 0,
+            incoming_request_methods: HashMap::default(),
+            outgoing_request_methods: HashMap::default(),
+            _task: task,
+        });
+        self.ingest_log_snapshot(snapshot, cx);
+    }
+
+    fn ingest_log_snapshot(&mut self, snapshot: MessageLogSnapshot, cx: &mut Context<Self>) {
+        if snapshot.messages.is_empty() && snapshot.skipped == 0 {
+            if let Some(connection) = self.watched_connection.as_mut() {
+                connection.last_seen_total = snapshot.total_count;
+            }
+            return;
         }
 
-        if let Some(connection) = active_connection.connection.upgrade() {
-            let mut receiver = connection.subscribe();
-            let task = cx.spawn(async move |this, cx| {
-                while let Ok(message) = receiver.recv().await {
-                    this.update(cx, |this, cx| {
-                        this.push_stream_message(message, cx);
-                    })
-                    .ok();
-                }
-            });
+        for message in snapshot.messages {
+            self.push_stream_message(message, cx);
+        }
 
-            self.watched_connection = Some(WatchedConnection {
-                agent_id: active_connection.agent_id.clone(),
-                messages: vec![],
-                list_state: ListState::new(0, ListAlignment::Bottom, px(2048.)),
-                connection: active_connection.connection.clone(),
-                incoming_request_methods: HashMap::default(),
-                outgoing_request_methods: HashMap::default(),
-                _task: task,
-            });
+        if let Some(connection) = self.watched_connection.as_mut() {
+            connection.last_seen_total = snapshot.total_count;
         }
     }
 

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -2,7 +2,7 @@ use acp_thread::{
     AgentConnection, AgentSessionInfo, AgentSessionList, AgentSessionListRequest,
     AgentSessionListResponse,
 };
-use acp_tools::AcpConnectionRegistry;
+use acp_tools::{AcpConnectionRegistry, MessageLog};
 use action_log::ActionLog;
 use agent_client_protocol::{self as acp, Agent as _, ErrorCode};
 use anyhow::anyhow;
@@ -57,9 +57,14 @@ pub struct AcpConnection {
     default_config_options: HashMap<String, String>,
     child: Option<Child>,
     session_list: Option<Rc<AcpSessionList>>,
+    // Keep the log alive for the lifetime of the connection so that the
+    // [`AcpConnectionRegistry`]'s `Weak<MessageLog>` can always be upgraded
+    // while the connection exists.
+    _message_log: Rc<MessageLog>,
     _io_task: Task<Result<(), acp::Error>>,
     _wait_task: Task<Result<()>>,
     _stderr_task: Task<Result<()>>,
+    _log_task: Task<()>,
 }
 
 struct PendingAcpSession {
@@ -321,9 +326,27 @@ impl AcpConnection {
 
         let connection = Rc::new(connection);
 
+        // Create the message log and start draining the connection's broadcast
+        // stream into it *before* we initialize, so that the initialize
+        // request/response pair itself ends up in the log.
+        //
+        // The task must run on the foreground executor because `Rc<MessageLog>`
+        // is `!Send`, and because readers of the log are GPUI entities that
+        // expect to observe updates on the main thread anyway.
+        let message_log = MessageLog::new();
+        let log_task = cx.spawn({
+            let message_log = message_log.clone();
+            let mut receiver = connection.subscribe();
+            async move |_cx| {
+                while let Ok(message) = receiver.recv().await {
+                    message_log.push(message);
+                }
+            }
+        });
+
         cx.update(|cx| {
             AcpConnectionRegistry::default_global(cx).update(cx, |registry, cx| {
-                registry.set_active_connection(agent_id.clone(), &connection, cx)
+                registry.set_active_connection(agent_id.clone(), &message_log, cx)
             });
         });
 
@@ -406,9 +429,11 @@ impl AcpConnection {
             default_model,
             default_config_options,
             session_list,
+            _message_log: message_log,
             _io_task: io_task,
             _wait_task: wait_task,
             _stderr_task: stderr_task,
+            _log_task: log_task,
             child: Some(child),
         })
     }
@@ -440,9 +465,11 @@ impl AcpConnection {
             default_config_options: HashMap::default(),
             child: None,
             session_list: None,
+            _message_log: MessageLog::new(),
             _io_task: io_task,
             _wait_task: Task::ready(Ok(())),
             _stderr_task: Task::ready(Ok(())),
+            _log_task: Task::ready(()),
         }
     }
 


### PR DESCRIPTION
Today the ACP log pane (`dev::OpenAcpLogs`) subscribes to a connection's live message stream on open, so if you open it after noticing something went wrong, the traffic that led up to the problem is already gone.

This adds a bounded ring buffer (`MessageLog`) on each `AcpConnection` that captures every ACP stream message from the moment the connection is created, independent of whether any UI is observing. When the log pane opens, it pre-populates from the buffer and then tails live updates via a `watch` channel.

## How it works

- `MessageLog` holds a `VecDeque<acp::StreamMessage>` capped at 500 entries, plus a monotonic `total_count` and a `watch::Sender<u64>` used purely as a wakeup signal.
- `AcpConnection::stdio` creates the log immediately after constructing the `ClientSideConnection` and spawns a foreground task that drains `connection.subscribe()` into it — crucially, *before* `initialize`, so the init handshake is captured too.
- `AcpConnectionRegistry` now holds a `Weak<MessageLog>` instead of a `Weak<ClientSideConnection>`; the log's identity tracks the connection 1:1.
- `AcpTools::update_connection` snapshots the log on open, then subscribes to the watch channel and calls `read_since(last_seen_total)` on each notification. The monotonic counter makes the tail idempotent regardless of watch coalescing.

## Known limitations

- If the ring rolls (>500 messages) while the pane is open, those messages silently disappear from the view. `MessageLogSnapshot` carries a `skipped` field so we know when this happens, but nothing surfaces it yet.
- Each live `AcpConnection` now holds up to 500 buffered messages for its lifetime (previously the UI-side buffer only existed while the pane was open). In practice this is ~5–20MB for a busy session, dominated by JSON param payloads.
- When an agent connection is restarted, conversations stay bound to the old connection while the registry points at the new one — so the log pane ends up watching an idle new connection. The ring buffer itself works correctly per-connection, but the pane's 'active connection' concept needs to grow to handle this. Deferred.

Release Notes:

- N/A