### PR TITLE
rpc: Accept unpadded base64 in `decrypt_string` to fix Zed account sign-in

### DIFF
--- a/crates/rpc/src/auth.rs
+++ b/crates/rpc/src/auth.rs
@@ -67,8 +67,9 @@ impl PublicKey {
 impl PrivateKey {
     /// Decrypt a base64-encoded string that was encrypted by the corresponding public key.
     pub fn decrypt_string(&self, encrypted_string: &str) -> Result<String> {
-        let encrypted_bytes = BASE64_URL_SAFE
-            .decode(encrypted_string)
+        let unpadded = encrypted_string.trim_end_matches('=');
+        let encrypted_bytes = BASE64_URL_SAFE_NO_PAD
+            .decode(unpadded)
             .context("failed to base64-decode encrypted string")?;
         let bytes = self
             .0
@@ -223,6 +224,23 @@ mod tests {
             assert_printable(&public_key_str);
             assert_printable(&encrypted_token);
         }
+    }
+
+    #[test]
+    fn test_decrypt_string_with_unpadded_base64() {
+        let (public, private) = keypair().unwrap();
+        let token = random_token();
+        let encrypted_token = public.encrypt_string(&token, EncryptionFormat::V1).unwrap();
+
+        // Simulate the server stripping trailing '=' padding (standard URL-safe practice).
+        let unpadded = encrypted_token.trim_end_matches('=');
+        assert!(
+            !unpadded.contains('='),
+            "test precondition: token should have no padding"
+        );
+
+        let decrypted_token = private.decrypt_string(unpadded).unwrap();
+        assert_eq!(decrypted_token, token);
     }
 
     fn assert_printable(token: &str) {


### PR DESCRIPTION
## Problem

Zed account sign-in intermittently fails at the OAuth callback step for some users with:

```
failed to decrypt access token
Caused by:
    0: failed to base64-decode encrypted string
    1: Invalid padding
```

The `zed.dev` server embeds the RSA-encrypted token in the redirect URL as URL-safe base64 **without** `=` padding — which is standard practice, since `=` in URLs requires percent-encoding. However, `PrivateKey::decrypt_string` was decoding via `BASE64_URL_SAFE`, which requires the padding characters to be present, causing `InvalidPadding` on every sign-in attempt.

Verified: the raw callback token uses the URL-safe alphabet (`-`/`_`) and is 342 chars long (no `=`). Decoding it with `BASE64_URL_SAFE_NO_PAD` yields exactly 256 bytes — correct for RSA-2048 ciphertext.

## Solution

In `decrypt_string`, strip any trailing `=` with `trim_end_matches('=')` then decode with `BASE64_URL_SAFE_NO_PAD`, which accepts tokens both with and without padding. The encode side (`encrypt_string`) is unchanged.

A new test `test_decrypt_string_with_unpadded_base64` explicitly covers the stripped-padding case.

---

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54994
Release Notes:

- Fixed intermittent Zed account sign-in failure ("failed to decrypt access token") caused by missing base64 padding in the OAuth callback token.
