### PR TITLE
edit_prediction: Skip type definition lookup for intrinsic TSX/JSX tags

### DIFF
--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -563,7 +563,7 @@ impl RelatedBuffer {
             })
             .collect::<Vec<_>>();
         self.cached_file = Some(CachedRelatedFile {
-            excerpts: excerpts,
+            excerpts,
             buffer_version: buffer.version().clone(),
         });
         self.cached_file.as_ref().unwrap()
@@ -669,6 +669,7 @@ fn identifiers_for_position(
             if let Some(config) = config
                 && config.identifier_capture_indices.contains(&capture.index)
                 && range.contains_inclusive(&node_range)
+                && !is_tsx_tag(&buffer, &capture.node)
                 && Some(&node_range) != last_range.as_ref()
             {
                 let name = buffer.text_for_range(node_range.clone()).collect();
@@ -685,4 +686,40 @@ fn identifiers_for_position(
     }
 
     identifiers
+}
+
+fn is_tsx_tag(buffer: &BufferSnapshot, node: &tree_sitter::Node) -> bool {
+    let Some(language_config) = buffer
+        .language()
+        .and_then(|l| l.config().jsx_tag_auto_close.as_ref())
+    else {
+        return false;
+    };
+    let Some(parent_kind) = node.parent().map(|n| n.kind()) else {
+        return false;
+    };
+
+    if parent_kind != &language_config.open_tag_node_name
+        && parent_kind != &language_config.close_tag_node_name
+        && parent_kind != &language_config.tag_name_node_name
+        && language_config
+            .erroneous_close_tag_name_node_name
+            .as_ref()
+            .is_some_and(|kind| parent_kind != kind)
+        && language_config
+            .erroneous_close_tag_node_name
+            .as_ref()
+            .is_some_and(|kind| parent_kind == kind)
+        && parent_kind != &language_config.jsx_element_node_name
+    {
+        return false;
+    }
+    // do fetch `<Component />`, model probably understands `<div>`, but needs info for user defined components
+    if !buffer
+        .text_for_range(node.byte_range())
+        .all(|str| str.chars().all(|c| c.is_lowercase()))
+    {
+        return false;
+    }
+    true
 }


### PR DESCRIPTION
Skip intrinsic TSX/JSX tag names when gathering identifiers for edit prediction context.

I bisected a TypeScript regression to https://github.com/zed-industries/zed/pull/49748. That change caused edit prediction context to query `definition` / `typeDefinition` for lowercase JSX tags like `p`, which could trigger incorrect unversioned TypeScript diagnostics, such as `Cannot find name 'p'`.

This change filters those intrinsic tag names out while still keeping user-defined component tags like `Component`.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #51316

Release Notes:

- Fixed a TypeScript issue that could show incorrect diagnostics caused by edit prediction context lookups.
