### PR TITLE
Avoid sending null "params" in MCP notification

### DIFF
--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -131,6 +131,7 @@ struct Notification<'a, T> {
     jsonrpc: &'static str,
     #[serde(borrow)]
     method: &'a str,
+    #[serde(skip_serializing_if = "is_null_value")]
     params: T,
 }
 


### PR DESCRIPTION
MCP servers that strictly validate the schema will reject notification requests with params:null. Zed needs to either send an empty object or omit the key altogether:

https://modelcontextprotocol.io/specification/2024-11-05/basic/messages#notifications

This one-line patch omits the key, consistent with the behavior in Request messages.

I tested it with a dev build and confirmed that our internal MCP server now accepts Zed's "notifications/initialized" request, and Zed is subsequently able to discover the tools provided by this server.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A