### PR TITLE
agent_ui: Fix placeholder wrapping in the message editor

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3211,10 +3211,9 @@ impl ThreadView {
             .child(
                 v_flex()
                     .when_some(max_content_width, |this, max_w| this.flex_basis(max_w))
-                    .when(max_content_width.is_none(), |this| this.w_full())
+                    .when(fills_container, |this| this.h_full())
                     .flex_shrink()
                     .flex_grow_0()
-                    .when(fills_container, |this| this.h_full())
                     .justify_between()
                     .gap_2()
                     .child(
@@ -3275,6 +3274,7 @@ impl ThreadView {
                             )
                             .child(
                                 h_flex()
+                                    .flex_wrap()
                                     .gap_1()
                                     .children(self.render_token_usage(cx))
                                     .children(self.profile_selector.clone())


### PR DESCRIPTION
Fixes this:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6068009d-a0d4-4255-9fe1-16a41751806f" />

Release Notes:

- Fixed a bug where placeholder text in the agent panel's message editor wouldn't properly wrap.
