### PR TITLE
agent_ui: Add thread search to the agent panel

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -297,6 +297,8 @@
       "ctrl-alt-down": "agent::ScrollOutputLineDown",
       "ctrl-alt-shift-pageup": "agent::ScrollOutputToPreviousMessage",
       "ctrl-alt-shift-pagedown": "agent::ScrollOutputToNextMessage",
+      "find": "buffer_search::Deploy",
+      "ctrl-f": "buffer_search::Deploy",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -340,6 +340,7 @@
       "ctrl-alt-down": "agent::ScrollOutputLineDown",
       "ctrl-alt-pageup": "agent::ScrollOutputToPreviousMessage",
       "ctrl-alt-pagedown": "agent::ScrollOutputToNextMessage",
+      "cmd-f": "buffer_search::Deploy",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -298,6 +298,8 @@
       "ctrl-alt-down": "agent::ScrollOutputLineDown",
       "ctrl-alt-shift-pageup": "agent::ScrollOutputToPreviousMessage",
       "ctrl-alt-shift-pagedown": "agent::ScrollOutputToNextMessage",
+      "find": "buffer_search::Deploy",
+      "ctrl-f": "buffer_search::Deploy",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1117,6 +1117,12 @@
     },
   },
   {
+    "context": "AcpThread > Editor && VimControl",
+    "bindings": {
+      "/": "buffer_search::Deploy",
+    },
+  },
+  {
     "context": "FileHistoryView",
     "bindings": {
       "j": "menu::SelectNext",

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -247,6 +247,12 @@ impl AgentThreadEntry {
 pub struct ToolCall {
     pub id: acp::ToolCallId,
     pub label: Entity<Markdown>,
+    /// For `Execute` tool calls, this mirrors `label` but wraps the title in
+    /// a fenced code block. It is used to render the command in a monospace
+    /// block with line breaks preserved, and lets thread search attach
+    /// highlights to the visible command text even before (or when) no
+    /// terminal entity exists for the call.
+    pub command_markdown: Option<Entity<Markdown>>,
     pub kind: acp::ToolKind,
     pub content: Vec<ToolCallContent>,
     pub status: ToolCallStatus,
@@ -299,10 +305,30 @@ impl ToolCall {
 
         let subagent_session_info = subagent_session_info_from_meta(&tool_call.meta);
 
+        let label = cx.new(|cx| {
+            Markdown::new(
+                title.clone().into(),
+                Some(language_registry.clone()),
+                None,
+                cx,
+            )
+        });
+        let command_markdown = if tool_call.kind == acp::ToolKind::Execute {
+            Some(cx.new(|cx| {
+                Markdown::new(
+                    format!("```\n{}\n```", title).into(),
+                    Some(language_registry.clone()),
+                    None,
+                    cx,
+                )
+            }))
+        } else {
+            None
+        };
         let result = Self {
             id: tool_call.tool_call_id,
-            label: cx
-                .new(|cx| Markdown::new(title.into(), Some(language_registry.clone()), None, cx)),
+            label,
+            command_markdown,
             kind: tool_call.kind,
             content,
             locations: tool_call.locations,
@@ -355,6 +381,21 @@ impl ToolCall {
                     terminal.update(cx, |terminal, cx| {
                         terminal.update_command_label(&title, cx);
                     });
+                }
+                let fenced_source = format!("```\n{}\n```", title);
+                if let Some(command_markdown) = &self.command_markdown {
+                    command_markdown.update(cx, |md, cx| {
+                        md.replace(fenced_source, cx);
+                    });
+                } else {
+                    self.command_markdown = Some(cx.new(|cx| {
+                        Markdown::new(
+                            fenced_source.into(),
+                            Some(language_registry.clone()),
+                            None,
+                            cx,
+                        )
+                    }));
                 }
             }
             self.label.update(cx, |label, cx| {
@@ -1821,6 +1862,7 @@ impl AcpThread {
                 let failed_tool_call = ToolCall {
                     id: update.id().clone(),
                     label: cx.new(|cx| Markdown::new("Tool call not found".into(), None, None, cx)),
+                    command_markdown: None,
                     kind: acp::ToolKind::Fetch,
                     content: vec![ToolCallContent::ContentBlock(ContentBlock::new(
                         "Tool call not found".into(),

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -90,6 +90,7 @@ remote_connection.workspace = true
 rope.workspace = true
 rules_library.workspace = true
 schemars.workspace = true
+search.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6447,6 +6447,101 @@ mod tests {
         });
     }
 
+    #[gpui::test]
+    async fn test_collapse_search_auto_expanded_sections_preserves_user_ownership(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", json!({})).await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |mw, _cx| mw.workspace().clone())
+            .unwrap();
+        let mut cx = VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel = workspace.update_in(&mut cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+
+        let thread_view = panel
+            .read_with(&mut cx, |panel, cx| panel.active_thread_view(cx))
+            .expect("agent panel should have an active thread view");
+
+        let tool_tracked = acp::ToolCallId::new("tool-tracked");
+        let tool_user_owned = acp::ToolCallId::new("tool-user-owned");
+        let think_tracked = (1usize, 0usize);
+        let think_user_owned = (2usize, 0usize);
+
+        thread_view.update(&mut cx, |view, _cx| {
+            // Search auto-expanded this tool call and the tracker still holds
+            // it → collapse should roll it back.
+            view.expanded_tool_calls.insert(tool_tracked.clone());
+            view.search_auto_expanded_tool_calls
+                .insert(tool_tracked.clone());
+
+            // Search auto-expanded this tool call, but a later user click
+            // cleared the tracker (what the chevron handlers now do).
+            // Collapse must leave the user's expansion alone.
+            view.expanded_tool_calls.insert(tool_user_owned.clone());
+
+            // Same pair for thinking blocks: the tracked one gets rolled back,
+            // while the user-toggled one is protected by
+            // `user_toggled_thinking_blocks`.
+            view.expanded_thinking_blocks.insert(think_tracked);
+            view.search_auto_expanded_thinking_blocks
+                .insert(think_tracked);
+
+            view.expanded_thinking_blocks.insert(think_user_owned);
+            view.search_auto_expanded_thinking_blocks
+                .insert(think_user_owned);
+            view.user_toggled_thinking_blocks.insert(think_user_owned);
+        });
+
+        thread_view.update(&mut cx, |view, cx| {
+            view.collapse_search_auto_expanded_sections(cx);
+        });
+
+        thread_view.read_with(&mut cx, |view, _cx| {
+            assert!(
+                !view.expanded_tool_calls.contains(&tool_tracked),
+                "tracked tool call should be collapsed"
+            );
+            assert!(
+                view.expanded_tool_calls.contains(&tool_user_owned),
+                "user-owned tool call must survive search cleanup"
+            );
+            assert!(
+                !view.expanded_thinking_blocks.contains(&think_tracked),
+                "tracked thinking block should be collapsed"
+            );
+            assert!(
+                view.expanded_thinking_blocks.contains(&think_user_owned),
+                "user-toggled thinking block must survive search cleanup"
+            );
+            assert!(
+                view.search_auto_expanded_tool_calls.is_empty(),
+                "tool-call tracker should be drained"
+            );
+            assert!(
+                view.search_auto_expanded_thinking_blocks.is_empty(),
+                "thinking-block tracker should be drained"
+            );
+        });
+    }
+
     /// Connection that tracks closed sessions and detects prompts against
     /// sessions that no longer exist, used to reproduce session disassociation.
     #[derive(Clone, Default)]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6346,7 +6346,7 @@ mod tests {
         });
     }
     #[gpui::test]
-    async fn test_vim_search_does_not_steal_focus_from_agent_panel(cx: &mut TestAppContext) {
+    async fn test_vim_slash_deploys_thread_search_not_center_pane(cx: &mut TestAppContext) {
         init_test(cx);
         cx.update(|cx| {
             agent::ThreadStore::init_global(cx);
@@ -6354,12 +6354,10 @@ mod tests {
             vim::init(cx);
             search::init(cx);
 
-            // Enable vim mode
             settings::SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |s| s.vim_mode = Some(true));
             });
 
-            // Load vim keybindings
             let mut vim_key_bindings =
                 settings::KeymapFile::load_asset_allow_partial_failure("keymaps/vim.json", cx)
                     .unwrap();
@@ -6369,7 +6367,6 @@ mod tests {
             cx.bind_keys(vim_key_bindings);
         });
 
-        // Create a project with a file so we have a buffer in the center pane.
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree("/project", json!({ "file.txt": "hello world" }))
             .await;
@@ -6382,7 +6379,6 @@ mod tests {
             .unwrap();
         let mut cx = VisualTestContext::from_window(multi_workspace.into(), cx);
 
-        // Open a file in the center pane.
         workspace
             .update_in(&mut cx, |workspace, window, cx| {
                 workspace.open_paths(
@@ -6396,34 +6392,29 @@ mod tests {
             .await;
         cx.run_until_parked();
 
-        // Add a BufferSearchBar to the center pane's toolbar, as a real
-        // workspace would have.
-        workspace.update_in(&mut cx, |workspace, window, cx| {
+        let center_search_bar = workspace.update_in(&mut cx, |workspace, window, cx| {
+            let bar = cx.new(|cx| search::BufferSearchBar::new(None, window, cx));
             workspace.active_pane().update(cx, |pane, cx| {
                 pane.toolbar().update(cx, |toolbar, cx| {
-                    let search_bar = cx.new(|cx| search::BufferSearchBar::new(None, window, cx));
-                    toolbar.add_item(search_bar, window, cx);
+                    toolbar.add_item(bar.clone(), window, cx);
                 });
             });
+            bar
         });
 
-        // Create the agent panel and add it to the workspace.
         let panel = workspace.update_in(&mut cx, |workspace, window, cx| {
             let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
             workspace.add_panel(panel.clone(), window, cx);
             panel
         });
 
-        // Open a thread so the panel has an active editor.
         open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
 
-        // Focus the agent panel.
         workspace.update_in(&mut cx, |workspace, window, cx| {
             workspace.focus_panel::<AgentPanel>(window, cx);
         });
         cx.run_until_parked();
 
-        // Verify the agent panel has focus.
         workspace.update_in(&mut cx, |_, window, cx| {
             assert!(
                 panel.read(cx).focus_handle(cx).contains_focused(window, cx),
@@ -6431,14 +6422,27 @@ mod tests {
             );
         });
 
-        // Press '/' — the vim search keybinding.
         cx.simulate_keystrokes("/");
+        cx.run_until_parked();
 
-        // Focus should remain on the agent panel.
-        workspace.update_in(&mut cx, |_, window, cx| {
+        center_search_bar.read_with(&mut cx, |bar, _| {
             assert!(
-                panel.read(cx).focus_handle(cx).contains_focused(window, cx),
-                "Focus should remain on the agent panel after pressing '/'"
+                bar.is_dismissed(),
+                "pressing '/' in the agent panel must not deploy the center pane's BufferSearchBar"
+            );
+        });
+
+        let thread_view = panel
+            .read_with(&mut cx, |panel, cx| panel.active_thread_view(cx))
+            .expect("agent panel should have an active thread view");
+        thread_view.read_with(&mut cx, |thread_view, cx| {
+            let bar = thread_view
+                .search_bar
+                .as_ref()
+                .expect("thread view should have lazily constructed its search bar");
+            assert!(
+                !bar.read(cx).is_dismissed(),
+                "thread view's own search bar should be deployed after pressing '/'"
             );
         });
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1027,7 +1027,10 @@ impl AgentPanel {
             &ThreadMetadataStore::global(cx),
             |this, _store, event, cx| {
                 let ThreadMetadataStoreEvent::ThreadArchived(thread_id) = event;
-                if this.retained_threads.remove(thread_id).is_some() {
+                if let Some(conversation_view) = this.retained_threads.remove(thread_id) {
+                    conversation_view.update(cx, |view, cx| {
+                        view.release_search_bar_resources(cx);
+                    });
                     cx.notify();
                 }
             },
@@ -1999,7 +2002,7 @@ impl AgentPanel {
         self.cleanup_retained_threads(cx);
     }
 
-    fn cleanup_retained_threads(&mut self, cx: &App) {
+    fn cleanup_retained_threads(&mut self, cx: &mut Context<Self>) {
         let mut potential_removals = self
             .retained_threads
             .iter()
@@ -2022,7 +2025,11 @@ impl AgentPanel {
             .take(n)
             .collect::<Vec<_>>();
         for id in to_remove {
-            self.retained_threads.remove(&id);
+            if let Some(conversation_view) = self.retained_threads.remove(&id) {
+                conversation_view.update(cx, |view, cx| {
+                    view.release_search_bar_resources(cx);
+                });
+            }
         }
     }
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -101,7 +101,9 @@ use crate::{
 const STOPWATCH_THRESHOLD: Duration = Duration::from_secs(30);
 const TOKEN_THRESHOLD: u64 = 250;
 
+mod thread_search;
 mod thread_view;
+pub use thread_search::*;
 pub use thread_view::*;
 
 pub struct QueuedMessage {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1336,6 +1336,20 @@ impl ConversationView {
         }
     }
 
+    /// Release the `BufferSearchBar` / `ThreadView` cycle for every thread this
+    /// view owns so that dropping this `ConversationView` actually frees its
+    /// underlying `ThreadView` entities. See
+    /// `ThreadView::release_search_bar_resources` for the cycle it breaks.
+    pub fn release_search_bar_resources(&mut self, cx: &mut Context<Self>) {
+        if let ServerState::Connected(connected) = &self.server_state {
+            for thread_view in connected.threads.values() {
+                thread_view.update(cx, |thread_view, cx| {
+                    thread_view.release_search_bar_resources(cx);
+                });
+            }
+        }
+    }
+
     pub fn agent_key(&self) -> &Agent {
         &self.connection_key
     }

--- a/crates/agent_ui/src/conversation_view/thread_search.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use acp_thread::{AgentThreadEntry, AssistantMessageChunk, ContentBlock, ToolCallContent};
 use agent_client_protocol::schema as acp;
 use collections::{HashMap, HashSet};
+use editor::display_map::HighlightKey;
+use editor::{Anchor, Editor, MultiBufferOffset};
 use gpui::{
     App, AppContext, Context, Entity, EntityId, EventEmitter, ListOffset, SharedString, Task,
     Window, px,
@@ -16,6 +18,8 @@ use workspace::searchable::{
     SearchableItemHandle,
 };
 
+use crate::entry_view_state::EntryViewState;
+
 use super::ThreadView;
 
 /// Where inside the thread a match lives, so we can auto-expand disclosures
@@ -25,12 +29,45 @@ pub enum MatchOrigin {
     AlwaysVisible,
     ThinkingBlock { chunk_index: usize },
     ToolCallContent { id: acp::ToolCallId },
+    UserMessage,
 }
+
+/// A match in the thread is either inside a rendered markdown entity (assistant
+/// messages, thought blocks, tool-call content, plan entries, tool labels) or
+/// inside a user-message `Editor`. User messages are rendered through a
+/// `MessageEditor`, not the markdown entity that `UserMessage::content` holds,
+/// so highlights for them must be routed through the editor directly.
+#[derive(Debug, Clone)]
+pub enum MatchTarget {
+    Markdown(Entity<Markdown>),
+    Editor(Entity<Editor>),
+}
+
+impl MatchTarget {
+    fn entity_id(&self) -> EntityId {
+        match self {
+            Self::Markdown(markdown) => markdown.entity_id(),
+            Self::Editor(editor) => editor.entity_id(),
+        }
+    }
+}
+
+impl PartialEq for MatchTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Markdown(a), Self::Markdown(b)) => a == b,
+            (Self::Editor(a), Self::Editor(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for MatchTarget {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadSearchMatch {
     pub entry_index: usize,
-    pub markdown: Entity<Markdown>,
+    pub target: MatchTarget,
     pub byte_range: Range<usize>,
     pub origin: MatchOrigin,
 }
@@ -86,6 +123,11 @@ impl SearchableItem for ThreadView {
         for markdown in std::mem::take(&mut self.highlighted_markdowns) {
             markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
         }
+        for editor in std::mem::take(&mut self.highlighted_user_message_editors) {
+            editor.update(cx, |editor, cx| {
+                editor.clear_background_highlights(HighlightKey::BufferSearchHighlights, cx);
+            });
+        }
         self.collapse_search_auto_expanded_sections(cx);
         if had_matches {
             cx.emit(SearchEvent::MatchesInvalidated);
@@ -103,42 +145,43 @@ impl SearchableItem for ThreadView {
     ) {
         let changed = self.search_matches.as_slice() != matches;
 
-        let mut per_markdown: Vec<(Entity<Markdown>, Vec<Range<usize>>, Option<usize>)> =
-            Vec::new();
-        let mut index_map: HashMap<EntityId, usize> = HashMap::default();
-        for (global_idx, m) in matches.iter().enumerate() {
-            let group_idx = *index_map.entry(m.markdown.entity_id()).or_insert_with(|| {
-                per_markdown.push((m.markdown.clone(), Vec::new(), None));
-                per_markdown.len() - 1
-            });
-            let (_, ranges, active_local) = &mut per_markdown[group_idx];
-            ranges.push(m.byte_range.clone());
-            if Some(global_idx) == active_match_index {
-                *active_local = Some(ranges.len() - 1);
-            }
-        }
+        let per_target = group_matches_by_target(matches, active_match_index);
 
-        let new_ids: HashSet<EntityId> = per_markdown
+        let new_ids: HashSet<EntityId> = per_target
             .iter()
-            .map(|(markdown, _, _)| markdown.entity_id())
+            .map(|(target, _, _)| target.entity_id())
             .collect();
         for markdown in std::mem::take(&mut self.highlighted_markdowns) {
             if !new_ids.contains(&markdown.entity_id()) {
                 markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
             }
         }
-
-        for (markdown, ranges, active_local) in &per_markdown {
-            let ranges = ranges.clone();
-            let active_local = *active_local;
-            markdown.update(cx, |md, cx| {
-                md.set_search_highlights(ranges, active_local, cx);
-            });
+        for editor in std::mem::take(&mut self.highlighted_user_message_editors) {
+            if !new_ids.contains(&editor.entity_id()) {
+                editor.update(cx, |editor, cx| {
+                    editor.clear_background_highlights(HighlightKey::BufferSearchHighlights, cx);
+                });
+            }
         }
-        self.highlighted_markdowns = per_markdown
-            .into_iter()
-            .map(|(markdown, _, _)| markdown)
-            .collect();
+
+        let mut new_highlighted_markdowns = Vec::new();
+        let mut new_highlighted_editors = Vec::new();
+        for (target, ranges, active_local) in per_target {
+            match target {
+                MatchTarget::Markdown(markdown) => {
+                    markdown.update(cx, |md, cx| {
+                        md.set_search_highlights(ranges, active_local, cx);
+                    });
+                    new_highlighted_markdowns.push(markdown);
+                }
+                MatchTarget::Editor(editor) => {
+                    apply_editor_highlights(&editor, &ranges, active_local, cx);
+                    new_highlighted_editors.push(editor);
+                }
+            }
+        }
+        self.highlighted_markdowns = new_highlighted_markdowns;
+        self.highlighted_user_message_editors = new_highlighted_editors;
 
         self.search_matches = matches.to_vec();
         self.active_search_match_index = active_match_index;
@@ -176,10 +219,10 @@ impl SearchableItem for ThreadView {
 
         self.ensure_origin_expanded(m.entry_index, &m.origin, cx);
 
-        let target_id = m.markdown.entity_id();
+        let target_id = m.target.entity_id();
         let local_index = matches[..=index]
             .iter()
-            .filter(|other| other.markdown.entity_id() == target_id)
+            .filter(|other| other.target.entity_id() == target_id)
             .count()
             - 1;
 
@@ -188,10 +231,27 @@ impl SearchableItem for ThreadView {
                 other.update(cx, |md, cx| md.set_active_search_highlight(None, cx));
             }
         }
-        m.markdown.update(cx, |md, cx| {
-            md.set_active_search_highlight(Some(local_index), cx);
-            md.request_autoscroll_to_source_index(m.byte_range.start, cx);
-        });
+        // Editor highlights capture the active index inside a color closure at
+        // insertion time, so whenever the active index changes we have to
+        // re-apply highlights for every editor — otherwise a previously-active
+        // editor would keep showing the orange "active" color on a stale match.
+        let per_target = group_matches_by_target(matches, Some(index));
+        for (target, ranges, active_local) in per_target {
+            if let MatchTarget::Editor(editor) = target {
+                apply_editor_highlights(&editor, &ranges, active_local, cx);
+            }
+        }
+        match &m.target {
+            MatchTarget::Markdown(markdown) => {
+                markdown.update(cx, |md, cx| {
+                    md.set_active_search_highlight(Some(local_index), cx);
+                    md.request_autoscroll_to_source_index(m.byte_range.start, cx);
+                });
+            }
+            MatchTarget::Editor(active_editor) => {
+                autoscroll_editor_to_range(active_editor, m.byte_range.clone(), cx);
+            }
+        }
 
         self.list_state.scroll_to(ListOffset {
             item_ix: m.entry_index,
@@ -234,32 +294,33 @@ impl SearchableItem for ThreadView {
 
         let expanded_tool_calls = self.expanded_tool_calls.clone();
         let expanded_thinking_blocks = self.expanded_thinking_blocks.clone();
+        let entry_view_state = self.entry_view_state.read(cx);
 
-        let mut entries_data: Vec<(usize, Vec<(Entity<Markdown>, String, MatchOrigin)>)> =
-            Vec::new();
+        let mut entries_data: Vec<(usize, Vec<(MatchTarget, String, MatchOrigin)>)> = Vec::new();
         for (entry_index, entry) in self.thread.read(cx).entries().iter().enumerate() {
-            let mut markdowns = Vec::new();
-            collect_searchable_markdowns(
+            let mut targets = Vec::new();
+            collect_searchable_targets(
                 entry,
                 cx,
                 include_hidden,
                 &expanded_tool_calls,
                 entry_index,
                 &expanded_thinking_blocks,
-                &mut markdowns,
+                entry_view_state,
+                &mut targets,
             );
-            if !markdowns.is_empty() {
-                entries_data.push((entry_index, markdowns));
+            if !targets.is_empty() {
+                entries_data.push((entry_index, targets));
             }
         }
         cx.background_spawn(async move {
             let mut matches = Vec::new();
-            for (entry_index, markdowns) in entries_data {
-                for (markdown, source, origin) in markdowns {
+            for (entry_index, targets) in entries_data {
+                for (target, source, origin) in targets {
                     for byte_range in query.search_str(&source) {
                         matches.push(ThreadSearchMatch {
                             entry_index,
-                            markdown: markdown.clone(),
+                            target: target.clone(),
                             byte_range,
                             origin: origin.clone(),
                         });
@@ -305,7 +366,7 @@ impl ThreadView {
         cx: &mut Context<Self>,
     ) {
         match origin {
-            MatchOrigin::AlwaysVisible => {}
+            MatchOrigin::AlwaysVisible | MatchOrigin::UserMessage => {}
             MatchOrigin::ThinkingBlock { chunk_index } => {
                 let key = (entry_index, *chunk_index);
                 if !self.expanded_thinking_blocks.contains(&key) {
@@ -343,18 +404,31 @@ impl ThreadView {
     }
 }
 
-fn collect_searchable_markdowns(
+fn collect_searchable_targets(
     entry: &AgentThreadEntry,
     cx: &App,
     include_hidden: bool,
     expanded_tool_calls: &HashSet<acp::ToolCallId>,
     entry_index: usize,
     expanded_thinking_blocks: &HashSet<(usize, usize)>,
-    out: &mut Vec<(Entity<Markdown>, String, MatchOrigin)>,
+    entry_view_state: &EntryViewState,
+    out: &mut Vec<(MatchTarget, String, MatchOrigin)>,
 ) {
     match entry {
-        AgentThreadEntry::UserMessage(message) => {
-            push_content_block(&message.content, cx, MatchOrigin::AlwaysVisible, out);
+        AgentThreadEntry::UserMessage(_message) => {
+            // User messages are rendered through a `MessageEditor`, so search
+            // the editor's buffer text directly rather than the (unrendered)
+            // markdown entity on `UserMessage::content`. The two texts diverge
+            // for image chunks — the markdown uses ``Image`` while the editor
+            // uses a mention link — so the editor text is the source of truth.
+            if let Some(editor) = entry_view_state
+                .entry(entry_index)
+                .and_then(|entry| entry.message_editor())
+                .map(|message_editor| message_editor.read(cx).editor().clone())
+            {
+                let text = editor.read(cx).text(cx);
+                out.push((MatchTarget::Editor(editor), text, MatchOrigin::UserMessage));
+            }
         }
         AgentThreadEntry::AssistantMessage(message) => {
             for (chunk_index, chunk) in message.chunks.iter().enumerate() {
@@ -406,7 +480,7 @@ fn push_content_block(
     block: &ContentBlock,
     cx: &App,
     origin: MatchOrigin,
-    out: &mut Vec<(Entity<Markdown>, String, MatchOrigin)>,
+    out: &mut Vec<(MatchTarget, String, MatchOrigin)>,
 ) {
     if let Some(markdown) = block.markdown() {
         push_markdown(markdown, cx, origin, out);
@@ -417,11 +491,80 @@ fn push_markdown(
     markdown: &Entity<Markdown>,
     cx: &App,
     origin: MatchOrigin,
-    out: &mut Vec<(Entity<Markdown>, String, MatchOrigin)>,
+    out: &mut Vec<(MatchTarget, String, MatchOrigin)>,
 ) {
     out.push((
-        markdown.clone(),
+        MatchTarget::Markdown(markdown.clone()),
         markdown.read(cx).source().to_string(),
         origin,
     ));
+}
+
+fn group_matches_by_target(
+    matches: &[ThreadSearchMatch],
+    active_match_index: Option<usize>,
+) -> Vec<(MatchTarget, Vec<Range<usize>>, Option<usize>)> {
+    let mut per_target: Vec<(MatchTarget, Vec<Range<usize>>, Option<usize>)> = Vec::new();
+    let mut index_map: HashMap<EntityId, usize> = HashMap::default();
+    for (global_idx, m) in matches.iter().enumerate() {
+        let group_idx = *index_map.entry(m.target.entity_id()).or_insert_with(|| {
+            per_target.push((m.target.clone(), Vec::new(), None));
+            per_target.len() - 1
+        });
+        let (_, ranges, active_local) = &mut per_target[group_idx];
+        ranges.push(m.byte_range.clone());
+        if Some(global_idx) == active_match_index {
+            *active_local = Some(ranges.len() - 1);
+        }
+    }
+    per_target
+}
+
+fn apply_editor_highlights(
+    editor: &Entity<Editor>,
+    ranges: &[Range<usize>],
+    active_local: Option<usize>,
+    cx: &mut Context<ThreadView>,
+) {
+    let snapshot = editor.read(cx).buffer().read(cx).snapshot(cx);
+    let anchor_ranges: Vec<Range<Anchor>> = ranges
+        .iter()
+        .map(|range| {
+            let start = snapshot.anchor_after(MultiBufferOffset(range.start));
+            let end = snapshot.anchor_before(MultiBufferOffset(range.end));
+            start..end
+        })
+        .collect();
+    editor.update(cx, |editor, cx| {
+        editor.highlight_background(
+            HighlightKey::BufferSearchHighlights,
+            &anchor_ranges,
+            move |index, theme| {
+                if active_local == Some(*index) {
+                    theme.colors().search_active_match_background
+                } else {
+                    theme.colors().search_match_background
+                }
+            },
+            cx,
+        );
+    });
+}
+
+fn autoscroll_editor_to_range(
+    editor: &Entity<Editor>,
+    byte_range: Range<usize>,
+    cx: &mut Context<ThreadView>,
+) {
+    let snapshot = editor.read(cx).buffer().read(cx).snapshot(cx);
+    let anchor = snapshot.anchor_before(MultiBufferOffset(byte_range.start));
+    editor.update(cx, |editor, cx| {
+        editor.request_autoscroll(
+            editor::scroll::Autoscroll::Strategy(
+                editor::scroll::AutoscrollStrategy::Center,
+                Some(anchor),
+            ),
+            cx,
+        );
+    });
 }

--- a/crates/agent_ui/src/conversation_view/thread_search.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search.rs
@@ -1,6 +1,13 @@
+use std::ops::Range;
 use std::sync::Arc;
 
-use gpui::{App, AppContext, Context, Entity, EventEmitter, ListOffset, SharedString, Task, Window, px};
+use acp_thread::{AgentThreadEntry, AssistantMessageChunk, ContentBlock, ToolCallContent};
+use collections::{HashMap, HashSet};
+use gpui::{
+    App, AppContext, Context, Entity, EntityId, EventEmitter, ListOffset, SharedString, Task,
+    Window, px,
+};
+use markdown::Markdown;
 use project::search::SearchQuery;
 use workspace::item::{Item, ItemBufferKind, ItemEvent};
 use workspace::searchable::{
@@ -12,7 +19,8 @@ use super::ThreadView;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadSearchMatch {
     pub entry_index: usize,
-    pub byte_range: std::ops::Range<usize>,
+    pub markdown: Entity<Markdown>,
+    pub byte_range: Range<usize>,
 }
 
 impl EventEmitter<SearchEvent> for ThreadView {}
@@ -62,6 +70,9 @@ impl SearchableItem for ThreadView {
         self.search_matches.clear();
         self.active_search_match_index = None;
         self.active_search_position = None;
+        for markdown in std::mem::take(&mut self.highlighted_markdowns) {
+            markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
+        }
         if had_matches {
             cx.emit(SearchEvent::MatchesInvalidated);
         }
@@ -77,15 +88,52 @@ impl SearchableItem for ThreadView {
         cx: &mut Context<Self>,
     ) {
         let changed = self.search_matches.as_slice() != matches;
-        if changed {
-            self.search_matches = matches.to_vec();
-            cx.emit(SearchEvent::MatchesInvalidated);
+
+        // Group matches by their Markdown entity while preserving the global order.
+        let mut per_markdown: Vec<(Entity<Markdown>, Vec<Range<usize>>, Option<usize>)> = Vec::new();
+        let mut index_map: HashMap<EntityId, usize> = HashMap::default();
+        for (global_idx, m) in matches.iter().enumerate() {
+            let group_idx = *index_map.entry(m.markdown.entity_id()).or_insert_with(|| {
+                per_markdown.push((m.markdown.clone(), Vec::new(), None));
+                per_markdown.len() - 1
+            });
+            let (_, ranges, active_local) = &mut per_markdown[group_idx];
+            ranges.push(m.byte_range.clone());
+            if Some(global_idx) == active_match_index {
+                *active_local = Some(ranges.len() - 1);
+            }
         }
+
+        // Clear highlights on previously-highlighted markdowns that no longer have matches.
+        let new_ids: HashSet<EntityId> = per_markdown
+            .iter()
+            .map(|(markdown, _, _)| markdown.entity_id())
+            .collect();
+        for markdown in std::mem::take(&mut self.highlighted_markdowns) {
+            if !new_ids.contains(&markdown.entity_id()) {
+                markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
+            }
+        }
+
+        for (markdown, ranges, active_local) in &per_markdown {
+            let ranges = ranges.clone();
+            let active_local = *active_local;
+            markdown.update(cx, |md, cx| {
+                md.set_search_highlights(ranges, active_local, cx);
+            });
+        }
+        self.highlighted_markdowns = per_markdown
+            .into_iter()
+            .map(|(markdown, _, _)| markdown)
+            .collect();
+
+        self.search_matches = matches.to_vec();
         self.active_search_match_index = active_match_index;
-        if let Some(idx) = active_match_index
-            && let Some(m) = matches.get(idx)
-        {
-            self.active_search_position = Some((m.entry_index, m.byte_range.start));
+        self.active_search_position = active_match_index
+            .and_then(|i| matches.get(i))
+            .map(|m| (m.entry_index, m.byte_range.start));
+        if changed {
+            cx.emit(SearchEvent::MatchesInvalidated);
         }
         cx.notify();
     }
@@ -107,16 +155,41 @@ impl SearchableItem for ThreadView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(m) = matches.get(index) {
-            self.active_search_match_index = Some(index);
-            self.active_search_position = Some((m.entry_index, m.byte_range.start));
-            self.list_state.scroll_to(ListOffset {
-                item_ix: m.entry_index,
-                offset_in_item: px(0.0),
-            });
-            cx.emit(SearchEvent::ActiveMatchChanged);
-            cx.notify();
+        let Some(m) = matches.get(index) else {
+            return;
+        };
+        self.active_search_match_index = Some(index);
+        self.active_search_position = Some((m.entry_index, m.byte_range.start));
+
+        // Count how many matches sharing this markdown precede (and include) the
+        // activated one — that's the active index within the per-markdown range list.
+        let target_id = m.markdown.entity_id();
+        let local_index = matches[..=index]
+            .iter()
+            .filter(|other| other.markdown.entity_id() == target_id)
+            .count()
+            - 1;
+
+        for other in self.highlighted_markdowns.clone() {
+            if other.entity_id() != target_id {
+                other.update(cx, |md, cx| md.set_active_search_highlight(None, cx));
+            }
         }
+        m.markdown.update(cx, |md, cx| {
+            md.set_active_search_highlight(Some(local_index), cx);
+            md.request_autoscroll_to_source_index(m.byte_range.start, cx);
+        });
+
+        // Place the entry at the viewport top as a coarse jump. The Markdown
+        // autoscroll request above then propagates a `window.request_autoscroll`
+        // during paint, which the List honors to bring the specific match into
+        // view if it sits deeper in a tall entry.
+        self.list_state.scroll_to(ListOffset {
+            item_ix: m.entry_index,
+            offset_in_item: px(0.0),
+        });
+        cx.emit(SearchEvent::ActiveMatchChanged);
+        cx.notify();
     }
 
     fn select_matches(
@@ -144,22 +217,25 @@ impl SearchableItem for ThreadView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Vec<Self::Match>> {
-        let entries: Vec<(usize, String)> = self
-            .thread
-            .read(cx)
-            .entries()
-            .iter()
-            .enumerate()
-            .map(|(idx, entry)| (idx, entry.to_markdown(cx)))
-            .collect();
+        let mut entries_data: Vec<(usize, Vec<(Entity<Markdown>, String)>)> = Vec::new();
+        for (entry_index, entry) in self.thread.read(cx).entries().iter().enumerate() {
+            let mut markdowns = Vec::new();
+            collect_searchable_markdowns(entry, cx, &mut markdowns);
+            if !markdowns.is_empty() {
+                entries_data.push((entry_index, markdowns));
+            }
+        }
         cx.background_spawn(async move {
             let mut matches = Vec::new();
-            for (entry_index, text) in entries {
-                for byte_range in query.search_str(&text) {
-                    matches.push(ThreadSearchMatch {
-                        entry_index,
-                        byte_range,
-                    });
+            for (entry_index, markdowns) in entries_data {
+                for (markdown, source) in markdowns {
+                    for byte_range in query.search_str(&source) {
+                        matches.push(ThreadSearchMatch {
+                            entry_index,
+                            markdown: markdown.clone(),
+                            byte_range,
+                        });
+                    }
                 }
             }
             matches
@@ -191,4 +267,52 @@ impl SearchableItem for ThreadView {
                 .or(Some(matches.len().saturating_sub(1))),
         }
     }
+}
+
+fn collect_searchable_markdowns(
+    entry: &AgentThreadEntry,
+    cx: &App,
+    out: &mut Vec<(Entity<Markdown>, String)>,
+) {
+    match entry {
+        AgentThreadEntry::UserMessage(message) => {
+            push_content_block(&message.content, cx, out);
+        }
+        AgentThreadEntry::AssistantMessage(message) => {
+            for chunk in &message.chunks {
+                let block = match chunk {
+                    AssistantMessageChunk::Message { block } => block,
+                    AssistantMessageChunk::Thought { block } => block,
+                };
+                push_content_block(block, cx, out);
+            }
+        }
+        AgentThreadEntry::ToolCall(call) => {
+            push_markdown(&call.label, cx, out);
+            for content in &call.content {
+                if let ToolCallContent::ContentBlock(block) = content {
+                    push_content_block(block, cx, out);
+                }
+            }
+        }
+        AgentThreadEntry::CompletedPlan(plan_entries) => {
+            for plan_entry in plan_entries {
+                push_markdown(&plan_entry.content, cx, out);
+            }
+        }
+    }
+}
+
+fn push_content_block(
+    block: &ContentBlock,
+    cx: &App,
+    out: &mut Vec<(Entity<Markdown>, String)>,
+) {
+    if let Some(markdown) = block.markdown() {
+        push_markdown(markdown, cx, out);
+    }
+}
+
+fn push_markdown(markdown: &Entity<Markdown>, cx: &App, out: &mut Vec<(Entity<Markdown>, String)>) {
+    out.push((markdown.clone(), markdown.read(cx).source().to_string()));
 }

--- a/crates/agent_ui/src/conversation_view/thread_search.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search.rs
@@ -451,7 +451,30 @@ fn collect_searchable_targets(
             }
         }
         AgentThreadEntry::ToolCall(call) => {
-            push_markdown(&call.label, cx, MatchOrigin::AlwaysVisible, out);
+            // For Execute tool calls, `call.label` carries the full command,
+            // but the visible rendering is a code-fenced markdown: once a
+            // terminal has been created, `terminal.command()`; otherwise (in
+            // the pre-approval "Run Command" preview, or for rejected
+            // commands) `call.command_markdown`. Indexing those fenced
+            // entities — rather than the plain label — means highlights end
+            // up on the markdown the user actually sees.
+            let mut has_terminal = false;
+            for terminal in call.terminals() {
+                has_terminal = true;
+                push_markdown(
+                    terminal.read(cx).command(),
+                    cx,
+                    MatchOrigin::AlwaysVisible,
+                    out,
+                );
+            }
+            if !has_terminal {
+                if let Some(command_markdown) = &call.command_markdown {
+                    push_markdown(command_markdown, cx, MatchOrigin::AlwaysVisible, out);
+                } else {
+                    push_markdown(&call.label, cx, MatchOrigin::AlwaysVisible, out);
+                }
+            }
             let content_visible = include_hidden || expanded_tool_calls.contains(&call.id);
             if content_visible {
                 for content in &call.content {

--- a/crates/agent_ui/src/conversation_view/thread_search.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search.rs
@@ -8,7 +8,7 @@ use editor::display_map::HighlightKey;
 use editor::{Anchor, Editor, MultiBufferOffset};
 use gpui::{
     App, AppContext, Context, Entity, EntityId, EventEmitter, ListOffset, SharedString, Task,
-    Window, px,
+    WeakEntity, Window, px,
 };
 use markdown::Markdown;
 use project::search::SearchQuery;
@@ -37,10 +37,15 @@ pub enum MatchOrigin {
 /// inside a user-message `Editor`. User messages are rendered through a
 /// `MessageEditor`, not the markdown entity that `UserMessage::content` holds,
 /// so highlights for them must be routed through the editor directly.
+///
+/// Handles are weak so that a match surviving in `search_matches` after the
+/// underlying editor or markdown entity has been dropped (for instance because
+/// `EntryViewState` replaced a message editor) does not extend the entity's
+/// lifetime. Consumers upgrade and skip on failure.
 #[derive(Debug, Clone)]
 pub enum MatchTarget {
-    Markdown(Entity<Markdown>),
-    Editor(Entity<Editor>),
+    Markdown(WeakEntity<Markdown>),
+    Editor(WeakEntity<Editor>),
 }
 
 impl MatchTarget {
@@ -121,12 +126,16 @@ impl SearchableItem for ThreadView {
         self.active_search_match_index = None;
         self.active_search_position = None;
         for markdown in std::mem::take(&mut self.highlighted_markdowns) {
-            markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
+            if let Some(markdown) = markdown.upgrade() {
+                markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
+            }
         }
         for editor in std::mem::take(&mut self.highlighted_user_message_editors) {
-            editor.update(cx, |editor, cx| {
-                editor.clear_background_highlights(HighlightKey::BufferSearchHighlights, cx);
-            });
+            if let Some(editor) = editor.upgrade() {
+                editor.update(cx, |editor, cx| {
+                    editor.clear_background_highlights(HighlightKey::BufferSearchHighlights, cx);
+                });
+            }
         }
         self.collapse_search_auto_expanded_sections(cx);
         if had_matches {
@@ -152,12 +161,16 @@ impl SearchableItem for ThreadView {
             .map(|(target, _, _)| target.entity_id())
             .collect();
         for markdown in std::mem::take(&mut self.highlighted_markdowns) {
-            if !new_ids.contains(&markdown.entity_id()) {
+            if !new_ids.contains(&markdown.entity_id())
+                && let Some(markdown) = markdown.upgrade()
+            {
                 markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
             }
         }
         for editor in std::mem::take(&mut self.highlighted_user_message_editors) {
-            if !new_ids.contains(&editor.entity_id()) {
+            if !new_ids.contains(&editor.entity_id())
+                && let Some(editor) = editor.upgrade()
+            {
                 editor.update(cx, |editor, cx| {
                     editor.clear_background_highlights(HighlightKey::BufferSearchHighlights, cx);
                 });
@@ -168,15 +181,19 @@ impl SearchableItem for ThreadView {
         let mut new_highlighted_editors = Vec::new();
         for (target, ranges, active_local) in per_target {
             match target {
-                MatchTarget::Markdown(markdown) => {
-                    markdown.update(cx, |md, cx| {
-                        md.set_search_highlights(ranges, active_local, cx);
-                    });
-                    new_highlighted_markdowns.push(markdown);
+                MatchTarget::Markdown(weak) => {
+                    if let Some(markdown) = weak.upgrade() {
+                        markdown.update(cx, |md, cx| {
+                            md.set_search_highlights(ranges, active_local, cx);
+                        });
+                        new_highlighted_markdowns.push(weak);
+                    }
                 }
-                MatchTarget::Editor(editor) => {
-                    apply_editor_highlights(&editor, &ranges, active_local, cx);
-                    new_highlighted_editors.push(editor);
+                MatchTarget::Editor(weak) => {
+                    if let Some(editor) = weak.upgrade() {
+                        apply_editor_highlights(&editor, &ranges, active_local, cx);
+                        new_highlighted_editors.push(weak);
+                    }
                 }
             }
         }
@@ -226,8 +243,10 @@ impl SearchableItem for ThreadView {
             .count()
             - 1;
 
-        for other in self.highlighted_markdowns.clone() {
-            if other.entity_id() != target_id {
+        for other in self.highlighted_markdowns.iter() {
+            if other.entity_id() != target_id
+                && let Some(other) = other.upgrade()
+            {
                 other.update(cx, |md, cx| md.set_active_search_highlight(None, cx));
             }
         }
@@ -237,19 +256,25 @@ impl SearchableItem for ThreadView {
         // editor would keep showing the orange "active" color on a stale match.
         let per_target = group_matches_by_target(matches, Some(index));
         for (target, ranges, active_local) in per_target {
-            if let MatchTarget::Editor(editor) = target {
+            if let MatchTarget::Editor(editor) = target
+                && let Some(editor) = editor.upgrade()
+            {
                 apply_editor_highlights(&editor, &ranges, active_local, cx);
             }
         }
         match &m.target {
             MatchTarget::Markdown(markdown) => {
-                markdown.update(cx, |md, cx| {
-                    md.set_active_search_highlight(Some(local_index), cx);
-                    md.request_autoscroll_to_source_index(m.byte_range.start, cx);
-                });
+                if let Some(markdown) = markdown.upgrade() {
+                    markdown.update(cx, |md, cx| {
+                        md.set_active_search_highlight(Some(local_index), cx);
+                        md.request_autoscroll_to_source_index(m.byte_range.start, cx);
+                    });
+                }
             }
             MatchTarget::Editor(active_editor) => {
-                autoscroll_editor_to_range(active_editor, m.byte_range.clone(), cx);
+                if let Some(active_editor) = active_editor.upgrade() {
+                    autoscroll_editor_to_range(&active_editor, m.byte_range.clone(), cx);
+                }
             }
         }
 
@@ -296,7 +321,7 @@ impl SearchableItem for ThreadView {
         let expanded_thinking_blocks = self.expanded_thinking_blocks.clone();
         let entry_view_state = self.entry_view_state.read(cx);
 
-        let mut entries_data: Vec<(usize, Vec<(MatchTarget, String, MatchOrigin)>)> = Vec::new();
+        let mut entries_data: Vec<(usize, Vec<SearchTarget>)> = Vec::new();
         for (entry_index, entry) in self.thread.read(cx).entries().iter().enumerate() {
             let mut targets = Vec::new();
             collect_searchable_targets(
@@ -316,12 +341,19 @@ impl SearchableItem for ThreadView {
         cx.background_spawn(async move {
             let mut matches = Vec::new();
             for (entry_index, targets) in entries_data {
-                for (target, source, origin) in targets {
-                    for byte_range in query.search_str(&source) {
+                for SearchTarget {
+                    target,
+                    text,
+                    origin,
+                    byte_offset,
+                } in targets
+                {
+                    for byte_range in query.search_str(text.as_ref()) {
                         matches.push(ThreadSearchMatch {
                             entry_index,
                             target: target.clone(),
-                            byte_range,
+                            byte_range: (byte_range.start + byte_offset)
+                                ..(byte_range.end + byte_offset),
                             origin: origin.clone(),
                         });
                     }
@@ -396,13 +428,39 @@ impl ThreadView {
             self.expanded_tool_calls.remove(&id);
         }
         for key in std::mem::take(&mut self.search_auto_expanded_thinking_blocks) {
-            if !self.user_toggled_thinking_blocks.contains(&key) {
-                self.expanded_thinking_blocks.remove(&key);
+            // `user_toggled_thinking_blocks` guards explicit user expansion;
+            // `auto_expanded_thinking_block` guards the still-streaming block
+            // that `auto_expand_streaming_thought` opened. Both must survive
+            // search cleanup — otherwise the user could find-and-dismiss a
+            // block that is mid-stream and watch it snap shut.
+            if self.user_toggled_thinking_blocks.contains(&key)
+                || self.auto_expanded_thinking_block == Some(key)
+            {
+                continue;
             }
+            self.expanded_thinking_blocks.remove(&key);
         }
         cx.notify();
     }
 }
+
+struct SearchTarget {
+    target: MatchTarget,
+    /// The text actually handed to `SearchQuery::search_str`. Using
+    /// `SharedString` here lets markdown sources be collected via cheap
+    /// `Arc<str>` clones so foreground work on a keystroke is proportional
+    /// to the entry count, not the total byte size of the thread.
+    text: SharedString,
+    origin: MatchOrigin,
+    /// Added to each byte range produced by `search_str` so matches point back
+    /// into the full markdown/editor source — used by fenced code-block
+    /// sources, where we search only the inner content but highlights are
+    /// applied to the fenced source.
+    byte_offset: usize,
+}
+
+const FENCE_PREFIX: &str = "```\n";
+const FENCE_SUFFIX: &str = "\n```";
 
 fn collect_searchable_targets(
     entry: &AgentThreadEntry,
@@ -412,22 +470,34 @@ fn collect_searchable_targets(
     entry_index: usize,
     expanded_thinking_blocks: &HashSet<(usize, usize)>,
     entry_view_state: &EntryViewState,
-    out: &mut Vec<(MatchTarget, String, MatchOrigin)>,
+    out: &mut Vec<SearchTarget>,
 ) {
     match entry {
-        AgentThreadEntry::UserMessage(_message) => {
+        AgentThreadEntry::UserMessage(message) => {
             // User messages are rendered through a `MessageEditor`, so search
             // the editor's buffer text directly rather than the (unrendered)
             // markdown entity on `UserMessage::content`. The two texts diverge
             // for image chunks — the markdown uses ``Image`` while the editor
             // uses a mention link — so the editor text is the source of truth.
+            //
+            // If the editor hasn't been synced into `EntryViewState` yet (rare,
+            // but possible before a `NewEntry` handler runs) we fall back to
+            // the message's content markdown so the user message still shows
+            // up in the match counter.
             if let Some(editor) = entry_view_state
                 .entry(entry_index)
                 .and_then(|entry| entry.message_editor())
                 .map(|message_editor| message_editor.read(cx).editor().clone())
             {
-                let text = editor.read(cx).text(cx);
-                out.push((MatchTarget::Editor(editor), text, MatchOrigin::UserMessage));
+                let text = SharedString::from(editor.read(cx).text(cx));
+                out.push(SearchTarget {
+                    target: MatchTarget::Editor(editor.downgrade()),
+                    text,
+                    origin: MatchOrigin::UserMessage,
+                    byte_offset: 0,
+                });
+            } else if let Some(markdown) = message.content.markdown() {
+                push_markdown(markdown, cx, MatchOrigin::UserMessage, out);
             }
         }
         AgentThreadEntry::AssistantMessage(message) => {
@@ -455,13 +525,15 @@ fn collect_searchable_targets(
             // but the visible rendering is a code-fenced markdown: once a
             // terminal has been created, `terminal.command()`; otherwise (in
             // the pre-approval "Run Command" preview, or for rejected
-            // commands) `call.command_markdown`. Indexing those fenced
-            // entities — rather than the plain label — means highlights end
-            // up on the markdown the user actually sees.
+            // commands) `call.command_markdown`. We index only the inner
+            // (unfenced) text so a query like a backtick doesn't match the
+            // fence bytes, and offset back into the source when recording
+            // match byte ranges so the markdown renderer highlights the
+            // command itself.
             let mut has_terminal = false;
             for terminal in call.terminals() {
                 has_terminal = true;
-                push_markdown(
+                push_fenced_markdown(
                     terminal.read(cx).command(),
                     cx,
                     MatchOrigin::AlwaysVisible,
@@ -470,7 +542,7 @@ fn collect_searchable_targets(
             }
             if !has_terminal {
                 if let Some(command_markdown) = &call.command_markdown {
-                    push_markdown(command_markdown, cx, MatchOrigin::AlwaysVisible, out);
+                    push_fenced_markdown(command_markdown, cx, MatchOrigin::AlwaysVisible, out);
                 } else {
                     push_markdown(&call.label, cx, MatchOrigin::AlwaysVisible, out);
                 }
@@ -503,7 +575,7 @@ fn push_content_block(
     block: &ContentBlock,
     cx: &App,
     origin: MatchOrigin,
-    out: &mut Vec<(MatchTarget, String, MatchOrigin)>,
+    out: &mut Vec<SearchTarget>,
 ) {
     if let Some(markdown) = block.markdown() {
         push_markdown(markdown, cx, origin, out);
@@ -514,13 +586,40 @@ fn push_markdown(
     markdown: &Entity<Markdown>,
     cx: &App,
     origin: MatchOrigin,
-    out: &mut Vec<(MatchTarget, String, MatchOrigin)>,
+    out: &mut Vec<SearchTarget>,
 ) {
-    out.push((
-        MatchTarget::Markdown(markdown.clone()),
-        markdown.read(cx).source().to_string(),
+    out.push(SearchTarget {
+        target: MatchTarget::Markdown(markdown.downgrade()),
+        text: markdown.read(cx).source_shared(),
         origin,
-    ));
+        byte_offset: 0,
+    });
+}
+
+/// Pushes a markdown entity whose source is wrapped in a ``` `\n` ... `\n``` ```
+/// fence (as produced by `acp_thread::ToolCall::command_markdown` and
+/// `terminal::Terminal::command`). Only the inner text is searched so queries
+/// containing backticks or newlines don't match the fence bytes, and the
+/// resulting byte ranges are offset by the prefix length so highlights land on
+/// the command characters inside the fenced source.
+fn push_fenced_markdown(
+    markdown: &Entity<Markdown>,
+    cx: &App,
+    origin: MatchOrigin,
+    out: &mut Vec<SearchTarget>,
+) {
+    let source = markdown.read(cx).source_shared();
+    let (text, byte_offset) = source
+        .strip_prefix(FENCE_PREFIX)
+        .and_then(|rest| rest.strip_suffix(FENCE_SUFFIX))
+        .map(|inner| (SharedString::from(inner.to_string()), FENCE_PREFIX.len()))
+        .unwrap_or_else(|| (source.clone(), 0));
+    out.push(SearchTarget {
+        target: MatchTarget::Markdown(markdown.downgrade()),
+        text,
+        origin,
+        byte_offset,
+    });
 }
 
 fn group_matches_by_target(

--- a/crates/agent_ui/src/conversation_view/thread_search.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search.rs
@@ -2,6 +2,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use acp_thread::{AgentThreadEntry, AssistantMessageChunk, ContentBlock, ToolCallContent};
+use agent_client_protocol::schema as acp;
 use collections::{HashMap, HashSet};
 use gpui::{
     App, AppContext, Context, Entity, EntityId, EventEmitter, ListOffset, SharedString, Task,
@@ -11,16 +12,27 @@ use markdown::Markdown;
 use project::search::SearchQuery;
 use workspace::item::{Item, ItemBufferKind, ItemEvent};
 use workspace::searchable::{
-    Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle,
+    Direction, SearchEvent, SearchOptions as SearchableOptions, SearchToken, SearchableItem,
+    SearchableItemHandle,
 };
 
 use super::ThreadView;
+
+/// Where inside the thread a match lives, so we can auto-expand disclosures
+/// when the user has opted into searching hidden context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchOrigin {
+    AlwaysVisible,
+    ThinkingBlock { chunk_index: usize },
+    ToolCallContent { id: acp::ToolCallId },
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadSearchMatch {
     pub entry_index: usize,
     pub markdown: Entity<Markdown>,
     pub byte_range: Range<usize>,
+    pub origin: MatchOrigin,
 }
 
 impl EventEmitter<SearchEvent> for ThreadView {}
@@ -53,8 +65,8 @@ impl Item for ThreadView {
 impl SearchableItem for ThreadView {
     type Match = ThreadSearchMatch;
 
-    fn supported_options(&self) -> SearchOptions {
-        SearchOptions {
+    fn supported_options(&self) -> SearchableOptions {
+        SearchableOptions {
             case: true,
             word: true,
             regex: true,
@@ -62,6 +74,7 @@ impl SearchableItem for ThreadView {
             selection: false,
             select_all: false,
             find_in_results: false,
+            include_hidden: true,
         }
     }
 
@@ -73,6 +86,7 @@ impl SearchableItem for ThreadView {
         for markdown in std::mem::take(&mut self.highlighted_markdowns) {
             markdown.update(cx, |md, cx| md.clear_search_highlights(cx));
         }
+        self.collapse_search_auto_expanded_sections(cx);
         if had_matches {
             cx.emit(SearchEvent::MatchesInvalidated);
         }
@@ -89,8 +103,8 @@ impl SearchableItem for ThreadView {
     ) {
         let changed = self.search_matches.as_slice() != matches;
 
-        // Group matches by their Markdown entity while preserving the global order.
-        let mut per_markdown: Vec<(Entity<Markdown>, Vec<Range<usize>>, Option<usize>)> = Vec::new();
+        let mut per_markdown: Vec<(Entity<Markdown>, Vec<Range<usize>>, Option<usize>)> =
+            Vec::new();
         let mut index_map: HashMap<EntityId, usize> = HashMap::default();
         for (global_idx, m) in matches.iter().enumerate() {
             let group_idx = *index_map.entry(m.markdown.entity_id()).or_insert_with(|| {
@@ -104,7 +118,6 @@ impl SearchableItem for ThreadView {
             }
         }
 
-        // Clear highlights on previously-highlighted markdowns that no longer have matches.
         let new_ids: HashSet<EntityId> = per_markdown
             .iter()
             .map(|(markdown, _, _)| markdown.entity_id())
@@ -161,8 +174,8 @@ impl SearchableItem for ThreadView {
         self.active_search_match_index = Some(index);
         self.active_search_position = Some((m.entry_index, m.byte_range.start));
 
-        // Count how many matches sharing this markdown precede (and include) the
-        // activated one — that's the active index within the per-markdown range list.
+        self.ensure_origin_expanded(m.entry_index, &m.origin, cx);
+
         let target_id = m.markdown.entity_id();
         let local_index = matches[..=index]
             .iter()
@@ -180,10 +193,6 @@ impl SearchableItem for ThreadView {
             md.request_autoscroll_to_source_index(m.byte_range.start, cx);
         });
 
-        // Place the entry at the viewport top as a coarse jump. The Markdown
-        // autoscroll request above then propagates a `window.request_autoscroll`
-        // during paint, which the List honors to bring the specific match into
-        // view if it sits deeper in a tall entry.
         self.list_state.scroll_to(ListOffset {
             item_ix: m.entry_index,
             offset_in_item: px(0.0),
@@ -217,10 +226,28 @@ impl SearchableItem for ThreadView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Vec<Self::Match>> {
-        let mut entries_data: Vec<(usize, Vec<(Entity<Markdown>, String)>)> = Vec::new();
+        let include_hidden = query.include_hidden();
+
+        if !include_hidden {
+            self.collapse_search_auto_expanded_sections(cx);
+        }
+
+        let expanded_tool_calls = self.expanded_tool_calls.clone();
+        let expanded_thinking_blocks = self.expanded_thinking_blocks.clone();
+
+        let mut entries_data: Vec<(usize, Vec<(Entity<Markdown>, String, MatchOrigin)>)> =
+            Vec::new();
         for (entry_index, entry) in self.thread.read(cx).entries().iter().enumerate() {
             let mut markdowns = Vec::new();
-            collect_searchable_markdowns(entry, cx, &mut markdowns);
+            collect_searchable_markdowns(
+                entry,
+                cx,
+                include_hidden,
+                &expanded_tool_calls,
+                entry_index,
+                &expanded_thinking_blocks,
+                &mut markdowns,
+            );
             if !markdowns.is_empty() {
                 entries_data.push((entry_index, markdowns));
             }
@@ -228,12 +255,13 @@ impl SearchableItem for ThreadView {
         cx.background_spawn(async move {
             let mut matches = Vec::new();
             for (entry_index, markdowns) in entries_data {
-                for (markdown, source) in markdowns {
+                for (markdown, source, origin) in markdowns {
                     for byte_range in query.search_str(&source) {
                         matches.push(ThreadSearchMatch {
                             entry_index,
                             markdown: markdown.clone(),
                             byte_range,
+                            origin: origin.clone(),
                         });
                     }
                 }
@@ -269,35 +297,106 @@ impl SearchableItem for ThreadView {
     }
 }
 
+impl ThreadView {
+    fn ensure_origin_expanded(
+        &mut self,
+        entry_index: usize,
+        origin: &MatchOrigin,
+        cx: &mut Context<Self>,
+    ) {
+        match origin {
+            MatchOrigin::AlwaysVisible => {}
+            MatchOrigin::ThinkingBlock { chunk_index } => {
+                let key = (entry_index, *chunk_index);
+                if !self.expanded_thinking_blocks.contains(&key) {
+                    self.expanded_thinking_blocks.insert(key);
+                    self.search_auto_expanded_thinking_blocks.insert(key);
+                    cx.notify();
+                }
+            }
+            MatchOrigin::ToolCallContent { id } => {
+                if !self.expanded_tool_calls.contains(id) {
+                    self.expanded_tool_calls.insert(id.clone());
+                    self.search_auto_expanded_tool_calls.insert(id.clone());
+                    cx.notify();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn collapse_search_auto_expanded_sections(&mut self, cx: &mut Context<Self>) {
+        if self.search_auto_expanded_tool_calls.is_empty()
+            && self.search_auto_expanded_thinking_blocks.is_empty()
+        {
+            return;
+        }
+
+        for id in std::mem::take(&mut self.search_auto_expanded_tool_calls) {
+            self.expanded_tool_calls.remove(&id);
+        }
+        for key in std::mem::take(&mut self.search_auto_expanded_thinking_blocks) {
+            if !self.user_toggled_thinking_blocks.contains(&key) {
+                self.expanded_thinking_blocks.remove(&key);
+            }
+        }
+        cx.notify();
+    }
+}
+
 fn collect_searchable_markdowns(
     entry: &AgentThreadEntry,
     cx: &App,
-    out: &mut Vec<(Entity<Markdown>, String)>,
+    include_hidden: bool,
+    expanded_tool_calls: &HashSet<acp::ToolCallId>,
+    entry_index: usize,
+    expanded_thinking_blocks: &HashSet<(usize, usize)>,
+    out: &mut Vec<(Entity<Markdown>, String, MatchOrigin)>,
 ) {
     match entry {
         AgentThreadEntry::UserMessage(message) => {
-            push_content_block(&message.content, cx, out);
+            push_content_block(&message.content, cx, MatchOrigin::AlwaysVisible, out);
         }
         AgentThreadEntry::AssistantMessage(message) => {
-            for chunk in &message.chunks {
-                let block = match chunk {
-                    AssistantMessageChunk::Message { block } => block,
-                    AssistantMessageChunk::Thought { block } => block,
-                };
-                push_content_block(block, cx, out);
+            for (chunk_index, chunk) in message.chunks.iter().enumerate() {
+                match chunk {
+                    AssistantMessageChunk::Message { block } => {
+                        push_content_block(block, cx, MatchOrigin::AlwaysVisible, out);
+                    }
+                    AssistantMessageChunk::Thought { block } => {
+                        let key = (entry_index, chunk_index);
+                        if include_hidden || expanded_thinking_blocks.contains(&key) {
+                            push_content_block(
+                                block,
+                                cx,
+                                MatchOrigin::ThinkingBlock { chunk_index },
+                                out,
+                            );
+                        }
+                    }
+                }
             }
         }
         AgentThreadEntry::ToolCall(call) => {
-            push_markdown(&call.label, cx, out);
-            for content in &call.content {
-                if let ToolCallContent::ContentBlock(block) = content {
-                    push_content_block(block, cx, out);
+            push_markdown(&call.label, cx, MatchOrigin::AlwaysVisible, out);
+            let content_visible = include_hidden || expanded_tool_calls.contains(&call.id);
+            if content_visible {
+                for content in &call.content {
+                    if let ToolCallContent::ContentBlock(block) = content {
+                        push_content_block(
+                            block,
+                            cx,
+                            MatchOrigin::ToolCallContent {
+                                id: call.id.clone(),
+                            },
+                            out,
+                        );
+                    }
                 }
             }
         }
         AgentThreadEntry::CompletedPlan(plan_entries) => {
             for plan_entry in plan_entries {
-                push_markdown(&plan_entry.content, cx, out);
+                push_markdown(&plan_entry.content, cx, MatchOrigin::AlwaysVisible, out);
             }
         }
     }
@@ -306,13 +405,23 @@ fn collect_searchable_markdowns(
 fn push_content_block(
     block: &ContentBlock,
     cx: &App,
-    out: &mut Vec<(Entity<Markdown>, String)>,
+    origin: MatchOrigin,
+    out: &mut Vec<(Entity<Markdown>, String, MatchOrigin)>,
 ) {
     if let Some(markdown) = block.markdown() {
-        push_markdown(markdown, cx, out);
+        push_markdown(markdown, cx, origin, out);
     }
 }
 
-fn push_markdown(markdown: &Entity<Markdown>, cx: &App, out: &mut Vec<(Entity<Markdown>, String)>) {
-    out.push((markdown.clone(), markdown.read(cx).source().to_string()));
+fn push_markdown(
+    markdown: &Entity<Markdown>,
+    cx: &App,
+    origin: MatchOrigin,
+    out: &mut Vec<(Entity<Markdown>, String, MatchOrigin)>,
+) {
+    out.push((
+        markdown.clone(),
+        markdown.read(cx).source().to_string(),
+        origin,
+    ));
 }

--- a/crates/agent_ui/src/conversation_view/thread_search.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+
+use gpui::{App, AppContext, Context, Entity, EventEmitter, ListOffset, SharedString, Task, Window, px};
+use project::search::SearchQuery;
+use workspace::item::{Item, ItemBufferKind, ItemEvent};
+use workspace::searchable::{
+    Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle,
+};
+
+use super::ThreadView;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadSearchMatch {
+    pub entry_index: usize,
+    pub byte_range: std::ops::Range<usize>,
+}
+
+impl EventEmitter<SearchEvent> for ThreadView {}
+
+impl Item for ThreadView {
+    type Event = super::AcpThreadViewEvent;
+
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        self.thread
+            .read(cx)
+            .title()
+            .unwrap_or_else(|| SharedString::new_static(crate::DEFAULT_THREAD_TITLE))
+    }
+
+    fn buffer_kind(&self, _cx: &App) -> ItemBufferKind {
+        ItemBufferKind::Singleton
+    }
+
+    fn to_item_events(_event: &Self::Event, _f: &mut dyn FnMut(ItemEvent)) {}
+
+    fn as_searchable(
+        &self,
+        handle: &Entity<Self>,
+        _cx: &App,
+    ) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(handle.clone()))
+    }
+}
+
+impl SearchableItem for ThreadView {
+    type Match = ThreadSearchMatch;
+
+    fn supported_options(&self) -> SearchOptions {
+        SearchOptions {
+            case: true,
+            word: true,
+            regex: true,
+            replacement: false,
+            selection: false,
+            select_all: false,
+            find_in_results: false,
+        }
+    }
+
+    fn clear_matches(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let had_matches = !self.search_matches.is_empty();
+        self.search_matches.clear();
+        self.active_search_match_index = None;
+        self.active_search_position = None;
+        if had_matches {
+            cx.emit(SearchEvent::MatchesInvalidated);
+        }
+        cx.notify();
+    }
+
+    fn update_matches(
+        &mut self,
+        matches: &[Self::Match],
+        active_match_index: Option<usize>,
+        _token: SearchToken,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let changed = self.search_matches.as_slice() != matches;
+        if changed {
+            self.search_matches = matches.to_vec();
+            cx.emit(SearchEvent::MatchesInvalidated);
+        }
+        self.active_search_match_index = active_match_index;
+        if let Some(idx) = active_match_index
+            && let Some(m) = matches.get(idx)
+        {
+            self.active_search_position = Some((m.entry_index, m.byte_range.start));
+        }
+        cx.notify();
+    }
+
+    fn query_suggestion(
+        &mut self,
+        _ignore_settings: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> String {
+        String::new()
+    }
+
+    fn activate_match(
+        &mut self,
+        index: usize,
+        matches: &[Self::Match],
+        _token: SearchToken,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(m) = matches.get(index) {
+            self.active_search_match_index = Some(index);
+            self.active_search_position = Some((m.entry_index, m.byte_range.start));
+            self.list_state.scroll_to(ListOffset {
+                item_ix: m.entry_index,
+                offset_in_item: px(0.0),
+            });
+            cx.emit(SearchEvent::ActiveMatchChanged);
+            cx.notify();
+        }
+    }
+
+    fn select_matches(
+        &mut self,
+        _matches: &[Self::Match],
+        _token: SearchToken,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
+    fn replace(
+        &mut self,
+        _: &Self::Match,
+        _: &SearchQuery,
+        _token: SearchToken,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) {
+    }
+
+    fn find_matches(
+        &mut self,
+        query: Arc<SearchQuery>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Vec<Self::Match>> {
+        let entries: Vec<(usize, String)> = self
+            .thread
+            .read(cx)
+            .entries()
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| (idx, entry.to_markdown(cx)))
+            .collect();
+        cx.background_spawn(async move {
+            let mut matches = Vec::new();
+            for (entry_index, text) in entries {
+                for byte_range in query.search_str(&text) {
+                    matches.push(ThreadSearchMatch {
+                        entry_index,
+                        byte_range,
+                    });
+                }
+            }
+            matches
+        })
+    }
+
+    fn active_match_index(
+        &mut self,
+        direction: Direction,
+        matches: &[Self::Match],
+        _token: SearchToken,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<usize> {
+        if matches.is_empty() {
+            return None;
+        }
+
+        let anchor = self.active_search_position.unwrap_or((0, 0));
+
+        match direction {
+            Direction::Next => matches
+                .iter()
+                .position(|m| (m.entry_index, m.byte_range.start) >= anchor)
+                .or(Some(0)),
+            Direction::Prev => matches
+                .iter()
+                .rposition(|m| (m.entry_index, m.byte_range.start) <= anchor)
+                .or(Some(matches.len().saturating_sub(1))),
+        }
+    }
+}

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -329,6 +329,13 @@ pub struct ThreadView {
     pub show_codex_windows_warning: bool,
     pub multi_root_callout_dismissed: bool,
     pub generating_indicator_in_list: bool,
+    pub search_matches: Vec<crate::conversation_view::ThreadSearchMatch>,
+    pub active_search_match_index: Option<usize>,
+    /// (entry_index, byte_start) — tracked independently of `active_search_match_index`
+    /// so that when the match set changes, we can re-anchor to the nearest remaining match.
+    pub active_search_position: Option<(usize, usize)>,
+    pub search_bar: Option<Entity<search::BufferSearchBar>>,
+    pub search_bar_subscription: Option<Subscription>,
 }
 impl Focusable for ThreadView {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
@@ -553,6 +560,11 @@ impl ThreadView {
             show_codex_windows_warning,
             multi_root_callout_dismissed: false,
             generating_indicator_in_list: false,
+            search_matches: Vec::new(),
+            active_search_match_index: None,
+            active_search_position: None,
+            search_bar: None,
+            search_bar_subscription: None,
         };
 
         this.sync_generating_indicator(cx);

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -296,7 +296,7 @@ pub struct ThreadView {
     pub expanded_tool_calls: HashSet<acp::ToolCallId>,
     pub expanded_tool_call_raw_inputs: HashSet<acp::ToolCallId>,
     pub expanded_thinking_blocks: HashSet<(usize, usize)>,
-    auto_expanded_thinking_block: Option<(usize, usize)>,
+    pub(crate) auto_expanded_thinking_block: Option<(usize, usize)>,
     pub(crate) user_toggled_thinking_blocks: HashSet<(usize, usize)>,
     pub(crate) search_auto_expanded_tool_calls: HashSet<acp::ToolCallId>,
     pub(crate) search_auto_expanded_thinking_blocks: HashSet<(usize, usize)>,
@@ -340,15 +340,21 @@ pub struct ThreadView {
     /// so that when the match set changes, we can re-anchor to the nearest remaining match.
     pub active_search_position: Option<(usize, usize)>,
     /// Markdown entities that currently hold search highlights, so we can clear
-    /// them when the match set shrinks or the search is dismissed.
-    pub highlighted_markdowns: Vec<Entity<Markdown>>,
+    /// them when the match set shrinks or the search is dismissed. Stored as
+    /// weak handles so that entities dropped from `EntryViewState` aren't
+    /// retained purely for their search-highlight membership.
+    pub highlighted_markdowns: Vec<WeakEntity<Markdown>>,
     /// User-message editors that currently hold search highlights, tracked for
     /// the same reason — user-message rendering goes through a `MessageEditor`
     /// (see `conversation_view/thread_view.rs` user-message arm), not the
     /// markdown entity, so highlights must be applied to the editor directly.
-    pub highlighted_user_message_editors: Vec<Entity<Editor>>,
+    pub highlighted_user_message_editors: Vec<WeakEntity<Editor>>,
     pub search_bar: Option<Entity<search::BufferSearchBar>>,
     pub search_bar_subscription: Option<Subscription>,
+    /// Set when a `deploy_search` has been queued via `window.defer` but not
+    /// yet run. Coalesces duplicate deploys within the same frame so two
+    /// action dispatches don't deploy-then-dismiss the bar.
+    search_deploy_pending: bool,
 }
 impl Focusable for ThreadView {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
@@ -582,6 +588,7 @@ impl ThreadView {
             highlighted_user_message_editors: Vec::new(),
             search_bar: None,
             search_bar_subscription: None,
+            search_deploy_pending: false,
         };
 
         this.sync_generating_indicator(cx);
@@ -5507,6 +5514,12 @@ impl ThreadView {
     }
 
     fn toggle_thinking_block_expansion(&mut self, key: (usize, usize), cx: &mut Context<Self>) {
+        // Once the user manually toggles, the block is user-owned; drop the
+        // search tracker so a later `collapse_search_auto_expanded_sections`
+        // doesn't try to roll back the user's explicit choice. Mirrors the
+        // tool-call chevron handler.
+        self.search_auto_expanded_thinking_blocks.remove(&key);
+
         let thinking_display = AgentSettings::get_global(cx).thinking_display;
 
         match thinking_display {
@@ -5573,19 +5586,24 @@ impl ThreadView {
         let thinking_display = AgentSettings::get_global(cx).thinking_display;
         let is_user_toggled = self.user_toggled_thinking_blocks.contains(&key);
         let is_in_expanded_set = self.expanded_thinking_blocks.contains(&key);
+        // Search auto-expansion is an extra "open" force that has to apply in
+        // all display modes, not just Auto/Preview. Without this,
+        // `AlwaysCollapsed` users who navigate via search would see the match
+        // counter advance but no block actually open.
+        let is_search_expanded = self.search_auto_expanded_thinking_blocks.contains(&key);
 
         let (is_open, is_constrained) = match thinking_display {
             ThinkingBlockDisplay::Auto => {
-                let is_open = is_user_toggled || is_in_expanded_set;
+                let is_open = is_user_toggled || is_in_expanded_set || is_search_expanded;
                 (is_open, false)
             }
             ThinkingBlockDisplay::Preview => {
-                let is_open = is_user_toggled || is_in_expanded_set;
-                let is_constrained = is_in_expanded_set && !is_user_toggled;
+                let is_open = is_user_toggled || is_in_expanded_set || is_search_expanded;
+                let is_constrained = (is_in_expanded_set || is_search_expanded) && !is_user_toggled;
                 (is_open, is_constrained)
             }
-            ThinkingBlockDisplay::AlwaysExpanded => (!is_user_toggled, false),
-            ThinkingBlockDisplay::AlwaysCollapsed => (is_user_toggled, false),
+            ThinkingBlockDisplay::AlwaysExpanded => (!is_user_toggled || is_search_expanded, false),
+            ThinkingBlockDisplay::AlwaysCollapsed => (is_user_toggled || is_search_expanded, false),
         };
 
         let should_auto_scroll = self.auto_expanded_thinking_block == Some(key);
@@ -8984,6 +9002,13 @@ impl ThreadView {
     }
 
     fn deploy_search(&mut self, action: &Deploy, window: &mut Window, cx: &mut Context<Self>) {
+        // Guard against two action dispatches in the same frame both landing
+        // here before either deferred closure runs — without this, the first
+        // deploys + toggles (opens) and the second re-toggles (dismisses).
+        if self.search_deploy_pending {
+            return;
+        }
+
         let needs_init = self.search_bar.is_none();
         if needs_init {
             let languages = self
@@ -9002,11 +9027,13 @@ impl ThreadView {
         let Some(bar) = self.search_bar.clone() else {
             return;
         };
+        self.search_deploy_pending = true;
         let this = cx.entity();
         let action = action.clone();
         // `set_active_pane_item` and `toggle` can re-enter this view (via
         // SearchableItem callbacks), so run them outside of the current update.
         window.defer(cx, move |window, cx| {
+            this.update(cx, |this, _| this.search_deploy_pending = false);
             bar.update(cx, |bar, cx| {
                 if needs_init {
                     bar.set_active_pane_item(Some(&this), window, cx);
@@ -9014,6 +9041,21 @@ impl ThreadView {
                 bar.toggle(&action, window, cx);
             });
         });
+    }
+
+    /// Tell the owned `BufferSearchBar` to drop its strong handle back to this
+    /// view, then drop the bar itself. This exists because `BufferSearchBar`
+    /// retains its active SearchableItem (here, `Entity<ThreadView>`) as a
+    /// strong handle, closing a cycle with the `search_bar` field below — if
+    /// nobody explicitly releases one side, neither ever drops. Callers
+    /// (`AgentPanel`, via `ConversationView::release_search_bar_resources`)
+    /// must invoke this before discarding the last external reference to
+    /// this view.
+    pub fn release_search_bar_resources(&mut self, cx: &mut Context<Self>) {
+        if let Some(bar) = self.search_bar.take() {
+            bar.update(cx, |bar, cx| bar.release_active_searchable_item(cx));
+        }
+        self.search_bar_subscription = None;
     }
 }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -342,6 +342,11 @@ pub struct ThreadView {
     /// Markdown entities that currently hold search highlights, so we can clear
     /// them when the match set shrinks or the search is dismissed.
     pub highlighted_markdowns: Vec<Entity<Markdown>>,
+    /// User-message editors that currently hold search highlights, tracked for
+    /// the same reason — user-message rendering goes through a `MessageEditor`
+    /// (see `conversation_view/thread_view.rs` user-message arm), not the
+    /// markdown entity, so highlights must be applied to the editor directly.
+    pub highlighted_user_message_editors: Vec<Entity<Editor>>,
     pub search_bar: Option<Entity<search::BufferSearchBar>>,
     pub search_bar_subscription: Option<Subscription>,
 }
@@ -574,6 +579,7 @@ impl ThreadView {
             active_search_match_index: None,
             active_search_position: None,
             highlighted_markdowns: Vec::new(),
+            highlighted_user_message_editors: Vec::new(),
             search_bar: None,
             search_bar_subscription: None,
         };

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -15,10 +15,10 @@ use crate::message_editor::SharedSessionCapabilities;
 use gpui::List;
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
-use settings::{SidebarSide, update_settings_file};
-use ui::{ButtonLike, SpinnerLabel, SpinnerVariant, SplitButton, SplitButtonStyle, Tab};
 use search::BufferSearchBar;
 use search::buffer_search::DivRegistrar;
+use settings::{SidebarSide, update_settings_file};
+use ui::{ButtonLike, SpinnerLabel, SpinnerVariant, SplitButton, SplitButtonStyle, Tab};
 use workspace::{SERIALIZATION_THROTTLE_TIME, ToolbarItemView};
 use zed_actions::buffer_search::Deploy;
 
@@ -297,7 +297,9 @@ pub struct ThreadView {
     pub expanded_tool_call_raw_inputs: HashSet<acp::ToolCallId>,
     pub expanded_thinking_blocks: HashSet<(usize, usize)>,
     auto_expanded_thinking_block: Option<(usize, usize)>,
-    user_toggled_thinking_blocks: HashSet<(usize, usize)>,
+    pub(crate) user_toggled_thinking_blocks: HashSet<(usize, usize)>,
+    pub(crate) search_auto_expanded_tool_calls: HashSet<acp::ToolCallId>,
+    pub(crate) search_auto_expanded_thinking_blocks: HashSet<(usize, usize)>,
     pub subagent_scroll_handles: RefCell<HashMap<acp::SessionId, ScrollHandle>>,
     pub edits_expanded: bool,
     pub plan_expanded: bool,
@@ -534,6 +536,8 @@ impl ThreadView {
             expanded_thinking_blocks: HashSet::default(),
             auto_expanded_thinking_block: None,
             user_toggled_thinking_blocks: HashSet::default(),
+            search_auto_expanded_tool_calls: HashSet::default(),
+            search_auto_expanded_thinking_blocks: HashSet::default(),
             subagent_scroll_handles: RefCell::new(HashMap::default()),
             edits_expanded: false,
             plan_expanded: false,
@@ -6049,6 +6053,7 @@ impl ThreadView {
                 .on_click(cx.listener({
                     let id = tool_call.id.clone();
                     move |this, _event, _window, cx| {
+                        this.search_auto_expanded_tool_calls.remove(&id);
                         if is_expanded {
                             this.expanded_tool_calls.remove(&id);
                         } else {
@@ -6611,6 +6616,8 @@ impl ThreadView {
                                                                   _,
                                                                   _,
                                                                   cx: &mut Context<Self>| {
+                                                                this.search_auto_expanded_tool_calls
+                                                                    .remove(&id);
                                                                 if is_open {
                                                                     this.expanded_tool_calls
                                                                         .remove(&id);
@@ -7691,6 +7698,7 @@ impl ThreadView {
                         .icon_color(Color::Muted)
                         .on_click(cx.listener({
                             move |this: &mut Self, _, _, cx: &mut Context<Self>| {
+                                this.search_auto_expanded_tool_calls.remove(&tool_call_id);
                                 this.expanded_tool_calls.remove(&tool_call_id);
                                 cx.notify();
                             }
@@ -8015,6 +8023,8 @@ impl ThreadView {
                                     .on_click(cx.listener({
                                         let tool_call_id = tool_call.id.clone();
                                         move |this, _, _, cx| {
+                                            this.search_auto_expanded_tool_calls
+                                                .remove(&tool_call_id);
                                             if this.expanded_tool_calls.contains(&tool_call_id) {
                                                 this.expanded_tool_calls.remove(&tool_call_id);
                                             } else {
@@ -9029,204 +9039,206 @@ impl Render for ThreadView {
             .cloned();
 
         search_actions.size_full().child(
-        v_flex()
-            .key_context("AcpThread")
-            .track_focus(&self.focus_handle)
-            .on_action(cx.listener(Self::deploy_search))
-            .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
-                if this.parent_session_id.is_none() {
-                    this.cancel_generation(cx);
-                }
-            }))
-            .on_action(cx.listener(|this, _: &workspace::GoBack, window, cx| {
-                if let Some(parent_session_id) = this.thread.read(cx).parent_session_id().cloned() {
-                    this.server_view
-                        .update(cx, |view, cx| {
-                            view.navigate_to_thread(parent_session_id, window, cx);
-                        })
-                        .ok();
-                }
-            }))
-            .on_action(cx.listener(Self::keep_all))
-            .on_action(cx.listener(Self::reject_all))
-            .on_action(cx.listener(Self::undo_last_reject))
-            .on_action(cx.listener(Self::allow_always))
-            .on_action(cx.listener(Self::allow_once))
-            .on_action(cx.listener(Self::reject_once))
-            .on_action(cx.listener(Self::handle_authorize_tool_call))
-            .on_action(cx.listener(Self::handle_select_permission_granularity))
-            .on_action(cx.listener(Self::handle_toggle_command_pattern))
-            .on_action(cx.listener(Self::open_permission_dropdown))
-            .on_action(cx.listener(Self::open_add_context_menu))
-            .on_action(cx.listener(Self::scroll_output_page_up))
-            .on_action(cx.listener(Self::scroll_output_page_down))
-            .on_action(cx.listener(Self::scroll_output_line_up))
-            .on_action(cx.listener(Self::scroll_output_line_down))
-            .on_action(cx.listener(Self::scroll_output_to_top))
-            .on_action(cx.listener(Self::scroll_output_to_bottom))
-            .on_action(cx.listener(Self::scroll_output_to_previous_message))
-            .on_action(cx.listener(Self::scroll_output_to_next_message))
-            .on_action(cx.listener(|this, _: &ToggleFastMode, _window, cx| {
-                this.toggle_fast_mode(cx);
-            }))
-            .on_action(cx.listener(|this, _: &ToggleThinkingMode, _window, cx| {
-                if this.thread.read(cx).status() != ThreadStatus::Idle {
-                    return;
-                }
-                if let Some(thread) = this.as_native_thread(cx) {
-                    thread.update(cx, |thread, cx| {
-                        thread.set_thinking_enabled(!thread.thinking_enabled(), cx);
-                    });
-                }
-            }))
-            .on_action(cx.listener(|this, _: &CycleThinkingEffort, _window, cx| {
-                if this.thread.read(cx).status() != ThreadStatus::Idle {
-                    return;
-                }
-                this.cycle_thinking_effort(cx);
-            }))
-            .on_action(
-                cx.listener(|this, action: &ToggleThinkingEffortMenu, window, cx| {
+            v_flex()
+                .key_context("AcpThread")
+                .track_focus(&self.focus_handle)
+                .on_action(cx.listener(Self::deploy_search))
+                .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
+                    if this.parent_session_id.is_none() {
+                        this.cancel_generation(cx);
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &workspace::GoBack, window, cx| {
+                    if let Some(parent_session_id) =
+                        this.thread.read(cx).parent_session_id().cloned()
+                    {
+                        this.server_view
+                            .update(cx, |view, cx| {
+                                view.navigate_to_thread(parent_session_id, window, cx);
+                            })
+                            .ok();
+                    }
+                }))
+                .on_action(cx.listener(Self::keep_all))
+                .on_action(cx.listener(Self::reject_all))
+                .on_action(cx.listener(Self::undo_last_reject))
+                .on_action(cx.listener(Self::allow_always))
+                .on_action(cx.listener(Self::allow_once))
+                .on_action(cx.listener(Self::reject_once))
+                .on_action(cx.listener(Self::handle_authorize_tool_call))
+                .on_action(cx.listener(Self::handle_select_permission_granularity))
+                .on_action(cx.listener(Self::handle_toggle_command_pattern))
+                .on_action(cx.listener(Self::open_permission_dropdown))
+                .on_action(cx.listener(Self::open_add_context_menu))
+                .on_action(cx.listener(Self::scroll_output_page_up))
+                .on_action(cx.listener(Self::scroll_output_page_down))
+                .on_action(cx.listener(Self::scroll_output_line_up))
+                .on_action(cx.listener(Self::scroll_output_line_down))
+                .on_action(cx.listener(Self::scroll_output_to_top))
+                .on_action(cx.listener(Self::scroll_output_to_bottom))
+                .on_action(cx.listener(Self::scroll_output_to_previous_message))
+                .on_action(cx.listener(Self::scroll_output_to_next_message))
+                .on_action(cx.listener(|this, _: &ToggleFastMode, _window, cx| {
+                    this.toggle_fast_mode(cx);
+                }))
+                .on_action(cx.listener(|this, _: &ToggleThinkingMode, _window, cx| {
                     if this.thread.read(cx).status() != ThreadStatus::Idle {
                         return;
                     }
-                    this.toggle_thinking_effort_menu(action, window, cx);
-                }),
-            )
-            .on_action(cx.listener(|this, _: &SendNextQueuedMessage, window, cx| {
-                this.send_queued_message_at_index(0, true, window, cx);
-            }))
-            .on_action(cx.listener(|this, _: &RemoveFirstQueuedMessage, _, cx| {
-                this.remove_from_queue(0, cx);
-                cx.notify();
-            }))
-            .on_action(cx.listener(|this, _: &EditFirstQueuedMessage, window, cx| {
-                this.move_queued_message_to_main_editor(0, None, None, window, cx);
-            }))
-            .on_action(cx.listener(|this, _: &ClearMessageQueue, _, cx| {
-                this.local_queued_messages.clear();
-                this.sync_queue_flag_to_native_thread(cx);
-                this.can_fast_track_queue = false;
-                cx.notify();
-            }))
-            .on_action(cx.listener(|this, _: &ToggleProfileSelector, window, cx| {
-                if this.thread.read(cx).status() != ThreadStatus::Idle {
-                    return;
-                }
-                if let Some(config_options_view) = this.config_options_view.clone() {
-                    let handled = config_options_view.update(cx, |view, cx| {
-                        view.toggle_category_picker(
-                            acp::SessionConfigOptionCategory::Mode,
-                            window,
-                            cx,
-                        )
-                    });
-                    if handled {
+                    if let Some(thread) = this.as_native_thread(cx) {
+                        thread.update(cx, |thread, cx| {
+                            thread.set_thinking_enabled(!thread.thinking_enabled(), cx);
+                        });
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &CycleThinkingEffort, _window, cx| {
+                    if this.thread.read(cx).status() != ThreadStatus::Idle {
                         return;
                     }
-                }
-
-                if let Some(profile_selector) = this.profile_selector.clone() {
-                    profile_selector.read(cx).menu_handle().toggle(window, cx);
-                } else if let Some(mode_selector) = this.mode_selector.clone() {
-                    mode_selector.read(cx).menu_handle().toggle(window, cx);
-                }
-            }))
-            .on_action(cx.listener(|this, _: &CycleModeSelector, window, cx| {
-                if this.thread.read(cx).status() != ThreadStatus::Idle {
-                    return;
-                }
-                if let Some(config_options_view) = this.config_options_view.clone() {
-                    let handled = config_options_view.update(cx, |view, cx| {
-                        view.cycle_category_option(
-                            acp::SessionConfigOptionCategory::Mode,
-                            false,
-                            cx,
-                        )
-                    });
-                    if handled {
+                    this.cycle_thinking_effort(cx);
+                }))
+                .on_action(
+                    cx.listener(|this, action: &ToggleThinkingEffortMenu, window, cx| {
+                        if this.thread.read(cx).status() != ThreadStatus::Idle {
+                            return;
+                        }
+                        this.toggle_thinking_effort_menu(action, window, cx);
+                    }),
+                )
+                .on_action(cx.listener(|this, _: &SendNextQueuedMessage, window, cx| {
+                    this.send_queued_message_at_index(0, true, window, cx);
+                }))
+                .on_action(cx.listener(|this, _: &RemoveFirstQueuedMessage, _, cx| {
+                    this.remove_from_queue(0, cx);
+                    cx.notify();
+                }))
+                .on_action(cx.listener(|this, _: &EditFirstQueuedMessage, window, cx| {
+                    this.move_queued_message_to_main_editor(0, None, None, window, cx);
+                }))
+                .on_action(cx.listener(|this, _: &ClearMessageQueue, _, cx| {
+                    this.local_queued_messages.clear();
+                    this.sync_queue_flag_to_native_thread(cx);
+                    this.can_fast_track_queue = false;
+                    cx.notify();
+                }))
+                .on_action(cx.listener(|this, _: &ToggleProfileSelector, window, cx| {
+                    if this.thread.read(cx).status() != ThreadStatus::Idle {
                         return;
                     }
-                }
+                    if let Some(config_options_view) = this.config_options_view.clone() {
+                        let handled = config_options_view.update(cx, |view, cx| {
+                            view.toggle_category_picker(
+                                acp::SessionConfigOptionCategory::Mode,
+                                window,
+                                cx,
+                            )
+                        });
+                        if handled {
+                            return;
+                        }
+                    }
 
-                if let Some(profile_selector) = this.profile_selector.clone() {
-                    profile_selector.update(cx, |profile_selector, cx| {
-                        profile_selector.cycle_profile(cx);
-                    });
-                } else if let Some(mode_selector) = this.mode_selector.clone() {
-                    mode_selector.update(cx, |mode_selector, cx| {
-                        mode_selector.cycle_mode(window, cx);
-                    });
-                }
-            }))
-            .on_action(cx.listener(|this, _: &ToggleModelSelector, window, cx| {
-                if this.thread.read(cx).status() != ThreadStatus::Idle {
-                    return;
-                }
-                if let Some(config_options_view) = this.config_options_view.clone() {
-                    let handled = config_options_view.update(cx, |view, cx| {
-                        view.toggle_category_picker(
-                            acp::SessionConfigOptionCategory::Model,
-                            window,
-                            cx,
-                        )
-                    });
-                    if handled {
+                    if let Some(profile_selector) = this.profile_selector.clone() {
+                        profile_selector.read(cx).menu_handle().toggle(window, cx);
+                    } else if let Some(mode_selector) = this.mode_selector.clone() {
+                        mode_selector.read(cx).menu_handle().toggle(window, cx);
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &CycleModeSelector, window, cx| {
+                    if this.thread.read(cx).status() != ThreadStatus::Idle {
                         return;
                     }
-                }
+                    if let Some(config_options_view) = this.config_options_view.clone() {
+                        let handled = config_options_view.update(cx, |view, cx| {
+                            view.cycle_category_option(
+                                acp::SessionConfigOptionCategory::Mode,
+                                false,
+                                cx,
+                            )
+                        });
+                        if handled {
+                            return;
+                        }
+                    }
 
-                if let Some(model_selector) = this.model_selector.clone() {
-                    model_selector
-                        .update(cx, |model_selector, cx| model_selector.toggle(window, cx));
-                }
-            }))
-            .on_action(cx.listener(|this, _: &CycleFavoriteModels, window, cx| {
-                if this.thread.read(cx).status() != ThreadStatus::Idle {
-                    return;
-                }
-                if let Some(config_options_view) = this.config_options_view.clone() {
-                    let handled = config_options_view.update(cx, |view, cx| {
-                        view.cycle_category_option(
-                            acp::SessionConfigOptionCategory::Model,
-                            true,
-                            cx,
-                        )
-                    });
-                    if handled {
+                    if let Some(profile_selector) = this.profile_selector.clone() {
+                        profile_selector.update(cx, |profile_selector, cx| {
+                            profile_selector.cycle_profile(cx);
+                        });
+                    } else if let Some(mode_selector) = this.mode_selector.clone() {
+                        mode_selector.update(cx, |mode_selector, cx| {
+                            mode_selector.cycle_mode(window, cx);
+                        });
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &ToggleModelSelector, window, cx| {
+                    if this.thread.read(cx).status() != ThreadStatus::Idle {
                         return;
                     }
-                }
+                    if let Some(config_options_view) = this.config_options_view.clone() {
+                        let handled = config_options_view.update(cx, |view, cx| {
+                            view.toggle_category_picker(
+                                acp::SessionConfigOptionCategory::Model,
+                                window,
+                                cx,
+                            )
+                        });
+                        if handled {
+                            return;
+                        }
+                    }
 
-                if let Some(model_selector) = this.model_selector.clone() {
-                    model_selector.update(cx, |model_selector, cx| {
-                        model_selector.cycle_favorite_models(window, cx);
-                    });
-                }
-            }))
-            .size_full()
-            .children(self.render_subagent_titlebar(cx))
-            .when_some(visible_search_bar, |this, bar| this.child(bar))
-            .child(conversation)
-            .children(self.render_multi_root_callout(cx))
-            .children(self.render_activity_bar(window, cx))
-            .when(self.show_external_source_prompt_warning, |this| {
-                this.child(self.render_external_source_prompt_warning(cx))
-            })
-            .when(self.show_codex_windows_warning, |this| {
-                this.child(self.render_codex_windows_warning(cx))
-            })
-            .children(self.render_thread_retry_status_callout())
-            .children(self.render_thread_error(window, cx))
-            .when_some(
-                match has_messages {
-                    true => None,
-                    false => self.new_server_version_available.clone(),
-                },
-                |this, version| this.child(self.render_new_version_callout(&version, cx)),
-            )
-            .children(self.render_token_limit_callout(cx))
-            .child(self.render_message_editor(window, cx)),
+                    if let Some(model_selector) = this.model_selector.clone() {
+                        model_selector
+                            .update(cx, |model_selector, cx| model_selector.toggle(window, cx));
+                    }
+                }))
+                .on_action(cx.listener(|this, _: &CycleFavoriteModels, window, cx| {
+                    if this.thread.read(cx).status() != ThreadStatus::Idle {
+                        return;
+                    }
+                    if let Some(config_options_view) = this.config_options_view.clone() {
+                        let handled = config_options_view.update(cx, |view, cx| {
+                            view.cycle_category_option(
+                                acp::SessionConfigOptionCategory::Model,
+                                true,
+                                cx,
+                            )
+                        });
+                        if handled {
+                            return;
+                        }
+                    }
+
+                    if let Some(model_selector) = this.model_selector.clone() {
+                        model_selector.update(cx, |model_selector, cx| {
+                            model_selector.cycle_favorite_models(window, cx);
+                        });
+                    }
+                }))
+                .size_full()
+                .children(self.render_subagent_titlebar(cx))
+                .when_some(visible_search_bar, |this, bar| this.child(bar))
+                .child(conversation)
+                .children(self.render_multi_root_callout(cx))
+                .children(self.render_activity_bar(window, cx))
+                .when(self.show_external_source_prompt_warning, |this| {
+                    this.child(self.render_external_source_prompt_warning(cx))
+                })
+                .when(self.show_codex_windows_warning, |this| {
+                    this.child(self.render_codex_windows_warning(cx))
+                })
+                .children(self.render_thread_retry_status_callout())
+                .children(self.render_thread_error(window, cx))
+                .when_some(
+                    match has_messages {
+                        true => None,
+                        false => self.new_server_version_available.clone(),
+                    },
+                    |this, version| this.child(self.render_new_version_callout(&version, cx)),
+                )
+                .children(self.render_token_limit_callout(cx))
+                .child(self.render_message_editor(window, cx)),
         )
     }
 }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -5900,8 +5900,12 @@ impl ThreadView {
         window: &Window,
         cx: &Context<Self>,
     ) -> Div {
-        // The label's markdown source is a fenced code block (```\n...\n```);
-        // strip the fences so the copy button yields just the command text.
+        // The command's markdown source is a fenced code block (```\n...\n```),
+        // produced by `Terminal::command` (post-execution) and
+        // `ToolCall::command_markdown` (preview/rejected). Strip the fences so
+        // the copy button yields just the command text. Rendering as a code
+        // block (rather than stacked Labels) preserves line breaks and lets
+        // thread search paint highlights on the visible command.
         let command_source = command.read(cx).source();
         let command_text = command_source
             .strip_prefix("```\n")
@@ -5963,6 +5967,7 @@ impl ThreadView {
     ) -> AnyElement {
         let terminal_data = terminal.read(cx);
         let working_dir = terminal_data.working_dir();
+        let command = terminal_data.command();
         let started_at = terminal_data.started_at();
 
         let tool_failed = matches!(
@@ -6016,7 +6021,7 @@ impl ThreadView {
         let command_element = self.render_collapsible_command(
             header_group.clone(),
             false,
-            tool_call.label.clone(),
+            command.clone(),
             window,
             cx,
         );
@@ -6562,11 +6567,13 @@ impl ThreadView {
                 .mr_5()
             })
             .map(|this| {
-                if is_terminal_tool {
+                if is_terminal_tool
+                    && let Some(command_markdown) = tool_call.command_markdown.clone()
+                {
                     this.child(self.render_collapsible_command(
                         card_header_id.clone(),
                         true,
-                        tool_call.label.clone(),
+                        command_markdown,
                         window,
                         cx,
                     ))

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -17,7 +17,10 @@ use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
 use settings::{SidebarSide, update_settings_file};
 use ui::{ButtonLike, SpinnerLabel, SpinnerVariant, SplitButton, SplitButtonStyle, Tab};
-use workspace::SERIALIZATION_THROTTLE_TIME;
+use search::BufferSearchBar;
+use search::buffer_search::DivRegistrar;
+use workspace::{SERIALIZATION_THROTTLE_TIME, ToolbarItemView};
+use zed_actions::buffer_search::Deploy;
 
 use super::*;
 
@@ -8952,6 +8955,39 @@ impl ThreadView {
             menu_handle.toggle(window, cx);
         });
     }
+
+    fn deploy_search(&mut self, action: &Deploy, window: &mut Window, cx: &mut Context<Self>) {
+        let needs_init = self.search_bar.is_none();
+        if needs_init {
+            let languages = self
+                .project
+                .upgrade()
+                .map(|project| project.read(cx).languages().clone());
+            let bar = cx.new(|cx| BufferSearchBar::new(languages, window, cx));
+            self.search_bar_subscription = Some(cx.subscribe(
+                &bar,
+                |_this, _bar, _event: &search::buffer_search::Event, cx| {
+                    cx.notify();
+                },
+            ));
+            self.search_bar = Some(bar);
+        }
+        let Some(bar) = self.search_bar.clone() else {
+            return;
+        };
+        let this = cx.entity();
+        let action = action.clone();
+        // `set_active_pane_item` and `toggle` can re-enter this view (via
+        // SearchableItem callbacks), so run them outside of the current update.
+        window.defer(cx, move |window, cx| {
+            bar.update(cx, |bar, cx| {
+                if needs_init {
+                    bar.set_active_pane_item(Some(&this), window, cx);
+                }
+                bar.toggle(&action, window, cx);
+            });
+        });
+    }
 }
 
 impl Render for ThreadView {
@@ -8975,9 +9011,24 @@ impl Render for ThreadView {
                 }
             });
 
+        let mut search_registrar = DivRegistrar::new(
+            |this: &ThreadView, _window, _cx| this.search_bar.clone(),
+            cx,
+        );
+        BufferSearchBar::register(&mut search_registrar);
+        let search_actions = search_registrar.into_div();
+
+        let visible_search_bar = self
+            .search_bar
+            .as_ref()
+            .filter(|bar| !bar.read(cx).is_dismissed())
+            .cloned();
+
+        search_actions.size_full().child(
         v_flex()
             .key_context("AcpThread")
             .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::deploy_search))
             .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
                 if this.parent_session_id.is_none() {
                     this.cancel_generation(cx);
@@ -9151,6 +9202,7 @@ impl Render for ThreadView {
             }))
             .size_full()
             .children(self.render_subagent_titlebar(cx))
+            .when_some(visible_search_bar, |this, bar| this.child(bar))
             .child(conversation)
             .children(self.render_multi_root_callout(cx))
             .children(self.render_activity_bar(window, cx))
@@ -9170,7 +9222,8 @@ impl Render for ThreadView {
                 |this, version| this.child(self.render_new_version_callout(&version, cx)),
             )
             .children(self.render_token_limit_callout(cx))
-            .child(self.render_message_editor(window, cx))
+            .child(self.render_message_editor(window, cx)),
+        )
     }
 }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -337,6 +337,9 @@ pub struct ThreadView {
     /// (entry_index, byte_start) — tracked independently of `active_search_match_index`
     /// so that when the match set changes, we can re-anchor to the nearest remaining match.
     pub active_search_position: Option<(usize, usize)>,
+    /// Markdown entities that currently hold search highlights, so we can clear
+    /// them when the match set shrinks or the search is dismissed.
+    pub highlighted_markdowns: Vec<Entity<Markdown>>,
     pub search_bar: Option<Entity<search::BufferSearchBar>>,
     pub search_bar_subscription: Option<Subscription>,
 }
@@ -566,6 +569,7 @@ impl ThreadView {
             search_matches: Vec::new(),
             active_search_match_index: None,
             active_search_position: None,
+            highlighted_markdowns: Vec::new(),
             search_bar: None,
             search_bar_subscription: None,
         };

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -664,7 +664,6 @@ impl MessageEditor {
             .detach();
     }
 
-    #[cfg(test)]
     pub(crate) fn editor(&self) -> &Entity<Editor> {
         &self.editor
     }

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -1093,6 +1093,7 @@ impl SearchableItem for DapLogView {
             replacement: false,
             selection: false,
             select_all: true,
+            include_hidden: false,
         }
     }
     fn active_match_index(

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1646,6 +1646,7 @@ impl SearchableItem for Editor {
                 selection: false,
                 select_all: true,
                 find_in_results: true,
+                include_hidden: false,
             }
         } else {
             SearchOptions {
@@ -1656,6 +1657,7 @@ impl SearchableItem for Editor {
                 selection: true,
                 select_all: true,
                 find_in_results: false,
+                include_hidden: false,
             }
         }
     }

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -360,8 +360,9 @@ impl WrappedLineLayout {
 
     /// Returns the pixel position for the given byte index.
     pub fn position_for_index(&self, index: usize, line_height: Pixels) -> Option<Point<Pixels>> {
+        let num_wraps = self.wrap_boundaries.len();
         let mut line_start_ix = 0;
-        let mut line_end_indices = self
+        let line_end_indices = self
             .wrap_boundaries
             .iter()
             .map(|wrap_boundary| {
@@ -373,9 +374,18 @@ impl WrappedLineLayout {
             .enumerate();
         for (ix, line_end_ix) in line_end_indices {
             let line_y = ix as f32 * line_height;
+            // For wrap boundaries, the index `line_end_ix` is the first index of the
+            // *next* visual line, so an index equal to the boundary belongs there.
+            // For the final (non-wrap) entry, `line_end_ix == self.len()` is still on
+            // the last line (end-of-text cursor position), so keep the strict `>`.
+            let past_this_line = if ix < num_wraps {
+                index >= line_end_ix
+            } else {
+                index > line_end_ix
+            };
             if index < line_start_ix {
                 break;
-            } else if index > line_end_ix {
+            } else if past_this_line {
                 line_start_ix = line_end_ix;
                 continue;
             } else {

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -1085,4 +1085,115 @@ mod tests {
         let positions = glyph_x_positions(&layout);
         assert_eq!(positions, vec![0.5, 0.5]);
     }
+
+    fn wrapped_layout(
+        glyph_count: usize,
+        text_len: usize,
+        wrap_glyph_indices: &[usize],
+    ) -> WrappedLineLayout {
+        let glyphs: Vec<ShapedGlyph> = (0..glyph_count)
+            .map(|i| glyph_at((i * 10) as f32, i))
+            .collect();
+        let mut inner = make_layout(glyphs);
+        inner.len = text_len;
+        inner.width = px((glyph_count * 10) as f32);
+        WrappedLineLayout {
+            unwrapped_layout: Arc::new(inner),
+            wrap_boundaries: wrap_glyph_indices
+                .iter()
+                .map(|&glyph_ix| WrapBoundary {
+                    run_ix: 0,
+                    glyph_ix,
+                })
+                .collect(),
+            wrap_width: None,
+        }
+    }
+
+    #[test]
+    fn test_position_for_index_no_wrap() {
+        let layout = wrapped_layout(5, 5, &[]);
+        let lh = px(20.);
+
+        assert_eq!(
+            layout.position_for_index(0, lh),
+            Some(point(px(0.), px(0.)))
+        );
+        assert_eq!(
+            layout.position_for_index(3, lh),
+            Some(point(px(30.), px(0.)))
+        );
+        assert_eq!(
+            layout.position_for_index(5, lh),
+            Some(point(px(50.), px(0.)))
+        );
+        assert_eq!(layout.position_for_index(6, lh), None);
+    }
+
+    #[test]
+    fn test_position_for_index_at_wrap_boundary() {
+        // Text laid out across two visual lines, wrap at byte 5. The boundary
+        // itself (index 5) belongs to the *next* visual line — that's the
+        // behavior `crates/agent_ui/src/conversation_view/thread_search.rs`
+        // and the markdown highlight autoscroll rely on.
+        let layout = wrapped_layout(10, 10, &[5]);
+        let lh = px(20.);
+
+        assert_eq!(
+            layout.position_for_index(4, lh),
+            Some(point(px(40.), px(0.)))
+        );
+        assert_eq!(
+            layout.position_for_index(5, lh),
+            Some(point(px(0.), px(20.))),
+            "index on the wrap boundary lives on the next visual line",
+        );
+        assert_eq!(
+            layout.position_for_index(6, lh),
+            Some(point(px(10.), px(20.))),
+        );
+    }
+
+    #[test]
+    fn test_position_for_index_multiple_wraps() {
+        let layout = wrapped_layout(9, 9, &[3, 6]);
+        let lh = px(20.);
+
+        assert_eq!(
+            layout.position_for_index(0, lh),
+            Some(point(px(0.), px(0.)))
+        );
+        assert_eq!(
+            layout.position_for_index(3, lh),
+            Some(point(px(0.), px(20.))),
+        );
+        assert_eq!(
+            layout.position_for_index(5, lh),
+            Some(point(px(20.), px(20.))),
+        );
+        assert_eq!(
+            layout.position_for_index(6, lh),
+            Some(point(px(0.), px(40.))),
+        );
+        assert_eq!(
+            layout.position_for_index(9, lh),
+            Some(point(px(30.), px(40.))),
+        );
+        assert_eq!(layout.position_for_index(10, lh), None);
+    }
+
+    #[test]
+    fn test_position_for_index_end_of_last_line() {
+        // On the last (non-wrapping) line, the index equal to `len` is a valid
+        // cursor position — it should land at the end of the last visual line,
+        // not return None.
+        let layout = wrapped_layout(5, 5, &[2]);
+        let lh = px(20.);
+
+        assert_eq!(
+            layout.position_for_index(5, lh),
+            Some(point(px(30.), px(20.))),
+            "index at len on last line should resolve to end of that line",
+        );
+    }
 }

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -886,6 +886,7 @@ impl SearchableItem for LspLogView {
             replacement: false,
             selection: false,
             select_all: true,
+            include_hidden: false,
         }
     }
     fn active_match_index(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -585,6 +585,13 @@ impl Markdown {
         &self.source
     }
 
+    /// Cheap clone of the source as a `SharedString` — use instead of
+    /// `source().to_string()` when the caller needs an owned value but does
+    /// not need exclusive ownership of the bytes.
+    pub fn source_shared(&self) -> SharedString {
+        self.source.clone()
+    }
+
     pub fn append(&mut self, text: &str, cx: &mut Context<Self>) {
         self.source = SharedString::new(self.source.to_string() + text);
         self.parse(cx);

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -964,6 +964,7 @@ impl SearchableItem for MarkdownPreviewView {
             selection: false,
             select_all: false,
             find_in_results: false,
+            include_hidden: false,
         }
     }
 

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -67,6 +67,7 @@ pub enum SearchQuery {
         whole_word: bool,
         case_sensitive: bool,
         include_ignored: bool,
+        include_hidden: bool,
         inner: SearchInputs,
     },
     Regex {
@@ -76,6 +77,7 @@ pub enum SearchQuery {
         whole_word: bool,
         case_sensitive: bool,
         include_ignored: bool,
+        include_hidden: bool,
         one_match_per_line: bool,
         inner: SearchInputs,
     },
@@ -134,6 +136,7 @@ impl SearchQuery {
             whole_word,
             case_sensitive,
             include_ignored,
+            include_hidden: false,
             inner,
         })
     }
@@ -251,6 +254,7 @@ impl SearchQuery {
             whole_word,
             case_sensitive,
             include_ignored,
+            include_hidden: false,
             inner,
             one_match_per_line,
         })
@@ -357,6 +361,22 @@ impl SearchQuery {
                 ..
             } => {
                 *replacement = Some(new_replacement);
+                self
+            }
+        }
+    }
+
+    pub fn with_include_hidden(mut self, new_include_hidden: bool) -> Self {
+        match self {
+            Self::Text {
+                ref mut include_hidden,
+                ..
+            }
+            | Self::Regex {
+                ref mut include_hidden,
+                ..
+            } => {
+                *include_hidden = new_include_hidden;
                 self
             }
         }
@@ -604,6 +624,13 @@ impl SearchQuery {
             Self::Regex {
                 include_ignored, ..
             } => *include_ignored,
+        }
+    }
+
+    pub fn include_hidden(&self) -> bool {
+        match self {
+            Self::Text { include_hidden, .. } => *include_hidden,
+            Self::Regex { include_hidden, .. } => *include_hidden,
         }
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -997,6 +997,22 @@ impl BufferSearchBar {
         cx.notify();
     }
 
+    /// Drop every strong handle the bar holds to the active searchable item
+    /// and its per-item match state. Call this when a SearchableItem is about
+    /// to be dropped while the bar still holds it through `active_searchable_item`
+    /// — e.g. a ThreadView whose owning container is being released — to break
+    /// the strong-handle cycle introduced by `set_active_pane_item`.
+    pub fn release_active_searchable_item(&mut self, cx: &mut Context<Self>) {
+        self.active_searchable_item_subscriptions.take();
+        self.active_searchable_item.take();
+        self.searchable_items_with_matches.clear();
+        self.pending_search.take();
+        self.active_search.take();
+        self.active_match_index = None;
+        self.dismissed = true;
+        cx.notify();
+    }
+
     pub fn deploy(&mut self, deploy: &Deploy, window: &mut Window, cx: &mut Context<Self>) -> bool {
         let filtered_search_range = if deploy.selection_search_enabled {
             Some(FilteredSearchRange::Default)
@@ -1486,6 +1502,15 @@ impl BufferSearchBar {
             editor::EditorEvent::Focused => self.query_editor_focused = true,
             editor::EditorEvent::Blurred => self.query_editor_focused = false,
             editor::EditorEvent::Edited { .. } => {
+                // When the bar is dismissed, the query editor can still emit
+                // `Edited` events (smartcase updates, external mutations).
+                // Running `clear_matches` + `update_matches` on the active
+                // searchable item in that state causes a spurious re-render
+                // and — for SearchableItems that keep a backpointer to the
+                // bar — pointless work on a hidden UI.
+                if self.dismissed {
+                    return;
+                }
                 self.smartcase(window, cx);
                 self.clear_matches(window, cx);
                 let search = self.update_matches(false, true, window, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1310,23 +1310,23 @@ impl BufferSearchBar {
         let search = self.update_matches(false, false, window, cx);
         self.adjust_query_regex_language(cx);
         self.sync_select_next_case_sensitivity(cx);
-        // For `Include Hidden`, the newly-revealed match may live inside a
-        // previously-collapsed section; re-activate so the searchable item
-        // gets a chance to unfold/scroll to it. Other options only narrow the
-        // match set, so keep the cursor where the user left it.
-        if search_option == SearchOptions::INCLUDE_HIDDEN {
-            cx.spawn_in(window, async move |this, cx| {
-                if search.await.is_ok() {
-                    this.update_in(cx, |this, window, cx| {
-                        if !this.dismissed {
-                            this.activate_current_match(window, cx);
-                        }
-                    })?;
-                }
-                anyhow::Ok(())
-            })
-            .detach_and_log_err(cx);
-        }
+        // Any option toggle can shift the active match set — Include Hidden
+        // reveals new matches inside collapsed sections, and narrowing
+        // toggles (case / whole word / regex) can leave the cursor off a
+        // remaining match. Re-activate once the search settles so the
+        // counter, scroll position, and "active" highlight stay in sync with
+        // what the user is actually looking at.
+        cx.spawn_in(window, async move |this, cx| {
+            if search.await.is_ok() {
+                this.update_in(cx, |this, window, cx| {
+                    if !this.dismissed {
+                        this.activate_current_match(window, cx);
+                    }
+                })?;
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
         cx.notify();
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1291,9 +1291,26 @@ impl BufferSearchBar {
     ) {
         self.search_options.toggle(search_option);
         self.default_options = self.search_options;
-        drop(self.update_matches(false, false, window, cx));
+        let search = self.update_matches(false, false, window, cx);
         self.adjust_query_regex_language(cx);
         self.sync_select_next_case_sensitivity(cx);
+        // For `Include Hidden`, the newly-revealed match may live inside a
+        // previously-collapsed section; re-activate so the searchable item
+        // gets a chance to unfold/scroll to it. Other options only narrow the
+        // match set, so keep the cursor where the user left it.
+        if search_option == SearchOptions::INCLUDE_HIDDEN {
+            cx.spawn_in(window, async move |this, cx| {
+                if search.await.is_ok() {
+                    this.update_in(cx, |this, window, cx| {
+                        if !this.dismissed {
+                            this.activate_current_match(window, cx);
+                        }
+                    })?;
+                }
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
         cx.notify();
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3,7 +3,8 @@ mod registrar;
 use crate::{
     FocusSearch, NextHistoryQuery, PreviousHistoryQuery, ReplaceAll, ReplaceNext, SearchOption,
     SearchOptions, SearchSource, SelectAllMatches, SelectNextMatch, SelectPreviousMatch,
-    ToggleCaseSensitive, ToggleRegex, ToggleReplace, ToggleSelection, ToggleWholeWord,
+    ToggleCaseSensitive, ToggleIncludeHidden, ToggleRegex, ToggleReplace, ToggleSelection,
+    ToggleWholeWord,
     buffer_search::registrar::WithResultsOrExternalQuery,
     search_bar::{
         ActionButtonState, HistoryNavigationDirection, alignment_element,
@@ -295,6 +296,7 @@ impl Render for BufferSearchBar {
             selection,
             select_all,
             find_in_results,
+            include_hidden,
         } = self.supported_options(cx);
 
         self.query_editor.update(cx, |query_editor, cx| {
@@ -377,6 +379,13 @@ impl Render for BufferSearchBar {
                     })
                     .when(regex, |div| {
                         div.child(SearchOption::Regex.as_button(
+                            self.search_options,
+                            SearchSource::Buffer,
+                            focus_handle.clone(),
+                        ))
+                    })
+                    .when(include_hidden, |div| {
+                        div.child(SearchOption::IncludeHidden.as_button(
                             self.search_options,
                             SearchSource::Buffer,
                             focus_handle.clone(),
@@ -618,6 +627,9 @@ impl Render for BufferSearchBar {
             .when(regex, |this| {
                 this.on_action(cx.listener(Self::toggle_regex))
             })
+            .when(include_hidden, |this| {
+                this.on_action(cx.listener(Self::toggle_include_hidden))
+            })
             .when(selection, |this| {
                 this.on_action(cx.listener(Self::toggle_selection))
             })
@@ -769,6 +781,13 @@ impl BufferSearchBar {
                 this.toggle_regex(action, window, cx);
             }
         }));
+        registrar.register_handler(ForDeployed(
+            |this, action: &ToggleIncludeHidden, window, cx| {
+                if this.supported_options(cx).include_hidden {
+                    this.toggle_include_hidden(action, window, cx);
+                }
+            },
+        ));
         registrar.register_handler(ForDeployed(|this, action: &ToggleSelection, window, cx| {
             if this.supported_options(cx).selection {
                 this.toggle_selection(action, window, cx);
@@ -1282,6 +1301,10 @@ impl BufferSearchBar {
         self.search_options.contains(search_option)
     }
 
+    pub fn search_options(&self) -> SearchOptions {
+        self.search_options
+    }
+
     pub fn enable_search_option(
         &mut self,
         search_option: SearchOptions,
@@ -1532,6 +1555,15 @@ impl BufferSearchBar {
         self.toggle_search_option(SearchOptions::REGEX, window, cx)
     }
 
+    fn toggle_include_hidden(
+        &mut self,
+        _: &ToggleIncludeHidden,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.toggle_search_option(SearchOptions::INCLUDE_HIDDEN, window, cx)
+    }
+
     fn clear_active_searchable_item_matches(&mut self, window: &mut Window, cx: &mut App) {
         if let Some(active_searchable_item) = self.active_searchable_item.as_ref() {
             self.active_match_index = None;
@@ -1590,6 +1622,8 @@ impl BufferSearchBar {
                 } else {
                     // Value doesn't matter, we only construct empty matchers with it
 
+                    let include_hidden =
+                        self.search_options.contains(SearchOptions::INCLUDE_HIDDEN);
                     if self.search_options.contains(SearchOptions::REGEX) {
                         match SearchQuery::regex(
                             query,
@@ -1603,7 +1637,9 @@ impl BufferSearchBar {
                             false,
                             None,
                         ) {
-                            Ok(query) => query.with_replacement(self.replacement(cx)),
+                            Ok(query) => query
+                                .with_include_hidden(include_hidden)
+                                .with_replacement(self.replacement(cx)),
                             Err(e) => {
                                 self.query_error = Some(e.to_string());
                                 self.clear_active_searchable_item_matches(window, cx);
@@ -1622,7 +1658,9 @@ impl BufferSearchBar {
                             false,
                             None,
                         ) {
-                            Ok(query) => query.with_replacement(self.replacement(cx)),
+                            Ok(query) => query
+                                .with_include_hidden(include_hidden)
+                                .with_replacement(self.replacement(cx)),
                             Err(e) => {
                                 self.query_error = Some(e.to_string());
                                 self.clear_active_searchable_item_matches(window, cx);

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -37,6 +37,8 @@ actions!(
         ToggleCaseSensitive,
         /// Toggles regular expression mode.
         ToggleRegex,
+        /// Toggles searching content hidden behind disclosures.
+        ToggleIncludeHidden,
         /// Toggles the replace interface.
         ToggleReplace,
         /// Toggles searching within selection only.
@@ -71,6 +73,7 @@ bitflags! {
         const ONE_MATCH_PER_LINE = 1 << SearchOption::OneMatchPerLine as u8;
         /// If set, reverse direction when finding the active match
         const BACKWARDS = 1 << SearchOption::Backwards as u8;
+        const INCLUDE_HIDDEN = 1 << SearchOption::IncludeHidden as u8;
     }
 }
 
@@ -83,6 +86,7 @@ pub enum SearchOption {
     Regex,
     OneMatchPerLine,
     Backwards,
+    IncludeHidden,
 }
 
 pub enum SearchSource<'a, 'b> {
@@ -103,6 +107,7 @@ impl SearchOption {
             SearchOption::Regex => "Use Regular Expressions",
             SearchOption::OneMatchPerLine => "One Match Per Line",
             SearchOption::Backwards => "Search Backwards",
+            SearchOption::IncludeHidden => "Include Hidden Context",
         }
     }
 
@@ -112,6 +117,7 @@ impl SearchOption {
             SearchOption::CaseSensitive => ui::IconName::CaseSensitive,
             SearchOption::IncludeIgnored => ui::IconName::Sliders,
             SearchOption::Regex => ui::IconName::Regex,
+            SearchOption::IncludeHidden => ui::IconName::Eye,
             _ => panic!("{self:?} is not a named SearchOption"),
         }
     }
@@ -122,6 +128,7 @@ impl SearchOption {
             SearchOption::CaseSensitive => &ToggleCaseSensitive,
             SearchOption::IncludeIgnored => &ToggleIncludeIgnored,
             SearchOption::Regex => &ToggleRegex,
+            SearchOption::IncludeHidden => &ToggleIncludeHidden,
             _ => panic!("{self:?} is not a toggle action"),
         }
     }
@@ -173,6 +180,7 @@ impl SearchOptions {
         options.set(SearchOptions::CASE_SENSITIVE, query.case_sensitive());
         options.set(SearchOptions::INCLUDE_IGNORED, query.include_ignored());
         options.set(SearchOptions::REGEX, query.is_regex());
+        options.set(SearchOptions::INCLUDE_HIDDEN, query.include_hidden());
         options
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1836,6 +1836,7 @@ impl SearchableItem for TerminalView {
             selection: false,
             select_all: false,
             find_in_results: false,
+            include_hidden: false,
         }
     }
 

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -57,6 +57,9 @@ pub struct SearchOptions {
     pub selection: bool,
     pub select_all: bool,
     pub find_in_results: bool,
+    /// Whether the item has sections hidden behind disclosures whose contents
+    /// can also be searched.
+    pub include_hidden: bool,
 }
 
 // Whether to always select the current selection (even if empty)
@@ -81,6 +84,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
             selection: true,
             select_all: true,
             find_in_results: false,
+            include_hidden: false,
         }
     }
 


### PR DESCRIPTION
Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #ISSUE https://github.com/zed-industries/zed/discussions/39338 partially

Release Notes:

Adds in-thread search to the agent panel: Cmd/Ctrl+F (and `/` in vim mode) deploys a `BufferSearchBar` over the active thread, matches the query against assistant messages, user messages, tool-call labels, plan entries, and terminal commands, and highlights the matches inline. The bar's existing "next / previous / case / whole-word / regex" controls work unchanged; an "Include Hidden Context" toggle extends search into collapsed tool calls and thinking blocks on demand, auto-expanding only what the match lives  inside and collapsing again on dismiss.




https://github.com/user-attachments/assets/5b910cfb-0c92-40e8-aeca-b3866b27aa9f

