### PR TITLE
Fix json! empty-string highlighting in Rust

### DIFF
--- a/crates/grammars/src/rust/injections.scm
+++ b/crates/grammars/src/rust/injections.scm
@@ -10,7 +10,7 @@
     (scoped_identifier
       (identifier) @_macro_name .)
   ]
-  (#not-any-of? @_macro_name "view" "html")
+  (#not-any-of? @_macro_name "view" "html" "json")
   (token_tree) @injection.content
   (#set! injection.language "rust"))
 

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -350,6 +350,56 @@ fn test_dynamic_language_injection(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_rust_json_macro_empty_string_highlighting(cx: &mut App) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    let language = rust_lang();
+    registry.add(language.clone());
+
+    let buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        r#"
+            serde_json::json!({
+                "email": "",
+                "password": "password123",
+                "requires2FA": false
+            })
+        "#
+        .unindent(),
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(language, &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["string"],
+        r#"
+            serde_json::json!({
+                «"email"»: «""»,
+                «"password"»: «"password123"»,
+                «"requires2FA"»: false
+            })
+        "#,
+    );
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["boolean"],
+        r#"
+            serde_json::json!({
+                "email": "",
+                "password": "password123",
+                "requires2FA": «false»
+            })
+        "#,
+    );
+}
+
+#[gpui::test]
 fn test_typing_multiple_new_injections(cx: &mut App) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Rust",


### PR DESCRIPTION
## Context

This fixes incorrect syntax highlighting inside Rust `json!` macros when a JSON value is an empty string. In the current Rust tree-sitter injection setup, most macro bodies are reparsed as nested Rust, which works for macros like `vec!` but breaks down for JSON-shaped `json!({ ... })` content. When the nested Rust parse loses sync at `""`, later values can inherit incorrect highlighting.

Closes #54838

The fix treats `json!` as an exception to the generic nested-Rust macro injection rule. That keeps the outer Rust layer responsible for token-level highlighting inside the macro body, which is enough to correctly color JSON keys, string values, and booleans without introducing a brittle JSON-specific injection for Rust token trees.

Manual test after the fix below :

[Screencast from 2026-04-29 00-53-01.webm](https://github.com/user-attachments/assets/26453acf-1d72-4a97-9969-3f8e236dc0cd)

## How to Review

- `crates/grammars/src/rust/injections.scm`: Start here. This is the functional fix. The generic Rust macro injection rule now excludes `json`, so `json!` and `serde_json::json!` bodies are no longer reparsed as nested Rust. Existing special cases like `view!`, `html!`, `sql!`, and regex-related behavior are left unchanged.

- `crates/language/src/syntax_map/syntax_map_tests.rs`: This adds a regression test covering the reported case. It verifies that an empty string inside `serde_json::json!({ ... })` does not break subsequent highlighting, and that the expected string and boolean captures still appear for the later JSON entries.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed incorrect Rust syntax highlighting after empty string values inside `json!` macros.

