### PR TITLE
Fix Copy Command copying tool call title instead of command

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -350,13 +350,6 @@ impl ToolCall {
         }
 
         if let Some(title) = title {
-            if self.kind == acp::ToolKind::Execute {
-                for terminal in self.terminals() {
-                    terminal.update(cx, |terminal, cx| {
-                        terminal.update_command_label(&title, cx);
-                    });
-                }
-            }
             self.label.update(cx, |label, cx| {
                 if self.kind == acp::ToolKind::Execute {
                     label.replace(title, cx);

--- a/crates/acp_thread/src/terminal.rs
+++ b/crates/acp_thread/src/terminal.rs
@@ -167,12 +167,6 @@ impl Terminal {
         &self.command
     }
 
-    pub fn update_command_label(&self, label: &str, cx: &mut App) {
-        self.command.update(cx, |command, cx| {
-            command.replace(format!("```\n{}\n```", label), cx);
-        });
-    }
-
     pub fn working_dir(&self) -> &Option<PathBuf> {
         &self.working_dir
     }


### PR DESCRIPTION
When using an ACP agent (e.g. Codex) that sends a human-readable title for terminal tool calls like `Run ping -c 4 zed.dev`, clicking Copy Command on the terminal card copied that title instead of the actual command (`ping -c 4 zed.dev`).

## Root cause

The `Terminal` entity is created via the `terminal/create` ACP call with the real command string, so the authoritative command is already stored in `Terminal::command`. However, in `ToolCall::update_fields`, whenever the agent sent a tool-call update with a `title`, we reached into every attached terminal and overwrote its command label with that title via `Terminal::update_command_label`.

After that overwrite, `render_terminal_tool_call` reads `terminal.command()` and sees the title instead of the real command, so both the rendered command text in the card and the Copy Command button got the wrong value.

The native agent wasn't affected because its title happens to equal the command, making the clobber a no-op.

## Fix

Stop overwriting `Terminal::command` with the tool call title. The title continues to update `ToolCall::label` (used for non-terminal rendering paths); the terminal's command stays as whatever was passed to `terminal/create`. `Terminal::update_command_label` is removed since it had no other callers.

Closes https://github.com/zed-industries/zed/issues/51025

Closes AI-132

Release Notes:

- Fixed the Copy Command button on ACP agent terminal cards copying the tool call's display title instead of the actual command being run