### PR TITLE
Add force setting for branch deletion

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1548,6 +1548,7 @@
     // Control which information is shown in the branch picker.
     "branch_picker": {
       "show_author_name": true,
+      "force_delete": false,
     },
     // How git hunks are displayed visually in the editor.
     // This setting can take two values:

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -879,7 +879,12 @@ impl GitRepository for FakeGitRepository {
         })
     }
 
-    fn delete_branch(&self, _is_remote: bool, name: String) -> BoxFuture<'_, Result<()>> {
+    fn delete_branch(
+        &self,
+        _is_remote: bool,
+        _force: bool,
+        name: String,
+    ) -> BoxFuture<'_, Result<()>> {
         self.with_state_async(true, move |state| {
             if !state.branches.remove(&name) {
                 bail!("no such branch: {name}");

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -60,6 +60,7 @@ pub struct FakeGitRepositoryState {
     pub blames: HashMap<RepoPath, Blame>,
     pub current_branch_name: Option<String>,
     pub branches: HashSet<String>,
+    pub unmerged_branches: HashSet<String>,
     /// List of remotes, keys are names and values are URLs
     pub remotes: HashMap<String, String>,
     pub simulated_index_write_error_message: Option<String>,
@@ -80,6 +81,7 @@ impl FakeGitRepositoryState {
             blames: Default::default(),
             current_branch_name: Default::default(),
             branches: Default::default(),
+            unmerged_branches: Default::default(),
             simulated_index_write_error_message: Default::default(),
             simulated_create_worktree_error: Default::default(),
             simulated_graph_error: None,
@@ -882,10 +884,13 @@ impl GitRepository for FakeGitRepository {
     fn delete_branch(
         &self,
         _is_remote: bool,
-        _force: bool,
+        force: bool,
         name: String,
     ) -> BoxFuture<'_, Result<()>> {
         self.with_state_async(true, move |state| {
+            if !force && state.unmerged_branches.contains(&name) {
+                bail!("error: The branch '{name}' is not fully merged");
+            }
             if !state.branches.remove(&name) {
                 bail!("no such branch: {name}");
             }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -779,7 +779,12 @@ pub trait GitRepository: Send + Sync {
     -> BoxFuture<'_, Result<()>>;
     fn rename_branch(&self, branch: String, new_name: String) -> BoxFuture<'_, Result<()>>;
 
-    fn delete_branch(&self, is_remote: bool, name: String) -> BoxFuture<'_, Result<()>>;
+    fn delete_branch(
+        &self,
+        is_remote: bool,
+        force: bool,
+        name: String,
+    ) -> BoxFuture<'_, Result<()>>;
 
     fn worktrees(&self) -> BoxFuture<'_, Result<Vec<Worktree>>>;
 
@@ -2031,14 +2036,24 @@ impl GitRepository for RealGitRepository {
             .boxed()
     }
 
-    fn delete_branch(&self, is_remote: bool, name: String) -> BoxFuture<'_, Result<()>> {
+    fn delete_branch(
+        &self,
+        is_remote: bool,
+        force: bool,
+        name: String,
+    ) -> BoxFuture<'_, Result<()>> {
         let git_binary = self.git_binary();
+
+        let deletion_flag = match (is_remote, force) {
+            (true, false) => "-dr",
+            (true, true) => "-Dr",
+            (false, false) => "-d",
+            (false, true) => "-D",
+        };
 
         self.executor
             .spawn(async move {
-                git_binary?
-                    .run(&["branch", if is_remote { "-dr" } else { "-d" }, &name])
-                    .await?;
+                git_binary?.run(&["branch", deletion_flag, &name]).await?;
                 anyhow::Ok(())
             })
             .boxed()

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -513,6 +513,9 @@ impl BranchListDelegate {
 
         cx.spawn_in(window, async move |picker, cx| {
             let is_remote;
+            let force = ProjectSettings::get_global(cx)
+                .git_branch_picker
+                .force_delete;
             let result = match &entry {
                 Entry::Branch { branch, .. } => {
                     if branch.is_head {
@@ -521,7 +524,7 @@ impl BranchListDelegate {
 
                     is_remote = branch.is_remote();
                     repo.update(cx, |repo, _| {
-                        repo.delete_branch(is_remote, branch.name().to_string())
+                        repo.delete_branch(is_remote, force, branch.name().to_string())
                     })
                     .await?
                 }

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1377,7 +1377,7 @@ mod tests {
     use project::{FakeFs, Project};
     use rand::{Rng, rngs::StdRng};
     use serde_json::json;
-    use settings::SettingsStore;
+    use settings::{BranchPickerSettingsContent, GitSettings, SettingsStore};
     use util::path;
     use workspace::MultiWorkspace;
 
@@ -1725,6 +1725,143 @@ mod tests {
                 assert_eq!(branches, expected_branches);
             })
         });
+    }
+
+    #[gpui::test]
+    async fn test_force_delete_unmerged_branch(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                ".git": {},
+                "file.txt": "buffer_text".to_string()
+            }),
+        )
+        .await;
+        fs.set_head_for_repo(
+            path!("/dir/.git").as_ref(),
+            &[("file.txt", "test".to_string())],
+            "deadbeef",
+        );
+        fs.set_index_for_repo(
+            path!("/dir/.git").as_ref(),
+            &[("file.txt", "index_text".to_string())],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let repository = cx
+            .read(|cx| project.read(cx).active_repository(cx))
+            .unwrap();
+
+        let branches = create_test_branches();
+        let branch_names = branches
+            .iter()
+            .map(|branch| branch.name().to_string())
+            .collect::<Vec<String>>();
+        let repo = repository.clone();
+        cx.spawn(async move |mut cx| {
+            for branch in branch_names {
+                repo.update(&mut cx, |repo, _| repo.create_branch(branch, None))
+                    .await
+                    .unwrap()
+                    .unwrap();
+            }
+        })
+        .await;
+        cx.run_until_parked();
+
+        let branch_to_delete = "feature-auth".to_string();
+        fs.with_git_state(path!("/dir/.git").as_ref(), false, |state| {
+            state.unmerged_branches.insert(branch_to_delete.clone());
+        })
+        .unwrap();
+
+        let (branch_list, mut ctx) =
+            init_branch_list_test(repository.into(), branches, cx).await;
+        let cx = &mut ctx;
+
+        update_branch_list_matches_with_empty_query(&branch_list, cx).await;
+
+        let branch_idx = branch_list.update(cx, |branch_list, cx| {
+            branch_list.picker.update(cx, |picker, _cx| {
+                picker
+                    .delegate
+                    .matches
+                    .iter()
+                    .position(|e| e.name() == branch_to_delete)
+                    .unwrap()
+            })
+        });
+
+        // Attempt delete without force — should be refused because branch is unmerged
+        branch_list.update_in(cx, |branch_list, window, cx| {
+            branch_list.picker.update(cx, |picker, cx| {
+                picker.delegate.delete_at(branch_idx, window, cx);
+            })
+        });
+        cx.run_until_parked();
+
+        let repo_branches: Vec<_> = branch_list
+            .update(cx, |branch_list, cx| {
+                branch_list.picker.update(cx, |picker, cx| {
+                    picker
+                        .delegate
+                        .repo
+                        .as_ref()
+                        .unwrap()
+                        .update(cx, |repo, _cx| repo.branches())
+                })
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            repo_branches.iter().any(|b| b.name() == branch_to_delete),
+            "branch should still exist after attempted delete without force"
+        );
+
+        // Enable force_delete and try again — should succeed
+        cx.update(|_window, cx| {
+            cx.update_global::<SettingsStore, _>(|store: &mut SettingsStore, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.git = Some(GitSettings {
+                        branch_picker: Some(BranchPickerSettingsContent {
+                            force_delete: Some(true),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    });
+                });
+            });
+        });
+
+        branch_list.update_in(cx, |branch_list, window, cx| {
+            branch_list.picker.update(cx, |picker, cx| {
+                picker.delegate.delete_at(branch_idx, window, cx);
+            })
+        });
+        cx.run_until_parked();
+
+        let repo_branches: Vec<_> = branch_list
+            .update(cx, |branch_list, cx| {
+                branch_list.picker.update(cx, |picker, cx| {
+                    picker
+                        .delegate
+                        .repo
+                        .as_ref()
+                        .unwrap()
+                        .update(cx, |repo, _cx| repo.branches())
+                })
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            !repo_branches.iter().any(|b| b.name() == branch_to_delete),
+            "branch should be deleted after force delete"
+        );
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -511,11 +511,14 @@ impl BranchListDelegate {
 
         let workspace = self.workspace.clone();
 
+        let force = ProjectSettings::get_global(cx)
+            .git
+            .branch_picker
+            .force_delete;
+
         cx.spawn_in(window, async move |picker, cx| {
             let is_remote;
-            let force = ProjectSettings::get_global(cx)
-                .git_branch_picker
-                .force_delete;
+
             let result = match &entry {
                 Entry::Branch { branch, .. } => {
                     if branch.is_head {
@@ -543,21 +546,18 @@ impl BranchListDelegate {
 
                 if let Some(workspace) = workspace.upgrade() {
                     cx.update(|_window, cx| {
-                        if is_remote {
-                            show_error_toast(
-                                workspace,
-                                format!("branch -dr {}", entry.name()),
-                                e,
-                                cx,
-                            )
-                        } else {
-                            show_error_toast(
-                                workspace,
-                                format!("branch -d {}", entry.name()),
-                                e,
-                                cx,
-                            )
-                        }
+                        let deletion_flag = match (is_remote, force) {
+                            (true, false) => "-dr",
+                            (true, true) => "-Dr",
+                            (false, false) => "-d",
+                            (false, true) => "-D",
+                        };
+                        show_error_toast(
+                            workspace,
+                            format!("branch {} {}", deletion_flag, entry.name()),
+                            e,
+                            cx,
+                        )
                     })?;
                 }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -6632,6 +6632,7 @@ impl Repository {
                                 project_id: project_id.0,
                                 repository_id: id.to_proto(),
                                 is_remote,
+                                force,
                                 branch_name,
                             })
                             .await?;

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2682,11 +2682,12 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
         let is_remote = envelope.payload.is_remote;
+        let force = envelope.payload.force;
         let branch_name = envelope.payload.branch_name;
 
         repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.delete_branch(is_remote, branch_name)
+                repository_handle.delete_branch(is_remote, force, branch_name)
             })
             .await??;
 
@@ -6605,22 +6606,25 @@ impl Repository {
     pub fn delete_branch(
         &mut self,
         is_remote: bool,
+        force: bool,
         branch_name: String,
     ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
+        let deletion_flag = match (is_remote, force) {
+            (true, false) => "-dr",
+            (true, true) => "-Dr",
+            (false, false) => "-d",
+            (false, true) => "-D",
+        };
         self.send_job(
-            Some(
-                format!(
-                    "git branch {} {}",
-                    if is_remote { "-dr" } else { "-d" },
-                    branch_name
-                )
-                .into(),
-            ),
+            Some(format!("git branch {} {}", deletion_flag, branch_name).into()),
             move |repo, _cx| async move {
                 match repo {
                     RepositoryState::Local(state) => {
-                        state.backend.delete_branch(is_remote, branch_name).await
+                        state
+                            .backend
+                            .delete_branch(is_remote, force, branch_name)
+                            .await
                     }
                     RepositoryState::Remote(RemoteRepositoryState { project_id, client }) => {
                         client

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -542,15 +542,21 @@ impl GitSettings {
 pub struct BranchPickerSettings {
     /// Whether to show author name as part of the commit information.
     ///
-    /// Default: false
+    /// Default: true
     #[serde(default)]
     pub show_author_name: bool,
+    #[serde(default)]
+    // whether branch deletion uses the soft delete ('-d') or hard delete ('-D') flag
+    //
+    /// Default: false
+    pub force_delete: bool,
 }
 
 impl Default for BranchPickerSettings {
     fn default() -> Self {
         Self {
             show_author_name: true,
+            force_delete: false,
         }
     }
 }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -546,8 +546,8 @@ pub struct BranchPickerSettings {
     #[serde(default)]
     pub show_author_name: bool,
     #[serde(default)]
-    // whether branch deletion uses the soft delete ('-d') or hard delete ('-D') flag
-    //
+    /// whether branch deletion uses the soft delete ('-d') or hard delete ('-D') flag
+    ///
     /// Default: false
     pub force_delete: bool,
 }
@@ -653,6 +653,7 @@ impl Settings for ProjectSettings {
                 let branch_picker = git.branch_picker.unwrap();
                 BranchPickerSettings {
                     show_author_name: branch_picker.show_author_name.unwrap(),
+                    force_delete: branch_picker.force_delete.unwrap(),
                 }
             },
             hunk_style: git.hunk_style.unwrap(),

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -211,6 +211,7 @@ message GitDeleteBranch {
   uint64 repository_id = 2;
   string branch_name = 3;
   bool is_remote = 4;
+  bool force = 5;
 }
 
 message GitDiff {

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -615,8 +615,11 @@ pub struct BlameSettings {
 pub struct BranchPickerSettingsContent {
     /// Whether to show author name as part of the commit information.
     ///
-    /// Default: false
+    /// Default: true
     pub show_author_name: Option<bool>,
+    /// whether branch deletion uses the soft delete ('-d') or hard delete ('-D') flag
+    ///
+    /// Default: false
     pub force_delete: Option<bool>,
 }
 

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -617,6 +617,7 @@ pub struct BranchPickerSettingsContent {
     ///
     /// Default: false
     pub show_author_name: Option<bool>,
+    pub force_delete: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7079,7 +7079,7 @@ fn version_control_page() -> SettingsPage {
         ]
     }
 
-    fn branch_picker_section() -> [SettingsPageItem; 2] {
+    fn branch_picker_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Branch Picker"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -7103,6 +7103,32 @@ fn version_control_page() -> SettingsPage {
                             .branch_picker
                             .get_or_insert_default()
                             .show_author_name = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Force Delete",
+                description: "Use force delete ('-D') instead of safe delete ('-d') when deleting branches in the branch picker.",
+                field: Box::new(SettingField {
+                    json_path: Some("git.branch_picker.force_delete"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git
+                            .as_ref()?
+                            .branch_picker
+                            .as_ref()?
+                            .force_delete
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .git
+                            .get_or_insert_default()
+                            .branch_picker
+                            .get_or_insert_default()
+                            .force_delete = value;
                     },
                 }),
                 metadata: None,


### PR DESCRIPTION
Made a discussion here: https://github.com/zed-industries/zed/discussions/54594
but essentially, right now there is no way to force delete branches from the UI. This is the default behavior in other editors like Intellij. Added a setting to configure this.

Chose to add this as a setting instead of a new endpoint to make the blast radius as small as possible an opt in.

Tested locally

https://github.com/user-attachments/assets/7b97b16a-9e37-4099-87f7-d743aeaed380

<img width="889" height="343" alt="image" src="https://github.com/user-attachments/assets/9be311c7-06d6-4994-98e6-c828705c4b56" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:
- added an option to override the default branch deletion behavior for the branch picker to use `-D` instead of `-d`

