### PR TITLE
git_ui: Add setting to automatically expand diffs on file open

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -987,6 +987,11 @@
     //
     // Default: 72
     "commit_title_max_length": 72,
+    // Whether opening a file from the git panel should automatically expand
+    // the diff hunks.
+    //
+    // Default: true
+    "open_file_with_diff": true,
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -988,10 +988,10 @@
     // Default: 72
     "commit_title_max_length": 72,
     // Whether opening a file from the git panel should automatically expand
-    // the diff hunks.
+    // all diff hunks and navigate to the first change.
     //
     // Default: true
-    "open_file_with_diff": true,
+    "expand_diff_hunks_on_open": true,
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1338,6 +1338,7 @@ impl GitPanel {
                 })
                 .ok()?;
 
+            let open_file_with_diff = GitPanelSettings::get_global(cx).open_file_with_diff;
             let workspace = self.workspace.clone();
             cx.spawn_in(window, async move |_, mut cx| {
                 let item = open_task
@@ -1351,22 +1352,24 @@ impl GitPanel {
                         diff_task.await;
                     }
 
-                    cx.update(|window, cx| {
-                        active_editor.update(cx, |editor, cx| {
-                            editor.expand_all_diff_hunks(&ExpandAllDiffHunks, window, cx);
+                    if open_file_with_diff {
+                        cx.update(|window, cx| {
+                            active_editor.update(cx, |editor, cx| {
+                                editor.expand_all_diff_hunks(&ExpandAllDiffHunks, window, cx);
 
-                            let snapshot = editor.snapshot(window, cx);
-                            editor.go_to_hunk_before_or_after_position(
-                                &snapshot,
-                                language::Point::new(0, 0),
-                                Direction::Next,
-                                true,
-                                window,
-                                cx,
-                            );
+                                let snapshot = editor.snapshot(window, cx);
+                                editor.go_to_hunk_before_or_after_position(
+                                    &snapshot,
+                                    language::Point::new(0, 0),
+                                    Direction::Next,
+                                    true,
+                                    window,
+                                    cx,
+                                );
+                            })
                         })
-                    })
-                    .log_err();
+                        .log_err();
+                    }
                 }
 
                 anyhow::Ok(())

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1338,7 +1338,8 @@ impl GitPanel {
                 })
                 .ok()?;
 
-            let open_file_with_diff = GitPanelSettings::get_global(cx).open_file_with_diff;
+            let expand_diff_hunks_on_open =
+                GitPanelSettings::get_global(cx).expand_diff_hunks_on_open;
             let workspace = self.workspace.clone();
             cx.spawn_in(window, async move |_, mut cx| {
                 let item = open_task
@@ -1352,7 +1353,7 @@ impl GitPanel {
                         diff_task.await;
                     }
 
-                    if open_file_with_diff {
+                    if expand_diff_hunks_on_open {
                         cx.update(|window, cx| {
                             active_editor.update(cx, |editor, cx| {
                                 editor.expand_all_diff_hunks(&ExpandAllDiffHunks, window, cx);

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -31,6 +31,7 @@ pub struct GitPanelSettings {
     pub show_count_badge: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
+    pub open_file_with_diff: bool,
 }
 
 #[derive(Default)]
@@ -78,6 +79,7 @@ impl Settings for GitPanelSettings {
             show_count_badge: git_panel.show_count_badge.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
+            open_file_with_diff: git_panel.open_file_with_diff.unwrap(),
         }
     }
 }

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -31,7 +31,7 @@ pub struct GitPanelSettings {
     pub show_count_badge: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
-    pub open_file_with_diff: bool,
+    pub expand_diff_hunks_on_open: bool,
 }
 
 #[derive(Default)]
@@ -79,7 +79,7 @@ impl Settings for GitPanelSettings {
             show_count_badge: git_panel.show_count_badge.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
-            open_file_with_diff: git_panel.open_file_with_diff.unwrap(),
+            expand_diff_hunks_on_open: git_panel.expand_diff_hunks_on_open.unwrap(),
         }
     }
 }

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -676,10 +676,10 @@ pub struct GitPanelSettingsContent {
     pub starts_open: Option<bool>,
 
     /// Whether opening a file from the git panel should automatically expand
-    /// the diff hunks.
+    /// all diff hunks and navigate to the first change.
     ///
     /// Default: true
-    pub open_file_with_diff: Option<bool>,
+    pub expand_diff_hunks_on_open: Option<bool>,
 
     /// Maximum length of the commit message title before a warning is shown.
     /// Set to 0 to disable.

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -675,6 +675,12 @@ pub struct GitPanelSettingsContent {
     /// Default: false
     pub starts_open: Option<bool>,
 
+    /// Whether opening a file from the git panel should automatically expand
+    /// the diff hunks.
+    ///
+    /// Default: true
+    pub open_file_with_diff: Option<bool>,
+
     /// Maximum length of the commit message title before a warning is shown.
     /// Set to 0 to disable.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5455,7 +5455,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn git_panel_section() -> [SettingsPageItem; 15] {
+    fn git_panel_section() -> [SettingsPageItem; 16] {
         [
             SettingsPageItem::SectionHeader("Git Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5718,6 +5718,28 @@ fn panels_page() -> SettingsPage {
                             .scrollbar
                             .get_or_insert_default()
                             .show = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Open File With Diff",
+                description: "When opening a file from the Git panel, automatically expand all diff hunks and navigate to the first change.",
+                field: Box::new(SettingField {
+                    json_path: Some("git_panel.open_file_with_diff"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_panel
+                            .as_ref()?
+                            .open_file_with_diff
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .open_file_with_diff = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5724,22 +5724,22 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
-                title: "Open File With Diff",
+                title: "Expand Diff Hunks On Open",
                 description: "When opening a file from the Git panel, automatically expand all diff hunks and navigate to the first change.",
                 field: Box::new(SettingField {
-                    json_path: Some("git_panel.open_file_with_diff"),
+                    json_path: Some("git_panel.expand_diff_hunks_on_open"),
                     pick: |settings_content| {
                         settings_content
                             .git_panel
                             .as_ref()?
-                            .open_file_with_diff
+                            .expand_diff_hunks_on_open
                             .as_ref()
                     },
                     write: |settings_content, value, _| {
                         settings_content
                             .git_panel
                             .get_or_insert_default()
-                            .open_file_with_diff = value;
+                            .expand_diff_hunks_on_open = value;
                     },
                 }),
                 metadata: None,


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

from disscussion #53717
this PR adds a setting for the user to be able to control whether or not the diff hunks are automatically expanded when opening a file from the GitPanel.
the name of the setting is `git_panel.open_file_with_diff` and the default setting is `true` which preserves the current behavior.

just to be upfront, claude knocked this one out for me as i have not done any work with the settings system before. it's a pretty simple change and seems to be written the same as the other settings. 

i have successfully built and ran this change and it seems to be functioning as intended.

<img width="1350" height="934" alt="Screenshot 2026-04-27 at 22 10 48" src="https://github.com/user-attachments/assets/206c8482-f8d8-4821-a274-87cee1fc801f" />


Release Notes:

- Added a setting for opening files with diffs automatically expanded
