### PR TITLE
gpui_macos: Enable gpui/test-support feature for tests

### DIFF
--- a/crates/gpui_macos/Cargo.toml
+++ b/crates/gpui_macos/Cargo.toml
@@ -61,3 +61,13 @@ uuid.workspace = true
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cbindgen = { version = "0.28.0", default-features = false }
 gpui.workspace = true
+
+# When this crate is itself being tested (cargo test -p gpui_macos), its own
+# cfg(test) flag enables impls of test-only traits like PlatformHeadlessRenderer
+# and PlatformWindow::render_to_image. Those traits/methods only exist in gpui
+# when gpui's `test-support` feature is on, so we have to turn that feature on
+# as a dev-dependency. The `cfg(test)` flag of a dependent crate doesn't
+# propagate to its dependencies, but dev-dependencies do, so this is the
+# correct way to enable the feature exactly when needed.
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
PR #51415 introduced the `PlatformHeadlessRenderer` trait and `PlatformWindow::render_to_image` method in `gpui`, both gated on `#[cfg(any(test, feature = "test-support"))]`, plus corresponding impls in `gpui_macos` (`window.rs` and `metal_renderer.rs`) gated on the same cfg.

A dependent crate's `cfg(test)` flag does **not** propagate to its dependencies. So when `cargo test -p gpui_macos` is run in isolation, `gpui_macos`'s own `cfg(test)` is true (its impls get compiled) but `gpui` is just a regular dependency without `test-support` enabled (the trait and method don't exist), and the build fails:

```
error[E0405]: cannot find trait `PlatformHeadlessRenderer` in crate `gpui`
error[E0407]: method `render_to_image` is not a member of trait `PlatformWindow`
```

The fix is to enable `gpui/test-support` as a dev-dependency, so the feature is on exactly when `gpui_macos`'s tests are being built.

This bug is latent on `main` — workspace-level `cargo test` typically pulls in `gpui/test-support` transitively from other crates, masking it. Running `cargo test -p gpui_macos` alone is what surfaces it.

Release Notes:

- N/A