### PR TITLE
sidebar: Group agent threads by linked git worktree

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1203,6 +1203,12 @@
     //
     // Default: true
     "show_merge_conflict_indicator": true,
+    // Whether to group threads in the agent panel sidebar by linked git
+    // worktree, rendering a worktree subsection header (with branch and a
+    // "+" button) under each project section.
+    //
+    // Default: false
+    "group_threads_by_worktree": false,
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -597,6 +597,7 @@ mod tests {
             tool_permissions,
             show_turn_stats: false,
             show_merge_conflict_indicator: true,
+            group_threads_by_worktree: false,
             new_thread_location: Default::default(),
             sidebar_side: Default::default(),
             thinking_display: Default::default(),

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -166,6 +166,7 @@ pub struct AgentSettings {
     pub message_editor_min_lines: usize,
     pub show_turn_stats: bool,
     pub show_merge_conflict_indicator: bool,
+    pub group_threads_by_worktree: bool,
     pub tool_permissions: ToolPermissions,
     pub new_thread_location: NewThreadLocation,
 }
@@ -670,6 +671,7 @@ impl Settings for AgentSettings {
             message_editor_min_lines: agent.message_editor_min_lines.unwrap(),
             show_turn_stats: agent.show_turn_stats.unwrap(),
             show_merge_conflict_indicator: agent.show_merge_conflict_indicator.unwrap(),
+            group_threads_by_worktree: agent.group_threads_by_worktree.unwrap_or(false),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
             new_thread_location: agent.new_thread_location.unwrap_or_default(),
         }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -714,6 +714,7 @@ mod tests {
             tool_permissions: Default::default(),
             show_turn_stats: false,
             show_merge_conflict_indicator: true,
+            group_threads_by_worktree: false,
             new_thread_location: Default::default(),
             sidebar_side: Default::default(),
             thinking_display: Default::default(),

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -226,6 +226,12 @@ pub struct AgentSettingsContent {
     ///
     /// Default: true
     pub show_merge_conflict_indicator: Option<bool>,
+    /// Whether to group threads in the agent panel sidebar by linked git
+    /// worktree, rendering a worktree subsection header (with branch and a
+    /// "+" button) under each project section.
+    ///
+    /// Default: false
+    pub group_threads_by_worktree: Option<bool>,
     /// Per-tool permission rules for granular control over which tool actions
     /// require confirmation.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7691,6 +7691,24 @@ fn ai_page(cx: &App) -> SettingsPage {
                 metadata: None,
                 files: USER,
             }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Group Threads By Worktree",
+                description: "Whether to group threads in the agent panel sidebar by linked git worktree, rendering a worktree subsection header (with branch and a \"+\" button) under each project section.",
+                field: Box::new(SettingField {
+                    json_path: Some("agent.group_threads_by_worktree"),
+                    pick: |settings_content| {
+                        settings_content.agent.as_ref()?.group_threads_by_worktree.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .group_threads_by_worktree = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
         ]);
 
         items.into_boxed_slice()

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -231,6 +231,17 @@ enum ListEntry {
         is_active: bool,
         has_threads: bool,
     },
+    WorktreeHeader {
+        project_key: ProjectGroupKey,
+        /// The folder paths of this worktree bucket — used to open the
+        /// matching workspace from the header's "+" button when no open
+        /// workspace currently has these as roots.
+        folder_paths: PathList,
+        label: SharedString,
+        branch: Option<SharedString>,
+        workspace: Option<WeakEntity<Workspace>>,
+        is_collapsed: bool,
+    },
     Thread(ThreadEntry),
 }
 
@@ -255,6 +266,11 @@ impl ListEntry {
             },
             ListEntry::ProjectHeader { key, .. } => multi_workspace
                 .workspaces_for_project_group(key, cx)
+                .unwrap_or_default(),
+            ListEntry::WorktreeHeader { workspace, .. } => workspace
+                .as_ref()
+                .and_then(|ws| ws.upgrade())
+                .map(|ws| vec![ws])
                 .unwrap_or_default(),
         }
     }
@@ -326,6 +342,57 @@ fn root_repository_snapshots(
 
 fn workspace_path_list(workspace: &Entity<Workspace>, cx: &App) -> PathList {
     PathList::new(&workspace.read(cx).root_paths(cx))
+}
+
+/// Bucket the given threads by their full `WorktreePaths` (preserving the
+/// first-seen order of each bucket), returning a list of
+/// `(worktree_paths, threads_in_bucket)` pairs.
+fn bucket_threads_by_worktree(
+    threads: Vec<ThreadEntry>,
+) -> Vec<(WorktreePaths, Vec<ThreadEntry>)> {
+    let mut buckets: Vec<(WorktreePaths, Vec<ThreadEntry>)> = Vec::new();
+    for thread in threads {
+        match buckets
+            .iter()
+            .position(|(k, _)| k == &thread.metadata.worktree_paths)
+        {
+            Some(i) => buckets[i].1.push(thread),
+            None => buckets.push((thread.metadata.worktree_paths.clone(), vec![thread])),
+        }
+    }
+    buckets
+}
+
+/// Build a `ListEntry::WorktreeHeader` for a bucket of threads sharing the
+/// same `WorktreePaths`. Resolves the open workspace whose root paths match
+/// the bucket's folder paths so the header's "+" button can route a new
+/// thread there directly.
+fn make_worktree_header_entry(
+    project_key: &ProjectGroupKey,
+    worktree_paths: &WorktreePaths,
+    group_workspaces: &[Entity<Workspace>],
+    branch_by_path: &HashMap<PathBuf, SharedString>,
+    is_collapsed: bool,
+    cx: &App,
+) -> ListEntry {
+    let infos = worktree_info_from_thread_paths(worktree_paths, branch_by_path);
+    let label = infos
+        .first()
+        .and_then(|info| info.worktree_name.clone())
+        .unwrap_or_else(|| SharedString::from("worktree"));
+    let branch = infos.first().and_then(|info| info.branch_name.clone());
+    let workspace = group_workspaces
+        .iter()
+        .find(|ws| workspace_path_list(ws, cx) == *worktree_paths.folder_path_list())
+        .map(|ws| ws.downgrade());
+    ListEntry::WorktreeHeader {
+        project_key: project_key.clone(),
+        folder_paths: worktree_paths.folder_path_list().clone(),
+        label,
+        branch,
+        workspace,
+        is_collapsed,
+    }
 }
 
 #[derive(Clone)]
@@ -608,6 +675,25 @@ impl Sidebar {
                 mw.serialize(cx);
             });
         }
+    }
+
+    /// Toggles the collapse state of a worktree subsection within a project
+    /// group. Only used when the `group_threads_by_worktree` setting is on.
+    /// State is persisted on the owning [`MultiWorkspace`] alongside the
+    /// project-group expanded flag, so it survives restarts.
+    fn toggle_worktree_collapsed(
+        &mut self,
+        project_key: &ProjectGroupKey,
+        folder_paths: &PathList,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(mw) = self.multi_workspace.upgrade() {
+            mw.update(cx, |mw, cx| {
+                let now_collapsed = !mw.is_worktree_collapsed(project_key, folder_paths);
+                mw.set_worktree_collapsed(project_key, folder_paths, now_collapsed, cx);
+            });
+        }
+        self.update_entries(cx);
     }
 
     fn is_active_workspace(&self, workspace: &Entity<Workspace>, cx: &App) -> bool {
@@ -930,11 +1016,31 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let path_list = project_group_key.path_list().clone();
+        self.open_workspace_at_paths_and_create_draft(
+            path_list,
+            project_group_key,
+            window,
+            cx,
+        );
+    }
+
+    /// Opens (or activates) a workspace at the given paths and creates a new
+    /// draft thread there. Unlike [`open_workspace_and_create_draft`], the
+    /// caller chooses the exact path list — useful when targeting a specific
+    /// linked worktree (whose paths differ from the project group's main
+    /// paths).
+    fn open_workspace_at_paths_and_create_draft(
+        &mut self,
+        path_list: PathList,
+        project_group_key: &ProjectGroupKey,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let Some(multi_workspace) = self.multi_workspace.upgrade() else {
             return;
         };
 
-        let path_list = project_group_key.path_list().clone();
         let host = project_group_key.host();
         let provisional_key = Some(project_group_key.clone());
         let active_workspace = multi_workspace.read(cx).workspace().clone();
@@ -1310,6 +1416,64 @@ impl Sidebar {
                         .is_some()
             };
 
+            let group_threads_by_worktree =
+                AgentSettings::get_global(cx).group_threads_by_worktree;
+            let group_state = mw.group_state_by_key(group_key);
+            let collapsed_worktrees: Option<&HashSet<PathList>> =
+                group_state.map(|state| &state.collapsed_worktrees);
+
+            let emit_threads = |entries: &mut Vec<ListEntry>,
+                                    threads: Vec<ThreadEntry>,
+                                    current_session_ids: &mut HashSet<acp::SessionId>,
+                                    current_thread_ids: &mut HashSet<agent_ui::ThreadId>| {
+                if !group_threads_by_worktree {
+                    for thread in threads {
+                        if let Some(sid) = thread.metadata.session_id.clone() {
+                            current_session_ids.insert(sid);
+                        }
+                        current_thread_ids.insert(thread.metadata.thread_id);
+                        entries.push(thread.into());
+                    }
+                    return;
+                }
+
+                let has_query = !query.is_empty();
+                for (worktree_paths, bucket_threads) in bucket_threads_by_worktree(threads) {
+                    if bucket_threads.is_empty() {
+                        continue;
+                    }
+                    // During search, ignore the user's collapse state so
+                    // matched threads always remain visible (mirrors the
+                    // project-header behavior).
+                    let bucket_collapsed = !has_query
+                        && collapsed_worktrees.is_some_and(|set| {
+                            set.contains(worktree_paths.folder_path_list())
+                        });
+                    entries.push(make_worktree_header_entry(
+                        group_key,
+                        &worktree_paths,
+                        group_workspaces,
+                        &branch_by_path,
+                        bucket_collapsed,
+                        cx,
+                    ));
+                    if bucket_collapsed {
+                        continue;
+                    }
+                    for mut thread in bucket_threads {
+                        // Each thread is now under its worktree's subsection
+                        // header, so the per-thread worktree chips would be
+                        // redundant.
+                        thread.worktrees.clear();
+                        if let Some(sid) = thread.metadata.session_id.clone() {
+                            current_session_ids.insert(sid);
+                        }
+                        current_thread_ids.insert(thread.metadata.thread_id);
+                        entries.push(thread.into());
+                    }
+                }
+            };
+
             if !query.is_empty() {
                 let workspace_highlight_positions =
                     fuzzy_match_positions(&query, &label).unwrap_or_default();
@@ -1358,13 +1522,12 @@ impl Sidebar {
                     has_threads,
                 });
 
-                for thread in matched_threads {
-                    if let Some(sid) = thread.metadata.session_id.clone() {
-                        current_session_ids.insert(sid);
-                    }
-                    current_thread_ids.insert(thread.metadata.thread_id);
-                    entries.push(thread.into());
-                }
+                emit_threads(
+                    &mut entries,
+                    matched_threads,
+                    &mut current_session_ids,
+                    &mut current_thread_ids,
+                );
             } else {
                 project_header_indices.push(entries.len());
                 entries.push(ListEntry::ProjectHeader {
@@ -1381,13 +1544,12 @@ impl Sidebar {
                     continue;
                 }
 
-                for thread in threads {
-                    if let Some(sid) = &thread.metadata.session_id {
-                        current_session_ids.insert(sid.clone());
-                    }
-                    current_thread_ids.insert(thread.metadata.thread_id);
-                    entries.push(thread.into());
-                }
+                emit_threads(
+                    &mut entries,
+                    threads,
+                    &mut current_session_ids,
+                    &mut current_thread_ids,
+                );
             }
         }
 
@@ -1501,6 +1663,24 @@ impl Sidebar {
                     cx,
                 )
             }
+            ListEntry::WorktreeHeader {
+                project_key,
+                folder_paths,
+                label,
+                branch,
+                workspace,
+                is_collapsed,
+            } => self.render_worktree_header(
+                ix,
+                project_key,
+                folder_paths,
+                label,
+                branch.as_ref(),
+                workspace.as_ref(),
+                *is_collapsed,
+                is_selected,
+                cx,
+            ),
             ListEntry::Thread(thread) => self.render_thread(ix, thread, is_active, is_selected, cx),
         };
 
@@ -1765,6 +1945,155 @@ impl Sidebar {
         } else {
             header.into_any_element()
         }
+    }
+
+    fn render_worktree_header(
+        &self,
+        ix: usize,
+        project_key: &ProjectGroupKey,
+        folder_paths: &PathList,
+        label: &SharedString,
+        branch: Option<&SharedString>,
+        workspace: Option<&WeakEntity<Workspace>>,
+        is_collapsed: bool,
+        is_focused: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let id = SharedString::from(format!("worktree-header-{ix}"));
+        let group_name = SharedString::from(format!("worktree-header-group-{ix}"));
+        let color = cx.theme().colors();
+        let focus_handle = self.focus_handle.clone();
+        let project_key_for_plus = project_key.clone();
+        let folder_paths_for_plus = folder_paths.clone();
+        let workspace_for_plus = workspace.cloned();
+        let project_key_for_toggle = project_key.clone();
+        let folder_paths_for_toggle = folder_paths.clone();
+
+        let disclosure_icon = if is_collapsed {
+            IconName::ChevronRight
+        } else {
+            IconName::ChevronDown
+        };
+
+        let sidebar_base_bg = color
+            .title_bar_background
+            .blend(color.panel_background.opacity(0.25));
+        let base_bg = color.background.blend(sidebar_base_bg);
+        let hover_base = color
+            .element_active
+            .blend(color.element_background.opacity(0.2));
+        let hover_solid = base_bg.blend(hover_base);
+
+        let group_name_for_gradient = group_name.clone();
+        let gradient_overlay = move || {
+            GradientFade::new(base_bg, hover_solid, hover_solid)
+                .width(px(64.0))
+                .right(px(-2.0))
+                .gradient_stop(0.75)
+                .group_name(group_name_for_gradient.clone())
+        };
+
+        h_flex()
+            .id(id)
+            .group(&group_name)
+            .cursor_pointer()
+            .relative()
+            .h(Tab::content_height(cx))
+            .w_full()
+            .pl_2()
+            .pr_1p5()
+            .justify_between()
+            .border_1()
+            .map(|this| {
+                if is_focused {
+                    this.border_color(color.border_focused)
+                } else {
+                    this.border_color(gpui::transparent_black())
+                }
+            })
+            .hover(|s| s.bg(hover_solid))
+            .child(
+                h_flex()
+                    .relative()
+                    .min_w_0()
+                    .w_full()
+                    .gap_1()
+                    .child(
+                        Icon::new(IconName::GitWorktree)
+                            .size(IconSize::XSmall)
+                            .color(Color::Default),
+                    )
+                    .child(
+                        Label::new(label.clone())
+                            .color(Color::Default)
+                            .truncate(),
+                    )
+                    .when_some(branch.cloned(), |this, branch| {
+                        this.child(
+                            Label::new(branch)
+                                .size(LabelSize::Small)
+                                .color(Color::Muted)
+                                .truncate(),
+                        )
+                    })
+                    .child(
+                        div()
+                            .when(!is_focused, |this| this.visible_on_hover(&group_name))
+                            .child(
+                                Icon::new(disclosure_icon)
+                                    .size(IconSize::Small)
+                                    .color(Color::Muted),
+                            ),
+                    ),
+            )
+            .child(gradient_overlay())
+            .child(
+                h_flex()
+                    .child(gradient_overlay())
+                    .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+                        cx.stop_propagation();
+                    })
+                    .child(
+                        IconButton::new(
+                            SharedString::from(format!("worktree-header-new-thread-{ix}")),
+                            IconName::Plus,
+                        )
+                        .icon_size(IconSize::Small)
+                        .visible_on_hover(&group_name)
+                        .tooltip(move |_, cx| {
+                            Tooltip::for_action_in(
+                                "Start New Agent Thread in This Worktree",
+                                &NewThread,
+                                &focus_handle,
+                                cx,
+                            )
+                        })
+                        .on_click(cx.listener(move |this, _, window, cx| {
+                            this.set_group_expanded(&project_key_for_plus, true, cx);
+                            this.selection = None;
+                            let workspace =
+                                workspace_for_plus.as_ref().and_then(|ws| ws.upgrade());
+                            if let Some(workspace) = workspace {
+                                this.create_new_thread(&workspace, window, cx);
+                            } else {
+                                this.open_workspace_at_paths_and_create_draft(
+                                    folder_paths_for_plus.clone(),
+                                    &project_key_for_plus,
+                                    window,
+                                    cx,
+                                );
+                            }
+                        })),
+                    ),
+            )
+            .on_click(cx.listener(move |this, _, _window, cx| {
+                this.toggle_worktree_collapsed(
+                    &project_key_for_toggle,
+                    &folder_paths_for_toggle,
+                    cx,
+                );
+            }))
+            .into_any_element()
     }
 
     fn render_project_header_ellipsis_menu(
@@ -2367,6 +2696,19 @@ impl Sidebar {
                 let key = key.clone();
                 self.toggle_collapse(&key, window, cx);
             }
+            ListEntry::WorktreeHeader {
+                project_key,
+                workspace,
+                ..
+            } => {
+                let project_key = project_key.clone();
+                let workspace = workspace.as_ref().and_then(|ws| ws.upgrade());
+                if let Some(workspace) = workspace {
+                    self.activate_workspace(&workspace, window, cx);
+                } else {
+                    self.activate_or_open_workspace_for_group(&project_key, window, cx);
+                }
+            }
             ListEntry::Thread(thread) => {
                 let metadata = thread.metadata.clone();
                 match &thread.workspace {
@@ -2956,6 +3298,13 @@ impl Sidebar {
                     self.update_entries(cx);
                 }
             }
+            Some(ListEntry::WorktreeHeader { project_key, .. }) => {
+                let key = project_key.clone();
+                if !self.is_group_collapsed(&key, cx) {
+                    self.set_group_expanded(&key, false, cx);
+                    self.update_entries(cx);
+                }
+            }
             Some(ListEntry::Thread(_)) => {
                 for i in (0..ix).rev() {
                     if let Some(ListEntry::ProjectHeader { key, .. }) = self.contents.entries.get(i)
@@ -2983,12 +3332,14 @@ impl Sidebar {
         // Find the group header for the current selection.
         let header_ix = match self.contents.entries.get(ix) {
             Some(ListEntry::ProjectHeader { .. }) => Some(ix),
-            Some(ListEntry::Thread(_)) => (0..ix).rev().find(|&i| {
-                matches!(
-                    self.contents.entries.get(i),
-                    Some(ListEntry::ProjectHeader { .. })
-                )
-            }),
+            Some(ListEntry::WorktreeHeader { .. }) | Some(ListEntry::Thread(_)) => {
+                (0..ix).rev().find(|&i| {
+                    matches!(
+                        self.contents.entries.get(i),
+                        Some(ListEntry::ProjectHeader { .. })
+                    )
+                })
+            }
             None => None,
         };
 
@@ -3659,6 +4010,7 @@ impl Sidebar {
                     current_header_key = Some(key.clone());
                     None
                 }
+                ListEntry::WorktreeHeader { .. } => None,
                 ListEntry::Thread(thread) => {
                     let session_id = thread.metadata.session_id.clone()?;
                     let workspace = match &thread.workspace {
@@ -4146,6 +4498,7 @@ impl Sidebar {
         let ix = self.selection?;
         match self.contents.entries.get(ix) {
             Some(ListEntry::ProjectHeader { key, .. }) => Some(key.clone()),
+            Some(ListEntry::WorktreeHeader { project_key, .. }) => Some(project_key.clone()),
             Some(ListEntry::Thread(_)) => {
                 (0..ix)
                     .rev()

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -130,6 +130,7 @@ fn assert_remote_project_integration_sidebar_state(
                     "expected the only sidebar project header to be `project`"
                 );
             }
+            ListEntry::WorktreeHeader { .. } => {}
             ListEntry::Thread(thread)
                 if thread.metadata.session_id.as_ref() == Some(main_thread_id) =>
             {
@@ -493,6 +494,19 @@ fn visible_entries_as_strings(
                             "v"
                         };
                         format!("{} [{}]{}", icon, label, selected)
+                    }
+                    ListEntry::WorktreeHeader {
+                        label,
+                        branch,
+                        is_collapsed,
+                        ..
+                    } => {
+                        let branch_str = branch
+                            .as_ref()
+                            .map(|b| format!(" ({b})"))
+                            .unwrap_or_default();
+                        let icon = if *is_collapsed { ">" } else { "v" };
+                        format!("  {} [{}]{}{}", icon, label, branch_str, selected)
                     }
                     ListEntry::Thread(thread) => {
                         let title = thread.metadata.display_title();
@@ -3851,6 +3865,7 @@ async fn test_clicking_worktree_thread_does_not_briefly_render_as_separate_proje
                         "expected the only sidebar project header to be `project`"
                     );
                 }
+                ListEntry::WorktreeHeader { .. } => {}
                 ListEntry::Thread(thread)
                     if thread.metadata.title.as_ref().map(|t| t.as_ref()) == Some("WT Thread")
                         && thread
@@ -11203,5 +11218,223 @@ async fn test_cmd_click_project_header_returns_to_last_active_linked_worktree_wo
         active_after_cmd_click, main_workspace_a,
         "cmd-click must not fall back to the main-paths workspace when a \
          linked-worktree workspace was the last-active one for the group"
+    );
+}
+
+fn enable_group_threads_by_worktree(
+    sidebar: &Entity<Sidebar>,
+    cx: &mut gpui::VisualTestContext,
+) {
+    use gpui::UpdateGlobal as _;
+    cx.update(|_, cx| {
+        settings::SettingsStore::update_global(cx, |store, cx| {
+            store
+                .set_user_settings(
+                    r#"{ "agent": { "group_threads_by_worktree": true } }"#,
+                    cx,
+                )
+                .unwrap();
+        });
+    });
+    sidebar.update_in(cx, |sidebar, _window, cx| sidebar.update_entries(cx));
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+async fn test_group_threads_by_worktree_setting_off_keeps_flat_list(cx: &mut TestAppContext) {
+    let (project, _fs) = init_test_project_with_git("/project", cx).await;
+
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_named_thread_metadata("main-t", "Main Thread", &project, cx).await;
+    save_thread_metadata_with_main_paths(
+        "wt-t",
+        "WT Thread",
+        PathList::new(&[PathBuf::from("/wt/feature")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 1).unwrap(),
+        cx,
+    );
+
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [project]",
+            "  WT Thread {feature}",
+            "  Main Thread",
+        ],
+        "with the setting off, threads should be flat-listed under the project header"
+    );
+}
+
+#[gpui::test]
+async fn test_group_threads_by_worktree_setting_on_emits_subsection_headers(
+    cx: &mut TestAppContext,
+) {
+    let (project, _fs) = init_test_project_with_git("/project", cx).await;
+
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_named_thread_metadata("main-t", "Main Thread", &project, cx).await;
+    save_thread_metadata_with_main_paths(
+        "wt-a",
+        "Feature A Thread",
+        PathList::new(&[PathBuf::from("/wt/feature-a")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 1).unwrap(),
+        cx,
+    );
+    save_thread_metadata_with_main_paths(
+        "wt-b",
+        "Feature B Thread",
+        PathList::new(&[PathBuf::from("/wt/feature-b")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 2).unwrap(),
+        cx,
+    );
+
+    enable_group_threads_by_worktree(&sidebar, cx);
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [project]",
+            "  v [feature-b]",
+            "  Feature B Thread",
+            "  v [feature-a]",
+            "  Feature A Thread",
+            "  v [project]",
+            "  Main Thread",
+        ],
+        "with the setting on, each unique worktree should get its own subsection \
+         header and per-thread worktree chips should be hidden"
+    );
+}
+
+#[gpui::test]
+async fn test_group_threads_by_worktree_skips_empty_buckets(cx: &mut TestAppContext) {
+    let (project, _fs) = init_test_project_with_git("/project", cx).await;
+
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    // Only the linked worktree has a thread; the main worktree has none.
+    save_thread_metadata_with_main_paths(
+        "wt-only",
+        "Only WT Thread",
+        PathList::new(&[PathBuf::from("/wt/feature")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 1).unwrap(),
+        cx,
+    );
+
+    enable_group_threads_by_worktree(&sidebar, cx);
+
+    // No header should be emitted for the empty main worktree bucket.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [project]",
+            "  v [feature]",
+            "  Only WT Thread",
+        ],
+        "worktrees with no threads must not get a subsection header"
+    );
+}
+
+#[gpui::test]
+async fn test_group_threads_by_worktree_collapse_toggle(cx: &mut TestAppContext) {
+    let (project, _fs) = init_test_project_with_git("/project", cx).await;
+
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_named_thread_metadata("main-t", "Main Thread", &project, cx).await;
+    save_thread_metadata_with_main_paths(
+        "wt-t",
+        "WT Thread",
+        PathList::new(&[PathBuf::from("/wt/feature")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 1).unwrap(),
+        cx,
+    );
+
+    enable_group_threads_by_worktree(&sidebar, cx);
+
+    let project_key = project.read_with(cx, |p, cx| p.project_group_key(cx));
+    let feature_paths = PathList::new(&[PathBuf::from("/wt/feature")]);
+
+    // Both buckets start expanded.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [project]",
+            "  v [feature]",
+            "  WT Thread",
+            "  v [project]",
+            "  Main Thread",
+        ],
+        "buckets should default to expanded"
+    );
+
+    // Collapse the feature worktree bucket.
+    sidebar.update_in(cx, |sidebar, _window, cx| {
+        sidebar.toggle_worktree_collapsed(&project_key, &feature_paths, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [project]",
+            "  > [feature]",
+            "  v [project]",
+            "  Main Thread",
+        ],
+        "collapsing a worktree subsection should hide its threads while \
+         leaving other buckets unchanged"
+    );
+
+    // Toggle back to expanded.
+    sidebar.update_in(cx, |sidebar, _window, cx| {
+        sidebar.toggle_worktree_collapsed(&project_key, &feature_paths, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            "v [project]",
+            "  v [feature]",
+            "  WT Thread",
+            "  v [project]",
+            "  Main Thread",
+        ],
+        "toggling again should re-expand the bucket"
     );
 }

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -11,6 +11,7 @@ use project::{DisableAiSettings, Project};
 use remote::RemoteConnectionOptions;
 use settings::Settings;
 pub use settings::SidebarSide;
+use std::collections::HashSet;
 use std::future::Future;
 
 use std::path::PathBuf;
@@ -274,6 +275,7 @@ pub struct ProjectGroup {
 pub struct SerializedProjectGroupState {
     pub key: ProjectGroupKey,
     pub expanded: bool,
+    pub collapsed_worktrees: Vec<PathList>,
 }
 
 #[derive(Clone)]
@@ -281,6 +283,10 @@ pub struct ProjectGroupState {
     pub key: ProjectGroupKey,
     pub expanded: bool,
     pub last_active_workspace: Option<WeakEntity<Workspace>>,
+    /// Folder paths of worktree subsections the user has collapsed within
+    /// this project group. Used by the agent sidebar's
+    /// `group_threads_by_worktree` setting; persisted across restarts.
+    pub collapsed_worktrees: HashSet<PathList>,
 }
 
 pub struct MultiWorkspace {
@@ -636,6 +642,7 @@ impl MultiWorkspace {
                 key,
                 expanded: true,
                 last_active_workspace: None,
+                collapsed_worktrees: HashSet::new(),
             },
         );
     }
@@ -771,7 +778,12 @@ impl MultiWorkspace {
         _cx: &mut Context<Self>,
     ) {
         let mut restored: Vec<ProjectGroupState> = Vec::new();
-        for SerializedProjectGroupState { key, expanded } in groups {
+        for SerializedProjectGroupState {
+            key,
+            expanded,
+            collapsed_worktrees,
+        } in groups
+        {
             if key.path_list().paths().is_empty() {
                 continue;
             }
@@ -782,6 +794,7 @@ impl MultiWorkspace {
                 key,
                 expanded,
                 last_active_workspace: None,
+                collapsed_worktrees: collapsed_worktrees.into_iter().collect(),
             });
         }
         for existing in std::mem::take(&mut self.project_groups) {
@@ -841,6 +854,39 @@ impl MultiWorkspace {
         self.project_groups
             .iter_mut()
             .find(|group| group.key == *key)
+    }
+
+    /// Whether the worktree subsection identified by `folder_paths` (the
+    /// folder-path portion of a `WorktreePaths`) within the given project
+    /// group is currently collapsed.
+    pub fn is_worktree_collapsed(
+        &self,
+        project_key: &ProjectGroupKey,
+        folder_paths: &PathList,
+    ) -> bool {
+        self.group_state_by_key(project_key)
+            .is_some_and(|group| group.collapsed_worktrees.contains(folder_paths))
+    }
+
+    /// Sets the collapsed state of a worktree subsection within a project
+    /// group and persists the change.
+    pub fn set_worktree_collapsed(
+        &mut self,
+        project_key: &ProjectGroupKey,
+        folder_paths: &PathList,
+        collapsed: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(group) = self.group_state_by_key_mut(project_key) {
+            let changed = if collapsed {
+                group.collapsed_worktrees.insert(folder_paths.clone())
+            } else {
+                group.collapsed_worktrees.remove(folder_paths)
+            };
+            if changed {
+                self.serialize(cx);
+            }
+        }
     }
 
     pub fn set_all_groups_expanded(&mut self, expanded: bool) {
@@ -1544,9 +1590,12 @@ impl MultiWorkspace {
                             .project_groups
                             .iter()
                             .map(|group| {
+                                let collapsed: Vec<PathList> =
+                                    group.collapsed_worktrees.iter().cloned().collect();
                                 crate::persistence::model::SerializedProjectGroup::from_group(
                                     &group.key,
                                     group.expanded,
+                                    &collapsed,
                                 )
                             })
                             .collect::<Vec<_>>(),
@@ -1744,6 +1793,7 @@ impl MultiWorkspace {
             key: group.key,
             expanded: group.expanded,
             last_active_workspace: None,
+            collapsed_worktrees: HashSet::new(),
         });
     }
 

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -68,6 +68,12 @@ pub struct SerializedProjectGroup {
     pub(crate) location: SerializedWorkspaceLocation,
     #[serde(default = "default_expanded")]
     pub expanded: bool,
+    /// Folder paths of worktree subsections the user has collapsed within
+    /// this project group. Each entry is a serialized [`PathList`]. Empty by
+    /// default for backward compatibility with persisted state written before
+    /// the worktree-grouping feature existed.
+    #[serde(default)]
+    pub collapsed_worktrees: Vec<SerializedPathList>,
 }
 
 fn default_expanded() -> bool {
@@ -75,7 +81,11 @@ fn default_expanded() -> bool {
 }
 
 impl SerializedProjectGroup {
-    pub fn from_group(key: &ProjectGroupKey, expanded: bool) -> Self {
+    pub fn from_group(
+        key: &ProjectGroupKey,
+        expanded: bool,
+        collapsed_worktrees: &[PathList],
+    ) -> Self {
         Self {
             path_list: key.path_list().serialize(),
             location: match key.host() {
@@ -83,6 +93,10 @@ impl SerializedProjectGroup {
                 None => SerializedWorkspaceLocation::Local,
             },
             expanded,
+            collapsed_worktrees: collapsed_worktrees
+                .iter()
+                .map(|paths| paths.serialize())
+                .collect(),
         }
     }
 
@@ -92,9 +106,15 @@ impl SerializedProjectGroup {
             SerializedWorkspaceLocation::Local => None,
             SerializedWorkspaceLocation::Remote(opts) => Some(opts),
         };
+        let collapsed_worktrees = self
+            .collapsed_worktrees
+            .into_iter()
+            .map(|serialized| PathList::deserialize(&serialized))
+            .collect();
         SerializedProjectGroupState {
             key: ProjectGroupKey::new(host, path_list),
             expanded: self.expanded,
+            collapsed_worktrees,
         }
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8940,7 +8940,11 @@ pub async fn apply_restored_multiworkspace_state(
         // stale keys from previous sessions get normalized and deduped.
         let mut resolved_groups: Vec<SerializedProjectGroupState> = Vec::new();
         for serialized in project_groups.iter().cloned() {
-            let SerializedProjectGroupState { key, expanded } = serialized.into_restored_state();
+            let SerializedProjectGroupState {
+                key,
+                expanded,
+                collapsed_worktrees,
+            } = serialized.into_restored_state();
             if key.path_list().paths().is_empty() {
                 continue;
             }
@@ -8961,6 +8965,7 @@ pub async fn apply_restored_multiworkspace_state(
                 resolved_groups.push(SerializedProjectGroupState {
                     key: resolved,
                     expanded,
+                    collapsed_worktrees,
                 });
             }
         }


### PR DESCRIPTION
Adds an opt-in `agent.group_threads_by_worktree` setting (default off). When enabled, each project section in the agent panel sidebar is split into per-worktree subsections, each with its own collapsible header (worktree name + branch + "+" button that creates a draft thread routed to that worktree's workspace). Per-thread worktree chips are hidden in this mode since the section heading already conveys that info, and worktree-subsection collapse state is persisted on `MultiWorkspace`/`ProjectGroupState` alongside the existing project-group `expanded` flag so it survives restarts.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added an `agent.group_threads_by_worktree` setting that, when enabled, groups agent threads in the sidebar under collapsible per-worktree subsections within each project section