### PR TITLE
Don't show branch and worktree title bar buttons if Git is disabled

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -32,9 +32,12 @@ use gpui::{
     pulsating_between,
 };
 use onboarding_banner::OnboardingBanner;
-use project::{Project, git_store::GitStoreEvent, trusted_worktrees::TrustedWorktrees};
+use project::{
+    Project, git_store::GitStoreEvent, project_settings::ProjectSettings,
+    trusted_worktrees::TrustedWorktrees,
+};
 use remote::RemoteConnectionOptions;
-use settings::Settings;
+use settings::Settings as _;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -175,6 +178,7 @@ impl Render for TitleBar {
 
         let title_bar_settings = *TitleBarSettings::get_global(cx);
         let button_layout = title_bar_settings.button_layout;
+        let is_git_enabled = ProjectSettings::get_global(cx).git.enabled.status;
 
         let show_menus = show_menus(cx);
 
@@ -231,9 +235,9 @@ impl Render for TitleBar {
                                         .child(self.render_project_name(project_name, window, cx))
                                 })
                                 .when_some(
-                                    repository.filter(|_| title_bar_settings.show_branch_name),
+                                    repository.filter(|_| is_git_enabled),
                                     |title_bar, repository| {
-                                        title_bar.children(self.render_project_branch(
+                                        title_bar.children(self.render_worktree_and_branch(
                                             repository,
                                             linked_worktree_name,
                                             cx,
@@ -829,7 +833,7 @@ impl TitleBar {
             .anchor(gpui::Anchor::TopLeft)
     }
 
-    fn render_project_branch(
+    fn render_worktree_and_branch(
         &self,
         repository: Entity<project::git_store::Repository>,
         linked_worktree_name: Option<SharedString>,
@@ -874,7 +878,6 @@ impl TitleBar {
             (branch_name, icon_info, is_detached_head)
         };
 
-        let branch_name = branch_name?;
         let settings = TitleBarSettings::get_global(cx);
         let effective_repository = Some(repository);
 
@@ -935,66 +938,77 @@ impl TitleBar {
                 .anchor(gpui::Anchor::TopLeft)
         };
 
-        let branch_tooltip_label = branch_name.clone();
-        let (branch_icon, branch_icon_color) = if settings.show_branch_status_icon {
-            icon_info
-        } else {
-            (IconName::GitBranch, Color::Muted)
-        };
-
-        let trigger = if is_detached_head {
-            Button::new("project_branch_trigger", "Create Branch")
-                .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-                .label_size(LabelSize::Small)
-                .start_icon(
-                    Icon::new(IconName::GitBranchPlus)
-                        .size(IconSize::XSmall)
-                        .color(Color::Muted),
-                )
-        } else {
-            Button::new("project_branch_trigger", branch_name)
-                .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-                .label_size(LabelSize::Small)
-                .color(Color::Muted)
-                .start_icon(
-                    Icon::new(branch_icon)
-                        .size(IconSize::XSmall)
-                        .color(branch_icon_color),
-                )
-        };
-
-        let git_picker_button = PopoverMenu::new("branch-menu")
-            .menu(move |window, cx| {
-                Some(git_ui::git_picker::popover(
-                    workspace.downgrade(),
-                    effective_repository.clone(),
-                    git_ui::git_picker::GitPickerTab::Branches,
-                    gpui::rems(34.),
-                    window,
-                    cx,
-                ))
-            })
-            .trigger_with_tooltip(trigger, move |_window, cx| {
-                let meta = if is_detached_head {
-                    format!("Detached HEAD: {}", branch_tooltip_label)
+        let branch_picker = branch_name.and_then(|branch_name| {
+            settings.show_branch_name.then(|| {
+                let branch_tooltip_label = branch_name.clone();
+                let (branch_icon, branch_icon_color) = if settings.show_branch_status_icon {
+                    icon_info
                 } else {
-                    format!("Currently Checked Out: {}", branch_tooltip_label)
+                    (IconName::GitBranch, Color::Muted)
                 };
-                Tooltip::with_meta("Branch & Stash", Some(&zed_actions::git::Branch), meta, cx)
+
+                let trigger = if is_detached_head {
+                    Button::new("project_branch_trigger", "Create Branch")
+                        .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                        .label_size(LabelSize::Small)
+                        .start_icon(
+                            Icon::new(IconName::GitBranchPlus)
+                                .size(IconSize::XSmall)
+                                .color(Color::Muted),
+                        )
+                } else {
+                    Button::new("project_branch_trigger", branch_name)
+                        .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                        .label_size(LabelSize::Small)
+                        .color(Color::Muted)
+                        .start_icon(
+                            Icon::new(branch_icon)
+                                .size(IconSize::XSmall)
+                                .color(branch_icon_color),
+                        )
+                };
+
+                PopoverMenu::new("branch-menu")
+                    .menu(move |window, cx| {
+                        Some(git_ui::git_picker::popover(
+                            workspace.downgrade(),
+                            effective_repository.clone(),
+                            git_ui::git_picker::GitPickerTab::Branches,
+                            gpui::rems(34.),
+                            window,
+                            cx,
+                        ))
+                    })
+                    .trigger_with_tooltip(trigger, move |_window, cx| {
+                        let meta = if is_detached_head {
+                            format!("Detached HEAD: {}", branch_tooltip_label)
+                        } else {
+                            format!("Currently Checked Out: {}", branch_tooltip_label)
+                        };
+                        Tooltip::with_meta(
+                            "Branch & Stash",
+                            Some(&zed_actions::git::Branch),
+                            meta,
+                            cx,
+                        )
+                    })
+                    .anchor(gpui::Anchor::TopLeft)
             })
-            .anchor(gpui::Anchor::TopLeft);
+        });
 
         Some(
             h_flex()
                 .gap_px()
                 .child(worktree_button)
-                .child(
-                    Label::new("/")
-                        .size(LabelSize::Small)
-                        .color(Color::Muted)
-                        .alpha(0.25),
-                )
-                .child(git_picker_button)
+                .when_some(branch_picker, |this, branch_picker| {
+                    this.child(
+                        Label::new("/")
+                            .size(LabelSize::Small)
+                            .color(Color::Muted)
+                            .alpha(0.25),
+                    )
+                    .child(branch_picker)
+                })
                 .into_any_element(),
         )
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/54628

Release Notes:

- Fixed a bug where the worktree and branch buttons in the title bar were still being displayed despite `disable_git` being turned on.
