### PR TITLE
Revert "jsonc: Recognize `renovate.json` as JSONC"

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -49,7 +49,7 @@
   },
   "file_types": {
     "Dockerfile": ["Dockerfile*[!dockerignore]"],
-    "JSONC": ["**/assets/**/*.json"],
+    "JSONC": ["**/assets/**/*.json", "renovate.json"],
     "Git Ignore": ["dockerignore"],
   },
   "hard_tabs": false,

--- a/crates/grammars/src/jsonc/config.toml
+++ b/crates/grammars/src/jsonc/config.toml
@@ -1,6 +1,6 @@
 name = "JSONC"
 grammar = "jsonc"
-path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "renovate.json", "luaurc", "swcrc", "babelrc", "eslintrc", "stylelintrc", "jshintrc"]
+path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "luaurc", "swcrc", "babelrc", "eslintrc", "stylelintrc", "jshintrc"]
 line_comments = ["// "]
 block_comment = { start = "/*", prefix = "", end = "*/", tab_size = 1 }
 autoclose_before = ",]}"


### PR DESCRIPTION
Reverts zed-industries/zed#54527

This has unintended side effects, thus revert it to the prior state for now.

Release Notes:

- N/A