### PR TITLE
Enable Vim/Helix keybindings when the base keymap is set to None

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2074,16 +2074,16 @@ fn reload_keymaps(cx: &mut App, mut user_key_bindings: Vec<KeyBinding>) {
 
 pub fn load_default_keymap(cx: &mut App) {
     let base_keymap = *BaseKeymap::get_global(cx);
-    if base_keymap == BaseKeymap::None {
-        return;
-    }
+    if base_keymap != BaseKeymap::None {
+        cx.bind_keys(
+            KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, Some(KeybindSource::Default), cx).unwrap(),
+        );
 
-    cx.bind_keys(
-        KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, Some(KeybindSource::Default), cx).unwrap(),
-    );
-
-    if let Some(asset_path) = base_keymap.asset_path() {
-        cx.bind_keys(KeymapFile::load_asset(asset_path, Some(KeybindSource::Base), cx).unwrap());
+        if let Some(asset_path) = base_keymap.asset_path() {
+            cx.bind_keys(
+                KeymapFile::load_asset(asset_path, Some(KeybindSource::Base), cx).unwrap(),
+            );
+        }
     }
 
     if VimModeSetting::get_global(cx).0 || vim_mode_setting::HelixModeSetting::get_global(cx).0 {


### PR DESCRIPTION
Hi! 👋 When `base_keymap` is set to `None`, it disables all the keybindings, even if `vim_mode` or `helix_mode` is enabled. However, I think the Vim/Helix keybindings should be applied on top of the empty base keymap.

My use case for this is to start with the minimal set of Vim/Helix key shortcuts and add other bindings on top of that, instead of flooding the keymap with hundreds of predefined shortcuts from some base keymap.