### PR TITLE
workspace: Fix `close project` to focus another open project

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -519,6 +519,7 @@ impl Sidebar {
                     this.sync_active_entry_from_active_workspace(cx);
                     this.replace_archived_panel_thread(window, cx);
                     this.update_entries(cx);
+                    this.reveal_active_project_header(cx);
                 }
                 MultiWorkspaceEvent::WorkspaceAdded(workspace) => {
                     this.subscribe_to_workspace(workspace, window, cx);
@@ -767,11 +768,25 @@ impl Sidebar {
     }
 
     fn sync_active_entry_from_active_workspace(&mut self, cx: &App) {
-        let panel = self
-            .active_workspace(cx)
-            .and_then(|ws| ws.read(cx).panel::<AgentPanel>(cx));
-        if let Some(panel) = panel {
+        let Some(active_workspace) = self.active_workspace(cx) else {
+            return;
+        };
+        if let Some(panel) = active_workspace.read(cx).panel::<AgentPanel>(cx) {
             self.sync_active_entry_from_panel(&panel, cx);
+        } else if self
+            .active_entry
+            .as_ref()
+            .is_some_and(|entry| entry.workspace != active_workspace)
+        {
+            self.active_entry = None;
+        }
+    }
+
+    fn reveal_active_project_header(&mut self, cx: &mut Context<Self>) {
+        if let Some(header_pos) = self.active_project_header_position(cx) {
+            if let Some(&entry_ix) = self.contents.project_header_indices.get(header_pos) {
+                self.list_state.scroll_to_reveal_item(entry_ix);
+            }
         }
     }
 

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -802,15 +802,23 @@ impl MultiWorkspace {
     fn derived_project_groups(&self, cx: &App) -> Vec<ProjectGroup> {
         self.project_groups
             .iter()
-            .map(|group| ProjectGroup {
-                key: group.key.clone(),
-                workspaces: self
+            .map(|group| {
+                let mut workspaces: Vec<_> = self
                     .retained_workspaces
                     .iter()
                     .filter(|workspace| workspace.read(cx).project_group_key(cx) == group.key)
                     .cloned()
-                    .collect(),
-                expanded: group.expanded,
+                    .collect();
+                if self.active_workspace.read(cx).project_group_key(cx) == group.key
+                    && !workspaces.contains(&self.active_workspace)
+                {
+                    workspaces.push(self.active_workspace.clone());
+                }
+                ProjectGroup {
+                    key: group.key.clone(),
+                    workspaces,
+                    expanded: group.expanded,
+                }
             })
             .collect()
     }
@@ -858,14 +866,22 @@ impl MultiWorkspace {
             || self
                 .retained_workspaces
                 .iter()
-                .any(|workspace| workspace.read(cx).project_group_key(cx) == *key);
+                .any(|workspace| workspace.read(cx).project_group_key(cx) == *key)
+            || self.active_workspace.read(cx).project_group_key(cx) == *key;
 
         has_group.then(|| {
-            self.retained_workspaces
+            let mut workspaces: Vec<_> = self
+                .retained_workspaces
                 .iter()
                 .filter(|workspace| workspace.read(cx).project_group_key(cx) == *key)
                 .cloned()
-                .collect()
+                .collect();
+            if self.active_workspace.read(cx).project_group_key(cx) == *key
+                && !workspaces.contains(&self.active_workspace)
+            {
+                workspaces.push(self.active_workspace.clone());
+            }
+            workspaces
         })
     }
 
@@ -1008,6 +1024,14 @@ impl MultiWorkspace {
                         window,
                         cx,
                     );
+                }
+
+                if let Some(existing_workspace) = this
+                    .workspaces()
+                    .find(|workspace| !excluded_workspaces.contains(workspace))
+                    .cloned()
+                {
+                    return Task::ready(Ok(existing_workspace));
                 }
 
                 // No other project groups remain — create an empty workspace.
@@ -1523,6 +1547,7 @@ impl MultiWorkspace {
                         .log_err();
                 }));
         }
+
     }
 
     fn sync_sidebar_to_workspace(&self, workspace: &Entity<Workspace>, cx: &mut Context<Self>) {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1169,63 +1169,28 @@ fn register_actions(
                 .detach();
             }
         })
-        .register_action({
-            let app_state = app_state.clone();
-            move |workspace, _: &CloseProject, window, cx| {
-                let Some(window_handle) = window.window_handle().downcast::<MultiWorkspace>() else {
-                    return;
-                };
-                let app_state = app_state.clone();
-                let old_group_key = workspace.project_group_key(cx);
-                cx.spawn_in(window, async move |this, cx| {
-                    let should_continue = this
-                        .update_in(cx, |workspace, window, cx| {
-                            workspace.prepare_to_close(
-                                CloseIntent::ReplaceWindow,
-                                window,
-                                cx,
-                            )
-                        })?
-                        .await?;
-                    if should_continue {
-                        let task = cx.update(|_window, cx| {
-                            open_new(
-                                workspace::OpenOptions {
-                                    requesting_window: Some(window_handle),
-                                    ..Default::default()
-                                },
-                                app_state,
-                                cx,
-                                |workspace, window, cx| {
-                                    cx.activate(true);
-                                    let project = workspace.project().clone();
-                                    let buffer = project.update(cx, |project, cx| {
-                                        project.create_local_buffer("", None, true, cx)
-                                    });
-                                    let editor = cx.new(|cx| {
-                                        Editor::for_buffer(buffer, Some(project), window, cx)
-                                    });
-                                    workspace.add_item_to_active_pane(
-                                        Box::new(editor),
-                                        None,
-                                        true,
-                                        window,
-                                        cx,
-                                    );
-                                },
-                            )
-                        })?;
-                        task.await?;
-                        window_handle.update(cx, |mw, window, cx| {
-                            mw.remove_project_group(&old_group_key, window, cx)
-                        })?.await.log_err();
-                        Ok::<(), anyhow::Error>(())
-                    } else {
-                        Ok(())
-                    }
-                })
-                .detach_and_log_err(cx);
-            }
+        .register_action(move |workspace, _: &CloseProject, window, cx| {
+            let Some(window_handle) = window.window_handle().downcast::<MultiWorkspace>() else {
+                return;
+            };
+            let old_group_key = workspace.project_group_key(cx);
+
+            cx.spawn_in(window, async move |_this, cx| {
+                window_handle
+                    .update(cx, |mw, window, cx| {
+                        mw.remove_project_group(&old_group_key, window, cx)
+                    })?
+                    .await?;
+                window_handle
+                    .update(cx, |mw, window, cx| {
+                        mw.focus_active_workspace(window, cx);
+                    })
+                    .ok();
+                let flush = window_handle.update(cx, |mw, _, _cx| mw.flush_serialization())?;
+                flush.await;
+                Ok::<(), anyhow::Error>(())
+            })
+            .detach_and_log_err(cx);
         })
         .register_action({
             let app_state = app_state.clone();


### PR DESCRIPTION
`workspace: close project` now follows the same project-group removal flow as sidebar `Remove Project`, so closing project in a multi-project window reliably switches to another remaining project instead of fallin back to an empty untitled workspace. 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54772 

Release Notes:
- fixed `Workspace: close project` not switching focus to another open project in multi-project windows
