### PR TITLE
open_ai: Use responses API for all models

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -384,7 +384,22 @@ impl LanguageModel for OpenAiLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        if self.model.supports_chat_completions() {
+        if self.model.uses_responses_api() {
+            let request = into_open_ai_response(
+                request,
+                self.model.id(),
+                self.model.supports_parallel_tool_calls(),
+                self.model.supports_prompt_cache_key(),
+                self.max_output_tokens(),
+                self.model.reasoning_effort(),
+            );
+            let completions = self.stream_response(request, cx);
+            async move {
+                let mapper = OpenAiResponseEventMapper::new();
+                Ok(mapper.map_stream(completions.await?).boxed())
+            }
+            .boxed()
+        } else {
             let request = into_open_ai(
                 request,
                 self.model.id(),
@@ -397,21 +412,6 @@ impl LanguageModel for OpenAiLanguageModel {
             let completions = self.stream_completion(request, cx);
             async move {
                 let mapper = OpenAiEventMapper::new();
-                Ok(mapper.map_stream(completions.await?).boxed())
-            }
-            .boxed()
-        } else {
-            let request = into_open_ai_response(
-                request,
-                self.model.id(),
-                self.model.supports_parallel_tool_calls(),
-                self.model.supports_prompt_cache_key(),
-                self.max_output_tokens(),
-                self.model.reasoning_effort(),
-            );
-            let completions = self.stream_response(request, cx);
-            async move {
-                let mapper = OpenAiResponseEventMapper::new();
                 Ok(mapper.map_stream(completions.await?).boxed())
             }
             .boxed()

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -272,18 +272,30 @@ impl Model {
         }
     }
 
-    pub fn supports_chat_completions(&self) -> bool {
+    pub fn uses_responses_api(&self) -> bool {
         match self {
             Self::Custom {
                 supports_chat_completions,
                 ..
-            } => *supports_chat_completions,
-            Self::FiveCodex
+            } => !*supports_chat_completions,
+            Self::ThreePointFiveTurbo | Self::Four | Self::FourTurbo => false,
+            Self::FourOmniMini
+            | Self::FourPointOneNano
+            | Self::O1
+            | Self::O3
+            | Self::O3Mini
+            | Self::Five
+            | Self::FiveCodex
+            | Self::FiveMini
+            | Self::FiveNano
+            | Self::FivePointOne
+            | Self::FivePointTwo
             | Self::FivePointTwoCodex
             | Self::FivePointThreeCodex
+            | Self::FivePointFour
             | Self::FivePointFourPro
-            | Self::FivePointFivePro => false,
-            _ => true,
+            | Self::FivePointFive
+            | Self::FivePointFivePro => true,
         }
     }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -278,26 +278,7 @@ impl Model {
                 supports_chat_completions,
                 ..
             } => !*supports_chat_completions,
-            Self::ThreePointFiveTurbo
-            | Self::Four
-            | Self::FourTurbo
-            | Self::FourOmniMini
-            | Self::FourPointOneNano
-            | Self::O1
-            | Self::O3
-            | Self::O3Mini
-            | Self::Five
-            | Self::FiveCodex
-            | Self::FiveMini
-            | Self::FiveNano
-            | Self::FivePointOne
-            | Self::FivePointTwo
-            | Self::FivePointTwoCodex
-            | Self::FivePointThreeCodex
-            | Self::FivePointFour
-            | Self::FivePointFourPro
-            | Self::FivePointFive
-            | Self::FivePointFivePro => true,
+            _ => true,
         }
     }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -278,8 +278,10 @@ impl Model {
                 supports_chat_completions,
                 ..
             } => !*supports_chat_completions,
-            Self::ThreePointFiveTurbo | Self::Four | Self::FourTurbo => false,
-            Self::FourOmniMini
+            Self::ThreePointFiveTurbo
+            | Self::Four
+            | Self::FourTurbo
+            | Self::FourOmniMini
             | Self::FourPointOneNano
             | Self::O1
             | Self::O3


### PR DESCRIPTION
From the [docs](https://developers.openai.com/api/docs/guides/migrate-to-responses#responses-benefits):

> Better performance: Using reasoning models, like GPT-5, with Responses will result in better model intelligence when compared to Chat Completions. Our internal evals reveal a 3% improvement in SWE-bench with same prompt and setup.
Agentic by default: The Responses API is an agentic loop, allowing the model to call multiple tools, like web_search, image_generation, file_search, code_interpreter, remote MCP servers, as well as your own custom functions, within the span of one API request.
Lower costs: Results in lower costs due to improved cache utilization (40% to 80% improvement when compared to Chat Completions in internal tests).
Stateful context: Use store: true to maintain state from turn to turn, preserving reasoning and tool context from turn-to-turn.
Flexible inputs: Pass a string with input or a list of messages; use instructions for system-level guidance.
Encrypted reasoning: Opt-out of statefulness while still benefiting from advanced reasoning.
Future-proof: Future-proofed for upcoming models.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Always use Responses API for OpenAI models
