### PR TITLE
agent_ui: Switch to All filter when last archived thread is removed

### DIFF
--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -261,6 +261,19 @@ impl ThreadsArchiveView {
     }
 
     fn update_items(&mut self, cx: &mut Context<Self>) {
+        // If we're filtering to archived threads but none remain (e.g. the
+        // user just deleted the last one), fall back to showing all threads
+        // so they aren't stranded with an empty list and a disabled toggle.
+        if self.thread_filter == ThreadFilter::ArchivedOnly
+            && ThreadMetadataStore::global(cx)
+                .read(cx)
+                .archived_entries()
+                .next()
+                .is_none()
+        {
+            self.thread_filter = ThreadFilter::All;
+        }
+
         let thread_filter = self.thread_filter;
         let sessions = ThreadMetadataStore::global(cx)
             .read(cx)

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -261,22 +261,19 @@ impl ThreadsArchiveView {
     }
 
     fn update_items(&mut self, cx: &mut Context<Self>) {
+        let store = ThreadMetadataStore::global(cx).read(cx);
+
         // If we're filtering to archived threads but none remain (e.g. the
         // user just deleted the last one), fall back to showing all threads
         // so they aren't stranded with an empty list and a disabled toggle.
         if self.thread_filter == ThreadFilter::ArchivedOnly
-            && ThreadMetadataStore::global(cx)
-                .read(cx)
-                .archived_entries()
-                .next()
-                .is_none()
+            && store.archived_entries().next().is_none()
         {
             self.thread_filter = ThreadFilter::All;
         }
 
         let thread_filter = self.thread_filter;
-        let sessions = ThreadMetadataStore::global(cx)
-            .read(cx)
+        let sessions = store
             .entries()
             .filter(|t| match thread_filter {
                 ThreadFilter::All => true,


### PR DESCRIPTION
When the archive view's filter is set to "Archived Only" and the user deletes (or unarchives) the last archived thread, the toggle button becomes disabled because there are no archived threads left. With the filter still pinned to "Archived Only", the list goes empty and there's no way for the user to switch back to the All view.

This fixes it by automatically falling back to `ThreadFilter::All` inside `update_items` whenever the current filter is `ArchivedOnly` but the store has no archived entries. Since `update_items` is invoked from the `ThreadMetadataStore` observer, this covers all paths that mutate the store, not only deletions triggered from this view.

Release Notes:

- Fixed the agent thread archive view getting stuck on an empty "Archived Only" list after the last archived thread was removed.