### PR TITLE
terminal: Add setting to show terminal title in tabs

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1868,6 +1868,10 @@
       // Example: `echo -e "\e]2;New Title\007";`
       "breadcrumbs": false,
     },
+    // Whether to show the shell-driven terminal title in the tab.
+    //
+    // When enabled, terminal breadcrumbs are hidden and terminal tab rename is disabled.
+    "show_title_in_tab": false,
     // Scrollbar-related settings
     "scrollbar": {
       // When to show the scrollbar in the terminal.

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -922,6 +922,7 @@ impl VsCodeSettings {
             scrollbar: None,
             scroll_multiplier: None,
             toolbar: None,
+            show_title_in_tab: None,
             show_count_badge: None,
             flexible: None,
         })

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -157,6 +157,12 @@ pub struct TerminalSettingsContent {
     pub scroll_multiplier: Option<f32>,
     /// Toolbar related settings
     pub toolbar: Option<TerminalToolbarContent>,
+    /// Whether to show the shell-driven terminal title in the tab.
+    ///
+    /// When enabled, terminal breadcrumbs are hidden and terminal tab rename is disabled.
+    ///
+    /// Default: false
+    pub show_title_in_tab: Option<bool>,
     /// Scrollbar-related settings
     pub scrollbar: Option<ScrollbarSettingsContent>,
     /// The minimum APCA perceptual contrast between foreground and background colors.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6818,7 +6818,7 @@ fn terminal_page() -> SettingsPage {
         ]
     }
 
-    fn toolbar_section() -> [SettingsPageItem; 2] {
+    fn toolbar_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Toolbar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -6842,6 +6842,28 @@ fn terminal_page() -> SettingsPage {
                             .toolbar
                             .get_or_insert_default()
                             .breadcrumbs = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Show Title in Tab",
+                description: "Show the terminal title in the tab, hide terminal breadcrumbs, and disable terminal tab renaming.",
+                field: Box::new(SettingField {
+                    json_path: Some("terminal.show_title_in_tab"),
+                    pick: |settings_content| {
+                        settings_content
+                            .terminal
+                            .as_ref()?
+                            .show_title_in_tab
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .terminal
+                            .get_or_insert_default()
+                            .show_title_in_tab = value;
                     },
                 }),
                 metadata: None,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -51,7 +51,7 @@ use terminal_hyperlinks::RegexSearches;
 use terminal_settings::{AlternateScroll, CursorShape, TerminalSettings};
 use theme::{ActiveTheme, Theme};
 use urlencoding;
-use util::{paths::PathStyle, truncate_and_trailoff};
+use util::{paths::{PathStyle, SanitizedPath}, truncate_and_trailoff};
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
@@ -60,7 +60,7 @@ use std::{
     cmp::{self, min},
     fmt::Display,
     ops::{Deref, RangeInclusive},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::ExitStatus,
     sync::Arc,
     time::{Duration, Instant},
@@ -944,7 +944,7 @@ impl Terminal {
                     if self
                         .shell_program
                         .as_ref()
-                        .map(|e| *e == title)
+                        .map(|e| SanitizedPath::new(Path::new(e)) == SanitizedPath::new(Path::new(&title)))
                         .unwrap_or(false)
                     {
                         return;
@@ -3561,6 +3561,38 @@ mod tests {
                     );
                 }
             }
+        }
+
+        #[cfg(windows)]
+        #[gpui::test]
+        fn test_ignores_windows_shell_title_with_verbatim_prefix(cx: &mut TestAppContext) {
+            let terminal = cx.new(|cx| {
+                TerminalBuilder::new_display_only(
+                    CursorShape::default(),
+                    AlternateScroll::On,
+                    None,
+                    0,
+                    cx.background_executor(),
+                    PathStyle::local(),
+                )
+                .unwrap()
+                .subscribe(cx)
+            });
+
+            terminal.update(cx, |terminal, cx| {
+                terminal.shell_program =
+                    Some(r"\\?\C:\Program Files\PowerShell\7\pwsh.exe".to_string());
+
+                terminal.process_event(
+                    AlacTermEvent::Title(r"C:\Program Files\PowerShell\7\pwsh.exe".to_string()),
+                    cx,
+                );
+
+                assert!(
+                    terminal.breadcrumb_text.is_empty(),
+                    "default shell title should be ignored even when shell_program uses the \\\\?\\ prefix"
+                );
+            });
         }
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -47,6 +47,7 @@ pub struct TerminalSettings {
     pub max_scroll_history_lines: Option<usize>,
     pub scroll_multiplier: f32,
     pub toolbar: Toolbar,
+    pub show_title_in_tab: bool,
     pub scrollbar: ScrollbarSettings,
     pub minimum_contrast: f32,
     pub path_hyperlink_regexes: Vec<String>,
@@ -119,6 +120,7 @@ impl settings::Settings for TerminalSettings {
             toolbar: Toolbar {
                 breadcrumbs: user_content.toolbar.unwrap().breadcrumbs.unwrap(),
             },
+            show_title_in_tab: user_content.show_title_in_tab.unwrap(),
             scrollbar: ScrollbarSettings {
                 show: user_content.scrollbar.unwrap().show,
             },

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -138,6 +138,7 @@ pub struct TerminalView {
     hover_tooltip_update: Task<()>,
     workspace_id: Option<WorkspaceId>,
     show_breadcrumbs: bool,
+    show_title_in_tab: bool,
     block_below_cursor: Option<Rc<BlockProperties>>,
     scroll_top: Pixels,
     scroll_handle: TerminalScrollHandle,
@@ -282,6 +283,7 @@ impl TerminalView {
             mode: TerminalMode::Standalone,
             workspace_id,
             show_breadcrumbs: TerminalSettings::get_global(cx).toolbar.breadcrumbs,
+            show_title_in_tab: TerminalSettings::get_global(cx).show_title_in_tab,
             block_below_cursor: None,
             scroll_top: Pixels::ZERO,
             scroll_handle,
@@ -441,7 +443,7 @@ impl TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.terminal.read(cx).task().is_some() {
+        if self.show_title_in_tab || self.terminal.read(cx).task().is_some() {
             return;
         }
 
@@ -548,7 +550,9 @@ impl TerminalView {
     fn settings_changed(&mut self, cx: &mut Context<Self>) {
         let settings = TerminalSettings::get_global(cx);
         let breadcrumb_visibility_changed = self.show_breadcrumbs != settings.toolbar.breadcrumbs;
+        let title_mode_changed = self.show_title_in_tab != settings.show_title_in_tab;
         self.show_breadcrumbs = settings.toolbar.breadcrumbs;
+        self.show_title_in_tab = settings.show_title_in_tab;
 
         let should_blink = match settings.blinking {
             TerminalBlink::Off => false,
@@ -575,6 +579,14 @@ impl TerminalView {
 
         if breadcrumb_visibility_changed {
             cx.emit(ItemEvent::UpdateBreadcrumbs);
+        }
+        if title_mode_changed {
+            if self.show_title_in_tab {
+                self.rename_editor = None;
+                self.rename_editor_subscription = None;
+            }
+            cx.emit(ItemEvent::UpdateBreadcrumbs);
+            cx.emit(ItemEvent::UpdateTab);
         }
         cx.notify();
     }
@@ -1098,7 +1110,10 @@ fn subscribe_for_terminal_events(
                         cx,
                     ),
                 },
-                Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
+                Event::BreadcrumbsChanged => {
+                    cx.emit(ItemEvent::UpdateBreadcrumbs);
+                    cx.emit(ItemEvent::UpdateTab);
+                }
                 Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
                 Event::SelectionsChanged => {
                     window.invalidate_character_coordinates();
@@ -1330,13 +1345,8 @@ impl Item for TerminalView {
     }
 
     fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
+        let title = self.tab_content_text(params.detail.unwrap_or_default(), cx);
         let terminal = self.terminal().read(cx);
-        let title = self
-            .custom_title
-            .as_ref()
-            .filter(|title| !title.trim().is_empty())
-            .cloned()
-            .unwrap_or_else(|| terminal.title(true));
 
         let (icon, icon_color, rerun_button) = match terminal.task() {
             Some(terminal_task) => match &terminal_task.status {
@@ -1433,7 +1443,12 @@ impl Item for TerminalView {
     }
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
-        if let Some(custom_title) = self.custom_title.as_ref().filter(|l| !l.trim().is_empty()) {
+        if self.show_title_in_tab {
+            let dynamic_title = self.terminal().read(cx).breadcrumb_text.trim().to_owned();
+            if !dynamic_title.is_empty() {
+                return dynamic_title.into();
+            }
+        } else if let Some(custom_title) = self.custom_title.as_ref().filter(|l| !l.trim().is_empty()) {
             return custom_title.clone().into();
         }
         let terminal = self.terminal().read(cx);
@@ -1598,7 +1613,7 @@ impl Item for TerminalView {
         cx: &mut Context<Self>,
     ) -> Vec<(SharedString, Box<dyn gpui::Action>)> {
         let terminal = self.terminal.read(cx);
-        if terminal.task().is_none() {
+        if terminal.task().is_none() && !self.show_title_in_tab {
             vec![("Rename".into(), Box::new(RenameTerminal))]
         } else {
             Vec::new()
@@ -1669,7 +1684,7 @@ impl Item for TerminalView {
     }
 
     fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
-        if self.show_breadcrumbs && !self.terminal().read(cx).breadcrumb_text.trim().is_empty() {
+        if self.show_breadcrumbs && !self.show_title_in_tab && !self.terminal().read(cx).breadcrumb_text.trim().is_empty() {
             ToolbarItemLocation::PrimaryLeft
         } else {
             ToolbarItemLocation::Hidden
@@ -2038,7 +2053,7 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::TestAppContext;
+    use gpui::{TestAppContext, UpdateGlobal};
     use project::{Entry, Project, ProjectPath, Worktree};
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
@@ -2813,5 +2828,165 @@ mod tests {
                 text
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_prefers_dynamic_terminal_title(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text = "server: api-01".to_owned();
+        });
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        terminal_view.update(cx, |view, cx| {
+            view.set_custom_title(Some("manual-name".to_owned()), cx);
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), "server: api-01");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_falls_back_to_default_tab_title(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        let expected_default_title = terminal.read_with(cx, |terminal, _| terminal.title(true));
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text.clear();
+        });
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        terminal_view.update(cx, |view, cx| {
+            view.set_custom_title(Some("manual-name".to_owned()), cx);
+            assert_eq!(view.tab_content_text(0, cx).as_ref(), expected_default_title);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_hides_terminal_breadcrumbs(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.toolbar.get_or_insert_default().breadcrumbs = Some(true);
+                    terminal.show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+        terminal.update(cx, |terminal, _| {
+            terminal.breadcrumb_text = "server: api-01".to_owned();
+        });
+
+        cx.add_window(|window, cx| {
+            let view = TerminalView::new(
+                terminal.clone(),
+                workspace.downgrade(),
+                None,
+                project.downgrade(),
+                window,
+                cx,
+            );
+            assert_eq!(view.breadcrumb_location(cx), ToolbarItemLocation::Hidden);
+            view
+        })
+        .root(cx)
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_show_title_in_tab_disables_rename(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.show_title_in_tab = Some(true);
+                });
+            });
+        });
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+
+        cx.add_window(|window, cx| {
+            let mut view = TerminalView::new(
+                terminal.clone(),
+                workspace.downgrade(),
+                None,
+                project.downgrade(),
+                window,
+                cx,
+            );
+            let actions = view.tab_extra_context_menu_actions(window, cx);
+            assert!(!actions.iter().any(|(label, _)| label.as_ref() == "Rename"));
+            view.rename_terminal(&RenameTerminal, window, cx);
+            assert!(view.rename_editor.is_none());
+            view
+        })
+        .root(cx)
+        .unwrap();
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4099,6 +4099,7 @@ List of `integer` column numbers
     "toolbar": {
       "breadcrumbs": false
     },
+    "show_title_in_tab": false,
     "working_directory": "current_project_directory",
     "scrollbar": {
       "show": null
@@ -4550,9 +4551,34 @@ At the moment, only the `breadcrumbs` option is available, it controls displayin
 
 If the terminal title is empty, the breadcrumbs won't be shown.
 
+If `show_title_in_tab` is enabled, Zed hides terminal breadcrumbs even
+when `breadcrumbs` is `true`.
+
 The shell running in the terminal needs to be configured to emit the title.
 
 Example command to set the title: `echo -e "\e]2;New Title\007";`
+
+### Terminal: Show Title In Tab
+
+- Description: Whether to show the shell-driven terminal title in the tab.
+- Setting: `show_title_in_tab`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
+When enabled, Zed hides terminal breadcrumbs and disables terminal tab
+renaming. If the shell does not set a title, Zed falls back to the
+default terminal tab label.
+
+```json [settings]
+{
+  "terminal": {
+    "show_title_in_tab": true
+  }
+}
+```
 
 ### Terminal: Button
 

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -335,6 +335,27 @@ Show the terminal title in a breadcrumb toolbar:
 
 The title can be set by your shell using the escape sequence `\e]2;Title\007`.
 
+If `terminal.show_title_in_tab` is enabled, Zed hides terminal
+breadcrumbs even when `terminal.toolbar.breadcrumbs` is `true`.
+
+### Tab Titles
+
+If your shell sets a terminal title, you can show that title in the tab
+instead of the terminal toolbar:
+
+```json [settings]
+{
+  "terminal": {
+    "show_title_in_tab": true
+  }
+}
+```
+
+When enabled, Zed uses the shell-driven terminal title for the tab,
+hides terminal breadcrumbs, and disables terminal tab renaming. If the
+shell does not set a title, the tab falls back to Zed's default terminal
+label.
+
 ## Integration with Tasks
 
 The terminal integrates with Zed's [task system](./tasks.md). When you run a task, it executes in the terminal. Rerun the last task from a terminal with:


### PR DESCRIPTION
## Context

This adds a `terminal.show_title_in_tab` setting so terminal tabs can show
the current terminal title instead of only the default tab label.

When enabled, the terminal title takes ownership of the tab title and the
terminal breadcrumbs are hidden to avoid showing the same information twice.
Terminal rename is also disabled while the setting is on, but any existing
custom title is preserved and becomes visible again once the setting is
turned off.

This also fixes a Windows-specific issue where shell title events could show
the full shell path in tabs when the incoming title and the resolved shell
path differed only by the `\\?\` verbatim-path prefix.

## How to Review

- Review the new setting wiring in terminal settings, default settings,
  settings UI content, and VS Code import.
- Review the terminal tab title priority changes in `terminal_view`:
  terminal title when enabled, fallback to the existing default title when
  empty, and temporary suppression of custom rename titles while enabled.
- Review the rename gating in terminal tabs and context menus when
  `terminal.show_title_in_tab` is enabled.
- Review the Windows shell-title comparison in `terminal.rs`.
- Review the new tests covering dynamic-title precedence, fallback to the
  default tab title, breadcrumbs hiding, rename disabling, and the Windows
  path regression.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added `terminal.show_title_in_tab` to display terminal titles in tabs,
  hide duplicate terminal breadcrumbs, and disable terminal rename while the
  terminal title owns the tab title.
- Fixed Windows terminal tabs showing full shell paths when shell title
  events differed from the resolved shell path only by the `\\?\` prefix.