### PR TITLE
settings: Expand sensitive file patterns to prevent AI access

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -399,7 +399,7 @@
     "**/*.key",
     "**/*.pem",
     "**/*.tfstate",
-    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
     "**/id_{dsa,ecdsa,ed25519,rsa}*",
   ],
   // Whether to use additional LSP queries to format (and amend) the code after
@@ -1661,7 +1661,7 @@
       "**/*.key",
       "**/*.pem",
       "**/*.tfstate",
-      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
       "**/id_{dsa,ecdsa,ed25519,rsa}*",
       "**/.zed/settings.json", // zed project settings
       "/**/zed/settings.json", // zed user settings

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -393,7 +393,15 @@
   // The default number of context lines shown in multibuffer excerpts.
   "excerpt_context_lines": 2,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.{cert,crt}",
+    "**/*.key",
+    "**/*.pem",
+    "**/*.tfstate",
+    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    "**/id_{dsa,ecdsa,ed25519,rsa}*",
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -1647,13 +1655,14 @@
     // Globs are matched relative to the worktree root,
     // except when starting with a slash (/) or equivalent in Windows.
     "disabled_globs": [
-      "**/.env*",
-      "**/*.pem",
-      "**/*.key",
-      "**/*.cert",
-      "**/*.crt",
       "**/.dev.vars",
-      "**/secrets.yml",
+      "**/.env*",
+      "**/*.{cert,crt}",
+      "**/*.key",
+      "**/*.pem",
+      "**/*.tfstate",
+      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+      "**/id_{dsa,ecdsa,ed25519,rsa}*",
       "**/.zed/settings.json", // zed project settings
       "/**/zed/settings.json", // zed user settings
       "/**/zed/keymap.json",

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -121,7 +121,15 @@ pub struct WorktreeSettingsContent {
     pub file_scan_inclusions: Option<Vec<String>>,
 
     /// Treat the files matching these globs as `.env` files.
-    /// Default: ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"]
+    /// Default: [
+    ///   "**/.env*",
+    ///   "**/*.pem",
+    ///   "**/*.key",
+    ///   "**/*.{cert,crt}",
+    ///   "**/*.tfstate",
+    ///   "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    ///   "**/id_{dsa,ecdsa,ed25519,rsa}*",
+    /// ]
     pub private_files: Option<ExtendingVec<String>>,
 
     /// Treat the files matching these globs as hidden files. You can hide hidden files in the project panel.

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -127,7 +127,7 @@ pub struct WorktreeSettingsContent {
     ///   "**/*.key",
     ///   "**/*.{cert,crt}",
     ///   "**/*.tfstate",
-    ///   "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    ///   "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
     ///   "**/id_{dsa,ecdsa,ed25519,rsa}*",
     /// ]
     pub private_files: Option<ExtendingVec<String>>,

--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -102,7 +102,7 @@ Certain files are always excluded from edit predictions—regardless of opt-in s
       "**/*.key",
       "**/*.pem",
       "**/*.tfstate",
-      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
       "**/id_{dsa,ecdsa,ed25519,rsa}*"
     ]
   }

--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -103,7 +103,10 @@ Certain files are always excluded from edit predictions—regardless of opt-in s
       "**/*.pem",
       "**/*.tfstate",
       "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
-      "**/id_{dsa,ecdsa,ed25519,rsa}*"
+      "**/id_{dsa,ecdsa,ed25519,rsa}*",
+      "**/.zed/settings.json", // zed project settings
+      "/**/zed/settings.json", // zed user settings
+      "/**/zed/keymap.json",
     ]
   }
 }

--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -96,12 +96,14 @@ Certain files are always excluded from edit predictions—regardless of opt-in s
 {
   "edit_predictions": {
     "disabled_globs": [
+      "**/.dev.vars",
       "**/.env*",
-      "**/*.pem",
+      "**/*.{cert,crt}",
       "**/*.key",
-      "**/*.cert",
-      "**/*.crt",
-      "**/secrets.yml"
+      "**/*.pem",
+      "**/*.tfstate",
+      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+      "**/id_{dsa,ecdsa,ed25519,rsa}*",
     ]
   }
 }

--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -106,7 +106,7 @@ Certain files are always excluded from edit predictions—regardless of opt-in s
       "**/id_{dsa,ecdsa,ed25519,rsa}*",
       "**/.zed/settings.json", // zed project settings
       "/**/zed/settings.json", // zed user settings
-      "/**/zed/keymap.json",
+      "/**/zed/keymap.json"
     ]
   }
 }

--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -103,7 +103,7 @@ Certain files are always excluded from edit predictions—regardless of opt-in s
       "**/*.pem",
       "**/*.tfstate",
       "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
-      "**/id_{dsa,ecdsa,ed25519,rsa}*",
+      "**/id_{dsa,ecdsa,ed25519,rsa}*"
     ]
   }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -634,19 +634,19 @@ For the case of "open", regular selection behavior can be achieved by holding `a
 - Default:
 
 ```json [settings]
-  [
-    "**/.dev.vars",
-    "**/.env*",
-    "**/*.{cert,crt}",
-    "**/*.key",
-    "**/*.pem",
-    "**/*.tfstate",
-    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
-    "**/id_{dsa,ecdsa,ed25519,rsa}*",
-    "**/.zed/settings.json", // zed project settings
-    "/**/zed/settings.json", // zed user settings
-    "/**/zed/keymap.json",
-  ]
+[
+  "**/.dev.vars",
+  "**/.env*",
+  "**/*.{cert,crt}",
+  "**/*.key",
+  "**/*.pem",
+  "**/*.tfstate",
+  "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+  "**/id_{dsa,ecdsa,ed25519,rsa}*",
+  "**/.zed/settings.json", // zed project settings
+  "/**/zed/settings.json", // zed user settings
+  "/**/zed/keymap.json"
+]
 ```
 
 **Options**

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -610,13 +610,17 @@ For the case of "open", regular selection behavior can be achieved by holding `a
 ```json [settings]
   "edit_predictions": {
     "disabled_globs": [
-      "**/.env*",
-      "**/*.pem",
-      "**/*.key",
-      "**/*.cert",
-      "**/*.crt",
       "**/.dev.vars",
-      "**/secrets.yml"
+      "**/.env*",
+      "**/*.{cert,crt}",
+      "**/*.key",
+      "**/*.pem",
+      "**/*.tfstate",
+      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+      "**/id_{dsa,ecdsa,ed25519,rsa}*",
+      "**/.zed/settings.json", // zed project settings
+      "/**/zed/settings.json", // zed user settings
+      "/**/zed/keymap.json",
     ]
   }
 ```
@@ -627,7 +631,23 @@ For the case of "open", regular selection behavior can be achieved by holding `a
 
 - Description: A list of globs for which edit predictions should be disabled for. This list adds to a pre-existing, sensible default set of globs. Any additional ones you add are combined with them.
 - Setting: `disabled_globs`
-- Default: `["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/.dev.vars", "**/secrets.yml"]`
+- Default:
+
+```json [settings]
+  [
+    "**/.dev.vars",
+    "**/.env*",
+    "**/*.{cert,crt}",
+    "**/*.key",
+    "**/*.pem",
+    "**/*.tfstate",
+    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    "**/id_{dsa,ecdsa,ed25519,rsa}*",
+    "**/.zed/settings.json", // zed project settings
+    "/**/zed/settings.json", // zed user settings
+    "/**/zed/keymap.json",
+  ]
+```
 
 **Options**
 
@@ -3355,7 +3375,19 @@ Examples:
 
 - Description: Globs to match against file paths to determine if a file is private
 - Setting: `private_files`
-- Default: `["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"]`
+- Default:
+
+```json[settings]
+  [
+    "**/.env*",
+    "**/*.{cert,crt}",
+    "**/*.key",
+    "**/*.pem",
+    "**/*.tfstate",
+    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    "**/id_{dsa,ecdsa,ed25519,rsa}*",
+  ]
+```
 
 **Options**
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -631,23 +631,7 @@ For the case of "open", regular selection behavior can be achieved by holding `a
 
 - Description: A list of globs for which edit predictions should be disabled for. This list adds to a pre-existing, sensible default set of globs. Any additional ones you add are combined with them.
 - Setting: `disabled_globs`
-- Default:
-
-```json [settings]
-[
-  "**/.dev.vars",
-  "**/.env*",
-  "**/*.{cert,crt}",
-  "**/*.key",
-  "**/*.pem",
-  "**/*.tfstate",
-  "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
-  "**/id_{dsa,ecdsa,ed25519,rsa}*",
-  "**/.zed/settings.json", // zed project settings
-  "/**/zed/settings.json", // zed user settings
-  "/**/zed/keymap.json"
-]
-```
+- Default: `["**/.dev.vars", "**/.env*", "**/*.{cert,crt}", "**/*.key", "**/*.pem", "**/*.tfstate", "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", "**/id_{dsa,ecdsa,ed25519,rsa}*", "**/.zed/settings.json", "/**/zed/settings.json", "/**/zed/keymap.json"]`
 
 **Options**
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -616,7 +616,7 @@ For the case of "open", regular selection behavior can be achieved by holding `a
       "**/*.key",
       "**/*.pem",
       "**/*.tfstate",
-      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+      "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
       "**/id_{dsa,ecdsa,ed25519,rsa}*",
       "**/.zed/settings.json", // zed project settings
       "/**/zed/settings.json", // zed user settings
@@ -3368,7 +3368,7 @@ Examples:
     "**/*.key",
     "**/*.pem",
     "**/*.tfstate",
-    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}",
+    "**/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}", // secrets.tfvars and similar files
     "**/id_{dsa,ecdsa,ed25519,rsa}*",
   ]
 ```


### PR DESCRIPTION
Previously, private_files and edit_predictions.disabled_globs only blocked
a limited set of sensitive files (secrets.yml, .env*, .pem, .key, .cert, .crt).
This adds broader patterns to catch more sensitive file types:

- Certificate files: **/*.{cert,crt}
- Private key files: **/*.key
- SSH private keys: **/id_{dsa,ecdsa,ed25519,rsa}*
- Terraform state: **/*.tfstate
- Sensitive config files: **/*{credential,password,secret}*.{json,tfvars,toml,xml,yaml,yml}

The new patterns catch files like secrets.json, credentials.yaml, prod-password.tfvars,
and various SSH key file names that were previously missed.

---

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- settings: Expanded sensitive file patterns to prevent AI access
