### PR TITLE
branch_picker: Add button to filter remote branches

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -627,6 +627,9 @@ impl PickerDelegate for BranchListDelegate {
         let focus_handle = self.focus_handle.clone();
         let editor = editor.as_any().downcast_ref::<Entity<Editor>>().unwrap();
 
+        let show_inline_filter =
+            self.editor_position() == PickerEditorPosition::End || !self.show_footer;
+
         v_flex()
             .when(
                 self.editor_position() == PickerEditorPosition::End,
@@ -639,34 +642,32 @@ impl PickerDelegate for BranchListDelegate {
                     .h_9()
                     .px_2p5()
                     .child(editor.clone())
-                    .when(
-                        self.editor_position() == PickerEditorPosition::End,
-                        |this| {
-                            let tooltip_label = match self.branch_filter {
-                                BranchFilter::All => "Filter Remote Branches",
-                                BranchFilter::Remote => "Show All Branches",
-                            };
+                    .when(show_inline_filter, |this| {
+                        let tooltip_label = match self.branch_filter {
+                            BranchFilter::All => "Filter Remote Branches",
+                            BranchFilter::Remote => "Show All Branches",
+                        };
 
-                            this.gap_1().justify_between().child({
-                                IconButton::new("filter-remotes", IconName::Filter)
-                                    .toggle_state(self.branch_filter == BranchFilter::Remote)
-                                    .tooltip(move |_, cx| {
-                                        Tooltip::for_action_in(
-                                            tooltip_label,
-                                            &branch_picker::FilterRemotes,
-                                            &focus_handle,
-                                            cx,
-                                        )
-                                    })
-                                    .on_click(|_click, window, cx| {
-                                        window.dispatch_action(
-                                            branch_picker::FilterRemotes.boxed_clone(),
-                                            cx,
-                                        );
-                                    })
-                            })
-                        },
-                    ),
+                        this.gap_1().justify_between().child({
+                            IconButton::new("filter-remotes", IconName::Filter)
+                                .toggle_state(self.branch_filter == BranchFilter::Remote)
+                                .icon_size(IconSize::Small)
+                                .tooltip(move |_, cx| {
+                                    Tooltip::for_action_in(
+                                        tooltip_label,
+                                        &branch_picker::FilterRemotes,
+                                        &focus_handle,
+                                        cx,
+                                    )
+                                })
+                                .on_click(|_click, window, cx| {
+                                    window.dispatch_action(
+                                        branch_picker::FilterRemotes.boxed_clone(),
+                                        cx,
+                                    );
+                                })
+                        })
+                    }),
             )
             .when(
                 self.editor_position() == PickerEditorPosition::Start,


### PR DESCRIPTION
This PR brings back the button to filter remote branches when accessing the title bar's branch picker with the mouse. It was unintentionally removed when we introduced the new worktree picker.

Release Notes:

- N/A
