### PR TITLE
Fix spinner in activity indicator

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -729,14 +729,7 @@ impl Render for ActivityIndicator {
                         }
                     })
                     .label_size(LabelSize::Small)
-                    .when(content.icon.is_some(), |this| {
-                        this.start_icon(
-                            Icon::new(IconName::LoadCircle)
-                                .color(Color::Muted)
-                                .size(IconSize::Small)
-                                .with_rotate_animation(2),
-                        )
-                    })
+                    .loading(content.icon.is_some())
                     .map(|button| {
                         if truncate_content {
                             button.tooltip(Tooltip::text(content.message))

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -733,7 +733,8 @@ impl Render for ActivityIndicator {
                         this.start_icon(
                             Icon::new(IconName::LoadCircle)
                                 .color(Color::Muted)
-                                .size(IconSize::Small),
+                                .size(IconSize::Small)
+                                .with_rotate_animation(2),
                         )
                     })
                     .map(|button| {

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -83,8 +83,8 @@ pub struct Button {
     label_size: Option<LabelSize>,
     selected_label: Option<SharedString>,
     selected_label_color: Option<Color>,
-    start_icon: Option<AnyElement>,
-    end_icon: Option<AnyElement>,
+    start_icon: Option<Icon>,
+    end_icon: Option<Icon>,
     key_binding: Option<KeyBinding>,
     key_binding_position: KeybindingPosition,
     alpha: Option<f32>,
@@ -144,16 +144,16 @@ impl Button {
     /// Sets an icon to display at the start (left) of the button label.
     ///
     /// The icon's color will be overridden to `Color::Disabled` when the button is disabled.
-    pub fn start_icon<E: IntoElement>(mut self, start_icon: impl Into<Option<E>>) -> Self {
-        self.start_icon = start_icon.into().map(IntoElement::into_any_element);
+    pub fn start_icon(mut self, icon: impl Into<Option<Icon>>) -> Self {
+        self.start_icon = icon.into();
         self
     }
 
     /// Sets an icon to display at the end (right) of the button label.
     ///
     /// The icon's color will be overridden to `Color::Disabled` when the button is disabled.
-    pub fn end_icon<E: IntoElement>(mut self, end_icon: impl Into<Option<E>>) -> Self {
-        self.end_icon = end_icon.into().map(IntoElement::into_any_element);
+    pub fn end_icon(mut self, icon: impl Into<Option<Icon>>) -> Self {
+        self.end_icon = icon.into();
         self
     }
 

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -83,8 +83,8 @@ pub struct Button {
     label_size: Option<LabelSize>,
     selected_label: Option<SharedString>,
     selected_label_color: Option<Color>,
-    start_icon: Option<Icon>,
-    end_icon: Option<Icon>,
+    start_icon: Option<AnyElement>,
+    end_icon: Option<AnyElement>,
     key_binding: Option<KeyBinding>,
     key_binding_position: KeybindingPosition,
     alpha: Option<f32>,
@@ -144,16 +144,16 @@ impl Button {
     /// Sets an icon to display at the start (left) of the button label.
     ///
     /// The icon's color will be overridden to `Color::Disabled` when the button is disabled.
-    pub fn start_icon(mut self, icon: impl Into<Option<Icon>>) -> Self {
-        self.start_icon = icon.into();
+    pub fn start_icon<E: IntoElement>(mut self, start_icon: impl Into<Option<E>>) -> Self {
+        self.start_icon = start_icon.into().map(IntoElement::into_any_element);
         self
     }
 
     /// Sets an icon to display at the end (right) of the button label.
     ///
     /// The icon's color will be overridden to `Color::Disabled` when the button is disabled.
-    pub fn end_icon(mut self, icon: impl Into<Option<Icon>>) -> Self {
-        self.end_icon = icon.into();
+    pub fn end_icon<E: IntoElement>(mut self, end_icon: impl Into<Option<E>>) -> Self {
+        self.end_icon = end_icon.into().map(IntoElement::into_any_element);
         self
     }
 


### PR DESCRIPTION
Quick fix for a little regression I introduced in https://github.com/zed-industries/zed/pull/54791 accidentally removing the rotating spinner icon in the activity indicator.

Release Notes:

- N/A
