### PR TITLE
Fix process teardown deadlock on Windows

### DIFF
--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -410,6 +410,17 @@ impl Platform for WindowsPlatform {
 
         self.inner
             .with_callback(|callbacks| &callbacks.quit, |callback| callback());
+
+        // Bypass the CRT exit logic, which runs atexit handlers before calling ExitProcess.
+        // aws-lc registers an atexit handler that intentionally acquires a lock without releasing it.
+        // aws-lc also has thread_local objects which acquire this lock in their destructor.
+        // Destructors for thread_locals run under the loader lock, so there is a race condition
+        // where, if a thread exits after atexit handlers have run, the TLS destructors will block
+        // indefinitely on this lock while holding the loader lock. Since ExitProcess also requires
+        // the loader lock, process teardown will deadlock.
+        unsafe {
+            windows::Win32::System::Threading::ExitProcess(0);
+        }
     }
 
     fn quit(&self) {


### PR DESCRIPTION
AWS-LC registers an `atexit` handler that intentionally acquires a lock without releasing it. AWS-LC also has `thread_local` objects which acquire this lock in their destructor. Destructors for `thread_local`s run under the loader lock. So, there is a race condition where, if a thread exits after `atexit` handlers have run, the TLS destructors will block indefinitely on this lock while holding the loader lock. Since `ExitProcess` also requires the loader lock, process teardown will deadlock.


Closes #54856

Release Notes:

- Fixed an issue where the Zed process wouldn't exit after closing all windows
