### PR TITLE
gpui_macos: Fix unintended modifier-only shortcuts when typing with an input method

### DIFF
--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -57,6 +57,17 @@ impl InputEvent for KeyUpEvent {
 }
 impl KeyEvent for KeyUpEvent {}
 
+/// The key down event handled by the input method equivalent for the platform.
+#[derive(Clone, Debug)]
+pub struct KeyDownHandledByInputMethodEvent;
+
+impl Sealed for KeyDownHandledByInputMethodEvent {}
+impl InputEvent for KeyDownHandledByInputMethodEvent {
+    fn to_platform_input(self) -> PlatformInput {
+        PlatformInput::KeyDownHandledByInputMethod(self)
+    }
+}
+
 /// The modifiers changed event equivalent for the platform.
 #[derive(Clone, Debug, Default)]
 pub struct ModifiersChangedEvent {
@@ -652,6 +663,8 @@ pub enum PlatformInput {
     KeyDown(KeyDownEvent),
     /// A key was released.
     KeyUp(KeyUpEvent),
+    /// A key down event was handled by the input method.
+    KeyDownHandledByInputMethod(KeyDownHandledByInputMethodEvent),
     /// The keyboard modifiers were changed.
     ModifiersChanged(ModifiersChangedEvent),
     /// The mouse was pressed.
@@ -677,6 +690,7 @@ impl PlatformInput {
         match self {
             PlatformInput::KeyDown { .. } => None,
             PlatformInput::KeyUp { .. } => None,
+            PlatformInput::KeyDownHandledByInputMethod { .. } => None,
             PlatformInput::ModifiersChanged { .. } => None,
             PlatformInput::MouseDown(event) => Some(event),
             PlatformInput::MouseUp(event) => Some(event),
@@ -693,6 +707,7 @@ impl PlatformInput {
         match self {
             PlatformInput::KeyDown(event) => Some(event),
             PlatformInput::KeyUp(event) => Some(event),
+            PlatformInput::KeyDownHandledByInputMethod(_) => None,
             PlatformInput::ModifiersChanged(event) => Some(event),
             PlatformInput::MouseDown(_) => None,
             PlatformInput::MouseUp(_) => None,

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -629,9 +629,10 @@ mod tests {
     use std::{cell::RefCell, ops::Range, rc::Rc};
 
     use crate::{
-        ActionRegistry, App, Bounds, Context, DispatchTree, FocusHandle, InputHandler, IntoElement,
-        KeyBinding, KeyContext, Keymap, Pixels, Point, Render, Subscription, TestAppContext,
-        UTF16Selection, Unbind, Window,
+        ActionRegistry, App, Bounds, Context, DispatchPhase, DispatchTree, FocusHandle,
+        InputHandler, IntoElement, KeyBinding, KeyContext, KeyDownHandledByInputMethodEvent,
+        Keymap, Modifiers, Pixels, Point, Render, Subscription, TestAppContext, UTF16Selection,
+        Unbind, Window,
     };
 
     actions!(dispatch_test, [TestAction, SecondaryTestAction]);
@@ -1131,5 +1132,120 @@ mod tests {
         });
         cx.simulate_keystrokes("ctrl-b [");
         test.update(cx, |test, _| assert_eq!(test.text.borrow().as_str(), "["))
+    }
+
+    #[crate::test]
+    fn test_key_down_handled_by_input_method_counts_for_modifier_only_bindings(
+        cx: &mut TestAppContext,
+    ) {
+        #[derive(Clone)]
+        struct CustomElement {
+            focus_handle: FocusHandle,
+            action_count: Rc<RefCell<usize>>,
+        }
+        impl CustomElement {
+            fn new(cx: &mut Context<Self>) -> Self {
+                Self {
+                    focus_handle: cx.focus_handle(),
+                    action_count: Rc::default(),
+                }
+            }
+        }
+        impl Element for CustomElement {
+            type RequestLayoutState = ();
+
+            type PrepaintState = ();
+
+            fn id(&self) -> Option<ElementId> {
+                Some("custom".into())
+            }
+            fn source_location(&self) -> Option<&'static panic::Location<'static>> {
+                None
+            }
+            fn request_layout(
+                &mut self,
+                _: Option<&GlobalElementId>,
+                _: Option<&InspectorElementId>,
+                window: &mut Window,
+                cx: &mut App,
+            ) -> (LayoutId, Self::RequestLayoutState) {
+                (window.request_layout(Style::default(), [], cx), ())
+            }
+            fn prepaint(
+                &mut self,
+                _: Option<&GlobalElementId>,
+                _: Option<&InspectorElementId>,
+                _: Bounds<Pixels>,
+                _: &mut Self::RequestLayoutState,
+                window: &mut Window,
+                cx: &mut App,
+            ) -> Self::PrepaintState {
+                window.set_focus_handle(&self.focus_handle, cx);
+            }
+            fn paint(
+                &mut self,
+                _: Option<&GlobalElementId>,
+                _: Option<&InspectorElementId>,
+                _: Bounds<Pixels>,
+                _: &mut Self::RequestLayoutState,
+                _: &mut Self::PrepaintState,
+                window: &mut Window,
+                _: &mut App,
+            ) {
+                let mut key_context = KeyContext::default();
+                key_context.add("Terminal");
+                window.set_key_context(key_context);
+                let action_count = self.action_count.clone();
+                window.on_action(
+                    std::any::TypeId::of::<TestAction>(),
+                    move |_, phase, _, _| {
+                        if phase == DispatchPhase::Bubble {
+                            *action_count.borrow_mut() += 1;
+                        }
+                    },
+                );
+            }
+        }
+        impl IntoElement for CustomElement {
+            type Element = Self;
+
+            fn into_element(self) -> Self::Element {
+                self
+            }
+        }
+        impl Render for CustomElement {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                self.clone()
+            }
+        }
+
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new("shift shift", TestAction, Some("Terminal"))]);
+        });
+        let (test, cx) = cx.add_window_view(|_, cx| CustomElement::new(cx));
+        let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        cx.simulate_modifiers_change(Modifiers::shift());
+        cx.simulate_event(KeyDownHandledByInputMethodEvent);
+        cx.simulate_modifiers_change(Modifiers::none());
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        cx.simulate_modifiers_change(Modifiers::shift());
+        cx.simulate_event(KeyDownHandledByInputMethodEvent);
+        cx.simulate_modifiers_change(Modifiers::none());
+
+        test.update(cx, |test, _| assert_eq!(*test.action_count.borrow(), 0));
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+
+        cx.simulate_modifiers_change(Modifiers::shift());
+        cx.simulate_modifiers_change(Modifiers::none());
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+        cx.simulate_modifiers_change(Modifiers::shift());
+        cx.simulate_modifiers_change(Modifiers::none());
+
+        test.update(cx, |test, _| assert_eq!(*test.action_count.borrow(), 1));
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4373,6 +4373,10 @@ impl Window {
                     PlatformInput::FileDrop(FileDropEvent::Exited)
                 }
             },
+            PlatformInput::KeyDownHandledByInputMethod(_) => {
+                self.pending_modifier.saw_keystroke = true;
+                event
+            }
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -26,12 +26,12 @@ use cocoa::{
 use dispatch2::DispatchQueue;
 use gpui::{
     AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, CursorStyle, ExternalPaths,
-    FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas,
-    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
-    PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
-    WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind, WindowParams, point,
-    px, size,
+    FileDropEvent, ForegroundExecutor, KeyDownEvent, KeyDownHandledByInputMethodEvent, Keystroke,
+    Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow,
+    Point, PromptButton, PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind,
+    WindowParams, point, px, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -2026,6 +2026,9 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
                 if let Some(handled) = window_state.as_ref().lock().do_command_handled.take() {
                     return handled as BOOL;
                 } else if handled == YES {
+                    run_callback(PlatformInput::KeyDownHandledByInputMethod(
+                        KeyDownHandledByInputMethodEvent,
+                    ));
                     return YES;
                 }
 


### PR DESCRIPTION
## Summary

By ignoring key events during IME input, unintended modifier-only shortcuts are triggered. This fix will correctly handle key events during IME input to prevent it.

## Details

When an input method is not involved, typing `shift+a shift+a` to type `AA` does not trigger `shift shift`. The `a` key down events reach GPUI, so `ModifierState.saw_keystroke` is set to true and the Shift presses are not treated as standalone modifier keystrokes.

When an input method handles a character key down directly and does not route it back to GPUI as a regular `KeyDownEvent`, `ModifierState.saw_keystroke` can remain false. In that case, the Shift portions of `shift+a shift+a` can be interpreted as `shift shift`.

This change notifies GPUI with `KeyDownHandledByInputMethod` when an input method handles a key down. The event is not dispatched as a keybinding; the receiver only sets `ModifierState.saw_keystroke` to true.

## Testing

Added a GPUI test covering `KeyDownHandledByInputMethodEvent` and modifier-only shortcut detection.

## Extra

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed unintended modifier-only shortcuts when typing with an input method.
