### PR TITLE
Fix agent thread sidebar covering window buttons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "parking_lot",
  "paths",
  "picker",
+ "platform_title_bar",
  "postage",
  "pretty_assertions",
  "project",

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -77,6 +77,7 @@ ordered-float.workspace = true
 parking_lot.workspace = true
 paths.workspace = true
 picker.workspace = true
+platform_title_bar.workspace = true
 postage.workspace = true
 project.workspace = true
 prompt_store.workspace = true

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -39,8 +39,8 @@ use ui_input::ErasedEditor;
 use util::ResultExt;
 use util::paths::PathExt;
 use workspace::{
-    ModalView, PathList, SerializedWorkspaceLocation, Workspace, WorkspaceDb, WorkspaceId,
-    resolve_worktree_workspaces,
+    CloseWindow, ModalView, PathList, SerializedWorkspaceLocation, Workspace, WorkspaceDb,
+    WorkspaceId, resolve_worktree_workspaces,
 };
 
 use zed_actions::agents_sidebar::FocusSidebarFilter;
@@ -828,8 +828,12 @@ impl ThreadsArchiveView {
             AgentSettings::get_global(cx).sidebar_side(),
             settings::SidebarSide::Left
         );
-        let traffic_lights =
-            cfg!(target_os = "macos") && !window.is_fullscreen() && sidebar_on_left;
+        let sidebar_on_right = !sidebar_on_left;
+        let not_fullscreen = !window.is_fullscreen();
+        let traffic_lights = cfg!(target_os = "macos") && not_fullscreen && sidebar_on_left;
+        let left_window_controls = !cfg!(target_os = "macos") && not_fullscreen && sidebar_on_left;
+        let right_window_controls =
+            !cfg!(target_os = "macos") && not_fullscreen && sidebar_on_right;
         let header_height = platform_title_bar_height(window);
         let show_focus_keybinding =
             self.selection.is_some() && !self.filter_editor.focus_handle(cx).is_focused(window);
@@ -838,14 +842,19 @@ impl ThreadsArchiveView {
             .h(header_height)
             .mt_px()
             .pb_px()
+            .when(left_window_controls, |this| {
+                this.children(Self::render_left_window_controls(window, cx))
+            })
             .map(|this| {
                 if traffic_lights {
                     this.pl(px(ui::utils::TRAFFIC_LIGHT_PADDING))
-                } else {
+                } else if !left_window_controls {
                     this.pl_1p5()
+                } else {
+                    this
                 }
             })
-            .pr_1p5()
+            .when(!right_window_controls, |this| this.pr_1p5())
             .gap_1()
             .justify_between()
             .border_b_1()
@@ -880,6 +889,25 @@ impl ThreadsArchiveView {
                         })),
                 )
             })
+            .when(right_window_controls, |this| {
+                this.children(Self::render_right_window_controls(window, cx))
+            })
+    }
+
+    fn render_left_window_controls(window: &Window, cx: &mut App) -> Option<AnyElement> {
+        platform_title_bar::render_left_window_controls(
+            cx.button_layout(),
+            Box::new(CloseWindow),
+            window,
+        )
+    }
+
+    fn render_right_window_controls(window: &Window, cx: &mut App) -> Option<AnyElement> {
+        platform_title_bar::render_right_window_controls(
+            cx.button_layout(),
+            Box::new(CloseWindow),
+            window,
+        )
     }
 
     fn render_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {


### PR DESCRIPTION
## Summary

Fixes an oversight in the agent threads archive sidebar's header: on Linux and Windows it only accounted for macOS traffic lights, so the custom window controls (minimize/maximize/close) rendered on top of the sidebar. The main sidebar (`crates/sidebar/src/sidebar.rs::render_sidebar_header`) already handles this correctly — this PR mirrors that pattern in `ThreadsArchiveView::render_header`.

### What changed
- `crates/agent_ui/src/threads_archive_view.rs`
  - `render_header` now computes `traffic_lights`, `left_window_controls`, and `right_window_controls` (matching `sidebar.rs`) and reserves space / renders controls accordingly when not fullscreen.
  - Added `render_left_window_controls` / `render_right_window_controls` helpers that delegate to `platform_title_bar`.
  - Imported `workspace::CloseWindow`.
- `crates/agent_ui/Cargo.toml`
  - Added `platform_title_bar` dependency.

### Behavior
- macOS (sidebar on left): unchanged — traffic-light padding + divider.
- Linux/Windows, sidebar on left: renders left-side window controls inside the header.
- Linux/Windows, sidebar on right: renders right-side window controls inside the header.
- Fullscreen: no controls rendered, same as before.

#### Closes #54596

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

### Video 

[Screencast from 2026-04-24 14-27-51.webm](https://github.com/user-attachments/assets/47009458-2acb-4b65-bff6-d25302a0342e)

Release Notes:

- Agent: Fixed the threads sidebar overlapping the window control buttons on Linux and Windows.