### PR TITLE
Fix offline lookup of clangd on Windows

### DIFF
--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::OnceLock};
+use std::{env::consts, path::PathBuf, sync::OnceLock};
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
@@ -374,7 +374,10 @@ impl DebugAdapter for CodeLldbDebugAdapter {
                 }
             };
             let adapter_dir = version_path.join("extension").join("adapter");
-            let path = adapter_dir.join("codelldb").to_string_lossy().into_owned();
+            let path = adapter_dir
+                .join(format!("codelldb{}", consts::EXE_SUFFIX))
+                .to_string_lossy()
+                .into_owned();
             self.path_to_codelldb.set(path.clone()).ok();
             command = Some(path);
         };

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -446,7 +446,8 @@ impl DebugAdapter for GoDebugAdapter {
         _cx: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
         let adapter_path = paths::debug_adapters_dir().join(&Self::ADAPTER_NAME);
-        let dlv_path = adapter_path.join("dlv");
+        let dlv_binary = format!("dlv{}", consts::EXE_SUFFIX);
+        let dlv_path = adapter_path.join(&dlv_binary);
 
         let delve_path = if let Some(path) = user_installed_path {
             path.to_string_lossy().into_owned()
@@ -477,7 +478,10 @@ impl DebugAdapter for GoDebugAdapter {
                 );
             }
 
-            adapter_path.join("dlv").to_string_lossy().into_owned()
+            adapter_path
+                .join(&dlv_binary)
+                .to_string_lossy()
+                .into_owned()
         };
 
         let cwd = Some(

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -80,7 +80,9 @@ impl LspInstaller for CLspAdapter {
             digest: expected_digest,
         } = version;
         let version_dir = container_dir.join(format!("clangd_{name}"));
-        let binary_path = version_dir.join("bin/clangd");
+        let binary_path = version_dir
+            .join("bin")
+            .join(format!("clangd{}", consts::EXE_SUFFIX));
 
         let binary = LanguageServerBinary {
             path: binary_path.clone(),
@@ -388,7 +390,9 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
             }
         }
         let clangd_dir = last_clangd_dir.context("no cached binary")?;
-        let clangd_bin = clangd_dir.join("bin/clangd");
+        let clangd_bin = clangd_dir
+            .join("bin")
+            .join(format!("clangd{}", consts::EXE_SUFFIX));
         anyhow::ensure!(
             clangd_bin.exists(),
             "missing clangd binary in directory {clangd_dir:?}"


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/54042
Part of https://github.com/zed-industries/zed/issues/9789

This binary was not found when Zed first downloads the release, and then rerun offline on the same project.

Using a `clangd-windows-21.1.0.zip ` archive from https://github.com/clangd/clangd/releases/tag/21.1.0

```
~/Downloads ❯ unzip -l clangd-windows-21.1.0.zip|rg clangd.exe
 46908928  08-27-2025 01:40   clangd_21.1.0/bin/clangd.exe
```

Similarly, delve releases are in https://github.com/go-delve/delve/releases and codelldb are in https://github.com/vadimcn/codelldb/releases

```
~/Downloads ❯ unzip -l codelldb-win32-x64.vsix|rg exe
  1014272  04-21-2026 03:05   extension/bin/codelldb-launch.exe
  4400128  04-21-2026 03:05   extension/adapter/codelldb.exe
   242176  04-14-2026 04:14   extension/lldb/bin/lldb.exe
  6272000  04-14-2026 04:14   extension/lldb/bin/lldb-server.exe
    96768  04-14-2026 01:42   extension/lldb/bin/lldb-argdumper.exe
    96768  04-14-2026 04:13   extension/lldb/lib/lldb-python/lldb/lldb-argdumper.exe
    35284  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/pygments/lexer.py
   101888  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/distlib/w64.exe
   168448  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/distlib/w64-arm.exe
    91648  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/distlib/w32.exe
   108032  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/distlib/t64.exe
   182784  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/distlib/t64-arm.exe
    97792  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/distlib/t32.exe
    12161  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/pygments/lexers/__init__.py
    74926  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/pygments/lexers/_mapping.py
    53448  04-14-2026 01:36   extension/lldb/lib/site-packages/pip/_vendor/pygments/lexers/python.py
```


Release Notes:

- Fixed offline lookup of clangd on Windows
