### PR TITLE
git_ui: Add option to jump to project file from commit

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -902,6 +902,16 @@ pub trait Addon: 'static {
         None
     }
 
+    fn extend_buffer_header_context_menu(
+        &self,
+        menu: ui::ContextMenu,
+        _: &language::BufferSnapshot,
+        _: &mut Window,
+        _: &mut App,
+    ) -> ui::ContextMenu {
+        menu
+    }
+
     fn override_status_for_buffer_id(&self, _: BufferId, _: &App) -> Option<FileStatus> {
         None
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8734,6 +8734,7 @@ pub(crate) fn render_buffer_header(
 
     let file = buffer.file().cloned();
     let editor = editor.clone();
+    let buffer_snapshot = buffer.clone();
 
     right_click_menu("buffer-header-context-menu")
         .trigger(move |_, _, _| header)
@@ -8741,6 +8742,7 @@ pub(crate) fn render_buffer_header(
             let menu_context = focus_handle.clone();
             let editor = editor.clone();
             let file = file.clone();
+            let buffer_snapshot = buffer_snapshot.clone();
             ContextMenu::build(window, cx, move |mut menu, window, cx| {
                 if let Some(file) = file
                     && let Some(project) = editor.read(cx).project()
@@ -8826,6 +8828,19 @@ pub(crate) fn render_buffer_header(
                             )
                         });
                 }
+
+                menu = editor.update(cx, |editor, cx| {
+                    let mut menu = menu;
+                    for addon in editor.addons.values() {
+                        menu = addon.extend_buffer_header_context_menu(
+                            menu,
+                            &buffer_snapshot,
+                            window,
+                            cx,
+                        );
+                    }
+                    menu
+                });
 
                 menu.context(menu_context)
             })

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -27,7 +27,7 @@ use std::{
     sync::Arc,
 };
 use theme::ActiveTheme;
-use ui::{DiffStat, Divider, Tooltip, prelude::*};
+use ui::{ContextMenu, DiffStat, Divider, Tooltip, prelude::*};
 use util::{ResultExt, paths::PathStyle, rel_path::RelPath, truncate_and_trailoff};
 use workspace::item::TabTooltipContent;
 use workspace::{
@@ -42,7 +42,15 @@ use workspace::{
 use crate::commit_tooltip::CommitAvatar;
 use crate::git_panel::GitPanel;
 
-actions!(git, [ApplyCurrentStash, PopCurrentStash, DropCurrentStash,]);
+actions!(
+    git,
+    [
+        ApplyCurrentStash,
+        PopCurrentStash,
+        DropCurrentStash,
+        OpenFileAtHead,
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
@@ -65,6 +73,7 @@ pub struct CommitView {
     stash: Option<usize>,
     multibuffer: Entity<MultiBuffer>,
     repository: Entity<Repository>,
+    workspace: WeakEntity<Workspace>,
     remote: Option<GitRemote>,
 }
 
@@ -78,6 +87,7 @@ struct GitBlob {
 
 struct CommitDiffAddon {
     file_statuses: HashMap<language::BufferId, FileStatus>,
+    commit_view: WeakEntity<CommitView>,
 }
 
 impl Addon for CommitDiffAddon {
@@ -91,6 +101,45 @@ impl Addon for CommitDiffAddon {
         _cx: &App,
     ) -> Option<FileStatus> {
         self.file_statuses.get(&buffer_id).copied()
+    }
+
+    fn extend_buffer_header_context_menu(
+        &self,
+        menu: ContextMenu,
+        buffer: &language::BufferSnapshot,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> ContextMenu {
+        let file_to_open = buffer.file().and_then(|file| {
+            let commit_view = self.commit_view.upgrade()?;
+            let commit_view = commit_view.read(cx);
+            let project_path = commit_view
+                .repository
+                .read(cx)
+                .repo_path_to_project_path(&RepoPath::from_rel_path(file.path()), cx)?;
+            let exists_at_head = commit_view
+                .workspace
+                .upgrade()?
+                .read(cx)
+                .project()
+                .read(cx)
+                .entry_for_path(&project_path, cx)
+                .is_some();
+            exists_at_head.then(|| file.clone())
+        });
+
+        menu.when_some(file_to_open, |menu, file| {
+            let commit_view = self.commit_view.clone();
+            menu.entry(
+                "Open File in Project",
+                Some(Box::new(OpenFileAtHead)),
+                move |window, cx| {
+                    commit_view
+                        .update(cx, |view, cx| view.open_file_at_head(&file, window, cx))
+                        .log_err();
+                },
+            )
+        })
     }
 }
 
@@ -130,12 +179,14 @@ impl CommitView {
                 workspace
                     .update_in(cx, |workspace, window, cx| {
                         let project = workspace.project();
+                        let workspace_handle = cx.weak_entity();
                         let commit_view = cx.new(|cx| {
                             CommitView::new(
                                 commit_details,
                                 commit_diff,
                                 repo,
                                 project.clone(),
+                                workspace_handle,
                                 stash,
                                 window,
                                 cx,
@@ -166,6 +217,7 @@ impl CommitView {
         commit_diff: CommitDiff,
         repository: Entity<Repository>,
         project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
         stash: Option<usize>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -361,8 +413,12 @@ impl CommitView {
             }
 
             this.update(cx, |this, cx| {
+                let commit_view = cx.weak_entity();
                 this.editor.update(cx, |editor, _cx| {
-                    editor.register_addon(CommitDiffAddon { file_statuses });
+                    editor.register_addon(CommitDiffAddon {
+                        file_statuses,
+                        commit_view,
+                    });
                 });
                 if !binary_buffer_ids.is_empty() {
                     this.editor.update(cx, |editor, cx| {
@@ -396,6 +452,7 @@ impl CommitView {
             multibuffer,
             stash,
             repository,
+            workspace,
             remote,
         }
     }
@@ -418,6 +475,50 @@ impl CommitView {
 
     fn calculate_changed_lines(&self, cx: &App) -> (u32, u32) {
         self.multibuffer.read(cx).snapshot(cx).total_changed_lines()
+    }
+
+    fn open_file_at_head(
+        &mut self,
+        file: &Arc<dyn language::File>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let rel_path = file.path().clone();
+        let worktree_id = file.worktree_id(cx);
+        let repo_path = RepoPath::from_rel_path(&rel_path);
+        let project_path = self
+            .repository
+            .read(cx)
+            .repo_path_to_project_path(&repo_path, cx)
+            .unwrap_or(project::ProjectPath {
+                worktree_id,
+                path: rel_path,
+            });
+
+        self.workspace
+            .update(cx, |workspace, cx| {
+                workspace
+                    .open_path_preview(project_path, None, false, false, true, window, cx)
+                    .detach_and_log_err(cx);
+            })
+            .log_err();
+    }
+
+    fn open_file_at_head_action(
+        &mut self,
+        _: &OpenFileAtHead,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(file) = self
+            .editor
+            .read(cx)
+            .active_buffer(cx)
+            .and_then(|buffer| buffer.read(cx).file().cloned())
+        else {
+            return;
+        };
+        self.open_file_at_head(&file, window, cx);
     }
 
     fn render_header(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
@@ -934,13 +1035,17 @@ impl Item for CommitView {
             .map(|addon| addon.file_statuses.clone())
             .unwrap_or_default();
         Task::ready(Some(cx.new(|cx| {
+            let commit_view = cx.weak_entity();
             let editor = cx.new({
                 let file_statuses = file_statuses.clone();
                 |cx| {
                     let mut editor = self
                         .editor
                         .update(cx, |editor, cx| editor.clone(window, cx));
-                    editor.register_addon(CommitDiffAddon { file_statuses });
+                    editor.register_addon(CommitDiffAddon {
+                        file_statuses,
+                        commit_view,
+                    });
                     editor
                 }
             });
@@ -951,6 +1056,7 @@ impl Item for CommitView {
                 commit: self.commit.clone(),
                 stash: self.stash,
                 repository: self.repository.clone(),
+                workspace: self.workspace.clone(),
                 remote: self.remote.clone(),
             }
         })))
@@ -963,6 +1069,7 @@ impl Render for CommitView {
 
         v_flex()
             .key_context(if is_stash { "StashDiff" } else { "CommitDiff" })
+            .on_action(cx.listener(Self::open_file_at_head_action))
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .child(self.render_header(window, cx))


### PR DESCRIPTION
Using the `Open File` action from a file in commit context takes you to a read-only snapshot of the file at the point in time of the commit. This change makes it so you navigate to the current working copy of the file, if one exists. This has similar semantics to copy file reference.

For a file that still exists at HEAD:
<img width="715" height="469" alt="image" src="https://github.com/user-attachments/assets/e217e0be-b549-46fa-9d1b-eba92728fa4a" />

For a file that no longer exists:
<img width="438" height="271" alt="image" src="https://github.com/user-attachments/assets/ac87465b-971b-4413-8bf3-71e49a71bdea" />

Release Notes:

- Add affordance to jump to project file from commit view
