### PR TITLE
Recognize CITATION.cff as YAML

### DIFF
--- a/crates/grammars/src/yaml/config.toml
+++ b/crates/grammars/src/yaml/config.toml
@@ -1,6 +1,6 @@
 name = "YAML"
 grammar = "yaml"
-path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format", "clangd", "bst"]
+path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format", "clangd", "bst", "CITATION.cff"]
 modeline_aliases = ["yml"]
 line_comments = ["# "]
 autoclose_before = ",]}"


### PR DESCRIPTION
Add support for `CITATION.cff` files to be autorecognized as YAML.

Docs:
- [GitHub: About Citation files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
- [Citation File Format (CFF)](https://citation-file-format.github.io/)

Self-Review Checklist:

- [Yes] I've reviewed my own diff for quality, security, and reliability
- [N/A] Unsafe blocks (if any) have justifying comments
- [N/A] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [N/A] Tests cover the new/changed behavior
- [N/A] Performance impact has been considered and is acceptable

Release Notes:

- N/A
