### PR TITLE
Trim nonalphanumeric chars before prefixing image tag name

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -301,6 +301,7 @@ impl DevContainerManifest {
             None => "zed-dc",
         };
         let prefix = prefix.get(..6).unwrap_or(prefix);
+        let prefix = prefix.trim_matches(|c: char| !c.is_alphanumeric());
 
         dockerfile_build_path.hash(&mut hasher);
 
@@ -5607,6 +5608,34 @@ FROM docker.io/hexpm/elixir:1.21-erlang-28.4.1-debian-trixie-20260316-slim AS de
             panic!("expected MultipleMatchingContainers, got {result:?}");
         };
         assert_eq!(ids, vec!["abc123".to_string(), "def456".to_string()]);
+    }
+
+    #[gpui::test]
+    async fn trim_non_alphanumeric_chars_from_image_tag(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        env_logger::try_init().ok();
+        let given_devcontainer_contents = r#"
+            {
+              "name": "abcde test",
+              "image": "test_image:latest",
+            }
+            "#;
+
+        let (_, devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, given_devcontainer_contents)
+                .await
+                .unwrap();
+
+        let image_tag = devcontainer_manifest.generate_features_image_tag("Dockerfile".to_string());
+
+        assert!(
+            image_tag.starts_with("abcde-"),
+            "expected prefix 'abcde-', got: {image_tag}"
+        );
+        assert!(
+            image_tag.ends_with("-features"),
+            "expected suffix '-features', got: {image_tag}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54452

Release Notes:

- Fixed bug where the sixth character of a devcontainer name is nonalpanumeric
