### PR TITLE
Fix bare worktree identity in worktree switcher

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -74,6 +74,7 @@ pub fn original_repo_path(
 ) -> PathBuf {
     if common_dir != repository_dir {
         original_repo_path_from_common_dir(common_dir)
+            .or_else(|| original_repo_path_from_bare_common_dir(common_dir, repository_dir))
             .unwrap_or_else(|| work_directory.to_path_buf())
     } else {
         work_directory.to_path_buf()
@@ -95,6 +96,17 @@ pub fn original_repo_path_from_common_dir(common_dir: &Path) -> Option<PathBuf> 
     } else {
         None
     }
+}
+
+fn original_repo_path_from_bare_common_dir(
+    common_dir: &Path,
+    repository_dir: &Path,
+) -> Option<PathBuf> {
+    if !repository_dir.starts_with(common_dir.join("worktrees")) {
+        return None;
+    }
+
+    common_dir.parent().map(|path| path.to_path_buf())
 }
 
 /// Commit data needed for the git graph visualization.
@@ -4509,6 +4521,45 @@ mod tests {
         assert_eq!(
             original_repo_path_from_common_dir(Path::new("/.git")),
             Some(PathBuf::from("/"))
+        );
+    }
+
+    #[test]
+    fn test_original_repo_path() {
+        assert_eq!(
+            original_repo_path(
+                Path::new("/tmp/monty"),
+                Path::new("/tmp/monty/.git"),
+                Path::new("/tmp/monty/.git"),
+            ),
+            PathBuf::from("/tmp/monty")
+        );
+
+        assert_eq!(
+            original_repo_path(
+                Path::new("/tmp/monty/feature-a"),
+                Path::new("/tmp/monty/.git"),
+                Path::new("/tmp/monty/.git/worktrees/feature-a"),
+            ),
+            PathBuf::from("/tmp/monty")
+        );
+
+        assert_eq!(
+            original_repo_path(
+                Path::new("/tmp/monty/feature-a"),
+                Path::new("/tmp/monty/.bare"),
+                Path::new("/tmp/monty/.bare/worktrees/feature-a"),
+            ),
+            PathBuf::from("/tmp/monty")
+        );
+
+        assert_eq!(
+            original_repo_path(
+                Path::new("/tmp/monty/.bare"),
+                Path::new("/tmp/monty/.bare"),
+                Path::new("/tmp/monty/.bare"),
+            ),
+            PathBuf::from("/tmp/monty/.bare")
         );
     }
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12141,6 +12141,93 @@ async fn test_git_worktrees_and_submodules(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_git_worktree_in_bare_layout_uses_shared_project_root(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/monty"),
+        json!({
+            ".bare": {
+                "HEAD": "",
+                "config": "",
+                "worktrees": {
+                    "main": {
+                        "commondir": "../..\n",
+                        "HEAD": "",
+                        "config": ""
+                    },
+                    "feature-a": {
+                        "commondir": "../..\n",
+                        "HEAD": "",
+                        "config": ""
+                    }
+                }
+            },
+            "main": {
+                ".git": "gitdir: ../.bare/worktrees/main\n",
+                "src": {
+                    "a.txt": "A",
+                }
+            },
+            "feature-a": {
+                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+                "src": {
+                    "b.txt": "B",
+                }
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/monty/feature-a").as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let repositories = project.update(cx, |project, cx| {
+        project
+            .repositories(cx)
+            .values()
+            .map(|repo| repo.read(cx).work_directory_abs_path.clone())
+            .collect::<Vec<_>>()
+    });
+    pretty_assertions::assert_eq!(repositories, [Path::new(path!("/monty/feature-a")).into()]);
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/monty/feature-a/src/b.txt"), cx)
+        })
+        .await
+        .unwrap();
+    let (repository, barrier) = project.update(cx, |project, cx| {
+        let (repo, _) = project
+            .git_store()
+            .read(cx)
+            .repository_and_path_for_buffer_id(buffer.read(cx).remote_id(), cx)
+            .unwrap();
+        let barrier = repo.update(cx, |repo, _| repo.barrier());
+        (repo.clone(), barrier)
+    });
+    barrier.await.unwrap();
+
+    repository.read_with(cx, |repo, _| {
+        pretty_assertions::assert_eq!(
+            repo.work_directory_abs_path,
+            Path::new(path!("/monty/feature-a")).into(),
+        );
+        pretty_assertions::assert_eq!(
+            repo.original_repo_abs_path,
+            Path::new(path!("/monty")).into(),
+        );
+        assert!(
+            repo.linked_worktree_path().is_some(),
+            "bare-layout worktree should be detected as a linked worktree"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_repository_deduplication(cx: &mut gpui::TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());


### PR DESCRIPTION
## Context

This fixes #54830, where switching to an existing git worktree in a bare shared-dir layout caused Zed to treat the linked worktree directory as the project root. In a layout like `monty/.bare`, `monty/main`, and `monty/feature-a`, the repository metadata fell back to the linked checkout path because `original_repo_path_from_common_dir` only recognized `.git` common dirs. That made the title bar show the project as `feature-a` and the worktree label as `main`.

The fix teaches `original_repo_path(...)` to recognize linked worktrees whose shared git dir is bare and stored under `common_dir/worktrees/...`. In that case, it now resolves the original repo path to `common_dir.parent()`, which matches how `WorktreeStore` already groups these worktrees. I also added targeted regression coverage for both the path resolution helper and the bare-layout project scan path.

Closes #54830

Video of the manual test below :

[Screencast from 2026-04-28 01-31-39.webm](https://github.com/user-attachments/assets/5ca31221-2d90-49d7-97bc-6fb5bec6ccf3)


## How to Review

- `crates/git/src/repository.rs`: Updates original repo path resolution so linked worktrees backed by a bare shared git dir resolve to the shared project root instead of the linked checkout path. Adds unit coverage for normal repos, non-bare linked worktrees, bare linked worktrees, and plain bare repos.
- `crates/project/tests/integration/project_tests.rs`: Adds an integration regression test for the `.bare + main + feature-a` layout and verifies that scanning `feature-a` produces repository metadata rooted at `monty` while still identifying the checkout as a linked worktree.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed git worktree switching to preserve the shared project identity for repositories using a bare `.bare` worktree layout

