### PR TITLE
agent_ui: Fix file hyperlinks not opening in agent panel

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -9266,7 +9266,72 @@ pub(crate) fn open_link(
             MentionUri::GitDiff { .. } => {}
             MentionUri::MergeConflict { .. } => {}
         })
+    } else if !url.contains("://") {
+        // The link has no URL scheme — treat it as a bare file path (absolute or relative)
+        // and try to open it within the workspace. find_project_path handles both cases.
+        workspace.update(cx, |workspace, cx| {
+            let project = workspace.project();
+            let Some(path) = project.update(cx, |project, cx| {
+                project.find_project_path(url.as_ref(), cx)
+            }) else {
+                return;
+            };
+            workspace
+                .open_path(path, None, true, window, cx)
+                .detach_and_log_err(cx);
+        });
     } else {
         cx.open_url(&url);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use project::{FakeFs, Project};
+    use serde_json::json;
+    use util::path;
+    use workspace::MultiWorkspace;
+
+    #[gpui::test]
+    async fn test_open_link_bare_path(cx: &mut gpui::TestAppContext) {
+        crate::test_support::init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({"src": {"main.rs": ""}}))
+            .await;
+
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let workspace_weak = workspace.downgrade();
+
+        // Relative path — call from multi_workspace so the inner workspace entity is not locked
+        multi_workspace.update_in(cx, |_, window, cx| {
+            open_link("src/main.rs".into(), &workspace_weak, window, cx);
+        });
+        cx.run_until_parked();
+        workspace.read_with(cx, |workspace, cx| {
+            let active = workspace
+                .active_item(cx)
+                .and_then(|item| item.project_path(cx))
+                .expect("file should be open");
+            assert!(*active.path == *"src/main.rs");
+        });
+
+        // Absolute path
+        let abs_path: SharedString = path!("/project/src/main.rs").to_string().into();
+        multi_workspace.update_in(cx, |_, window, cx| {
+            open_link(abs_path, &workspace_weak, window, cx);
+        });
+        cx.run_until_parked();
+        workspace.read_with(cx, |workspace, cx| {
+            let active = workspace
+                .active_item(cx)
+                .and_then(|item| item.project_path(cx))
+                .expect("file should be open");
+            assert!(*active.path == *"src/main.rs");
+        });
     }
 }


### PR DESCRIPTION
## Context

Closes https://github.com/zed-industries/zed/issues/54840

Clicking file hyperlinks in the agent panel did nothing. The root cause was in `open_link`: it delegates to `MentionUri::parse`, which requires a URL scheme (`file://`, `zed://`, etc.). Links the model writes inline in its responses use bare paths — either relative (`src/main.rs`) or absolute (`/home/.../src/main.rs`) — with no scheme. These failed
`url::Url::parse` with "relative URL without a base", logged a terminal error, and fell through to `cx.open_url()` which also errored with "MissingScheme".

The fix adds a fallback branch in `open_link`: when `MentionUri::parse` fails and the URL has no `://`, treat it as a bare file path and pass it to `project.find_project_path`, which already handles both absolute and relative paths against all open worktrees.

Manual test video below :

[Screencast from 2026-04-26 21-33-56.webm](https://github.com/user-attachments/assets/fa6b12a0-63e8-4fb0-8472-80872245701b)


## How to Review

- `crates/agent_ui/src/conversation_view/thread_view.rs` — All changes are in `open_link` and a new test module at the bottom of the file. The new `else if !url.contains("://")` branch resolves bare paths via `find_project_path` and opens the file. `test_open_link_bare_path` covers both relative (`src/main.rs`) and absolute (`/project/src/main.rs`) path formats.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Release Notes

- Fixed file hyperlinks in the agent panel not opening files when clicked

