### PR TITLE
Update v1.1.x Preview Release Channel

### DIFF
--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-dev
+preview


### PR DESCRIPTION
Updates `crates/zed/RELEASE_CHANNEL` from `dev` to `preview` to activate the `v1.1.x` branch as the new preview release channel.

Release Notes:

- N/A