### PR TITLE
Clarify import thread support

### DIFF
--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -39,6 +39,8 @@ You can search your threads in history; search will fuzzy match on thread titles
 
 If you have external agents installed, Zed will detect whether you have existing threads and invite you to import them into Zed. Once you open Thread History, you'll find an import icon button in the Thread History toolbar that lets you import threads at any time. Clicking on it opens a modal where you can select the agents whose threads you want to import.
 
+> **Note:** Thread import is subject to agent support. Some agents (such as Cursor and Gemini CLI) are not currently supported.
+
 ## Running Multiple Threads {#running-multiple-threads}
 
 Each thread runs independently, so you can send a prompt, open a second thread, and give it a different task while the first continues working. To scope a new thread to a specific project, hover over that project's header in the Threads Sidebar and click the `+` button, or use {#action agents_sidebar::NewThreadInGroup} from the keyboard. See [Creating New Threads](./agent-panel.md#new-thread) for the other entry points.


### PR DESCRIPTION
Adds a note to the Parallel Agents docs clarifying that thread import is subject to agent support, and that some agents like Cursor and Gemini CLI are not currently supported.

Release Notes:

- N/A