### PR TITLE
Avoid breaking YAML curly braces

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2197,6 +2197,7 @@
       },
     },
     "YAML": {
+      "formatter": "language_server",
       "prettier": {
         "allowed": true,
       },

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -21447,6 +21447,190 @@ fn completion_menu_entries(menu: &CompletionsMenu) -> Vec<String> {
 }
 
 #[gpui::test]
+async fn test_yaml_document_format_defaults_to_language_server(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.formatter = Some(FormatterList::default())
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.yaml"), Default::default()).await;
+
+    let project = Project::test(fs, [path!("/file.yaml").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(Arc::new(Language::new(
+        LanguageConfig {
+            name: "YAML".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["yaml".to_string(), "yml".to_string()],
+                ..Default::default()
+            },
+            ..LanguageConfig::default()
+        },
+        Some(tree_sitter_yaml::LANGUAGE.into()),
+    )));
+
+    update_test_language_settings(cx, &|settings| {
+        settings.defaults.prettier.get_or_insert_default().allowed = Some(true);
+        settings.languages.0.insert(
+            "YAML".into(),
+            LanguageSettingsContent {
+                formatter: Some(FormatterList::Single(Formatter::LanguageServer(
+                    settings::LanguageServerFormatterSpecifier::Current,
+                ))),
+                ..Default::default()
+            },
+        );
+    });
+
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "YAML",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                document_formatting_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            prettier_plugins: vec!["test_plugin"],
+            ..Default::default()
+        },
+    );
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.yaml"), cx)
+        })
+        .await
+        .unwrap();
+
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), buffer, window, cx)
+    });
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("key: value\n", window, cx)
+    });
+
+    let fake_server = fake_servers.next().await.unwrap();
+    fake_server.set_request_handler::<lsp::request::Formatting, _, _>(
+        move |params, _| async move {
+            assert_eq!(
+                params.text_document.uri,
+                lsp::Uri::from_file_path(path!("/file.yaml")).unwrap()
+            );
+            Ok(Some(vec![lsp::TextEdit::new(
+                lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 0)),
+                "lsp-format\n".to_string(),
+            )]))
+        },
+    );
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.perform_format(
+                project.clone(),
+                FormatTrigger::Manual,
+                FormatTarget::Buffers(editor.buffer().read(cx).all_buffers()),
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await;
+
+    let formatted = editor.update(cx, |editor, cx| editor.text(cx));
+    assert!(
+        formatted.starts_with("lsp-format\nkey: value\n"),
+        "YAML default formatting should include language-server edits"
+    );
+}
+
+#[gpui::test]
+async fn test_yaml_document_format_can_be_overridden_to_prettier(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.formatter = Some(FormatterList::default())
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.yaml"), Default::default()).await;
+
+    let project = Project::test(fs, [path!("/file.yaml").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(Arc::new(Language::new(
+        LanguageConfig {
+            name: "YAML".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["yaml".to_string(), "yml".to_string()],
+                ..Default::default()
+            },
+            ..LanguageConfig::default()
+        },
+        Some(tree_sitter_yaml::LANGUAGE.into()),
+    )));
+
+    update_test_language_settings(cx, &|settings| {
+        settings.defaults.prettier.get_or_insert_default().allowed = Some(true);
+        settings.languages.0.insert(
+            "YAML".into(),
+            LanguageSettingsContent {
+                formatter: Some(FormatterList::Single(Formatter::Prettier)),
+                ..Default::default()
+            },
+        );
+    });
+
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "YAML",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                document_formatting_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            prettier_plugins: vec!["test_plugin"],
+            ..Default::default()
+        },
+    );
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.yaml"), cx)
+        })
+        .await
+        .unwrap();
+
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), buffer, window, cx)
+    });
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text("key: value\n", window, cx)
+    });
+
+    let fake_server = fake_servers.next().await.unwrap();
+    fake_server.set_request_handler::<lsp::request::Formatting, _, _>(
+        move |_, _| async move {
+            panic!("LSP formatter should not run when YAML formatter is set to Prettier")
+        },
+    );
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.perform_format(
+                project.clone(),
+                FormatTrigger::Manual,
+                FormatTarget::Buffers(editor.buffer().read(cx).all_buffers()),
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await;
+
+    assert_eq!(
+        editor.update(cx, |editor, cx| editor.text(cx)),
+        "key: value\n".to_string() + project::TEST_PRETTIER_FORMAT_SUFFIX,
+    );
+}
+
+#[gpui::test]
 async fn test_document_format_with_prettier(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.formatter = Some(FormatterList::Single(Formatter::Prettier))

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1502,7 +1502,8 @@ mod tests {
     use std::num::NonZeroU32;
 
     use crate::{
-        ClosePosition, ItemSettingsContent, VsCodeSettingsSource, default_settings,
+        ClosePosition, Formatter, FormatterList, ItemSettingsContent,
+        LanguageServerFormatterSpecifier, VsCodeSettingsSource, default_settings,
         settings_content::LanguageSettingsContent, test_settings,
     };
 
@@ -1673,6 +1674,27 @@ mod tests {
                 path: rel_path("root2/something")
             })),
             &AutoUpdateSetting { auto_update: false }
+        );
+    }
+
+    #[gpui::test]
+    fn test_default_yaml_formatter_is_language_server(cx: &mut App) {
+        let store = SettingsStore::new(cx, &default_settings());
+
+        let yaml = store
+            .raw_default_settings()
+            .project
+            .all_languages
+            .languages
+            .0
+            .get("YAML")
+            .expect("default settings should define YAML language settings");
+
+        assert_eq!(
+            yaml.formatter,
+            Some(FormatterList::Single(Formatter::LanguageServer(
+                LanguageServerFormatterSpecifier::Current,
+            ))),
         );
     }
 

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -42,9 +42,19 @@ Note, settings keys must be nested, so `yaml.keyOrdering` becomes `{"yaml": { "k
 
 ## Formatting
 
-By default, Zed uses Prettier for formatting YAML files.
+By default, Zed uses `yaml-language-server` for formatting YAML files.
 
 ### Prettier Formatting
+
+To use Prettier instead of `yaml-language-server` for YAML formatting, configure in Settings ({#kb zed::OpenSettings}) under Languages > YAML, or add to your settings file:
+
+```json [settings]
+  "languages": {
+    "YAML": {
+      "formatter": "prettier"
+    }
+  }
+```
 
 You can customize the formatting behavior of Prettier. For example to use single-quotes in yaml files add the following to your `.prettierrc` configuration file:
 
@@ -63,7 +73,8 @@ You can customize the formatting behavior of Prettier. For example to use single
 
 ### yaml-language-server Formatting
 
-To use `yaml-language-server` instead of Prettier for YAML formatting, configure in Settings ({#kb zed::OpenSettings}) under Languages > YAML, or add to your settings file:
+`yaml-language-server` is the default YAML formatter. To explicitly set it your settings
+you can add the following to your settings file
 
 ```json [settings]
   "languages": {


### PR DESCRIPTION
YAML files that contain templating syntax with double curly braces (for example Ansible-style expressions) could be rewritten into invalid output when saved after edits. This was especially visible on long lines, where formatting expanded the expression into broken multi-line braces.

The fix changes YAML to use the language server formatter by default instead of relying on Prettier defaults for this language. This preserves templated expressions and prevents Zed from emitting invalid YAML when users edit and save these files.

Tests were added to confirm that YAML uses language server formatting by default and that users can still configure Prettier formatting in settings.

The fix gives the user the option to revert to the previous Prettier formatting by modifying the settings file.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #46632

Release Notes:

- Fixed YAML formatting breaking templated expressions with double curly braces
