### PR TITLE
Fix ACP thread titles being uneditable

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1767,8 +1767,10 @@ impl AcpThread {
         cx.emit(AcpThreadEvent::NewEntry);
     }
 
-    pub fn can_set_title(&mut self, cx: &mut Context<Self>) -> bool {
-        self.connection.set_title(&self.session_id, cx).is_some()
+    pub fn can_set_title(&mut self, _cx: &mut Context<Self>) -> bool {
+        // set_title() always persists locally even when the connection doesn't
+        // propagate to the remote server, so we only need to exclude subagents.
+        self.parent_session_id.is_none()
     }
 
     pub fn set_title(&mut self, title: SharedString, cx: &mut Context<Self>) -> Task<Result<()>> {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -38,8 +38,8 @@ use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore, ThreadMetadata
 use crate::{
     AddContextServer, AgentDiffPane, ConversationView, CopyThreadToClipboard, Follow,
     InlineAssistant, LoadThreadFromClipboard, NewThread, OpenActiveThreadAsMarkdown, OpenAgentDiff,
-    ResetTrialEndUpsell, ResetTrialUpsell, ShowAllSidebarThreadMetadata, ShowThreadMetadata,
-    ToggleNewThreadMenu, ToggleOptionsMenu,
+    RenameThread, ResetTrialEndUpsell, ResetTrialUpsell, ShowAllSidebarThreadMetadata,
+    ShowThreadMetadata, ToggleNewThreadMenu, ToggleOptionsMenu,
     agent_configuration::{AgentConfiguration, AssistantConfigurationEvent},
     conversation_view::{AcpThreadViewEvent, ThreadView},
     ui::EndTrialUpsell,
@@ -3292,6 +3292,15 @@ impl AgentPanel {
             .into_any()
     }
 
+    pub fn focus_active_thread_title(&self, window: &mut Window, cx: &mut Context<Self>) {
+        if let VisibleSurface::AgentThread(conversation_view) = self.visible_surface() {
+            if let Some(thread_view) = conversation_view.read(cx).root_thread_view() {
+                let title_editor = thread_view.read(cx).title_editor.clone();
+                window.focus(&title_editor.focus_handle(cx), cx);
+            }
+        }
+    }
+
     fn handle_regenerate_thread_title(conversation_view: Entity<ConversationView>, cx: &mut App) {
         conversation_view.update(cx, |conversation_view, cx| {
             if let Some(thread) = conversation_view.as_native_thread(cx) {
@@ -4102,6 +4111,9 @@ impl Render for AgentPanel {
                 this.open_configuration(window, cx);
             }))
             .on_action(cx.listener(Self::open_active_thread_as_markdown))
+            .on_action(cx.listener(|this, _: &RenameThread, window, cx| {
+                this.focus_active_thread_title(window, cx);
+            }))
             .on_action(cx.listener(Self::deploy_rules_library))
             .on_action(cx.listener(Self::go_back))
             .on_action(cx.listener(Self::toggle_options_menu))
@@ -7750,5 +7762,79 @@ mod tests {
                 "panel should have an active, connected agent thread"
             );
         });
+    }
+
+    // Verify that focus_active_thread_title moves focus to the title editor of the active thread.
+    #[gpui::test]
+    async fn test_focus_active_thread_title_focuses_title_editor(cx: &mut TestAppContext) {
+        let (workspace, panel, mut cx) = setup_workspace_panel(cx).await;
+
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+
+        workspace.update_in(&mut cx, |workspace, window, cx| {
+            workspace.focus_panel::<AgentPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        // Call focus_active_thread_title and check focus within the same update context,
+        // before any subsequent re-renders can steal focus back to the message editor.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.focus_active_thread_title(window, cx);
+
+            let title_editor = panel
+                .active_thread_view(cx)
+                .expect("should have an active thread view")
+                .read(cx)
+                .title_editor
+                .clone();
+            assert!(
+                title_editor.focus_handle(cx).is_focused(window),
+                "title editor should be focused after focus_active_thread_title"
+            );
+        });
+    }
+
+    // Verify that dispatching RenameThread when there is an active thread does not panic,
+    // and that it remains safe to call even when focus is already within the panel.
+    #[gpui::test]
+    async fn test_rename_thread_action_does_not_panic(cx: &mut TestAppContext) {
+        let (workspace, panel, mut cx) = setup_workspace_panel(cx).await;
+
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+
+        workspace.update_in(&mut cx, |workspace, window, cx| {
+            workspace.focus_panel::<AgentPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        // Dispatching should not panic regardless of current focus state.
+        workspace.update_in(&mut cx, |_, window, cx| {
+            window.dispatch_action(Box::new(RenameThread), cx);
+        });
+        cx.run_until_parked();
+
+        // Panel should still have an active thread after the action.
+        panel.read_with(&cx, |panel, cx| {
+            assert!(
+                panel.active_thread_view(cx).is_some(),
+                "active thread should still be present after RenameThread"
+            );
+        });
+    }
+
+    // Verify that calling focus_active_thread_title when there is no active thread does not panic.
+    #[gpui::test]
+    async fn test_focus_active_thread_title_is_noop_without_active_thread(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+
+        panel.read_with(&cx, |panel, cx| {
+            assert!(panel.active_thread_view(cx).is_none());
+        });
+
+        // Should not panic.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.focus_active_thread_title(window, cx);
+        });
+        cx.run_until_parked();
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -189,6 +189,8 @@ actions!(
         ScrollOutputToNextMessage,
         /// Import agent threads from other Zed release channels (e.g. Preview, Nightly).
         ImportThreadsFromOtherChannels,
+        /// Renames the title of the currently active thread.
+        RenameThread,
     ]
 );
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7014,9 +7014,13 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
-    async fn test_title_editor_is_read_only_when_set_title_unsupported(cx: &mut TestAppContext) {
+    async fn test_title_editor_is_editable_even_when_connection_does_not_support_set_title(
+        cx: &mut TestAppContext,
+    ) {
         init_test(cx);
 
+        // ResumeOnlyAgentConnection does not implement set_title(), but the title
+        // editor should still be writable so users can rename threads locally.
         let (conversation_view, cx) =
             setup_conversation_view(StubAgentServer::new(ResumeOnlyAgentConnection), cx).await;
 
@@ -7025,8 +7029,8 @@ pub(crate) mod tests {
 
         title_editor.read_with(cx, |editor, cx| {
             assert!(
-                editor.read_only(cx),
-                "Title editor should be read-only when the connection does not support set_title"
+                !editor.read_only(cx),
+                "Title editor should be editable for non-subagent threads"
             );
         });
     }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -14,7 +14,7 @@ use agent_ui::threads_archive_view::{
 use agent_ui::{
     AcpThreadImportOnboarding, Agent, AgentPanel, AgentPanelEvent, AgentPanelTerminalInfo,
     ArchiveSelectedThread, CrossChannelImportOnboarding, DEFAULT_THREAD_TITLE, NewThread,
-    TerminalId, ThreadId, ThreadImportModal, channels_with_threads,
+    RenameThread, TerminalId, ThreadId, ThreadImportModal, channels_with_threads,
     import_threads_from_other_channels,
 };
 use chrono::{DateTime, Utc};
@@ -25,8 +25,9 @@ use feature_flags::{
 };
 use gpui::{
     Action as _, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EntityId, FocusHandle,
-    Focusable, KeyContext, ListState, Modifiers, Pixels, Render, SharedString, Task, TaskExt,
-    WeakEntity, Window, WindowHandle, linear_color_stop, linear_gradient, list, prelude::*, px,
+    Focusable, KeyContext, ListState, Modifiers, MouseDownEvent, Pixels, Point, Render,
+    SharedString, Task, TaskExt, WeakEntity, Window, WindowHandle, anchored, deferred,
+    linear_color_stop, linear_gradient, list, prelude::*, px,
 };
 use itertools::Itertools;
 use menu::{
@@ -601,6 +602,7 @@ pub struct Sidebar {
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
     project_header_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
     project_header_menu_ix: Option<usize>,
+    thread_context_menu: Option<(Entity<ContextMenu>, Point<Pixels>, gpui::Subscription)>,
     _subscriptions: Vec<gpui::Subscription>,
     /// For the thread import banners, if there is just one we show "Import
     /// Threads" but if we are showing both the external agents and other
@@ -707,6 +709,7 @@ impl Sidebar {
             recent_projects_popover_handle: PopoverMenuHandle::default(),
             project_header_menu_handles: HashMap::new(),
             project_header_menu_ix: None,
+            thread_context_menu: None,
             _subscriptions: Vec::new(),
             import_banners_use_verbose_labels: None,
         }
@@ -4227,6 +4230,81 @@ impl Sidebar {
         window.focus(&focus, cx);
     }
 
+    fn deploy_thread_context_menu(
+        &mut self,
+        thread: &ThreadEntry,
+        position: Point<Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let weak_self = cx.weak_entity();
+        let metadata = thread.metadata.clone();
+        let thread_workspace = thread.workspace.clone();
+        let session_id_for_archive = thread.metadata.session_id.clone();
+        let can_archive = matches!(
+            thread.status,
+            AgentThreadStatus::Completed | AgentThreadStatus::Error
+        );
+
+        let context_menu = ContextMenu::build(window, cx, move |mut menu, _, _| {
+            let rename_workspace = thread_workspace.clone();
+            let rename_metadata = metadata.clone();
+            let rename_weak_self = weak_self.clone();
+
+            menu = menu.entry(
+                "Rename Thread",
+                Some(Box::new(RenameThread)),
+                move |window, cx| {
+                    if let ThreadEntryWorkspace::Open(workspace) = &rename_workspace {
+                        rename_weak_self
+                            .update(cx, |sidebar, cx| {
+                                sidebar.activate_thread_locally(
+                                    &rename_metadata,
+                                    workspace,
+                                    false,
+                                    window,
+                                    cx,
+                                );
+                            })
+                            .ok();
+                        workspace.update(cx, |ws, cx| {
+                            if let Some(panel) = ws.panel::<AgentPanel>(cx) {
+                                panel.update(cx, |panel, cx| {
+                                    panel.focus_active_thread_title(window, cx);
+                                });
+                            }
+                        });
+                    }
+                },
+            );
+
+            if can_archive {
+                menu = menu.separator().entry(
+                    "Archive Thread",
+                    Some(Box::new(ArchiveSelectedThread)),
+                    move |window, cx| {
+                        if let Some(ref session_id) = session_id_for_archive {
+                            weak_self
+                                .update(cx, |sidebar, cx| {
+                                    sidebar.archive_thread(session_id, window, cx);
+                                })
+                                .ok();
+                        }
+                    },
+                );
+            }
+
+            menu
+        });
+
+        window.focus(&context_menu.focus_handle(cx), cx);
+        let subscription = cx.subscribe(&context_menu, |this, _, _: &DismissEvent, cx| {
+            this.thread_context_menu.take();
+            cx.notify();
+        });
+        self.thread_context_menu = Some((context_menu, position, subscription));
+    }
+
     fn render_thread(
         &self,
         ix: usize,
@@ -4337,6 +4415,13 @@ impl Sidebar {
                             })
                         }),
                 )
+            })
+            .on_secondary_mouse_down({
+                let thread_entry = thread.clone();
+                cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                    cx.stop_propagation();
+                    this.deploy_thread_context_menu(&thread_entry, event.position, window, cx);
+                })
             })
             .on_click({
                 cx.listener(move |this, _, window, cx| {
@@ -5487,6 +5572,19 @@ impl Render for Sidebar {
                 })
             })
             .child(self.render_sidebar_bottom_bar(cx))
+            .children(
+                self.thread_context_menu
+                    .as_ref()
+                    .map(|(menu, position, _)| {
+                        deferred(
+                            anchored()
+                                .position(*position)
+                                .anchor(gpui::Anchor::TopLeft)
+                                .child(menu.clone()),
+                        )
+                        .with_priority(3)
+                    }),
+            )
     }
 }
 

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -1,7 +1,8 @@
 use crate::{CommonAnimationExt, DiffStat, GradientFade, HighlightedLabel, Tooltip, prelude::*};
 
 use gpui::{
-    Animation, AnimationExt, ClickEvent, Hsla, MouseButton, SharedString, pulsating_between,
+    Animation, AnimationExt, ClickEvent, Hsla, MouseButton, MouseDownEvent, SharedString,
+    pulsating_between,
 };
 use itertools::Itertools as _;
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -57,6 +58,7 @@ pub struct ThreadItem {
     is_remote: bool,
     archived: bool,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
+    on_secondary_mouse_down: Option<Box<dyn Fn(&MouseDownEvent, &mut Window, &mut App) + 'static>>,
     on_hover: Box<dyn Fn(&bool, &mut Window, &mut App) + 'static>,
     action_slot: Option<AnyElement>,
     base_bg: Option<Hsla>,
@@ -89,6 +91,7 @@ impl ThreadItem {
             is_remote: false,
             archived: false,
             on_click: None,
+            on_secondary_mouse_down: None,
             on_hover: Box::new(|_, _, _| {}),
             action_slot: None,
             base_bg: None,
@@ -205,6 +208,14 @@ impl ThreadItem {
         handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     ) -> Self {
         self.on_click = Some(Box::new(handler));
+        self
+    }
+
+    pub fn on_secondary_mouse_down(
+        mut self,
+        handler: impl Fn(&MouseDownEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_secondary_mouse_down = Some(Box::new(handler));
         self
     }
 
@@ -583,6 +594,11 @@ impl RenderOnce for ThreadItem {
                         .into_any_element(),
                     _ => gpui::Empty.into_any_element(),
                 }))
+            })
+            .when_some(self.on_secondary_mouse_down, |this, handler| {
+                this.on_mouse_down(MouseButton::Right, move |event, window, cx| {
+                    handler(event, window, cx);
+                })
             })
             .when_some(self.on_click, |this, on_click| this.on_click(on_click))
     }


### PR DESCRIPTION
## Context

ACP thread titles (external agent connections) were permanently read-only in the title editor because `can_set_title()` checked whether the connection supported propagating the title to the remote server. However, `AcpThread::set_title()` already persists the title locally and emits `TitleUpdated` regardless of whether the connection supports remote propagation — the `TitleUpdated` event triggers `ThreadMetadataStore` to save the title to SQLite. The check was therefore too strict: it blocked local renaming entirely for ACP threads, even though the full persistence chain was already in place.

The fix changes `can_set_title()` to gate only on whether the thread is a subagent (which should remain read-only), matching the behavior that native Zed threads already have.

Closes #54689

Video of manual test below :


[Screencast from 2026-04-24 03-04-56.webm](https://github.com/user-attachments/assets/eb676d1f-f0e0-44ca-9313-aa190e3600a1)


## How to Review

- `crates/acp_thread/src/acp_thread.rs` — `can_set_title()` now returns `true` for any non-subagent thread. The old check (`connection.set_title().is_some()`) is replaced with `self.parent_session_id.is_none()`.

- `crates/agent_ui/src/conversation_view.rs` — Updated the test that previously asserted the title editor was read-only when the connection did not support `set_title`. It now asserts the opposite: the editor should be writable for
non-subagent threads regardless of connection capability.

**Edit :** 

## Context

Follows up on the initial fix for ACP thread title editing. Based on additional feedback on #54689, this adds two more ways to rename a thread:

1. **Command palette** — a new `agent: rename thread` action that focuses the title editor in the agent panel titlebar.
2. **Right-click context menu** — secondary mouse click on any thread item in the sidebar shows a menu with "Rename Thread" (activates the thread and focuses its title editor) and "Archive Thread" entries.

Video of manual test below :

[Screencast from 2026-05-10 22-11-37.webm](https://github.com/user-attachments/assets/91dcf9c8-b838-4fb6-9b01-b190259155ee)


## How to Review

- **`crates/agent_ui/src/agent_ui.rs`** : adds `RenameThread` to the `actions!` macro with a doc comment (the doc comment is what appears in the command palette as the description).
- **`crates/agent_ui/src/agent_panel.rs`** : adds `focus_active_thread_title` method that resolves the active thread's title editor and focuses it; registers an `on_action` handler for `RenameThread` in `render()`; includes three tests covering the focus behavior, the action dispatch, and the no-op case when no thread is active.
- **`crates/ui/src/components/ai/thread_item.rs`** : adds an `on_secondary_mouse_down` builder method to `ThreadItem` so callers can attach a right-click handler without `ThreadItem` knowing about the menu.
- **`crates/sidebar/src/sidebar.rs`** : adds `deploy_thread_context_menu` that builds a `ContextMenu` with "Rename Thread" and "Archive Thread"; wires `on_secondary_mouse_down` into `render_thread`; renders the menu overlay via `deferred(anchored(...))` in `Sidebar::render`.


## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed ACP thread titles being uneditable by the user, added `agent: rename thread` command palette action and right-click context menu on thread items to rename or archive threads

