### PR TITLE
language_models: Fix `is_authenticated` state for Cloud provider

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -250,8 +250,7 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
 
     fn is_authenticated(&self, cx: &App) -> bool {
         let state = self.state.read(cx);
-        let status = *state.client.status().borrow();
-        matches!(status, Status::Authenticated | Status::Connected { .. })
+        !state.is_signed_out(cx)
     }
 
     fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -1,6 +1,5 @@
 use ai_onboarding::YoungAccountBanner;
 use anyhow::Result;
-use client::Status;
 use client::{Client, RefreshLlmTokenListener, UserStore, global_llm_token, zed_urls};
 use cloud_api_client::LlmApiToken;
 use cloud_api_types::OrganizationId;


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/zed-industries/zed/pull/54397 where the Zed Cloud provider would not be reflected as "authenticated" if a connection to Collab was attempted, but could not be established.

This was especially noticable when running Zed against a local version of Cloud and not having Collab running.

This restores the original logic prior to that change.

Release Notes:

- N/A
