### PR TITLE
docs: Link to Task hooks from Worktree Isolation section

### DIFF
--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -66,6 +66,8 @@ Worktrees are managed from the title bar. Click the worktree picker (to the righ
 
 Once you're in a new worktree, use the branch picker next to the worktree picker to create a new branch or check out an existing one. If the branch you pick is already checked out in another worktree, the current worktree stays in detached HEAD until you choose a different branch.
 
+To automate setup steps whenever a new worktree is created use a [Task hook](../tasks.md#hooks). The `create_worktree` hook runs automatically after Zed creates a linked worktree, with `ZED_WORKTREE_ROOT` pointing at the new worktree and `ZED_MAIN_GIT_WORKTREE` pointing at the original repository.
+
 After the agent finishes, review the diff and merge the changes through your normal Git workflow. If the thread was running in a linked worktree and no other active threads use it, moving the thread to Thread History saves the worktree's Git state and removes it from disk. Restoring the thread from history restores the worktree.
 
 ## See Also {#see-also}


### PR DESCRIPTION
Adds a link to the Tasks section of the docs from the Worktree Isolation section in parallel-agents.md

Release Notes:

- N/A