### PR TITLE
agent_ui: Add dual-surface external agent threads

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -15,7 +15,7 @@ use agent_servers::AgentServer;
 use collections::HashSet;
 use db::kvp::{Dismissable, KeyValueStore};
 use itertools::Itertools;
-use project::AgentId;
+use project::{AgentId, agent_server_store::ExternalAgentSurface};
 use serde::{Deserialize, Serialize};
 use settings::{LanguageModelProviderSetting, LanguageModelSelection};
 
@@ -33,7 +33,8 @@ use crate::DEFAULT_THREAD_TITLE;
 use crate::ExpandMessageEditor;
 use crate::ManageProfiles;
 use crate::agent_connection_store::AgentConnectionStore;
-use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore};
+use crate::terminal_agent_view::TerminalAgentView;
+use crate::thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore};
 use crate::{
     AddContextServer, AgentDiffPane, ConversationView, CopyThreadToClipboard, Follow,
     InlineAssistant, LoadThreadFromClipboard, NewThread, OpenActiveThreadAsMarkdown, OpenAgentDiff,
@@ -44,7 +45,7 @@ use crate::{
     ui::EndTrialUpsell,
 };
 use crate::{
-    Agent, AgentInitialContent, ExternalSourcePrompt, NewExternalAgentThread,
+    Agent, AgentInitialContent, AgentThreadSurface, ExternalSourcePrompt, NewExternalAgentThread,
     NewNativeAgentThreadFromSummary,
 };
 use agent_settings::AgentSettings;
@@ -165,6 +166,8 @@ struct SerializedAgentPanel {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct SerializedActiveThread {
+    #[serde(default)]
+    surface: AgentThreadSurface,
     session_id: Option<String>,
     agent_type: Agent,
     title: Option<String>,
@@ -631,10 +634,17 @@ pub(crate) struct AgentThread {
     conversation_view: Entity<ConversationView>,
 }
 
+pub(crate) struct TerminalThread {
+    terminal_agent_view: Entity<TerminalAgentView>,
+}
+
 enum BaseView {
     Uninitialized,
     AgentThread {
         conversation_view: Entity<ConversationView>,
+    },
+    TerminalThread {
+        terminal_agent_view: Entity<TerminalAgentView>,
     },
 }
 
@@ -646,6 +656,14 @@ impl From<AgentThread> for BaseView {
     }
 }
 
+impl From<TerminalThread> for BaseView {
+    fn from(thread: TerminalThread) -> Self {
+        BaseView::TerminalThread {
+            terminal_agent_view: thread.terminal_agent_view,
+        }
+    }
+}
+
 enum OverlayView {
     Configuration,
 }
@@ -653,6 +671,7 @@ enum OverlayView {
 enum VisibleSurface<'a> {
     Uninitialized,
     AgentThread(&'a Entity<ConversationView>),
+    TerminalThread(&'a Entity<TerminalAgentView>),
     Configuration(Option<&'a Entity<AgentConfiguration>>),
 }
 
@@ -703,6 +722,7 @@ pub struct AgentPanel {
     new_user_onboarding: Entity<AgentPanelOnboarding>,
     new_user_onboarding_upsell_dismissed: AtomicBool,
     selected_agent: Agent,
+    selected_surface: AgentThreadSurface,
     _thread_view_subscription: Option<Subscription>,
     _active_thread_focus_subscription: Option<Subscription>,
     show_trust_workspace_message: bool,
@@ -727,6 +747,7 @@ impl AgentPanel {
                 let title = thread.title();
                 let work_dirs = thread.work_dirs().cloned();
                 SerializedActiveThread {
+                    surface: AgentThreadSurface::Acp,
                     session_id: (!is_draft_active).then(|| thread.session_id().0.to_string()),
                     agent_type: self.selected_agent.clone(),
                     title: title.map(|t| t.to_string()),
@@ -747,6 +768,10 @@ impl AgentPanel {
                 let metadata = ThreadMetadataStore::try_global(cx)
                     .and_then(|store| store.read(cx).entry_by_session(&session_id).cloned());
                 Some(SerializedActiveThread {
+                    surface: metadata
+                        .as_ref()
+                        .map(|m| m.surface)
+                        .unwrap_or(AgentThreadSurface::Acp),
                     session_id: Some(session_id.0.to_string()),
                     agent_type: self.selected_agent.clone(),
                     title: metadata
@@ -827,13 +852,16 @@ impl AgentPanel {
             {
                 match &thread_info.session_id {
                     Some(session_id_str) => {
-                        let session_id = acp::SessionId::new(session_id_str.clone());
                         let is_restorable = cx
                             .update(|_window, cx| {
                                 let store = ThreadMetadataStore::global(cx);
                                 store
                                     .read(cx)
-                                    .entry_by_session(&session_id)
+                                    .entry_by_agent_session(
+                                        &thread_info.agent_type.id(),
+                                        thread_info.surface,
+                                        session_id_str,
+                                    )
                                     .is_some_and(|entry| !entry.archived)
                             })
                             .unwrap_or(false);
@@ -881,19 +909,22 @@ impl AgentPanel {
                 if let Some(thread_info) = last_active_thread {
                     if let Some(session_id_str) = &thread_info.session_id {
                         let agent = thread_info.agent_type.clone();
-                        let session_id: acp::SessionId = session_id_str.clone().into();
                         panel.update(cx, |panel, cx| {
                             panel.selected_agent = agent.clone();
-                            panel.load_agent_thread(
-                                agent,
-                                session_id,
-                                thread_info.work_dirs.as_ref().map(|dirs| PathList::deserialize(dirs)),
-                                thread_info.title.as_ref().map(|t| t.clone().into()),
-                                false,
-                                "agent_panel",
-                                window,
-                                cx,
-                            );
+                            panel.selected_surface = thread_info.surface;
+                            let metadata = ThreadMetadataStore::global(cx)
+                                .read(cx)
+                                .entry_by_agent_session(&agent.id(), thread_info.surface, session_id_str)
+                                .cloned();
+                            if let Some(metadata) = metadata {
+                                panel.open_thread_from_metadata(
+                                    &metadata,
+                                    false,
+                                    "agent_panel",
+                                    window,
+                                    cx,
+                                );
+                            }
                         });
                     }
                 }
@@ -1049,6 +1080,7 @@ impl AgentPanel {
             new_user_onboarding: onboarding,
             thread_store,
             selected_agent: Agent::default(),
+            selected_surface: AgentThreadSurface::Acp,
             _thread_view_subscription: None,
             _active_thread_focus_subscription: None,
             show_trust_workspace_message: false,
@@ -1191,7 +1223,16 @@ impl AgentPanel {
         if let Some(agent) = action.agent.clone() {
             self.selected_agent = agent;
         }
-        self.activate_draft(true, "agent_panel", window, cx);
+        if let Some(surface) = action.surface {
+            self.selected_surface = surface;
+        }
+
+        match self.selected_surface {
+            AgentThreadSurface::Acp => self.activate_draft(true, "agent_panel", window, cx),
+            AgentThreadSurface::Terminal => {
+                self.new_terminal_thread(self.selected_agent(cx), true, "agent_panel", window, cx)
+            }
+        }
     }
 
     pub fn activate_draft(
@@ -1336,7 +1377,10 @@ impl AgentPanel {
             BaseView::AgentThread { conversation_view } => {
                 Some(conversation_view.read(cx).thread_id)
             }
-            _ => None,
+            BaseView::TerminalThread {
+                terminal_agent_view,
+            } => Some(terminal_agent_view.read(cx).thread_id()),
+            BaseView::Uninitialized => None,
         }
     }
 
@@ -2043,8 +2087,9 @@ impl AgentPanel {
     }
 
     fn retain_running_thread(&mut self, old_view: BaseView, cx: &mut Context<Self>) {
-        let BaseView::AgentThread { conversation_view } = old_view else {
-            return;
+        let conversation_view = match old_view {
+            BaseView::AgentThread { conversation_view } => conversation_view,
+            BaseView::TerminalThread { .. } | BaseView::Uninitialized => return,
         };
 
         if self
@@ -2113,12 +2158,28 @@ impl AgentPanel {
         let old_view = std::mem::replace(&mut self.base_view, new_view);
         self.retain_running_thread(old_view, cx);
 
-        if let BaseView::AgentThread { conversation_view } = &self.base_view {
-            let thread_agent = conversation_view.read(cx).agent_key().clone();
-            if self.selected_agent != thread_agent {
-                self.selected_agent = thread_agent;
-                self.serialize(cx);
+        match &self.base_view {
+            BaseView::AgentThread { conversation_view } => {
+                let thread_agent = conversation_view.read(cx).agent_key().clone();
+                if self.selected_agent != thread_agent {
+                    self.selected_agent = thread_agent;
+                    self.selected_surface = AgentThreadSurface::Acp;
+                    self.serialize(cx);
+                }
             }
+            BaseView::TerminalThread {
+                terminal_agent_view,
+            } => {
+                let thread_agent = terminal_agent_view.read(cx).agent().clone();
+                if self.selected_agent != thread_agent
+                    || self.selected_surface != AgentThreadSurface::Terminal
+                {
+                    self.selected_agent = thread_agent;
+                    self.selected_surface = AgentThreadSurface::Terminal;
+                    self.serialize(cx);
+                }
+            }
+            BaseView::Uninitialized => {}
         }
 
         self.refresh_base_view_subscriptions(window, cx);
@@ -2181,6 +2242,26 @@ impl AgentPanel {
                     },
                 ))
             }
+            BaseView::TerminalThread {
+                terminal_agent_view,
+            } => {
+                self._thread_view_subscription = None;
+                let focus_handle = terminal_agent_view.focus_handle(cx);
+                self._active_thread_focus_subscription =
+                    Some(cx.on_focus_in(&focus_handle, window, |_this, _window, cx| {
+                        cx.emit(AgentPanelEvent::ThreadFocused);
+                        cx.notify();
+                    }));
+                Some(cx.observe_in(
+                    terminal_agent_view,
+                    window,
+                    |this, _terminal_agent_view, _window, cx| {
+                        cx.emit(AgentPanelEvent::ActiveViewChanged);
+                        this.serialize(cx);
+                        cx.notify();
+                    },
+                ))
+            }
             BaseView::Uninitialized => {
                 self._thread_view_subscription = None;
                 self._active_thread_focus_subscription = None;
@@ -2204,6 +2285,9 @@ impl AgentPanel {
             BaseView::AgentThread { conversation_view } => {
                 VisibleSurface::AgentThread(conversation_view)
             }
+            BaseView::TerminalThread {
+                terminal_agent_view,
+            } => VisibleSurface::TerminalThread(terminal_agent_view),
         }
     }
 
@@ -2289,6 +2373,164 @@ impl AgentPanel {
             window,
             cx,
         );
+    }
+
+    pub fn open_thread_from_metadata(
+        &mut self,
+        metadata: &ThreadMetadata,
+        focus: bool,
+        source: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.selected_agent = Agent::from(metadata.agent_id.clone());
+        self.selected_surface = metadata.surface;
+
+        match metadata.surface {
+            AgentThreadSurface::Acp => {
+                let Some(session_id) = metadata.session_id.clone() else {
+                    log::error!(
+                        "ACP thread metadata missing session_id for {:?}",
+                        metadata.thread_id
+                    );
+                    return;
+                };
+                self.load_agent_thread(
+                    Agent::from(metadata.agent_id.clone()),
+                    session_id,
+                    Some(metadata.folder_paths().clone()),
+                    metadata.title.clone(),
+                    focus,
+                    source,
+                    window,
+                    cx,
+                );
+            }
+            AgentThreadSurface::Terminal => {
+                self.load_terminal_thread_from_metadata(metadata, focus, source, window, cx);
+            }
+        }
+    }
+
+    fn new_terminal_thread(
+        &mut self,
+        agent: Agent,
+        focus: bool,
+        _source: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let thread_id = ThreadId::new();
+        let agent_session_id = SharedString::from(uuid::Uuid::new_v4().to_string());
+        let title = Some(agent.label());
+        let work_dirs = self.project.read(cx).default_path_list(cx);
+        let worktree_paths = self.project.read(cx).worktree_paths(cx);
+        let remote_connection = self.project.read(cx).remote_connection_options(cx);
+
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            store.save(
+                ThreadMetadata {
+                    thread_id,
+                    surface: AgentThreadSurface::Terminal,
+                    session_id: None,
+                    agent_session_id: Some(agent_session_id.clone()),
+                    agent_id: agent.id(),
+                    title: title.clone(),
+                    updated_at: Utc::now(),
+                    created_at: Some(Utc::now()),
+                    interacted_at: Some(Utc::now()),
+                    worktree_paths,
+                    remote_connection,
+                    archived: false,
+                },
+                cx,
+            );
+        });
+
+        let terminal_thread = self.create_terminal_thread(
+            thread_id,
+            agent,
+            agent_session_id,
+            work_dirs,
+            title,
+            true,
+            window,
+            cx,
+        );
+        self.set_base_view(terminal_thread.into(), focus, window, cx);
+    }
+
+    fn load_terminal_thread_from_metadata(
+        &mut self,
+        metadata: &ThreadMetadata,
+        focus: bool,
+        _source: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(agent_session_id) = metadata.agent_session_id.clone() else {
+            log::error!(
+                "terminal thread metadata missing agent_session_id for {:?}",
+                metadata.thread_id
+            );
+            return;
+        };
+
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            store.unarchive(metadata.thread_id, cx);
+        });
+
+        let terminal_thread = self.create_terminal_thread(
+            metadata.thread_id,
+            Agent::from(metadata.agent_id.clone()),
+            agent_session_id,
+            metadata.folder_paths().clone(),
+            metadata.title.clone(),
+            false,
+            window,
+            cx,
+        );
+        self.set_base_view(terminal_thread.into(), focus, window, cx);
+    }
+
+    fn create_terminal_thread(
+        &mut self,
+        thread_id: ThreadId,
+        agent: Agent,
+        agent_session_id: SharedString,
+        work_dirs: PathList,
+        title: Option<SharedString>,
+        is_new_session: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> TerminalThread {
+        let terminal_agent_view = cx.new(|cx| {
+            TerminalAgentView::new(
+                thread_id,
+                agent.clone(),
+                agent_session_id.clone(),
+                title.clone(),
+                work_dirs.clone(),
+                self.workspace.clone(),
+                self.project.downgrade(),
+                window,
+                cx,
+            )
+        });
+
+        if is_new_session {
+            terminal_agent_view
+                .update(cx, |view, cx| view.launch_new_session(window, cx))
+                .detach_and_log_err(cx);
+        } else {
+            terminal_agent_view
+                .update(cx, |view, cx| view.resume_session(window, cx))
+                .detach_and_log_err(cx);
+        }
+
+        TerminalThread {
+            terminal_agent_view,
+        }
     }
 
     pub fn load_agent_thread(
@@ -2487,6 +2729,9 @@ impl Focusable for AgentPanel {
         match self.visible_surface() {
             VisibleSurface::Uninitialized => self.focus_handle.clone(),
             VisibleSurface::AgentThread(conversation_view) => conversation_view.focus_handle(cx),
+            VisibleSurface::TerminalThread(terminal_agent_view) => {
+                terminal_agent_view.focus_handle(cx)
+            }
             VisibleSurface::Configuration(configuration) => {
                 if let Some(configuration) = configuration {
                     configuration.focus_handle(cx)
@@ -2660,6 +2905,9 @@ impl AgentPanel {
                                 .is_empty()
                     })
             }
+            BaseView::TerminalThread {
+                terminal_agent_view,
+            } => terminal_agent_view.read(cx).terminal_view().is_some(),
         }
     }
 
@@ -2821,6 +3069,12 @@ impl AgentPanel {
                         .truncate()
                         .into_any_element()
                 }
+            }
+            VisibleSurface::TerminalThread(terminal_agent_view) => {
+                Label::new(terminal_agent_view.read(cx).title())
+                    .color(Color::Muted)
+                    .truncate()
+                    .into_any_element()
             }
             VisibleSurface::Configuration(_) => {
                 Label::new("Settings").truncate().into_any_element()
@@ -2985,13 +3239,14 @@ impl AgentPanel {
             BaseView::AgentThread { conversation_view } => {
                 conversation_view.read(cx).as_native_thread(cx)
             }
-            BaseView::Uninitialized => None,
+            BaseView::TerminalThread { .. } | BaseView::Uninitialized => None,
         };
 
         let new_thread_menu_builder: Rc<
             dyn Fn(&mut Window, &mut App) -> Option<Entity<ContextMenu>>,
         > = {
             let selected_agent = self.selected_agent.clone();
+            let selected_surface = self.selected_surface;
             let is_agent_selected = move |agent: Agent| selected_agent == agent;
 
             let workspace = self.workspace.clone();
@@ -3033,7 +3288,10 @@ impl AgentPanel {
                         .item(
                             ContextMenuEntry::new("Zed Agent")
                                 .when(is_agent_selected(Agent::NativeAgent), |this| {
-                                    this.action(Box::new(NewExternalAgentThread { agent: None }))
+                                    this.action(Box::new(NewExternalAgentThread {
+                                        agent: None,
+                                        surface: Some(AgentThreadSurface::Acp),
+                                    }))
                                 })
                                 .icon(IconName::ZedAgent)
                                 .icon_color(Color::Muted)
@@ -3049,6 +3307,9 @@ impl AgentPanel {
                                                         panel.new_external_agent_thread(
                                                             &NewExternalAgentThread {
                                                                 agent: Some(Agent::NativeAgent),
+                                                                surface: Some(
+                                                                    AgentThreadSurface::Acp,
+                                                                ),
                                                             },
                                                             window,
                                                             cx,
@@ -3068,6 +3329,8 @@ impl AgentPanel {
                             struct AgentMenuItem {
                                 id: AgentId,
                                 display_name: SharedString,
+                                supports_acp: bool,
+                                supports_terminal: bool,
                             }
 
                             let agent_items = agent_server_store
@@ -3085,6 +3348,12 @@ impl AgentPanel {
                                     AgentMenuItem {
                                         id: agent_id.clone(),
                                         display_name,
+                                        supports_acp: agent_server_store
+                                            .agent_supports_surface(agent_id, ExternalAgentSurface::Acp),
+                                        supports_terminal: agent_server_store.agent_supports_surface(
+                                            agent_id,
+                                            ExternalAgentSurface::Terminal,
+                                        ),
                                     }
                                 })
                                 .sorted_unstable_by_key(|e| e.display_name.to_lowercase())
@@ -3110,14 +3379,93 @@ impl AgentPanel {
                                     entry = entry.icon(IconName::Sparkle);
                                 }
 
+                                if item.supports_acp && item.supports_terminal {
+                                    let agent_id = item.id.clone();
+                                    let workspace_for_acp = workspace.clone();
+                                    let workspace_for_terminal = workspace.clone();
+                                    menu = menu.submenu(
+                                        item.display_name.clone(),
+                                        move |menu, _window, _cx| {
+                                            menu.item(
+                                                ContextMenuEntry::new("Open in ACP")
+                                                    .icon_color(Color::Muted)
+                                                    .handler({
+                                                        let agent_id = agent_id.clone();
+                                                        let workspace = workspace_for_acp.clone();
+                                                        move |window, cx| {
+                                                            if let Some(workspace) = workspace.upgrade() {
+                                                                workspace.update(cx, |workspace, cx| {
+                                                                    if let Some(panel) =
+                                                                        workspace.panel::<AgentPanel>(cx)
+                                                                    {
+                                                                        panel.update(cx, |panel, cx| {
+                                                                            panel.new_external_agent_thread(
+                                                                                &NewExternalAgentThread {
+                                                                                    agent: Some(Agent::Custom {
+                                                                                        id: agent_id.clone(),
+                                                                                    }),
+                                                                                    surface: Some(AgentThreadSurface::Acp),
+                                                                                },
+                                                                                window,
+                                                                                cx,
+                                                                            );
+                                                                        });
+                                                                    }
+                                                                });
+                                                            }
+                                                        }
+                                                    }),
+                                            )
+                                            .item(
+                                                ContextMenuEntry::new("Open in Terminal")
+                                                    .icon_color(Color::Muted)
+                                                    .handler({
+                                                        let agent_id = agent_id.clone();
+                                                        let workspace = workspace_for_terminal.clone();
+                                                        move |window, cx| {
+                                                            if let Some(workspace) = workspace.upgrade() {
+                                                                workspace.update(cx, |workspace, cx| {
+                                                                    if let Some(panel) =
+                                                                        workspace.panel::<AgentPanel>(cx)
+                                                                    {
+                                                                        panel.update(cx, |panel, cx| {
+                                                                            panel.new_external_agent_thread(
+                                                                                &NewExternalAgentThread {
+                                                                                    agent: Some(Agent::Custom {
+                                                                                        id: agent_id.clone(),
+                                                                                    }),
+                                                                                    surface: Some(AgentThreadSurface::Terminal),
+                                                                                },
+                                                                                window,
+                                                                                cx,
+                                                                            );
+                                                                        });
+                                                                    }
+                                                                });
+                                                            }
+                                                        }
+                                                    }),
+                                            )
+                                        },
+                                    );
+                                    continue;
+                                }
+
+                                let surface = if item.supports_terminal {
+                                    AgentThreadSurface::Terminal
+                                } else {
+                                    AgentThreadSurface::Acp
+                                };
+
                                 entry = entry
                                     .when(
                                         is_agent_selected(Agent::Custom {
                                             id: item.id.clone(),
-                                        }),
+                                        }) && selected_surface == surface,
                                         |this| {
                                             this.action(Box::new(NewExternalAgentThread {
                                                 agent: None,
+                                                surface: Some(surface),
                                             }))
                                         },
                                     )
@@ -3138,6 +3486,7 @@ impl AgentPanel {
                                                                     agent: Some(Agent::Custom {
                                                                         id: agent_id.clone(),
                                                                     }),
+                                                                    surface: Some(surface),
                                                                 },
                                                                 window,
                                                                 cx,
@@ -3393,7 +3742,7 @@ impl AgentPanel {
                     return false;
                 }
             }
-            BaseView::Uninitialized => {
+            BaseView::TerminalThread { .. } | BaseView::Uninitialized => {
                 return false;
             }
         }
@@ -3454,6 +3803,7 @@ impl AgentPanel {
                     false
                 }
             }
+            BaseView::TerminalThread { .. } => false,
         }
     }
 
@@ -3574,7 +3924,7 @@ impl AgentPanel {
                     conversation_view.insert_dragged_files(paths, added_worktrees, window, cx);
                 });
             }
-            BaseView::Uninitialized => {}
+            BaseView::TerminalThread { .. } | BaseView::Uninitialized => {}
         }
     }
 
@@ -3615,6 +3965,7 @@ impl AgentPanel {
         key_context.add("AgentPanel");
         match &self.base_view {
             BaseView::AgentThread { .. } => key_context.add("acp_thread"),
+            BaseView::TerminalThread { .. } => key_context.add("terminal_thread"),
             BaseView::Uninitialized => {}
         }
         key_context
@@ -3666,6 +4017,9 @@ impl Render for AgentPanel {
                 VisibleSurface::AgentThread(conversation_view) => parent
                     .child(conversation_view.clone())
                     .child(self.render_drag_target(cx)),
+                VisibleSurface::TerminalThread(terminal_agent_view) => {
+                    parent.child(terminal_agent_view.clone())
+                }
                 VisibleSurface::Configuration(configuration) => {
                     parent.children(configuration.cloned())
                 }
@@ -4242,7 +4596,9 @@ mod tests {
                 store.save(
                     ThreadMetadata {
                         thread_id: ThreadId::new(),
+                        surface: AgentThreadSurface::Acp,
                         session_id: Some(resume_session_id.clone()),
+                        agent_session_id: Some(resume_session_id.0.to_string().into()),
                         agent_id: ProjectAgentId::new("Flaky"),
                         title: Some("Persistent chat".into()),
                         updated_at: Utc::now(),
@@ -5791,7 +6147,10 @@ mod tests {
         });
 
         // Press cmd-n (activate_draft again with the same agent).
-        cx.dispatch_action(NewExternalAgentThread { agent: None });
+        cx.dispatch_action(NewExternalAgentThread {
+            agent: None,
+            surface: Some(AgentThreadSurface::Acp),
+        });
         cx.run_until_parked();
 
         // The draft entity should not have changed.
@@ -5871,6 +6230,7 @@ mod tests {
         // content from the old draft and pre-fill the new one.
         cx.dispatch_action(NewExternalAgentThread {
             agent: Some(Agent::Stub),
+            surface: Some(AgentThreadSurface::Acp),
         });
         cx.run_until_parked();
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -23,6 +23,7 @@ mod mode_selector;
 mod model_selector;
 mod model_selector_popover;
 mod profile_selector;
+mod terminal_agent_view;
 mod terminal_codegen;
 mod terminal_inline_assistant;
 #[cfg(any(test, feature = "test-support"))]
@@ -242,6 +243,14 @@ pub struct ToggleCommandPattern {
 #[serde(deny_unknown_fields)]
 pub struct NewThread;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentThreadSurface {
+    #[default]
+    Acp,
+    Terminal,
+}
+
 /// Creates a new external agent conversation thread.
 #[derive(Default, Clone, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = agent)]
@@ -249,6 +258,8 @@ pub struct NewThread;
 pub struct NewExternalAgentThread {
     /// Which agent to use for the conversation.
     agent: Option<Agent>,
+    /// Which surface to launch for the selected external agent.
+    surface: Option<AgentThreadSurface>,
 }
 
 #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -3366,7 +3366,9 @@ pub(crate) mod tests {
                 store.save(
                     ThreadMetadata {
                         thread_id: ThreadId::new(),
+                        surface: crate::AgentThreadSurface::Acp,
                         session_id: Some(resume_session_id.clone()),
+                        agent_session_id: Some(resume_session_id.0.to_string().into()),
                         agent_id: ProjectAgentId::new("Flaky"),
                         title: Some(stored_title.clone()),
                         updated_at: Utc::now(),

--- a/crates/agent_ui/src/terminal_agent_view.rs
+++ b/crates/agent_ui/src/terminal_agent_view.rs
@@ -9,7 +9,7 @@ use project::{
 };
 use task::{HideStrategy, RevealStrategy, SpawnInTerminal, TaskId};
 use terminal_view::TerminalView;
-use ui::prelude::*;
+use ui::{Button, Callout, CommonAnimationExt, prelude::*};
 use workspace::{PathList, Workspace};
 
 use crate::{Agent, ThreadId};
@@ -20,6 +20,13 @@ pub enum TerminalAgentViewEvent {
 
 impl EventEmitter<TerminalAgentViewEvent> for TerminalAgentView {}
 
+#[derive(Clone)]
+enum TerminalLaunchState {
+    Launching,
+    Failed(SharedString),
+    Loaded,
+}
+
 pub struct TerminalAgentView {
     thread_id: ThreadId,
     agent: Agent,
@@ -27,6 +34,8 @@ pub struct TerminalAgentView {
     title: Option<SharedString>,
     work_dirs: PathList,
     terminal_view: Option<Entity<TerminalView>>,
+    launch_state: TerminalLaunchState,
+    last_request: Option<ExternalAgentTerminalRequest>,
     focus_handle: FocusHandle,
     workspace: WeakEntity<Workspace>,
     project: WeakEntity<Project>,
@@ -59,6 +68,8 @@ impl TerminalAgentView {
             title,
             work_dirs,
             terminal_view: None,
+            launch_state: TerminalLaunchState::Launching,
+            last_request: None,
             focus_handle,
             workspace,
             project,
@@ -110,16 +121,34 @@ impl TerminalAgentView {
         )
     }
 
+    pub fn retry(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Task<Result<()>> {
+        let Some(request) = self.last_request.clone() else {
+            return Task::ready(Err(anyhow::anyhow!(
+                "terminal launch request is unavailable"
+            )));
+        };
+        self.launch_terminal(request, window, cx)
+    }
+
     fn launch_terminal(
         &mut self,
         request: ExternalAgentTerminalRequest,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
+        self.last_request = Some(request.clone());
+        self.launch_state = TerminalLaunchState::Launching;
+        self.terminal_view = None;
+        cx.notify();
+
         let Some(project) = self.project.upgrade() else {
+            self.launch_state = TerminalLaunchState::Failed("Project no longer exists".into());
+            cx.notify();
             return Task::ready(Err(anyhow::anyhow!("project no longer exists")));
         };
         let Some(workspace) = self.workspace.upgrade() else {
+            self.launch_state = TerminalLaunchState::Failed("Workspace no longer exists".into());
+            cx.notify();
             return Task::ready(Err(anyhow::anyhow!("workspace no longer exists")));
         };
 
@@ -141,35 +170,95 @@ impl TerminalAgentView {
         let project_weak = project.downgrade();
 
         cx.spawn_in(window, async move |this, cx| {
-            let command_task = command_task?;
-            let command = command_task.await?;
-            let spawn_task = build_spawn_in_terminal(&agent_id, &title, &work_dirs, &command);
-            let terminal_task = project_for_command.update(cx, |project, cx| {
-                project.create_terminal_task(spawn_task, cx)
-            });
-            let terminal = terminal_task.await?;
+            let result = async {
+                let command_task = command_task?;
+                let command = command_task.await?;
+                let spawn_task = build_spawn_in_terminal(&agent_id, &title, &work_dirs, &command);
+                let terminal_task = project_for_command.update(cx, |project, cx| {
+                    project.create_terminal_task(spawn_task, cx)
+                });
+                let terminal = terminal_task.await?;
 
-            let terminal_view = cx.new_window_entity(|window, cx| {
-                let mut terminal_view = TerminalView::new(
-                    terminal,
-                    workspace_weak.clone(),
-                    None,
-                    project_weak.clone(),
-                    window,
-                    cx,
-                );
-                terminal_view.set_embedded_mode(Some(1000), cx);
-                terminal_view
-            })?;
+                let terminal_view = cx.new_window_entity(|window, cx| {
+                    let mut terminal_view = TerminalView::new(
+                        terminal,
+                        workspace_weak.clone(),
+                        None,
+                        project_weak.clone(),
+                        window,
+                        cx,
+                    );
+                    terminal_view.set_embedded_mode(Some(1000), cx);
+                    terminal_view
+                })?;
 
-            this.update_in(cx, |this, _window, cx| {
-                this.terminal_view = Some(terminal_view);
-                cx.emit(TerminalAgentViewEvent::Loaded);
-                cx.notify();
-            })?;
+                this.update_in(cx, |this, _window, cx| {
+                    this.terminal_view = Some(terminal_view);
+                    this.launch_state = TerminalLaunchState::Loaded;
+                    cx.emit(TerminalAgentViewEvent::Loaded);
+                    cx.notify();
+                })?;
 
-            anyhow::Ok(())
+                anyhow::Ok(())
+            }
+            .await;
+
+            if let Err(error) = &result {
+                let error_message: SharedString = format!("{error:#}").into();
+                this.update_in(cx, |this, _window, cx| {
+                    this.terminal_view = None;
+                    this.launch_state = TerminalLaunchState::Failed(error_message.clone());
+                    cx.notify();
+                })
+                .ok();
+            }
+
+            result
         })
+    }
+
+    fn render_loading_state(&self) -> impl IntoElement {
+        v_flex().size_full().items_center().justify_center().child(
+            h_flex()
+                .gap_1p5()
+                .justify_center()
+                .child(
+                    Icon::new(IconName::LoadCircle)
+                        .size(IconSize::XSmall)
+                        .color(Color::Muted)
+                        .with_rotate_animation(3),
+                )
+                .child(
+                    Label::new(format!("Launching {}…", self.title()))
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                ),
+        )
+    }
+
+    fn render_error_state(&self, error: SharedString, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .size_full()
+            .items_center()
+            .justify_center()
+            .p_4()
+            .child(
+                div().max_w_112().child(
+                    Callout::new()
+                        .severity(Severity::Error)
+                        .icon(IconName::XCircle)
+                        .title("Failed to launch terminal")
+                        .description(error)
+                        .actions_slot(
+                            Button::new("retry-launch-terminal", "Retry")
+                                .label_size(LabelSize::Small)
+                                .style(ButtonStyle::Outlined)
+                                .on_click(cx.listener(|this, _, window, cx| {
+                                    this.retry(window, cx).detach_and_log_err(cx);
+                                })),
+                        ),
+                ),
+            )
     }
 }
 
@@ -211,10 +300,20 @@ impl Focusable for TerminalAgentView {
 
 impl Render for TerminalAgentView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let content = match (&self.launch_state, self.terminal_view.clone()) {
+            (_, Some(terminal_view)) => terminal_view.into_any_element(),
+            (TerminalLaunchState::Failed(error), None) => self
+                .render_error_state(error.clone(), cx)
+                .into_any_element(),
+            (TerminalLaunchState::Launching | TerminalLaunchState::Loaded, None) => {
+                self.render_loading_state().into_any_element()
+            }
+        };
+
         div()
             .track_focus(&self.focus_handle)
             .size_full()
             .bg(cx.theme().colors().editor_background)
-            .children(self.terminal_view.clone())
+            .child(content)
     }
 }

--- a/crates/agent_ui/src/terminal_agent_view.rs
+++ b/crates/agent_ui/src/terminal_agent_view.rs
@@ -173,7 +173,9 @@ impl TerminalAgentView {
             let result = async {
                 let command_task = command_task?;
                 let command = command_task.await?;
-                let spawn_task = build_spawn_in_terminal(&agent_id, &title, &work_dirs, &command);
+                let thread_id = this.read_with(cx, |this, _| this.thread_id)?;
+                let spawn_task =
+                    build_spawn_in_terminal(thread_id, &agent_id, &title, &work_dirs, &command);
                 let terminal_task = project_for_command.update(cx, |project, cx| {
                     project.create_terminal_task(spawn_task, cx)
                 });
@@ -263,13 +265,14 @@ impl TerminalAgentView {
 }
 
 fn build_spawn_in_terminal(
+    thread_id: ThreadId,
     agent_id: &AgentId,
     title: &SharedString,
     work_dirs: &PathList,
     command: &AgentServerCommand,
 ) -> SpawnInTerminal {
     SpawnInTerminal {
-        id: TaskId(format!("agent-terminal:{}:{}", agent_id, title)),
+        id: TaskId(format!("agent-terminal:{}:{}", agent_id, thread_id)),
         full_label: title.to_string(),
         label: title.to_string(),
         command_label: command.args.iter().fold(

--- a/crates/agent_ui/src/terminal_agent_view.rs
+++ b/crates/agent_ui/src/terminal_agent_view.rs
@@ -1,0 +1,220 @@
+use anyhow::{Context as _, Result};
+use gpui::{
+    App, Context, Entity, EventEmitter, FocusHandle, Focusable, Render, SharedString, Subscription,
+    Task, WeakEntity,
+};
+use project::{
+    AgentId, Project,
+    agent_server_store::{AgentServerCommand, ExternalAgentTerminalRequest},
+};
+use task::{HideStrategy, RevealStrategy, SpawnInTerminal, TaskId};
+use terminal_view::TerminalView;
+use ui::prelude::*;
+use workspace::{PathList, Workspace};
+
+use crate::{Agent, ThreadId};
+
+pub enum TerminalAgentViewEvent {
+    Loaded,
+}
+
+impl EventEmitter<TerminalAgentViewEvent> for TerminalAgentView {}
+
+pub struct TerminalAgentView {
+    thread_id: ThreadId,
+    agent: Agent,
+    agent_session_id: SharedString,
+    title: Option<SharedString>,
+    work_dirs: PathList,
+    terminal_view: Option<Entity<TerminalView>>,
+    focus_handle: FocusHandle,
+    workspace: WeakEntity<Workspace>,
+    project: WeakEntity<Project>,
+    _subscriptions: [Subscription; 1],
+}
+
+impl TerminalAgentView {
+    pub fn new(
+        thread_id: ThreadId,
+        agent: Agent,
+        agent_session_id: SharedString,
+        title: Option<SharedString>,
+        work_dirs: PathList,
+        workspace: WeakEntity<Workspace>,
+        project: WeakEntity<Project>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let focus_handle = cx.focus_handle();
+        let focus_subscription = cx.on_focus(&focus_handle, window, |this, window, cx| {
+            if let Some(terminal_view) = this.terminal_view.as_ref() {
+                terminal_view.focus_handle(cx).focus(window, cx);
+            }
+        });
+
+        Self {
+            thread_id,
+            agent,
+            agent_session_id,
+            title,
+            work_dirs,
+            terminal_view: None,
+            focus_handle,
+            workspace,
+            project,
+            _subscriptions: [focus_subscription],
+        }
+    }
+
+    pub fn thread_id(&self) -> ThreadId {
+        self.thread_id
+    }
+
+    pub fn agent(&self) -> &Agent {
+        &self.agent
+    }
+
+    pub fn title(&self) -> SharedString {
+        self.title.clone().unwrap_or_else(|| self.agent.label())
+    }
+
+    pub fn terminal_view(&self) -> Option<&Entity<TerminalView>> {
+        self.terminal_view.as_ref()
+    }
+
+    pub fn launch_new_session(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.launch_terminal(
+            ExternalAgentTerminalRequest::NewSession {
+                session_id: self.agent_session_id.clone(),
+            },
+            window,
+            cx,
+        )
+    }
+
+    pub fn resume_session(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.launch_terminal(
+            ExternalAgentTerminalRequest::ResumeSession {
+                session_id: self.agent_session_id.clone(),
+            },
+            window,
+            cx,
+        )
+    }
+
+    fn launch_terminal(
+        &mut self,
+        request: ExternalAgentTerminalRequest,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        let Some(project) = self.project.upgrade() else {
+            return Task::ready(Err(anyhow::anyhow!("project no longer exists")));
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return Task::ready(Err(anyhow::anyhow!("workspace no longer exists")));
+        };
+
+        let work_dirs = self.work_dirs.clone();
+        let agent_id = self.agent.id();
+        let title = self.title();
+        let project_for_command = project.clone();
+        let command_task = project.update(cx, |project, cx| {
+            let store = project.agent_server_store().clone();
+            let mut async_cx = cx.to_async();
+            store.update(cx, |store, _| {
+                store
+                    .terminal_command(&agent_id, request, Default::default(), &mut async_cx)
+                    .context("external agent is not registered for terminal launch")
+            })
+        });
+
+        let workspace_weak = workspace.downgrade();
+        let project_weak = project.downgrade();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let command_task = command_task?;
+            let command = command_task.await?;
+            let spawn_task = build_spawn_in_terminal(&agent_id, &title, &work_dirs, &command);
+            let terminal_task = project_for_command.update(cx, |project, cx| {
+                project.create_terminal_task(spawn_task, cx)
+            });
+            let terminal = terminal_task.await?;
+
+            let terminal_view = cx.new_window_entity(|window, cx| {
+                let mut terminal_view = TerminalView::new(
+                    terminal,
+                    workspace_weak.clone(),
+                    None,
+                    project_weak.clone(),
+                    window,
+                    cx,
+                );
+                terminal_view.set_embedded_mode(Some(1000), cx);
+                terminal_view
+            })?;
+
+            this.update_in(cx, |this, _window, cx| {
+                this.terminal_view = Some(terminal_view);
+                cx.emit(TerminalAgentViewEvent::Loaded);
+                cx.notify();
+            })?;
+
+            anyhow::Ok(())
+        })
+    }
+}
+
+fn build_spawn_in_terminal(
+    agent_id: &AgentId,
+    title: &SharedString,
+    work_dirs: &PathList,
+    command: &AgentServerCommand,
+) -> SpawnInTerminal {
+    SpawnInTerminal {
+        id: TaskId(format!("agent-terminal:{}:{}", agent_id, title)),
+        full_label: title.to_string(),
+        label: title.to_string(),
+        command_label: command.args.iter().fold(
+            command.path.to_string_lossy().to_string(),
+            |mut label, arg| {
+                label.push(' ');
+                label.push_str(arg);
+                label
+            },
+        ),
+        command: Some(command.path.to_string_lossy().to_string()),
+        args: command.args.clone(),
+        cwd: work_dirs.paths().first().cloned(),
+        env: command.env.clone().unwrap_or_default(),
+        use_new_terminal: true,
+        allow_concurrent_runs: true,
+        reveal: RevealStrategy::Always,
+        hide: HideStrategy::Never,
+        ..Default::default()
+    }
+}
+
+impl Focusable for TerminalAgentView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for TerminalAgentView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .children(self.terminal_view.clone())
+    }
+}

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -24,7 +24,7 @@ use util::ResultExt;
 use workspace::{ModalView, MultiWorkspace, Workspace};
 
 use crate::{
-    Agent, AgentPanel,
+    Agent, AgentPanel, AgentThreadSurface,
     agent_connection_store::AgentConnectionStore,
     thread_metadata_store::{ThreadId, ThreadMetadata, ThreadMetadataStore, WorktreePaths},
 };
@@ -587,7 +587,9 @@ fn collect_importable_threads(
             };
             to_insert.push(ThreadMetadata {
                 thread_id: ThreadId::new(),
-                session_id: Some(session.session_id),
+                surface: AgentThreadSurface::Acp,
+                session_id: Some(session.session_id.clone()),
+                agent_session_id: Some(session.session_id.0.to_string().into()),
                 agent_id: agent_id.clone(),
                 title: session.title,
                 updated_at: session.updated_at.unwrap_or_else(|| Utc::now()),

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -39,6 +39,12 @@ impl ThreadId {
     }
 }
 
+impl std::fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl Bind for ThreadId {
     fn bind(&self, statement: &Statement, start_index: i32) -> anyhow::Result<i32> {
         self.0.bind(statement, start_index)

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -28,7 +28,7 @@ use ui::{App, Context, SharedString, ThreadItemWorktreeInfo, WorktreeKind};
 use util::{ResultExt as _, debug_panic};
 use workspace::{PathList, SerializedWorkspaceLocation, WorkspaceDb};
 
-use crate::DEFAULT_THREAD_TITLE;
+use crate::{AgentThreadSurface, DEFAULT_THREAD_TITLE};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ThreadId(uuid::Uuid);
@@ -100,7 +100,7 @@ fn migrate_thread_metadata(cx: &mut App) -> Task<anyhow::Result<()>> {
         let is_first_migration = existing_list.is_empty();
         let existing_session_ids: HashSet<Arc<str>> = existing_list
             .into_iter()
-            .filter_map(|m| m.session_id.map(|s| s.0))
+            .filter_map(|m| m.agent_session_id.map(|s| Arc::<str>::from(s.as_ref())))
             .collect();
 
         let mut to_migrate = store.read_with(cx, |_store, cx| {
@@ -114,7 +114,9 @@ fn migrate_thread_metadata(cx: &mut App) -> Task<anyhow::Result<()>> {
 
                     Some(ThreadMetadata {
                         thread_id: ThreadId::new(),
-                        session_id: Some(entry.id),
+                        surface: AgentThreadSurface::Acp,
+                        session_id: Some(entry.id.clone()),
+                        agent_session_id: Some(entry.id.0.to_string().into()),
                         agent_id: ZED_AGENT_ID.clone(),
                         title: if entry.title.is_empty()
                             || entry.title.as_ref() == DEFAULT_THREAD_TITLE
@@ -285,12 +287,14 @@ fn migrate_thread_ids(cx: &mut App) {
 struct GlobalThreadMetadataStore(Entity<ThreadMetadataStore>);
 impl Global for GlobalThreadMetadataStore {}
 
-/// Lightweight metadata for any thread (native or ACP), enough to populate
+/// Lightweight metadata for any thread (native, ACP, or terminal-backed), enough to populate
 /// the sidebar list and route to the correct load path when clicked.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ThreadMetadata {
     pub thread_id: ThreadId,
+    pub surface: AgentThreadSurface,
     pub session_id: Option<acp::SessionId>,
+    pub agent_session_id: Option<SharedString>,
     pub agent_id: AgentId,
     pub title: Option<SharedString>,
     pub updated_at: DateTime<Utc>,
@@ -313,8 +317,19 @@ impl ThreadMetadata {
     pub fn folder_paths(&self) -> &PathList {
         self.worktree_paths.folder_path_list()
     }
+
     pub fn main_worktree_paths(&self) -> &PathList {
         self.worktree_paths.main_worktree_path_list()
+    }
+
+    pub fn acp_session_id(&self) -> Option<&acp::SessionId> {
+        (self.surface == AgentThreadSurface::Acp)
+            .then_some(self.session_id.as_ref())
+            .flatten()
+    }
+
+    pub fn agent_session_id_str(&self) -> Option<&str> {
+        self.agent_session_id.as_deref().map(|id| id.as_ref())
     }
 }
 
@@ -393,8 +408,8 @@ pub fn worktree_info_from_thread_paths<S: std::hash::BuildHasher>(
 impl From<&ThreadMetadata> for acp_thread::AgentSessionInfo {
     fn from(meta: &ThreadMetadata) -> Self {
         let session_id = meta
-            .session_id
-            .clone()
+            .acp_session_id()
+            .cloned()
             .unwrap_or_else(|| acp::SessionId::new(meta.thread_id.0.to_string()));
         Self {
             session_id,
@@ -458,6 +473,7 @@ pub struct ThreadMetadataStore {
     threads_by_paths: HashMap<PathList, HashSet<ThreadId>>,
     threads_by_main_paths: HashMap<PathList, HashSet<ThreadId>>,
     threads_by_session: HashMap<acp::SessionId, ThreadId>,
+    threads_by_agent_session: HashMap<(AgentId, AgentThreadSurface, SharedString), ThreadId>,
     reload_task: Option<Shared<Task<()>>>,
     conversation_subscriptions: HashMap<gpui::EntityId, Subscription>,
     pending_thread_ops_tx: smol::channel::Sender<DbOperation>,
@@ -551,6 +567,20 @@ impl ThreadMetadataStore {
         self.threads.get(thread_id)
     }
 
+    pub fn entry_by_agent_session(
+        &self,
+        agent_id: &AgentId,
+        surface: AgentThreadSurface,
+        agent_session_id: &str,
+    ) -> Option<&ThreadMetadata> {
+        let thread_id = self.threads_by_agent_session.get(&(
+            agent_id.clone(),
+            surface,
+            SharedString::from(agent_session_id.to_string()),
+        ))?;
+        self.threads.get(thread_id)
+    }
+
     /// Returns all threads.
     pub fn entries(&self) -> impl Iterator<Item = &ThreadMetadata> + '_ {
         self.threads.values()
@@ -625,6 +655,7 @@ impl ThreadMetadataStore {
                     this.threads_by_paths.clear();
                     this.threads_by_main_paths.clear();
                     this.threads_by_session.clear();
+                    this.threads_by_agent_session.clear();
 
                     for row in rows {
                         this.cache_thread_metadata(row);
@@ -652,12 +683,31 @@ impl ThreadMetadataStore {
     }
 
     fn save_internal(&mut self, metadata: ThreadMetadata) {
-        if metadata.session_id.is_none() {
-            debug_panic!("cannot store thread metadata without a session_id");
+        if metadata.agent_session_id.is_none() {
+            debug_panic!("cannot store thread metadata without an agent_session_id");
             return;
-        };
+        }
+
+        if metadata.surface == AgentThreadSurface::Acp && metadata.session_id.is_none() {
+            debug_panic!("cannot store ACP thread metadata without a session_id");
+            return;
+        }
 
         if let Some(thread) = self.threads.get(&metadata.thread_id) {
+            if let Some(session_id) = thread.acp_session_id()
+                && metadata.acp_session_id() != Some(session_id)
+            {
+                self.threads_by_session.remove(session_id);
+            }
+            if let Some(agent_session_id) = thread.agent_session_id.clone()
+                && metadata.agent_session_id.as_ref() != Some(&agent_session_id)
+            {
+                self.threads_by_agent_session.remove(&(
+                    thread.agent_id.clone(),
+                    thread.surface,
+                    agent_session_id,
+                ));
+            }
             if thread.folder_paths() != metadata.folder_paths() {
                 if let Some(thread_ids) = self.threads_by_paths.get_mut(thread.folder_paths()) {
                     thread_ids.remove(&metadata.thread_id);
@@ -682,13 +732,21 @@ impl ThreadMetadataStore {
     }
 
     fn cache_thread_metadata(&mut self, metadata: ThreadMetadata) {
-        let Some(session_id) = metadata.session_id.as_ref() else {
-            debug_panic!("cannot store thread metadata without a session_id");
-            return;
-        };
+        if let Some(session_id) = metadata.acp_session_id() {
+            self.threads_by_session
+                .insert(session_id.clone(), metadata.thread_id);
+        }
 
-        self.threads_by_session
-            .insert(session_id.clone(), metadata.thread_id);
+        if let Some(agent_session_id) = metadata.agent_session_id.clone() {
+            self.threads_by_agent_session.insert(
+                (
+                    metadata.agent_id.clone(),
+                    metadata.surface,
+                    agent_session_id,
+                ),
+                metadata.thread_id,
+            );
+        }
 
         self.threads.insert(metadata.thread_id, metadata.clone());
 
@@ -1047,8 +1105,15 @@ impl ThreadMetadataStore {
 
     pub fn delete(&mut self, thread_id: ThreadId, cx: &mut Context<Self>) {
         if let Some(thread) = self.threads.get(&thread_id) {
-            if let Some(sid) = &thread.session_id {
+            if let Some(sid) = thread.acp_session_id() {
                 self.threads_by_session.remove(sid);
+            }
+            if let Some(agent_session_id) = thread.agent_session_id.clone() {
+                self.threads_by_agent_session.remove(&(
+                    thread.agent_id.clone(),
+                    thread.surface,
+                    agent_session_id,
+                ));
             }
             if let Some(thread_ids) = self.threads_by_paths.get_mut(thread.folder_paths()) {
                 thread_ids.remove(&thread_id);
@@ -1128,6 +1193,7 @@ impl ThreadMetadataStore {
             threads_by_paths: HashMap::default(),
             threads_by_main_paths: HashMap::default(),
             threads_by_session: HashMap::default(),
+            threads_by_agent_session: HashMap::default(),
             reload_task: None,
             conversation_subscriptions: HashMap::default(),
             pending_thread_ops_tx: tx,
@@ -1211,7 +1277,9 @@ impl ThreadMetadataStore {
 
         let metadata = ThreadMetadata {
             thread_id,
-            session_id,
+            surface: AgentThreadSurface::Acp,
+            session_id: session_id.clone(),
+            agent_session_id: session_id.map(|id| id.0.to_string().into()),
             agent_id,
             title,
             created_at: Some(created_at),
@@ -1322,6 +1390,16 @@ impl Domain for ThreadMetadataDb {
         sql!(
             ALTER TABLE sidebar_threads ADD COLUMN interacted_at TEXT;
         ),
+        sql!(
+            ALTER TABLE sidebar_threads ADD COLUMN surface TEXT NOT NULL DEFAULT "acp";
+        ),
+        sql!(
+            ALTER TABLE sidebar_threads ADD COLUMN agent_session_id TEXT;
+
+            UPDATE sidebar_threads
+            SET agent_session_id = COALESCE(agent_session_id, session_id)
+            WHERE session_id IS NOT NULL;
+        ),
     ];
 }
 
@@ -1332,21 +1410,21 @@ impl ThreadMetadataDb {
     pub fn list_ids(&self) -> anyhow::Result<Vec<ThreadId>> {
         self.select::<ThreadId>(
             "SELECT thread_id FROM sidebar_threads \
-             WHERE session_id IS NOT NULL \
+             WHERE agent_session_id IS NOT NULL \
              ORDER BY updated_at DESC",
         )?()
     }
 
-    const LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
+    const LIST_QUERY: &str = "SELECT thread_id, surface, session_id, agent_session_id, agent_id, title, updated_at, \
         created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, \
         main_worktree_paths_order, remote_connection \
         FROM sidebar_threads \
-        WHERE session_id IS NOT NULL \
+        WHERE agent_session_id IS NOT NULL \
         ORDER BY updated_at DESC";
 
     /// List all sidebar thread metadata, ordered by updated_at descending.
     ///
-    /// Only returns threads that have a `session_id`.
+    /// Only returns threads that have a stored external agent session identifier.
     pub fn list(&self) -> anyhow::Result<Vec<ThreadMetadata>> {
         self.select::<ThreadMetadata>(Self::LIST_QUERY)?()
     }
@@ -1354,11 +1432,20 @@ impl ThreadMetadataDb {
     /// Upsert metadata for a thread.
     pub async fn save(&self, row: ThreadMetadata) -> anyhow::Result<()> {
         anyhow::ensure!(
-            row.session_id.is_some(),
-            "refusing to persist thread metadata without a session_id"
+            row.agent_session_id.is_some(),
+            "refusing to persist thread metadata without an agent_session_id"
+        );
+        anyhow::ensure!(
+            row.surface != AgentThreadSurface::Acp || row.session_id.is_some(),
+            "refusing to persist ACP thread metadata without a session_id"
         );
 
+        let surface = match row.surface {
+            AgentThreadSurface::Acp => "acp",
+            AgentThreadSurface::Terminal => "terminal",
+        };
         let session_id = row.session_id.as_ref().map(|s| s.0.clone());
+        let agent_session_id = row.agent_session_id.as_ref().map(|s| s.to_string());
         let agent_id = if row.agent_id.as_ref() == ZED_AGENT_ID.as_ref() {
             None
         } else {
@@ -1395,10 +1482,12 @@ impl ThreadMetadataDb {
         let archived = row.archived;
 
         self.write(move |conn| {
-            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection) \
-                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+            let sql = "INSERT INTO sidebar_threads(thread_id, surface, session_id, agent_session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection) \
+                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15) \
                        ON CONFLICT(thread_id) DO UPDATE SET \
+                           surface = excluded.surface, \
                            session_id = excluded.session_id, \
+                           agent_session_id = excluded.agent_session_id, \
                            agent_id = excluded.agent_id, \
                            title = excluded.title, \
                            updated_at = excluded.updated_at, \
@@ -1412,7 +1501,9 @@ impl ThreadMetadataDb {
                            remote_connection = excluded.remote_connection";
             let mut stmt = Statement::prepare(conn, sql)?;
             let mut i = stmt.bind(&thread_id, 1)?;
+            i = stmt.bind(&surface, i)?;
             i = stmt.bind(&session_id, i)?;
+            i = stmt.bind(&agent_session_id, i)?;
             i = stmt.bind(&agent_id, i)?;
             i = stmt.bind(&title, i)?;
             i = stmt.bind(&updated_at, i)?;
@@ -1564,7 +1655,9 @@ impl ThreadMetadataDb {
 impl Column for ThreadMetadata {
     fn column(statement: &mut Statement, start_index: i32) -> anyhow::Result<(Self, i32)> {
         let (thread_id_uuid, next): (uuid::Uuid, i32) = Column::column(statement, start_index)?;
+        let (surface, next): (String, i32) = Column::column(statement, next)?;
         let (id, next): (Option<Arc<str>>, i32) = Column::column(statement, next)?;
+        let (agent_session_id, next): (Option<String>, i32) = Column::column(statement, next)?;
         let (agent_id, next): (Option<String>, i32) = Column::column(statement, next)?;
         let (title, next): (String, i32) = Column::column(statement, next)?;
         let (updated_at_str, next): (String, i32) = Column::column(statement, next)?;
@@ -1580,6 +1673,12 @@ impl Column for ThreadMetadata {
             Column::column(statement, next)?;
         let (remote_connection_json, next): (Option<String>, i32) =
             Column::column(statement, next)?;
+
+        let surface = match surface.as_str() {
+            "acp" => AgentThreadSurface::Acp,
+            "terminal" => AgentThreadSurface::Terminal,
+            other => anyhow::bail!("unknown thread surface `{other}`"),
+        };
 
         let agent_id = agent_id
             .map(|id| AgentId::new(id))
@@ -1627,10 +1726,17 @@ impl Column for ThreadMetadata {
 
         let thread_id = ThreadId(thread_id_uuid);
 
+        let session_id = id.clone().map(acp::SessionId::new);
+        let agent_session_id = agent_session_id
+            .map(Into::into)
+            .or_else(|| id.map(|id| id.to_string().into()));
+
         Ok((
             ThreadMetadata {
                 thread_id,
-                session_id: id.map(acp::SessionId::new),
+                surface,
+                session_id,
+                agent_session_id,
                 agent_id,
                 title: if title.is_empty() || title == DEFAULT_THREAD_TITLE {
                     None
@@ -1719,7 +1825,9 @@ mod tests {
         ThreadMetadata {
             thread_id: ThreadId::new(),
             archived: false,
+            surface: AgentThreadSurface::Acp,
             session_id: Some(acp::SessionId::new(session_id)),
+            agent_session_id: Some(session_id.to_string().into()),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: if title.is_empty() {
                 None
@@ -1905,7 +2013,9 @@ mod tests {
 
         let moved_metadata = ThreadMetadata {
             thread_id: session1_thread_id,
+            surface: AgentThreadSurface::Acp,
             session_id: Some(acp::SessionId::new("session-1")),
+            agent_session_id: Some("session-1".into()),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("First Thread".into()),
             updated_at: updated_time,
@@ -1989,7 +2099,9 @@ mod tests {
 
         let existing_metadata = ThreadMetadata {
             thread_id: ThreadId::new(),
+            surface: AgentThreadSurface::Acp,
             session_id: Some(acp::SessionId::new("a-session-0")),
+            agent_session_id: Some("a-session-0".into()),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("Existing Metadata".into()),
             updated_at: now - chrono::Duration::seconds(10),
@@ -2110,7 +2222,9 @@ mod tests {
 
         let existing_metadata = ThreadMetadata {
             thread_id: ThreadId::new(),
+            surface: AgentThreadSurface::Acp,
             session_id: Some(acp::SessionId::new("existing-session")),
+            agent_session_id: Some("existing-session".into()),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("Existing Metadata".into()),
             updated_at: existing_updated_at,
@@ -2784,7 +2898,9 @@ mod tests {
         let local_linked_thread = ThreadMetadata {
             thread_id: ThreadId::new(),
             archived: false,
+            surface: AgentThreadSurface::Acp,
             session_id: Some(acp::SessionId::new("local-linked")),
+            agent_session_id: Some("local-linked".into()),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("Local Linked".into()),
             updated_at: now,
@@ -2797,7 +2913,9 @@ mod tests {
         let remote_linked_thread = ThreadMetadata {
             thread_id: ThreadId::new(),
             archived: false,
+            surface: AgentThreadSurface::Acp,
             session_id: Some(acp::SessionId::new("remote-linked")),
+            agent_session_id: Some("remote-linked".into()),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("Remote Linked".into()),
             updated_at: now - chrono::Duration::seconds(1),

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -113,6 +113,21 @@ pub enum ExternalAgentSource {
     Registry,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExternalAgentSurface {
+    Acp,
+    Terminal,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExternalAgentTerminalRequest {
+    NewSession { session_id: SharedString },
+    ResumeSession { session_id: SharedString },
+}
+
+const CLAUDE_EXTERNAL_AGENT_ID: &str = "claude-acp";
+const CLAUDE_CLI_COMMAND: &str = "claude";
+
 pub trait ExternalAgentServer {
     fn get_command(
         &self,
@@ -120,6 +135,19 @@ pub trait ExternalAgentServer {
         extra_env: HashMap<String, String>,
         cx: &mut AsyncApp,
     ) -> Task<Result<AgentServerCommand>>;
+
+    fn supports_surface(&self, surface: ExternalAgentSurface) -> bool {
+        matches!(surface, ExternalAgentSurface::Acp)
+    }
+
+    fn get_terminal_command(
+        &self,
+        _request: ExternalAgentTerminalRequest,
+        _extra_env: HashMap<String, String>,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<AgentServerCommand>> {
+        cx.spawn(async |_| anyhow::bail!("external agent does not support terminal launch"))
+    }
 
     fn version(&self) -> Option<&SharedString> {
         None
@@ -367,6 +395,24 @@ pub fn resolve_extension_icon_path(
 }
 
 impl AgentServerStore {
+    pub fn agent_supports_surface(&self, name: &AgentId, surface: ExternalAgentSurface) -> bool {
+        self.external_agents
+            .get(name)
+            .is_some_and(|entry| entry.server.supports_surface(surface))
+    }
+
+    pub fn terminal_command(
+        &mut self,
+        name: &AgentId,
+        request: ExternalAgentTerminalRequest,
+        extra_env: HashMap<String, String>,
+        cx: &mut AsyncApp,
+    ) -> Option<Task<Result<AgentServerCommand>>> {
+        self.external_agents
+            .get_mut(name)
+            .map(|entry| entry.server.get_terminal_command(request, extra_env, cx))
+    }
+
     pub fn agent_display_name(&self, name: &AgentId) -> Option<SharedString> {
         self.external_agents
             .get(name)
@@ -1512,9 +1558,95 @@ struct LocalRegistryNpxAgent {
     new_version_available_tx: Option<watch::Sender<Option<String>>>,
 }
 
+async fn build_local_registry_npx_command(
+    fs: Arc<dyn Fs>,
+    node_runtime: NodeRuntime,
+    project_environment: gpui::WeakEntity<ProjectEnvironment>,
+    registry_id: Arc<str>,
+    package: SharedString,
+    package_args: Vec<String>,
+    distribution_env: HashMap<String, String>,
+    settings_env: HashMap<String, String>,
+    extra_args: Vec<String>,
+    extra_env: HashMap<String, String>,
+    cx: &mut AsyncApp,
+) -> Result<AgentServerCommand> {
+    let mut env = project_environment
+        .update(cx, |project_environment, cx| {
+            project_environment.default_environment(cx)
+        })?
+        .await
+        .unwrap_or_default();
+
+    let prefix_dir = paths::external_agents_dir()
+        .join("registry")
+        .join("npx")
+        .join(sanitize_path_component(&registry_id));
+    fs.create_dir(&prefix_dir).await?;
+
+    let mut exec_args = vec!["--yes".to_string(), "--".to_string(), package.to_string()];
+    exec_args.extend(package_args);
+
+    let npm_command = node_runtime
+        .npm_command(
+            Some(&prefix_dir),
+            "exec",
+            &exec_args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>(),
+        )
+        .await?;
+
+    env.extend(npm_command.env);
+    env.extend(distribution_env);
+    env.extend(extra_env);
+    env.extend(settings_env);
+
+    let mut args = npm_command.args;
+    args.extend(extra_args);
+
+    Ok(AgentServerCommand {
+        path: npm_command.path,
+        args,
+        env: Some(env),
+    })
+}
+
+fn build_claude_terminal_args(request: ExternalAgentTerminalRequest) -> Vec<String> {
+    match request {
+        ExternalAgentTerminalRequest::NewSession { session_id } => {
+            vec!["--session-id".to_string(), session_id.to_string()]
+        }
+        ExternalAgentTerminalRequest::ResumeSession { session_id } => {
+            vec!["--resume".to_string(), session_id.to_string()]
+        }
+    }
+}
+
+fn build_claude_terminal_command(
+    mut env: HashMap<String, String>,
+    settings_env: HashMap<String, String>,
+    extra_env: HashMap<String, String>,
+    request: ExternalAgentTerminalRequest,
+) -> AgentServerCommand {
+    env.extend(extra_env);
+    env.extend(settings_env);
+
+    AgentServerCommand {
+        path: PathBuf::from(CLAUDE_CLI_COMMAND),
+        args: build_claude_terminal_args(request),
+        env: Some(env),
+    }
+}
+
 impl ExternalAgentServer for LocalRegistryNpxAgent {
     fn version(&self) -> Option<&SharedString> {
         Some(&self.version)
+    }
+
+    fn supports_surface(&self, surface: ExternalAgentSurface) -> bool {
+        match surface {
+            ExternalAgentSurface::Acp => true,
+            ExternalAgentSurface::Terminal => self.registry_id.as_ref() == CLAUDE_EXTERNAL_AGENT_ID,
+        }
     }
 
     fn take_new_version_available_tx(&mut self) -> Option<watch::Sender<Option<String>>> {
@@ -1541,45 +1673,53 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
         let settings_env = self.settings_env.clone();
 
         cx.spawn(async move |cx| {
-            let mut env = project_environment
+            build_local_registry_npx_command(
+                fs,
+                node_runtime,
+                project_environment,
+                registry_id,
+                package,
+                args,
+                distribution_env,
+                settings_env,
+                extra_args,
+                extra_env,
+                cx,
+            )
+            .await
+        })
+    }
+
+    fn get_terminal_command(
+        &self,
+        request: ExternalAgentTerminalRequest,
+        extra_env: HashMap<String, String>,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<AgentServerCommand>> {
+        let project_environment = self.project_environment.downgrade();
+        let registry_id = self.registry_id.clone();
+        let settings_env = self.settings_env.clone();
+
+        cx.spawn(async move |cx| {
+            anyhow::ensure!(
+                registry_id.as_ref() == CLAUDE_EXTERNAL_AGENT_ID,
+                "terminal launch unsupported for registry agent `{}`",
+                registry_id,
+            );
+
+            let env = project_environment
                 .update(cx, |project_environment, cx| {
                     project_environment.default_environment(cx)
                 })?
                 .await
                 .unwrap_or_default();
 
-            let prefix_dir = paths::external_agents_dir()
-                .join("registry")
-                .join("npx")
-                .join(sanitize_path_component(&registry_id));
-            fs.create_dir(&prefix_dir).await?;
-
-            let mut exec_args = vec!["--yes".to_string(), "--".to_string(), package.to_string()];
-            exec_args.extend(args);
-
-            let npm_command = node_runtime
-                .npm_command(
-                    Some(&prefix_dir),
-                    "exec",
-                    &exec_args.iter().map(|a| a.as_str()).collect::<Vec<_>>(),
-                )
-                .await?;
-
-            env.extend(npm_command.env);
-            env.extend(distribution_env);
-            env.extend(extra_env);
-            env.extend(settings_env);
-
-            let mut args = npm_command.args;
-            args.extend(extra_args);
-
-            let command = AgentServerCommand {
-                path: npm_command.path,
-                args,
-                env: Some(env),
-            };
-
-            Ok(command)
+            Ok(build_claude_terminal_command(
+                env,
+                settings_env,
+                extra_env,
+                request,
+            ))
         })
     }
 
@@ -1994,6 +2134,65 @@ mod tests {
                 )
             })
         })
+    }
+
+    #[test]
+    fn builds_claude_terminal_command_for_new_sessions() {
+        let command = build_claude_terminal_command(
+            vec![
+                ("PATH".to_string(), "/usr/bin".to_string()),
+                ("SHARED".to_string(), "project".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            vec![
+                ("CLAUDE_CONFIG_DIR".to_string(), "/tmp/claude".to_string()),
+                ("SHARED".to_string(), "settings".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            vec![
+                ("EXTRA".to_string(), "1".to_string()),
+                ("SHARED".to_string(), "extra".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            ExternalAgentTerminalRequest::NewSession {
+                session_id: SharedString::from("session-123"),
+            },
+        );
+
+        assert_eq!(command.path, PathBuf::from(CLAUDE_CLI_COMMAND));
+        assert_eq!(
+            command.args,
+            vec!["--session-id".to_string(), "session-123".to_string()]
+        );
+        let env = command.env.expect("terminal command should include env");
+        assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
+        assert_eq!(env.get("EXTRA"), Some(&"1".to_string()));
+        assert_eq!(
+            env.get("CLAUDE_CONFIG_DIR"),
+            Some(&"/tmp/claude".to_string())
+        );
+        assert_eq!(env.get("SHARED"), Some(&"settings".to_string()));
+    }
+
+    #[test]
+    fn builds_claude_terminal_command_for_resumed_sessions() {
+        let command = build_claude_terminal_command(
+            HashMap::default(),
+            HashMap::default(),
+            HashMap::default(),
+            ExternalAgentTerminalRequest::ResumeSession {
+                session_id: SharedString::from("session-456"),
+            },
+        );
+
+        assert_eq!(command.path, PathBuf::from(CLAUDE_CLI_COMMAND));
+        assert_eq!(
+            command.args,
+            vec!["--resume".to_string(), "session-456".to_string()]
+        );
     }
 
     #[test]

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -126,7 +126,7 @@ pub enum ExternalAgentTerminalRequest {
 }
 
 const CLAUDE_EXTERNAL_AGENT_ID: &str = "claude-acp";
-const CLAUDE_CLI_COMMAND: &str = "claude";
+const CLAUDE_ADAPTER_CLI_FLAG: &str = "--cli";
 
 pub trait ExternalAgentServer {
     fn get_command(
@@ -1611,30 +1611,20 @@ async fn build_local_registry_npx_command(
 }
 
 fn build_claude_terminal_args(request: ExternalAgentTerminalRequest) -> Vec<String> {
+    let mut args = vec![CLAUDE_ADAPTER_CLI_FLAG.to_string()];
+
     match request {
         ExternalAgentTerminalRequest::NewSession { session_id } => {
-            vec!["--session-id".to_string(), session_id.to_string()]
+            args.push("--session-id".to_string());
+            args.push(session_id.to_string());
         }
         ExternalAgentTerminalRequest::ResumeSession { session_id } => {
-            vec!["--resume".to_string(), session_id.to_string()]
+            args.push("--resume".to_string());
+            args.push(session_id.to_string());
         }
     }
-}
 
-fn build_claude_terminal_command(
-    mut env: HashMap<String, String>,
-    settings_env: HashMap<String, String>,
-    extra_env: HashMap<String, String>,
-    request: ExternalAgentTerminalRequest,
-) -> AgentServerCommand {
-    env.extend(extra_env);
-    env.extend(settings_env);
-
-    AgentServerCommand {
-        path: PathBuf::from(CLAUDE_CLI_COMMAND),
-        args: build_claude_terminal_args(request),
-        env: Some(env),
-    }
+    args
 }
 
 impl ExternalAgentServer for LocalRegistryNpxAgent {
@@ -1696,8 +1686,12 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
         extra_env: HashMap<String, String>,
         cx: &mut AsyncApp,
     ) -> Task<Result<AgentServerCommand>> {
+        let fs = self.fs.clone();
+        let node_runtime = self.node_runtime.clone();
         let project_environment = self.project_environment.downgrade();
         let registry_id = self.registry_id.clone();
+        let package = self.package.clone();
+        let distribution_env = self.distribution_env.clone();
         let settings_env = self.settings_env.clone();
 
         cx.spawn(async move |cx| {
@@ -1707,19 +1701,20 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
                 registry_id,
             );
 
-            let env = project_environment
-                .update(cx, |project_environment, cx| {
-                    project_environment.default_environment(cx)
-                })?
-                .await
-                .unwrap_or_default();
-
-            Ok(build_claude_terminal_command(
-                env,
+            build_local_registry_npx_command(
+                fs,
+                node_runtime,
+                project_environment,
+                registry_id,
+                package,
+                build_claude_terminal_args(request),
+                distribution_env,
                 settings_env,
+                Vec::new(),
                 extra_env,
-                request,
-            ))
+                cx,
+            )
+            .await
         })
     }
 
@@ -2137,62 +2132,50 @@ mod tests {
     }
 
     #[test]
-    fn builds_claude_terminal_command_for_new_sessions() {
-        let command = build_claude_terminal_command(
-            vec![
-                ("PATH".to_string(), "/usr/bin".to_string()),
-                ("SHARED".to_string(), "project".to_string()),
-            ]
-            .into_iter()
-            .collect(),
-            vec![
-                ("CLAUDE_CONFIG_DIR".to_string(), "/tmp/claude".to_string()),
-                ("SHARED".to_string(), "settings".to_string()),
-            ]
-            .into_iter()
-            .collect(),
-            vec![
-                ("EXTRA".to_string(), "1".to_string()),
-                ("SHARED".to_string(), "extra".to_string()),
-            ]
-            .into_iter()
-            .collect(),
-            ExternalAgentTerminalRequest::NewSession {
-                session_id: SharedString::from("session-123"),
-            },
-        );
+    fn builds_claude_terminal_args_for_new_sessions() {
+        let args = build_claude_terminal_args(ExternalAgentTerminalRequest::NewSession {
+            session_id: SharedString::from("session-123"),
+        });
 
-        assert_eq!(command.path, PathBuf::from(CLAUDE_CLI_COMMAND));
         assert_eq!(
-            command.args,
-            vec!["--session-id".to_string(), "session-123".to_string()]
+            args,
+            vec![
+                CLAUDE_ADAPTER_CLI_FLAG.to_string(),
+                "--session-id".to_string(),
+                "session-123".to_string()
+            ]
         );
-        let env = command.env.expect("terminal command should include env");
-        assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
-        assert_eq!(env.get("EXTRA"), Some(&"1".to_string()));
-        assert_eq!(
-            env.get("CLAUDE_CONFIG_DIR"),
-            Some(&"/tmp/claude".to_string())
-        );
-        assert_eq!(env.get("SHARED"), Some(&"settings".to_string()));
     }
 
     #[test]
-    fn builds_claude_terminal_command_for_resumed_sessions() {
-        let command = build_claude_terminal_command(
-            HashMap::default(),
-            HashMap::default(),
-            HashMap::default(),
-            ExternalAgentTerminalRequest::ResumeSession {
-                session_id: SharedString::from("session-456"),
-            },
-        );
+    fn builds_claude_terminal_args_for_resumed_sessions() {
+        let args = build_claude_terminal_args(ExternalAgentTerminalRequest::ResumeSession {
+            session_id: SharedString::from("session-456"),
+        });
 
-        assert_eq!(command.path, PathBuf::from(CLAUDE_CLI_COMMAND));
         assert_eq!(
-            command.args,
-            vec!["--resume".to_string(), "session-456".to_string()]
+            args,
+            vec![
+                CLAUDE_ADAPTER_CLI_FLAG.to_string(),
+                "--resume".to_string(),
+                "session-456".to_string()
+            ]
         );
+    }
+
+    #[test]
+    fn claude_terminal_args_use_adapter_cli_handoff() {
+        let args = build_claude_terminal_args(ExternalAgentTerminalRequest::NewSession {
+            session_id: SharedString::from("session-789"),
+        });
+
+        assert_eq!(
+            args.first().map(String::as_str),
+            Some(CLAUDE_ADAPTER_CLI_FLAG)
+        );
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"--stdio".to_string()));
+        assert!(!args.contains(&"--json".to_string()));
     }
 
     #[test]

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2436,20 +2436,8 @@ impl Sidebar {
                            focus: bool,
                            window: &mut Window,
                            cx: &mut App| {
-            let Some(session_id) = metadata.session_id.clone() else {
-                return;
-            };
             agent_panel.update(cx, |panel, cx| {
-                panel.load_agent_thread(
-                    Agent::from(metadata.agent_id.clone()),
-                    session_id,
-                    Some(metadata.folder_paths().clone()),
-                    metadata.title.clone(),
-                    focus,
-                    "sidebar",
-                    window,
-                    cx,
-                );
+                panel.open_thread_from_metadata(metadata, focus, "sidebar", window, cx);
             });
         };
 


### PR DESCRIPTION
## Summary

<img width="1840" height="1196" alt="Screenshot 2026-04-23 at 8 32 39 PM" src="https://github.com/user-attachments/assets/dd657ff0-076f-4615-be2c-8b5a4de2e11e" />


This adds dual-surface external agent threads so remembered external-agent sessions can reopen into the correct UI surface instead of assuming ACP.

It introduces a persisted `AgentThreadSurface` model with `Acp` and `Terminal` variants, stores surface-aware thread metadata, and routes sidebar/archive reopen through metadata instead of ACP-specific session loading.

For Claude specifically, this adds a terminal-backed `AgentPanel` surface that embeds a `TerminalView`, remembers a stable Claude-side session id, starts new terminal sessions with `--session-id <uuid>`, and reopens remembered sessions with `--resume <uuid>`.

## What this changes

- Adds `AgentThreadSurface` to external-agent thread creation and active-thread serialization.
- Persists remembered thread metadata with:
  - thread surface
  - ACP session id when applicable
  - durable external agent session id for surface-aware reopen
- Adds metadata-driven reopen from the sidebar/archive so remembered threads load into ACP or terminal appropriately.
- Adds a terminal-backed `AgentPanel` host view via `TerminalAgentView`.
- Extends `ExternalAgentServer` with surface capability checks and terminal command construction.
- Implements a Claude terminal launch path that uses the interactive `claude` CLI with stable session ids instead of the ACP adapter package.
- Updates the external-agent menu to show `Open in ACP` / `Open in Terminal` when supported.

## Validation

- `cargo check -p project -p agent_ui -p sidebar`
- `cargo test -p project builds_claude_terminal_command`

## Remaining follow-ups

- [ ] Surface terminal launch failures in the panel UI instead of showing a blank embedded panel.
- [ ] Add a loading/error/retry state to `TerminalAgentView`.
- [ ] Decide whether terminal-backed threads should participate in retained-thread behavior like ACP threads.
- [ ] Harden Claude command resolution so launch is less dependent on inherited `PATH` state.
- [ ] Add focused tests for remembered terminal-thread reopen through sidebar/archive flows.
- [ ] Add tests for active-thread serialization/deserialization across ACP and terminal surfaces.
- [ ] Review sidebar active-entry syncing and live-state updates for terminal-backed threads.
- [ ] Consider replacing ambiguous serialized `session_id` naming with surface-specific naming.
- [ ] Consider using a durable terminal task id based on `thread_id` or `agent_session_id` instead of title.
- [ ] Review metadata index update paths in `ThreadMetadataStore` for stale `(agent_id, surface, agent_session_id)` keys.

Release Notes:

- Improved external agent threads so remembered sessions can reopen into ACP or terminal surfaces, including Claude terminal session resume support.
