### PR TITLE
compliance: Add temporary allowlist

### DIFF
--- a/tooling/compliance/src/git.rs
+++ b/tooling/compliance/src/git.rs
@@ -273,7 +273,7 @@ impl CommitDetails {
         &self.title
     }
 
-    pub(crate) fn sha(&self) -> &CommitSha {
+    pub fn sha(&self) -> &CommitSha {
         &self.sha
     }
 

--- a/tooling/compliance/src/report.rs
+++ b/tooling/compliance/src/report.rs
@@ -47,6 +47,12 @@ impl<R: ToString> ReportEntry<R> {
     }
 }
 
+impl ReportEntry<ReviewResult> {
+    pub fn is_unknown_error(&self) -> bool {
+        matches!(self.reason, Err(ReviewFailure::Other(_)))
+    }
+}
+
 impl ReportEntry<ReviewFailure> {
     fn issue_kind(&self) -> IssueKind {
         match self.reason {
@@ -109,7 +115,7 @@ impl ReportSummary {
                 .count(),
             errors: entries
                 .iter()
-                .filter(|entry| matches!(entry.reason, Err(ReviewFailure::Other(_))))
+                .filter(|entry| entry.is_unknown_error())
                 .count(),
         }
     }

--- a/tooling/xtask/src/tasks/compliance.rs
+++ b/tooling/xtask/src/tasks/compliance.rs
@@ -16,6 +16,10 @@ pub(crate) struct ComplianceArgs {
     mode: ComplianceMode,
 }
 
+const IGNORE_LIST: &[&str] = &[
+    "75fa566511e3ae7d03cfd76008512080291bd81d", // GitHub nuked this PR out of orbit
+];
+
 #[derive(Subcommand)]
 pub(crate) enum ComplianceMode {
     // Check compliance for all commits between two version tags
@@ -131,6 +135,10 @@ async fn check_compliance_impl(args: ComplianceArgs) -> Result<()> {
         summary.prs_with_errors()
     );
 
+    let all_errors_known = report.errors().all(|error| {
+        error.is_unknown_error() && IGNORE_LIST.contains(&error.commit.sha().as_str())
+    });
+
     for report in report.errors() {
         if let Some(pr_number) = report.commit.pr_number()
             && let Ok(pull_request) = client.get_pull_request(&Repository::ZED, pr_number).await
@@ -161,6 +169,14 @@ async fn check_compliance_impl(args: ComplianceArgs) -> Result<()> {
             "Compliance check failed, found {} commits not reviewed",
             summary.not_reviewed
         )),
+        ReportReviewSummary::MissingReviewsWithErrors if all_errors_known => {
+            println!(
+                "Compliance check failed with {} unreviewed commits, but all errors are known.",
+                summary.not_reviewed
+            );
+
+            Ok(())
+        }
         ReportReviewSummary::MissingReviewsWithErrors => Err(anyhow::anyhow!(
             "Compliance check failed with {} unreviewed commits and {} other issues",
             summary.not_reviewed,


### PR DESCRIPTION
To not have another week of failing checks on Preview and until we find a better way of handling these errors.

Release Notes:

- N/A