### PR TITLE
git: Stage files automatically when no conflict markers left

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1621,6 +1621,9 @@
     //
     // Trailing slashes are ignored.
     "worktree_directory": "../worktrees",
+    // Whether to automatically stage files when all conflict markers
+    // have been resolved and the file is saved.
+    "auto_stage_on_conflict_resolution": true,
   },
   // The list of custom Git hosting providers.
   "git_hosting_providers": [

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1746,13 +1746,19 @@ impl GitStore {
         match event {
             BufferStoreEvent::BufferAdded(buffer) => {
                 cx.subscribe(buffer, |this, buffer, event, cx| {
-                    if let BufferEvent::LanguageChanged(_) = event {
-                        let buffer_id = buffer.read(cx).remote_id();
-                        if let Some(diff_state) = this.diffs.get(&buffer_id) {
-                            diff_state.update(cx, |diff_state, cx| {
-                                diff_state.buffer_language_changed(buffer, cx);
-                            });
+                    match event {
+                        BufferEvent::LanguageChanged(_) => {
+                            let buffer_id = buffer.read(cx).remote_id();
+                            if let Some(diff_state) = this.diffs.get(&buffer_id) {
+                                diff_state.update(cx, |diff_state, cx| {
+                                    diff_state.buffer_language_changed(buffer, cx);
+                                });
+                            }
                         }
+                        BufferEvent::Saved => {
+                            this.auto_stage_resolved_conflict(buffer, cx);
+                        }
+                        _ => {}
                     }
                 })
                 .detach();
@@ -1808,6 +1814,34 @@ impl GitStore {
                 }
             }
         }
+    }
+
+    fn auto_stage_resolved_conflict(
+        &mut self,
+        buffer: Entity<Buffer>,
+        cx: &mut Context<Self>,
+    ) {
+        if !ProjectSettings::get_global(cx)
+            .git
+            .auto_stage_on_conflict_resolution
+        {
+            return;
+        }
+        let buffer_id = buffer.read(cx).remote_id();
+        let Some((repo, repo_path)) = self.repository_and_path_for_buffer_id(buffer_id, cx) else {
+            return;
+        };
+        if !repo.read(cx).snapshot.has_conflict(&repo_path) {
+            return;
+        }
+        let parsed = ConflictSet::parse(&buffer.read(cx).text_snapshot());
+        if !parsed.conflicts.is_empty() {
+            return;
+        }
+        cx.defer(move |cx| {
+            repo.update(cx, |repo, cx| repo.stage_entries(vec![repo_path], cx))
+                .detach_and_log_err(cx);
+        });
     }
 
     pub fn recalculate_buffer_diffs(

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -462,6 +462,11 @@ pub struct GitSettings {
     ///
     /// Default: ../worktrees
     pub worktree_directory: String,
+    /// Whether to automatically stage files when all conflict markers
+    /// have been resolved and the file is saved.
+    ///
+    /// Default: true
+    pub auto_stage_on_conflict_resolution: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -655,6 +660,9 @@ impl Settings for ProjectSettings {
                 .worktree_directory
                 .clone()
                 .unwrap_or_else(|| DEFAULT_WORKTREE_DIRECTORY.to_string()),
+            auto_stage_on_conflict_resolution: git
+                .auto_stage_on_conflict_resolution
+                .unwrap_or(true),
         };
         Self {
             context_servers: project

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -623,6 +623,328 @@ mod conflict_set_tests {
             assert_eq!(conflict_set.snapshot.conflicts.len(), 0);
         });
     }
+
+    #[gpui::test]
+    async fn test_auto_stage_on_save_when_conflicts_resolved(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        zlog::init_test();
+        cx.update(|cx| {
+            settings::init(cx);
+        });
+
+        let conflicted_text = "
+            zero
+            <<<<<<< HEAD
+            one
+            =======
+            two
+            >>>>>>> branch
+            three
+        "
+        .unindent();
+
+        let resolved_text = "
+            zero
+            one
+            three
+        "
+        .unindent();
+
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": conflicted_text.clone(),
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("a.txt", "zero\none\nthree\n".into())],
+        );
+        fs.with_git_state(path!("/project/.git").as_ref(), true, |state| {
+            state.unmerged_paths.insert(
+                repo_path("a.txt"),
+                UnmergedStatus {
+                    first_head: UnmergedStatusCode::Updated,
+                    second_head: UnmergedStatusCode::Updated,
+                },
+            );
+        })
+        .unwrap();
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/a.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        cx.run_until_parked();
+
+        buffer.update(cx, |buffer, cx| {
+            buffer.set_text(resolved_text.clone(), cx);
+        });
+
+        project
+            .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        fs.with_git_state(path!("/project/.git").as_ref(), false, |state| {
+            assert!(
+                state.index_contents.contains_key(&repo_path("a.txt")),
+                "file should be staged after saving with conflicts resolved"
+            );
+        })
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_no_auto_stage_when_conflicts_remain(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        zlog::init_test();
+        cx.update(|cx| {
+            settings::init(cx);
+        });
+
+        let conflicted_text = "
+            zero
+            <<<<<<< HEAD
+            one
+            =======
+            two
+            >>>>>>> branch
+            three
+        "
+        .unindent();
+
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": conflicted_text.clone(),
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("a.txt", "zero\none\nthree\n".into())],
+        );
+        fs.with_git_state(path!("/project/.git").as_ref(), true, |state| {
+            state.unmerged_paths.insert(
+                repo_path("a.txt"),
+                UnmergedStatus {
+                    first_head: UnmergedStatusCode::Updated,
+                    second_head: UnmergedStatusCode::Updated,
+                },
+            );
+        })
+        .unwrap();
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/a.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        cx.run_until_parked();
+
+        let index_before = fs
+            .with_git_state(path!("/project/.git").as_ref(), false, |state| {
+                state.index_contents.get(&repo_path("a.txt")).cloned()
+            })
+            .unwrap();
+
+        project
+            .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let index_after = fs
+            .with_git_state(path!("/project/.git").as_ref(), false, |state| {
+                state.index_contents.get(&repo_path("a.txt")).cloned()
+            })
+            .unwrap();
+
+        assert_eq!(
+            index_before, index_after,
+            "index should not change when conflict markers are still present"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_no_auto_stage_when_file_not_conflicted(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        zlog::init_test();
+        cx.update(|cx| {
+            settings::init(cx);
+        });
+
+        let initial_text = "
+            zero
+            one
+            three
+        "
+        .unindent();
+
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": initial_text.clone(),
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("a.txt", initial_text.clone())],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/a.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        cx.run_until_parked();
+
+        buffer.update(cx, |buffer, cx| {
+            buffer.set_text("modified content\n".to_string(), cx);
+        });
+
+        project
+            .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        fs.with_git_state(path!("/project/.git").as_ref(), false, |state| {
+            assert_eq!(
+                state.index_contents.get(&repo_path("a.txt")).map(|s| s.as_str()),
+                Some(initial_text.as_str()),
+                "index should remain unchanged for non-conflicted files"
+            );
+        })
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_no_auto_stage_when_setting_disabled(
+        executor: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        zlog::init_test();
+        cx.update(|cx| {
+            settings::init(cx);
+        });
+
+        let conflicted_text = "
+            zero
+            <<<<<<< HEAD
+            one
+            =======
+            two
+            >>>>>>> branch
+            three
+        "
+        .unindent();
+
+        let resolved_text = "
+            zero
+            one
+            three
+        "
+        .unindent();
+
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": conflicted_text.clone(),
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("a.txt", "zero\none\nthree\n".into())],
+        );
+        fs.with_git_state(path!("/project/.git").as_ref(), true, |state| {
+            state.unmerged_paths.insert(
+                repo_path("a.txt"),
+                UnmergedStatus {
+                    first_head: UnmergedStatusCode::Updated,
+                    second_head: UnmergedStatusCode::Updated,
+                },
+            );
+        })
+        .unwrap();
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings
+                        .git
+                        .get_or_insert_default()
+                        .auto_stage_on_conflict_resolution = Some(false);
+                });
+            });
+        });
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/a.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        cx.run_until_parked();
+
+        let index_before = fs
+            .with_git_state(path!("/project/.git").as_ref(), false, |state| {
+                state.index_contents.get(&repo_path("a.txt")).cloned()
+            })
+            .unwrap();
+
+        buffer.update(cx, |buffer, cx| {
+            buffer.set_text(resolved_text.clone(), cx);
+        });
+
+        project
+            .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let index_after = fs
+            .with_git_state(path!("/project/.git").as_ref(), false, |state| {
+                state.index_contents.get(&repo_path("a.txt")).cloned()
+            })
+            .unwrap();
+
+        assert_eq!(
+            index_before, index_after,
+            "index should not change when auto_stage_on_conflict_resolution is disabled"
+        );
+    }
 }
 
 mod git_traversal {

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -8,7 +8,7 @@ mod conflict_set_tests {
         repository::{RepoPath, repo_path},
         status::{UnmergedStatus, UnmergedStatusCode},
     };
-    use gpui::{BackgroundExecutor, TestAppContext};
+    use gpui::{BackgroundExecutor, TestAppContext, UpdateGlobal as _};
     use project::git_store::*;
     use serde_json::json;
     use text::{Buffer, BufferId, OffsetRangeExt, Point, ReplicaId, ToOffset as _};

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -521,6 +521,11 @@ pub struct GitSettings {
     ///
     /// Default: ../worktrees
     pub worktree_directory: Option<String>,
+    /// Whether to automatically stage files when all conflict markers
+    /// have been resolved and the file is saved.
+    ///
+    /// Default: true
+    pub auto_stage_on_conflict_resolution: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6995,6 +6995,29 @@ fn version_control_page() -> SettingsPage {
                             }),
                             metadata: None,
                         },
+                        SettingItem {
+                            files: USER,
+                            title: "Auto-Stage on Conflict Resolution",
+                            description:
+                                "Automatically stage files when all conflict markers have been resolved and the file is saved.",
+                            field: Box::new(SettingField::<bool> {
+                                json_path: Some("git.auto_stage_on_conflict_resolution"),
+                                pick: |settings_content| {
+                                    settings_content
+                                        .git
+                                        .as_ref()?
+                                        .auto_stage_on_conflict_resolution
+                                        .as_ref()
+                                },
+                                write: |settings_content, value, _| {
+                                    settings_content
+                                        .git
+                                        .get_or_insert_default()
+                                        .auto_stage_on_conflict_resolution = value;
+                                },
+                            }),
+                            metadata: None,
+                        },
                     ],
                 ],
             }),

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -197,6 +197,20 @@ Click a button to resolve that conflict. The conflict markers are removed and re
 
 > **Tip:** For complex conflicts that need manual editing, you can edit the file directly. Remove the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and keep the content you want.
 
+### Auto-Staging Resolved Files
+
+By default, when you resolve all conflict markers in a file and save it, Zed automatically stages the file for you. This mirrors the typical Git workflow where resolved files need to be staged before committing.
+
+To disable this behavior, add the following to your `settings.json`:
+
+```json
+{
+  "git": {
+    "auto_stage_on_conflict_resolution": false
+  }
+}
+```
+
 ## Stashing
 
 Git stash allows you to temporarily save your uncommitted changes and revert your working directory to a clean state. This is particularly useful when you need to quickly switch branches or pull updates without committing incomplete work.


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [-] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes NA

Release Notes:

- Zed will automatically stage files that are in conflicts with no markers left (can be configured via ``git.auto_stage_on_conflict_resolution`` option).