### PR TITLE
Update AI rules to reflect that `AsyncApp` updates are now infallible

### DIFF
--- a/.rules
+++ b/.rules
@@ -63,8 +63,6 @@ Within the closures, the inner `cx` provided to the closure must be used instead
 
 Trying to update an entity while it's already being updated must be avoided as this will cause a panic.
 
-When  `read_with`, `update`, or `update_in` are used with an async context, the closure's return value is wrapped in an `anyhow::Result`.
-
 `WeakEntity<T>` is a weak handle. It has `read_with`, `update`, and `update_in` methods that work the same, but always return an `anyhow::Result` so that they can fail if the entity no longer exists. This can be useful to avoid memory leaks - if entities have mutually recursive handles to each other they will never be dropped.
 
 ## Concurrency


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A