### PR TITLE
agent: Add Skipped status to update_plan tool for abandoned steps

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -922,6 +922,9 @@ pub struct PlanStats<'a> {
     pub in_progress_entry: Option<&'a PlanEntry>,
     pub pending: u32,
     pub completed: u32,
+    /// Steps marked skipped are excluded from both pending and completed counts
+    /// so they do not block plan completion detection.
+    pub skipped: u32,
 }
 
 impl Plan {
@@ -934,6 +937,7 @@ impl Plan {
             in_progress_entry: None,
             pending: 0,
             completed: 0,
+            skipped: 0,
         };
 
         for entry in &self.entries {
@@ -948,7 +952,10 @@ impl Plan {
                 acp::PlanEntryStatus::Completed => {
                     stats.completed += 1;
                 }
-                _ => {}
+                _ => {
+                    // Unknown or Skipped variants: not pending, not completed.
+                    stats.skipped += 1;
+                }
             }
         }
 

--- a/crates/agent/src/tools/update_plan_tool.rs
+++ b/crates/agent/src/tools/update_plan_tool.rs
@@ -15,6 +15,10 @@ pub enum PlanEntryStatus {
     InProgress,
     /// The task has been successfully completed.
     Completed,
+    /// The task was intentionally skipped or became irrelevant.
+    /// Use this when a planned step no longer applies due to a scope change
+    /// or a preceding step that made this one unnecessary.
+    Skipped,
 }
 
 impl From<PlanEntryStatus> for acp::PlanEntryStatus {
@@ -23,6 +27,7 @@ impl From<PlanEntryStatus> for acp::PlanEntryStatus {
             PlanEntryStatus::Pending => acp::PlanEntryStatus::Pending,
             PlanEntryStatus::InProgress => acp::PlanEntryStatus::InProgress,
             PlanEntryStatus::Completed => acp::PlanEntryStatus::Completed,
+            PlanEntryStatus::Skipped => acp::PlanEntryStatus::Pending,
         }
     }
 }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2824,8 +2824,16 @@ impl ThreadView {
                                             .color(Color::Success)
                                             .into_any_element()
                                     }
-                                    acp::PlanEntryStatus::Pending | _ => {
+                                    acp::PlanEntryStatus::Pending => {
                                         Icon::new(IconName::TodoPending)
+                                            .size(IconSize::Small)
+                                            .color(Color::Muted)
+                                            .into_any_element()
+                                    }
+                                    _ => {
+                                        // Skipped or future unknown status: render
+                                        // a muted dash to signal intentional omission.
+                                        Icon::new(IconName::Dash)
                                             .size(IconSize::Small)
                                             .color(Color::Muted)
                                             .into_any_element()


### PR DESCRIPTION
Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:
- Improved: `update_plan` tool now accepts a `skipped` status for steps that
  became irrelevant mid-task. Skipped steps render with a distinct muted dash
  icon in the plan UI and are excluded from the pending count, so plan
  completion detection is unaffected.