### PR TITLE
agent: Handle server errors and missing Content-Type in fetch tool

### DIFF
--- a/crates/agent/src/tools/fetch_tool.rs
+++ b/crates/agent/src/tools/fetch_tool.rs
@@ -54,7 +54,7 @@ impl FetchTool {
             .await
             .context("error reading response body")?;
 
-        if response.status().is_client_error() {
+        if response.status().is_client_error() || response.status().is_server_error() {
             let text = String::from_utf8_lossy(body.as_slice());
             bail!(
                 "status error {}, response: {text:?}",
@@ -62,12 +62,12 @@ impl FetchTool {
             );
         }
 
-        let Some(content_type) = response.headers().get("content-type") else {
-            bail!("missing Content-Type header");
-        };
-        let content_type = content_type
-            .to_str()
-            .context("invalid Content-Type header")?;
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("text/html");
+        let content_type = if content_type.starts_with("text/plain") {
 
         let content_type = if content_type.starts_with("text/plain") {
             ContentType::Plaintext


### PR DESCRIPTION
Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #28076

Release Notes:
- Fixed: `fetch` tool now correctly surfaces 5xx server errors instead of
  silently attempting to parse the error response as content.
- Fixed: `fetch` tool no longer fails on responses with a missing or
  non-standard Content-Type header; it falls back to HTML parsing instead.