### PR TITLE
Revert "workspace: Fix edge case when saving workspace with no paths"

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1529,21 +1529,6 @@ impl WorkspaceDb {
                     .context("clearing out old locations")?;
                 }
 
-                // If there are no paths in the workspace, make sure to save
-                // paths as NULL in the database, not as an empty string.
-                // Otherwise, the workspace may fail to restore, potentially
-                // losing any unsaved buffers.
-                let maybe_paths = if !paths.paths.is_empty() {
-                    Some(paths.paths.clone())
-                } else {
-                    None
-                };
-                let maybe_order = if !paths.order.is_empty() {
-                    Some(paths.order.clone())
-                } else {
-                    None
-                };
-
                 // Upsert
                 let query = sql!(
                     INSERT INTO workspaces(
@@ -1586,8 +1571,8 @@ impl WorkspaceDb {
                 let mut prepared_query = conn.exec_bound(query)?;
                 let args = (
                     workspace.id,
-                    maybe_paths,
-                    maybe_order,
+                    paths.paths.clone(),
+                    paths.order.clone(),
                     remote_connection_id,
                     workspace.docks,
                     workspace.session_id,


### PR DESCRIPTION
Reverts zed-industries/zed#52810

This seems to have broken CI, after this was merged every test run failed with:

```
Summary [ 145.368s] 5753 tests run: 5750 passed, 3 failed, 20 skipped
        FAIL [   0.411s] (5476/5753) workspace persistence::tests::test_gc_preserves_current_and_last_sessions
        FAIL [   0.431s] (5477/5753) workspace persistence::tests::test_gc_deletes_empty_workspace_with_items
        FAIL [   0.452s] (5479/5753) workspace persistence::tests::test_gc_deletes_stale_outside_window
```

Release Notes:
- N/A 