### PR TITLE
Fix:Bug: “Static” **color** theme from Dynamic + System mode always used the **dark** slot

### DIFF
--- a/crates/settings_ui/src/components/ollama_model_picker.rs
+++ b/crates/settings_ui/src/components/ollama_model_picker.rs
@@ -185,10 +185,11 @@ pub fn render_ollama_model_picker(
                             field.json_path,
                             window,
                             cx,
-                            move |settings, _cx| {
+                            move |settings, app| {
                                 (field.write)(
                                     settings,
                                     Some(settings::OllamaModelName(model_name.to_string())),
+                                    app,
                                 );
                             },
                         )

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1,4 +1,5 @@
 use gpui::{Action as _, App};
+use theme::SystemAppearance;
 use itertools::Itertools as _;
 use settings::{
     AudioInputDeviceName, AudioOutputDeviceName, LanguageSettingsContent, SemanticTokens,
@@ -119,7 +120,7 @@ fn general_page(cx: &App) -> SettingsPage {
                             .when_closing_with_no_tabs
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.when_closing_with_no_tabs = value;
                     },
                 }),
@@ -134,7 +135,7 @@ fn general_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.workspace.on_last_window_closed.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.on_last_window_closed = value;
                     },
                 }),
@@ -149,7 +150,7 @@ fn general_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.workspace.use_system_path_prompts.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.use_system_path_prompts = value;
                     },
                 }),
@@ -162,7 +163,7 @@ fn general_page(cx: &App) -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("use_system_prompts"),
                     pick: |settings_content| settings_content.workspace.use_system_prompts.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.use_system_prompts = value;
                     },
                 }),
@@ -175,7 +176,7 @@ fn general_page(cx: &App) -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("redact_private_values"),
                     pick: |settings_content| settings_content.editor.redact_private_values.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.redact_private_values = value;
                     },
                 }),
@@ -191,7 +192,7 @@ fn general_page(cx: &App) -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.project.worktree.private_files.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.project.worktree.private_files = value;
                         },
                     }
@@ -211,7 +212,7 @@ fn general_page(cx: &App) -> SettingsPage {
                             .cli_default_open_behavior
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.cli_default_open_behavior = value;
                     },
                 }),
@@ -237,7 +238,7 @@ fn general_page(cx: &App) -> SettingsPage {
                             .as_ref()
                             .and_then(|session| session.trust_all_worktrees.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .session
                             .get_or_insert_default()
@@ -264,7 +265,7 @@ fn general_page(cx: &App) -> SettingsPage {
                             .as_ref()
                             .and_then(|session| session.restore_unsaved_buffers.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .session
                             .get_or_insert_default()
@@ -280,7 +281,7 @@ fn general_page(cx: &App) -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("restore_on_startup"),
                     pick: |settings_content| settings_content.workspace.restore_on_startup.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.restore_on_startup = value;
                     },
                 }),
@@ -301,7 +302,7 @@ fn general_page(cx: &App) -> SettingsPage {
                     SettingField {
                         json_path: Some("preview_channel_settings"),
                         pick: |settings_content| Some(settings_content),
-                        write: |_settings_content, _value| {},
+                        write: |_settings_content, _value, _app: &App| {},
                     }
                     .unimplemented(),
                 ),
@@ -315,7 +316,7 @@ fn general_page(cx: &App) -> SettingsPage {
                     SettingField {
                         json_path: Some("settings_profiles"),
                         pick: |settings_content| Some(settings_content),
-                        write: |_settings_content, _value| {},
+                        write: |_settings_content, _value, _app: &App| {},
                     }
                     .unimplemented(),
                 ),
@@ -338,7 +339,7 @@ fn general_page(cx: &App) -> SettingsPage {
                             .as_ref()
                             .and_then(|telemetry| telemetry.diagnostics.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .telemetry
                             .get_or_insert_default()
@@ -359,7 +360,7 @@ fn general_page(cx: &App) -> SettingsPage {
                             .as_ref()
                             .and_then(|telemetry| telemetry.metrics.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.telemetry.get_or_insert_default().metrics = value;
                     },
                 }),
@@ -378,7 +379,7 @@ fn general_page(cx: &App) -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("auto_update"),
                     pick: |settings_content| settings_content.auto_update.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.auto_update = value;
                     },
                 }),
@@ -422,7 +423,7 @@ fn appearance_page() -> SettingsPage {
                                     .as_ref()?
                                     .discriminant() as usize])
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             let Some(value) = value else {
                                 settings_content.theme.theme = None;
                                 return;
@@ -436,7 +437,13 @@ fn appearance_page() -> SettingsPage {
                                             match mode {
                                                 theme_settings::ThemeAppearanceMode::Light => light.clone(),
                                                 theme_settings::ThemeAppearanceMode::Dark => dark.clone(),
-                                                theme_settings::ThemeAppearanceMode::System => dark.clone(), // no cx, can't determine correct choice
+                                                theme_settings::ThemeAppearanceMode::System => {
+                                                    if SystemAppearance::global(_app).is_light() {
+                                                        light.clone()
+                                                    } else {
+                                                        dark.clone()
+                                                    }
+                                                }
                                             }
                                         },
                                     };
@@ -477,7 +484,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -505,7 +512,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -531,7 +538,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -557,7 +564,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -590,7 +597,7 @@ fn appearance_page() -> SettingsPage {
                                     .as_ref()?
                                     .discriminant() as usize])
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             let Some(value) = value else {
                                 settings_content.theme.icon_theme = None;
                                 return;
@@ -647,7 +654,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -675,7 +682,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -701,7 +708,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -727,7 +734,7 @@ fn appearance_page() -> SettingsPage {
                                             _ => None
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -757,7 +764,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("buffer_font_family"),
                     pick: |settings_content| settings_content.theme.buffer_font_family.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.buffer_font_family = value;
                     },
                 }),
@@ -770,7 +777,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("buffer_font_size"),
                     pick: |settings_content| settings_content.theme.buffer_font_size.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.buffer_font_size = value;
                     },
                 }),
@@ -783,7 +790,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("buffer_font_weight"),
                     pick: |settings_content| settings_content.theme.buffer_font_weight.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.buffer_font_weight = value;
                     },
                 }),
@@ -807,7 +814,7 @@ fn appearance_page() -> SettingsPage {
                                     as usize],
                             )
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             let Some(value) = value else {
                                 settings_content.theme.buffer_line_height = None;
                                 return;
@@ -862,7 +869,7 @@ fn appearance_page() -> SettingsPage {
                                     Some(settings::BufferLineHeight::Custom(value)) => Some(value),
                                     _ => None,
                                 },
-                                write: |settings_content, value| {
+                                write: |settings_content, value, _app: &App| {
                                     let Some(value) = value else {
                                         return;
                                     };
@@ -889,7 +896,7 @@ fn appearance_page() -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.theme.buffer_font_features.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.theme.buffer_font_features = value;
                         },
                     }
@@ -907,7 +914,7 @@ fn appearance_page() -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.theme.buffer_font_fallbacks.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.theme.buffer_font_fallbacks = value;
                         },
                     }
@@ -927,7 +934,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("ui_font_family"),
                     pick: |settings_content| settings_content.theme.ui_font_family.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.ui_font_family = value;
                     },
                 }),
@@ -940,7 +947,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("ui_font_size"),
                     pick: |settings_content| settings_content.theme.ui_font_size.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.ui_font_size = value;
                     },
                 }),
@@ -953,7 +960,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("ui_font_weight"),
                     pick: |settings_content| settings_content.theme.ui_font_weight.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.ui_font_weight = value;
                     },
                 }),
@@ -968,7 +975,7 @@ fn appearance_page() -> SettingsPage {
                     SettingField {
                         json_path: Some("ui_font_features"),
                         pick: |settings_content| settings_content.theme.ui_font_features.as_ref(),
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.theme.ui_font_features = value;
                         },
                     }
@@ -984,7 +991,7 @@ fn appearance_page() -> SettingsPage {
                     SettingField {
                         json_path: Some("ui_font_fallbacks"),
                         pick: |settings_content| settings_content.theme.ui_font_fallbacks.as_ref(),
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.theme.ui_font_fallbacks = value;
                         },
                     }
@@ -1010,7 +1017,7 @@ fn appearance_page() -> SettingsPage {
                             .as_ref()
                             .or(settings_content.theme.ui_font_size.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.agent_ui_font_size = value;
                     },
                 }),
@@ -1029,7 +1036,7 @@ fn appearance_page() -> SettingsPage {
                             .as_ref()
                             .or(settings_content.theme.buffer_font_size.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.agent_buffer_font_size = value;
                     },
                 }),
@@ -1050,7 +1057,7 @@ fn appearance_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.workspace.text_rendering_mode.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.text_rendering_mode = value;
                     },
                 }),
@@ -1069,7 +1076,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("multi_cursor_modifier"),
                     pick: |settings_content| settings_content.editor.multi_cursor_modifier.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.multi_cursor_modifier = value;
                     },
                 }),
@@ -1082,7 +1089,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("cursor_blink"),
                     pick: |settings_content| settings_content.editor.cursor_blink.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.cursor_blink = value;
                     },
                 }),
@@ -1095,7 +1102,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("cursor_shape"),
                     pick: |settings_content| settings_content.editor.cursor_shape.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.cursor_shape = value;
                     },
                 }),
@@ -1108,7 +1115,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("hide_mouse"),
                     pick: |settings_content| settings_content.editor.hide_mouse.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.hide_mouse = value;
                     },
                 }),
@@ -1127,7 +1134,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("unnecessary_code_fade"),
                     pick: |settings_content| settings_content.theme.unnecessary_code_fade.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.theme.unnecessary_code_fade = value;
                     },
                 }),
@@ -1142,7 +1149,7 @@ fn appearance_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.current_line_highlight.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.current_line_highlight = value;
                     },
                 }),
@@ -1155,7 +1162,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("selection_highlight"),
                     pick: |settings_content| settings_content.editor.selection_highlight.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.selection_highlight = value;
                     },
                 }),
@@ -1168,7 +1175,7 @@ fn appearance_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("rounded_selection"),
                     pick: |settings_content| settings_content.editor.rounded_selection.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.rounded_selection = value;
                     },
                 }),
@@ -1186,7 +1193,7 @@ fn appearance_page() -> SettingsPage {
                             .minimum_contrast_for_highlights
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.minimum_contrast_for_highlights = value;
                     },
                 }),
@@ -1212,7 +1219,7 @@ fn appearance_page() -> SettingsPage {
                             .show_wrap_guides
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project
                             .all_languages
@@ -1238,7 +1245,7 @@ fn appearance_page() -> SettingsPage {
                                 .wrap_guides
                                 .as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.project.all_languages.defaults.wrap_guides = value;
                         },
                     }
@@ -1302,7 +1309,7 @@ fn keymap_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("base_keymap"),
                     pick: |settings_content| settings_content.base_keymap.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.base_keymap = value;
                     },
                 }),
@@ -1376,7 +1383,7 @@ fn editor_page() -> SettingsPage {
                                     as usize],
                             )
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             let Some(value) = value else {
                                 settings_content.workspace.autosave = None;
                                 return;
@@ -1432,7 +1439,7 @@ fn editor_page() -> SettingsPage {
                                     }) => Some(milliseconds),
                                     _ => None,
                                 },
-                                write: |settings_content, value| {
+                                write: |settings_content, value, _app: &App| {
                                     let Some(value) = value else {
                                         settings_content.workspace.autosave = None;
                                         return;
@@ -1469,7 +1476,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|settings| settings.enabled.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.which_key.get_or_insert_default().enabled = value;
                     },
                 }),
@@ -1487,7 +1494,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|settings| settings.delay_ms.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.which_key.get_or_insert_default().delay_ms = value;
                     },
                 }),
@@ -1508,7 +1515,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.double_click_in_multibuffer.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.double_click_in_multibuffer = value;
                     },
                 }),
@@ -1521,7 +1528,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("expand_excerpt_lines"),
                     pick: |settings_content| settings_content.editor.expand_excerpt_lines.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.expand_excerpt_lines = value;
                     },
                 }),
@@ -1534,7 +1541,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("excerpt_context_lines"),
                     pick: |settings_content| settings_content.editor.excerpt_context_lines.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.excerpt_context_lines = value;
                     },
                 }),
@@ -1554,7 +1561,7 @@ fn editor_page() -> SettingsPage {
                                 outline_panel.expand_outlines_with_depth.as_ref()
                             })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -1570,7 +1577,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("diff_view_style"),
                     pick: |settings_content| settings_content.editor.diff_view_style.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.diff_view_style = value;
                     },
                 }),
@@ -1585,7 +1592,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.minimum_split_diff_width.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.minimum_split_diff_width = value;
                     },
                 }),
@@ -1606,7 +1613,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.scroll_beyond_last_line.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.scroll_beyond_last_line = value;
                     },
                 }),
@@ -1621,7 +1628,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.vertical_scroll_margin.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.vertical_scroll_margin = value;
                     },
                 }),
@@ -1636,7 +1643,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.horizontal_scroll_margin.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.horizontal_scroll_margin = value;
                     },
                 }),
@@ -1649,7 +1656,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("scroll_sensitivity"),
                     pick: |settings_content| settings_content.editor.scroll_sensitivity.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.scroll_sensitivity = value;
                     },
                 }),
@@ -1662,7 +1669,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("mouse_wheel_zoom"),
                     pick: |settings_content| settings_content.editor.mouse_wheel_zoom.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.mouse_wheel_zoom = value;
                     },
                 }),
@@ -1677,7 +1684,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.fast_scroll_sensitivity.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.fast_scroll_sensitivity = value;
                     },
                 }),
@@ -1690,7 +1697,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("autoscroll_on_clicks"),
                     pick: |settings_content| settings_content.editor.autoscroll_on_clicks.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.autoscroll_on_clicks = value;
                     },
                 }),
@@ -1709,7 +1716,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|sticky_scroll| sticky_scroll.enabled.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .sticky_scroll
@@ -1732,7 +1739,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("auto_signature_help"),
                     pick: |settings_content| settings_content.editor.auto_signature_help.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.auto_signature_help = value;
                     },
                 }),
@@ -1750,7 +1757,7 @@ fn editor_page() -> SettingsPage {
                             .show_signature_help_after_edits
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.show_signature_help_after_edits = value;
                     },
                 }),
@@ -1763,7 +1770,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("snippet_sort_order"),
                     pick: |settings_content| settings_content.editor.snippet_sort_order.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.snippet_sort_order = value;
                     },
                 }),
@@ -1782,7 +1789,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("hover_popover_enabled"),
                     pick: |settings_content| settings_content.editor.hover_popover_enabled.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.hover_popover_enabled = value;
                     },
                 }),
@@ -1796,7 +1803,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("hover_popover_delay"),
                     pick: |settings_content| settings_content.editor.hover_popover_delay.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.hover_popover_delay = value;
                     },
                 }),
@@ -1809,7 +1816,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("hover_popover_sticky"),
                     pick: |settings_content| settings_content.editor.hover_popover_sticky.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.hover_popover_sticky = value;
                     },
                 }),
@@ -1825,7 +1832,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.hover_popover_hiding_delay.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.hover_popover_hiding_delay = value;
                     },
                 }),
@@ -1850,7 +1857,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|drag_and_drop| drag_and_drop.enabled.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .drag_and_drop_selection
@@ -1873,7 +1880,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|drag_and_drop| drag_and_drop.delay.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .drag_and_drop_selection
@@ -1902,7 +1909,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|gutter| gutter.line_numbers.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .gutter
@@ -1919,7 +1926,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("relative_line_numbers"),
                     pick: |settings_content| settings_content.editor.relative_line_numbers.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.relative_line_numbers = value;
                     },
                 }),
@@ -1938,7 +1945,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|gutter| gutter.runnables.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .gutter
@@ -1961,7 +1968,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|gutter| gutter.breakpoints.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .gutter
@@ -1984,7 +1991,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|gutter| gutter.bookmarks.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .gutter
@@ -2007,7 +2014,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|gutter| gutter.folds.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.gutter.get_or_insert_default().folds = value;
                     },
                 }),
@@ -2026,7 +2033,7 @@ fn editor_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|gutter| gutter.min_line_number_digits.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .gutter
@@ -2043,7 +2050,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("inline_code_actions"),
                     pick: |settings_content| settings_content.editor.inline_code_actions.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.inline_code_actions = value;
                     },
                 }),
@@ -2064,7 +2071,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.scrollbar.as_ref()?.show.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2083,7 +2090,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.scrollbar.as_ref()?.cursors.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2107,7 +2114,7 @@ fn editor_page() -> SettingsPage {
                             .git_diff
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2131,7 +2138,7 @@ fn editor_page() -> SettingsPage {
                             .search_results
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2155,7 +2162,7 @@ fn editor_page() -> SettingsPage {
                             .selected_text
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2179,7 +2186,7 @@ fn editor_page() -> SettingsPage {
                             .selected_symbol
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2203,7 +2210,7 @@ fn editor_page() -> SettingsPage {
                             .diagnostics
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2229,7 +2236,7 @@ fn editor_page() -> SettingsPage {
                             .horizontal
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2257,7 +2264,7 @@ fn editor_page() -> SettingsPage {
                             .vertical
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .scrollbar
@@ -2284,7 +2291,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.minimap.as_ref()?.show.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.minimap.get_or_insert_default().show = value;
                     },
                 }),
@@ -2304,7 +2311,7 @@ fn editor_page() -> SettingsPage {
                             .display_in
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .minimap
@@ -2323,7 +2330,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.minimap.as_ref()?.thumb.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .minimap
@@ -2347,7 +2354,7 @@ fn editor_page() -> SettingsPage {
                             .thumb_border
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .minimap
@@ -2371,7 +2378,7 @@ fn editor_page() -> SettingsPage {
                             .and_then(|minimap| minimap.current_line_highlight.as_ref())
                             .or(settings_content.editor.current_line_highlight.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .minimap
@@ -2395,7 +2402,7 @@ fn editor_page() -> SettingsPage {
                             .max_width_columns
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .minimap
@@ -2425,7 +2432,7 @@ fn editor_page() -> SettingsPage {
                             .breadcrumbs
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .toolbar
@@ -2449,7 +2456,7 @@ fn editor_page() -> SettingsPage {
                             .quick_actions
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .toolbar
@@ -2473,7 +2480,7 @@ fn editor_page() -> SettingsPage {
                             .selections_menu
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .toolbar
@@ -2497,7 +2504,7 @@ fn editor_page() -> SettingsPage {
                             .agent_review
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .toolbar
@@ -2521,7 +2528,7 @@ fn editor_page() -> SettingsPage {
                             .code_actions
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .toolbar
@@ -2544,7 +2551,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("vim.default_mode"),
                     pick: |settings_content| settings_content.vim.as_ref()?.default_mode.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.vim.get_or_insert_default().default_mode = value;
                     },
                 }),
@@ -2563,7 +2570,7 @@ fn editor_page() -> SettingsPage {
                             .toggle_relative_line_numbers
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2581,7 +2588,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.vim.as_ref()?.use_system_clipboard.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2599,7 +2606,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.vim.as_ref()?.use_smartcase_find.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2615,7 +2622,7 @@ fn editor_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("vim.gdefault"),
                     pick: |settings_content| settings_content.vim.as_ref()?.gdefault.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.vim.get_or_insert_default().gdefault = value;
                     },
                 }),
@@ -2634,7 +2641,7 @@ fn editor_page() -> SettingsPage {
                             .highlight_on_yank_duration
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2652,7 +2659,7 @@ fn editor_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.vim.as_ref()?.use_regex_search.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2676,7 +2683,7 @@ fn editor_page() -> SettingsPage {
                             .normal
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2702,7 +2709,7 @@ fn editor_page() -> SettingsPage {
                             .insert
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2728,7 +2735,7 @@ fn editor_page() -> SettingsPage {
                             .replace
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2754,7 +2761,7 @@ fn editor_page() -> SettingsPage {
                             .visual
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .vim
                             .get_or_insert_default()
@@ -2775,7 +2782,7 @@ fn editor_page() -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.vim.as_ref()?.custom_digraphs.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.vim.get_or_insert_default().custom_digraphs = value;
                         },
                     }
@@ -2822,7 +2829,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.project.all_languages.file_types.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.project.all_languages.file_types = value;
                         },
                     }
@@ -2845,7 +2852,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.diagnostics_max_severity.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.diagnostics_max_severity = value;
                     },
                 }),
@@ -2864,7 +2871,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .include_warnings
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -2894,7 +2901,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .enabled
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -2920,7 +2927,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .update_debounce_ms
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -2946,7 +2953,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .padding
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -2972,7 +2979,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .min_column
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -3004,7 +3011,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .enabled
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -3031,7 +3038,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             .debounce_ms
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .diagnostics
                             .get_or_insert_default()
@@ -3057,7 +3064,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.lsp_highlight_debounce.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.lsp_highlight_debounce = value;
                     },
                 }),
@@ -3127,7 +3134,7 @@ fn search_and_files_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.search.as_ref()?.whole_word.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .search
@@ -3151,7 +3158,7 @@ fn search_and_files_page() -> SettingsPage {
                             .case_sensitive
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .search
@@ -3168,7 +3175,7 @@ fn search_and_files_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("use_smartcase_search"),
                     pick: |settings_content| settings_content.editor.use_smartcase_search.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.use_smartcase_search = value;
                     },
                 }),
@@ -3188,7 +3195,7 @@ fn search_and_files_page() -> SettingsPage {
                             .include_ignored
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .search
@@ -3207,7 +3214,7 @@ fn search_and_files_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.search.as_ref()?.regex.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.search.get_or_insert_default().regex = value;
                     },
                 }),
@@ -3220,7 +3227,7 @@ fn search_and_files_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("search_wrap"),
                     pick: |settings_content| settings_content.editor.search_wrap.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.search_wrap = value;
                     },
                 }),
@@ -3239,7 +3246,7 @@ fn search_and_files_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|search| search.center_on_match.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .search
@@ -3261,7 +3268,7 @@ fn search_and_files_page() -> SettingsPage {
                             .seed_search_query_from_cursor
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.seed_search_query_from_cursor = value;
                     },
                 }),
@@ -3287,7 +3294,7 @@ fn search_and_files_page() -> SettingsPage {
                             .include_ignored
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .file_finder
                             .get_or_insert_default()
@@ -3305,7 +3312,7 @@ fn search_and_files_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.file_finder.as_ref()?.file_icons.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .file_finder
                             .get_or_insert_default()
@@ -3327,7 +3334,7 @@ fn search_and_files_page() -> SettingsPage {
                             .modal_max_width
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .file_finder
                             .get_or_insert_default()
@@ -3349,7 +3356,7 @@ fn search_and_files_page() -> SettingsPage {
                             .skip_focus_for_active_in_search
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .file_finder
                             .get_or_insert_default()
@@ -3378,7 +3385,7 @@ fn search_and_files_page() -> SettingsPage {
                                 .file_scan_exclusions
                                 .as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.project.worktree.file_scan_exclusions = value;
                         },
                     }
@@ -3400,7 +3407,7 @@ fn search_and_files_page() -> SettingsPage {
                                 .file_scan_inclusions
                                 .as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.project.worktree.file_scan_inclusions = value;
                         },
                     }
@@ -3417,7 +3424,7 @@ fn search_and_files_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.workspace.restore_on_file_reopen.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.restore_on_file_reopen = value;
                     },
                 }),
@@ -3432,7 +3439,7 @@ fn search_and_files_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.workspace.close_on_file_delete.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.close_on_file_delete = value;
                     },
                 }),
@@ -3460,7 +3467,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project_panel.as_ref()?.button.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -3482,7 +3489,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .active_language_button
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .status_bar
                             .get_or_insert_default()
@@ -3504,7 +3511,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .active_encoding_button
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .status_bar
                             .get_or_insert_default()
@@ -3526,7 +3533,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .cursor_position_button
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .status_bar
                             .get_or_insert_default()
@@ -3542,7 +3549,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("terminal.button"),
                     pick: |settings_content| settings_content.terminal.as_ref()?.button.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.terminal.get_or_insert_default().button = value;
                     },
                 }),
@@ -3555,7 +3562,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("diagnostics.button"),
                     pick: |settings_content| settings_content.diagnostics.as_ref()?.button.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.diagnostics.get_or_insert_default().button = value;
                     },
                 }),
@@ -3570,7 +3577,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.editor.search.as_ref()?.button.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .editor
                             .search
@@ -3587,7 +3594,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("debugger.button"),
                     pick: |settings_content| settings_content.debugger.as_ref()?.button.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.debugger.get_or_insert_default().button = value;
                     },
                 }),
@@ -3606,7 +3613,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_active_file
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .status_bar
                             .get_or_insert_default()
@@ -3634,7 +3641,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_branch_status_icon
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3656,7 +3663,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_branch_name
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3678,7 +3685,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_project_items
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3700,7 +3707,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_onboarding_banner
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3718,7 +3725,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.title_bar.as_ref()?.show_sign_in.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3736,7 +3743,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.title_bar.as_ref()?.show_user_menu.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3758,7 +3765,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_user_picture
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3776,7 +3783,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.title_bar.as_ref()?.show_menus.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .title_bar
                             .get_or_insert_default()
@@ -3805,7 +3812,7 @@ fn window_and_layout_page() -> SettingsPage {
                                     as usize],
                             )
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             let Some(value) = value else {
                                 settings_content
                                     .title_bar
@@ -3885,7 +3892,7 @@ fn window_and_layout_page() -> SettingsPage {
                                         }
                                         _ => DEFAULT_EMPTY_STRING,
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         settings_content
                                             .title_bar
                                             .get_or_insert_default()
@@ -3914,7 +3921,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("tab_bar.show"),
                     pick: |settings_content| settings_content.tab_bar.as_ref()?.show.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.tab_bar.get_or_insert_default().show = value;
                     },
                 }),
@@ -3927,7 +3934,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("tabs.git_status"),
                     pick: |settings_content| settings_content.tabs.as_ref()?.git_status.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.tabs.get_or_insert_default().git_status = value;
                     },
                 }),
@@ -3940,7 +3947,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("tabs.file_icons"),
                     pick: |settings_content| settings_content.tabs.as_ref()?.file_icons.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.tabs.get_or_insert_default().file_icons = value;
                     },
                 }),
@@ -3955,7 +3962,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.tabs.as_ref()?.close_position.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.tabs.get_or_insert_default().close_position = value;
                     },
                 }),
@@ -3972,7 +3979,7 @@ fn window_and_layout_page() -> SettingsPage {
                     SettingField {
                         json_path: Some("max_tabs"),
                         pick: |settings_content| settings_content.workspace.max_tabs.as_ref(),
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.workspace.max_tabs = value;
                         },
                     }
@@ -3992,7 +3999,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_nav_history_buttons
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .tab_bar
                             .get_or_insert_default()
@@ -4014,7 +4021,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_tab_bar_buttons
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .tab_bar
                             .get_or_insert_default()
@@ -4036,7 +4043,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .show_pinned_tabs_in_separate_row
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .tab_bar
                             .get_or_insert_default()
@@ -4060,7 +4067,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.tabs.as_ref()?.activate_on_close.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .tabs
                             .get_or_insert_default()
@@ -4078,7 +4085,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.tabs.as_ref()?.show_diagnostics.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .tabs
                             .get_or_insert_default()
@@ -4096,7 +4103,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.tabs.as_ref()?.show_close_button.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .tabs
                             .get_or_insert_default()
@@ -4120,7 +4127,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.preview_tabs.as_ref()?.enabled.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4142,7 +4149,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .enable_preview_from_project_panel
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4164,7 +4171,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .enable_preview_from_file_finder
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4186,7 +4193,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .enable_preview_from_multibuffer
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4208,7 +4215,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .enable_preview_multibuffer_from_code_navigation
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4230,7 +4237,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .enable_preview_file_from_code_navigation
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4252,7 +4259,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .enable_keep_preview_on_code_navigation
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .preview_tabs
                             .get_or_insert_default()
@@ -4274,7 +4281,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("bottom_dock_layout"),
                     pick: |settings_content| settings_content.workspace.bottom_dock_layout.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.bottom_dock_layout = value;
                     },
                 }),
@@ -4295,7 +4302,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .left_padding
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .workspace
                             .centered_layout
@@ -4319,7 +4326,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .right_padding
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .workspace
                             .centered_layout
@@ -4341,7 +4348,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|s| s.enabled.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .workspace
                             .focus_follows_mouse
@@ -4364,7 +4371,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .as_ref()
                             .and_then(|s| s.debounce_ms.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .workspace
                             .focus_follows_mouse
@@ -4390,7 +4397,7 @@ fn window_and_layout_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.workspace.use_system_window_tabs.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.use_system_window_tabs = value;
                     },
                 }),
@@ -4403,7 +4410,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("window_decorations"),
                     pick: |settings_content| settings_content.workspace.window_decorations.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.window_decorations = value;
                     },
                 }),
@@ -4429,7 +4436,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .inactive_opacity
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .workspace
                             .active_pane_modifiers
@@ -4453,7 +4460,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .border_size
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .workspace
                             .active_pane_modifiers
@@ -4470,7 +4477,7 @@ fn window_and_layout_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("zoomed_padding"),
                     pick: |settings_content| settings_content.workspace.zoomed_padding.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.zoomed_padding = value;
                     },
                 }),
@@ -4494,7 +4501,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .pane_split_direction_vertical
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.pane_split_direction_vertical = value;
                     },
                 }),
@@ -4512,7 +4519,7 @@ fn window_and_layout_page() -> SettingsPage {
                             .pane_split_direction_horizontal
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.pane_split_direction_horizontal = value;
                     },
                 }),
@@ -4548,7 +4555,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("project_panel.dock"),
                     pick: |settings_content| settings_content.project_panel.as_ref()?.dock.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.project_panel.get_or_insert_default().dock = value;
                     },
                 }),
@@ -4567,7 +4574,7 @@ fn panels_page() -> SettingsPage {
                             .default_width
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4589,7 +4596,7 @@ fn panels_page() -> SettingsPage {
                             .hide_gitignore
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4611,7 +4618,7 @@ fn panels_page() -> SettingsPage {
                             .entry_spacing
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4629,7 +4636,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project_panel.as_ref()?.file_icons.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4651,7 +4658,7 @@ fn panels_page() -> SettingsPage {
                             .folder_icons
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4669,7 +4676,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project_panel.as_ref()?.git_status.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4691,7 +4698,7 @@ fn panels_page() -> SettingsPage {
                             .indent_size
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4713,7 +4720,7 @@ fn panels_page() -> SettingsPage {
                             .auto_reveal_entries
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4735,7 +4742,7 @@ fn panels_page() -> SettingsPage {
                             .starts_open
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4757,7 +4764,7 @@ fn panels_page() -> SettingsPage {
                             .auto_fold_dirs
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4779,7 +4786,7 @@ fn panels_page() -> SettingsPage {
                             .bold_folder_labels
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4805,7 +4812,7 @@ fn panels_page() -> SettingsPage {
                                 .as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4831,7 +4838,7 @@ fn panels_page() -> SettingsPage {
                             .horizontal_scroll
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4855,7 +4862,7 @@ fn panels_page() -> SettingsPage {
                             .show_diagnostics
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4877,7 +4884,7 @@ fn panels_page() -> SettingsPage {
                             .diagnostic_badges
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4899,7 +4906,7 @@ fn panels_page() -> SettingsPage {
                             .git_status_indicator
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4921,7 +4928,7 @@ fn panels_page() -> SettingsPage {
                             .sticky_scroll
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4946,7 +4953,7 @@ fn panels_page() -> SettingsPage {
                             .show
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4969,7 +4976,7 @@ fn panels_page() -> SettingsPage {
                             .drag_and_drop
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -4987,7 +4994,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project_panel.as_ref()?.hide_root.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5009,7 +5016,7 @@ fn panels_page() -> SettingsPage {
                             .hide_hidden
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5027,7 +5034,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project_panel.as_ref()?.sort_mode.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5044,7 +5051,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project_panel.as_ref()?.sort_order.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5069,7 +5076,7 @@ fn panels_page() -> SettingsPage {
                             .on_create
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5095,7 +5102,7 @@ fn panels_page() -> SettingsPage {
                             .on_paste
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5121,7 +5128,7 @@ fn panels_page() -> SettingsPage {
                             .on_drop
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
@@ -5142,7 +5149,7 @@ fn panels_page() -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.project.worktree.hidden_files.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content.project.worktree.hidden_files = value;
                         },
                     }
@@ -5163,7 +5170,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("terminal.dock"),
                     pick: |settings_content| settings_content.terminal.as_ref()?.dock.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.terminal.get_or_insert_default().dock = value;
                     },
                 }),
@@ -5176,7 +5183,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("terminal.flexible"),
                     pick: |settings_content| settings_content.terminal.as_ref()?.flexible.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.terminal.get_or_insert_default().flexible = value;
                     },
                 }),
@@ -5195,7 +5202,7 @@ fn panels_page() -> SettingsPage {
                             .show_count_badge
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -5219,7 +5226,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.outline_panel.as_ref()?.button.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5235,7 +5242,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("outline_panel.dock"),
                     pick: |settings_content| settings_content.outline_panel.as_ref()?.dock.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.outline_panel.get_or_insert_default().dock = value;
                     },
                 }),
@@ -5254,7 +5261,7 @@ fn panels_page() -> SettingsPage {
                             .default_width
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5272,7 +5279,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.outline_panel.as_ref()?.file_icons.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5294,7 +5301,7 @@ fn panels_page() -> SettingsPage {
                             .folder_icons
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5312,7 +5319,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.outline_panel.as_ref()?.git_status.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5334,7 +5341,7 @@ fn panels_page() -> SettingsPage {
                             .indent_size
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5356,7 +5363,7 @@ fn panels_page() -> SettingsPage {
                             .auto_reveal_entries
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5378,7 +5385,7 @@ fn panels_page() -> SettingsPage {
                             .auto_fold_dirs
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5403,7 +5410,7 @@ fn panels_page() -> SettingsPage {
                             .show
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .outline_panel
                             .get_or_insert_default()
@@ -5426,7 +5433,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git_panel.button"),
                     pick: |settings_content| settings_content.git_panel.as_ref()?.button.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git_panel.get_or_insert_default().button = value;
                     },
                 }),
@@ -5439,7 +5446,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git_panel.dock"),
                     pick: |settings_content| settings_content.git_panel.as_ref()?.dock.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git_panel.get_or_insert_default().dock = value;
                     },
                 }),
@@ -5454,7 +5461,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.default_width.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5472,7 +5479,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.status_style.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5494,7 +5501,7 @@ fn panels_page() -> SettingsPage {
                             .fallback_branch_name
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5512,7 +5519,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.sort_by_path.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5534,7 +5541,7 @@ fn panels_page() -> SettingsPage {
                             .collapse_untracked_diff
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5552,7 +5559,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.tree_view.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git_panel.get_or_insert_default().tree_view = value;
                     },
                 }),
@@ -5567,7 +5574,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.file_icons.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5585,7 +5592,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.folder_icons.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5603,7 +5610,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git_panel.as_ref()?.diff_stats.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5625,7 +5632,7 @@ fn panels_page() -> SettingsPage {
                             .show_count_badge
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5651,7 +5658,7 @@ fn panels_page() -> SettingsPage {
                                 .as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
@@ -5675,7 +5682,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("debugger.dock"),
                     pick: |settings_content| settings_content.debugger.as_ref()?.dock.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.debugger.get_or_insert_default().dock = value;
                     },
                 }),
@@ -5700,7 +5707,7 @@ fn panels_page() -> SettingsPage {
                             .button
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .collaboration_panel
                             .get_or_insert_default()
@@ -5718,7 +5725,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.collaboration_panel.as_ref()?.dock.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .collaboration_panel
                             .get_or_insert_default()
@@ -5740,7 +5747,7 @@ fn panels_page() -> SettingsPage {
                             .default_width
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .collaboration_panel
                             .get_or_insert_default()
@@ -5762,7 +5769,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("agent.button"),
                     pick: |settings_content| settings_content.agent.as_ref()?.button.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.agent.get_or_insert_default().button = value;
                     },
                 }),
@@ -5775,7 +5782,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("agent.dock"),
                     pick: |settings_content| settings_content.agent.as_ref()?.dock.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.agent.get_or_insert_default().dock = value;
                     },
                 }),
@@ -5788,7 +5795,7 @@ fn panels_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("agent.flexible"),
                     pick: |settings_content| settings_content.agent.as_ref()?.flexible.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.agent.get_or_insert_default().flexible = value;
                     },
                 }),
@@ -5803,7 +5810,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.default_width.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.agent.get_or_insert_default().default_width = value;
                     },
                 }),
@@ -5818,7 +5825,7 @@ fn panels_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.default_height.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -5842,7 +5849,7 @@ fn panels_page() -> SettingsPage {
                                 .limit_content_width
                                 .as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content
                                 .agent
                                 .get_or_insert_default()
@@ -5870,7 +5877,7 @@ fn panels_page() -> SettingsPage {
                             pick: |settings_content| {
                                 settings_content.agent.as_ref()?.max_content_width.as_ref()
                             },
-                            write: |settings_content, value| {
+                            write: |settings_content, value, _app: &App| {
                                 settings_content
                                     .agent
                                     .get_or_insert_default()
@@ -5914,7 +5921,7 @@ fn debugger_page() -> SettingsPage {
                             .stepping_granularity
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .debugger
                             .get_or_insert_default()
@@ -5936,7 +5943,7 @@ fn debugger_page() -> SettingsPage {
                             .save_breakpoints
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .debugger
                             .get_or_insert_default()
@@ -5952,7 +5959,7 @@ fn debugger_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("debugger.timeout"),
                     pick: |settings_content| settings_content.debugger.as_ref()?.timeout.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.debugger.get_or_insert_default().timeout = value;
                     },
                 }),
@@ -5971,7 +5978,7 @@ fn debugger_page() -> SettingsPage {
                             .log_dap_communications
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .debugger
                             .get_or_insert_default()
@@ -5993,7 +6000,7 @@ fn debugger_page() -> SettingsPage {
                             .format_dap_log_messages
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .debugger
                             .get_or_insert_default()
@@ -6034,7 +6041,7 @@ fn terminal_page() -> SettingsPage {
                                         .discriminant() as usize
                                 ])
                             },
-                            write: |settings_content, value| {
+                            write: |settings_content, value, _app: &App| {
                                 let Some(value) = value else {
                                     if let Some(terminal) = settings_content.terminal.as_mut() {
                                         terminal.project.shell = None;
@@ -6109,7 +6116,7 @@ fn terminal_page() -> SettingsPage {
                                         Some(settings::Shell::Program(program)) => Some(program),
                                         _ => None,
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let Some(value) = value else {
                                             return;
                                         };
@@ -6140,7 +6147,7 @@ fn terminal_page() -> SettingsPage {
                                                 _ => None,
                                             }
                                         },
-                                        write: |settings_content, value| {
+                                        write: |settings_content, value, _app: &App| {
                                             let Some(value) = value else {
                                                 return;
                                             };
@@ -6173,7 +6180,7 @@ fn terminal_page() -> SettingsPage {
                                                     _ => None,
                                                 }
                                             },
-                                            write: |settings_content, value| {
+                                            write: |settings_content, value, _app: &App| {
                                                 let Some(value) = value else {
                                                     return;
                                                 };
@@ -6207,7 +6214,7 @@ fn terminal_page() -> SettingsPage {
                                                 _ => None,
                                             }
                                         },
-                                        write: |settings_content, value| {
+                                        write: |settings_content, value, _app: &App| {
                                             match settings_content
                                                 .terminal
                                                 .get_or_insert_default()
@@ -6246,7 +6253,7 @@ fn terminal_page() -> SettingsPage {
                                         .discriminant() as usize
                                 ])
                             },
-                            write: |settings_content, value| {
+                            write: |settings_content, value, _app: &App| {
                                 let Some(value) = value else {
                                     if let Some(terminal) = settings_content.terminal.as_mut() {
                                         terminal.project.working_directory = None;
@@ -6314,7 +6321,7 @@ fn terminal_page() -> SettingsPage {
                                             _ => None,
                                         }
                                     },
-                                    write: |settings_content, value| {
+                                    write: |settings_content, value, _app: &App| {
                                         let value = value.unwrap_or_default();
                                         match settings_content
                                             .terminal
@@ -6340,7 +6347,7 @@ fn terminal_page() -> SettingsPage {
                         SettingField {
                             json_path: Some("terminal.env"),
                             pick: |settings_content| settings_content.terminal.as_ref()?.project.env.as_ref(),
-                            write: |settings_content, value| {
+                            write: |settings_content, value, _app: &App| {
                                 settings_content.terminal.get_or_insert_default().project.env = value;
                             },
                         }
@@ -6356,7 +6363,7 @@ fn terminal_page() -> SettingsPage {
                         SettingField {
                             json_path: Some("terminal.detect_venv"),
                             pick: |settings_content| settings_content.terminal.as_ref()?.project.detect_venv.as_ref(),
-                            write: |settings_content, value| {
+                            write: |settings_content, value, _app: &App| {
                                 settings_content
                                     .terminal
                                     .get_or_insert_default()
@@ -6387,7 +6394,7 @@ fn terminal_page() -> SettingsPage {
                             .and_then(|terminal| terminal.font_size.as_ref())
                             .or(settings_content.theme.buffer_font_size.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.terminal.get_or_insert_default().font_size = value;
                     },
                 }),
@@ -6406,7 +6413,7 @@ fn terminal_page() -> SettingsPage {
                             .and_then(|terminal| terminal.font_family.as_ref())
                             .or(settings_content.theme.buffer_font_family.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6429,7 +6436,7 @@ fn terminal_page() -> SettingsPage {
                                 .and_then(|terminal| terminal.font_fallbacks.as_ref())
                                 .or(settings_content.theme.buffer_font_fallbacks.as_ref())
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content
                                 .terminal
                                 .get_or_insert_default()
@@ -6449,7 +6456,7 @@ fn terminal_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.terminal.as_ref()?.font_weight.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6472,7 +6479,7 @@ fn terminal_page() -> SettingsPage {
                                 .and_then(|terminal| terminal.font_features.as_ref())
                                 .or(settings_content.theme.buffer_font_features.as_ref())
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content
                                 .terminal
                                 .get_or_insert_default()
@@ -6499,7 +6506,7 @@ fn terminal_page() -> SettingsPage {
                         pick: |settings_content| {
                             settings_content.terminal.as_ref()?.line_height.as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content
                                 .terminal
                                 .get_or_insert_default()
@@ -6519,7 +6526,7 @@ fn terminal_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.terminal.as_ref()?.cursor_shape.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6535,7 +6542,7 @@ fn terminal_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("terminal.blinking"),
                     pick: |settings_content| settings_content.terminal.as_ref()?.blinking.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.terminal.get_or_insert_default().blinking = value;
                     },
                 }),
@@ -6554,7 +6561,7 @@ fn terminal_page() -> SettingsPage {
                             .alternate_scroll
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6576,7 +6583,7 @@ fn terminal_page() -> SettingsPage {
                             .minimum_contrast
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6600,7 +6607,7 @@ fn terminal_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.terminal.as_ref()?.option_as_meta.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6618,7 +6625,7 @@ fn terminal_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.terminal.as_ref()?.copy_on_select.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6640,7 +6647,7 @@ fn terminal_page() -> SettingsPage {
                             .keep_selection_on_copy
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6664,7 +6671,7 @@ fn terminal_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.terminal.as_ref()?.default_width.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6682,7 +6689,7 @@ fn terminal_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.terminal.as_ref()?.default_height.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6710,7 +6717,7 @@ fn terminal_page() -> SettingsPage {
                             .max_scroll_history_lines
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6732,7 +6739,7 @@ fn terminal_page() -> SettingsPage {
                             .scroll_multiplier
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6762,7 +6769,7 @@ fn terminal_page() -> SettingsPage {
                             .breadcrumbs
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6796,7 +6803,7 @@ fn terminal_page() -> SettingsPage {
                                 .as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .terminal
                             .get_or_insert_default()
@@ -6846,7 +6853,7 @@ fn version_control_page() -> SettingsPage {
                                 .disable_git
                                 .as_ref()
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             settings_content
                                 .git
                                 .get_or_insert_default()
@@ -6885,7 +6892,7 @@ fn version_control_page() -> SettingsPage {
                                         .enable_status
                                         .as_ref()
                                 },
-                                write: |settings_content, value| {
+                                write: |settings_content, value, _app: &App| {
                                     settings_content
                                         .git
                                         .get_or_insert_default()
@@ -6911,7 +6918,7 @@ fn version_control_page() -> SettingsPage {
                                         .enable_diff
                                         .as_ref()
                                 },
-                                write: |settings_content, value| {
+                                write: |settings_content, value, _app: &App| {
                                     settings_content
                                         .git
                                         .get_or_insert_default()
@@ -6937,7 +6944,7 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.git_gutter"),
                     pick: |settings_content| settings_content.git.as_ref()?.git_gutter.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git.get_or_insert_default().git_gutter = value;
                     },
                 }),
@@ -6953,7 +6960,7 @@ fn version_control_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.git.as_ref()?.gutter_debounce.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git.get_or_insert_default().gutter_debounce = value;
                     },
                 }),
@@ -6980,7 +6987,7 @@ fn version_control_page() -> SettingsPage {
                             .enabled
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7006,7 +7013,7 @@ fn version_control_page() -> SettingsPage {
                             .delay_ms
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7032,7 +7039,7 @@ fn version_control_page() -> SettingsPage {
                             .padding
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7058,7 +7065,7 @@ fn version_control_page() -> SettingsPage {
                             .min_column
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7084,7 +7091,7 @@ fn version_control_page() -> SettingsPage {
                             .show_commit_summary
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7116,7 +7123,7 @@ fn version_control_page() -> SettingsPage {
                             .show_avatar
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7148,7 +7155,7 @@ fn version_control_page() -> SettingsPage {
                             .show_author_name
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .git
                             .get_or_insert_default()
@@ -7172,7 +7179,7 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.hunk_style"),
                     pick: |settings_content| settings_content.git.as_ref()?.hunk_style.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git.get_or_insert_default().hunk_style = value;
                     },
                 }),
@@ -7185,7 +7192,7 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.path_style"),
                     pick: |settings_content| settings_content.git.as_ref()?.path_style.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.git.get_or_insert_default().path_style = value;
                     },
                 }),
@@ -7218,7 +7225,7 @@ fn collaboration_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("calls.mute_on_join"),
                     pick: |settings_content| settings_content.calls.as_ref()?.mute_on_join.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.calls.get_or_insert_default().mute_on_join = value;
                     },
                 }),
@@ -7233,7 +7240,7 @@ fn collaboration_page() -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.calls.as_ref()?.share_on_join.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.calls.get_or_insert_default().share_on_join = value;
                     },
                 }),
@@ -7267,7 +7274,7 @@ fn collaboration_page() -> SettingsPage {
                             .as_ref()
                             .or(DEFAULT_EMPTY_AUDIO_OUTPUT)
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .audio
                             .get_or_insert_default()
@@ -7290,7 +7297,7 @@ fn collaboration_page() -> SettingsPage {
                             .as_ref()
                             .or(DEFAULT_EMPTY_AUDIO_INPUT)
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .audio
                             .get_or_insert_default()
@@ -7319,7 +7326,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("disable_ai"),
                     pick: |settings_content| settings_content.project.disable_ai.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.project.disable_ai = value;
                     },
                 }),
@@ -7332,7 +7339,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("agent.sidebar_side"),
                     pick: |settings_content| settings_content.agent.as_ref()?.sidebar_side.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.agent.get_or_insert_default().sidebar_side = value;
                     },
                 }),
@@ -7368,7 +7375,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                         .new_thread_location
                         .as_ref()
                 },
-                write: |settings_content, value| {
+                write: |settings_content, value, _app: &App| {
                     settings_content
                         .agent
                         .get_or_insert_default()
@@ -7388,7 +7395,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.single_file_review.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7406,7 +7413,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.enable_feedback.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7428,7 +7435,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .notify_when_agent_waiting
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7450,7 +7457,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .play_sound_when_agent_done
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7468,7 +7475,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.expand_edit_card.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7490,7 +7497,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .expand_terminal_card
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7512,7 +7519,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .thinking_display
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7534,7 +7541,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .cancel_generation_on_terminal_stop
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7556,7 +7563,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .use_modifier_to_send
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7578,7 +7585,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                             .message_editor_min_lines
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7596,7 +7603,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.show_turn_stats.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7614,7 +7621,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.agent.as_ref()?.show_merge_conflict_indicator.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .agent
                             .get_or_insert_default()
@@ -7640,7 +7647,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                     pick: |settings_content| {
                         settings_content.project.context_server_timeout.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.project.context_server_timeout = value;
                     },
                 }),
@@ -7665,7 +7672,7 @@ fn ai_page(cx: &App) -> SettingsPage {
                         .mode
                         .as_ref()
                 },
-                write: |settings_content, value| {
+                write: |settings_content, value, _app: &App| {
                     settings_content
                         .project
                         .all_languages
@@ -7701,7 +7708,7 @@ fn network_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("proxy"),
                     pick: |settings_content| settings_content.proxy.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.proxy = value;
                     },
                 }),
@@ -7717,7 +7724,7 @@ fn network_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("server_url"),
                     pick: |settings_content| settings_content.server_url.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.server_url = value;
                     },
                 }),
@@ -7785,7 +7792,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.tab_size.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.tab_size = value;
                         })
@@ -7804,7 +7811,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.hard_tabs.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.hard_tabs = value;
                         })
@@ -7823,7 +7830,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.auto_indent.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.auto_indent = value;
                         })
@@ -7842,7 +7849,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.auto_indent_on_paste.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.auto_indent_on_paste = value;
                         })
@@ -7867,7 +7874,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.soft_wrap.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.soft_wrap = value;
                         })
@@ -7886,7 +7893,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.show_wrap_guides.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.show_wrap_guides = value;
                         })
@@ -7905,7 +7912,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.preferred_line_length.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.preferred_line_length = value;
                         })
@@ -7925,7 +7932,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.wrap_guides.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -7950,7 +7957,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.allow_rewrap.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.allow_rewrap = value;
                         })
@@ -7978,7 +7985,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 .and_then(|indent_guides| indent_guides.enabled.as_ref())
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.indent_guides.get_or_insert_default().enabled = value;
                         })
@@ -8000,7 +8007,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 .and_then(|indent_guides| indent_guides.line_width.as_ref())
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.indent_guides.get_or_insert_default().line_width = value;
                         })
@@ -8022,7 +8029,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 .and_then(|indent_guides| indent_guides.active_line_width.as_ref())
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .indent_guides
@@ -8047,7 +8054,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 .and_then(|indent_guides| indent_guides.coloring.as_ref())
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.indent_guides.get_or_insert_default().coloring = value;
                         })
@@ -8068,7 +8075,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             })
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .indent_guides
@@ -8098,7 +8105,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.format_on_save.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8122,7 +8129,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.remove_trailing_whitespace_on_save.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.remove_trailing_whitespace_on_save = value;
                         })
@@ -8141,7 +8148,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.ensure_final_newline_on_save.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.ensure_final_newline_on_save = value;
                         })
@@ -8160,7 +8167,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.line_ending.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.line_ending = value;
                         })
@@ -8183,7 +8190,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.formatter.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8208,7 +8215,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.use_on_type_format.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.use_on_type_format = value;
                         })
@@ -8228,7 +8235,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.code_actions_on_format.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8259,7 +8266,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.use_autoclose.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.use_autoclose = value;
                         })
@@ -8278,7 +8285,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.use_auto_surround.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.use_auto_surround = value;
                         })
@@ -8297,7 +8304,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.always_treat_brackets_as_autoclosed.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.always_treat_brackets_as_autoclosed = value;
                         })
@@ -8317,7 +8324,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.jsx_tag_auto_close.as_ref()?.enabled.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.jsx_tag_auto_close.get_or_insert_default().enabled = value;
                         })
@@ -8342,7 +8349,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.show_whitespaces.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.show_whitespaces = value;
                         })
@@ -8362,7 +8369,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.whitespace_map.as_ref()?.space.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8388,7 +8395,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.whitespace_map.as_ref()?.tab.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8419,7 +8426,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.show_completions_on_input.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.show_completions_on_input = value;
                         })
@@ -8438,7 +8445,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.show_completion_documentation.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.show_completion_documentation = value;
                         })
@@ -8457,7 +8464,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.completions.as_ref()?.words.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.completions.get_or_insert_default().words = value;
                         })
@@ -8476,7 +8483,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.completions.as_ref()?.words_min_length.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .completions
@@ -8496,7 +8503,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                     pick: |settings_content| {
                         settings_content.editor.completion_menu_scrollbar.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.completion_menu_scrollbar = value;
                     },
                 }),
@@ -8511,7 +8518,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                     pick: |settings_content| {
                         settings_content.editor.completion_detail_alignment.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.completion_detail_alignment = value;
                     },
                 }),
@@ -8534,7 +8541,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.enabled.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.inlay_hints.get_or_insert_default().enabled = value;
                         })
@@ -8553,7 +8560,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.show_value_hints.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .inlay_hints
@@ -8575,7 +8582,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.show_type_hints.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.inlay_hints.get_or_insert_default().show_type_hints = value;
                         })
@@ -8594,7 +8601,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.show_parameter_hints.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .inlay_hints
@@ -8616,7 +8623,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.show_other_hints.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .inlay_hints
@@ -8638,7 +8645,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.show_background.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.inlay_hints.get_or_insert_default().show_background = value;
                         })
@@ -8657,7 +8664,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.edit_debounce_ms.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .inlay_hints
@@ -8679,7 +8686,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.inlay_hints.as_ref()?.scroll_debounce_ms.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .inlay_hints
@@ -8708,7 +8715,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                     .as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8742,7 +8749,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.tasks.as_ref()?.enabled.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.tasks.get_or_insert_default().enabled = value;
                         })
@@ -8762,7 +8769,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.tasks.as_ref()?.variables.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8787,7 +8794,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.tasks.as_ref()?.prefer_lsp.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.tasks.get_or_insert_default().prefer_lsp = value;
                         })
@@ -8812,7 +8819,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.word_diff_enabled.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.word_diff_enabled = value;
                         })
@@ -8832,7 +8839,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.debuggers.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -8853,7 +8860,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                 field: Box::new(SettingField {
                     json_path: Some("languages.$(language).editor.middle_click_paste"),
                     pick: |settings_content| settings_content.editor.middle_click_paste.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.middle_click_paste = value;
                     },
                 }),
@@ -8870,7 +8877,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.extend_comment_on_newline.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.extend_comment_on_newline = value;
                         })
@@ -8889,7 +8896,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             language.colorize_brackets.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.colorize_brackets = value;
                         })
@@ -8904,7 +8911,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                 field: Box::new(SettingField {
                     json_path: Some("modeline_lines"),
                     pick: |settings_content| settings_content.modeline_lines.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.modeline_lines = value;
                     },
                 }),
@@ -8927,7 +8934,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                             .as_ref()
                             .and_then(|image_viewer| image_viewer.unit.as_ref())
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.image_viewer.get_or_insert_default().unit = value;
                     },
                 }),
@@ -8947,7 +8954,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                                 message_editor.auto_replace_emoji_shortcode.as_ref()
                             })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .message_editor
                             .get_or_insert_default()
@@ -8963,7 +8970,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                 field: Box::new(SettingField {
                     json_path: Some("drop_target_size"),
                     pick: |settings_content| settings_content.workspace.drop_target_size.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.workspace.drop_target_size = value;
                     },
                 }),
@@ -8981,7 +8988,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
         field: Box::new(SettingField {
             json_path: Some("code_lens"),
             pick: |settings_content| settings_content.editor.code_lens.as_ref(),
-            write: |settings_content, value| {
+            write: |settings_content, value, _app: &App| {
                 settings_content.editor.code_lens = value;
             },
         }),
@@ -8995,7 +9002,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
         field: Box::new(SettingField {
             json_path: Some("lsp_document_colors"),
             pick: |settings_content| settings_content.editor.lsp_document_colors.as_ref(),
-            write: |settings_content, value| {
+            write: |settings_content, value, _app: &App| {
                 settings_content.editor.lsp_document_colors = value;
             },
         }),
@@ -9052,7 +9059,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.enable_language_server.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.enable_language_server = value;
                         })
@@ -9072,7 +9079,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.language_servers.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -9097,7 +9104,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.linked_edits.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.linked_edits = value;
                         })
@@ -9114,7 +9121,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                     pick: |settings_content| {
                         settings_content.editor.go_to_definition_fallback.as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.editor.go_to_definition_fallback = value;
                     },
                 }),
@@ -9145,7 +9152,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             .semantic_tokens
                             .as_ref()
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content
                             .project
                             .all_languages
@@ -9166,7 +9173,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.document_folding_ranges.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.document_folding_ranges = value;
                         })
@@ -9185,7 +9192,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.document_symbols.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.document_symbols = value;
                         })
@@ -9210,7 +9217,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.completions.as_ref()?.lsp.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.completions.get_or_insert_default().lsp = value;
                         })
@@ -9229,7 +9236,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.completions.as_ref()?.lsp_fetch_timeout_ms.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language
                                 .completions
@@ -9251,7 +9258,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.completions.as_ref()?.lsp_insert_mode.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.completions.get_or_insert_default().lsp_insert_mode = value;
                         })
@@ -9277,7 +9284,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.debuggers.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -9308,7 +9315,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.prettier.as_ref()?.allowed.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.prettier.get_or_insert_default().allowed = value;
                         })
@@ -9327,7 +9334,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                             language.prettier.as_ref()?.parser.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.prettier.get_or_insert_default().parser = value;
                         })
@@ -9347,7 +9354,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.prettier.as_ref()?.plugins.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -9373,7 +9380,7 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                                 language.prettier.as_ref()?.options.as_ref()
                             })
                         },
-                        write: |settings_content, value| {
+                        write: |settings_content, value, _app: &App| {
                             language_settings_field_mut(
                                 settings_content,
                                 value,
@@ -9421,7 +9428,7 @@ fn edit_prediction_language_settings_section() -> [SettingsPageItem; 4] {
                         language.show_edit_predictions.as_ref()
                     })
                 },
-                write: |settings_content, value| {
+                write: |settings_content, value, _app: &App| {
                     language_settings_field_mut(settings_content, value, |language, value| {
                         language.show_edit_predictions = value;
                     })
@@ -9441,7 +9448,7 @@ fn edit_prediction_language_settings_section() -> [SettingsPageItem; 4] {
                             language.edit_predictions_disabled_in.as_ref()
                         })
                     },
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.edit_predictions_disabled_in = value;
                         })
@@ -9476,7 +9483,11 @@ where
 
 /// Updates the `vim_mode` setting, disabling `helix_mode` if present and
 /// `vim_mode` is being enabled.
-fn write_vim_mode(settings: &mut SettingsContent, value: Option<bool>) {
+fn write_vim_mode(settings: &mut SettingsContent, value: Option<bool>, _app: &App) {
+    write_vim_mode_inner(settings, value);
+}
+
+fn write_vim_mode_inner(settings: &mut SettingsContent, value: Option<bool>) {
     if value == Some(true) && settings.helix_mode == Some(true) {
         settings.helix_mode = Some(false);
     }
@@ -9485,7 +9496,11 @@ fn write_vim_mode(settings: &mut SettingsContent, value: Option<bool>) {
 
 /// Updates the `helix_mode` setting, disabling `vim_mode` if present and
 /// `helix_mode` is being enabled.
-fn write_helix_mode(settings: &mut SettingsContent, value: Option<bool>) {
+fn write_helix_mode(settings: &mut SettingsContent, value: Option<bool>, _app: &App) {
+    write_helix_mode_inner(settings, value);
+}
+
+fn write_helix_mode_inner(settings: &mut SettingsContent, value: Option<bool>) {
     if value == Some(true) && settings.vim_mode == Some(true) {
         settings.vim_mode = Some(false);
     }
@@ -9501,38 +9516,38 @@ mod tests {
         // Enabling vim mode while `vim_mode` and `helix_mode` are not yet set
         // should only update the `vim_mode` setting.
         let mut settings = SettingsContent::default();
-        write_vim_mode(&mut settings, Some(true));
+        write_vim_mode_inner(&mut settings, Some(true));
         assert_eq!(settings.vim_mode, Some(true));
         assert_eq!(settings.helix_mode, None);
 
         // Enabling helix mode while `vim_mode` and `helix_mode` are not yet set
         // should only update the `helix_mode` setting.
         let mut settings = SettingsContent::default();
-        write_helix_mode(&mut settings, Some(true));
+        write_helix_mode_inner(&mut settings, Some(true));
         assert_eq!(settings.helix_mode, Some(true));
         assert_eq!(settings.vim_mode, None);
 
         // Disabling helix mode should only touch `helix_mode` setting when
         // `vim_mode` is not set.
-        write_helix_mode(&mut settings, Some(false));
+        write_helix_mode_inner(&mut settings, Some(false));
         assert_eq!(settings.helix_mode, Some(false));
         assert_eq!(settings.vim_mode, None);
 
         // Enabling vim mode should update `vim_mode` but leave `helix_mode`
         // untouched.
-        write_vim_mode(&mut settings, Some(true));
+        write_vim_mode_inner(&mut settings, Some(true));
         assert_eq!(settings.vim_mode, Some(true));
         assert_eq!(settings.helix_mode, Some(false));
 
         // Enabling helix mode should update `helix_mode` and disable
         // `vim_mode`.
-        write_helix_mode(&mut settings, Some(true));
+        write_helix_mode_inner(&mut settings, Some(true));
         assert_eq!(settings.helix_mode, Some(true));
         assert_eq!(settings.vim_mode, Some(false));
 
         // Enabling vim mode should update `vim_mode` and disable
         // `helix_mode`.
-        write_vim_mode(&mut settings, Some(true));
+        write_vim_mode_inner(&mut settings, Some(true));
         assert_eq!(settings.vim_mode, Some(true));
         assert_eq!(settings.helix_mode, Some(false));
     }

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6663,7 +6663,7 @@ fn terminal_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("terminal.bell"),
                     pick: |settings_content| settings_content.terminal.as_ref()?.bell.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _app: &App| {
                         settings_content.terminal.get_or_insert_default().bell = value;
                     },
                 }),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1,5 +1,4 @@
 use gpui::{Action as _, App};
-use theme::SystemAppearance;
 use itertools::Itertools as _;
 use settings::{
     AudioInputDeviceName, AudioOutputDeviceName, LanguageSettingsContent, SemanticTokens,
@@ -7,6 +6,7 @@ use settings::{
 };
 use std::sync::{Arc, OnceLock};
 use strum::{EnumMessage, IntoDiscriminant as _, VariantArray};
+use theme::SystemAppearance;
 use ui::IntoElement;
 
 use crate::{

--- a/crates/settings_ui/src/pages/audio_input_output_setup.rs
+++ b/crates/settings_ui/src/pages/audio_input_output_setup.rs
@@ -121,8 +121,8 @@ fn render_settings_audio_device_dropdown<T: AsRef<Option<String>> + From<Option<
                 field.json_path,
                 window,
                 cx,
-                move |settings, _cx| {
-                    (field.write)(settings, value);
+                move |settings, app| {
+                    (field.write)(settings, value, app);
                 },
             )
             .log_err();

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -5,7 +5,7 @@ use edit_prediction::{
     open_ai_compatible::{open_ai_compatible_api_token, open_ai_compatible_api_url},
 };
 use edit_prediction_ui::{get_available_providers, set_completion_provider};
-use gpui::{Entity, ScrollHandle, prelude::*};
+use gpui::{App, Entity, ScrollHandle, prelude::*};
 use language::language_settings::AllLanguageSettings;
 
 use settings::Settings as _;
@@ -373,7 +373,7 @@ fn ollama_settings() -> Box<[SettingsPageItem]> {
                         .api_url
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -406,7 +406,7 @@ fn ollama_settings() -> Box<[SettingsPageItem]> {
                         .model
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -439,7 +439,7 @@ fn ollama_settings() -> Box<[SettingsPageItem]> {
                         .prompt_format
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -469,7 +469,7 @@ fn ollama_settings() -> Box<[SettingsPageItem]> {
                         .max_output_tokens
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -504,7 +504,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                         .api_url
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -537,7 +537,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                         .model
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -570,7 +570,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                         .prompt_format
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -600,7 +600,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                         .max_output_tokens
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -635,7 +635,7 @@ fn codestral_settings() -> Box<[SettingsPageItem]> {
                         .api_url
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -668,7 +668,7 @@ fn codestral_settings() -> Box<[SettingsPageItem]> {
                         .max_tokens
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages
@@ -698,7 +698,7 @@ fn codestral_settings() -> Box<[SettingsPageItem]> {
                         .model
                         .as_ref()
                 },
-                write: |settings, value| {
+                write: |settings, value, _app: &App| {
                     settings
                         .project
                         .all_languages

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -100,7 +100,7 @@ struct FocusFile(pub u32);
 
 struct SettingField<T: 'static> {
     pick: fn(&SettingsContent) -> Option<&T>,
-    write: fn(&mut SettingsContent, Option<T>),
+    write: fn(&mut SettingsContent, Option<T>, &App),
 
     /// A json-path-like string that gives a unique-ish string that identifies
     /// where in the JSON the setting is defined.
@@ -149,7 +149,7 @@ impl<T: 'static> SettingField<T> {
     fn unimplemented(self) -> SettingField<UnimplementedSettingField> {
         SettingField {
             pick: |_| Some(&UnimplementedSettingField),
-            write: |_, _| unreachable!(),
+            write: |_, _, _| unreachable!(),
             json_path: self.json_path,
         }
     }
@@ -232,8 +232,8 @@ impl<T: PartialEq + Clone + Send + Sync + 'static> AnySettingField for SettingFi
                 None,
                 window,
                 cx,
-                move |settings, _| {
-                    (this.write)(settings, value_to_set);
+                move |settings, app| {
+                    (this.write)(settings, value_to_set, app);
                 },
             )
             // todo(settings_ui): Don't log err
@@ -4089,8 +4089,8 @@ fn render_text_field<T: From<String> + Into<String> + AsRef<str> + Clone>(
                     field.json_path,
                     window,
                     cx,
-                    move |settings, _cx| {
-                        (field.write)(settings, new_text.map(Into::into));
+                    move |settings, app| {
+                        (field.write)(settings, new_text.map(Into::into), app);
                     },
                 )
                 .log_err(); // todo(settings_ui) don't log err
@@ -4121,8 +4121,8 @@ fn render_toggle_button<B: Into<bool> + From<bool> + Copy>(
                 telemetry::event!("Settings Change", setting = field.json_path, type = file.setting_type());
 
                 let state = *state == ui::ToggleState::Selected;
-                update_settings_file(file.clone(), field.json_path, window, cx, move |settings, _cx| {
-                    (field.write)(settings, Some(state.into()));
+                update_settings_file(file.clone(), field.json_path, window, cx, move |settings, app| {
+                    (field.write)(settings, Some(state.into()), app);
                 })
                 .log_err(); // todo(settings_ui) don't log err
             }
@@ -4156,8 +4156,8 @@ fn render_editable_number_field<T: NumberFieldType + Send + Sync>(
                     field.json_path,
                     window,
                     cx,
-                    move |settings, _cx| {
-                        (field.write)(settings, Some(value));
+                    move |settings, app| {
+                        (field.write)(settings, Some(value), app);
                     },
                 )
                 .log_err(); // todo(settings_ui) don't log err
@@ -4196,8 +4196,8 @@ where
                 field.json_path,
                 window,
                 cx,
-                move |settings, _cx| {
-                    (field.write)(settings, Some(value));
+                move |settings, app| {
+                    (field.write)(settings, Some(value), app);
                 },
             )
             .log_err(); // todo(settings_ui) don't log err
@@ -4251,8 +4251,8 @@ fn render_font_picker(
                             field.json_path,
                             window,
                             cx,
-                            move |settings, _cx| {
-                                (field.write)(settings, Some(font_name.to_string().into()));
+                            move |settings, app| {
+                                (field.write)(settings, Some(font_name.to_string().into()), app);
                             },
                         )
                         .log_err(); // todo(settings_ui) don't log err
@@ -4301,10 +4301,11 @@ fn render_theme_picker(
                             field.json_path,
                             window,
                             cx,
-                            move |settings, _cx| {
+                            move |settings, app| {
                                 (field.write)(
                                     settings,
                                     Some(settings::ThemeName(theme_name.into())),
+                                    app,
                                 );
                             },
                         )
@@ -4354,10 +4355,11 @@ fn render_icon_theme_picker(
                             field.json_path,
                             window,
                             cx,
-                            move |settings, _cx| {
+                            move |settings, app| {
                                 (field.write)(
                                     settings,
                                     Some(settings::IconThemeName(theme_name.into())),
+                                    app,
                                 );
                             },
                         )


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54607

Release Notes:

- Settings UI theme conversion now respects system appearance.
When switching Theme Mode from Dynamic (System) to Static, Zed now picks the static theme that matches the current OS app appearance (light or dark) instead of always defaulting to the dark variant.
