### PR TITLE
Fix line comment rewrap in golang and C/C++

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5513,6 +5513,7 @@ dependencies = [
  "tracing",
  "tree-sitter-bash",
  "tree-sitter-c",
+ "tree-sitter-go",
  "tree-sitter-html",
  "tree-sitter-md",
  "tree-sitter-python",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -124,6 +124,7 @@ settings = { workspace = true, features = ["test-support"] }
 text = { workspace = true, features = ["test-support"] }
 theme = { workspace = true, features = ["test-support"] }
 tree-sitter-c.workspace = true
+tree-sitter-go.workspace = true
 tree-sitter-html.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -14003,7 +14003,8 @@ impl Editor {
                                     Some(CommentFormat::BlockCommentWithEnd(config.clone()))
                                 }
                                 (Some(config), _) | (_, Some(config))
-                                    if buffer.contains_str_at(indent_end, &config.prefix) =>
+                                    if !config.prefix.is_empty()
+                                        && buffer.contains_str_at(indent_end, &config.prefix) =>
                                 {
                                     Some(CommentFormat::BlockLine(config.prefix.to_string()))
                                 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8452,6 +8452,62 @@ async fn test_rewrap_block_comments(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_rewrap_line_comment_in_go(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.languages.0.extend([(
+            "Go".into(),
+            LanguageSettingsContent {
+                allow_rewrap: Some(language_settings::RewrapBehavior::InComments),
+                preferred_line_length: Some(40),
+                ..Default::default()
+            },
+        )])
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let go_lang = languages::language("go", tree_sitter_go::LANGUAGE.into());
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(go_lang), cx));
+    cx.set_state(indoc! {"
+        // Lorem ipsum dolor sit amet, consectetur adipiscing elit.ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.rewrap(&Rewrap, window, cx));
+    cx.assert_editor_state(indoc! {"
+        // Lorem ipsum dolor sit amet,
+        // consectetur adipiscing elit.ˇ
+    "});
+}
+
+#[gpui::test]
+async fn test_rewrap_line_comment_in_c(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.languages.0.extend([(
+            "C".into(),
+            LanguageSettingsContent {
+                allow_rewrap: Some(language_settings::RewrapBehavior::InComments),
+                preferred_line_length: Some(40),
+                ..Default::default()
+            },
+        )])
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let c_lang = languages::language("c", tree_sitter_c::LANGUAGE.into());
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(c_lang), cx));
+    cx.set_state(indoc! {"
+        // Lorem ipsum dolor sit amet, consectetur adipiscing elit.ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.rewrap(&Rewrap, window, cx));
+    cx.assert_editor_state(indoc! {"
+        // Lorem ipsum dolor sit amet,
+        // consectetur adipiscing elit.ˇ
+    "});
+}
+
+#[gpui::test]
 async fn test_hard_wrap(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54737.

#48752 added empty-prefix `block_comment` entries to several language configs (Go, C, C++, JSONC, Python, JSX inner) to support the new toggle-block-comments action.

In `Editor::rewrap_impl`, the comment-format matcher used `buffer.contains_str_at(indent_end, &config.prefix)` to decide whether the current line is a continuation of a block comment. When the language is configured with an empty prefix, this is true on every line. `//` (and `#`) line comments inside a `comment` override scope were classified as `BlockLine("")` and never reached the line-comment fallback. The result was that the line-comment prefix was not stripped before wrapping and not re-prepended after, embedding `//` markers as text in the wrapped paragraph.

Skip the BlockLine arm when the configured prefix is empty so the matcher falls through to `line_comment_prefixes`.

I've included regression tests for both golang (which adds a new treesitter dep to the editor package) and C/C++.

Release Notes:

- Fixed line comment rewrapping in golang and C/C++
