### PR TITLE
gpui_web: Implement clipboard paste/copy/cut

### DIFF
--- a/crates/gpui_web/Cargo.toml
+++ b/crates/gpui_web/Cargo.toml
@@ -35,6 +35,7 @@ raw-window-handle = "0.6"
 wasm_thread = { version = "0.3", features = ["es_modules"], optional = true }
 web-sys = { version = "0.3", features = [
     "console",
+    "ClipboardEvent",
     "CompositionEvent",
     "CssStyleDeclaration",
     "DataTransfer",

--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -64,6 +64,9 @@ impl WebWindowInner {
             self.register_dragleave(),
             self.register_key_down(),
             self.register_key_up(),
+            self.register_paste(),
+            self.register_copy(),
+            self.register_cut(),
             self.register_composition_start(),
             self.register_composition_update(),
             self.register_composition_end(),
@@ -351,7 +354,22 @@ impl WebWindowInner {
                 return;
             }
 
-            event.prevent_default();
+            // Let the browser fire its native clipboard events for
+            // Cmd+V / Ctrl+V (paste), Cmd+C / Ctrl+C (copy), and
+            // Cmd+X / Ctrl+X (cut). The `register_paste` / `register_copy`
+            // / `register_cut` handlers below bridge them to the platform
+            // input handler.
+            let primary_modifier = if this.is_mac {
+                modifiers.platform
+            } else {
+                modifiers.control
+            };
+            let is_clipboard_shortcut =
+                primary_modifier && (key == "v" || key == "c" || key == "x");
+
+            if !is_clipboard_shortcut {
+                event.prevent_default();
+            }
 
             let is_held = event.repeat();
             let key_char = compute_key_char(&event, &key, &modifiers);
@@ -431,6 +449,65 @@ impl WebWindowInner {
         let this = Rc::clone(self);
         self.listen_input("compositionstart", move |_event: JsValue| {
             this.is_composing.set(true);
+        })
+    }
+
+    fn register_paste(self: &Rc<Self>) -> Closure<dyn FnMut(JsValue)> {
+        let this = Rc::clone(self);
+        self.listen_input("paste", move |event: JsValue| {
+            let event: web_sys::ClipboardEvent = event.unchecked_into();
+            let Some(data) = event.clipboard_data() else {
+                return;
+            };
+            let Ok(text) = data.get_data("text/plain") else {
+                return;
+            };
+            if text.is_empty() {
+                return;
+            }
+
+            // We handle the insertion ourselves; keep the browser from
+            // also pasting the text into our hidden capture `<input>`.
+            event.prevent_default();
+
+            this.with_input_handler(|handler| {
+                handler.replace_text_in_range(None, &text);
+            });
+        })
+    }
+
+    fn register_copy(self: &Rc<Self>) -> Closure<dyn FnMut(JsValue)> {
+        let this = Rc::clone(self);
+        self.listen_input("copy", move |event: JsValue| {
+            let event: web_sys::ClipboardEvent = event.unchecked_into();
+            let Some(data) = event.clipboard_data() else {
+                return;
+            };
+            let Some(text) = this.read_selected_text() else {
+                return;
+            };
+            event.prevent_default();
+            data.set_data("text/plain", &text).ok();
+        })
+    }
+
+    fn register_cut(self: &Rc<Self>) -> Closure<dyn FnMut(JsValue)> {
+        let this = Rc::clone(self);
+        self.listen_input("cut", move |event: JsValue| {
+            let event: web_sys::ClipboardEvent = event.unchecked_into();
+            let Some(data) = event.clipboard_data() else {
+                return;
+            };
+            let Some((range, text)) = this.read_selected_range_and_text() else {
+                return;
+            };
+            event.prevent_default();
+            if data.set_data("text/plain", &text).is_err() {
+                return;
+            }
+            this.with_input_handler(|handler| {
+                handler.replace_text_in_range(Some(range), "");
+            });
         })
     }
 

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -418,6 +418,29 @@ impl WebWindowInner {
         Some(result)
     }
 
+    /// Read the currently selected text via the platform input handler.
+    /// Returns `None` if no input is focused or nothing is selected.
+    pub(crate) fn read_selected_text(&self) -> Option<String> {
+        self.read_selected_range_and_text().map(|(_, text)| text)
+    }
+
+    /// As `read_selected_text`, but also returns the UTF-16 range — used
+    /// by cut, where we need to delete after copying.
+    pub(crate) fn read_selected_range_and_text(
+        &self,
+    ) -> Option<(std::ops::Range<usize>, String)> {
+        self.with_input_handler(|handler| {
+            let selection = handler.selected_text_range(true)?;
+            if selection.range.is_empty() {
+                return None;
+            }
+            let mut adjusted = None;
+            let text = handler.text_for_range(selection.range.clone(), &mut adjusted)?;
+            Some((selection.range, text))
+        })
+        .flatten()
+    }
+
     pub(crate) fn register_appearance_change(
         self: &Rc<Self>,
     ) -> Option<Closure<dyn FnMut(JsValue)>> {


### PR DESCRIPTION
Hook the browser's native `paste`, `copy`, and `cut` events on the window's hidden capture input element and bridge them to the `PlatformInputHandler`:
- paste: read clipboard text, replace selection via the input handler
- copy: read selected text via the input handler, write to clipboardData
- cut: read selected range+text, write to clipboardData, clear range

Exclude Cmd+V/Ctrl+V, Cmd+C/Ctrl+C, Cmd+X/Ctrl+X from the keydown `preventDefault()` such that the browser's clipboard event fires.

I used Claude to edit this and I tested all of it for my application. It works great :)

I am happy to clean this up a bit more, but I have some questions that I would like some input on how we should handle this before I would like to do that.