### PR TITLE
Handle eslint/status LSP notification to avoid log spam

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -13,6 +13,7 @@ pub mod clangd_ext;
 mod code_lens;
 mod document_colors;
 mod document_symbols;
+mod eslint_ext;
 mod folding_ranges;
 mod inlay_hints;
 pub mod json_language_server_ext;
@@ -1304,6 +1305,7 @@ impl LocalLspStore {
         json_language_server_ext::register_requests(lsp_store.clone(), language_server);
         rust_analyzer_ext::register_notifications(lsp_store.clone(), language_server);
         clangd_ext::register_notifications(lsp_store, language_server, adapter);
+        eslint_ext::register_notifications(language_server);
     }
 
     fn shutdown_language_servers_on_quit(&mut self) -> impl Future<Output = ()> + use<> {

--- a/crates/project/src/lsp_store/eslint_ext.rs
+++ b/crates/project/src/lsp_store/eslint_ext.rs
@@ -1,0 +1,24 @@
+use lsp::{LanguageServer, LanguageServerName};
+
+/// Use the same static name as `EsLintLspAdapter` in the `languages` crate (`"eslint"`).
+pub const ESLINT_SERVER_NAME: LanguageServerName = LanguageServerName::new_static("eslint");
+
+/// Custom notification from the vscode-eslint language server; used for UI status
+/// in VS Code. Zed has no use for the payload, but we must register a handler or
+/// every message is treated as unhandled and logged.
+pub struct EslintStatus;
+
+impl lsp::notification::Notification for EslintStatus {
+    type Params = serde_json::Value;
+    const METHOD: &'static str = "eslint/status";
+}
+
+pub fn register_notifications(language_server: &LanguageServer) {
+    if language_server.name() != ESLINT_SERVER_NAME {
+        return;
+    }
+
+    language_server
+        .on_notification::<EslintStatus, _>(|_params, _cx| {})
+        .detach();
+}


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54948 

Release Notes:

- Fixes
Reduced LSP log noise by handling ESLint’s custom eslint/status notification instead of treating it as unhandled.
Added ESLint-specific notification wiring in the project LSP store so routine status updates no longer emit repetitive INFO logs.
