### PR TITLE
Enable segment heap for Zed

### DIFF
--- a/crates/gpui/resources/windows/gpui.manifest.xml
+++ b/crates/gpui/resources/windows/gpui.manifest.xml
@@ -16,6 +16,7 @@
         <windowsSettings>
             <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+            <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
         </windowsSettings>
     </application>
     <dependency>


### PR DESCRIPTION
Reduces memory usage on Windows by using a newer heap implementation.

Memory usage after opening into the Welcome screen:
- Before: 124 MB
- After: 91 MB

Release Notes:

- N/A
