### PR TITLE
jsonc: Recognize `renovate.json` as JSONC

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -49,7 +49,7 @@
   },
   "file_types": {
     "Dockerfile": ["Dockerfile*[!dockerignore]"],
-    "JSONC": ["**/assets/**/*.json", "renovate.json"],
+    "JSONC": ["**/assets/**/*.json"],
     "Git Ignore": ["dockerignore"],
   },
   "hard_tabs": false,

--- a/crates/grammars/src/jsonc/config.toml
+++ b/crates/grammars/src/jsonc/config.toml
@@ -1,6 +1,6 @@
 name = "JSONC"
 grammar = "jsonc"
-path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "luaurc", "swcrc", "babelrc", "eslintrc", "stylelintrc", "jshintrc"]
+path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "renovate.json", "luaurc", "swcrc", "babelrc", "eslintrc", "stylelintrc", "jshintrc"]
 line_comments = ["// "]
 block_comment = { start = "/*", prefix = "", end = "*/", tab_size = 1 }
 autoclose_before = ",]}"


### PR DESCRIPTION
renovate.json supports comments [[source]](https://docs.renovatebot.com/configuration-options/)
Support this by default.

<img width="533" height="149" alt="Screenshot 2026-04-22 at 2 34 43 PM" src="https://github.com/user-attachments/assets/759fce97-8c48-47a9-8623-0b79d82c33cc" />


Self-Review Checklist:

- [Yes] I've reviewed my own diff for quality, security, and reliability
- [N/A] Unsafe blocks (if any) have justifying comments
- [N/A] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [N/A] Tests cover the new/changed behavior
- [N/A] Performance impact has been considered and is acceptable

Release Notes:

- N/A
