### PR TITLE
agent_ui: Add context usage indicator

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -4151,6 +4151,7 @@ mod tests {
                         interacted_at: None,
                         worktree_paths: WorktreePaths::from_folder_paths(&PathList::default()),
                         remote_connection: None,
+                        token_usage: None,
                         archived: false,
                     },
                     cx,

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -462,6 +462,7 @@ fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
     match event {
         AcpThreadEvent::NewEntry
         | AcpThreadEvent::TitleUpdated
+        | AcpThreadEvent::TokenUsageUpdated
         | AcpThreadEvent::ToolAuthorizationRequested(_)
         | AcpThreadEvent::ToolAuthorizationReceived(_)
         | AcpThreadEvent::Stopped(_)
@@ -473,7 +474,6 @@ fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
         AcpThreadEvent::EntryUpdated(_)
         | AcpThreadEvent::EntriesRemoved(_)
         | AcpThreadEvent::Retry(_)
-        | AcpThreadEvent::TokenUsageUpdated
         | AcpThreadEvent::PromptCapabilitiesUpdated
         | AcpThreadEvent::AvailableCommandsUpdated(_)
         | AcpThreadEvent::ModeUpdated(_)
@@ -952,6 +952,18 @@ impl ConversationView {
             this.update_in(cx, |this, window, cx| {
                 match result {
                     Ok(thread) => {
+                        if thread.read(cx).token_usage().is_none()
+                            && let Some(token_usage) = resume_session_id.as_ref().and_then(|id| {
+                                ThreadMetadataStore::try_global(cx)
+                                    .and_then(|store| store.read(cx).entry_by_session(id).cloned())
+                                    .and_then(|metadata| metadata.token_usage)
+                            })
+                        {
+                            thread.update(cx, |thread, cx| {
+                                thread.update_token_usage(Some(token_usage), cx);
+                            });
+                        }
+
                         let root_session_id = thread.read(cx).session_id().clone();
 
                         let conversation = cx.new(|cx| {
@@ -3438,6 +3450,7 @@ pub(crate) mod tests {
                         interacted_at: None,
                         worktree_paths: WorktreePaths::from_folder_paths(&PathList::default()),
                         remote_connection: None,
+                        token_usage: None,
                         archived: false,
                     },
                     cx,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3497,7 +3497,9 @@ impl ThreadView {
         };
 
         let progress_color = |ratio: f32| -> Hsla {
-            if ratio >= 0.85 {
+            if ratio >= 0.75 {
+                cx.theme().status().error
+            } else if ratio >= 0.6 {
                 cx.theme().status().warning
             } else {
                 cx.theme().colors().text_muted
@@ -3515,10 +3517,11 @@ impl ThreadView {
             0.0
         };
 
-        let ring_size = px(16.0);
+        let ring_size = px(14.0);
         let stroke_width = px(2.);
 
         let percentage = format!("{}%", (progress_ratio * 100.0).round() as u32);
+        let percentage_label = percentage.clone();
 
         let tooltip_separator_color = Color::Custom(cx.theme().colors().text_disabled.opacity(0.6));
 
@@ -3588,88 +3591,31 @@ impl ThreadView {
             }
         };
 
-        if show_split {
-            let input_max_raw = usage.max_tokens.saturating_sub(max_output_tokens);
-            let output_max_raw = max_output_tokens;
-
-            let input_ratio = if input_max_raw > 0 {
-                usage.input_tokens as f32 / input_max_raw as f32
-            } else {
-                0.0
-            };
-            let output_ratio = if output_max_raw > 0 {
-                usage.output_tokens as f32 / output_max_raw as f32
-            } else {
-                0.0
-            };
-
-            Some(
-                h_flex()
-                    .id("split_token_usage")
-                    .flex_shrink_0()
-                    .gap_1p5()
-                    .mr_1()
-                    .child(
-                        h_flex()
-                            .gap_0p5()
-                            .child(
-                                Icon::new(IconName::ArrowUp)
-                                    .size(IconSize::XSmall)
-                                    .color(Color::Muted),
-                            )
-                            .child(
-                                CircularProgress::new(
-                                    usage.input_tokens as f32,
-                                    input_max_raw as f32,
-                                    ring_size,
-                                    cx,
-                                )
-                                .stroke_width(stroke_width)
-                                .progress_color(progress_color(input_ratio)),
-                            ),
+        Some(
+            h_flex()
+                .id("context_usage_indicator")
+                .flex_shrink_0()
+                .items_center()
+                .gap_1()
+                .mr_1()
+                .child(
+                    CircularProgress::new(
+                        usage.used_tokens as f32,
+                        usage.max_tokens.max(1) as f32,
+                        ring_size,
+                        cx,
                     )
-                    .child(
-                        h_flex()
-                            .gap_0p5()
-                            .child(
-                                Icon::new(IconName::ArrowDown)
-                                    .size(IconSize::XSmall)
-                                    .color(Color::Muted),
-                            )
-                            .child(
-                                CircularProgress::new(
-                                    usage.output_tokens as f32,
-                                    output_max_raw as f32,
-                                    ring_size,
-                                    cx,
-                                )
-                                .stroke_width(stroke_width)
-                                .progress_color(progress_color(output_ratio)),
-                            ),
-                    )
-                    .hoverable_tooltip(build_tooltip)
-                    .into_any_element(),
-            )
-        } else {
-            Some(
-                h_flex()
-                    .id("circular_progress_tokens")
-                    .mt_px()
-                    .mr_1()
-                    .child(
-                        CircularProgress::new(
-                            usage.used_tokens as f32,
-                            usage.max_tokens as f32,
-                            ring_size,
-                            cx,
-                        )
-                        .stroke_width(stroke_width)
-                        .progress_color(progress_color(progress_ratio)),
-                    )
-                    .hoverable_tooltip(build_tooltip)
-                    .into_any_element(),
-            )
-        }
+                    .stroke_width(stroke_width)
+                    .progress_color(progress_color(progress_ratio)),
+                )
+                .child(
+                    Label::new(percentage_label)
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .tooltip(build_tooltip)
+                .into_any_element(),
+        )
     }
 
     fn fast_mode_available(&self, cx: &Context<Self>) -> bool {

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -595,6 +595,7 @@ fn collect_importable_threads(
                 interacted_at: None,
                 worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
                 remote_connection: remote_connection.clone(),
+                token_usage: None,
                 archived: true,
             });
         }

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -135,6 +135,7 @@ fn migrate_thread_metadata(cx: &mut App) -> Task<anyhow::Result<()>> {
                         interacted_at: None,
                         worktree_paths: WorktreePaths::from_folder_paths(&entry.folder_paths),
                         remote_connection: None,
+                        token_usage: None,
                         archived: true,
                     })
                 })
@@ -309,6 +310,7 @@ pub struct ThreadMetadata {
     pub interacted_at: Option<DateTime<Utc>>,
     pub worktree_paths: WorktreePaths,
     pub remote_connection: Option<RemoteConnectionOptions>,
+    pub token_usage: Option<acp_thread::TokenUsage>,
     pub archived: bool,
 }
 
@@ -1230,6 +1232,7 @@ impl ThreadMetadataStore {
             updated_at,
             worktree_paths,
             remote_connection,
+            token_usage: thread_ref.token_usage().cloned(),
             archived,
         };
 
@@ -1340,6 +1343,9 @@ impl Domain for ThreadMetadataDb {
         sql!(
             ALTER TABLE sidebar_threads ADD COLUMN interacted_at TEXT;
         ),
+        sql!(
+            ALTER TABLE sidebar_threads ADD COLUMN token_usage TEXT;
+        ),
     ];
 }
 
@@ -1357,7 +1363,7 @@ impl ThreadMetadataDb {
 
     const LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
         created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, \
-        main_worktree_paths_order, remote_connection \
+        main_worktree_paths_order, remote_connection, token_usage \
         FROM sidebar_threads \
         WHERE session_id IS NOT NULL \
         ORDER BY updated_at DESC";
@@ -1409,12 +1415,18 @@ impl ThreadMetadataDb {
             .map(serde_json::to_string)
             .transpose()
             .context("serialize thread metadata remote connection")?;
+        let token_usage = row
+            .token_usage
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .context("serialize thread metadata token usage")?;
         let thread_id = row.thread_id;
         let archived = row.archived;
 
         self.write(move |conn| {
-            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection) \
-                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection, token_usage) \
+                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
                        ON CONFLICT(thread_id) DO UPDATE SET \
                            session_id = excluded.session_id, \
                            agent_id = excluded.agent_id, \
@@ -1427,7 +1439,8 @@ impl ThreadMetadataDb {
                            archived = excluded.archived, \
                            main_worktree_paths = excluded.main_worktree_paths, \
                            main_worktree_paths_order = excluded.main_worktree_paths_order, \
-                           remote_connection = excluded.remote_connection";
+                           remote_connection = excluded.remote_connection, \
+                           token_usage = excluded.token_usage";
             let mut stmt = Statement::prepare(conn, sql)?;
             let mut i = stmt.bind(&thread_id, 1)?;
             i = stmt.bind(&session_id, i)?;
@@ -1441,7 +1454,8 @@ impl ThreadMetadataDb {
             i = stmt.bind(&archived, i)?;
             i = stmt.bind(&main_worktree_paths, i)?;
             i = stmt.bind(&main_worktree_paths_order, i)?;
-            stmt.bind(&remote_connection, i)?;
+            i = stmt.bind(&remote_connection, i)?;
+            stmt.bind(&token_usage, i)?;
             stmt.exec()
         })
         .await
@@ -1598,6 +1612,7 @@ impl Column for ThreadMetadata {
             Column::column(statement, next)?;
         let (remote_connection_json, next): (Option<String>, i32) =
             Column::column(statement, next)?;
+        let (token_usage_json, next): (Option<String>, i32) = Column::column(statement, next)?;
 
         let agent_id = agent_id
             .map(|id| AgentId::new(id))
@@ -1639,6 +1654,11 @@ impl Column for ThreadMetadata {
             .map(serde_json::from_str::<RemoteConnectionOptions>)
             .transpose()
             .context("deserialize thread metadata remote connection")?;
+        let token_usage = token_usage_json
+            .as_deref()
+            .map(serde_json::from_str::<acp_thread::TokenUsage>)
+            .transpose()
+            .context("deserialize thread metadata token usage")?;
 
         let worktree_paths = WorktreePaths::from_path_lists(main_worktree_paths, folder_paths)
             .unwrap_or_else(|_| WorktreePaths::default());
@@ -1660,6 +1680,7 @@ impl Column for ThreadMetadata {
                 interacted_at,
                 worktree_paths,
                 remote_connection,
+                token_usage,
                 archived,
             },
             next,
@@ -1749,6 +1770,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
             remote_connection: None,
+            token_usage: None,
         }
     }
 
@@ -1931,6 +1953,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: WorktreePaths::from_folder_paths(&second_paths),
             remote_connection: None,
+            token_usage: None,
             archived: false,
         };
 
@@ -2015,6 +2038,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: WorktreePaths::from_folder_paths(&project_a_paths),
             remote_connection: None,
+            token_usage: None,
             archived: false,
         };
 
@@ -2140,6 +2164,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: WorktreePaths::from_folder_paths(&project_paths),
             remote_connection: None,
+            token_usage: None,
             archived: false,
         };
 
@@ -2879,6 +2904,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: linked_worktree_paths.clone(),
             remote_connection: None,
+            token_usage: None,
         };
 
         let remote_linked_thread = ThreadMetadata {
@@ -2892,6 +2918,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: linked_worktree_paths,
             remote_connection: Some(remote_a.clone()),
+            token_usage: None,
         };
 
         cx.update(|cx| {


### PR DESCRIPTION
Adds a compact context usage indicator to the Agent Panel composer for ACP-backed sessions that report token usage.

The indicator appears alongside the composer controls near access, model, and effort selection. It shows a circular progress ring plus the current percentage, and keeps the existing detailed usage tooltip available on hover. The ring color now escalates from muted to warning at 60% usage and error at 75% usage, matching the higher urgency users need as the session approaches the context limit.

This builds on the existing ACP usage plumbing from #53894. That PR added storage for usage/cost updates and an initial usage UI; this PR makes the context state visible in the composer itself and persists the latest usage metadata so reopening an existing thread can show the indicator immediately, before the next message is sent.

Screenshots:

- Normal composer indicator at low usage: compact ring and percentage next to Full Access / model / effort controls.
- Full Agent Panel view showing the indicator in context.
- Hover tooltip showing context percentage and token counts.
- Warning/error states showing yellow above 60% and red above 75%.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Validation:

- `git diff --check`
- `cargo check -p agent_ui --all-targets --all-features`
- `./script/clippy -p agent_ui`

Release Notes:

- Added an Agent Panel composer indicator for ACP context usage.
