### PR TITLE
Update workspace mentions in the sidebar

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1886,9 +1886,9 @@ impl Sidebar {
                                             .child(Label::new("-click").color(Color::Muted));
 
                                         let label = if has_threads {
-                                            "Focus Last Workspace"
+                                            "Focus Last Project"
                                         } else {
-                                            "Focus Workspace"
+                                            "Focus Project"
                                         };
 
                                         h_flex()
@@ -2000,7 +2000,7 @@ impl Sidebar {
                                                     )
                                                     .icon_size(IconSize::Small)
                                                     .visible_on_hover(&row_group_name)
-                                                    .tooltip(Tooltip::text("Close Workspace"))
+                                                    .tooltip(Tooltip::text("Close Worktree"))
                                                     .on_click(move |_, window, cx| {
                                                         cx.stop_propagation();
                                                         window.prevent_default();


### PR DESCRIPTION
Replaces "workspace" labels in the sidebar with more accurate terminology:

- "Focus Last Workspace" → "Focus Last Project"
- "Focus Workspace" → "Focus Project"
- "Close Workspace" tooltip → "Close Worktree"

Release Notes:

- N/A
