### PR TITLE
svg_preview: Add zoom and pan support

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1532,6 +1532,17 @@
     },
   },
   {
+    "context": "SvgPreview",
+    "bindings": {
+      "ctrl-=": "svg::ZoomIn",
+      "ctrl-+": "svg::ZoomIn",
+      "ctrl--": "svg::ZoomOut",
+      "ctrl-0": "svg::ResetZoom",
+      "ctrl-1": "svg::ZoomToActualSize",
+      "ctrl-shift-0": "svg::FitToView",
+    },
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "alt-1": "new_process_modal::ActivateTaskTab",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1594,6 +1594,18 @@
     },
   },
   {
+    "context": "SvgPreview",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-=": "svg::ZoomIn",
+      "cmd-+": "svg::ZoomIn",
+      "cmd--": "svg::ZoomOut",
+      "cmd-0": "svg::ResetZoom",
+      "cmd-1": "svg::ZoomToActualSize",
+      "cmd-shift-0": "svg::FitToView",
+    },
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "cmd-1": "new_process_modal::ActivateTaskTab",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1512,6 +1512,17 @@
     },
   },
   {
+    "context": "SvgPreview",
+    "bindings": {
+      "ctrl-=": "svg::ZoomIn",
+      "ctrl-+": "svg::ZoomIn",
+      "ctrl--": "svg::ZoomOut",
+      "ctrl-0": "svg::ResetZoom",
+      "ctrl-1": "svg::ZoomToActualSize",
+      "ctrl-shift-0": "svg::FitToView",
+    },
+  },
+  {
     "context": "RunModal",
     "bindings": {
       "alt-1": "new_process_modal::ActivateTaskTab",

--- a/crates/svg_preview/src/svg_preview.rs
+++ b/crates/svg_preview/src/svg_preview.rs
@@ -9,7 +9,17 @@ actions!(
     svg,
     [
         /// Opens a following SVG preview that syncs with the editor.
-        OpenFollowingPreview
+        OpenFollowingPreview,
+        /// Zoom in the SVG preview.
+        ZoomIn,
+        /// Zoom out the SVG preview.
+        ZoomOut,
+        /// Reset zoom to 100%.
+        ResetZoom,
+        /// Fit the SVG to view.
+        FitToView,
+        /// Zoom to actual size (100%).
+        ZoomToActualSize,
     ]
 );
 

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -3,21 +3,36 @@ use std::sync::Arc;
 
 use file_icons::FileIcons;
 use gpui::{
-    App, Context, Entity, EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement, Render,
-    RenderImage, Styled, Subscription, Task, WeakEntity, Window, div, img,
+    AnyElement, App, Bounds, Context, DispatchPhase, Element, ElementId, Entity, EventEmitter,
+    FocusHandle, Focusable, Font, GlobalElementId, InspectorElementId, InteractiveElement,
+    IntoElement, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    ParentElement, PinchEvent, Pixels, Point, Render, RenderImage, ScrollDelta, ScrollWheelEvent,
+    Style, Styled, Subscription, Task, WeakEntity, Window, div, img, point, px, relative, size,
 };
-use language::{Buffer, BufferEvent};
+use language::{Buffer, BufferEvent, HighlightedText};
 use multi_buffer::MultiBuffer;
-use ui::prelude::*;
-use workspace::item::Item;
-use workspace::{Pane, Workspace};
+use ui::{Tooltip, prelude::*};
+use workspace::item::{Item, ItemHandle};
+use workspace::{Pane, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace};
 
-use crate::{OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide};
+use crate::{
+    FitToView, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ResetZoom, ZoomIn, ZoomOut,
+    ZoomToActualSize,
+};
+
+const MIN_ZOOM: f32 = 0.1;
+const MAX_ZOOM: f32 = 20.0;
+const ZOOM_STEP: f32 = 1.1;
+const SCROLL_LINE_MULTIPLIER: f32 = 20.0;
 
 pub struct SvgPreviewView {
     focus_handle: FocusHandle,
     buffer: Option<Entity<Buffer>>,
     current_svg: Option<Result<Arc<RenderImage>, SharedString>>,
+    zoom_level: f32,
+    pan_offset: Point<Pixels>,
+    last_mouse_position: Option<Point<Pixels>>,
+    container_bounds: Option<Bounds<Pixels>>,
     _refresh: Task<()>,
     _buffer_subscription: Option<Subscription>,
     _workspace_subscription: Option<Subscription>,
@@ -58,6 +73,10 @@ impl SvgPreviewView {
                 focus_handle: cx.focus_handle(),
                 buffer,
                 current_svg: None,
+                zoom_level: 1.0,
+                pan_offset: Point::default(),
+                last_mouse_position: None,
+                container_bounds: None,
                 _buffer_subscription: subscription,
                 _workspace_subscription: workspace_subscription,
                 _refresh: Task::ready(()),
@@ -66,6 +85,153 @@ impl SvgPreviewView {
 
             this
         })
+    }
+
+    fn is_dragging(&self) -> bool {
+        self.last_mouse_position.is_some()
+    }
+
+    fn image_size(&self) -> Option<(u32, u32)> {
+        let Some(Ok(image)) = self.current_svg.as_ref() else {
+            return None;
+        };
+        let size = image.size(0);
+        Some((size.width.0 as u32, size.height.0 as u32))
+    }
+
+    fn zoom_in(&mut self, _: &ZoomIn, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(self.zoom_level * ZOOM_STEP, None, cx);
+    }
+
+    fn zoom_out(&mut self, _: &ZoomOut, _window: &mut Window, cx: &mut Context<Self>) {
+        self.set_zoom(self.zoom_level / ZOOM_STEP, None, cx);
+    }
+
+    fn reset_zoom(&mut self, _: &ResetZoom, _window: &mut Window, cx: &mut Context<Self>) {
+        self.zoom_level = 1.0;
+        self.pan_offset = Point::default();
+        cx.notify();
+    }
+
+    fn fit_to_view(&mut self, _: &FitToView, _window: &mut Window, cx: &mut Context<Self>) {
+        if let Some((bounds, image_size)) = self.container_bounds.zip(self.image_size()) {
+            self.zoom_level = Self::compute_fit_to_view_zoom(bounds, image_size);
+            self.pan_offset = Point::default();
+            cx.notify();
+        }
+    }
+
+    fn zoom_to_actual_size(
+        &mut self,
+        _: &ZoomToActualSize,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.zoom_level = 1.0;
+        self.pan_offset = Point::default();
+        cx.notify();
+    }
+
+    fn compute_fit_to_view_zoom(container_bounds: Bounds<Pixels>, image_size: (u32, u32)) -> f32 {
+        let (image_width, image_height) = image_size;
+        let container_width: f32 = container_bounds.size.width.into();
+        let container_height: f32 = container_bounds.size.height.into();
+        let scale_x = container_width / image_width as f32;
+        let scale_y = container_height / image_height as f32;
+        scale_x.min(scale_y).min(1.0)
+    }
+
+    fn set_zoom(
+        &mut self,
+        new_zoom: f32,
+        zoom_center: Option<Point<Pixels>>,
+        cx: &mut Context<Self>,
+    ) {
+        let old_zoom = self.zoom_level;
+        self.zoom_level = new_zoom.clamp(MIN_ZOOM, MAX_ZOOM);
+
+        if let Some((center, bounds)) = zoom_center.zip(self.container_bounds) {
+            let relative_center = point(
+                center.x - bounds.origin.x - bounds.size.width / 2.0,
+                center.y - bounds.origin.y - bounds.size.height / 2.0,
+            );
+
+            let mouse_offset_from_image = relative_center - self.pan_offset;
+            let zoom_ratio = self.zoom_level / old_zoom;
+            self.pan_offset += mouse_offset_from_image * (1.0 - zoom_ratio);
+        }
+
+        cx.notify();
+    }
+
+    fn handle_scroll_wheel(
+        &mut self,
+        event: &ScrollWheelEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.modifiers.control || event.modifiers.platform {
+            let delta: f32 = match event.delta {
+                ScrollDelta::Pixels(pixels) => pixels.y.into(),
+                ScrollDelta::Lines(lines) => lines.y * SCROLL_LINE_MULTIPLIER,
+            };
+            let zoom_factor = if delta > 0.0 {
+                1.0 + delta.abs() * 0.01
+            } else {
+                1.0 / (1.0 + delta.abs() * 0.01)
+            };
+            self.set_zoom(self.zoom_level * zoom_factor, Some(event.position), cx);
+        } else {
+            let delta = match event.delta {
+                ScrollDelta::Pixels(pixels) => pixels,
+                ScrollDelta::Lines(lines) => lines.map(|d| px(d * SCROLL_LINE_MULTIPLIER)),
+            };
+            self.pan_offset += delta;
+            cx.notify();
+        }
+    }
+
+    fn handle_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.button == MouseButton::Left || event.button == MouseButton::Middle {
+            self.last_mouse_position = Some(event.position);
+            cx.notify();
+        }
+    }
+
+    fn handle_mouse_up(
+        &mut self,
+        _event: &MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.last_mouse_position = None;
+        cx.notify();
+    }
+
+    fn handle_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.is_dragging() {
+            if let Some(last_pos) = self.last_mouse_position {
+                let delta = event.position - last_pos;
+                self.pan_offset += delta;
+            }
+            self.last_mouse_position = Some(event.position);
+            cx.notify();
+        }
+    }
+
+    fn handle_pinch(&mut self, event: &PinchEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        let zoom_factor = 1.0 + event.delta;
+        self.set_zoom(self.zoom_level * zoom_factor, Some(event.position), cx);
     }
 
     fn subscribe_to_workspace(
@@ -277,30 +443,189 @@ impl SvgPreviewView {
     }
 }
 
+struct SvgContentElement {
+    view: Entity<SvgPreviewView>,
+}
+
+impl SvgContentElement {
+    fn new(view: Entity<SvgPreviewView>) -> Self {
+        Self { view }
+    }
+}
+
+impl IntoElement for SvgContentElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for SvgContentElement {
+    type RequestLayoutState = ();
+    type PrepaintState = Option<(AnyElement, bool)>;
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        (
+            window.request_layout(
+                Style {
+                    size: size(relative(1.).into(), relative(1.).into()),
+                    ..Default::default()
+                },
+                [],
+                cx,
+            ),
+            (),
+        )
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        let view = self.view.read(cx);
+        let Some(Ok(image)) = view.current_svg.clone() else {
+            return None;
+        };
+        let image_size = view.image_size()?;
+
+        let first_layout = view.container_bounds.is_none();
+        let initial_zoom_level =
+            first_layout.then(|| SvgPreviewView::compute_fit_to_view_zoom(bounds, image_size));
+        let zoom_level = initial_zoom_level.unwrap_or(view.zoom_level);
+        let pan_offset = view.pan_offset;
+        let is_dragging = view.is_dragging();
+
+        let scaled_width = px(image_size.0 as f32 * zoom_level);
+        let scaled_height = px(image_size.1 as f32 * zoom_level);
+
+        let center_x = bounds.size.width / 2.0;
+        let center_y = bounds.size.height / 2.0;
+        let left = center_x - (scaled_width / 2.0) + pan_offset.x;
+        let top = center_y - (scaled_height / 2.0) + pan_offset.y;
+
+        self.view.update(cx, |this, _| {
+            this.container_bounds = Some(bounds);
+            if let Some(initial_zoom_level) = initial_zoom_level {
+                this.zoom_level = initial_zoom_level;
+            }
+        });
+
+        let entity_id = self.view.entity_id();
+        let mut content = div()
+            .relative()
+            .size_full()
+            .child(
+                div()
+                    .absolute()
+                    .left(left)
+                    .top(top)
+                    .w(scaled_width)
+                    .h(scaled_height)
+                    .child(img(image).id(("svg-preview-image", entity_id)).size_full()),
+            )
+            .into_any_element();
+
+        content.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);
+        Some((content, is_dragging))
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let Some((mut element, is_dragging)) = prepaint.take() else {
+            return;
+        };
+
+        if is_dragging {
+            let view = self.view.downgrade();
+            window.on_mouse_event(move |_event: &MouseUpEvent, phase, _window, cx| {
+                if phase == DispatchPhase::Bubble
+                    && let Some(entity) = view.upgrade()
+                {
+                    entity.update(cx, |this, cx| {
+                        this.last_mouse_position = None;
+                        cx.notify();
+                    });
+                }
+            });
+        }
+
+        element.paint(window, cx);
+    }
+}
+
 impl Render for SvgPreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex()
+        div()
             .id("SvgPreview")
             .key_context("SvgPreview")
             .track_focus(&self.focus_handle(cx))
+            .on_action(cx.listener(Self::zoom_in))
+            .on_action(cx.listener(Self::zoom_out))
+            .on_action(cx.listener(Self::reset_zoom))
+            .on_action(cx.listener(Self::fit_to_view))
+            .on_action(cx.listener(Self::zoom_to_actual_size))
             .size_full()
+            .relative()
             .bg(cx.theme().colors().editor_background)
-            .flex()
-            .justify_center()
-            .items_center()
-            .map(|this| match self.current_svg.clone() {
-                Some(Ok(image)) => {
-                    this.child(img(image).max_w_full().max_h_full().with_fallback(|| {
-                        h_flex()
-                            .p_4()
-                            .gap_2()
-                            .child(Icon::new(IconName::Warning))
-                            .child("Failed to load SVG image")
-                            .into_any_element()
-                    }))
-                }
-                Some(Err(e)) => this.child(div().p_4().child(e).into_any_element()),
-                None => this.child(div().p_4().child("No SVG file selected")),
+            .child(match &self.current_svg {
+                Some(Ok(_)) => div()
+                    .id("svg-container")
+                    .size_full()
+                    .overflow_hidden()
+                    .cursor(if self.is_dragging() {
+                        gpui::CursorStyle::ClosedHand
+                    } else {
+                        gpui::CursorStyle::OpenHand
+                    })
+                    .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel))
+                    .on_pinch(cx.listener(Self::handle_pinch))
+                    .on_mouse_down(MouseButton::Left, cx.listener(Self::handle_mouse_down))
+                    .on_mouse_down(MouseButton::Middle, cx.listener(Self::handle_mouse_down))
+                    .on_mouse_up(MouseButton::Left, cx.listener(Self::handle_mouse_up))
+                    .on_mouse_up(MouseButton::Middle, cx.listener(Self::handle_mouse_up))
+                    .on_mouse_move(cx.listener(Self::handle_mouse_move))
+                    .child(SvgContentElement::new(cx.entity()))
+                    .into_any_element(),
+                Some(Err(e)) => h_flex()
+                    .size_full()
+                    .justify_center()
+                    .items_center()
+                    .child(div().p_4().child(e.clone()))
+                    .into_any_element(),
+                None => h_flex()
+                    .size_full()
+                    .justify_center()
+                    .items_center()
+                    .child(div().p_4().child("No SVG file selected"))
+                    .into_any_element(),
             })
     }
 }
@@ -337,5 +662,145 @@ impl Item for SvgPreviewView {
         Some("svg preview: open")
     }
 
+    fn breadcrumb_location(&self, _cx: &App) -> ToolbarItemLocation {
+        ToolbarItemLocation::PrimaryLeft
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<(Vec<HighlightedText>, Option<Font>)> {
+        let text: SharedString = self
+            .buffer
+            .as_ref()
+            .and_then(|buffer| buffer.read(cx).file())
+            .map(|file| format!("{}", file.file_name(cx)).into())?;
+
+        Some((
+            vec![HighlightedText {
+                text,
+                highlights: vec![],
+            }],
+            None,
+        ))
+    }
+
     fn to_item_events(_event: &Self::Event, _f: &mut dyn FnMut(workspace::item::ItemEvent)) {}
+}
+
+pub struct SvgPreviewToolbarControls {
+    view: Option<WeakEntity<SvgPreviewView>>,
+    _subscription: Option<Subscription>,
+}
+
+impl SvgPreviewToolbarControls {
+    pub fn new() -> Self {
+        Self {
+            view: None,
+            _subscription: None,
+        }
+    }
+}
+
+impl Default for SvgPreviewToolbarControls {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Render for SvgPreviewToolbarControls {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(view) = self.view.as_ref().and_then(|v| v.upgrade()) else {
+            return div().into_any_element();
+        };
+
+        let zoom_level = view.read(cx).zoom_level;
+        let zoom_percentage = format!("{}%", (zoom_level * 100.0).round() as i32);
+
+        h_flex()
+            .gap_1()
+            .child(
+                IconButton::new("zoom-out", IconName::Dash)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Zoom Out", &ZoomOut, cx))
+                    .on_click({
+                        let view = view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.zoom_out(&ZoomOut, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                Button::new("zoom-level", zoom_percentage)
+                    .label_size(LabelSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Reset Zoom", &ResetZoom, cx))
+                    .on_click({
+                        let view = view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.reset_zoom(&ResetZoom, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                IconButton::new("zoom-in", IconName::Plus)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Zoom In", &ZoomIn, cx))
+                    .on_click({
+                        let view = view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.zoom_in(&ZoomIn, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .child(
+                IconButton::new("fit-to-view", IconName::Maximize)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|_window, cx| Tooltip::for_action("Fit to View", &FitToView, cx))
+                    .on_click({
+                        let view = view.downgrade();
+                        move |_, window, cx| {
+                            if let Some(view) = view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.fit_to_view(&FitToView, window, cx);
+                                });
+                            }
+                        }
+                    }),
+            )
+            .into_any_element()
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for SvgPreviewToolbarControls {}
+
+impl ToolbarItemView for SvgPreviewToolbarControls {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        self.view = None;
+        self._subscription = None;
+
+        if let Some(item) = active_pane_item.and_then(|i| i.downcast::<SvgPreviewView>()) {
+            self._subscription = Some(cx.observe(&item, |_, _, cx| {
+                cx.notify();
+            }));
+            self.view = Some(item.downgrade());
+            cx.notify();
+            return ToolbarItemLocation::PrimaryRight;
+        }
+
+        ToolbarItemLocation::Hidden
+    }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1418,6 +1418,8 @@ fn initialize_pane(
             toolbar.add_item(basedpyright_banner, window, cx);
             let image_view_toolbar = cx.new(|_| image_viewer::ImageViewToolbarControls::new());
             toolbar.add_item(image_view_toolbar, window, cx);
+            let svg_preview_toolbar = cx.new(|_| svg_preview::svg_preview_view::SvgPreviewToolbarControls::new());
+            toolbar.add_item(svg_preview_toolbar, window, cx);
         })
     });
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1418,7 +1418,8 @@ fn initialize_pane(
             toolbar.add_item(basedpyright_banner, window, cx);
             let image_view_toolbar = cx.new(|_| image_viewer::ImageViewToolbarControls::new());
             toolbar.add_item(image_view_toolbar, window, cx);
-            let svg_preview_toolbar = cx.new(|_| svg_preview::svg_preview_view::SvgPreviewToolbarControls::new());
+            let svg_preview_toolbar =
+                cx.new(|_| svg_preview::svg_preview_view::SvgPreviewToolbarControls::new());
             toolbar.add_item(svg_preview_toolbar, window, cx);
         })
     });


### PR DESCRIPTION
Adds zoom and pan to the SVG preview, matching the behavior of the
image viewer for PNG/JPG/GIF. Previously, opening the SVG preview
showed the rasterized image with no way to interact with it.

#### Changes:
- Added `svg::ZoomIn`, `svg::ZoomOut`, `svg::ResetZoom`, `svg::FitToView`, and `svg::ZoomToActualSize` actions.
- Added zoom/pan state to `SvgPreviewView` (`zoom_level`, `pan_offset`,  `last_mouse_position`, `container_bounds`) along with handlers for scroll wheel (Ctrl/Cmd to zoom toward cursor, plain scroll to pan), trackpad pinch, and click-and-drag pan with cursor swap (open-hand ↔ closed-hand).
- Introduced a `SvgContentElement` that captures container bounds during prepaint, so the rendered SVG can be centered, scaled by `zoom_level`, and offset by `pan_offset`. The first layout auto-fits the SVG to the viewport.
- Added `SvgPreviewToolbarControls` — a toolbar item that appears in the right slot when an SVG preview is active, showing `−`, the current zoom percentage (click to reset), `+`, and a fit-to-view button, all with action-aware tooltips.
- Implemented `breadcrumb_location` and `breadcrumbs` on the `SvgPreviewView` `Item` impl so the file name appears on the left side of the toolbar, mirroring the image viewer.
- Registered the new toolbar item in `zed.rs` next to `ImageViewToolbarControls`.
- Added a `SvgPreview` keymap context with bindings for the new actions in `default-macos.json`, `default-linux.json`, and `default-windows.json` — same shortcuts as the image viewer (`cmd/ctrl + =/+/-/0/1/shift-0`).

#### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable.

#### Closes #54802

Video :

[Screencast from 2026-04-26 12-00-42.webm](https://github.com/user-attachments/assets/b9238690-8b5b-4621-9d64-3a4f81405208)


Release Notes:

- Fixed zoom and pan not working in the SVG preview.
