### PR TITLE
docs: Document configuration boundaries for external agents

### DIFF
--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -253,7 +253,101 @@ This lets you see the messages being sent and received between Zed and the agent
 
 It's helpful to attach data from this view if you're opening issues about problems with external agents like Claude Agent, Codex, OpenCode, etc.
 
-## MCP Servers
+## Configuration Boundaries {#configuration-boundaries}
 
-Note that for external agents, access to MCP servers [installed from Zed](./mcp.md) may vary depending on the ACP implementation.
-For example, Claude Agent and Codex both support it, but Gemini CLI does not yet.
+External agents run as separate processes that communicate with Zed via the [Agent Client Protocol (ACP)](https://agentclientprotocol.com). This creates important boundaries between Zed's configuration and the agent's native configuration.
+
+### What Zed Forwards to External Agents
+
+When you start an external agent thread, Zed sends:
+
+| Setting               | How to Configure                                                      |
+| --------------------- | --------------------------------------------------------------------- |
+| Model selection       | `agent_servers.<agent>.default_model` in settings                     |
+| Mode selection        | `agent_servers.<agent>.default_mode` in settings                      |
+| Environment variables | `agent_servers.<agent>.env` in settings                               |
+| MCP servers           | `context_servers` in settings (see [limitations](#mcp-server-access)) |
+| Working directory     | Automatically set to project root                                     |
+| CLAUDE.md content     | Read from project via Zed's [rules system](./rules.md)                |
+
+**Not forwarded:**
+
+- [Profiles](./agent-panel.md#profiles) — profiles only apply to Zed's first-party agent
+- [Tool permissions](./tool-permissions.md) settings — external agents request permissions at runtime via UI prompts
+- Rules from `.rules` files — Zed injects these into its own prompts only
+
+### What External Agents Inherit from Native Installations {#native-config}
+
+External agents run in isolation from their standalone CLI installations. Most native configuration is **not used** when running via Zed.
+
+#### Claude Agent
+
+| Native Config                       | Used by Claude Agent in Zed?                                      |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| `~/.claude/` directory              | No — settings, memory, and project preferences are not used       |
+| MCP servers from Claude Code config | No — configure in Zed's `context_servers` instead                 |
+| Hooks                               | No — [not supported](https://code.claude.com/docs/en/hooks-guide) |
+| Authentication                      | No — you must authenticate separately via `/login` in Zed         |
+| Skills                              | Yes — exposed via the Claude Agent SDK                            |
+| CLAUDE.md files                     | Yes — read by Zed's rules system                                  |
+
+> **Why separate authentication?** Zed explicitly isolates Claude Agent authentication to give you control over which account and billing method you use. Even if you're logged into Claude Code CLI, you'll need to authenticate again in Zed.
+
+#### Codex
+
+| Native Config                 | Used by Codex in Zed?                                                    |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `~/.codex/config.toml`        | No — [not respected](https://github.com/zed-industries/zed/issues/40633) |
+| MCP servers from Codex config | No — configure in Zed's `context_servers` instead                        |
+| `CODEX_API_KEY` env var       | Yes — inherited from your shell environment                              |
+| `OPENAI_API_KEY` env var      | Yes — inherited from your shell environment                              |
+| ChatGPT OAuth login           | No — you must re-authenticate in Zed                                     |
+
+To use third-party providers with Codex, pass the required environment variables through Zed settings instead of `config.toml`:
+
+```json [settings]
+{
+  "agent_servers": {
+    "codex-acp": {
+      "type": "registry",
+      "env": {
+        "CODEX_API_KEY": "your-key",
+        "CUSTOM_PROVIDER_URL": "https://..."
+      }
+    }
+  }
+}
+```
+
+### MCP Server Access {#mcp-server-access}
+
+MCP servers configured in Zed's `context_servers` are forwarded to Claude Agent and Codex via the ACP protocol.
+
+- **Local stdio-based MCP servers:** Work reliably
+- **Remote MCP servers with OAuth:** May have issues ([#54410](https://github.com/zed-industries/zed/issues/54410))
+- **Gemini CLI:** Does not yet support MCP servers from Zed
+
+MCP servers from native agent configurations (`~/.claude/`, `~/.codex/config.toml`) are **not used** when running via Zed. If you have MCP servers configured in your standalone Claude Code or Codex installation, you'll need to add them to Zed's `context_servers` settings to use them with external agents.
+
+For more on configuring MCP servers, see [Model Context Protocol](./mcp.md).
+
+### Troubleshooting {#troubleshooting}
+
+**"I enabled MCP tools in Zed but the agent can't see them"**
+
+1. Verify the MCP server is enabled in `context_servers` settings
+2. Check that the agent supports MCP (Claude Agent and Codex do; Gemini CLI does not)
+3. For remote MCP servers with OAuth, this is a [known issue](https://github.com/zed-industries/zed/issues/54410) — try local stdio-based servers instead
+4. Open `dev: open acp logs` from the Command Palette to debug
+
+**"My existing Claude Code / Codex setup isn't working in Zed"**
+
+External agents in Zed run in isolation. You'll need to:
+
+1. Re-authenticate via `/login` (Claude Agent) or the authentication prompt (Codex)
+2. Re-configure MCP servers in Zed's `context_servers` settings
+3. Re-configure third-party providers via `agent_servers.<agent>.env` settings
+
+**"Profiles don't affect my external agent"**
+
+Correct — [profiles](./agent-panel.md#profiles) only apply to Zed's first-party agent. External agents have their own tool sets and don't use Zed's profile system.

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -268,42 +268,45 @@ When you start an external agent thread, Zed sends:
 | Environment variables | `agent_servers.<agent>.env` in settings                               |
 | MCP servers           | `context_servers` in settings (see [limitations](#mcp-server-access)) |
 | Working directory     | Automatically set to project root                                     |
-| CLAUDE.md content     | Read from project via Zed's [rules system](./rules.md)                |
 
 **Not forwarded:**
 
 - [Profiles](./agent-panel.md#profiles) — profiles only apply to Zed's first-party agent
 - [Tool permissions](./tool-permissions.md) settings — external agents request permissions at runtime via UI prompts
-- Rules from `.rules` files — Zed injects these into its own prompts only
+- Rules files — Zed's [rules system](./rules.md) only applies to Zed's first-party agent (external agents read their own rules files directly)
 
-### What External Agents Inherit from Native Installations {#native-config}
+### What External Agents Read Directly {#native-config}
 
-External agents run in isolation from their standalone CLI installations. Most native configuration is **not used** when running via Zed.
+External agents run as CLI tools with full filesystem access. They read their own configuration files directly — Zed doesn't forward or block these.
 
 #### Claude Agent
 
-| Native Config                       | Used by Claude Agent in Zed?                                      |
-| ----------------------------------- | ----------------------------------------------------------------- |
-| `~/.claude/` directory              | No — settings, memory, and project preferences are not used       |
-| MCP servers from Claude Code config | No — configure in Zed's `context_servers` instead                 |
-| Hooks                               | No — [not supported](https://code.claude.com/docs/en/hooks-guide) |
-| Authentication                      | No — you must authenticate separately via `/login` in Zed         |
-| Skills                              | Yes — exposed via the Claude Agent SDK                            |
-| CLAUDE.md files                     | Yes — read by Zed's rules system                                  |
+Claude Agent runs Claude Code under the hood, which reads its standard configuration:
 
-> **Why separate authentication?** Zed explicitly isolates Claude Agent authentication to give you control over which account and billing method you use. Even if you're logged into Claude Code CLI, you'll need to authenticate again in Zed.
+| Config                              | Read by Claude Agent?                                             |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| `~/.claude/` directory              | Yes — Claude Code reads its own settings and memory               |
+| CLAUDE.md files                     | Yes — Claude Code reads these directly from the project           |
+| Skills                              | Yes — exposed via the Claude Agent SDK                            |
+| MCP servers from Claude Code config | Yes — but Zed also forwards its own MCP servers via ACP           |
+| Hooks                               | No — [not supported](https://code.claude.com/docs/en/hooks-guide) |
+| Authentication                      | Separate — you must authenticate via `/login` in Zed              |
+
+> **Why separate authentication?** Zed isolates Claude Agent authentication to give you control over which account and billing method you use.
 
 #### Codex
 
-| Native Config                 | Used by Codex in Zed?                                                    |
-| ----------------------------- | ------------------------------------------------------------------------ |
-| `~/.codex/config.toml`        | No — [not respected](https://github.com/zed-industries/zed/issues/40633) |
-| MCP servers from Codex config | No — configure in Zed's `context_servers` instead                        |
-| `CODEX_API_KEY` env var       | Yes — inherited from your shell environment                              |
-| `OPENAI_API_KEY` env var      | Yes — inherited from your shell environment                              |
-| ChatGPT OAuth login           | No — you must re-authenticate in Zed                                     |
+Codex runs the Codex CLI under the hood, which reads its standard configuration:
 
-To use third-party providers with Codex, pass the required environment variables through Zed settings instead of `config.toml`:
+| Config                        | Read by Codex?                                  |
+| ----------------------------- | ----------------------------------------------- |
+| `~/.codex/config.toml`        | Yes — Codex CLI reads its own config            |
+| MCP servers from Codex config | Yes — but Zed also forwards its own MCP servers |
+| `CODEX_API_KEY` env var       | Yes — inherited from your shell environment     |
+| `OPENAI_API_KEY` env var      | Yes — inherited from your shell environment     |
+| ChatGPT OAuth login           | Separate — you must re-authenticate in Zed      |
+
+You can also pass environment variables through Zed settings:
 
 ```json [settings]
 {
@@ -326,7 +329,7 @@ MCP servers configured in Zed's `context_servers` are forwarded to Claude Agent 
 - **Local stdio-based MCP servers:** Work reliably
 - **Remote MCP servers with OAuth:** May have issues ([#54410](https://github.com/zed-industries/zed/issues/54410))
 
-MCP servers from native agent configurations (`~/.claude/`, `~/.codex/config.toml`) are **not used** when running via Zed. If you have MCP servers configured in your standalone Claude Code or Codex installation, you'll need to add them to Zed's `context_servers` settings to use them with external agents.
+External agents can access MCP servers from two sources: Zed's `context_servers` (forwarded via ACP) and their own native configuration files (`~/.claude/`, `~/.codex/config.toml`).
 
 For more on configuring MCP servers, see [Model Context Protocol](./mcp.md).
 
@@ -340,11 +343,11 @@ For more on configuring MCP servers, see [Model Context Protocol](./mcp.md).
 
 **"My existing Claude Code / Codex setup isn't working in Zed"**
 
-External agents in Zed run in isolation. You'll need to:
+External agents read their own config files, but authentication is handled separately:
 
 1. Re-authenticate via `/login` (Claude Agent) or the authentication prompt (Codex)
-2. Re-configure MCP servers in Zed's `context_servers` settings
-3. Re-configure third-party providers via `agent_servers.<agent>.env` settings
+2. Your existing MCP servers and settings from `~/.claude/` or `~/.codex/config.toml` should work
+3. You can also configure additional settings via `agent_servers.<agent>.env` in Zed
 
 **"Profiles don't affect my external agent"**
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -325,7 +325,6 @@ MCP servers configured in Zed's `context_servers` are forwarded to Claude Agent 
 
 - **Local stdio-based MCP servers:** Work reliably
 - **Remote MCP servers with OAuth:** May have issues ([#54410](https://github.com/zed-industries/zed/issues/54410))
-- **Gemini CLI:** Does not yet support MCP servers from Zed
 
 MCP servers from native agent configurations (`~/.claude/`, `~/.codex/config.toml`) are **not used** when running via Zed. If you have MCP servers configured in your standalone Claude Code or Codex installation, you'll need to add them to Zed's `context_servers` settings to use them with external agents.
 
@@ -336,9 +335,8 @@ For more on configuring MCP servers, see [Model Context Protocol](./mcp.md).
 **"I enabled MCP tools in Zed but the agent can't see them"**
 
 1. Verify the MCP server is enabled in `context_servers` settings
-2. Check that the agent supports MCP (Claude Agent and Codex do; Gemini CLI does not)
-3. For remote MCP servers with OAuth, this is a [known issue](https://github.com/zed-industries/zed/issues/54410) — try local stdio-based servers instead
-4. Open `dev: open acp logs` from the Command Palette to debug
+2. For remote MCP servers with OAuth, this is a [known issue](https://github.com/zed-industries/zed/issues/54410) — try local stdio-based servers instead
+3. Open `dev: open acp logs` from the Command Palette to debug
 
 **"My existing Claude Code / Codex setup isn't working in Zed"**
 

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -157,7 +157,7 @@ Learn more about [how tool permissions work](./tool-permissions.md), how to furt
 
 ### External Agents
 
-MCP servers configured in Zed are forwarded to [external agents](./external-agents.md) via the [Agent Client Protocol](https://agentclientprotocol.com/). Claude Agent and Codex both support this; Gemini CLI does not yet (see [their documentation](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers) for adding MCP support directly).
+MCP servers configured in Zed are forwarded to [external agents](./external-agents.md) via the [Agent Client Protocol](https://agentclientprotocol.com/).
 
 **Important:** MCP servers from native agent installations (`~/.claude/`, `~/.codex/config.toml`) are not used when running via Zed. You'll need to configure them in Zed's `context_servers` settings.
 

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -157,10 +157,11 @@ Learn more about [how tool permissions work](./tool-permissions.md), how to furt
 
 ### External Agents
 
-Note that for [external agents](./external-agents.md) connected through the [Agent Client Protocol](https://agentclientprotocol.com/), access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
+MCP servers configured in Zed are forwarded to [external agents](./external-agents.md) via the [Agent Client Protocol](https://agentclientprotocol.com/). Claude Agent and Codex both support this; Gemini CLI does not yet (see [their documentation](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers) for adding MCP support directly).
 
-Regarding the built-in ones, Claude Agent and Codex both support it, and Gemini CLI does not yet.
-In the meantime, learn how to add MCP server support to Gemini CLI through [their documentation](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers).
+**Important:** MCP servers from native agent installations (`~/.claude/`, `~/.codex/config.toml`) are not used when running via Zed. You'll need to configure them in Zed's `context_servers` settings.
+
+For details on what configuration is shared between Zed and external agents, see [Configuration Boundaries](./external-agents.md#configuration-boundaries).
 
 ### Error Handling
 

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -157,9 +157,7 @@ Learn more about [how tool permissions work](./tool-permissions.md), how to furt
 
 ### External Agents
 
-MCP servers configured in Zed are forwarded to [external agents](./external-agents.md) via the [Agent Client Protocol](https://agentclientprotocol.com/).
-
-**Important:** MCP servers from native agent installations (`~/.claude/`, `~/.codex/config.toml`) are not used when running via Zed. You'll need to configure them in Zed's `context_servers` settings.
+MCP servers configured in Zed are forwarded to [external agents](./external-agents.md) via the [Agent Client Protocol](https://agentclientprotocol.com/). External agents can also access MCP servers from their own native configuration files.
 
 For details on what configuration is shared between Zed and external agents, see [Configuration Boundaries](./external-agents.md#configuration-boundaries).
 


### PR DESCRIPTION
## Summary

- Add a new "Configuration Boundaries" section to the external agents documentation explaining what settings are shared between Zed and ACP agents
- Clarify bidirectional configuration story: what Zed forwards to agents AND what agents inherit from native installations
- Add troubleshooting section for common user confusion points
- Update MCP docs with clearer cross-links

## Context

Users are confused about which Zed settings apply to external ACP agents like Claude and Codex. Common questions:
- "I configured MCP in Zed but Claude can't see it"
- "My Codex config.toml isn't being used"
- "Do profiles apply to external agents?"

## Key Points

**What Zed forwards to ACP agents:**
- Model/mode selection, env vars, MCP servers (with limitations), CLAUDE.md

**What's NOT forwarded:**
- Profiles, tool permissions settings, `.rules` files

**What agents DON'T inherit from native installations:**
- `~/.claude/` config, `~/.codex/config.toml`, native MCP servers, authentication state

## Test plan

- [x] Review for technical accuracy against codebase
- [x] Check brand voice compliance

Release Notes:

- N/A