### PR TITLE
extension: Add on-worktree-added lifecycle event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6090,6 +6090,7 @@ dependencies = [
  "theme",
  "theme_extension",
  "theme_settings",
+ "tokio",
  "toml 0.8.23",
  "tracing",
  "url",
@@ -6097,6 +6098,7 @@ dependencies = [
  "wasmparser 0.221.3",
  "wasmtime",
  "wasmtime-wasi",
+ "which 6.0.3",
  "zlog",
  "ztracing",
 ]
@@ -21927,6 +21929,7 @@ dependencies = [
  "collections",
  "component",
  "db",
+ "extension",
  "fs",
  "futures 0.3.32",
  "futures-lite 1.13.0",
@@ -22720,7 +22723,7 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -22752,7 +22755,7 @@ dependencies = [
 name = "zed_test_extension"
 version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.8.0",
+ "zed_extension_api 0.9.0",
 ]
 
 [[package]]

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -179,6 +179,8 @@ pub trait Extension: Send + Sync + 'static {
         locator_name: String,
         config: SpawnInTerminal,
     ) -> Result<DebugRequest>;
+
+    async fn on_worktree_added(&self, worktree: Arc<dyn WorktreeDelegate>) -> Result<()>;
 }
 
 pub fn parse_wasm_extension_version(extension_id: &str, wasm_bytes: &[u8]) -> Result<Version> {

--- a/crates/extension/src/extension_host_proxy.rs
+++ b/crates/extension/src/extension_host_proxy.rs
@@ -32,6 +32,7 @@ pub struct ExtensionHostProxy {
     context_server_proxy: RwLock<Option<Arc<dyn ExtensionContextServerProxy>>>,
     debug_adapter_provider_proxy: RwLock<Option<Arc<dyn ExtensionDebugAdapterProviderProxy>>>,
     language_model_provider_proxy: RwLock<Option<Arc<dyn ExtensionLanguageModelProviderProxy>>>,
+    worktree_event_proxy: RwLock<Option<Arc<dyn ExtensionWorktreeEventProxy>>>,
 }
 
 impl ExtensionHostProxy {
@@ -57,6 +58,7 @@ impl ExtensionHostProxy {
             context_server_proxy: RwLock::default(),
             debug_adapter_provider_proxy: RwLock::default(),
             language_model_provider_proxy: RwLock::default(),
+            worktree_event_proxy: RwLock::default(),
         }
     }
 
@@ -88,6 +90,10 @@ impl ExtensionHostProxy {
         self.debug_adapter_provider_proxy
             .write()
             .replace(Arc::new(proxy));
+    }
+
+    pub fn register_worktree_event_proxy(&self, proxy: impl ExtensionWorktreeEventProxy) {
+        self.worktree_event_proxy.write().replace(Arc::new(proxy));
     }
 
     pub fn register_language_model_provider_proxy(
@@ -464,5 +470,18 @@ impl ExtensionLanguageModelProviderProxy for ExtensionHostProxy {
         };
 
         proxy.unregister_language_model_provider(provider_id, cx)
+    }
+}
+
+pub trait ExtensionWorktreeEventProxy: Send + Sync + 'static {
+    fn notify_worktree_added(&self, worktree_id: u64, worktree_root_path: String, cx: &mut App);
+}
+
+impl ExtensionWorktreeEventProxy for ExtensionHostProxy {
+    fn notify_worktree_added(&self, worktree_id: u64, worktree_root_path: String, cx: &mut App) {
+        let Some(proxy) = self.worktree_event_proxy.read().clone() else {
+            return;
+        };
+        proxy.notify_worktree_added(worktree_id, worktree_root_path, cx);
     }
 }

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_extension_api"
-version = "0.8.0"
+version = "0.9.0"
 description = "APIs for creating Zed extensions in Rust"
 repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/zed_extension_api"

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -281,6 +281,11 @@ pub trait Extension: Send + Sync {
     ) -> Result<DebugRequest, String> {
         Err("`run_dap_locator` not implemented".to_string())
     }
+
+    /// Called when a new worktree is added to the project.
+    fn on_worktree_added(&mut self, _worktree: &Worktree) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Registers the provided type as a Zed extension.
@@ -355,7 +360,7 @@ pub static ZED_API_VERSION: [u8; 6] = *include_bytes!(concat!(env!("OUT_DIR"), "
 mod wit {
     wit_bindgen::generate!({
         skip: ["init-extension"],
-        path: "./wit/since_v0.8.0",
+        path: "./wit/since_v0.9.0",
     });
 }
 
@@ -558,6 +563,10 @@ impl wit::Guest for Component {
         build_task: TaskTemplate,
     ) -> Result<DebugRequest, String> {
         extension().run_dap_locator(locator_name, build_task)
+    }
+
+    fn on_worktree_added(worktree: &Worktree) -> Result<(), String> {
+        extension().on_worktree_added(worktree)
     }
 }
 

--- a/crates/extension_api/wit/since_v0.9.0/common.wit
+++ b/crates/extension_api/wit/since_v0.9.0/common.wit
@@ -1,0 +1,12 @@
+interface common {
+    /// A (half-open) range (`[start, end)`).
+    record range {
+        /// The start of the range (inclusive).
+        start: u32,
+        /// The end of the range (exclusive).
+        end: u32,
+    }
+
+    /// A list of environment variables.
+    type env-vars = list<tuple<string, string>>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/context-server.wit
+++ b/crates/extension_api/wit/since_v0.9.0/context-server.wit
@@ -1,0 +1,11 @@
+interface context-server {
+    /// Configuration for context server setup and installation.
+    record context-server-configuration {
+        /// Installation instructions in Markdown format.
+        installation-instructions: string,
+        /// JSON schema for settings validation.
+        settings-schema: string,
+        /// Default settings template.
+        default-settings: string,
+    }
+}

--- a/crates/extension_api/wit/since_v0.9.0/dap.wit
+++ b/crates/extension_api/wit/since_v0.9.0/dap.wit
@@ -1,0 +1,123 @@
+interface dap {
+    use common.{env-vars};
+
+    /// Resolves a specified TcpArgumentsTemplate into TcpArguments
+    resolve-tcp-template: func(template: tcp-arguments-template) -> result<tcp-arguments, string>;
+
+    record launch-request {
+        program: string,
+        cwd: option<string>,
+        args: list<string>,
+        envs: env-vars,
+    }
+
+    record attach-request {
+        process-id: option<u32>,
+    }
+
+    variant debug-request {
+        launch(launch-request),
+        attach(attach-request)
+    }
+
+    record tcp-arguments {
+        port: u16,
+        host: u32,
+        timeout: option<u64>,
+    }
+
+    record tcp-arguments-template {
+        port: option<u16>,
+        host: option<u32>,
+        timeout: option<u64>,
+    }
+
+    /// Debug Config is the "highest-level" configuration for a debug session.
+    /// It comes from a new process modal UI; thus, it is essentially debug-adapter-agnostic.
+    /// It is expected of the extension to translate this generic configuration into something that can be debugged by the adapter (debug scenario).
+    record debug-config {
+        /// Name of the debug task
+        label: string,
+        /// The debug adapter to use
+        adapter: string,
+        request: debug-request,
+        stop-on-entry: option<bool>,
+    }
+
+    record task-template {
+        /// Human readable name of the task to display in the UI.
+        label: string,
+        /// Executable command to spawn.
+        command: string,
+        args: list<string>,
+        env: env-vars,
+        cwd: option<string>,
+    }
+
+    /// A task template with substituted task variables.
+    type resolved-task = task-template;
+
+    /// A task template for building a debug target.
+    type build-task-template = task-template;
+
+    variant build-task-definition {
+        by-name(string),
+        template(build-task-definition-template-payload )
+    }
+    record build-task-definition-template-payload {
+        locator-name: option<string>,
+        template: build-task-template
+    }
+
+    /// Debug Scenario is the user-facing configuration type (used in debug.json). It is still concerned with what to debug and not necessarily how to do it (except for any
+    /// debug-adapter-specific configuration options).
+    record debug-scenario {
+        /// Unsubstituted label for the task.DebugAdapterBinary
+        label: string,
+        /// Name of the Debug Adapter this configuration is intended for.
+        adapter: string,
+        /// An optional build step to be ran prior to starting a debug session. Build steps are used by Zed's locators to locate the executable to debug.
+        build: option<build-task-definition>,
+        /// JSON-encoded configuration for a given debug adapter.
+        config: string,
+        /// TCP connection parameters (if they were specified by user)
+        tcp-connection: option<tcp-arguments-template>,
+    }
+
+    enum start-debugging-request-arguments-request {
+        launch,
+        attach,
+    }
+
+    record debug-task-definition {
+        /// Unsubstituted label for the task.DebugAdapterBinary
+        label: string,
+        /// Name of the Debug Adapter this configuration is intended for.
+        adapter: string,
+        /// JSON-encoded configuration for a given debug adapter.
+        config: string,
+        /// TCP connection parameters (if they were specified by user)
+        tcp-connection: option<tcp-arguments-template>,
+    }
+
+    record start-debugging-request-arguments {
+        /// JSON-encoded configuration for a given debug adapter. It is specific to each debug adapter.
+        /// `configuration` will have it's Zed variable references substituted prior to being passed to the debug adapter.
+        configuration: string,
+        request: start-debugging-request-arguments-request,
+    }
+
+    /// The lowest-level representation of a debug session, which specifies:
+    /// - How to start a debug adapter process
+    /// - How to start a debug session with it (using DAP protocol)
+    /// for a given debug scenario.
+    record debug-adapter-binary {
+        command: option<string>,
+        arguments: list<string>,
+        envs: env-vars,
+        cwd: option<string>,
+        /// Zed will use TCP transport if `connection` is specified.
+        connection: option<tcp-arguments>,
+        request-args: start-debugging-request-arguments
+    }
+}

--- a/crates/extension_api/wit/since_v0.9.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.9.0/extension.wit
@@ -1,0 +1,182 @@
+package zed:extension;
+
+world extension {
+    import context-server;
+    import dap;
+    import github;
+    import http-client;
+    import platform;
+    import process;
+    import nodejs;
+
+    use common.{env-vars, range};
+    use context-server.{context-server-configuration};
+    use dap.{attach-request, build-task-template, debug-config, debug-adapter-binary, debug-task-definition, debug-request, debug-scenario, launch-request, resolved-task, start-debugging-request-arguments-request};
+    use lsp.{completion, symbol};
+    use process.{command};
+    use slash-command.{slash-command, slash-command-argument-completion, slash-command-output};
+
+    /// Initializes the extension.
+    export init-extension: func();
+
+    /// The type of a downloaded file.
+    enum downloaded-file-type {
+        /// A gzipped file (`.gz`).
+        gzip,
+        /// A gzipped tar archive (`.tar.gz`).
+        gzip-tar,
+        /// A ZIP file (`.zip`).
+        zip,
+        /// An uncompressed file.
+        uncompressed,
+    }
+
+    /// The installation status for a language server.
+    variant language-server-installation-status {
+        /// The language server has no installation status.
+        none,
+        /// The language server is being downloaded.
+        downloading,
+        /// The language server is checking for updates.
+        checking-for-update,
+        /// The language server installation failed for specified reason.
+        failed(string),
+    }
+
+    record settings-location {
+        worktree-id: u64,
+        path: string,
+    }
+
+    import get-settings: func(path: option<settings-location>, category: string, key: option<string>) -> result<string, string>;
+
+    /// Downloads a file from the given URL and saves it to the given path within the extension's
+    /// working directory.
+    ///
+    /// The file will be extracted according to the given file type.
+    import download-file: func(url: string, file-path: string, file-type: downloaded-file-type) -> result<_, string>;
+
+    /// Makes the file at the given path executable.
+    ///
+    /// This is a no-op on Windows.
+    import make-file-executable: func(filepath: string) -> result<_, string>;
+
+    /// Updates the installation status for the given language server.
+    import set-language-server-installation-status: func(language-server-name: string, status: language-server-installation-status);
+
+    /// A Zed worktree.
+    resource worktree {
+        /// Returns the ID of the worktree.
+        id: func() -> u64;
+        /// Returns the root path of the worktree.
+        root-path: func() -> string;
+        /// Returns the textual contents of the specified file in the worktree.
+        read-text-file: func(path: string) -> result<string, string>;
+        /// Returns the path to the given binary name, if one is present on the `$PATH`.
+        which: func(binary-name: string) -> option<string>;
+        /// Returns the current shell environment.
+        shell-env: func() -> env-vars;
+    }
+
+    /// A Zed project.
+    resource project {
+        /// Returns the IDs of all of the worktrees in this project.
+        worktree-ids: func() -> list<u64>;
+    }
+
+    /// A key-value store.
+    resource key-value-store {
+        /// Inserts an entry under the specified key.
+        insert: func(key: string, value: string) -> result<_, string>;
+    }
+
+    /// Returns the command used to start up the language server.
+    export language-server-command: func(language-server-id: string, worktree: borrow<worktree>) -> result<command, string>;
+
+    /// Returns the initialization options to pass to the language server on startup.
+    ///
+    /// The initialization options are represented as a JSON string.
+    export language-server-initialization-options: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
+    /// Returns the workspace configuration options to pass to the language server.
+    export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
+    /// Returns the JSON schema for the initialization options.
+    ///
+    /// The schema is represented as a JSON string conforming to the JSON Schema specification.
+    export language-server-initialization-options-schema: func(language-server-id: string, worktree: borrow<worktree>) -> option<string>;
+
+    /// Returns the JSON schema for the workspace configuration.
+    ///
+    /// The schema is represented as a JSON string conforming to the JSON Schema specification.
+    export language-server-workspace-configuration-schema: func(language-server-id: string, worktree: borrow<worktree>) -> option<string>;
+
+    /// Returns the initialization options to pass to the other language server.
+    export language-server-additional-initialization-options: func(language-server-id: string, target-language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
+    /// Returns the workspace configuration options to pass to the other language server.
+    export language-server-additional-workspace-configuration: func(language-server-id: string, target-language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
+    /// A label containing some code.
+    record code-label {
+        /// The source code to parse with Tree-sitter.
+        code: string,
+        /// The spans to display in the label.
+        spans: list<code-label-span>,
+        /// The range of the displayed label to include when filtering.
+        filter-range: range,
+    }
+
+    /// A span within a code label.
+    variant code-label-span {
+        /// A range into the parsed code.
+        code-range(range),
+        /// A span containing a code literal.
+        literal(code-label-span-literal),
+    }
+
+    /// A span containing a code literal.
+    record code-label-span-literal {
+        /// The literal text.
+        text: string,
+        /// The name of the highlight to use for this literal.
+        highlight-name: option<string>,
+    }
+
+    export labels-for-completions: func(language-server-id: string, completions: list<completion>) -> result<list<option<code-label>>, string>;
+    export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
+
+
+    /// Returns the completions that should be shown when completing the provided slash command with the given query.
+    export complete-slash-command-argument: func(command: slash-command, args: list<string>) -> result<list<slash-command-argument-completion>, string>;
+
+    /// Returns the output from running the provided slash command.
+    export run-slash-command: func(command: slash-command, args: list<string>, worktree: option<borrow<worktree>>) -> result<slash-command-output, string>;
+
+    /// Returns the command used to start up a context server.
+    export context-server-command: func(context-server-id: string, project: borrow<project>) -> result<command, string>;
+
+    /// Returns the configuration for a context server.
+    export context-server-configuration: func(context-server-id: string, project: borrow<project>) -> result<option<context-server-configuration>, string>;
+
+    /// Returns a list of packages as suggestions to be included in the `/docs`
+    /// search results.
+    ///
+    /// This can be used to provide completions for known packages (e.g., from the
+    /// local project or a registry) before a package has been indexed.
+    export suggest-docs-packages: func(provider-name: string) -> result<list<string>, string>;
+
+    /// Indexes the docs for the specified package.
+    export index-docs: func(provider-name: string, package-name: string, database: borrow<key-value-store>) -> result<_, string>;
+
+    /// Returns a configured debug adapter binary for a given debug task.
+    export get-dap-binary: func(adapter-name: string, config: debug-task-definition, user-installed-path: option<string>, worktree: borrow<worktree>) -> result<debug-adapter-binary, string>;
+    /// Returns the kind of a debug scenario (launch or attach).
+    export dap-request-kind: func(adapter-name: string, config: string) -> result<start-debugging-request-arguments-request, string>;
+    export dap-config-to-scenario: func(config: debug-config) -> result<debug-scenario, string>;
+    export dap-locator-create-scenario: func(locator-name: string, build-config-template: build-task-template, resolved-label: string, debug-adapter-name: string) -> option<debug-scenario>;
+    export run-dap-locator: func(locator-name: string, config: resolved-task) -> result<debug-request, string>;
+
+    /// Called when a new worktree is added to the project.
+    export on-worktree-added: func(worktree: borrow<worktree>) -> result<_, string>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/github.wit
+++ b/crates/extension_api/wit/since_v0.9.0/github.wit
@@ -1,0 +1,37 @@
+interface github {
+    /// A GitHub release.
+    record github-release {
+        /// The version of the release.
+        version: string,
+        /// The list of assets attached to the release.
+        assets: list<github-release-asset>,
+    }
+
+    /// An asset from a GitHub release.
+    record github-release-asset {
+        /// The name of the asset.
+        name: string,
+        /// The download URL for the asset.
+        download-url: string,
+        /// The SHA-256 of the release asset if provided by the GitHub API.
+        digest: option<string>,
+    }
+
+    /// The options used to filter down GitHub releases.
+    record github-release-options {
+        /// Whether releases without assets should be included.
+        require-assets: bool,
+        /// Whether pre-releases should be included.
+        pre-release: bool,
+    }
+
+    /// Returns the latest release for the given GitHub repository.
+    ///
+    /// Takes repo as a string in the form "<owner-name>/<repo-name>", for example: "zed-industries/zed".
+    latest-github-release: func(repo: string, options: github-release-options) -> result<github-release, string>;
+
+    /// Returns the GitHub release with the specified tag name for the given GitHub repository.
+    ///
+    /// Returns an error if a release with the given tag name does not exist.
+    github-release-by-tag-name: func(repo: string, tag: string) -> result<github-release, string>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/http-client.wit
+++ b/crates/extension_api/wit/since_v0.9.0/http-client.wit
@@ -1,0 +1,67 @@
+interface http-client {
+    /// An HTTP request.
+    record http-request {
+        /// The HTTP method for the request.
+        method: http-method,
+        /// The URL to which the request should be made.
+        url: string,
+        /// The headers for the request.
+        headers: list<tuple<string, string>>,
+        /// The request body.
+        body: option<list<u8>>,
+        /// The policy to use for redirects.
+        redirect-policy: redirect-policy,
+    }
+
+    /// HTTP methods.
+    enum http-method {
+        /// `GET`
+        get,
+        /// `HEAD`
+        head,
+        /// `POST`
+        post,
+        /// `PUT`
+        put,
+        /// `DELETE`
+        delete,
+        /// `OPTIONS`
+        options,
+        /// `PATCH`
+        patch,
+    }
+
+    /// The policy for dealing with redirects received from the server.
+    variant redirect-policy {
+        /// Redirects from the server will not be followed.
+        ///
+        /// This is the default behavior.
+        no-follow,
+        /// Redirects from the server will be followed up to the specified limit.
+        follow-limit(u32),
+        /// All redirects from the server will be followed.
+        follow-all,
+    }
+
+    /// An HTTP response.
+    record http-response {
+        /// The response headers.
+        headers: list<tuple<string, string>>,
+        /// The response body.
+        body: list<u8>,
+    }
+
+    /// Performs an HTTP request and returns the response.
+    fetch: func(req: http-request) -> result<http-response, string>;
+
+    /// An HTTP response stream.
+    resource http-response-stream {
+        /// Retrieves the next chunk of data from the response stream.
+        ///
+        /// Returns `Ok(None)` if the stream has ended.
+        next-chunk: func() -> result<option<list<u8>>, string>;
+    }
+
+    /// Performs an HTTP request and returns a response stream.
+    fetch-stream: func(req: http-request) -> result<http-response-stream, string>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/lsp.wit
+++ b/crates/extension_api/wit/since_v0.9.0/lsp.wit
@@ -1,0 +1,91 @@
+interface lsp {
+    /// An LSP completion.
+    record completion {
+        label: string,
+        label-details: option<completion-label-details>,
+        detail: option<string>,
+        kind: option<completion-kind>,
+        insert-text-format: option<insert-text-format>,
+    }
+
+    /// The kind of an LSP completion.
+    variant completion-kind {
+        text,
+        method,
+        function,
+        %constructor,
+        field,
+        variable,
+        class,
+        %interface,
+        module,
+        property,
+        unit,
+        value,
+        %enum,
+        keyword,
+        snippet,
+        color,
+        file,
+        reference,
+        folder,
+        enum-member,
+        constant,
+        struct,
+        event,
+        operator,
+        type-parameter,
+        other(s32),
+    }
+
+    /// Label details for an LSP completion.
+    record completion-label-details {
+        detail: option<string>,
+        description: option<string>,
+    }
+
+    /// Defines how to interpret the insert text in a completion item.
+    variant insert-text-format {
+        plain-text,
+        snippet,
+        other(s32),
+    }
+
+    /// An LSP symbol.
+    record symbol {
+        kind: symbol-kind,
+        name: string,
+        container-name: option<string>,
+    }
+
+    /// The kind of an LSP symbol.
+    variant symbol-kind {
+        file,
+        module,
+        namespace,
+        %package,
+        class,
+        method,
+        property,
+        field,
+        %constructor,
+        %enum,
+        %interface,
+        function,
+        variable,
+        constant,
+        %string,
+        number,
+        boolean,
+        array,
+        object,
+        key,
+        null,
+        enum-member,
+        struct,
+        event,
+        operator,
+        type-parameter,
+        other(s32),
+    }
+}

--- a/crates/extension_api/wit/since_v0.9.0/nodejs.wit
+++ b/crates/extension_api/wit/since_v0.9.0/nodejs.wit
@@ -1,0 +1,13 @@
+interface nodejs {
+    /// Returns the path to the Node binary used by Zed.
+    node-binary-path: func() -> result<string, string>;
+
+    /// Returns the latest version of the given NPM package.
+    npm-package-latest-version: func(package-name: string) -> result<string, string>;
+
+    /// Returns the installed version of the given NPM package, if it exists.
+    npm-package-installed-version: func(package-name: string) -> result<option<string>, string>;
+
+    /// Installs the specified NPM package.
+    npm-install-package: func(package-name: string, version: string) -> result<_, string>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/platform.wit
+++ b/crates/extension_api/wit/since_v0.9.0/platform.wit
@@ -1,0 +1,24 @@
+interface platform {
+    /// An operating system.
+    enum os {
+        /// macOS.
+        mac,
+        /// Linux.
+        linux,
+        /// Windows.
+        windows,
+    }
+
+    /// A platform architecture.
+    enum architecture {
+        /// AArch64 (e.g., Apple Silicon).
+        aarch64,
+        /// x86.
+        x86,
+        /// x86-64.
+        x8664,
+    }
+
+    /// Gets the current operating system and architecture.
+    current-platform: func() -> tuple<os, architecture>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/process.wit
+++ b/crates/extension_api/wit/since_v0.9.0/process.wit
@@ -1,0 +1,29 @@
+interface process {
+    use common.{env-vars};
+
+    /// A command.
+    record command {
+        /// The command to execute.
+        command: string,
+        /// The arguments to pass to the command.
+        args: list<string>,
+        /// The environment variables to set for the command.
+        env: env-vars,
+    }
+
+    /// The output of a finished process.
+    record output {
+        /// The status (exit code) of the process.
+        ///
+        /// On Unix, this will be `None` if the process was terminated by a signal.
+        status: option<s32>,
+        /// The data that the process wrote to stdout.
+        stdout: list<u8>,
+        /// The data that the process wrote to stderr.
+        stderr: list<u8>,
+    }
+
+    /// Executes the given command as a child process, waiting for it to finish
+    /// and collecting all of its output.
+    run-command: func(command: command) -> result<output, string>;
+}

--- a/crates/extension_api/wit/since_v0.9.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.9.0/settings.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, num::NonZeroU32};
+
+/// The settings for a particular language.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LanguageSettings {
+    /// How many columns a tab should occupy.
+    pub tab_size: NonZeroU32,
+    /// The preferred line length (column at which to wrap).
+    pub preferred_line_length: u32,
+}
+
+/// The settings for a particular language server.
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct LspSettings {
+    /// The settings for the language server binary.
+    pub binary: Option<CommandSettings>,
+    /// The initialization options to pass to the language server.
+    pub initialization_options: Option<serde_json::Value>,
+    /// The settings to pass to language server.
+    pub settings: Option<serde_json::Value>,
+}
+
+/// The settings for a particular context server.
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextServerSettings {
+    /// The settings for the context server binary.
+    pub command: Option<CommandSettings>,
+    /// The settings to pass to the context server.
+    pub settings: Option<serde_json::Value>,
+}
+
+/// The settings for a command.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandSettings {
+    /// The path to the command.
+    pub path: Option<String>,
+    /// The arguments to pass to the command.
+    pub arguments: Option<Vec<String>>,
+    /// The environment variables.
+    pub env: Option<HashMap<String, String>>,
+}

--- a/crates/extension_api/wit/since_v0.9.0/slash-command.wit
+++ b/crates/extension_api/wit/since_v0.9.0/slash-command.wit
@@ -1,0 +1,41 @@
+interface slash-command {
+    use common.{range};
+
+    /// A slash command for use in the Assistant.
+    record slash-command {
+        /// The name of the slash command.
+        name: string,
+        /// The description of the slash command.
+        description: string,
+        /// The tooltip text to display for the run button.
+        tooltip-text: string,
+        /// Whether this slash command requires an argument.
+        requires-argument: bool,
+    }
+
+    /// The output of a slash command.
+    record slash-command-output {
+        /// The text produced by the slash command.
+        text: string,
+        /// The list of sections to show in the slash command placeholder.
+        sections: list<slash-command-output-section>,
+    }
+
+    /// A section in the slash command output.
+    record slash-command-output-section {
+        /// The range this section occupies.
+        range: range,
+        /// The label to display in the placeholder for this section.
+        label: string,
+    }
+
+    /// A completion for a slash command argument.
+    record slash-command-argument-completion {
+        /// The label to display for this completion.
+        label: string,
+        /// The new text that should be inserted into the command when this completion is accepted.
+        new-text: string,
+        /// Whether the command should be run when accepting this completion.
+        run-command: bool,
+    }
+}

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -48,12 +48,14 @@ task.workspace = true
 telemetry.workspace = true
 tempfile.workspace = true
 toml.workspace = true
+tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 url.workspace = true
 util.workspace = true
 wasmparser.workspace = true
 wasmtime-wasi.workspace = true
 wasmtime.workspace = true
+which.workspace = true
 ztracing.workspace = true
 
 [dev-dependencies]

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -9,15 +9,17 @@ mod extension_store_test;
 use anyhow::{Context as _, Result, anyhow, bail};
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
+use async_trait::async_trait;
 use client::{Client, proto, telemetry::Telemetry};
 use cloud_api_types::{ExtensionMetadata, ExtensionProvides, GetExtensionsResponse};
 use collections::{BTreeMap, BTreeSet, HashSet, btree_map};
 pub use extension::ExtensionManifest;
 use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
 use extension::{
-    ExtensionContextServerProxy, ExtensionDebugAdapterProviderProxy, ExtensionEvents,
+    Extension, ExtensionContextServerProxy, ExtensionDebugAdapterProviderProxy, ExtensionEvents,
     ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy,
     ExtensionLanguageServerProxy, ExtensionSnippetProxy, ExtensionThemeProxy,
+    ExtensionWorktreeEventProxy, WorktreeDelegate,
 };
 use fs::{Fs, RemoveOptions};
 use futures::future::join_all;
@@ -125,6 +127,8 @@ pub struct ExtensionStore {
     pub tasks: Vec<Task<()>>,
     pub remote_clients: Vec<WeakEntity<RemoteClient>>,
     pub ssh_registered_tx: UnboundedSender<()>,
+    extensions_loaded: bool,
+    pending_worktree_notifications: Vec<(u64, String)>,
 }
 
 #[derive(Clone, Copy)]
@@ -263,7 +267,7 @@ impl ExtensionStore {
                 fs.clone(),
                 http_client.clone(),
                 node_runtime,
-                extension_host_proxy,
+                extension_host_proxy.clone(),
                 work_dir,
                 cx,
             ),
@@ -276,7 +280,15 @@ impl ExtensionStore {
 
             remote_clients: Default::default(),
             ssh_registered_tx: connection_registered_tx,
+            extensions_loaded: false,
+            pending_worktree_notifications: Vec::new(),
         };
+
+        {
+            let proxy = extension_host_proxy.clone();
+            let weak_store = cx.entity().downgrade();
+            proxy.register_worktree_event_proxy(WorktreeEventProxy { store: weak_store });
+        }
 
         // The extensions store maintains an index file, which contains a complete
         // list of the installed extensions and the resources that they provide.
@@ -1459,6 +1471,7 @@ impl ExtensionStore {
 
                 this.wasm_extensions.extend(wasm_extensions);
                 this.proxy.set_extensions_loaded();
+                this.replay_pending_worktree_notifications(cx);
                 this.proxy.reload_current_theme(cx);
                 this.proxy.reload_current_icon_theme(cx);
 
@@ -1886,4 +1899,104 @@ fn load_plugin_queries(root_path: &Path) -> LanguageQueries {
         }
     }
     result
+}
+
+impl ExtensionStore {
+    pub fn notify_worktree_added(
+        &mut self,
+        worktree_id: u64,
+        worktree_root_path: String,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.extensions_loaded {
+            self.pending_worktree_notifications
+                .push((worktree_id, worktree_root_path));
+            return;
+        }
+        self.dispatch_worktree_added(worktree_id, worktree_root_path, cx);
+    }
+
+    fn dispatch_worktree_added(
+        &self,
+        worktree_id: u64,
+        worktree_root_path: String,
+        cx: &mut Context<Self>,
+    ) {
+        let delegate = Arc::new(LocalWorktreeDelegate {
+            id: worktree_id,
+            root_path: worktree_root_path,
+        });
+        for (manifest, extension) in &self.wasm_extensions {
+            let extension = extension.clone();
+            let delegate = delegate.clone();
+            let extension_id = manifest.id.clone();
+            cx.spawn(async move |_, _| {
+                if let Err(err) = extension.on_worktree_added(delegate).await {
+                    log::warn!(
+                        "extension {extension_id} on_worktree_added callback failed: {err:#}"
+                    );
+                }
+            })
+            .detach();
+        }
+    }
+
+    pub fn replay_pending_worktree_notifications(&mut self, cx: &mut Context<Self>) {
+        self.extensions_loaded = true;
+        let pending = std::mem::take(&mut self.pending_worktree_notifications);
+        for (id, root_path) in pending {
+            self.dispatch_worktree_added(id, root_path, cx);
+        }
+    }
+}
+
+struct LocalWorktreeDelegate {
+    id: u64,
+    root_path: String,
+}
+
+#[async_trait]
+impl WorktreeDelegate for LocalWorktreeDelegate {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn root_path(&self) -> String {
+        self.root_path.clone()
+    }
+
+    async fn read_text_file(&self, path: &util::rel_path::RelPath) -> Result<String> {
+        let full_path = std::path::Path::new(&self.root_path).join(path);
+        String::from_utf8(
+            tokio::fs::read(&full_path)
+                .await
+                .with_context(|| format!("failed to read file: {}", full_path.display()))?,
+        )
+        .context("file is not valid UTF-8")
+    }
+
+    async fn which(&self, binary_name: String) -> Option<String> {
+        which::which(&binary_name)
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+    }
+
+    async fn shell_env(&self) -> Vec<(String, String)> {
+        std::env::vars().collect()
+    }
+}
+
+struct WorktreeEventProxy {
+    store: WeakEntity<ExtensionStore>,
+}
+
+impl ExtensionWorktreeEventProxy for WorktreeEventProxy {
+    fn notify_worktree_added(&self, worktree_id: u64, worktree_root_path: String, cx: &mut App) {
+        let Some(store) = self.store.upgrade() else {
+            return;
+        };
+        let _ = store.update(cx, |store, cx| {
+            store.notify_worktree_added(worktree_id, worktree_root_path, cx);
+        });
+    }
 }

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -527,6 +527,20 @@ impl extension::Extension for WasmExtension {
         })
         .await?
     }
+
+    async fn on_worktree_added(&self, worktree: Arc<dyn WorktreeDelegate>) -> Result<()> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table.push(worktree)?;
+                extension
+                    .call_on_worktree_added(store, resource)
+                    .await?
+                    .map_err(|err| store.data().extension_error(err))
+            }
+            .boxed()
+        })
+        .await?
+    }
 }
 
 pub struct WasmState {

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -8,6 +8,7 @@ mod since_v0_4_0;
 mod since_v0_5_0;
 mod since_v0_6_0;
 mod since_v0_8_0;
+mod since_v0_9_0;
 use dap::DebugRequest;
 use extension::{DebugTaskDefinition, KeyValueStoreDelegate, WorktreeDelegate};
 use gpui::BackgroundExecutor;
@@ -62,7 +63,7 @@ pub fn wasm_api_version_range(release_channel: ReleaseChannel) -> RangeInclusive
     let _ = release_channel;
 
     let max_version = match release_channel {
-        ReleaseChannel::Dev | ReleaseChannel::Nightly => latest::MAX_VERSION,
+        ReleaseChannel::Dev | ReleaseChannel::Nightly => since_v0_9_0::MAX_VERSION,
         ReleaseChannel::Stable | ReleaseChannel::Preview => since_v0_6_0::MAX_VERSION,
     };
 
@@ -92,6 +93,7 @@ pub fn authorize_access_to_unreleased_wasm_api_version(
 }
 
 pub enum Extension {
+    V0_9_0(since_v0_9_0::Extension),
     V0_8_0(since_v0_8_0::Extension),
     V0_6_0(since_v0_6_0::Extension),
     V0_5_0(since_v0_5_0::Extension),
@@ -115,7 +117,18 @@ impl Extension {
         // Note: The release channel can be used to stage a new version of the extension API.
         let _ = release_channel;
 
-        if version >= latest::MIN_VERSION {
+        if version >= since_v0_9_0::MIN_VERSION {
+            authorize_access_to_unreleased_wasm_api_version(release_channel)?;
+
+            let extension = since_v0_9_0::Extension::instantiate_async(
+                store,
+                component,
+                since_v0_9_0::linker(executor),
+            )
+            .await
+            .context("failed to instantiate wasm extension")?;
+            Ok(Self::V0_9_0(extension))
+        } else if version >= latest::MIN_VERSION {
             authorize_access_to_unreleased_wasm_api_version(release_channel)?;
 
             let extension =
@@ -209,6 +222,7 @@ impl Extension {
 
     pub async fn call_init_extension(&self, store: &mut Store<WasmState>) -> Result<()> {
         match self {
+            Extension::V0_9_0(ext) => ext.call_init_extension(store).await,
             Extension::V0_8_0(ext) => ext.call_init_extension(store).await,
             Extension::V0_6_0(ext) => ext.call_init_extension(store).await,
             Extension::V0_5_0(ext) => ext.call_init_extension(store).await,
@@ -230,6 +244,10 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Command, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_command(store, &language_server_id.0, resource)
+                    .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_command(store, &language_server_id.0, resource)
                     .await
@@ -296,6 +314,14 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_initialization_options(
+                    store,
+                    &language_server_id.0,
+                    resource,
+                )
+                .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
@@ -393,6 +419,14 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_workspace_configuration(
+                    store,
+                    &language_server_id.0,
+                    resource,
+                )
+                .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_workspace_configuration(
                     store,
@@ -468,6 +502,14 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Option<String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_initialization_options_schema(
+                    store,
+                    &language_server_id.0,
+                    resource,
+                )
+                .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_initialization_options_schema(
                     store,
@@ -495,6 +537,14 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Option<String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_workspace_configuration_schema(
+                    store,
+                    &language_server_id.0,
+                    resource,
+                )
+                .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_workspace_configuration_schema(
                     store,
@@ -523,6 +573,15 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_additional_initialization_options(
+                    store,
+                    &language_server_id.0,
+                    &target_language_server_id.0,
+                    resource,
+                )
+                .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_additional_initialization_options(
                     store,
@@ -576,6 +635,15 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_language_server_additional_workspace_configuration(
+                    store,
+                    &language_server_id.0,
+                    &target_language_server_id.0,
+                    resource,
+                )
+                .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_language_server_additional_workspace_configuration(
                     store,
@@ -628,6 +696,15 @@ impl Extension {
         completions: Vec<latest::Completion>,
     ) -> Result<Result<Vec<Option<CodeLabel>>, String>> {
         match self {
+            Extension::V0_9_0(ext) => Ok(ext
+                .call_labels_for_completions(store, &language_server_id.0, &completions)
+                .await?
+                .map(|labels| {
+                    labels
+                        .into_iter()
+                        .map(|label| label.map(Into::into))
+                        .collect()
+                })),
             Extension::V0_8_0(ext) => {
                 ext.call_labels_for_completions(store, &language_server_id.0, &completions)
                     .await
@@ -734,6 +811,15 @@ impl Extension {
         symbols: Vec<latest::Symbol>,
     ) -> Result<Result<Vec<Option<CodeLabel>>, String>> {
         match self {
+            Extension::V0_9_0(ext) => Ok(ext
+                .call_labels_for_symbols(store, &language_server_id.0, &symbols)
+                .await?
+                .map(|labels| {
+                    labels
+                        .into_iter()
+                        .map(|label| label.map(Into::into))
+                        .collect()
+                })),
             Extension::V0_8_0(ext) => {
                 ext.call_labels_for_symbols(store, &language_server_id.0, &symbols)
                     .await
@@ -840,6 +926,10 @@ impl Extension {
         arguments: &[String],
     ) -> Result<Result<Vec<SlashCommandArgumentCompletion>, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_complete_slash_command_argument(store, command, arguments)
+                    .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_complete_slash_command_argument(store, command, arguments)
                     .await
@@ -882,6 +972,10 @@ impl Extension {
         resource: Option<Resource<Arc<dyn WorktreeDelegate>>>,
     ) -> Result<Result<SlashCommandOutput, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_run_slash_command(store, command, arguments, resource)
+                    .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_run_slash_command(store, command, arguments, resource)
                     .await
@@ -923,6 +1017,10 @@ impl Extension {
         project: Resource<ExtensionProject>,
     ) -> Result<Result<Command, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_context_server_command(store, &context_server_id, project)
+                    .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_context_server_command(store, &context_server_id, project)
                     .await
@@ -963,6 +1061,10 @@ impl Extension {
         project: Resource<ExtensionProject>,
     ) -> Result<Result<Option<ContextServerConfiguration>, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_context_server_configuration(store, &context_server_id, project)
+                    .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_context_server_configuration(store, &context_server_id, project)
                     .await
@@ -993,6 +1095,7 @@ impl Extension {
         provider: &str,
     ) -> Result<Result<Vec<String>, String>> {
         match self {
+            Extension::V0_9_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
             Extension::V0_8_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
             Extension::V0_6_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
             Extension::V0_5_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
@@ -1014,6 +1117,10 @@ impl Extension {
         kv_store: Resource<Arc<dyn KeyValueStoreDelegate>>,
     ) -> Result<Result<(), String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                ext.call_index_docs(store, provider, package_name, kv_store)
+                    .await
+            }
             Extension::V0_8_0(ext) => {
                 ext.call_index_docs(store, provider, package_name, kv_store)
                     .await
@@ -1057,6 +1164,20 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<DebugAdapterBinary, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                let dap_binary = ext
+                    .call_get_dap_binary(
+                        store,
+                        &adapter_name,
+                        &task.try_into()?,
+                        user_installed_path.as_ref().and_then(|p| p.to_str()),
+                        resource,
+                    )
+                    .await?
+                    .map_err(|e| anyhow!("{e:?}"))?;
+
+                Ok(Ok(dap_binary))
+            }
             Extension::V0_8_0(ext) => {
                 let dap_binary = ext
                     .call_get_dap_binary(
@@ -1105,6 +1226,16 @@ impl Extension {
         config: serde_json::Value,
     ) -> Result<Result<StartDebuggingRequestArgumentsRequest, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                let config =
+                    serde_json::to_string(&config).context("Adapter config is not a valid JSON")?;
+                let dap_binary = ext
+                    .call_dap_request_kind(store, &adapter_name, &config)
+                    .await?
+                    .map_err(|e| anyhow!("{e:?}"))?;
+
+                Ok(Ok(dap_binary))
+            }
             Extension::V0_8_0(ext) => {
                 let config =
                     serde_json::to_string(&config).context("Adapter config is not a valid JSON")?;
@@ -1144,6 +1275,15 @@ impl Extension {
         config: ZedDebugConfig,
     ) -> Result<Result<DebugScenario, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                let config = config.into();
+                let dap_binary = ext
+                    .call_dap_config_to_scenario(store, &config)
+                    .await?
+                    .map_err(|e| anyhow!("{e:?}"))?;
+
+                Ok(Ok(dap_binary.try_into()?))
+            }
             Extension::V0_8_0(ext) => {
                 let config = config.into();
                 let dap_binary = ext
@@ -1184,6 +1324,20 @@ impl Extension {
         debug_adapter_name: String,
     ) -> Result<Option<DebugScenario>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                let build_config_template = build_config_template.into();
+                let dap_binary = ext
+                    .call_dap_locator_create_scenario(
+                        store,
+                        &locator_name,
+                        &build_config_template,
+                        &resolved_label,
+                        &debug_adapter_name,
+                    )
+                    .await?;
+
+                Ok(dap_binary.map(TryInto::try_into).transpose()?)
+            }
             Extension::V0_8_0(ext) => {
                 let build_config_template = build_config_template.into();
                 let dap_binary = ext
@@ -1232,6 +1386,15 @@ impl Extension {
         resolved_build_task: SpawnInTerminal,
     ) -> Result<Result<DebugRequest, String>> {
         match self {
+            Extension::V0_9_0(ext) => {
+                let build_config_template = resolved_build_task.try_into()?;
+                let dap_request = ext
+                    .call_run_dap_locator(store, &locator_name, &build_config_template)
+                    .await?
+                    .map_err(|e| anyhow!("{e:?}"))?;
+
+                Ok(Ok(dap_request.into()))
+            }
             Extension::V0_8_0(ext) => {
                 let build_config_template = resolved_build_task.try_into()?;
                 let dap_request = ext
@@ -1260,6 +1423,26 @@ impl Extension {
             | Extension::V0_0_1(_) => {
                 anyhow::bail!("`run_dap_locator` not available prior to v0.6.0");
             }
+        }
+    }
+
+    pub async fn call_on_worktree_added(
+        &self,
+        store: &mut Store<WasmState>,
+        resource: Resource<Arc<dyn WorktreeDelegate>>,
+    ) -> Result<Result<(), String>> {
+        match self {
+            Extension::V0_9_0(ext) => ext.call_on_worktree_added(store, resource).await,
+            Extension::V0_8_0(_)
+            | Extension::V0_6_0(_)
+            | Extension::V0_5_0(_)
+            | Extension::V0_4_0(_)
+            | Extension::V0_3_0(_)
+            | Extension::V0_2_0(_)
+            | Extension::V0_1_0(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_1(_) => Ok(Ok(())),
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -37,6 +37,7 @@ use util::{
 use wasmtime::component::{Linker, Resource};
 
 pub const MIN_VERSION: Version = Version::new(0, 8, 0);
+#[allow(dead_code)]
 pub const MAX_VERSION: Version = Version::new(0, 8, 0);
 
 wasmtime::component::bindgen!({

--- a/crates/extension_host/src/wasm_host/wit/since_v0_9_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_9_0.rs
@@ -1,0 +1,232 @@
+use crate::wasm_host::WasmState;
+use anyhow::Result;
+use extension::{KeyValueStoreDelegate, ProjectDelegate, WorktreeDelegate};
+use gpui::BackgroundExecutor;
+use semver::Version;
+use std::sync::{Arc, OnceLock};
+use wasmtime::component::{Linker, Resource};
+
+use super::latest;
+
+pub const MIN_VERSION: Version = Version::new(0, 9, 0);
+#[allow(dead_code)]
+pub const MAX_VERSION: Version = Version::new(0, 9, 0);
+
+wasmtime::component::bindgen!({
+    imports: {
+        default: async | trappable,
+    },
+    exports: {
+        default: async,
+    },
+    path: "../extension_api/wit/since_v0.9.0",
+    with: {
+        "worktree": ExtensionWorktree,
+        "project": ExtensionProject,
+        "key-value-store": ExtensionKeyValueStore,
+        "zed:extension/common": latest::zed::extension::common,
+        "zed:extension/http-client": latest::zed::extension::http_client,
+        "zed:extension/nodejs": latest::zed::extension::nodejs,
+        "zed:extension/platform": latest::zed::extension::platform,
+        "zed:extension/process": latest::zed::extension::process,
+        "zed:extension/slash-command": latest::zed::extension::slash_command,
+        "zed:extension/context-server": latest::zed::extension::context_server,
+        "zed:extension/dap": latest::zed::extension::dap,
+        "zed:extension/lsp": latest::zed::extension::lsp,
+        "zed:extension/github": latest::zed::extension::github,
+    },
+});
+
+#[allow(unused_imports)]
+pub use self::zed::extension::*;
+
+mod settings {
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/since_v0.9.0/settings.rs"));
+}
+
+pub type ExtensionWorktree = Arc<dyn WorktreeDelegate>;
+pub type ExtensionProject = Arc<dyn ProjectDelegate>;
+pub type ExtensionKeyValueStore = Arc<dyn KeyValueStoreDelegate>;
+
+pub fn linker(executor: &BackgroundExecutor) -> &'static Linker<WasmState> {
+    static LINKER: OnceLock<Linker<WasmState>> = OnceLock::new();
+    LINKER.get_or_init(|| {
+        super::new_linker(executor, |linker| {
+            Extension::add_to_linker::<_, WasmState>(linker, |s| s)
+        })
+    })
+}
+
+impl From<CodeLabel> for latest::CodeLabel {
+    fn from(value: CodeLabel) -> Self {
+        Self {
+            code: value.code,
+            spans: value.spans.into_iter().map(Into::into).collect(),
+            filter_range: value.filter_range,
+        }
+    }
+}
+
+impl From<CodeLabelSpan> for latest::CodeLabelSpan {
+    fn from(value: CodeLabelSpan) -> Self {
+        match value {
+            CodeLabelSpan::CodeRange(range) => Self::CodeRange(range),
+            CodeLabelSpan::Literal(literal) => Self::Literal(literal.into()),
+        }
+    }
+}
+
+impl From<CodeLabelSpanLiteral> for latest::CodeLabelSpanLiteral {
+    fn from(value: CodeLabelSpanLiteral) -> Self {
+        Self {
+            text: value.text,
+            highlight_name: value.highlight_name,
+        }
+    }
+}
+
+impl From<SettingsLocation> for latest::SettingsLocation {
+    fn from(value: SettingsLocation) -> Self {
+        Self {
+            worktree_id: value.worktree_id,
+            path: value.path,
+        }
+    }
+}
+
+impl From<LanguageServerInstallationStatus> for latest::LanguageServerInstallationStatus {
+    fn from(value: LanguageServerInstallationStatus) -> Self {
+        match value {
+            LanguageServerInstallationStatus::None => Self::None,
+            LanguageServerInstallationStatus::Downloading => Self::Downloading,
+            LanguageServerInstallationStatus::CheckingForUpdate => Self::CheckingForUpdate,
+            LanguageServerInstallationStatus::Failed(message) => Self::Failed(message),
+        }
+    }
+}
+
+impl From<DownloadedFileType> for latest::DownloadedFileType {
+    fn from(value: DownloadedFileType) -> Self {
+        match value {
+            DownloadedFileType::Gzip => Self::Gzip,
+            DownloadedFileType::GzipTar => Self::GzipTar,
+            DownloadedFileType::Zip => Self::Zip,
+            DownloadedFileType::Uncompressed => Self::Uncompressed,
+        }
+    }
+}
+
+impl HostKeyValueStore for WasmState {
+    async fn insert(
+        &mut self,
+        kv_store: Resource<ExtensionKeyValueStore>,
+        key: String,
+        value: String,
+    ) -> wasmtime::Result<Result<(), String>> {
+        latest::HostKeyValueStore::insert(self, kv_store, key, value).await
+    }
+
+    async fn drop(&mut self, _worktree: Resource<ExtensionKeyValueStore>) -> Result<()> {
+        // We only ever hand out borrows of key-value stores.
+        Ok(())
+    }
+}
+
+impl HostProject for WasmState {
+    async fn worktree_ids(
+        &mut self,
+        project: Resource<ExtensionProject>,
+    ) -> wasmtime::Result<Vec<u64>> {
+        latest::HostProject::worktree_ids(self, project).await
+    }
+
+    async fn drop(&mut self, _project: Resource<Project>) -> Result<()> {
+        // We only ever hand out borrows of projects.
+        Ok(())
+    }
+}
+
+impl HostWorktree for WasmState {
+    async fn id(&mut self, delegate: Resource<Arc<dyn WorktreeDelegate>>) -> wasmtime::Result<u64> {
+        latest::HostWorktree::id(self, delegate).await
+    }
+
+    async fn root_path(
+        &mut self,
+        delegate: Resource<Arc<dyn WorktreeDelegate>>,
+    ) -> wasmtime::Result<String> {
+        latest::HostWorktree::root_path(self, delegate).await
+    }
+
+    async fn read_text_file(
+        &mut self,
+        delegate: Resource<Arc<dyn WorktreeDelegate>>,
+        path: String,
+    ) -> wasmtime::Result<Result<String, String>> {
+        latest::HostWorktree::read_text_file(self, delegate, path).await
+    }
+
+    async fn shell_env(
+        &mut self,
+        delegate: Resource<Arc<dyn WorktreeDelegate>>,
+    ) -> wasmtime::Result<EnvVars> {
+        latest::HostWorktree::shell_env(self, delegate).await
+    }
+
+    async fn which(
+        &mut self,
+        delegate: Resource<Arc<dyn WorktreeDelegate>>,
+        binary_name: String,
+    ) -> wasmtime::Result<Option<String>> {
+        latest::HostWorktree::which(self, delegate, binary_name).await
+    }
+
+    async fn drop(&mut self, _worktree: Resource<Worktree>) -> Result<()> {
+        // We only ever hand out borrows of worktrees.
+        Ok(())
+    }
+}
+
+impl ExtensionImports for WasmState {
+    async fn get_settings(
+        &mut self,
+        location: Option<self::SettingsLocation>,
+        category: String,
+        key: Option<String>,
+    ) -> wasmtime::Result<Result<String, String>> {
+        latest::ExtensionImports::get_settings(
+            self,
+            location.map(|location| location.into()),
+            category,
+            key,
+        )
+        .await
+    }
+
+    async fn set_language_server_installation_status(
+        &mut self,
+        server_name: String,
+        status: LanguageServerInstallationStatus,
+    ) -> wasmtime::Result<()> {
+        latest::ExtensionImports::set_language_server_installation_status(
+            self,
+            server_name,
+            status.into(),
+        )
+        .await
+    }
+
+    async fn download_file(
+        &mut self,
+        url: String,
+        path: String,
+        file_type: DownloadedFileType,
+    ) -> wasmtime::Result<Result<(), String>> {
+        latest::ExtensionImports::download_file(self, url, path, file_type.into()).await
+    }
+
+    async fn make_file_executable(&mut self, path: String) -> wasmtime::Result<Result<(), String>> {
+        latest::ExtensionImports::make_file_executable(self, path).await
+    }
+}

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -51,6 +51,7 @@ node_runtime.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 project.workspace = true
+extension.workspace = true
 remote.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -49,6 +49,7 @@ use client::{
 };
 use collections::{HashMap, HashSet, hash_map};
 use dock::{Dock, DockPosition, PanelButtons, PanelHandle, RESIZE_HANDLE_SIZE};
+use extension::{ExtensionHostProxy, ExtensionWorktreeEventProxy};
 use fs::Fs;
 use futures::{
     Future, FutureExt, StreamExt,
@@ -1495,14 +1496,17 @@ impl Workspace {
 
                 &project::Event::WorktreeAdded(id) => {
                     this.update_window_title(window, cx);
-                    if this
-                        .project()
-                        .read(cx)
-                        .worktree_for_id(id, cx)
-                        .is_some_and(|wt| wt.read(cx).is_visible())
-                    {
-                        this.serialize_workspace(window, cx);
-                        this.update_history(cx);
+                    if let Some(wt) = this.project().read(cx).worktree_for_id(id, cx) {
+                        let root_path = wt.read(cx).abs_path().to_string_lossy().to_string();
+                        ExtensionHostProxy::global(cx).notify_worktree_added(
+                            id.to_proto(),
+                            root_path,
+                            cx,
+                        );
+                        if wt.read(cx).is_visible() {
+                            this.serialize_workspace(window, cx);
+                            this.update_history(cx);
+                        }
                     }
                 }
                 project::Event::WorktreeUpdatedEntries(..) => {
@@ -1764,6 +1768,26 @@ impl Workspace {
             this.update_window_title(window, cx);
             this.show_initial_notifications(cx);
         });
+
+        // Replay existing worktrees so extensions receive on_worktree_added for
+        // worktrees that were added before the subscription was set up.
+        {
+            let proxy = ExtensionHostProxy::global(cx);
+            let existing_worktrees: Vec<(u64, String)> = project
+                .read(cx)
+                .worktrees(cx)
+                .map(|worktree| {
+                    let wt = worktree.read(cx);
+                    (
+                        wt.id().to_proto(),
+                        wt.abs_path().to_string_lossy().to_string(),
+                    )
+                })
+                .collect();
+            for (id, root_path) in existing_worktrees {
+                proxy.notify_worktree_added(id, root_path, cx);
+            }
+        }
 
         let mut center = PaneGroup::new(center_pane.clone());
         center.set_is_center(true);


### PR DESCRIPTION
## Summary

Add new extension API callback `on-worktree-added` that is invoked when a worktree is added to a project.

This allows extensions to automatically execute setup scripts (e.g., `.zed/worktree-setup.sh`) when a git worktree is created, without requiring manual file opening or LSP trigger workarounds.

## Changes

### WIT v0.9.0
- New `since_v0.9.0` WIT version with `on-worktree-added` export
- Backwards compatible: extensions targeting v0.8.0 or earlier work without changes
- Gates new version to dev/nightly builds (stable continues using v0.6.0)

### Extension API
- Add `async fn on_worktree_added(&self, worktree: WorktreeDelegate)` to `Extension` trait
- Guest-side `on-worktree-added` callback with `WorktreeDelegate` for file system access
- Default no-op implementation for backwards compatibility

### Extension Host
- Implement `WasmExtension::on_worktree_added` dispatch
- Add `WorktreeEventProxy` trait for workspace → extension host communication
- Buffer worktree notifications until extensions are loaded (prevents race conditions)
- Replay initial worktrees when project is opened (catches worktrees created before extension loads)

### Workspace Integration
- Hook `Workspace::WorktreeAdded` event to notify extensions
- Set up proxy registration during workspace initialization
- Provide `LocalWorktreeDelegate` with real file system access:
  - `read_text_file(path)`: Read file contents from worktree
  - `which(command)`: Find executable in PATH
  - `shell_env()`: Get current environment variables

### Testing
- Build verification: `cargo check -p extension -p zed_extension_api -p extension_host -p workspace` passes
- Format verification: `cargo fmt --check` passes
- 0 errors, 0 warnings

## Motivation

Previously, extensions had no way to detect when a worktree was added to a project. My `zed-worktree-setup` extension used `language_server_command` as a workaround trigger, but this required opening a file to execute.

This new API allows extensions to run setup scripts immediately when a worktree is created, enabling workflows like:
- Automatically running project-specific configuration scripts
- Installing dependencies via `.zed/worktree-setup.sh`
- Setting up toolchains or build environments

## Example Usage

```wit
// extension.wit
interface extension {
  // ... existing exports
  on-worktree-added: func(worktree: worktree-delegate)
}
```

```rust
// Extension implementation
impl zed_extension::Extension for MyExtension {
    fn on_worktree_added(&mut self, worktree: WorktreeDelegate) -> Result<(), anyhow::Error> {
        // Read .zed/worktree-setup.sh
        let setup_script = worktree.read_text_file(".zed/worktree-setup.sh")?;
        
        // Execute script with environment variables
        // ...
        
        Ok(())
    }
}
```

## Related Work

- Extension: https://github.com/HyeokjaeLee/zed-worktree-setup