### PR TITLE
Honor project-local worktree directory setting

### DIFF
--- a/crates/agent_ui/src/thread_worktree_archive.rs
+++ b/crates/agent_ui/src/thread_worktree_archive.rs
@@ -8,11 +8,10 @@ use gpui::{App, AsyncApp, Entity, Task};
 use project::{
     LocalProjectFlags, Project, WorktreeId,
     git_store::{Repository, resolve_git_worktree_to_main_repo, worktrees_directory_for_repo},
-    project_settings::ProjectSettings,
+    project_settings::worktree_directory_setting_for_repo,
 };
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
-use settings::{Settings, SettingsLocation};
-use util::{ResultExt, rel_path::RelPath};
+use util::ResultExt;
 use workspace::{AppState, MultiWorkspace, Workspace};
 
 use crate::thread_metadata_store::{ArchivedGitWorktree, ThreadId, ThreadMetadataStore};
@@ -72,24 +71,19 @@ fn archived_worktree_ref_name(id: i64) -> String {
     format!("refs/archived-worktrees/{}", id)
 }
 
-/// Resolves the Zed-managed worktrees base directory for a given repo using
-/// the archived worktree's project settings.
-fn worktrees_base_for_project(
+fn is_managed_worktree_path(
     main_repo_path: &Path,
-    affected_project: &AffectedProject,
+    worktree_path: &Path,
+    affected_projects: &[AffectedProject],
     cx: &App,
-) -> Option<PathBuf> {
-    let setting = ProjectSettings::get(
-        Some(SettingsLocation {
-            worktree_id: affected_project.worktree_id,
-            path: RelPath::empty(),
-        }),
-        cx,
-    )
-    .git
-    .worktree_directory
-    .clone();
-    worktrees_directory_for_repo(main_repo_path, &setting).log_err()
+) -> bool {
+    affected_projects.iter().any(|affected_project| {
+        let setting =
+            worktree_directory_setting_for_repo(&affected_project.project, main_repo_path, cx);
+        worktrees_directory_for_repo(main_repo_path, &setting)
+            .log_err()
+            .is_some_and(|worktrees_base| worktree_path.starts_with(&worktrees_base))
+    })
 }
 
 /// Builds a [`RootPlan`] for archiving the git worktree at `path`.
@@ -175,9 +169,7 @@ pub fn build_root_plan(
     // Only archive worktrees that live inside the Zed-managed worktrees
     // directory (configured via `git.worktree_directory`). Worktrees the
     // user created outside that directory should be left untouched.
-    let worktrees_base =
-        worktrees_base_for_project(&main_repo_path, affected_projects.first()?, cx)?;
-    if !path.starts_with(&worktrees_base) {
+    if !is_managed_worktree_path(&main_repo_path, &path, &affected_projects, cx) {
         return None;
     }
 
@@ -1255,9 +1247,7 @@ mod tests {
         });
         cx.update(|cx| {
             for (path, worktree_id) in worktree_ids {
-                if path == Path::new("/root/project")
-                    || path == Path::new("/root/custom-worktrees/project/feature/project")
-                {
+                if path == Path::new("/root/project") {
                     set_worktree_directory_setting(worktree_id, "../custom-worktrees", cx);
                 }
             }
@@ -1281,7 +1271,115 @@ mod tests {
             assert!(
                 plan.is_some(),
                 "build_root_plan should return Some for a nested repository worktree \
-                 inside the project-local worktree_directory",
+                 using the containing project's worktree_directory setting",
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_build_root_plan_is_not_order_dependent_across_workspaces(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": { "main.rs": "fn main() {}" }
+                }
+            }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/root/project/.git"), Some("main"));
+        fs.insert_branches(Path::new("/root/project/.git"), &["main", "feature"]);
+
+        fs.add_linked_worktree_for_repo(
+            Path::new("/root/project/.git"),
+            true,
+            GitWorktree {
+                path: PathBuf::from("/root/custom-worktrees/project/feature/project"),
+                ref_name: Some("refs/heads/feature".into()),
+                sha: "abc123".into(),
+                is_main: false,
+                is_bare: false,
+            },
+        )
+        .await;
+
+        let rooted_project = Project::test(
+            fs.clone(),
+            [
+                Path::new("/root/project"),
+                Path::new("/root/custom-worktrees/project/feature/project"),
+            ],
+            cx,
+        )
+        .await;
+        rooted_project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let standalone_project = Project::test(
+            fs.clone(),
+            [Path::new("/root/custom-worktrees/project/feature/project")],
+            cx,
+        )
+        .await;
+        standalone_project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let worktree_ids = rooted_project.read_with(cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .map(|worktree| {
+                    let worktree = worktree.read(cx);
+                    (worktree.abs_path().to_path_buf(), worktree.id())
+                })
+                .collect::<Vec<_>>()
+        });
+        cx.update(|cx| {
+            for (path, worktree_id) in worktree_ids {
+                if path == Path::new("/root/project") {
+                    set_worktree_directory_setting(worktree_id, "../custom-worktrees", cx);
+                }
+            }
+        });
+
+        let rooted_workspace = cx
+            .add_window(|window, cx| MultiWorkspace::test_new(rooted_project.clone(), window, cx));
+        let rooted_workspace = rooted_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+
+        let standalone_workspace = cx.add_window(|window, cx| {
+            MultiWorkspace::test_new(standalone_project.clone(), window, cx)
+        });
+        let standalone_workspace = standalone_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+
+        rooted_workspace.read_with(cx, |_workspace, cx| {
+            let workspaces = [standalone_workspace.clone(), rooted_workspace.clone()];
+            let plan = build_root_plan(
+                Path::new("/root/custom-worktrees/project/feature/project"),
+                None,
+                &workspaces,
+                cx,
+            );
+            assert!(
+                plan.is_some(),
+                "build_root_plan should not depend on workspace ordering when one \
+                 workspace provides the matching worktree_directory setting",
             );
         });
     }

--- a/crates/agent_ui/src/thread_worktree_archive.rs
+++ b/crates/agent_ui/src/thread_worktree_archive.rs
@@ -1151,9 +1151,9 @@ mod tests {
         });
         cx.update(|cx| {
             for (path, worktree_id) in worktree_ids {
-                if path == PathBuf::from("/project")
-                    || path == PathBuf::from("/custom-worktrees/project/feature/project")
-                    || path == PathBuf::from("/worktrees/project/feature2/project")
+                if path == Path::new("/project")
+                    || path == Path::new("/custom-worktrees/project/feature/project")
+                    || path == Path::new("/worktrees/project/feature2/project")
                 {
                     set_worktree_directory_setting(worktree_id, "../custom-worktrees", cx);
                 }
@@ -1194,6 +1194,94 @@ mod tests {
                 plan.is_none(),
                 "build_root_plan should return None for a worktree outside \
                  the custom worktree_directory, even if it would match the default",
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_build_root_plan_uses_project_worktree_directory_for_nested_repo(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": { "main.rs": "fn main() {}" }
+                }
+            }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/root/project/.git"), Some("main"));
+        fs.insert_branches(Path::new("/root/project/.git"), &["main", "feature"]);
+
+        fs.add_linked_worktree_for_repo(
+            Path::new("/root/project/.git"),
+            true,
+            GitWorktree {
+                path: PathBuf::from("/root/custom-worktrees/project/feature/project"),
+                ref_name: Some("refs/heads/feature".into()),
+                sha: "abc123".into(),
+                is_main: false,
+                is_bare: false,
+            },
+        )
+        .await;
+
+        let project = Project::test(
+            fs.clone(),
+            [
+                Path::new("/root/project"),
+                Path::new("/root/custom-worktrees/project/feature/project"),
+            ],
+            cx,
+        )
+        .await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let worktree_ids = project.read_with(cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .map(|worktree| {
+                    let worktree = worktree.read(cx);
+                    (worktree.abs_path().to_path_buf(), worktree.id())
+                })
+                .collect::<Vec<_>>()
+        });
+        cx.update(|cx| {
+            for (path, worktree_id) in worktree_ids {
+                if path == Path::new("/root/project")
+                    || path == Path::new("/root/custom-worktrees/project/feature/project")
+                {
+                    set_worktree_directory_setting(worktree_id, "../custom-worktrees", cx);
+                }
+            }
+        });
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |mw, _cx| mw.workspace().clone())
+            .unwrap();
+
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |_workspace, cx| {
+            let plan = build_root_plan(
+                Path::new("/root/custom-worktrees/project/feature/project"),
+                None,
+                std::slice::from_ref(&workspace),
+                cx,
+            );
+            assert!(
+                plan.is_some(),
+                "build_root_plan should return Some for a nested repository worktree \
+                 inside the project-local worktree_directory",
             );
         });
     }

--- a/crates/agent_ui/src/thread_worktree_archive.rs
+++ b/crates/agent_ui/src/thread_worktree_archive.rs
@@ -11,8 +11,8 @@ use project::{
     project_settings::ProjectSettings,
 };
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
-use settings::Settings;
-use util::ResultExt;
+use settings::{Settings, SettingsLocation};
+use util::{ResultExt, rel_path::RelPath};
 use workspace::{AppState, MultiWorkspace, Workspace};
 
 use crate::thread_metadata_store::{ArchivedGitWorktree, ThreadId, ThreadMetadataStore};
@@ -72,14 +72,24 @@ fn archived_worktree_ref_name(id: i64) -> String {
     format!("refs/archived-worktrees/{}", id)
 }
 
-/// Resolves the Zed-managed worktrees base directory for a given repo.
-///
-/// This intentionally reads the *global* `git.worktree_directory` setting
-/// rather than any project-local override, because Zed always uses the
-/// global value when creating worktrees and the archive check must match.
-fn worktrees_base_for_repo(main_repo_path: &Path, cx: &App) -> Option<PathBuf> {
-    let setting = &ProjectSettings::get_global(cx).git.worktree_directory;
-    worktrees_directory_for_repo(main_repo_path, setting).log_err()
+/// Resolves the Zed-managed worktrees base directory for a given repo using
+/// the archived worktree's project settings.
+fn worktrees_base_for_project(
+    main_repo_path: &Path,
+    affected_project: &AffectedProject,
+    cx: &App,
+) -> Option<PathBuf> {
+    let setting = ProjectSettings::get(
+        Some(SettingsLocation {
+            worktree_id: affected_project.worktree_id,
+            path: RelPath::empty(),
+        }),
+        cx,
+    )
+    .git
+    .worktree_directory
+    .clone();
+    worktrees_directory_for_repo(main_repo_path, &setting).log_err()
 }
 
 /// Builds a [`RootPlan`] for archiving the git worktree at `path`.
@@ -165,7 +175,8 @@ pub fn build_root_plan(
     // Only archive worktrees that live inside the Zed-managed worktrees
     // directory (configured via `git.worktree_directory`). Worktrees the
     // user created outside that directory should be left untouched.
-    let worktrees_base = worktrees_base_for_repo(&main_repo_path, cx)?;
+    let worktrees_base =
+        worktrees_base_for_project(&main_repo_path, affected_projects.first()?, cx)?;
     if !path.starts_with(&worktrees_base) {
         return None;
     }
@@ -843,7 +854,8 @@ mod tests {
     use gpui::{BorrowAppContext, TestAppContext};
     use project::Project;
     use serde_json::json;
-    use settings::SettingsStore;
+    use settings::{LocalSettingsKind, LocalSettingsPath, SettingsStore};
+    use util::rel_path::rel_path;
     use workspace::MultiWorkspace;
 
     fn init_test(cx: &mut TestAppContext) {
@@ -853,6 +865,31 @@ mod tests {
             theme_settings::init(theme::LoadThemes::JustBase, cx);
             editor::init(cx);
             release_channel::init(semver::Version::new(0, 0, 0), cx);
+        });
+    }
+
+    fn set_worktree_directory_setting(
+        worktree_id: WorktreeId,
+        worktree_directory: &str,
+        cx: &mut App,
+    ) {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            let settings_content = format!(
+                r#"{{
+  "git": {{
+    "worktree_directory": "{worktree_directory}"
+  }}
+}}"#
+            );
+            store
+                .set_local_settings(
+                    worktree_id,
+                    LocalSettingsPath::InWorktree(rel_path("").into()),
+                    LocalSettingsKind::Settings,
+                    Some(&settings_content),
+                    cx,
+                )
+                .expect("should set local worktree settings");
         });
     }
 
@@ -1048,18 +1085,6 @@ mod tests {
     async fn test_build_root_plan_with_custom_worktree_directory(cx: &mut TestAppContext) {
         init_test(cx);
 
-        // Override the worktree_directory setting to a non-default location.
-        // With main repo at /project and setting "../custom-worktrees", the
-        // resolved base is /custom-worktrees/project.
-        cx.update(|cx| {
-            cx.update_global::<SettingsStore, _>(|store, cx| {
-                store.update_user_settings(cx, |s| {
-                    s.git.get_or_insert(Default::default()).worktree_directory =
-                        Some("../custom-worktrees".to_string());
-                });
-            });
-        });
-
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
             "/project",
@@ -1114,6 +1139,26 @@ mod tests {
         project
             .update(cx, |project, cx| project.git_scans_complete(cx))
             .await;
+
+        let worktree_ids = project.read_with(cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .map(|worktree| {
+                    let worktree = worktree.read(cx);
+                    (worktree.abs_path().to_path_buf(), worktree.id())
+                })
+                .collect::<Vec<_>>()
+        });
+        cx.update(|cx| {
+            for (path, worktree_id) in worktree_ids {
+                if path == PathBuf::from("/project")
+                    || path == PathBuf::from("/custom-worktrees/project/feature/project")
+                    || path == PathBuf::from("/worktrees/project/feature2/project")
+                {
+                    set_worktree_directory_setting(worktree_id, "../custom-worktrees", cx);
+                }
+            }
+        });
 
         let multi_workspace =
             cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -10,8 +10,7 @@ use project::git_store::Repository;
 use project::project_settings::ProjectSettings;
 use project::trusted_worktrees::{PathTrust, TrustedWorktrees};
 use remote::RemoteConnectionOptions;
-use settings::Settings;
-use util::rel_path::RelPath;
+use settings::{Settings, SettingsLocation};
 use workspace::{MultiWorkspace, OpenMode, PreviousWorkspaceState, Workspace, dock::DockPosition};
 use zed_actions::NewWorktreeBranchTarget;
 
@@ -92,19 +91,24 @@ fn worktree_directory_setting_for_repo(
         .visible_worktrees(cx)
         .filter_map(|worktree| {
             let worktree = worktree.read(cx);
-            worktree
-                .abs_path()
-                .starts_with(repo_work_directory.as_ref())
-                .then_some((
-                    worktree.id(),
-                    worktree.abs_path().as_ref().components().count(),
-                ))
+            let worktree_path = worktree.abs_path();
+            let path = worktree
+                .path_style()
+                .strip_prefix(repo_work_directory.as_ref(), worktree_path.as_ref())?;
+            Some((
+                worktree.id(),
+                path.into_owned(),
+                worktree_path.as_ref().components().count(),
+            ))
         })
-        .max_by_key(|(_, depth)| *depth)
-        .map(|(worktree_id, _)| settings::SettingsLocation {
-            worktree_id,
-            path: RelPath::empty(),
-        });
+        .max_by_key(|(_, _, depth)| *depth);
+    let settings_location =
+        settings_location
+            .as_ref()
+            .map(|(worktree_id, path, _)| SettingsLocation {
+                worktree_id: *worktree_id,
+                path: path.as_rel_path(),
+            });
 
     ProjectSettings::get(settings_location, cx)
         .git
@@ -850,7 +854,7 @@ mod tests {
     use task::SpawnInTerminal;
     use theme::LoadThemes;
     use util::path;
-    use util::rel_path::rel_path;
+    use util::rel_path::{RelPath, rel_path};
     use workspace::{TerminalProvider, WorkspaceSettings};
 
     struct CountingTerminalProvider {
@@ -938,6 +942,15 @@ mod tests {
         worktree_directory: &str,
         cx: &mut App,
     ) {
+        set_worktree_directory_setting_at_path(worktree_id, rel_path(""), worktree_directory, cx);
+    }
+
+    fn set_worktree_directory_setting_at_path(
+        worktree_id: WorktreeId,
+        path: &RelPath,
+        worktree_directory: &str,
+        cx: &mut App,
+    ) {
         cx.update_global::<SettingsStore, _>(|store, cx| {
             let settings_content = format!(
                 r#"{{
@@ -949,13 +962,71 @@ mod tests {
             store
                 .set_local_settings(
                     worktree_id,
-                    LocalSettingsPath::InWorktree(rel_path("").into()),
+                    LocalSettingsPath::InWorktree(path.into()),
                     LocalSettingsKind::Settings,
                     Some(&settings_content),
                     cx,
                 )
                 .expect("should set local worktree settings");
         });
+    }
+
+    fn worktree_id_for_path(
+        project: &Entity<Project>,
+        path: &Path,
+        cx: &mut TestAppContext,
+    ) -> WorktreeId {
+        project.read_with(cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .find_map(|worktree| {
+                    let worktree = worktree.read(cx);
+                    (worktree.abs_path().as_ref() == path).then_some(worktree.id())
+                })
+                .expect("worktree should exist")
+        })
+    }
+
+    fn repository_for_path(
+        project: &Entity<Project>,
+        path: &Path,
+        cx: &mut TestAppContext,
+    ) -> Entity<Repository> {
+        project.read_with(cx, |project, cx| {
+            project
+                .repositories(cx)
+                .values()
+                .find(|repo| repo.read(cx).work_directory_abs_path.as_ref() == path)
+                .expect("repository should exist")
+                .clone()
+        })
+    }
+
+    fn path_for_created_worktree(
+        project: &Entity<Project>,
+        repo: &Entity<Repository>,
+        worktree_name: &str,
+        cx: &mut TestAppContext,
+    ) -> PathBuf {
+        let mut rng = rand::rng();
+        cx.update(|cx| {
+            let (_creation_infos, path_remapping) = start_worktree_creations(
+                project,
+                std::slice::from_ref(repo),
+                Some(worktree_name.to_string()),
+                &[],
+                &HashSet::default(),
+                None,
+                &mut rng,
+                cx,
+            )
+            .expect("should start worktree creation");
+            path_remapping
+                .into_iter()
+                .map(|(_, new_path)| new_path)
+                .next()
+                .expect("worktree path should be remapped")
+        })
     }
 
     #[gpui::test]
@@ -1026,6 +1097,128 @@ mod tests {
         assert_eq!(
             linked_worktree_path,
             PathBuf::from(path!("/root/custom-worktrees/project/feature/project"))
+        );
+    }
+
+    #[gpui::test]
+    async fn test_create_worktree_uses_containing_project_setting_for_nested_repo(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree(
+            "/root",
+            json!({
+                ".zed": {
+                    "settings.json": r#"{"git":{"worktree_directory":"../custom-worktrees"}}"#,
+                },
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}",
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root"))], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let root_worktree_id = worktree_id_for_path(&project, Path::new(path!("/root")), cx);
+        cx.update(|cx| {
+            set_worktree_directory_setting(root_worktree_id, "../custom-worktrees", cx);
+        });
+
+        let repo = repository_for_path(&project, Path::new(path!("/root/project")), cx);
+        let linked_worktree_path = path_for_created_worktree(&project, &repo, "feature", cx);
+
+        assert_eq!(
+            linked_worktree_path,
+            PathBuf::from(path!("/root/custom-worktrees/project/feature/project"))
+        );
+    }
+
+    #[gpui::test]
+    async fn test_create_worktree_falls_back_to_global_setting_for_nested_repo(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}",
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root"))], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let repo = repository_for_path(&project, Path::new(path!("/root/project")), cx);
+        let linked_worktree_path = path_for_created_worktree(&project, &repo, "feature", cx);
+
+        assert_eq!(
+            linked_worktree_path,
+            PathBuf::from(path!("/root/worktrees/project/feature/project"))
+        );
+    }
+
+    #[gpui::test]
+    async fn test_create_worktree_uses_deepest_containing_local_setting(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}",
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root"))], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let root_worktree_id = worktree_id_for_path(&project, Path::new(path!("/root")), cx);
+        cx.update(|cx| {
+            set_worktree_directory_setting(root_worktree_id, "../outer-worktrees", cx);
+            set_worktree_directory_setting_at_path(
+                root_worktree_id,
+                rel_path("project"),
+                "../inner-worktrees",
+                cx,
+            );
+        });
+
+        let repo = repository_for_path(&project, Path::new(path!("/root/project")), cx);
+        let linked_worktree_path = path_for_created_worktree(&project, &repo, "feature", cx);
+
+        assert_eq!(
+            linked_worktree_path,
+            PathBuf::from(path!("/root/inner-worktrees/project/feature/project"))
         );
     }
 

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -7,10 +7,10 @@ use fs::Fs;
 use gpui::{AsyncWindowContext, Entity, SharedString, WeakEntity};
 use project::Project;
 use project::git_store::Repository;
-use project::project_settings::ProjectSettings;
+use project::project_settings::{ProjectSettings, worktree_directory_setting_for_repo};
 use project::trusted_worktrees::{PathTrust, TrustedWorktrees};
 use remote::RemoteConnectionOptions;
-use settings::{Settings, SettingsLocation};
+use settings::Settings;
 use workspace::{MultiWorkspace, OpenMode, PreviousWorkspaceState, Workspace, dock::DockPosition};
 use zed_actions::NewWorktreeBranchTarget;
 
@@ -80,42 +80,6 @@ pub fn resolve_worktree_branch_target(branch_target: &NewWorktreeBranchTarget) -
     }
 }
 
-fn worktree_directory_setting_for_repo(
-    project: &Entity<Project>,
-    repo: &Entity<Repository>,
-    cx: &gpui::App,
-) -> String {
-    let repo_work_directory = repo.read(cx).work_directory_abs_path.clone();
-    let settings_location = project
-        .read(cx)
-        .visible_worktrees(cx)
-        .filter_map(|worktree| {
-            let worktree = worktree.read(cx);
-            let worktree_path = worktree.abs_path();
-            let path = worktree
-                .path_style()
-                .strip_prefix(repo_work_directory.as_ref(), worktree_path.as_ref())?;
-            Some((
-                worktree.id(),
-                path.into_owned(),
-                worktree_path.as_ref().components().count(),
-            ))
-        })
-        .max_by_key(|(_, _, depth)| *depth);
-    let settings_location =
-        settings_location
-            .as_ref()
-            .map(|(worktree_id, path, _)| SettingsLocation {
-                worktree_id: *worktree_id,
-                path: path.as_rel_path(),
-            });
-
-    ProjectSettings::get(settings_location, cx)
-        .git
-        .worktree_directory
-        .clone()
-}
-
 /// Kicks off an async git-worktree creation for each repository. Returns:
 ///
 /// - `creation_infos`: a vec of `(repo, new_path, receiver)` tuples.
@@ -147,7 +111,9 @@ fn start_worktree_creations(
     });
 
     for repo in git_repos {
-        let worktree_directory_setting = worktree_directory_setting_for_repo(project, repo, cx);
+        let repo_work_directory = repo.read(cx).work_directory_abs_path.clone();
+        let worktree_directory_setting =
+            worktree_directory_setting_for_repo(project, repo_work_directory.as_ref(), cx);
         let (work_dir, new_path, receiver) = repo.update(cx, |repo, _cx| {
             let new_path =
                 repo.path_for_new_linked_worktree(&worktree_name, &worktree_directory_setting)?;

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -11,6 +11,7 @@ use project::project_settings::ProjectSettings;
 use project::trusted_worktrees::{PathTrust, TrustedWorktrees};
 use remote::RemoteConnectionOptions;
 use settings::Settings;
+use util::rel_path::RelPath;
 use workspace::{MultiWorkspace, OpenMode, PreviousWorkspaceState, Workspace, dock::DockPosition};
 use zed_actions::NewWorktreeBranchTarget;
 
@@ -80,17 +81,48 @@ pub fn resolve_worktree_branch_target(branch_target: &NewWorktreeBranchTarget) -
     }
 }
 
+fn worktree_directory_setting_for_repo(
+    project: &Entity<Project>,
+    repo: &Entity<Repository>,
+    cx: &gpui::App,
+) -> String {
+    let repo_work_directory = repo.read(cx).work_directory_abs_path.clone();
+    let settings_location = project
+        .read(cx)
+        .visible_worktrees(cx)
+        .filter_map(|worktree| {
+            let worktree = worktree.read(cx);
+            worktree
+                .abs_path()
+                .starts_with(repo_work_directory.as_ref())
+                .then_some((
+                    worktree.id(),
+                    worktree.abs_path().as_ref().components().count(),
+                ))
+        })
+        .max_by_key(|(_, depth)| *depth)
+        .map(|(worktree_id, _)| settings::SettingsLocation {
+            worktree_id,
+            path: RelPath::empty(),
+        });
+
+    ProjectSettings::get(settings_location, cx)
+        .git
+        .worktree_directory
+        .clone()
+}
+
 /// Kicks off an async git-worktree creation for each repository. Returns:
 ///
 /// - `creation_infos`: a vec of `(repo, new_path, receiver)` tuples.
 /// - `path_remapping`: `(old_work_dir, new_worktree_path)` pairs for remapping editor tabs.
 fn start_worktree_creations(
+    project: &Entity<Project>,
     git_repos: &[Entity<Repository>],
     worktree_name: Option<String>,
     existing_worktree_names: &[String],
     existing_worktree_paths: &HashSet<PathBuf>,
     base_ref: Option<String>,
-    worktree_directory_setting: &str,
     rng: &mut impl rand::Rng,
     cx: &mut gpui::App,
 ) -> anyhow::Result<(
@@ -111,9 +143,10 @@ fn start_worktree_creations(
     });
 
     for repo in git_repos {
+        let worktree_directory_setting = worktree_directory_setting_for_repo(project, repo, cx);
         let (work_dir, new_path, receiver) = repo.update(cx, |repo, _cx| {
             let new_path =
-                repo.path_for_new_linked_worktree(&worktree_name, worktree_directory_setting)?;
+                repo.path_for_new_linked_worktree(&worktree_name, &worktree_directory_setting)?;
             if existing_worktree_paths.contains(&new_path) {
                 anyhow::bail!("A worktree already exists at {}", new_path.display());
             }
@@ -359,6 +392,7 @@ pub fn handle_create_worktree(
 
     cx.spawn_in(window, async move |_workspace_entity, mut cx| {
         let result = do_create_worktree(
+            project,
             git_repos,
             non_git_paths,
             worktree_name,
@@ -457,6 +491,7 @@ pub fn handle_switch_worktree(
 }
 
 async fn do_create_worktree(
+    project: Entity<Project>,
     git_repos: Vec<Entity<Repository>>,
     non_git_paths: Vec<PathBuf>,
     worktree_name: Option<String>,
@@ -473,12 +508,6 @@ async fn do_create_worktree(
             .iter()
             .map(|repo| repo.update(cx, |repo, _cx| repo.worktrees()))
             .collect()
-    })?;
-    let worktree_directory_setting = cx.update(|_, cx| {
-        ProjectSettings::get_global(cx)
-            .git
-            .worktree_directory
-            .clone()
     })?;
 
     let mut existing_worktree_names = Vec::new();
@@ -511,12 +540,12 @@ async fn do_create_worktree(
 
     let (creation_infos, path_remapping) = cx.update(|_, cx| {
         start_worktree_creations(
+            &project,
             &git_repos,
             worktree_name,
             &existing_worktree_names,
             &existing_worktree_paths,
             base_ref,
-            &worktree_directory_setting,
             &mut rng,
             cx,
         )
@@ -808,13 +837,13 @@ async fn open_worktree_workspace(
 mod tests {
     use super::*;
     use fs::Fs;
-    use gpui::{App, Task, TestAppContext};
+    use gpui::{App, BorrowAppContext, Task, TestAppContext};
     use language::language_settings::AllLanguageSettings;
     use project::project_settings::ProjectSettings;
     use project::task_store::{TaskSettingsLocation, TaskStore};
-    use project::{FakeFs, WorktreeSettings};
+    use project::{FakeFs, WorktreeId, WorktreeSettings};
     use serde_json::json;
-    use settings::{SettingsLocation, SettingsStore};
+    use settings::{LocalSettingsKind, LocalSettingsPath, SettingsLocation, SettingsStore};
     use std::path::{Path, PathBuf};
     use std::process::ExitStatus;
     use std::sync::Mutex;
@@ -902,6 +931,102 @@ mod tests {
                     .expect("should inject create_worktree hook tasks for linked worktree");
             });
         });
+    }
+
+    fn set_worktree_directory_setting(
+        worktree_id: WorktreeId,
+        worktree_directory: &str,
+        cx: &mut App,
+    ) {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            let settings_content = format!(
+                r#"{{
+  "git": {{
+    "worktree_directory": "{worktree_directory}"
+  }}
+}}"#
+            );
+            store
+                .set_local_settings(
+                    worktree_id,
+                    LocalSettingsPath::InWorktree(rel_path("").into()),
+                    LocalSettingsKind::Settings,
+                    Some(&settings_content),
+                    cx,
+                )
+                .expect("should set local worktree settings");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_create_worktree_uses_project_worktree_directory_setting(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}",
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let main_project_root = PathBuf::from(path!("/root/project"));
+        let project = Project::test(fs.clone(), [main_project_root.as_path()], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let main_worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        cx.update(|cx| {
+            set_worktree_directory_setting(main_worktree_id, "../custom-worktrees", cx);
+        });
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+        let main_workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+        main_workspace.update_in(cx, |workspace, window, cx| {
+            handle_create_worktree(
+                workspace,
+                &zed_actions::CreateWorktree {
+                    worktree_name: Some("feature".to_string()),
+                    branch_target: NewWorktreeBranchTarget::CurrentBranch,
+                },
+                window,
+                None,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let active_workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+        let linked_worktree_path = active_workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .abs_path()
+                .to_path_buf()
+        });
+
+        assert_eq!(
+            linked_worktree_path,
+            PathBuf::from(path!("/root/custom-worktrees/project/feature/project"))
+        );
     }
 
     #[gpui::test]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -21,7 +21,6 @@ use serde::{Deserialize, Serialize};
 pub use settings::BinarySettings;
 pub use settings::DirenvSettings;
 pub use settings::LspSettings;
-use settings::settings_content::MergeFromTrait;
 use settings::{
     DapSettingsContent, EditorconfigEvent, InvalidSettingsError, LocalSettingsKind,
     LocalSettingsPath, RegisterSetting, SemanticTokenRules, Settings, SettingsLocation,
@@ -622,7 +621,13 @@ impl Settings for ProjectSettings {
             .clone()
             .ok_or_else(|| anyhow!("missing git settings defaults"))
             .unwrap();
-        git.merge_from_option(project.git.as_ref());
+        if let Some(worktree_directory) = project
+            .git
+            .as_ref()
+            .and_then(|git| git.worktree_directory.clone())
+        {
+            git.worktree_directory = Some(worktree_directory);
+        }
         let git_enabled = {
             GitEnabledSettings {
                 status: git.enabled.as_ref().unwrap().is_git_status_enabled(),
@@ -659,7 +664,6 @@ impl Settings for ProjectSettings {
             path_style: git.path_style.unwrap().into(),
             worktree_directory: git
                 .worktree_directory
-                .clone()
                 .unwrap_or_else(|| DEFAULT_WORKTREE_DIRECTORY.to_string()),
         };
         Self {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -5,7 +5,7 @@ use dap::adapters::DebugAdapterName;
 use fs::Fs;
 use futures::StreamExt as _;
 use git::repository::DEFAULT_WORKTREE_DIRECTORY;
-use gpui::{AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task};
+use gpui::{App, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task};
 use lsp::{DEFAULT_LSP_REQUEST_TIMEOUT_SECS, LanguageServerName};
 use paths::{
     EDITORCONFIG_NAME, local_debug_file_relative_path, local_settings_file_relative_path,
@@ -26,16 +26,62 @@ use settings::{
     LocalSettingsPath, RegisterSetting, SemanticTokenRules, Settings, SettingsLocation,
     SettingsStore, parse_json_with_comments, watch_config_file,
 };
-use std::{cell::OnceCell, collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    cell::OnceCell,
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 use task::{DebugTaskFile, TaskTemplates, VsCodeDebugTaskFile, VsCodeTaskFile};
 use util::{ResultExt, rel_path::RelPath, serde::default_true};
 use worktree::{PathChange, UpdatedEntriesSet, Worktree, WorktreeId};
 
 use crate::{
+    Project,
     task_store::{TaskSettingsLocation, TaskStore},
     trusted_worktrees::{PathTrust, TrustedWorktrees, TrustedWorktreesEvent},
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
 };
+
+pub fn worktree_directory_setting_for_repo(
+    project: &Entity<Project>,
+    repo_path: &Path,
+    cx: &App,
+) -> String {
+    let matched_worktree = project
+        .read(cx)
+        .visible_worktrees(cx)
+        .filter_map(|worktree| {
+            let worktree = worktree.read(cx);
+            let worktree_path = worktree.abs_path();
+            let path = worktree
+                .path_style()
+                .strip_prefix(repo_path, worktree_path.as_ref())?;
+            Some((
+                worktree.id(),
+                path.into_owned(),
+                worktree_path.as_ref().components().count(),
+            ))
+        })
+        .max_by(|(left_id, _, left_depth), (right_id, _, right_depth)| {
+            left_depth
+                .cmp(right_depth)
+                .then_with(|| left_id.cmp(right_id))
+        });
+    let settings_location =
+        matched_worktree
+            .as_ref()
+            .map(|(worktree_id, path, _)| SettingsLocation {
+                worktree_id: *worktree_id,
+                path: path.as_rel_path(),
+            });
+
+    ProjectSettings::get(settings_location, cx)
+        .git
+        .worktree_directory
+        .clone()
+}
 
 #[derive(Debug, Clone, RegisterSetting)]
 pub struct ProjectSettings {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1,4 +1,4 @@
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow};
 use collections::HashMap;
 use context_server::ContextServerCommand;
 use dap::adapters::DebugAdapterName;
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 pub use settings::BinarySettings;
 pub use settings::DirenvSettings;
 pub use settings::LspSettings;
+use settings::settings_content::MergeFromTrait;
 use settings::{
     DapSettingsContent, EditorconfigEvent, InvalidSettingsError, LocalSettingsKind,
     LocalSettingsPath, RegisterSetting, SemanticTokenRules, Settings, SettingsLocation,
@@ -616,7 +617,12 @@ impl Settings for ProjectSettings {
         let lsp_pull_diagnostics = diagnostics.lsp_pull_diagnostics.as_ref().unwrap();
         let inline_diagnostics = diagnostics.inline.as_ref().unwrap();
 
-        let git = content.git.as_ref().unwrap();
+        let mut git = content
+            .git
+            .clone()
+            .ok_or_else(|| anyhow!("missing git settings defaults"))
+            .unwrap();
+        git.merge_from_option(project.git.as_ref());
         let git_enabled = {
             GitEnabledSettings {
                 status: git.enabled.as_ref().unwrap().is_git_status_enabled(),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -518,6 +518,7 @@ impl VsCodeSettings {
             context_servers: self.context_servers(),
             context_server_timeout: None,
             load_direnv: None,
+            git: None,
             git_hosting_providers: None,
             disable_ai: None,
         }

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -78,8 +78,8 @@ pub struct ProjectSettingsContent {
     /// Configuration for how direnv configuration should be loaded
     pub load_direnv: Option<DirenvSettings>,
 
-    /// Configuration for Git-related features
-    pub git: Option<GitSettings>,
+    /// Project-local configuration for Git-related features.
+    pub git: Option<ProjectGitSettings>,
 
     /// The list of custom Git hosting providers.
     pub git_hosting_providers: Option<ExtendingVec<GitHostingProviderConfig>>,
@@ -88,6 +88,16 @@ pub struct ProjectSettingsContent {
     ///
     /// Default: false
     pub disable_ai: Option<SaturatingBool>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct ProjectGitSettings {
+    /// Directory where git worktrees are created, relative to the repository
+    /// working directory.
+    ///
+    /// Default: ../worktrees
+    pub worktree_directory: Option<String>,
 }
 
 #[with_fallible_options]
@@ -798,4 +808,34 @@ pub enum GitHostingProviderKind {
     Gitea,
     Forgejo,
     SourceHut,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ParseStatus, RootUserSettings};
+
+    #[test]
+    fn test_project_git_settings_only_include_worktree_directory() {
+        let (settings, status) = ProjectSettingsContent::parse_json(
+            r#"{
+                "git": {
+                    "worktree_directory": "../custom-worktrees",
+                    "inline_blame": {
+                        "enabled": false
+                    }
+                }
+            }"#,
+        );
+
+        assert_eq!(status, ParseStatus::Success);
+        let git = settings
+            .expect("settings should parse")
+            .git
+            .expect("git settings should parse");
+        assert_eq!(
+            git.worktree_directory.as_deref(),
+            Some("../custom-worktrees")
+        );
+    }
 }

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -78,6 +78,9 @@ pub struct ProjectSettingsContent {
     /// Configuration for how direnv configuration should be loaded
     pub load_direnv: Option<DirenvSettings>,
 
+    /// Configuration for Git-related features
+    pub git: Option<GitSettings>,
+
     /// The list of custom Git hosting providers.
     pub git_hosting_providers: Option<ExtendingVec<GitHostingProviderConfig>>,
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Related: no exact matching open issue found

This change makes the default location for new linked worktrees configurable per project through `.zed/settings.json`.

Previously, worktree creation always used the global `git.worktree_directory` value, so project-local overrides were ignored. This updates the project settings schema to accept local git settings, merges those local git settings into `ProjectSettings`, uses the active project's resolved `git.worktree_directory` when creating new linked worktrees, and keeps linked-worktree archive detection aligned with the same project-scoped setting.

Validation:
- `cargo test -p git_ui test_create_worktree_uses_project_worktree_directory_setting`
- `cargo test -p agent_ui test_build_root_plan_with_custom_worktree_directory`
- `cargo fmt --all --check`

Release Notes:

- Improved project-local `git.worktree_directory` so new linked worktrees use the location configured in `.zed/settings.json`
