### PR TITLE
Fix ESLint not starting on Windows

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -14502,7 +14502,7 @@ impl LspAdapterDelegate for LocalLspAdapterDelegate {
             .output()
             .await?;
         let global_node_modules =
-            PathBuf::from(String::from_utf8_lossy(&output.stdout).to_string());
+            PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_string());
 
         if let Some(version) =
             read_package_installed_version(global_node_modules.clone(), package_name).await?


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54093 (at least the os error 123 in the comments of that bug)/#54901 (although the diagnosis in that bug is totally wrong)
Used process monitor to work out what that issue was:
<img width="1573" height="94" alt="image" src="https://github.com/user-attachments/assets/2f82ad1a-8532-465d-9dcd-ba0bd092e9e7" />
There's actually a '\n' after node_modules there so it's an invalid directory. Add trim() to fix.
After adding that change locally, eslint loaded fine

Release Notes:

- Fixed bug where eslint didn't start on Windows
