### PR TITLE
agent_ui: Open threads sidebar when fullscreening agent panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1008,6 +1008,8 @@
     "flexible": true,
     // Where to position the threads sidebar. Can be 'left' or 'right'.
     "sidebar_side": "left",
+    // Whether to open the threads sidebar when the agent panel enters full screen.
+    "open_threads_sidebar_on_agent_panel_fullscreen": false,
     // Default width when the agent panel is docked to the left or right.
     "default_width": 640,
     // Default height when the agent panel is docked to the bottom.

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -575,6 +575,7 @@ mod tests {
             default_width: px(300.),
             default_height: px(600.),
             max_content_width: Some(px(850.)),
+            open_threads_sidebar_on_agent_panel_fullscreen: false,
             default_model: None,
             inline_assistant_model: None,
             inline_assistant_use_streaming_tools: false,

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -140,6 +140,7 @@ pub struct AgentSettings {
     pub dock: DockPosition,
     pub flexible: bool,
     pub sidebar_side: SidebarDockPosition,
+    pub open_threads_sidebar_on_agent_panel_fullscreen: bool,
     pub default_width: Pixels,
     pub default_height: Pixels,
     pub max_content_width: Option<Pixels>,
@@ -632,6 +633,9 @@ impl Settings for AgentSettings {
             button: agent.button.unwrap(),
             dock: agent.dock.unwrap(),
             sidebar_side: agent.sidebar_side.unwrap(),
+            open_threads_sidebar_on_agent_panel_fullscreen: agent
+                .open_threads_sidebar_on_agent_panel_fullscreen
+                .unwrap(),
             default_width: px(agent.default_width.unwrap()),
             default_height: px(agent.default_height.unwrap()),
             max_content_width: if agent.limit_content_width.unwrap() {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -699,6 +699,7 @@ pub struct AgentPanel {
     _extension_subscription: Option<Subscription>,
     _project_subscription: Subscription,
     zoomed: bool,
+    opened_threads_sidebar_for_zoom: bool,
     pending_serialization: Option<Task<Result<()>>>,
     new_user_onboarding: Entity<AgentPanelOnboarding>,
     new_user_onboarding_upsell_dismissed: AtomicBool,
@@ -1056,6 +1057,7 @@ impl AgentPanel {
             _extension_subscription: extension_subscription,
             _project_subscription,
             zoomed: false,
+            opened_threads_sidebar_for_zoom: false,
             pending_serialization: None,
             new_user_onboarding: onboarding,
             thread_store,
@@ -1532,10 +1534,57 @@ impl AgentPanel {
         theme_settings::reset_agent_buffer_font_size(cx);
     }
 
+    fn close_threads_sidebar_opened_for_zoom(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.opened_threads_sidebar_for_zoom {
+            return;
+        }
+
+        self.opened_threads_sidebar_for_zoom = false;
+        let multi_workspace = self
+            .workspace
+            .upgrade()
+            .and_then(|workspace| workspace.read(cx).multi_workspace().cloned());
+        if let Some(multi_workspace) = multi_workspace {
+            multi_workspace
+                .update(cx, |multi_workspace, cx| {
+                    if multi_workspace.sidebar_open() {
+                        multi_workspace.close_sidebar(window, cx);
+                    }
+                })
+                .log_err();
+        }
+    }
+
     pub fn toggle_zoom(&mut self, _: &ToggleZoom, window: &mut Window, cx: &mut Context<Self>) {
         if self.zoomed {
+            self.close_threads_sidebar_opened_for_zoom(window, cx);
             cx.emit(PanelEvent::ZoomOut);
         } else {
+            if AgentSettings::get_global(cx).open_threads_sidebar_on_agent_panel_fullscreen {
+                let multi_workspace = self
+                    .workspace
+                    .upgrade()
+                    .and_then(|workspace| workspace.read(cx).multi_workspace().cloned());
+                if let Some(multi_workspace) = multi_workspace {
+                    multi_workspace
+                        .update(cx, |multi_workspace, cx| {
+                            if !multi_workspace.sidebar_open() {
+                                multi_workspace.open_sidebar(cx);
+                                true
+                            } else {
+                                false
+                            }
+                        })
+                        .map(|opened_sidebar| {
+                            self.opened_threads_sidebar_for_zoom = opened_sidebar;
+                        })
+                        .log_err();
+                }
+            }
             if !self.focus_handle(cx).contains_focused(window, cx) {
                 cx.focus_self(window);
             }
@@ -2547,8 +2596,11 @@ impl Panel for AgentPanel {
         self.zoomed
     }
 
-    fn set_zoomed(&mut self, zoomed: bool, _window: &mut Window, cx: &mut Context<Self>) {
+    fn set_zoomed(&mut self, zoomed: bool, window: &mut Window, cx: &mut Context<Self>) {
         self.zoomed = zoomed;
+        if !zoomed {
+            self.close_threads_sidebar_opened_for_zoom(window, cx);
+        }
         cx.notify();
     }
 }
@@ -3917,6 +3969,94 @@ mod tests {
         fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
             self
         }
+    }
+
+    #[gpui::test]
+    async fn test_agent_panel_full_screen_can_open_threads_sidebar(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(multi_workspace.clone().into(), cx);
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.toggle_zoom(&ToggleZoom, window, cx);
+        });
+        assert!(
+            !multi_workspace
+                .read_with(cx, |multi_workspace, _cx| multi_workspace.sidebar_open())
+                .unwrap(),
+            "the threads sidebar should stay closed by default"
+        );
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.toggle_zoom(&ToggleZoom, window, cx);
+        });
+
+        cx.update(|_, cx| {
+            AgentSettings::override_global(
+                AgentSettings {
+                    open_threads_sidebar_on_agent_panel_fullscreen: true,
+                    ..AgentSettings::get_global(cx).clone()
+                },
+                cx,
+            );
+        });
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.toggle_zoom(&ToggleZoom, window, cx);
+        });
+        assert!(
+            multi_workspace
+                .read_with(cx, |multi_workspace, _cx| multi_workspace.sidebar_open())
+                .unwrap(),
+            "the threads sidebar should open when configured"
+        );
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.toggle_zoom(&ToggleZoom, window, cx);
+        });
+        assert!(
+            !multi_workspace
+                .read_with(cx, |multi_workspace, _cx| multi_workspace.sidebar_open())
+                .unwrap(),
+            "the threads sidebar should close after leaving full screen if full screen opened it"
+        );
+
+        multi_workspace
+            .update(cx, |multi_workspace, _window, cx| {
+                multi_workspace.open_sidebar(cx);
+            })
+            .unwrap();
+        panel.update_in(cx, |panel, window, cx| {
+            panel.toggle_zoom(&ToggleZoom, window, cx);
+        });
+        panel.update_in(cx, |panel, window, cx| {
+            panel.toggle_zoom(&ToggleZoom, window, cx);
+        });
+        assert!(
+            multi_workspace
+                .read_with(cx, |multi_workspace, _cx| multi_workspace.sidebar_open())
+                .unwrap(),
+            "the threads sidebar should stay open after leaving full screen if it was already open"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -692,6 +692,7 @@ mod tests {
             default_width: px(300.),
             default_height: px(600.),
             max_content_width: Some(px(850.)),
+            open_threads_sidebar_on_agent_panel_fullscreen: false,
             default_model: None,
             inline_assistant_model: None,
             inline_assistant_use_streaming_tools: false,

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -118,6 +118,10 @@ pub struct AgentSettingsContent {
     ///
     /// Default: left
     pub sidebar_side: Option<SidebarDockPosition>,
+    /// Whether to open the threads sidebar when the agent panel enters full screen.
+    ///
+    /// Default: false
+    pub open_threads_sidebar_on_agent_panel_fullscreen: Option<bool>,
     /// Default width in pixels when the agent panel is docked to the left or right.
     ///
     /// Default: 640

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5807,7 +5807,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn agent_panel_section() -> [SettingsPageItem; 7] {
+    fn agent_panel_section() -> [SettingsPageItem; 8] {
         [
             SettingsPageItem::SectionHeader("Agent Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5877,6 +5877,28 @@ fn panels_page() -> SettingsPage {
                             .agent
                             .get_or_insert_default()
                             .default_height = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Open Threads Sidebar On Full Screen",
+                description: "Whether to open the threads sidebar when the agent panel enters full screen.",
+                field: Box::new(SettingField {
+                    json_path: Some("agent.open_threads_sidebar_on_agent_panel_fullscreen"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()?
+                            .open_threads_sidebar_on_agent_panel_fullscreen
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .open_threads_sidebar_on_agent_panel_fullscreen = value;
                     },
                 }),
                 metadata: None,

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5254,6 +5254,16 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 
 Visit [the Configuration page](../ai/configuration.md) under the AI section to learn more about all the agent-related settings.
 
+To open the Threads Sidebar when the Agent Panel enters full screen, set:
+
+```json [settings]
+{
+  "agent": {
+    "open_threads_sidebar_on_agent_panel_fullscreen": true
+  }
+}
+```
+
 ## Collaboration Panel
 
 - Description: Customizations for the collaboration panel.


### PR DESCRIPTION
Adds a new `agent.open_threads_sidebar_on_agent_panel_fullscreen` setting, disabled by default.

When enabled, entering Agent Panel full screen opens the Threads Sidebar if it was closed. Exiting full screen closes the Threads Sidebar again only if full screen opened it; if the sidebar was already open, it stays open. The setting is exposed under Panels > Agent Panel.

https://github.com/user-attachments/assets/63b4bbb6-2ea5-480e-a1ab-816d2dc0668d

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added a setting to open the Threads Sidebar when the Agent Panel enters full screen.
