### PR TITLE
terminal: Fix unreliable hyperlink display 

### DIFF
--- a/crates/terminal_view/src/terminal_path_like_target.rs
+++ b/crates/terminal_view/src/terminal_path_like_target.rs
@@ -106,17 +106,21 @@ fn possible_hover_target(
     cx.spawn(async move |terminal_view, cx| {
         let file_to_open = file_to_open_task.await;
         terminal_view
-            .update(cx, |terminal_view, _| match file_to_open {
-                Some(OpenTarget::File(path, _) | OpenTarget::Worktree(path, ..)) => {
-                    terminal_view.hover = Some(HoverTarget {
-                        tooltip: path
-                            .to_string(&|path: &PathBuf| path.to_string_lossy().into_owned()),
-                        hovered_word,
-                    });
+            .update(cx, |terminal_view, cx| {
+                match file_to_open {
+                    Some(OpenTarget::File(path, _) | OpenTarget::Worktree(path, ..)) => {
+                        terminal_view.hover = Some(HoverTarget {
+                            tooltip: path
+                                .to_string(&|path: &PathBuf| path.to_string_lossy().into_owned()),
+                            hovered_word,
+                        });
+                    }
+                    None => {
+                        terminal_view.hover = None;
+                    }
                 }
-                None => {
-                    terminal_view.hover = None;
-                }
+
+                cx.notify();
             })
             .ok();
     })


### PR DESCRIPTION
Improves reliability of hyperlink painting

We were missing a `cx.notify()` when updating the hyperlink target.

# TODO
- [ ] More manual testing
- [ ] Add a unit test

Release Notes:

- terminal: Fixed unreliable hyperlink navigation
