### PR TITLE
Wait for worktree scan to complete before starting search

### DIFF
--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -189,8 +189,15 @@ impl AgentTool for GrepTool {
                         return Err("Search cancelled by user".to_string());
                     }
                 };
-                let Some(SearchResult::Buffer { buffer, ranges }) = search_result else {
-                    break;
+
+                let (buffer, ranges) = match search_result {
+                    Some(SearchResult::Buffer { buffer, ranges }) => (buffer, ranges),
+                    Some(SearchResult::LimitReached) => {
+                        has_more_matches = true;
+                        break;
+                    }
+                    Some(SearchResult::WaitingForScan) => continue,
+                    None => break,
                 };
                 if ranges.is_empty() {
                     continue;

--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -5295,6 +5295,7 @@ async fn test_project_search(
                     "Unexpectedly reached search limit in tests. If you do want to assert limit-reached, change this panic call."
                 )
             }
+            SearchResult::WaitingForScan => {}
         };
     }
 

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -221,6 +221,7 @@ impl Search {
                                 query.clone(),
                                 input_paths_tx,
                                 sorted_search_results_tx,
+                                tx.clone(),
                             ))
                             .boxed_local(),
                             Self::open_buffers(
@@ -412,12 +413,21 @@ impl Search {
         query: Arc<SearchQuery>,
         tx: Sender<InputPath>,
         results: Sender<oneshot::Receiver<ProjectPath>>,
+        results_tx: Sender<SearchResult>,
     ) -> impl AsyncFnOnce(&mut AsyncApp) {
         async move |cx| {
             _ = maybe!(async move {
                 let gitignored_tracker = PathInclusionMatcher::new(query.clone());
                 let include_ignored = query.include_ignored();
                 for worktree in worktrees {
+                    let scan_complete = worktree.read_with(cx, |worktree, _| {
+                        worktree.as_local().map(|local| local.scan_complete())
+                    });
+                    if let Some(scan_complete) = scan_complete {
+                        _ = results_tx.send(SearchResult::WaitingForScan).await;
+                        scan_complete.await;
+                    }
+
                     let (mut snapshot, worktree_settings) = worktree
                         .read_with(cx, |this, _| {
                             Some((this.snapshot(), this.as_local()?.settings()))

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -25,6 +25,7 @@ pub enum SearchResult {
         ranges: Vec<Range<Anchor>>,
     },
     LimitReached,
+    WaitingForScan,
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12280,8 +12280,7 @@ async fn search(
             SearchResult::Buffer { buffer, ranges } => {
                 results.entry(buffer).or_insert(ranges);
             }
-            SearchResult::LimitReached => {}
-            SearchResult::WaitingForScan => {}
+            SearchResult::LimitReached | SearchResult::WaitingForScan => {}
         }
     }
     Ok(results

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12281,6 +12281,7 @@ async fn search(
                 results.entry(buffer).or_insert(ranges);
             }
             SearchResult::LimitReached => {}
+            SearchResult::WaitingForScan => {}
         }
     }
     Ok(results

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -536,7 +536,7 @@ impl Render for ProjectSearchView {
             let is_waiting_for_scan = model.waiting_for_scan;
 
             let heading_text = if is_waiting_for_scan {
-                "Waiting for project scan to complete…"
+                "Loading project…"
             } else if is_search_underway {
                 "Searching…"
             } else if has_no_results {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -237,6 +237,7 @@ pub struct ProjectSearch {
     search_id: usize,
     no_results: Option<bool>,
     limit_reached: bool,
+    waiting_for_scan: bool,
     search_history_cursor: SearchHistoryCursor,
     search_included_history_cursor: SearchHistoryCursor,
     search_excluded_history_cursor: SearchHistoryCursor,
@@ -299,6 +300,7 @@ impl ProjectSearch {
             search_id: 0,
             no_results: None,
             limit_reached: false,
+            waiting_for_scan: false,
             search_history_cursor: Default::default(),
             search_included_history_cursor: Default::default(),
             search_excluded_history_cursor: Default::default(),
@@ -323,6 +325,7 @@ impl ProjectSearch {
                 search_id: self.search_id,
                 no_results: self.no_results,
                 limit_reached: self.limit_reached,
+                waiting_for_scan: false,
                 search_history_cursor: self.search_history_cursor.clone(),
                 search_included_history_cursor: self.search_included_history_cursor.clone(),
                 search_excluded_history_cursor: self.search_excluded_history_cursor.clone(),
@@ -422,15 +425,17 @@ impl ProjectSearch {
                         .update(cx, |excerpts, cx| excerpts.clear(cx));
                     project_search.no_results = Some(true);
                     project_search.limit_reached = false;
+                    project_search.waiting_for_scan = false;
                 })
                 .ok()?;
 
             let mut limit_reached = false;
             while let Some(results) = matches.next().await {
-                let (buffers_with_ranges, has_reached_limit) = cx
+                let (buffers_with_ranges, has_reached_limit, is_waiting_for_scan) = cx
                     .background_executor()
                     .spawn(async move {
                         let mut limit_reached = false;
+                        let mut waiting_for_scan = false;
                         let mut buffers_with_ranges = Vec::with_capacity(results.len());
                         for result in results {
                             match result {
@@ -440,12 +445,23 @@ impl ProjectSearch {
                                 project::search::SearchResult::LimitReached => {
                                     limit_reached = true;
                                 }
+                                project::search::SearchResult::WaitingForScan => {
+                                    waiting_for_scan = true;
+                                }
                             }
                         }
-                        (buffers_with_ranges, limit_reached)
+                        (buffers_with_ranges, limit_reached, waiting_for_scan)
                     })
                     .await;
                 limit_reached |= has_reached_limit;
+                if is_waiting_for_scan {
+                    project_search
+                        .update(cx, |project_search, cx| {
+                            project_search.waiting_for_scan = true;
+                            cx.notify();
+                        })
+                        .ok()?;
+                }
                 let mut new_ranges = project_search
                     .update(cx, |project_search, cx| {
                         project_search.excerpts.update(cx, |excerpts, cx| {
@@ -483,6 +499,7 @@ impl ProjectSearch {
                         project_search.no_results = Some(false);
                     }
                     project_search.limit_reached = limit_reached;
+                    project_search.waiting_for_scan = false;
                     project_search.pending_search.take();
                     cx.notify();
                 })
@@ -516,8 +533,11 @@ impl Render for ProjectSearchView {
             let model = self.entity.read(cx);
             let has_no_results = model.no_results.unwrap_or(false);
             let is_search_underway = model.pending_search.is_some();
+            let is_waiting_for_scan = model.waiting_for_scan;
 
-            let heading_text = if is_search_underway {
+            let heading_text = if is_waiting_for_scan {
+                "Waiting for project scan to complete…"
+            } else if is_search_underway {
                 "Searching…"
             } else if has_no_results {
                 "No Results"


### PR DESCRIPTION
When starting a search on a project that is in the middle of a scan, we used to miss results in files that had not yet been scanned.

This change makes the search wait for the scan to complete.


Closes #9858

Release Notes:

- Fixed incomplete search results when the project scan is incomplete