### PR TITLE
gpui: Let exact keybindings override IME text

### DIFF
--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -32,6 +32,11 @@ pub struct KeyDownEvent {
     /// Whether to prefer character input over keybindings for this keystroke.
     /// In some cases, like AltGr on Windows, modifiers are significant for character input.
     pub prefer_character_input: bool,
+
+    /// Whether keybindings may still override character input when `prefer_character_input` is set.
+    /// This lets platforms give IMEs the default path for printable keys while still allowing an
+    /// exact keymap binding to win.
+    pub allow_keybinding_override: bool,
 }
 
 impl Sealed for KeyDownEvent {}

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -630,8 +630,8 @@ mod tests {
 
     use crate::{
         ActionRegistry, App, Bounds, Context, DispatchTree, FocusHandle, InputHandler, IntoElement,
-        KeyBinding, KeyContext, Keymap, Pixels, Point, Render, Subscription, TestAppContext,
-        UTF16Selection, Unbind, Window,
+        KeyBinding, KeyContext, KeyDownEvent, Keymap, Pixels, PlatformInput, Point, Render,
+        Subscription, TestAppContext, UTF16Selection, Unbind, Window,
     };
 
     actions!(dispatch_test, [TestAction, SecondaryTestAction]);
@@ -1191,5 +1191,274 @@ mod tests {
         });
         cx.simulate_keystrokes("ctrl-b [");
         test.update(cx, |test, _| assert_eq!(test.text.borrow().as_str(), "["))
+    }
+
+    #[derive(Clone)]
+    struct KeyDispatchInputElement {
+        focus_handle: FocusHandle,
+        text: Rc<RefCell<String>>,
+        action_count: Rc<RefCell<usize>>,
+    }
+
+    impl KeyDispatchInputElement {
+        fn new(cx: &mut Context<Self>) -> Self {
+            Self {
+                focus_handle: cx.focus_handle(),
+                text: Rc::default(),
+                action_count: Rc::default(),
+            }
+        }
+    }
+
+    impl Element for KeyDispatchInputElement {
+        type RequestLayoutState = ();
+
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            Some("custom".into())
+        }
+
+        fn source_location(&self) -> Option<&'static panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _: Option<&GlobalElementId>,
+            _: Option<&InspectorElementId>,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> (LayoutId, Self::RequestLayoutState) {
+            (window.request_layout(Style::default(), [], cx), ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _: Option<&GlobalElementId>,
+            _: Option<&InspectorElementId>,
+            _: Bounds<Pixels>,
+            _: &mut Self::RequestLayoutState,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> Self::PrepaintState {
+            window.set_focus_handle(&self.focus_handle, cx);
+        }
+
+        fn paint(
+            &mut self,
+            _: Option<&GlobalElementId>,
+            _: Option<&InspectorElementId>,
+            _: Bounds<Pixels>,
+            _: &mut Self::RequestLayoutState,
+            _: &mut Self::PrepaintState,
+            window: &mut Window,
+            cx: &mut App,
+        ) {
+            let mut key_context = KeyContext::default();
+            key_context.add("Terminal");
+            window.set_key_context(key_context);
+            window.handle_input(&self.focus_handle, self.clone(), cx);
+
+            let action_count = self.action_count.clone();
+            window.on_action(
+                std::any::TypeId::of::<TestAction>(),
+                move |_, phase, _, _| {
+                    if phase == gpui::DispatchPhase::Bubble {
+                        *action_count.borrow_mut() += 1;
+                    }
+                },
+            );
+        }
+    }
+
+    impl IntoElement for KeyDispatchInputElement {
+        type Element = Self;
+
+        fn into_element(self) -> Self::Element {
+            self
+        }
+    }
+
+    impl InputHandler for KeyDispatchInputElement {
+        fn selected_text_range(
+            &mut self,
+            _: bool,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<UTF16Selection> {
+            None
+        }
+
+        fn marked_text_range(&mut self, _: &mut Window, _: &mut App) -> Option<Range<usize>> {
+            None
+        }
+
+        fn text_for_range(
+            &mut self,
+            _: Range<usize>,
+            _: &mut Option<Range<usize>>,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<String> {
+            None
+        }
+
+        fn replace_text_in_range(
+            &mut self,
+            replacement_range: Option<Range<usize>>,
+            text: &str,
+            _: &mut Window,
+            _: &mut App,
+        ) {
+            if replacement_range.is_some() {
+                unimplemented!()
+            }
+            self.text.borrow_mut().push_str(text)
+        }
+
+        fn replace_and_mark_text_in_range(
+            &mut self,
+            replacement_range: Option<Range<usize>>,
+            new_text: &str,
+            _: Option<Range<usize>>,
+            _: &mut Window,
+            _: &mut App,
+        ) {
+            if replacement_range.is_some() {
+                unimplemented!()
+            }
+            self.text.borrow_mut().push_str(new_text)
+        }
+
+        fn unmark_text(&mut self, _: &mut Window, _: &mut App) {}
+
+        fn bounds_for_range(
+            &mut self,
+            _: Range<usize>,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<Bounds<Pixels>> {
+            None
+        }
+
+        fn character_index_for_point(
+            &mut self,
+            _: Point<Pixels>,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<usize> {
+            None
+        }
+    }
+
+    impl Render for KeyDispatchInputElement {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            self.clone()
+        }
+    }
+
+    fn dispatch_key_down(
+        window: &mut Window,
+        cx: &mut App,
+        keystroke: &str,
+        key_char: Option<&str>,
+        prefer_character_input: bool,
+        allow_keybinding_override: bool,
+    ) -> bool {
+        let mut keystroke = Keystroke::parse(keystroke).unwrap();
+        keystroke.key_char = key_char.map(ToOwned::to_owned);
+        window
+            .dispatch_event(
+                PlatformInput::KeyDown(KeyDownEvent {
+                    keystroke,
+                    is_held: false,
+                    prefer_character_input,
+                    allow_keybinding_override,
+                }),
+                cx,
+            )
+            .propagate
+    }
+
+    #[crate::test]
+    fn test_preferred_character_input_allows_exact_keybinding_override(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new("alt-shift-f", TestAction, Some("Terminal"))]);
+        });
+
+        let (test, cx) = cx.add_window_view(|_, cx| KeyDispatchInputElement::new(cx));
+        let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        let propagated = cx.update(|window, cx| {
+            dispatch_key_down(window, cx, "alt-shift-f", Some("\u{00cf}"), true, false)
+        });
+        assert!(propagated);
+        test.update(cx, |test, _| assert_eq!(*test.action_count.borrow(), 0));
+
+        let propagated = cx.update(|window, cx| {
+            dispatch_key_down(window, cx, "alt-shift-f", Some("\u{00cf}"), true, true)
+        });
+        assert!(!propagated);
+        test.update(cx, |test, _| {
+            assert_eq!(*test.action_count.borrow(), 1);
+            assert_eq!(test.text.borrow().as_str(), "");
+        });
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+    }
+
+    #[crate::test]
+    fn test_preferred_character_input_does_not_start_new_pending_sequence(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new("j j", TestAction, Some("Terminal"))]);
+        });
+
+        let (test, cx) = cx.add_window_view(|_, cx| KeyDispatchInputElement::new(cx));
+        let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        let propagated =
+            cx.update(|window, cx| dispatch_key_down(window, cx, "j", Some("j"), true, true));
+
+        assert!(propagated);
+        test.update(cx, |test, _| assert_eq!(*test.action_count.borrow(), 0));
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+    }
+
+    #[crate::test]
+    fn test_preferred_character_input_continues_existing_pending_sequence(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new("ctrl-x p f", TestAction, Some("Terminal"))]);
+        });
+
+        let (test, cx) = cx.add_window_view(|_, cx| KeyDispatchInputElement::new(cx));
+        let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        let propagated =
+            cx.update(|window, cx| dispatch_key_down(window, cx, "ctrl-x", None, false, false));
+        assert!(!propagated);
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+
+        let propagated =
+            cx.update(|window, cx| dispatch_key_down(window, cx, "p", Some("p"), true, true));
+        assert!(!propagated);
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+
+        let propagated =
+            cx.update(|window, cx| dispatch_key_down(window, cx, "f", Some("f"), true, true));
+        assert!(!propagated);
+        test.update(cx, |test, _| assert_eq!(*test.action_count.borrow(), 1));
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4509,6 +4509,7 @@ impl Window {
                 keystroke: keystroke.clone(),
                 is_held: false,
                 prefer_character_input: false,
+                allow_keybinding_override: false,
             }),
             cx,
         );
@@ -4733,6 +4734,16 @@ impl Window {
         }
     }
 
+    fn input_handler_accepts_text_input(&mut self, cx: &mut App) -> bool {
+        self.platform_window
+            .take_input_handler()
+            .map_or(false, |mut input_handler| {
+                let accepts = input_handler.accepts_text_input(self, cx);
+                self.platform_window.set_input_handler(input_handler);
+                accepts
+            })
+    }
+
     fn dispatch_key_event(&mut self, event: &dyn Any, cx: &mut App) {
         if self.invalidator.is_dirty() {
             self.draw(cx).clear();
@@ -4788,6 +4799,13 @@ impl Window {
             self.finish_dispatch_key_event(event, dispatch_path, self.context_stack(), cx);
             return;
         };
+        let key_down_event = event.downcast_ref::<KeyDownEvent>();
+        let key_down_has_char =
+            key_down_event.is_some_and(|key_down| key_down.keystroke.key_char.is_some());
+        let prefer_character_input =
+            key_down_event.is_some_and(|key_down| key_down.prefer_character_input);
+        let allow_keybinding_override =
+            key_down_event.is_some_and(|key_down| key_down.allow_keybinding_override);
 
         cx.propagate_event = true;
         self.dispatch_keystroke_interceptors(event, self.context_stack(), cx);
@@ -4800,6 +4818,7 @@ impl Window {
         if currently_pending.focus.is_some() && currently_pending.focus != self.focus {
             currently_pending = PendingInput::default();
         }
+        let had_pending_input = !currently_pending.keystrokes.is_empty();
 
         let match_result = self.rendered_frame.dispatch_tree.dispatch_key(
             currently_pending.keystrokes,
@@ -4813,72 +4832,63 @@ impl Window {
         }
 
         if !match_result.pending.is_empty() {
-            currently_pending.timer.take();
-            currently_pending.keystrokes = match_result.pending;
-            currently_pending.focus = self.focus;
+            let text_input_accepts = key_down_has_char && self.input_handler_accepts_text_input(cx);
+            let prefer_text_over_new_pending =
+                prefer_character_input && !had_pending_input && text_input_accepts;
 
-            let text_input_requires_timeout = event
-                .downcast_ref::<KeyDownEvent>()
-                .filter(|key_down| key_down.keystroke.key_char.is_some())
-                .and_then(|_| self.platform_window.take_input_handler())
-                .map_or(false, |mut input_handler| {
-                    let accepts = input_handler.accepts_text_input(self, cx);
-                    self.platform_window.set_input_handler(input_handler);
-                    accepts
-                });
+            if !prefer_text_over_new_pending {
+                currently_pending.timer.take();
+                currently_pending.keystrokes = match_result.pending;
+                currently_pending.focus = self.focus;
 
-            currently_pending.needs_timeout |=
-                match_result.pending_has_binding || text_input_requires_timeout;
+                currently_pending.needs_timeout |=
+                    match_result.pending_has_binding || text_input_accepts;
 
-            if currently_pending.needs_timeout {
-                currently_pending.timer = Some(self.spawn(cx, async move |cx| {
-                    cx.background_executor.timer(Duration::from_secs(1)).await;
-                    cx.update(move |window, cx| {
-                        let Some(currently_pending) = window
-                            .pending_input
-                            .take()
-                            .filter(|pending| pending.focus == window.focus)
-                        else {
-                            return;
-                        };
+                if currently_pending.needs_timeout {
+                    currently_pending.timer = Some(self.spawn(cx, async move |cx| {
+                        cx.background_executor.timer(Duration::from_secs(1)).await;
+                        cx.update(move |window, cx| {
+                            let Some(currently_pending) = window
+                                .pending_input
+                                .take()
+                                .filter(|pending| pending.focus == window.focus)
+                            else {
+                                return;
+                            };
 
-                        let node_id = window.focus_node_id_in_rendered_frame(window.focus);
-                        let dispatch_path =
-                            window.rendered_frame.dispatch_tree.dispatch_path(node_id);
+                            let node_id = window.focus_node_id_in_rendered_frame(window.focus);
+                            let dispatch_path =
+                                window.rendered_frame.dispatch_tree.dispatch_path(node_id);
 
-                        let to_replay = window
-                            .rendered_frame
-                            .dispatch_tree
-                            .flush_dispatch(currently_pending.keystrokes, &dispatch_path);
+                            let to_replay = window
+                                .rendered_frame
+                                .dispatch_tree
+                                .flush_dispatch(currently_pending.keystrokes, &dispatch_path);
 
-                        window.pending_input_changed(cx);
-                        window.replay_pending_input(to_replay, cx)
-                    })
-                    .log_err();
-                }));
-            } else {
-                currently_pending.timer = None;
+                            window.pending_input_changed(cx);
+                            window.replay_pending_input(to_replay, cx)
+                        })
+                        .log_err();
+                    }));
+                } else {
+                    currently_pending.timer = None;
+                }
+                self.pending_input = Some(currently_pending);
+                self.pending_input_changed(cx);
+                cx.propagate_event = false;
+                return;
             }
-            self.pending_input = Some(currently_pending);
+
+            cx.propagate_event = true;
             self.pending_input_changed(cx);
-            cx.propagate_event = false;
             return;
         }
 
-        let skip_bindings = event
-            .downcast_ref::<KeyDownEvent>()
-            .filter(|key_down_event| key_down_event.prefer_character_input)
-            .map(|_| {
-                self.platform_window
-                    .take_input_handler()
-                    .map_or(false, |mut input_handler| {
-                        let accepts = input_handler.accepts_text_input(self, cx);
-                        self.platform_window.set_input_handler(input_handler);
-                        // If modifiers are not excessive (e.g. AltGr), and the input handler is accepting text input,
-                        // we prefer the text input over bindings.
-                        accepts
-                    })
+        let skip_bindings = key_down_event
+            .filter(|key_down_event| {
+                key_down_event.prefer_character_input && !key_down_event.allow_keybinding_override
             })
+            .map(|_| self.input_handler_accepts_text_input(cx))
             .unwrap_or(false);
 
         if !skip_bindings {
@@ -4895,6 +4905,15 @@ impl Window {
                     return;
                 }
             }
+        }
+
+        if prefer_character_input
+            && allow_keybinding_override
+            && key_down_has_char
+            && self.input_handler_accepts_text_input(cx)
+        {
+            self.pending_input_changed(cx);
+            return;
         }
 
         self.finish_dispatch_key_event(event, dispatch_path, match_result.context_stack, cx);
@@ -5003,6 +5022,7 @@ impl Window {
                 keystroke: replay.keystroke.clone(),
                 is_held: false,
                 prefer_character_input: true,
+                allow_keybinding_override: false,
             };
 
             cx.propagate_event = true;

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -1701,6 +1701,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                             keystroke: keystroke.clone(),
                             is_held: false,
                             prefer_character_input: false,
+                            allow_keybinding_override: false,
                         });
 
                         state.repeat.current_id += 1;
@@ -1716,6 +1717,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                                     keystroke,
                                     is_held: true,
                                     prefer_character_input: false,
+                                    allow_keybinding_override: false,
                                 });
                                 move |event_timestamp, _metadata, this| {
                                     let client = this.get_client();
@@ -1802,6 +1804,7 @@ impl Dispatch<zwp_text_input_v3::ZwpTextInputV3, ()> for WaylandClientStatePtr {
                             },
                             is_held: false,
                             prefer_character_input: false,
+                            allow_keybinding_override: false,
                         }));
                     } else {
                         window.handle_ime(ImeInput::InsertText(commit_text));

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -1104,6 +1104,7 @@ impl X11Client {
                     keystroke,
                     is_held: false,
                     prefer_character_input: false,
+                    allow_keybinding_override: false,
                 }));
             }
             Event::KeyRelease(event) => {

--- a/crates/gpui_macos/src/events.rs
+++ b/crates/gpui_macos/src/events.rs
@@ -132,6 +132,7 @@ pub(crate) unsafe fn platform_input_from_native(
                 keystroke: parse_keystroke(native_event),
                 is_held: native_event.isARepeat() == YES,
                 prefer_character_input: false,
+                allow_keybinding_override: false,
             })),
             NSEventType::NSKeyUp => Some(PlatformInput::KeyUp(KeyUpEvent {
                 keystroke: parse_keystroke(native_event),

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -25,10 +25,10 @@ use cocoa::{
 use dispatch2::DispatchQueue;
 use gpui::{
     AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, CursorStyle, ExternalPaths,
-    FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas,
-    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
-    PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
+    FileDropEvent, ForegroundExecutor, KeyDownEvent, Modifiers, ModifiersChangedEvent, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas, PlatformDisplay,
+    PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton, PromptLevel,
+    RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind, WindowParams, point,
     px, size,
 };
@@ -507,7 +507,7 @@ struct MacWindowState {
     traffic_light_frames: Option<TrafficLightFrames>,
     transparent_titlebar: bool,
     previous_modifiers_changed_event: Option<PlatformInput>,
-    keystroke_for_do_command: Option<Keystroke>,
+    ime_key_event: Option<ImeKeyEventTransaction>,
     do_command_handled: Option<bool>,
     external_files_dragged: bool,
     // Whether the next left-mouse click is also the focusing click.
@@ -523,6 +523,25 @@ struct MacWindowState {
     accesskit_adapter: Option<accesskit_macos::SubclassingAdapter>,
     // The parent window if this window is a sheet (Dialog kind)
     sheet_parent: Option<id>,
+}
+
+struct ImeKeyEventTransaction {
+    key_down_event: KeyDownEvent,
+    dispatch_do_command: bool,
+    operations: Vec<BufferedImeOperation>,
+}
+
+enum BufferedImeOperation {
+    InsertText {
+        text: String,
+        replacement_range: Option<Range<usize>>,
+    },
+    SetMarkedText {
+        text: String,
+        selected_range: Option<Range<usize>>,
+        replacement_range: Option<Range<usize>>,
+    },
+    UnmarkText,
 }
 
 impl MacWindowState {
@@ -905,7 +924,7 @@ impl MacWindow {
                     .as_ref()
                     .is_none_or(|titlebar| titlebar.appears_transparent),
                 previous_modifiers_changed_event: None,
-                keystroke_for_do_command: None,
+                ime_key_event: None,
                 do_command_handled: None,
                 external_files_dragged: false,
                 first_mouse: false,
@@ -2128,21 +2147,21 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
                     .flatten()
                     .is_some();
 
-            // If we're composing, send the key to the input handler first;
-            // otherwise we only send to the input handler if we don't have a matching binding.
-            // The input handler may call `do_command_by_selector` if it doesn't know how to handle
-            // a key. If it does so, it will return YES so we won't send the key twice.
-            // We also do this for non-printing keys (like arrow keys and escape) as the IME menu
-            // may need them even if there is no marked text;
-            // however we skip keys with control or the input handler adds control-characters to the buffer.
-            // and keys with function, as the input handler swallows them.
-            // and keys with platform (Cmd), so that Cmd+key events (e.g. Cmd+`) are not
-            // consumed by the IME on non-QWERTY / dead-key layouts.
-            // We also send printable keys to the IME first when an IME input source (e.g. Japanese,
-            // Korean, Chinese) is active and the input handler accepts text input. This prevents
-            // multi-stroke keybindings like `jj` from intercepting keys that the IME should compose
-            // (e.g. typing 'ji' should produce 'じ', not 'jい'). If the IME doesn't handle the key,
-            // it calls `doCommandBySelector:` which routes it back to keybinding matching.
+            // If we're composing, send the key to the input handler first.
+            //
+            // For printable keys while a non-ASCII IME is active, first give GPUI
+            // keybindings a chance to handle exact bindings or continue an existing
+            // pending key sequence. Then still pass the native event through TSM inside
+            // a buffered transaction so IMEs see a complete key stream. If GPUI handled
+            // the key, buffered text changes are discarded; otherwise they are replayed
+            // only for input handlers that opt into IME-first printable keys.
+            //
+            // We also send non-printing keys (like arrow keys and escape) to the IME
+            // first as the IME menu may need them even if there is no marked text;
+            // however we skip keys with control or the input handler adds control-
+            // characters to the buffer, keys with function as the input handler swallows
+            // them, and keys with platform (Cmd), so that Cmd+key events (e.g. Cmd+`)
+            // are not consumed by the IME on non-QWERTY / dead-key layouts.
             let is_ime_printable_key = !is_composing
                 && key_down_event
                     .keystroke
@@ -2152,35 +2171,81 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
                 && !key_down_event.keystroke.modifiers.control
                 && !key_down_event.keystroke.modifiers.function
                 && !key_down_event.keystroke.modifiers.platform
-                && unsafe { is_ime_input_source_active() }
+                && unsafe { is_ime_input_source_active() };
+
+            let prefers_ime_for_printable_key = is_ime_printable_key
                 && with_input_handler(this, |input_handler| {
                     input_handler.query_prefers_ime_for_printable_keys()
                 })
                 .unwrap_or(false);
+            let should_send_printable_key_to_ime = is_ime_printable_key && !key_equivalent;
+
+            if is_ime_printable_key {
+                let mut key_down_event_for_keymap = key_down_event.clone();
+                key_down_event_for_keymap.prefer_character_input = prefers_ime_for_printable_key;
+                key_down_event_for_keymap.allow_keybinding_override = true;
+                let handled = run_callback(PlatformInput::KeyDown(key_down_event_for_keymap));
+                if handled == YES {
+                    if should_send_printable_key_to_ime {
+                        let _ = handle_event_with_ime_transaction(
+                            this,
+                            native_event,
+                            key_down_event.clone(),
+                            false,
+                        );
+                    }
+                    return YES;
+                }
+
+                if key_equivalent {
+                    return NO;
+                }
+
+                if !prefers_ime_for_printable_key {
+                    let _ = handle_event_with_ime_transaction(
+                        this,
+                        native_event,
+                        key_down_event.clone(),
+                        false,
+                    );
+                    return NO;
+                }
+            }
 
             if is_composing
-                || is_ime_printable_key
+                || (should_send_printable_key_to_ime && prefers_ime_for_printable_key)
                 || (key_down_event.keystroke.key_char.is_none()
                     && !key_down_event.keystroke.modifiers.control
                     && !key_down_event.keystroke.modifiers.function
                     && !key_down_event.keystroke.modifiers.platform)
             {
-                {
-                    let mut lock = window_state.as_ref().lock();
-                    lock.keystroke_for_do_command = Some(key_down_event.keystroke.clone());
-                    lock.do_command_handled.take();
-                    drop(lock);
+                let mut key_down_event_for_do_command = key_down_event.clone();
+                if should_send_printable_key_to_ime && prefers_ime_for_printable_key {
+                    key_down_event_for_do_command.prefer_character_input = true;
+                    key_down_event_for_do_command.allow_keybinding_override = true;
                 }
 
-                let handled: BOOL = unsafe {
-                    let input_context: id = msg_send![this, inputContext];
-                    msg_send![input_context, handleEvent: native_event]
-                };
-                window_state.as_ref().lock().keystroke_for_do_command.take();
-                if let Some(handled) = window_state.as_ref().lock().do_command_handled.take() {
+                let (handled, do_command_handled, operations) = handle_event_with_ime_transaction(
+                    this,
+                    native_event,
+                    key_down_event_for_do_command,
+                    true,
+                );
+                if let Some(handled) = do_command_handled {
+                    if handled {
+                        return YES;
+                    } else if !operations.is_empty() {
+                        replay_ime_operations(this, operations);
+                        return YES;
+                    }
                     return handled as BOOL;
                 } else if handled == YES {
+                    replay_ime_operations(this, operations);
                     return YES;
+                }
+
+                if should_send_printable_key_to_ime {
+                    return NO;
                 }
 
                 let handled = run_callback(PlatformInput::KeyDown(key_down_event));
@@ -2750,6 +2815,16 @@ extern "C" fn insert_text(this: &Object, _: Sel, text: id, replacement_range: NS
 
         let text = text.to_str();
         let replacement_range = replacement_range.to_range();
+        if buffer_ime_operation(
+            this,
+            BufferedImeOperation::InsertText {
+                text: text.to_string(),
+                replacement_range: replacement_range.clone(),
+            },
+        ) {
+            return;
+        }
+
         with_input_handler(this, |input_handler| {
             input_handler.replace_text_in_range(replacement_range, text)
         });
@@ -2774,12 +2849,27 @@ extern "C" fn set_marked_text(
         let selected_range = selected_range.to_range();
         let replacement_range = replacement_range.to_range();
         let text = text.to_str();
+        if buffer_ime_operation(
+            this,
+            BufferedImeOperation::SetMarkedText {
+                text: text.to_string(),
+                selected_range: selected_range.clone(),
+                replacement_range: replacement_range.clone(),
+            },
+        ) {
+            return;
+        }
+
         with_input_handler(this, |input_handler| {
             input_handler.replace_and_mark_text_in_range(replacement_range, text, selected_range)
         });
     }
 }
 extern "C" fn unmark_text(this: &Object, _: Sel) {
+    if buffer_ime_operation(this, BufferedImeOperation::UnmarkText) {
+        return;
+    }
+
     with_input_handler(this, |input_handler| input_handler.unmark_text());
 }
 
@@ -2817,16 +2907,20 @@ extern "C" fn attributed_substring_for_proposed_range(
 extern "C" fn do_command_by_selector(this: &Object, _: Sel, _: Sel) {
     let state = unsafe { get_window_state(this) };
     let mut lock = state.as_ref().lock();
-    let keystroke = lock.keystroke_for_do_command.take();
+    let Some(transaction) = lock.ime_key_event.as_ref() else {
+        return;
+    };
+    if !transaction.dispatch_do_command {
+        lock.do_command_handled = Some(true);
+        return;
+    }
+
+    let key_down_event = transaction.key_down_event.clone();
     let mut event_callback = lock.event_callback.take();
     drop(lock);
 
-    if let Some((keystroke, callback)) = keystroke.zip(event_callback.as_mut()) {
-        let handled = (callback)(PlatformInput::KeyDown(KeyDownEvent {
-            keystroke,
-            is_held: false,
-            prefer_character_input: false,
-        }));
+    if let Some(callback) = event_callback.as_mut() {
+        let handled = (callback)(PlatformInput::KeyDown(key_down_event));
         state.as_ref().lock().do_command_handled = Some(!handled.propagate);
     }
 
@@ -3002,6 +3096,90 @@ where
     } else {
         None
     }
+}
+
+fn begin_ime_key_event_transaction(
+    window: &Object,
+    key_down_event: KeyDownEvent,
+    dispatch_do_command: bool,
+) {
+    let window_state = unsafe { get_window_state(window) };
+    let mut lock = window_state.lock();
+    lock.ime_key_event = Some(ImeKeyEventTransaction {
+        key_down_event,
+        dispatch_do_command,
+        operations: Vec::new(),
+    });
+    lock.do_command_handled.take();
+}
+
+fn finish_ime_key_event_transaction(window: &Object) -> (Option<bool>, Vec<BufferedImeOperation>) {
+    let window_state = unsafe { get_window_state(window) };
+    let mut lock = window_state.lock();
+    let operations = lock
+        .ime_key_event
+        .take()
+        .map(|transaction| transaction.operations)
+        .unwrap_or_default();
+    let do_command_handled = lock.do_command_handled.take();
+    (do_command_handled, operations)
+}
+
+fn buffer_ime_operation(window: &Object, operation: BufferedImeOperation) -> bool {
+    let window_state = unsafe { get_window_state(window) };
+    let mut lock = window_state.lock();
+    if let Some(transaction) = lock.ime_key_event.as_mut() {
+        transaction.operations.push(operation);
+        true
+    } else {
+        false
+    }
+}
+
+fn replay_ime_operations(window: &Object, operations: Vec<BufferedImeOperation>) {
+    for operation in operations {
+        match operation {
+            BufferedImeOperation::InsertText {
+                text,
+                replacement_range,
+            } => {
+                with_input_handler(window, |input_handler| {
+                    input_handler.replace_text_in_range(replacement_range, &text)
+                });
+            }
+            BufferedImeOperation::SetMarkedText {
+                text,
+                selected_range,
+                replacement_range,
+            } => {
+                with_input_handler(window, |input_handler| {
+                    input_handler.replace_and_mark_text_in_range(
+                        replacement_range,
+                        &text,
+                        selected_range,
+                    )
+                });
+            }
+            BufferedImeOperation::UnmarkText => {
+                with_input_handler(window, |input_handler| input_handler.unmark_text());
+            }
+        }
+    }
+}
+
+fn handle_event_with_ime_transaction(
+    window: &Object,
+    native_event: id,
+    key_down_event: KeyDownEvent,
+    dispatch_do_command: bool,
+) -> (BOOL, Option<bool>, Vec<BufferedImeOperation>) {
+    begin_ime_key_event_transaction(window, key_down_event, dispatch_do_command);
+    let handled = unsafe {
+        let input_context: id = msg_send![window, inputContext];
+        msg_send![input_context, handleEvent: native_event]
+    };
+    let (do_command_handled, operations) = finish_ime_key_event_transaction(window);
+    (handled, do_command_handled, operations)
 }
 
 fn display_id_for_screen(screen: id) -> Option<CGDirectDisplayID> {

--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -366,6 +366,7 @@ impl WebWindowInner {
                 keystroke,
                 is_held,
                 prefer_character_input: false,
+                allow_keybinding_override: false,
             }));
 
             if let Some(result) = result {

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -371,6 +371,7 @@ impl WindowsWindowInner {
                     keystroke,
                     is_held: lparam.0 & (0x1 << 30) > 0,
                     prefer_character_input,
+                    allow_keybinding_override: false,
                 })
             },
         ) else {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53163

Release Notes:

- Fixed alt-key combos not working when cjk ime is on.
