### PR TITLE
editor: Make `editor: expand excerpts` actually expand all excerpts

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -192,7 +192,7 @@ pub struct SelectDownByLines {
     pub(super) lines: u32,
 }
 
-/// Expands all excerpts in the editor.
+/// Expands all excerpts with selections.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Expand all excerpts had a doc comment describing it as expanding all excerpts, but in practice it only expanded the excerpt that was the most relevant.

I fixed that to make it expand all excerpts. 

video:

https://github.com/user-attachments/assets/9858ebda-199c-4f72-8a2f-3cd606b0eff4

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54651 

Release Notes:

- editor: `expand excerpts` now has correct documentation explaining its function.
