### PR TITLE
markdown: Make table cell checkboxes clickable

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2131,7 +2131,7 @@ impl Element for MarkdownElement {
                         builder.table.end_row();
                     }
                     MarkdownTagEnd::TableCell => {
-                        builder.replace_pending_checkbox(range);
+                        builder.replace_pending_checkbox(self.on_checkbox_toggle.clone());
                         builder.pop_div();
                         builder.table.end_cell();
                     }
@@ -2689,26 +2689,53 @@ impl MarkdownElementBuilder {
         }
     }
 
-    fn replace_pending_checkbox(&mut self, source_range: &Range<usize>) {
-        let trimmed = self.pending_line.text.trim();
-        if trimmed == "[x]" || trimmed == "[X]" || trimmed == "[ ]" {
-            let checked = trimmed != "[ ]";
-            self.pending_line = PendingLine::default();
-            let checkbox = Checkbox::new(
-                ElementId::Name(
-                    format!("table_checkbox_{}_{}", source_range.start, source_range.end).into(),
-                ),
-                if checked {
-                    ToggleState::Selected
-                } else {
-                    ToggleState::Unselected
-                },
-            )
-            .fill()
-            .visualization_only(true)
-            .into_any_element();
-            self.div_stack.last_mut().unwrap().extend([checkbox]);
+    fn replace_pending_checkbox(&mut self, on_toggle: Option<CheckboxToggleCallback>) {
+        let text = &self.pending_line.text;
+        let trimmed = text.trim();
+        if trimmed != "[x]" && trimmed != "[X]" && trimmed != "[ ]" {
+            return;
         }
+        let checked = trimmed != "[ ]";
+
+        let leading_ws = text.len() - text.trim_start().len();
+        let marker_rendered = leading_ws..leading_ws + trimmed.len();
+        let marker_source = self
+            .source_range_for_rendered(&marker_rendered)
+            .expect("pending checkbox text must have source mappings");
+
+        self.pending_line = PendingLine::default();
+
+        let toggle_state = if checked {
+            ToggleState::Selected
+        } else {
+            ToggleState::Unselected
+        };
+        let checkbox = Checkbox::new(
+            ElementId::Name(
+                format!(
+                    "table_checkbox_{}_{}",
+                    marker_source.start, marker_source.end
+                )
+                .into(),
+            ),
+            toggle_state,
+        )
+        .fill();
+
+        let element = if let Some(on_toggle) = on_toggle {
+            checkbox
+                .on_click(move |_state, window, cx| {
+                    on_toggle(marker_source.clone(), !checked, window, cx);
+                })
+                .into_any_element()
+        } else {
+            checkbox.visualization_only(true).into_any_element()
+        };
+        self.div_stack.last_mut().unwrap().extend([element]);
+    }
+
+    fn source_range_for_rendered(&self, rendered: &Range<usize>) -> Option<Range<usize>> {
+        source_range_for_rendered(&self.pending_line.source_mappings, rendered)
     }
 
     fn render_source_anchor(&mut self, source_range: Range<usize>) -> AnyElement {
@@ -2862,6 +2889,30 @@ impl RenderedLine {
 struct SourceMapping {
     rendered_index: usize,
     source_index: usize,
+}
+
+fn source_range_for_rendered(
+    mappings: &[SourceMapping],
+    rendered: &Range<usize>,
+) -> Option<Range<usize>> {
+    if rendered.start >= rendered.end {
+        return None;
+    }
+    let start = source_index_for_rendered(mappings, rendered.start)?;
+    let end = source_index_for_rendered(mappings, rendered.end - 1)? + 1;
+    Some(start..end)
+}
+
+fn source_index_for_rendered(mappings: &[SourceMapping], rendered_index: usize) -> Option<usize> {
+    let mut last: Option<&SourceMapping> = None;
+    for mapping in mappings {
+        if mapping.rendered_index <= rendered_index {
+            last = Some(mapping);
+        } else {
+            break;
+        }
+    }
+    last.map(|m| m.source_index + (rendered_index - m.rendered_index))
 }
 
 pub struct RenderedMarkdown {
@@ -3369,6 +3420,83 @@ mod tests {
         );
         assert_eq!(checkbox_cells[0].trim(), "[x]");
         assert_eq!(checkbox_cells[1].trim(), "[ ]");
+    }
+
+    #[test]
+    fn test_table_checkbox_marker_source_range() {
+        let md = "| Done |\n|------|\n|  [x]  |\n| [ ] |";
+        let events = crate::parser::parse_markdown_with_options(md, false, false).events;
+
+        let mut in_cell = false;
+        let mut pending_text = String::new();
+        let mut mappings: Vec<SourceMapping> = Vec::new();
+        let mut cell_ranges: Vec<Range<usize>> = Vec::new();
+
+        for (range, event) in &events {
+            match event {
+                MarkdownEvent::Start(MarkdownTag::TableCell) => {
+                    in_cell = true;
+                    pending_text.clear();
+                    mappings.clear();
+                }
+                MarkdownEvent::End(MarkdownTagEnd::TableCell) => {
+                    if in_cell {
+                        let trimmed = pending_text.trim();
+                        if trimmed == "[x]" || trimmed == "[X]" || trimmed == "[ ]" {
+                            let leading = pending_text.len() - pending_text.trim_start().len();
+                            let rendered = leading..leading + trimmed.len();
+                            let marker_source = source_range_for_rendered(&mappings, &rendered)
+                                .expect("marker source range");
+                            cell_ranges.push(marker_source);
+                        }
+                    }
+                    in_cell = false;
+                }
+                MarkdownEvent::Text if in_cell => {
+                    mappings.push(SourceMapping {
+                        rendered_index: pending_text.len(),
+                        source_index: range.start,
+                    });
+                    pending_text.push_str(&md[range.clone()]);
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(cell_ranges.len(), 2);
+        for marker_range in &cell_ranges {
+            let slice = &md[marker_range.clone()];
+            assert!(
+                slice == "[x]" || slice == "[X]" || slice == "[ ]",
+                "expected `[x]`/`[X]`/`[ ]`, got {slice:?} at {marker_range:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_source_range_for_rendered_handles_split_chunks() {
+        let mappings = vec![
+            SourceMapping {
+                rendered_index: 0,
+                source_index: 20,
+            },
+            SourceMapping {
+                rendered_index: 1,
+                source_index: 21,
+            },
+            SourceMapping {
+                rendered_index: 2,
+                source_index: 22,
+            },
+        ];
+
+        let range = source_range_for_rendered(&mappings, &(0..3)).unwrap();
+        assert_eq!(range, 20..23);
+
+        let range = source_range_for_rendered(&mappings, &(1..2)).unwrap();
+        assert_eq!(range, 21..22);
+
+        assert_eq!(source_range_for_rendered(&mappings, &(2..2)), None);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #53587

Follow-up to #50595.

[#50595](https://github.com/zed-industries/zed/pull/50595) added display-only checkboxes when `[x]` / `[X]` / `[ ]` appears as the sole content of a markdown table cell. That PR called out interactivity as a later step — this PR delivers it.

https://github.com/user-attachments/assets/c666ee4c-7e31-4450-ab33-c07c82949818

## What this does

When a consumer of `MarkdownElement` supplies an `on_checkbox_toggle` callback, table-cell checkboxes now invoke it on click with the source range of the `[x]` / `[ ]` marker and the new checked state. This mirrors the existing list-item checkbox path.

For markdown preview (`markdown_preview_view.rs`) the callback is already wired to edit the source buffer, so clicking a checkbox in a previewed `.md` file now flips `[x]` to `[ ]` and back in the file, the same as it already did for list checkboxes.

## How it works

`replace_pending_checkbox` previously took the cell's outer source range and always built a visualization-only checkbox. It now takes the optional toggle callback instead, and reconstructs the marker's exact source range from `pending_line.source_mappings` — pulldown-cmark emits `[x]` in a table cell as three separate `Text` events, so the per-chunk mappings are needed to recover the 3-character range to rewrite. If a callback was supplied, the checkbox attaches an `on_click` that invokes it with that range and `!checked`; otherwise it falls back to the prior visualization-only rendering.

Two free helpers (`source_range_for_rendered` / `source_index_for_rendered`) were extracted so the mapping logic is unit-testable.

## Scope

One file: `crates/markdown/src/markdown.rs`. No changes to `markdown_preview` — since #52008 it renders through the shared `MarkdownElement`, so its existing `on_checkbox_toggle` wiring picks up table checkboxes for free.

## Relation to #53587

[#53587](https://github.com/zed-industries/zed/issues/53587) reports that markdown checkboxes in the **agent panel** can't be clicked. This PR is a necessary piece of that fix — without it, even if the agent panel wired `on_checkbox_toggle`, its table checkboxes would stay inert. It does not fully close #53587 on its own: the agent panel's `MarkdownElement` instances in `conversation_view.rs` / `thread_view.rs` don't currently wire `on_checkbox_toggle`, and wiring it there requires deciding how clicks should mutate the in-memory agent response (no source file to edit into). That's a follow-up.

## Test plan

**Unit tests** (2 new, both in `crates/markdown/src/markdown.rs`):
- `test_table_checkbox_marker_source_range` — walks parser events for a table with checkboxes, replays what the builder accumulates, and asserts the reconstructed source range slices to exactly `[x]` / `[ ]` in the original markdown (including a padded-whitespace case).
- `test_source_range_for_rendered_handles_split_chunks` — pins the mapping helper against the three-chunk layout pulldown-cmark produces.

**Automated**:
- [x] `cargo test -p markdown` — 46 tests pass (44 existing + 2 new)
- [x] `cargo test -p markdown_preview` — 3 tests pass
- [x] `./script/clippy -p markdown` — clean

**Manual** (against a preview of a markdown file with checkbox tables):
- [x] Click a checked `[x]` table cell — it becomes `[ ]` in the source and rerenders as unchecked
- [x] Click an unchecked `[ ]` — becomes `[x]`
- [x] Uppercase `[X]` toggles on click (replacement writes `[x]` / `[ ]`, matching the list-item behaviour)
- [x] Padded-whitespace cells still target just the three marker characters
- [x] Multiple checkbox columns in one table all independently clickable
- [x] Alignment variants (left/center/right) behave the same
- [x] Non-checkbox table text unaffected
- [x] List-item checkboxes continue to work (regression)

Release Notes:

- Made table-cell markdown checkboxes clickable in markdown preview, matching list-item checkbox behavior
