### PR TITLE
Revert terminal changes from #54728

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -185,14 +185,15 @@ impl LayoutRect {
         let position = {
             let alac_point = self.point;
             point(
-                origin.x + alac_point.column as f32 * dimensions.cell_width,
+                (origin.x + alac_point.column as f32 * dimensions.cell_width).floor(),
                 origin.y + alac_point.line as f32 * dimensions.line_height,
             )
         };
-        let size = size(
-            dimensions.cell_width * self.num_of_cells as f32,
+        let size = point(
+            (dimensions.cell_width * self.num_of_cells as f32).ceil(),
             dimensions.line_height,
-        );
+        )
+        .into();
 
         window.paint_quad(fill(Bounds::new(position, size), self.color));
     }
@@ -958,15 +959,13 @@ impl Element for TerminalElement {
                 let (dimensions, line_height_px) = {
                     let rem_size = window.rem_size();
                     let font_pixels = text_style.font_size.to_pixels(rem_size);
-                    let line_height = window.pixel_snap(px(f32::from(font_pixels) * line_height));
+                    let line_height = f32::from(font_pixels) * line_height;
                     let font_id = cx.text_system().resolve_font(&text_style.font());
 
-                    let cell_width = window.pixel_snap(
-                        text_system
-                            .advance(font_id, font_pixels, 'm')
-                            .unwrap()
-                            .width,
-                    );
+                    let cell_width = text_system
+                        .advance(font_id, font_pixels, 'm')
+                        .unwrap()
+                        .width;
                     gutter = cell_width;
 
                     let mut size = bounds.size;
@@ -983,7 +982,7 @@ impl Element for TerminalElement {
                     origin.x += gutter;
 
                     (
-                        TerminalBounds::new(line_height, cell_width, Bounds { origin, size }),
+                        TerminalBounds::new(px(line_height), cell_width, Bounds { origin, size }),
                         line_height,
                     )
                 };
@@ -1094,9 +1093,10 @@ impl Element for TerminalElement {
                     // internal line number (which can be negative in Scrollable mode for
                     // scrollback history).
                     let rows_above_viewport =
-                        ((intersection.top() - bounds.top()).max(px(0.)) / line_height_px) as usize;
+                        f32::from((intersection.top() - bounds.top()).max(px(0.)) / line_height_px)
+                            as usize;
                     let visible_row_count =
-                        (intersection.size.height / line_height_px).ceil() as usize + 1;
+                        f32::from((intersection.size.height / line_height_px).ceil()) as usize + 1;
 
                     TerminalElement::layout_grid(
                         // Group cells by line and filter to only the visible screen rows.


### PR DESCRIPTION
Reverts parts of #54728, which seems to have causes scrolling issues in the terminal

Release Notes:

- N/A
