### PR TITLE
Look for bracket pairs more aggressively

### DIFF
--- a/crates/editor/src/bracket_colorization.rs
+++ b/crates/editor/src/bracket_colorization.rs
@@ -107,11 +107,7 @@ impl Editor {
                     .ok();
             }
 
-            let viewport_start_row =
-                        buffer_snapshot.offset_to_point(buffer_range.start).row;
-                    let viewport_end_row = buffer_snapshot.offset_to_point(buffer_range.end).row;
-
-                    let (bracket_matches_by_accent, updated_chunks) = bracket_matches_by_accent.await;
+            let (bracket_matches_by_accent, updated_chunks) = bracket_matches_by_accent.await;
 
             editor
                 .update(cx, |editor, cx| {
@@ -150,29 +146,48 @@ fn compute_bracket_ranges(
     accents_count: usize,
 ) -> Vec<(usize, Vec<Range<Anchor>>)> {
     let context = excerpt_range.context.to_offset(buffer_snapshot);
+    let buffer_range = buffer_range.start.0..buffer_range.end.0;
 
-    buffer_snapshot
-        .fetch_bracket_ranges(
-            buffer_range.start.0..buffer_range.end.0,
-            Some(fetched_chunks),
-        )
+    // `fetch_bracket_ranges` already attributes each `>MAX_BYTES_TO_QUERY`
+    // pair to the chunk containing its opening bracket, so the existing
+    // `fetched_chunks` dedup keeps us from re-emitting them.  We still need
+    // the full list for the depth shift below: chunk-local nesting can't
+    // see ancestors that didn't fit inside a single query window.
+    let large_block_pairs = buffer_snapshot.bracket_pairs_for_large_enclosing_blocks(&buffer_range);
+
+    let mut bracket_pairs = buffer_snapshot
+        .fetch_bracket_ranges(buffer_range, Some(fetched_chunks))
         .into_iter()
         .flat_map(|(chunk_range, pairs)| {
-            if fetched_chunks.contains(&chunk_range) {
-                return Vec::new();
-                            }
-                            // Only claim chunks overlapping the viewport as
-                            // fetched.  Boundary chunks pulled in by
-                            // `extend_range_for_enclosing_brackets` contribute
-                            // their bracket pairs but must remain re-queryable
-            // when the user scrolls to them.
-                            if chunk_range.start <= viewport_end_row
-                                && chunk_range.end > viewport_start_row
-                            {
-                                fetched_chunks.insert(chunk_range);
-                            }
-            pairs
+            if fetched_chunks.insert(chunk_range) {
+                pairs
+            } else {
+                Vec::new()
+            }
         })
+        .collect::<Vec<_>>();
+
+    // Shift each bracket's depth by the number of large blocks that
+    // strictly enclose it.  This applies uniformly to chunk-local pairs
+    // (whose stack-based depth misses these ancestors) and to large pairs
+    // (which arrive with `color_index = Some(0)`); siblings of a large
+    // block keep their original depth.
+    for pair in &mut bracket_pairs {
+        let Some(idx) = pair.color_index.as_mut() else {
+            continue;
+        };
+        let extra_depth = large_block_pairs
+            .iter()
+            .filter(|outer| {
+                outer.open_range.start < pair.open_range.start
+                    && pair.close_range.end < outer.close_range.end
+            })
+            .count();
+        *idx += extra_depth;
+    }
+
+    bracket_pairs
+        .into_iter()
         .filter_map(|pair| {
             let color_index = pair.color_index?;
 
@@ -656,8 +671,9 @@ fn process_data«1()1» «1{
 
     #[gpui::test]
     async fn test_bracket_colorization_large_block(cx: &mut gpui::TestAppContext) {
-        // Each `//\n` is 3 bytes; 6000 lines ≈ 18 KB, exceeding MAX_BYTES_TO_QUERY (16 KB).
-        let comment_lines = 6000;
+        // Each padded comment line is 27 bytes; 620 lines = 16740 bytes,
+        // just over MAX_BYTES_TO_QUERY (16 KB) with head/tail overhead.
+        let comment_lines = 620;
 
         init_test(cx, |language_settings| {
             language_settings.defaults.colorize_brackets = Some(true);
@@ -685,33 +701,28 @@ mod foo {
             comment_lines,
         ));
 
+        let colored_head = "mod foo «1{\n\
+                            \x20   fn process_data_1«2()2» «2{\n\
+                            \x20       let map: Option«3<Vec«4<«5()5»>4»>3» = None;\n\
+                            \x20   }2»";
+        let uncolored_tail = "    fn process_data_2() {\n\
+                              \x20       let map: Option<Vec<()>> = None;\n\
+                              \x20   }\n\
+                              }1»";
+        let colored_tail = "    fn process_data_2«2()2» «2{\n\
+                            \x20       let map: Option«3<Vec«4<«5()5»>4»>3» = None;\n\
+                            \x20   }2»\n\
+                            }1»";
+
         cx.executor().advance_clock(Duration::from_millis(100));
         cx.executor().run_until_parked();
+        let markup = bracket_colors_markup(&mut cx);
+        let relevant = filter_bracket_relevant_lines(&markup);
         assert_eq!(
-            &separate_with_comment_lines(
-                indoc! {r#"
-mod foo «1{
-    fn process_data_1«2()2» «2{
-        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
-    }2»
-"#},
-                indoc! {r#"
-    fn process_data_2«2()2» «2{
-        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
-    }2»
-}1»
-
-1 hsla(207.80, 16.20%, 69.19%, 1.00)
-2 hsla(29.00, 54.00%, 65.88%, 1.00)
-3 hsla(286.00, 51.00%, 75.25%, 1.00)
-4 hsla(187.00, 47.00%, 59.22%, 1.00)
-5 hsla(355.00, 65.00%, 75.94%, 1.00)
-"#},
-                comment_lines,
-            ),
-            &bracket_colors_markup(&mut cx),
-            "Top chunk: brackets should be colorized even when the enclosing \
-             block exceeds MAX_BYTES_TO_QUERY"
+            relevant,
+            format!("{colored_head}\n{uncolored_tail}"),
+            "Top chunk: visible brackets should be colorized even when the \
+             enclosing block exceeds MAX_BYTES_TO_QUERY"
         );
 
         cx.update_editor(|editor, window, cx| {
@@ -720,29 +731,11 @@ mod foo «1{
         });
         cx.executor().advance_clock(Duration::from_millis(100));
         cx.executor().run_until_parked();
+        let markup = bracket_colors_markup(&mut cx);
+        let relevant = filter_bracket_relevant_lines(&markup);
         assert_eq!(
-            &separate_with_comment_lines(
-                indoc! {r#"
-mod foo «1{
-    fn process_data_1«2()2» «2{
-        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
-    }2»
-"#},
-                indoc! {r#"
-    fn process_data_2«2()2» «2{
-        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
-    }2»
-}1»
-
-1 hsla(207.80, 16.20%, 69.19%, 1.00)
-2 hsla(29.00, 54.00%, 65.88%, 1.00)
-3 hsla(286.00, 51.00%, 75.25%, 1.00)
-4 hsla(187.00, 47.00%, 59.22%, 1.00)
-5 hsla(355.00, 65.00%, 75.94%, 1.00)
-"#},
-                comment_lines,
-            ),
-            &bracket_colors_markup(&mut cx),
+            relevant,
+            format!("{colored_head}\n{colored_tail}"),
             "After scrolling to bottom, both chunks should have bracket \
              highlights across a large block"
         );
@@ -1691,9 +1684,14 @@ mod foo «1{
         cx.executor().advance_clock(Duration::from_millis(100));
         cx.executor().run_until_parked();
 
+        // The fold collapses both `big_function`'s outer `()` and `{...}`
+        // (color 1) and the 700 inner `(N)` pairs (color 2, since they
+        // nest inside the >MAX_BYTES_TO_QUERY `{...}` block discovered by
+        // `bracket_pairs_for_large_enclosing_blocks`).  Both colors
+        // therefore appear on the fold marker line.
         assert_eq!(
             indoc! {r#"
-⋯1»
+⋯2»1»
 
 fn small_function«1()1» «1{
     let x = «2(1, «3(2, 3)3»)2»;
@@ -1709,8 +1707,10 @@ fn small_function«1()1» «1{
 
     fn separate_with_comment_lines(head: &str, tail: &str, comment_lines: usize) -> String {
         let mut result = head.to_string();
-        result.push_str("\n");
-        result.push_str(&"//\n".repeat(comment_lines));
+        result.push('\n');
+        for _ in 0..comment_lines {
+            result.push_str("// padding padding padding\n");
+        }
         result.push_str(tail);
         result
     }
@@ -1760,16 +1760,25 @@ fn small_function«1()1» «1{
             }
         }
 
+        // Sort by descending position, then opens before closes, then by
+        // text so that identical `(offset, text)` annotations end up
+        // adjacent and `dedup` collapses them.  Without the text tiebreak,
+        // multiple bracket pairs that all collapse to the same fold marker
+        // can interleave in the input order and survive deduplication.
         annotations.sort_by(|(pos_a, text_a), (pos_b, text_b)| {
-            pos_a.cmp(pos_b).reverse().then_with(|| {
-                let a_is_opening = text_a.starts_with('«');
-                let b_is_opening = text_b.starts_with('«');
-                match (a_is_opening, b_is_opening) {
-                    (true, false) => cmp::Ordering::Less,
-                    (false, true) => cmp::Ordering::Greater,
-                    _ => cmp::Ordering::Equal,
-                }
-            })
+            pos_a
+                .cmp(pos_b)
+                .reverse()
+                .then_with(|| {
+                    let a_is_opening = text_a.starts_with('«');
+                    let b_is_opening = text_b.starts_with('«');
+                    match (a_is_opening, b_is_opening) {
+                        (true, false) => cmp::Ordering::Less,
+                        (false, true) => cmp::Ordering::Greater,
+                        _ => cmp::Ordering::Equal,
+                    }
+                })
+                .then_with(|| text_a.cmp(text_b))
         });
         annotations.dedup();
 
@@ -1788,5 +1797,19 @@ fn small_function«1()1» «1{
         }
 
         markup
+    }
+
+    fn filter_bracket_relevant_lines(markup: &str) -> String {
+        markup
+            .lines()
+            .filter(|line| {
+                let trimmed = line.trim();
+                !trimmed.is_empty()
+                    && !trimmed.starts_with("//")
+                    && !trimmed.starts_with("hsla(")
+                    && !trimmed.chars().next().is_some_and(|c| c.is_ascii_digit())
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }

--- a/crates/editor/src/bracket_colorization.rs
+++ b/crates/editor/src/bracket_colorization.rs
@@ -107,7 +107,11 @@ impl Editor {
                     .ok();
             }
 
-            let (bracket_matches_by_accent, updated_chunks) = bracket_matches_by_accent.await;
+            let viewport_start_row =
+                        buffer_snapshot.offset_to_point(buffer_range.start).row;
+                    let viewport_end_row = buffer_snapshot.offset_to_point(buffer_range.end).row;
+
+                    let (bracket_matches_by_accent, updated_chunks) = bracket_matches_by_accent.await;
 
             editor
                 .update(cx, |editor, cx| {
@@ -154,11 +158,20 @@ fn compute_bracket_ranges(
         )
         .into_iter()
         .flat_map(|(chunk_range, pairs)| {
-            if fetched_chunks.insert(chunk_range) {
-                pairs
-            } else {
-                Vec::new()
-            }
+            if fetched_chunks.contains(&chunk_range) {
+                return Vec::new();
+                            }
+                            // Only claim chunks overlapping the viewport as
+                            // fetched.  Boundary chunks pulled in by
+                            // `extend_range_for_enclosing_brackets` contribute
+                            // their bracket pairs but must remain re-queryable
+            // when the user scrolls to them.
+                            if chunk_range.start <= viewport_end_row
+                                && chunk_range.end > viewport_start_row
+                            {
+                                fetched_chunks.insert(chunk_range);
+                            }
+            pairs
         })
         .filter_map(|pair| {
             let color_index = pair.color_index?;
@@ -638,6 +651,100 @@ fn process_data«1()1» «1{
 5 hsla(355.00, 65.00%, 75.94%, 1.00)
 "#},
             &bracket_colors_markup(&mut cx),
+        );
+    }
+
+    #[gpui::test]
+    async fn test_bracket_colorization_large_block(cx: &mut gpui::TestAppContext) {
+        // Each `//\n` is 3 bytes; 6000 lines ≈ 18 KB, exceeding MAX_BYTES_TO_QUERY (16 KB).
+        let comment_lines = 6000;
+
+        init_test(cx, |language_settings| {
+            language_settings.defaults.colorize_brackets = Some(true);
+        });
+        let mut cx = EditorLspTestContext::new(
+            Arc::into_inner(rust_lang()).unwrap(),
+            lsp::ServerCapabilities::default(),
+            cx,
+        )
+        .await;
+
+        cx.set_state(&separate_with_comment_lines(
+            indoc! {r#"
+mod foo {
+    ˇfn process_data_1() {
+        let map: Option<Vec<()>> = None;
+    }
+"#},
+            indoc! {r#"
+    fn process_data_2() {
+        let map: Option<Vec<()>> = None;
+    }
+}
+"#},
+            comment_lines,
+        ));
+
+        cx.executor().advance_clock(Duration::from_millis(100));
+        cx.executor().run_until_parked();
+        assert_eq!(
+            &separate_with_comment_lines(
+                indoc! {r#"
+mod foo «1{
+    fn process_data_1«2()2» «2{
+        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
+    }2»
+"#},
+                indoc! {r#"
+    fn process_data_2«2()2» «2{
+        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
+    }2»
+}1»
+
+1 hsla(207.80, 16.20%, 69.19%, 1.00)
+2 hsla(29.00, 54.00%, 65.88%, 1.00)
+3 hsla(286.00, 51.00%, 75.25%, 1.00)
+4 hsla(187.00, 47.00%, 59.22%, 1.00)
+5 hsla(355.00, 65.00%, 75.94%, 1.00)
+"#},
+                comment_lines,
+            ),
+            &bracket_colors_markup(&mut cx),
+            "Top chunk: brackets should be colorized even when the enclosing \
+             block exceeds MAX_BYTES_TO_QUERY"
+        );
+
+        cx.update_editor(|editor, window, cx| {
+            editor.move_to_end(&MoveToEnd, window, cx);
+            editor.move_up(&MoveUp, window, cx);
+        });
+        cx.executor().advance_clock(Duration::from_millis(100));
+        cx.executor().run_until_parked();
+        assert_eq!(
+            &separate_with_comment_lines(
+                indoc! {r#"
+mod foo «1{
+    fn process_data_1«2()2» «2{
+        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
+    }2»
+"#},
+                indoc! {r#"
+    fn process_data_2«2()2» «2{
+        let map: Option«3<Vec«4<«5()5»>4»>3» = None;
+    }2»
+}1»
+
+1 hsla(207.80, 16.20%, 69.19%, 1.00)
+2 hsla(29.00, 54.00%, 65.88%, 1.00)
+3 hsla(286.00, 51.00%, 75.25%, 1.00)
+4 hsla(187.00, 47.00%, 59.22%, 1.00)
+5 hsla(355.00, 65.00%, 75.94%, 1.00)
+"#},
+                comment_lines,
+            ),
+            &bracket_colors_markup(&mut cx),
+            "After scrolling to bottom, both chunks should have bracket \
+             highlights across a large block"
         );
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -33,6 +33,7 @@ use gpui::{
     Task, TextStyle,
 };
 
+use itertools::Itertools;
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
 use settings::WorktreeId;
@@ -4599,10 +4600,16 @@ impl BufferSnapshot {
     ) -> HashMap<Range<BufferRow>, Vec<BracketMatch<usize>>> {
         let mut all_bracket_matches = HashMap::default();
 
+        let (query_ranges, max_bytes_to_query) = self.extend_range_for_enclosing_brackets(&range);
+        let point_ranges = query_ranges
+            .iter()
+            .map(|r| r.to_point(self))
+            .collect::<Vec<_>>();
+
         for chunk in self
             .tree_sitter_data
             .chunks
-            .applicable_chunks(&[range.to_point(self)])
+            .applicable_chunks(&point_ranges)
         {
             if known_chunks.is_some_and(|chunks| chunks.contains(&chunk.row_range())) {
                 continue;
@@ -4625,7 +4632,7 @@ impl BufferSnapshot {
                 chunk_range.clone(),
                 &self.text,
                 TreeSitterOptions {
-                    max_bytes_to_query: Some(MAX_BYTES_TO_QUERY),
+                    max_bytes_to_query: Some(max_bytes_to_query),
                     max_start_depth: None,
                 },
                 |grammar| grammar.brackets_config.as_ref().map(|c| &c.query),
@@ -4864,6 +4871,59 @@ impl BufferSnapshot {
         all_bracket_matches
     }
 
+    /// Walk the syntax tree upward from `range` and return a set of byte
+    /// ranges to query (plus the `max_bytes_to_query` limit) for bracket
+    /// matching.
+    ///
+    /// When the cursor sits inside a block whose byte extent exceeds
+    /// `MAX_BYTES_TO_QUERY`, the default containing-byte-range causes
+    /// tree-sitter's query cursor to skip its bracket children.  Rather than
+    /// expanding to the entire block (which would pull in every intermediate
+    /// chunk — catastrophic for huge files), we add small windows around the
+    /// block's start and end where bracket tokens actually live.
+    fn extend_range_for_enclosing_brackets(
+        &self,
+        range: &Range<usize>,
+    ) -> (Vec<Range<usize>>, usize) {
+        let mut ranges = vec![range.clone()];
+        let mut max_bytes = MAX_BYTES_TO_QUERY;
+
+        for layer in self
+            .syntax
+            .layers_for_range(range.clone(), &self.text, true)
+        {
+            let mut cursor = layer.node().walk();
+            if !Self::goto_node_enclosing_range(&mut cursor, range, false) {
+                continue;
+            }
+            loop {
+                let node = cursor.node();
+                let node_range = node.byte_range();
+                // Skip the syntax-layer root — it spans the whole document
+                // and never carries brackets itself.
+                if node_range.len() > max_bytes && node.parent().is_some() {
+                    let window = MAX_BYTES_TO_QUERY;
+                    ranges.push(
+                        node_range.start
+                            ..node_range.start.saturating_add(window).min(node_range.end),
+                    );
+                    ranges.push(
+                        node_range.end.saturating_sub(window).max(node_range.start)..node_range.end,
+                    );
+                    // The containing byte range is centered on each chunk's
+                    // midpoint, so we need 2× the block span to guarantee
+                    // every boundary chunk's window covers both brackets.
+                    max_bytes = max_bytes.max(node_range.len().saturating_mul(2));
+                }
+                if !cursor.goto_parent() {
+                    break;
+                }
+            }
+        }
+
+        (ranges, max_bytes)
+    }
+
     pub fn all_bracket_ranges(
         &self,
         range: Range<usize>,
@@ -4875,6 +4935,7 @@ impl BufferSnapshot {
                 let bracket_range = bracket_match.open_range.start..bracket_match.close_range.end;
                 bracket_range.overlaps(&range)
             })
+            .dedup_by(|a, b| a.open_range == b.open_range && a.close_range == b.close_range)
     }
 
     /// Returns bracket range pairs overlapping or adjacent to `range`

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -33,7 +33,6 @@ use gpui::{
     Task, TextStyle,
 };
 
-use itertools::Itertools;
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
 use settings::WorktreeId;
@@ -4599,17 +4598,17 @@ impl BufferSnapshot {
         known_chunks: Option<&HashSet<Range<BufferRow>>>,
     ) -> HashMap<Range<BufferRow>, Vec<BracketMatch<usize>>> {
         let mut all_bracket_matches = HashMap::default();
-
-        let (query_ranges, max_bytes_to_query) = self.extend_range_for_enclosing_brackets(&range);
-        let point_ranges = query_ranges
-            .iter()
-            .map(|r| r.to_point(self))
-            .collect::<Vec<_>>();
+        // Bracket pairs whose open and close are further apart than
+        // `MAX_BYTES_TO_QUERY` are missed by the per-chunk tree-sitter query
+        // below.  We collect them once and attribute each to the chunk that
+        // contains its opening bracket, so the chunk cache (and the caller's
+        // `known_chunks` set) deduplicates them just like any other pair.
+        let large_block_pairs = self.bracket_pairs_for_large_enclosing_blocks(&range);
 
         for chunk in self
             .tree_sitter_data
             .chunks
-            .applicable_chunks(&point_ranges)
+            .applicable_chunks(&[range.to_point(self)])
         {
             if known_chunks.is_some_and(|chunks| chunks.contains(&chunk.row_range())) {
                 continue;
@@ -4632,7 +4631,7 @@ impl BufferSnapshot {
                 chunk_range.clone(),
                 &self.text,
                 TreeSitterOptions {
-                    max_bytes_to_query: Some(max_bytes_to_query),
+                    max_bytes_to_query: Some(MAX_BYTES_TO_QUERY),
                     max_start_depth: None,
                 },
                 |grammar| grammar.brackets_config.as_ref().map(|c| &c.query),
@@ -4856,6 +4855,12 @@ impl BufferSnapshot {
                 }
             }
 
+            for large_pair in &large_block_pairs {
+                if chunk_range.contains(&large_pair.open_range.start) {
+                    all_brackets.push(large_pair.clone());
+                }
+            }
+
             all_brackets.sort_by_key(|bracket_match| {
                 (bracket_match.open_range.start, bracket_match.open_range.end)
             });
@@ -4871,71 +4876,184 @@ impl BufferSnapshot {
         all_bracket_matches
     }
 
-    /// Walk the syntax tree upward from `range` and return a set of byte
-    /// ranges to query (plus the `max_bytes_to_query` limit) for bracket
-    /// matching.
+    /// Walk the syntax tree upward from `range` and find bracket pairs for
+    /// nodes whose byte extent exceeds `MAX_BYTES_TO_QUERY`.
     ///
-    /// When the cursor sits inside a block whose byte extent exceeds
-    /// `MAX_BYTES_TO_QUERY`, the default containing-byte-range causes
-    /// tree-sitter's query cursor to skip its bracket children.  Rather than
-    /// expanding to the entire block (which would pull in every intermediate
-    /// chunk — catastrophic for huge files), we add small windows around the
-    /// block's start and end where bracket tokens actually live.
-    fn extend_range_for_enclosing_brackets(
+    /// Tree-sitter's `set_containing_byte_range` requires all captured nodes
+    /// to be fully contained within the range.  When a block is larger than
+    /// `MAX_BYTES_TO_QUERY`, the open and close brackets land in different
+    /// containing-range windows, so the query never returns the pair.
+    ///
+    /// Instead of expanding the query range (which is catastrophically slow),
+    /// we walk the syntax tree directly and inspect oversized nodes' first
+    /// and last children for bracket tokens.  Returned pairs always have
+    /// `color_index = Some(0)`; callers that need a real nesting depth must
+    /// shift it by the number of (also oversized) ancestors that enclose the
+    /// pair.
+    pub fn bracket_pairs_for_large_enclosing_blocks(
         &self,
         range: &Range<usize>,
-    ) -> (Vec<Range<usize>>, usize) {
-        let mut ranges = vec![range.clone()];
-        let mut max_bytes = MAX_BYTES_TO_QUERY;
+    ) -> Vec<BracketMatch<usize>> {
+        const BRACKET_PAIRS: &[(u8, u8)] =
+            &[(b'{', b'}'), (b'(', b')'), (b'[', b']'), (b'<', b'>')];
+
+        let mut result = Vec::new();
+
+        // No node in this buffer can possibly exceed `MAX_BYTES_TO_QUERY`,
+        // so the whole walk can be skipped on the hot path (newline
+        // insertion, enclosing-bracket lookups) for typical files.
+        if self.len() <= MAX_BYTES_TO_QUERY {
+            return result;
+        }
 
         for layer in self
             .syntax
             .layers_for_range(range.clone(), &self.text, true)
         {
+            let depth = layer.depth;
             let mut cursor = layer.node().walk();
-            if !Self::goto_node_enclosing_range(&mut cursor, range, false) {
-                continue;
-            }
+            // Descend to the deepest node covering `range.start` so the
+            // upward walk visits every bracket-carrying ancestor (e.g.
+            // `declaration_list` inside `mod_item`).  Unlike
+            // `goto_node_enclosing_range`, this only needs a single point
+            // inside the block, so it works even when the viewport extends
+            // past the enclosing node.
+            while cursor.goto_first_child_for_byte(range.start).is_some() {}
+
+            let mut seen = HashSet::default();
             loop {
                 let node = cursor.node();
-                let node_range = node.byte_range();
-                // Skip the syntax-layer root — it spans the whole document
-                // and never carries brackets itself.
-                if node_range.len() > max_bytes && node.parent().is_some() {
-                    let window = MAX_BYTES_TO_QUERY;
-                    ranges.push(
-                        node_range.start
-                            ..node_range.start.saturating_add(window).min(node_range.end),
-                    );
-                    ranges.push(
-                        node_range.end.saturating_sub(window).max(node_range.start)..node_range.end,
-                    );
-                    // The containing byte range is centered on each chunk's
-                    // midpoint, so we need 2× the block span to guarantee
-                    // every boundary chunk's window covers both brackets.
-                    max_bytes = max_bytes.max(node_range.len().saturating_mul(2));
-                }
+
+                // `goto_first_child_for_byte` follows one path (e.g.
+                // `impl_item` → `impl` keyword), so bracket-carrying siblings
+                // like `declaration_list` are only reachable as children of an
+                // ancestor.  Check every direct child, and one level deeper
+                // for cases like `impl_item` → `declaration_list` → `{ }`.
+                Self::collect_large_bracket_children(
+                    node,
+                    &self.text,
+                    BRACKET_PAIRS,
+                    depth,
+                    &mut seen,
+                    &mut result,
+                );
+
                 if !cursor.goto_parent() {
                     break;
                 }
             }
         }
 
-        (ranges, max_bytes)
+        result
+    }
+
+    fn collect_large_bracket_children(
+        node: tree_sitter::Node,
+        text: &text::BufferSnapshot,
+        bracket_pairs: &[(u8, u8)],
+        syntax_layer_depth: usize,
+        seen: &mut HashSet<(usize, usize)>,
+        result: &mut Vec<BracketMatch<usize>>,
+    ) {
+        for child_idx in 0..node.child_count() as u32 {
+            let Some(child) = node.child(child_idx) else {
+                continue;
+            };
+            let child_range = child.byte_range();
+            if child_range.len() <= MAX_BYTES_TO_QUERY {
+                continue;
+            }
+            if !seen.insert((child_range.start, child_range.end)) {
+                continue;
+            }
+            if let Some((open_range, close_range)) =
+                Self::find_bracket_children(child, text, bracket_pairs)
+            {
+                result.push(BracketMatch {
+                    open_range,
+                    close_range,
+                    syntax_layer_depth,
+                    newline_only: false,
+                    color_index: Some(0),
+                });
+            } else {
+                // Brackets may be one level deeper (e.g. `impl_item` has
+                // `declaration_list` as a child, which in turn holds `{ }`).
+                Self::collect_large_bracket_children(
+                    child,
+                    text,
+                    bracket_pairs,
+                    syntax_layer_depth,
+                    seen,
+                    result,
+                );
+            }
+        }
+    }
+
+    /// Check whether `node` has a first and last child that form a matching
+    /// bracket pair, returning their byte ranges if so.
+    fn find_bracket_children(
+        node: tree_sitter::Node,
+        text: &text::BufferSnapshot,
+        bracket_pairs: &[(u8, u8)],
+    ) -> Option<(Range<usize>, Range<usize>)> {
+        let child_count = node.child_count();
+        if child_count < 2 {
+            return None;
+        }
+        let first = node.child(0)?;
+        let last = node.child((child_count - 1) as u32)?;
+        if first.byte_range().len() != 1 || last.byte_range().len() != 1 {
+            return None;
+        }
+        let open_byte = *text
+            .as_rope()
+            .bytes_in_range(first.byte_range())
+            .next()?
+            .first()?;
+        let close_byte = *text
+            .as_rope()
+            .bytes_in_range(last.byte_range())
+            .next()?
+            .first()?;
+        bracket_pairs
+            .iter()
+            .any(|&(o, c)| o == open_byte && c == close_byte)
+            .then(|| (first.byte_range(), last.byte_range()))
     }
 
     pub fn all_bracket_ranges(
         &self,
         range: Range<usize>,
     ) -> impl Iterator<Item = BracketMatch<usize>> {
-        self.fetch_bracket_ranges(range.clone(), None)
+        // `fetch_bracket_ranges` only attaches each large pair to the chunk
+        // containing its opening bracket.  When `range` sits in the middle
+        // of a huge block, that chunk is not queried, so we must enumerate
+        // large pairs separately to make enclosing-bracket lookups work.
+        // Filter out the ones already returned by `fetch_bracket_ranges`
+        // (e.g. when `range` does include the open's chunk) so callers
+        // don't see the same pair twice.
+        let chunk_pairs = self
+            .fetch_bracket_ranges(range.clone(), None)
             .into_values()
             .flatten()
+            .collect::<Vec<_>>();
+        let chunk_pair_keys = chunk_pairs
+            .iter()
+            .map(|p| (p.open_range.start, p.close_range.end))
+            .collect::<HashSet<_>>();
+        let extra_large_pairs = self
+            .bracket_pairs_for_large_enclosing_blocks(&range)
+            .into_iter()
+            .filter(move |p| !chunk_pair_keys.contains(&(p.open_range.start, p.close_range.end)));
+        chunk_pairs
+            .into_iter()
+            .chain(extra_large_pairs)
             .filter(move |bracket_match| {
                 let bracket_range = bracket_match.open_range.start..bracket_match.close_range.end;
                 bracket_range.overlaps(&range)
             })
-            .dedup_by(|a, b| a.open_range == b.open_range && a.close_range == b.close_range)
     }
 
     /// Returns bracket range pairs overlapping or adjacent to `range`

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -14,6 +14,7 @@ use regex::RegexBuilder;
 use settings::SettingsStore;
 use settings::{AllLanguageSettingsContent, LanguageSettingsContent};
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use std::{
     env,
     ops::Range,
@@ -1368,6 +1369,61 @@ fn test_enclosing_bracket_ranges(cx: &mut App) {
             let foo = 1;ˇ"},
         Vec::new(),
         cx,
+    );
+}
+
+#[gpui::test]
+fn test_enclosing_bracket_ranges_large_block(cx: &mut App) {
+    // Build a buffer with an impl block large enough that the distance between
+    // `{` and `}` exceeds MAX_BYTES_TO_QUERY (16 KB). Each comment line is
+    // ~24 bytes, so ~700 lines push us past the limit.
+    let comment_line_count = 1000;
+    let mut source = String::from("impl Foo {\n");
+    for i in 0..comment_line_count {
+        writeln!(source, "    // line {i:04}  padding").unwrap();
+    }
+    source.push_str("}\n");
+
+    let buffer = cx.new(|cx| Buffer::local(source.clone(), cx).with_language(rust_lang(), cx));
+    let snapshot = buffer.update(cx, |buffer, _cx| buffer.snapshot());
+
+    let open_brace = source.find('{').unwrap();
+    let close_brace = source.rfind('}').unwrap();
+
+    // Cursor right after the opening brace — should find the enclosing pair.
+    let cursor = open_brace + 1;
+    let pairs = snapshot
+        .enclosing_bracket_ranges(cursor..cursor)
+        .map(|pair| (pair.open_range, pair.close_range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        pairs,
+        vec![(open_brace..open_brace + 1, close_brace..close_brace + 1)],
+        "enclosing_bracket_ranges should find the bracket pair even when \
+         open and close are in different row-chunks"
+    );
+
+    // Cursor at the opening brace itself.
+    let pairs = snapshot
+        .enclosing_bracket_ranges(open_brace..open_brace)
+        .map(|pair| (pair.open_range, pair.close_range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        pairs,
+        vec![(open_brace..open_brace + 1, close_brace..close_brace + 1)],
+        "cursor at the opening brace should also find the pair"
+    );
+
+    // Cursor somewhere in the middle of the block.
+    let middle = source.len() / 2;
+    let pairs = snapshot
+        .enclosing_bracket_ranges(middle..middle)
+        .map(|pair| (pair.open_range, pair.close_range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        pairs,
+        vec![(open_brace..open_brace + 1, close_brace..close_brace + 1)],
+        "cursor in the middle of a large block should find the enclosing pair"
     );
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1428,6 +1428,138 @@ fn test_enclosing_bracket_ranges_large_block(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_bracket_pairs_for_large_enclosing_blocks(cx: &mut App) {
+    use crate::syntax_map::MAX_BYTES_TO_QUERY;
+
+    // Build a source that looks like real code: uses, structs, and other
+    // items before a large impl block — similar to editor.rs.
+    let mut source = String::from(
+        "use std::collections::HashMap;\n\
+         use std::sync::Arc;\n\
+         \n\
+         pub struct Foo {\n\
+         \x20   field_a: i32,\n\
+         \x20   field_b: String,\n\
+         }\n\
+         \n\
+         pub struct Bar {\n\
+         \x20   items: Vec<Foo>,\n\
+         }\n\
+         \n",
+    );
+    let impl_start = source.len();
+    source.push_str("impl Foo {\n");
+    let fn_body = "        let x = 1;\n        let y = 2;\n        x + y\n";
+    let mut fn_count = 0;
+    while source.len() < MAX_BYTES_TO_QUERY + 1000 {
+        writeln!(
+            source,
+            "    fn func_{fn_count}() -> i32 {{\n{fn_body}    }}"
+        )
+        .unwrap();
+        fn_count += 1;
+    }
+    source.push_str("}\n");
+
+    let buffer = cx.new(|cx| Buffer::local(source.clone(), cx).with_language(rust_lang(), cx));
+    let snapshot = buffer.update(cx, |buffer, _cx| buffer.snapshot());
+
+    let open_brace = source[impl_start..].find('{').unwrap() + impl_start;
+    let close_brace = source.rfind('}').unwrap();
+
+    // Query from a viewport near the beginning of the impl block.
+    let viewport_start = open_brace + 1;
+    let viewport_end = (viewport_start + 500).min(source.len());
+    let pairs = snapshot.bracket_pairs_for_large_enclosing_blocks(&(viewport_start..viewport_end));
+    assert_eq!(
+        pairs.len(),
+        1,
+        "should find exactly one large enclosing bracket pair from top viewport"
+    );
+    assert_eq!(pairs[0].open_range, open_brace..open_brace + 1);
+    assert_eq!(pairs[0].close_range, close_brace..close_brace + 1);
+    assert_eq!(pairs[0].color_index, Some(0), "outermost block has depth 0");
+
+    // Query from a viewport in the middle of the impl block.
+    let middle = source.len() / 2;
+    let pairs = snapshot.bracket_pairs_for_large_enclosing_blocks(&(middle..middle + 500));
+    assert_eq!(
+        pairs.len(),
+        1,
+        "should find exactly one large enclosing bracket pair from middle viewport"
+    );
+    assert_eq!(pairs[0].open_range, open_brace..open_brace + 1);
+    assert_eq!(pairs[0].close_range, close_brace..close_brace + 1);
+
+    // Query from a viewport near the end of the impl block.
+    let near_end = close_brace.saturating_sub(200);
+    let pairs = snapshot.bracket_pairs_for_large_enclosing_blocks(&(near_end..close_brace + 1));
+    assert_eq!(
+        pairs.len(),
+        1,
+        "should find exactly one large enclosing bracket pair from bottom viewport"
+    );
+    assert_eq!(pairs[0].open_range, open_brace..open_brace + 1);
+    assert_eq!(pairs[0].close_range, close_brace..close_brace + 1);
+
+    // Viewport that extends past the closing brace should still find the pair
+    // (the viewport may include trailing content after `}`).
+    let pairs = snapshot.bracket_pairs_for_large_enclosing_blocks(&(near_end..source.len()));
+    assert_eq!(
+        pairs.len(),
+        1,
+        "should find the pair even when viewport extends past the block"
+    );
+    assert_eq!(pairs[0].open_range, open_brace..open_brace + 1);
+    assert_eq!(pairs[0].close_range, close_brace..close_brace + 1);
+}
+
+#[gpui::test]
+fn test_bracket_pairs_for_large_block_viewport_before_block(cx: &mut App) {
+    use crate::syntax_map::MAX_BYTES_TO_QUERY;
+
+    // Simulate a viewport that starts a few lines BEFORE `impl Foo {`,
+    // e.g. the user sees the closing `}` of the previous item and then
+    // `impl Foo {`.  `goto_first_child_for_byte(range.start)` descends
+    // into the previous item, so the `impl_item` node is only reachable
+    // as a sibling — and brackets live on its `declaration_list` child,
+    // one level deeper.
+    let preamble = "struct Bar {\n    field: i32,\n}\n\n";
+    let mut source = String::from(preamble);
+    let impl_start = source.len();
+    source.push_str("impl Foo {\n");
+    let fn_body = "        let x = 1;\n        let y = 2;\n        x + y\n";
+    let mut fn_count = 0;
+    while source.len() < impl_start + MAX_BYTES_TO_QUERY + 1000 {
+        writeln!(
+            source,
+            "    fn func_{fn_count}() -> i32 {{\n{fn_body}    }}"
+        )
+        .unwrap();
+        fn_count += 1;
+    }
+    source.push_str("}\n");
+
+    let buffer = cx.new(|cx| Buffer::local(source.clone(), cx).with_language(rust_lang(), cx));
+    let snapshot = buffer.update(cx, |buffer, _cx| buffer.snapshot());
+
+    let open_brace = source[impl_start..].find('{').unwrap() + impl_start;
+    let close_brace = source.rfind('}').unwrap();
+
+    // Viewport starts inside the preamble (before the impl block).
+    let viewport_start = preamble.len().saturating_sub(10);
+    let viewport_end = open_brace + 200;
+    let pairs = snapshot.bracket_pairs_for_large_enclosing_blocks(&(viewport_start..viewport_end));
+    assert_eq!(
+        pairs.len(),
+        1,
+        "should find the impl bracket pair even when viewport starts before the block"
+    );
+    assert_eq!(pairs[0].open_range, open_brace..open_brace + 1);
+    assert_eq!(pairs[0].close_range, close_brace..close_brace + 1);
+}
+
+#[gpui::test]
 fn test_enclosing_bracket_ranges_where_brackets_are_not_outermost_children(cx: &mut App) {
     let mut assert = |selection_text, bracket_pair_texts| {
         assert_bracket_pairs(


### PR DESCRIPTION
Fixes the case where `impl Editor {` could not navigate to enclosing `}` due to block being overly large.

Now, we try to ascend to the parent node and find all ranges that intersect it.


Release Notes:

- Added a way to hide sidebar buttons
