### PR TITLE
git: Add GoToNextConflict and GoToPreviousConflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7412,6 +7412,7 @@ dependencies = [
  "strum 0.27.2",
  "task",
  "telemetry",
+ "text",
  "theme",
  "theme_settings",
  "time",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -589,6 +589,8 @@
       "ctrl-alt-shift-c": "editor::DisplayCursorNames",
       "alt-.": "editor::GoToHunk",
       "alt-,": "editor::GoToPreviousHunk",
+      "alt-shift-.": "git::GoToNextConflict",
+      "alt-shift-,": "git::GoToPreviousConflict",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -943,6 +943,8 @@
       "cmd-shift-e": "pane::RevealInProjectPanel",
       "cmd-f8": "editor::GoToHunk",
       "cmd-shift-f8": "editor::GoToPreviousHunk",
+      "alt-shift-.": "git::GoToNextConflict",
+      "alt-shift-,": "git::GoToPreviousConflict",
       "ctrl-enter": "assistant::InlineAssist",
       "ctrl-:": "editor::ToggleInlayHints",
     },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -586,6 +586,8 @@
       "ctrl-\\": "pane::SplitRight",
       "alt-.": "editor::GoToHunk",
       "alt-,": "editor::GoToPreviousHunk",
+      "alt-shift-.": "git::GoToNextConflict",
+      "alt-shift-,": "git::GoToPreviousConflict",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -262,6 +262,8 @@
       "[ d": "editor::GoToPreviousDiagnostic",
       "] c": "editor::GoToHunk",
       "[ c": "editor::GoToPreviousHunk",
+      "] x": "git::GoToNextConflict",
+      "[ x": "git::GoToPreviousConflict",
       "g c": "vim::PushToggleComments",
       "g b": "vim::PushToggleBlockComments",
     },

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -58,6 +58,7 @@ settings.workspace = true
 smallvec.workspace = true
 strum.workspace = true
 telemetry.workspace = true
+text.workspace = true
 theme.workspace = true
 theme_settings.workspace = true
 time.workspace = true

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -2,16 +2,18 @@ use agent_settings::AgentSettings;
 use collections::{HashMap, HashSet};
 use editor::{
     ConflictsOurs, ConflictsOursMarker, ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker,
-    Editor, EditorEvent, MultiBuffer, RowHighlightOptions,
+    Editor, EditorEvent, MultiBuffer, RowHighlightOptions, SelectionEffects,
     display_map::{BlockContext, BlockPlacement, BlockProperties, BlockStyle, CustomBlockId},
+    scroll::Autoscroll,
 };
 use gpui::{
     App, ClickEvent, Context, Empty, Entity, InteractiveElement as _, ParentElement as _,
     Subscription, Task, WeakEntity,
 };
-use language::{Anchor, Buffer, BufferId};
+use language::{Anchor, Buffer, BufferId, ToOffset as _, ToPoint as _};
 use project::{
-    ConflictRegion, ConflictSet, ConflictSetUpdate, Project, ProjectItem as _,
+    ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate, Project, ProjectItem as _,
+    ProjectPath,
     git_store::{GitStore, GitStoreEvent, RepositoryEvent},
 };
 use settings::Settings;
@@ -411,7 +413,7 @@ fn render_conflict_buttons(
         .into_any()
 }
 
-fn collect_conflicted_file_paths(project: &Project, cx: &App) -> Vec<String> {
+fn collect_conflicted_project_paths(project: &Project, cx: &App) -> Vec<ProjectPath> {
     let git_store = project.git_store().read(cx);
     let mut paths = Vec::new();
 
@@ -425,18 +427,212 @@ fn collect_conflicted_file_paths(project: &Project, cx: &App) -> Vec<String> {
                 continue;
             }
             if let Some(project_path) = repo.read(cx).repo_path_to_project_path(repo_path, cx) {
-                paths.push(
-                    project_path
-                        .path
-                        .as_std_path()
-                        .to_string_lossy()
-                        .to_string(),
-                );
+                paths.push(project_path);
             }
         }
     }
 
+    paths.sort();
+    paths.dedup();
     paths
+}
+
+fn collect_conflicted_file_paths(project: &Project, cx: &App) -> Vec<String> {
+    collect_conflicted_project_paths(project, cx)
+        .into_iter()
+        .map(|p| p.path.as_std_path().to_string_lossy().to_string())
+        .collect()
+}
+
+fn find_next_path(
+    paths: &[ProjectPath],
+    current: Option<&ProjectPath>,
+    next: bool,
+) -> Option<ProjectPath> {
+    if paths.is_empty() {
+        return None;
+    }
+
+    let Some(current) = current else {
+        return if next {
+            paths.first().cloned()
+        } else {
+            paths.last().cloned()
+        };
+    };
+
+    if next {
+        let index = paths.partition_point(|p| p <= current);
+        paths.get(index).or_else(|| paths.first()).cloned()
+    } else {
+        let index = paths.partition_point(|p| p < current);
+        if index > 0 {
+            Some(paths[index - 1].clone())
+        } else {
+            paths.last().cloned()
+        }
+    }
+}
+
+fn find_conflict_in_snapshot(
+    conflict_set: &ConflictSetSnapshot,
+    snapshot: &text::BufferSnapshot,
+    cursor_offset: usize,
+    next: bool,
+) -> Option<text::Point> {
+    if conflict_set.conflicts.is_empty() {
+        return None;
+    }
+
+    if next {
+        conflict_set
+            .conflicts
+            .iter()
+            .find(|c| c.range.start.to_offset(snapshot) > cursor_offset)
+            .map(|c| c.range.start.to_point(snapshot))
+    } else {
+        conflict_set
+            .conflicts
+            .iter()
+            .rev()
+            .find(|c| c.range.start.to_offset(snapshot) < cursor_offset)
+            .map(|c| c.range.start.to_point(snapshot))
+    }
+}
+
+pub fn go_to_next_conflict(
+    workspace: &mut Workspace,
+    _action: &zed_actions::git::GoToNextConflict,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    go_to_conflict_impl(workspace, true, window, cx);
+}
+
+pub fn go_to_previous_conflict(
+    workspace: &mut Workspace,
+    _action: &zed_actions::git::GoToPreviousConflict,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    go_to_conflict_impl(workspace, false, window, cx);
+}
+
+fn jump_to_conflict_point(
+    editor: &mut Editor,
+    destination: text::Point,
+    window: &mut Window,
+    cx: &mut Context<Editor>,
+) {
+    editor.unfold_ranges(&[destination..destination], false, false, cx);
+    editor.change_selections(
+        SelectionEffects::scroll(Autoscroll::center()),
+        window,
+        cx,
+        |s| s.select_ranges([destination..destination]),
+    );
+}
+
+fn go_to_conflict_impl(
+    workspace: &mut Workspace,
+    next: bool,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let project = workspace.project().clone();
+    let conflicted_paths = collect_conflicted_project_paths(project.read(cx), cx);
+    if conflicted_paths.is_empty() {
+        return;
+    }
+
+    let active_editor = workspace
+        .active_item(cx)
+        .and_then(|item| item.act_as::<Editor>(cx));
+
+    let current_path = if let Some(ref editor_entity) = active_editor {
+        let jumped = editor_entity.update(cx, |editor, cx| {
+            let multibuffer = editor.buffer().read(cx);
+            let buffer = multibuffer.as_singleton()?;
+            let path = buffer.read(cx).project_path(cx)?;
+
+            if !conflicted_paths.iter().any(|p| p == &path) {
+                return Some((path, false));
+            }
+
+            let buffer_id = buffer.read(cx).remote_id();
+            let text_snapshot = buffer.read(cx).text_snapshot();
+            let conflict_set = editor
+                .addon::<ConflictAddon>()
+                .and_then(|addon| addon.conflict_set(buffer_id))
+                .map(|cs| cs.read(cx).snapshot())
+                .unwrap_or_else(|| ConflictSet::parse(&text_snapshot));
+            let display_snapshot = editor.display_snapshot(cx);
+            let cursor_point = editor
+                .selections
+                .newest::<text::Point>(&display_snapshot)
+                .head();
+            let cursor_offset = cursor_point.to_offset(&text_snapshot);
+
+            let target = find_conflict_in_snapshot(
+                &conflict_set,
+                &text_snapshot,
+                cursor_offset,
+                next,
+            );
+
+            if let Some(destination) = target {
+                jump_to_conflict_point(editor, destination, window, cx);
+                return Some((path, true));
+            }
+
+            Some((path, false))
+        });
+
+        match jumped {
+            Some((_path, true)) => return,
+            Some((path, false)) => Some(path),
+            None => None,
+        }
+    } else {
+        None
+    };
+
+    let target_path = find_next_path(&conflicted_paths, current_path.as_ref(), next);
+    let Some(target_path) = target_path else {
+        return;
+    };
+
+    let open_task = workspace.open_path(target_path, None, true, window, cx);
+
+    cx.spawn_in(window, async move |workspace, cx| {
+        let item = open_task.await?;
+        workspace.update_in(cx, |_workspace, window, cx| {
+            let Some(editor_entity) = item.act_as::<Editor>(&*cx) else {
+                return;
+            };
+            editor_entity.update(cx, |editor, cx| {
+                let multibuffer = editor.buffer().read(cx);
+                let Some(buffer) = multibuffer.as_singleton() else {
+                    return;
+                };
+                let text_snapshot = buffer.read(cx).text_snapshot();
+                let conflict_set = ConflictSet::parse(&text_snapshot);
+
+                let conflict = if next {
+                    conflict_set.conflicts.first()
+                } else {
+                    conflict_set.conflicts.last()
+                };
+
+                if let Some(conflict) = conflict {
+                    let destination = conflict.range.start.to_point(&text_snapshot);
+                    jump_to_conflict_point(editor, destination, window, cx);
+                }
+            });
+        })?;
+        anyhow::Ok(())
+    })
+    .detach_and_log_err(cx);
 }
 
 pub(crate) fn resolve_conflict(

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -875,3 +875,533 @@ impl StatusItemView for MergeConflictIndicator {
     ) {
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git::status::{UnmergedStatus, UnmergedStatusCode};
+    use gpui::{TestAppContext, VisualTestContext};
+    use project::{FakeFs, Project};
+    use serde_json::json;
+    use settings::SettingsStore;
+    use std::path::Path;
+    use text::{Buffer, BufferId, ReplicaId};
+    use unindent::Unindent as _;
+    use util::{path, rel_path::rel_path};
+    use workspace::MultiWorkspace;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let store = SettingsStore::test(cx);
+            cx.set_global(store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            language::language_settings::AllLanguageSettings::register(cx);
+            editor::init(cx);
+            crate::init(cx);
+        });
+    }
+
+    fn make_project_path(worktree_id: usize, path: &str) -> ProjectPath {
+        ProjectPath {
+            worktree_id: settings::WorktreeId::from_usize(worktree_id),
+            path: Arc::from(rel_path(path)),
+        }
+    }
+
+    // ── find_next_path tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_find_next_path_empty() {
+        let paths: Vec<ProjectPath> = vec![];
+        assert!(find_next_path(&paths, None, true).is_none());
+        assert!(find_next_path(&paths, None, false).is_none());
+    }
+
+    #[test]
+    fn test_find_next_path_no_current() {
+        let paths = vec![
+            make_project_path(0, "a.rs"),
+            make_project_path(0, "b.rs"),
+            make_project_path(0, "c.rs"),
+        ];
+
+        assert_eq!(find_next_path(&paths, None, true), Some(paths[0].clone()));
+        assert_eq!(find_next_path(&paths, None, false), Some(paths[2].clone()));
+    }
+
+    #[test]
+    fn test_find_next_path_advances() {
+        let paths = vec![
+            make_project_path(0, "a.rs"),
+            make_project_path(0, "b.rs"),
+            make_project_path(0, "c.rs"),
+        ];
+
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[0]), true),
+            Some(paths[1].clone())
+        );
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[1]), true),
+            Some(paths[2].clone())
+        );
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[2]), false),
+            Some(paths[1].clone())
+        );
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[1]), false),
+            Some(paths[0].clone())
+        );
+    }
+
+    #[test]
+    fn test_find_next_path_wraps() {
+        let paths = vec![
+            make_project_path(0, "a.rs"),
+            make_project_path(0, "b.rs"),
+        ];
+
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[1]), true),
+            Some(paths[0].clone()),
+        );
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[0]), false),
+            Some(paths[1].clone()),
+        );
+    }
+
+    #[test]
+    fn test_find_next_path_single() {
+        let paths = vec![make_project_path(0, "a.rs")];
+
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[0]), true),
+            Some(paths[0].clone()),
+        );
+        assert_eq!(
+            find_next_path(&paths, Some(&paths[0]), false),
+            Some(paths[0].clone()),
+        );
+    }
+
+    #[test]
+    fn test_find_next_path_current_not_in_list() {
+        let paths = vec![
+            make_project_path(0, "a.rs"),
+            make_project_path(0, "c.rs"),
+        ];
+        let current = make_project_path(0, "b.rs");
+
+        assert_eq!(
+            find_next_path(&paths, Some(&current), true),
+            Some(paths[1].clone()),
+        );
+        assert_eq!(
+            find_next_path(&paths, Some(&current), false),
+            Some(paths[0].clone()),
+        );
+    }
+
+    // ── find_conflict_in_snapshot tests ───────────────────────────────
+
+    fn make_conflicted_buffer(content: &str) -> (text::Buffer, ConflictSetSnapshot) {
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, content.to_string());
+        let snapshot = buffer.snapshot();
+        let conflict_set = ConflictSet::parse(&snapshot);
+        (buffer, conflict_set)
+    }
+
+    #[test]
+    fn test_find_conflict_in_snapshot_empty() {
+        let (buffer, conflict_set) = make_conflicted_buffer("no conflicts here\n");
+        let snapshot = buffer.snapshot();
+        assert!(find_conflict_in_snapshot(&conflict_set, &snapshot, 0, true).is_none());
+        assert!(find_conflict_in_snapshot(&conflict_set, &snapshot, 0, false).is_none());
+    }
+
+    #[test]
+    fn test_find_conflict_in_snapshot_next() {
+        let content = r#"
+            line 1
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            middle
+            <<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "#
+        .unindent();
+
+        let (buffer, conflict_set) = make_conflicted_buffer(&content);
+        let snapshot = buffer.snapshot();
+        assert_eq!(conflict_set.conflicts.len(), 2);
+
+        let first_start = conflict_set.conflicts[0].range.start.to_offset(&snapshot);
+        let second_start = conflict_set.conflicts[1].range.start.to_offset(&snapshot);
+
+        let result = find_conflict_in_snapshot(&conflict_set, &snapshot, 0, true);
+        assert_eq!(
+            result,
+            Some(conflict_set.conflicts[0].range.start.to_point(&snapshot))
+        );
+
+        let result = find_conflict_in_snapshot(&conflict_set, &snapshot, first_start, true);
+        assert_eq!(
+            result,
+            Some(conflict_set.conflicts[1].range.start.to_point(&snapshot))
+        );
+
+        let result = find_conflict_in_snapshot(&conflict_set, &snapshot, second_start, true);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_conflict_in_snapshot_previous() {
+        let content = r#"
+            line 1
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            middle
+            <<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "#
+        .unindent();
+
+        let (buffer, conflict_set) = make_conflicted_buffer(&content);
+        let snapshot = buffer.snapshot();
+        let second_start = conflict_set.conflicts[1].range.start.to_offset(&snapshot);
+        let second_end = conflict_set.conflicts[1].range.end.to_offset(&snapshot);
+
+        let result = find_conflict_in_snapshot(&conflict_set, &snapshot, second_end, false);
+        assert_eq!(
+            result,
+            Some(conflict_set.conflicts[1].range.start.to_point(&snapshot))
+        );
+
+        let result = find_conflict_in_snapshot(&conflict_set, &snapshot, second_start, false);
+        assert_eq!(
+            result,
+            Some(conflict_set.conflicts[0].range.start.to_point(&snapshot))
+        );
+
+        let result = find_conflict_in_snapshot(&conflict_set, &snapshot, 0, false);
+        assert!(result.is_none());
+    }
+
+    // ── Integration tests for go_to_next/previous_conflict ───────────
+
+    fn unmerged() -> git::status::FileStatus {
+        UnmergedStatus {
+            first_head: UnmergedStatusCode::Updated,
+            second_head: UnmergedStatusCode::Updated,
+        }
+        .into()
+    }
+
+    #[gpui::test]
+    async fn test_go_to_next_conflict_within_file(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "file.rs": "line 1\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\nmiddle\n<<<<<<< HEAD\nours2\n=======\ntheirs2\n>>>>>>> branch\n",
+            }),
+        )
+        .await;
+        fs.set_status_for_repo(
+            Path::new(path!("/project/.git")),
+            &[("file.rs", unmerged())],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window.read_with(cx, |mw, _| mw.workspace().clone()).unwrap();
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+
+        let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id()
+                .to_usize()
+        });
+
+        let editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    make_project_path(worktree_id, "file.rs"),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            go_to_conflict_impl(workspace, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, _window, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            let cursor = editor.selections.newest::<text::Point>(&snapshot).head();
+            assert_eq!(cursor, text::Point::new(1, 0));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            go_to_conflict_impl(workspace, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, _window, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            let cursor = editor.selections.newest::<text::Point>(&snapshot).head();
+            assert_eq!(cursor, text::Point::new(7, 0));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_go_to_previous_conflict_within_file(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "file.rs": "line 1\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\nmiddle\n<<<<<<< HEAD\nours2\n=======\ntheirs2\n>>>>>>> branch\n",
+            }),
+        )
+        .await;
+        fs.set_status_for_repo(
+            Path::new(path!("/project/.git")),
+            &[("file.rs", unmerged())],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window.read_with(cx, |mw, _| mw.workspace().clone()).unwrap();
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+
+        let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id()
+                .to_usize()
+        });
+
+        let editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    make_project_path(worktree_id, "file.rs"),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, window, cx| {
+            editor.change_selections(None.into(), window, cx, |s| {
+                s.select_ranges([text::Point::new(12, 0)..text::Point::new(12, 0)]);
+            });
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            go_to_conflict_impl(workspace, false, window, cx);
+        });
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, _window, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            let cursor = editor.selections.newest::<text::Point>(&snapshot).head();
+            assert_eq!(cursor, text::Point::new(7, 0));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            go_to_conflict_impl(workspace, false, window, cx);
+        });
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, _window, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            let cursor = editor.selections.newest::<text::Point>(&snapshot).head();
+            assert_eq!(cursor, text::Point::new(1, 0));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_go_to_conflict_crosses_files(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "aaa.rs": "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n",
+                "bbb.rs": "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n",
+            }),
+        )
+        .await;
+        fs.set_status_for_repo(
+            Path::new(path!("/project/.git")),
+            &[("aaa.rs", unmerged()), ("bbb.rs", unmerged())],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window.read_with(cx, |mw, _| mw.workspace().clone()).unwrap();
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+
+        let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id()
+                .to_usize()
+        });
+
+        workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    make_project_path(worktree_id, "aaa.rs"),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // Cursor starts at 0,0 which is the start of the only conflict in aaa.rs.
+        // "Next conflict" finds no conflict ahead (0 > 0 is false) and jumps
+        // to the next conflicted file (bbb.rs) asynchronously.
+        workspace.update_in(cx, |workspace, window, cx| {
+            go_to_conflict_impl(workspace, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, _window, cx| {
+            let item = workspace.active_item(cx).unwrap();
+            let editor = item.act_as::<Editor>(cx).unwrap();
+            let active_path = editor
+                .read(cx)
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .unwrap()
+                .read(cx)
+                .project_path(cx);
+            assert_eq!(
+                active_path,
+                Some(make_project_path(worktree_id, "bbb.rs"))
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_go_to_conflict_no_conflicts(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "file.rs": "fn main() {}\n",
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window.read_with(cx, |mw, _| mw.workspace().clone()).unwrap();
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+
+        let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id()
+                .to_usize()
+        });
+
+        let editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    make_project_path(worktree_id, "file.rs"),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            go_to_conflict_impl(workspace, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, _window, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            let cursor = editor.selections.newest::<text::Point>(&snapshot).head();
+            assert_eq!(cursor, text::Point::new(0, 0));
+        });
+    }
+}

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -857,6 +857,32 @@ impl Render for MergeConflictIndicator {
             )
             .child(
                 div().border_l_1().border_color(border_color).child(
+                    IconButton::new("prev-conflict", IconName::ChevronLeft)
+                        .icon_size(IconSize::XSmall)
+                        .tooltip(Tooltip::text("Previous Conflict"))
+                        .on_click(|_, window, cx| {
+                            window.dispatch_action(
+                                Box::new(zed_actions::git::GoToPreviousConflict),
+                                cx,
+                            );
+                        }),
+                ),
+            )
+            .child(
+                div().border_l_1().border_color(border_color).child(
+                    IconButton::new("next-conflict", IconName::ChevronRight)
+                        .icon_size(IconSize::XSmall)
+                        .tooltip(Tooltip::text("Next Conflict"))
+                        .on_click(|_, window, cx| {
+                            window.dispatch_action(
+                                Box::new(zed_actions::git::GoToNextConflict),
+                                cx,
+                            );
+                        }),
+                ),
+            )
+            .child(
+                div().border_l_1().border_color(border_color).child(
                     IconButton::new("dismiss-merge-conflicts", IconName::Close)
                         .icon_size(IconSize::XSmall)
                         .on_click(cx.listener(Self::dismiss)),

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -68,6 +68,9 @@ pub fn init(cx: &mut App) {
         repository_selector::register(workspace);
         git_picker::register(workspace);
 
+        workspace.register_action(conflict_view::go_to_next_conflict);
+        workspace.register_action(conflict_view::go_to_previous_conflict);
+
         workspace.register_action(
             |workspace, action: &zed_actions::CreateWorktree, window, cx| {
                 worktree_service::handle_create_worktree(workspace, action, window, None, cx);

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -319,7 +319,11 @@ pub mod git {
             /// Opens the git worktree selector.
             Worktree,
             /// Creates a pull request for the current branch.
-            CreatePullRequest
+            CreatePullRequest,
+            /// Navigates to the next git merge conflict.
+            GoToNextConflict,
+            /// Navigates to the previous git merge conflict.
+            GoToPreviousConflict
         ]
     );
 }


### PR DESCRIPTION
I like to navigate between conflicts easily when solving them. In emacs and vim, there are various ways to do it, but I couldn't find a way with zed. Here is the solution I came up with Claude help.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes NA

Release Notes:

- go-to-next/previous-conflict navigation have been added. They are bound to "alt-shift-". and "alt-shift-", by default.
