### PR TITLE
Add "Add to .git/info/exclude" action in project_panel and git_panel

### DIFF
--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -108,6 +108,8 @@ actions!(
         ViewCommit,
         /// Adds a file to .gitignore.
         AddToGitignore,
+        /// Adds a file to .git/info/exclude (local-only, not committed).
+        AddToGitExclude,
         /// Copies the current branch name to the clipboard.
         CopyBranchName,
     ]

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1473,6 +1473,43 @@ impl GitPanel {
         });
     }
 
+    fn add_to_git_exclude(
+        &mut self,
+        _: &git::AddToGitExclude,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        maybe!({
+            let list_entry = self.entries.get(self.selected_entry?)?.clone();
+            let entry = list_entry.status_entry()?.to_owned();
+
+            if !entry.status.is_created() {
+                return Some(());
+            }
+
+            let active_repository = self.active_repository.clone()?;
+            let workspace = self.workspace.clone();
+            let repo_path = entry.repo_path;
+
+            let receiver = active_repository
+                .update(cx, |repo, _| repo.add_path_to_exclude(&repo_path, false));
+
+            cx.spawn(async move |_, cx| {
+                if let Err(e) = receiver.await? {
+                    if let Some(workspace) = workspace.upgrade() {
+                        cx.update(|cx| {
+                            show_error_toast(workspace, "add to .git/info/exclude", e, cx);
+                        });
+                    }
+                }
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+
+            Some(())
+        });
+    }
+
     fn revert_entry(
         &mut self,
         entry: &GitStatusEntry,
@@ -5256,6 +5293,11 @@ impl GitPanel {
                     "Add to .gitignore",
                     git::AddToGitignore.boxed_clone(),
                 )
+                .action_disabled_when(
+                    !is_created,
+                    "Add to .git/info/exclude",
+                    git::AddToGitExclude.boxed_clone(),
+                )
                 .separator()
                 .action("Open Diff", menu::Confirm.boxed_clone())
                 .action("Open File", menu::SecondaryConfirm.boxed_clone())
@@ -5970,6 +6012,7 @@ impl Render for GitPanel {
                     .on_action(cx.listener(Self::restore_tracked_files))
                     .on_action(cx.listener(Self::revert_selected))
                     .on_action(cx.listener(Self::add_to_gitignore))
+                    .on_action(cx.listener(Self::add_to_git_exclude))
                     .on_action(cx.listener(Self::clean_all))
                     .on_action(cx.listener(Self::generate_commit_message_action))
                     .on_action(cx.listener(Self::stash_all))

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -29,7 +29,7 @@ use futures::{
     stream::{FuturesOrdered, FuturesUnordered},
 };
 use git::{
-    BuildPermalinkParams, GitHostingProviderRegistry, Oid, RunHook,
+    BuildPermalinkParams, GitHostingProviderRegistry, Oid, REPO_EXCLUDE, RunHook,
     blame::Blame,
     parse_git_remote_url,
     repository::{
@@ -5905,6 +5905,57 @@ impl Repository {
                 }
                 RepositoryState::Remote(_) => Err(anyhow::anyhow!(
                     "Cannot modify .gitignore on remote repository"
+                )),
+            }
+        })
+    }
+
+    pub fn add_path_to_exclude(
+        &mut self,
+        repo_path: &RepoPath,
+        is_dir: bool,
+    ) -> oneshot::Receiver<Result<()>> {
+        let path_display = repo_path.as_ref().display(PathStyle::Posix);
+        let file_path_str = if is_dir {
+            format!("{}/", path_display)
+        } else {
+            path_display.to_string()
+        };
+
+        self.send_job(None, move |git_repo, _cx| async move {
+            match git_repo {
+                RepositoryState::Local(LocalRepositoryState { fs, backend, .. }) => {
+                    let exclude_path = backend.main_repository_path().join(REPO_EXCLUDE);
+                    if let Some(parent) = exclude_path.parent() {
+                        fs.create_dir(parent).await?;
+                    }
+
+                    let existing_content = fs.load(&exclude_path).await.unwrap_or_default();
+
+                    if existing_content
+                        .lines()
+                        .any(|line| line.trim() == file_path_str)
+                    {
+                        return Ok(());
+                    }
+
+                    let new_content = if existing_content.is_empty() {
+                        format!("{}\n", file_path_str)
+                    } else if existing_content.ends_with('\n') {
+                        format!("{}{}\n", existing_content, file_path_str)
+                    } else {
+                        format!("{}\n{}\n", existing_content, file_path_str)
+                    };
+
+                    fs.save(
+                        &exclude_path,
+                        &text::Rope::from(new_content.as_str()),
+                        text::LineEnding::Unix,
+                    )
+                    .await
+                }
+                RepositoryState::Remote(_) => Err(anyhow::anyhow!(
+                    "Cannot modify .git/info/exclude on remote repository"
                 )),
             }
         })

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1143,6 +1143,10 @@ impl ProjectPanel {
                                         )
                                     })
                                     .action("Add to .gitignore", Box::new(git::AddToGitignore))
+                                    .action(
+                                        "Add to .git/info/exclude",
+                                        Box::new(git::AddToGitExclude),
+                                    )
                                     .when(has_file_history, |menu| {
                                         menu.action("View File History", Box::new(git::FileHistory))
                                     })
@@ -2293,6 +2297,52 @@ impl ProjectPanel {
                     if let Some(workspace) = workspace.upgrade() {
                         cx.update(|cx| {
                             let message = format!("Failed to add to .gitignore: {}", e);
+                            let toast = StatusToast::new(message, cx, |this, _| {
+                                this.icon(Icon::new(IconName::XCircle).color(Color::Error))
+                                    .dismiss_button(true)
+                            });
+                            workspace.update(cx, |workspace, cx| {
+                                workspace.toggle_status_toast(toast, cx);
+                            });
+                        });
+                    }
+                }
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+
+            Some(())
+        });
+    }
+
+    fn add_to_git_exclude(
+        &mut self,
+        _: &git::AddToGitExclude,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        maybe!({
+            let selection = self.selection?;
+            let (_, entry) = self.selected_sub_entry(cx)?;
+            let is_dir = entry.is_dir();
+            let project = self.project.read(cx);
+
+            let project_path = project.path_for_entry(selection.entry_id, cx)?;
+
+            let git_store = project.git_store();
+            let (repository, repo_path) = git_store
+                .read(cx)
+                .repository_and_path_for_project_path(&project_path, cx)?;
+
+            let workspace = self.workspace.clone();
+            let receiver =
+                repository.update(cx, |repo, _| repo.add_path_to_exclude(&repo_path, is_dir));
+
+            cx.spawn(async move |_, cx| {
+                if let Err(e) = receiver.await? {
+                    if let Some(workspace) = workspace.upgrade() {
+                        cx.update(|cx| {
+                            let message = format!("Failed to add to .git/info/exclude: {}", e);
                             let toast = StatusToast::new(message, cx, |this, _| {
                                 this.icon(Icon::new(IconName::XCircle).color(Color::Error))
                                     .dismiss_button(true)
@@ -6684,6 +6734,7 @@ impl Render for ProjectPanel {
                         .on_action(cx.listener(Self::duplicate))
                         .on_action(cx.listener(Self::restore_file))
                         .on_action(cx.listener(Self::add_to_gitignore))
+                        .on_action(cx.listener(Self::add_to_git_exclude))
                         .when(!project.is_remote(), |el| {
                             el.on_action(cx.listener(Self::trash))
                         })

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10339,3 +10339,219 @@ impl Render for TestProjectItemView {
         Empty
     }
 }
+
+#[gpui::test]
+async fn test_add_to_git_exclude_creates_file_when_missing(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {
+                "HEAD": "ref: refs/heads/main",
+            },
+            "scratch.log": "debug output",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/scratch.log", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.add_to_git_exclude(&git::AddToGitExclude, window, cx);
+    });
+    cx.run_until_parked();
+
+    let exclude_contents = fs
+        .load(Path::new("/root/.git/info/exclude"))
+        .await
+        .expect("info/exclude should exist after action");
+    assert_eq!(exclude_contents, "scratch.log\n");
+}
+
+#[gpui::test]
+async fn test_add_to_git_exclude_is_noop_when_already_present(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {
+                "HEAD": "ref: refs/heads/main",
+                "info": {
+                    "exclude": "scratch.log\n",
+                },
+            },
+            "scratch.log": "",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/scratch.log", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.add_to_git_exclude(&git::AddToGitExclude, window, cx);
+    });
+    cx.run_until_parked();
+
+    let exclude_contents = fs
+        .load(Path::new("/root/.git/info/exclude"))
+        .await
+        .unwrap();
+    assert_eq!(
+        exclude_contents, "scratch.log\n",
+        "duplicate add should leave file unchanged"
+    );
+}
+
+#[gpui::test]
+async fn test_add_to_git_exclude_inserts_newline_when_missing(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {
+                "HEAD": "ref: refs/heads/main",
+                "info": {
+                    "exclude": "first.log",
+                },
+            },
+            "second.log": "",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/second.log", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.add_to_git_exclude(&git::AddToGitExclude, window, cx);
+    });
+    cx.run_until_parked();
+
+    let exclude_contents = fs
+        .load(Path::new("/root/.git/info/exclude"))
+        .await
+        .unwrap();
+    assert_eq!(exclude_contents, "first.log\nsecond.log\n");
+}
+
+#[gpui::test]
+async fn test_add_to_git_exclude_appends_trailing_slash_for_dirs(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {
+                "HEAD": "ref: refs/heads/main",
+            },
+            "build": {
+                "out.txt": "",
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/build", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.add_to_git_exclude(&git::AddToGitExclude, window, cx);
+    });
+    cx.run_until_parked();
+
+    let exclude_contents = fs
+        .load(Path::new("/root/.git/info/exclude"))
+        .await
+        .unwrap();
+    assert_eq!(exclude_contents, "build/\n");
+}
+
+#[gpui::test]
+async fn test_add_to_git_exclude_appends_to_file_with_trailing_newline(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {
+                "HEAD": "ref: refs/heads/main",
+                "info": {
+                    "exclude": "first.log\n",
+                },
+            },
+            "second.log": "",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/second.log", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.add_to_git_exclude(&git::AddToGitExclude, window, cx);
+    });
+    cx.run_until_parked();
+
+    let exclude_contents = fs
+        .load(Path::new("/root/.git/info/exclude"))
+        .await
+        .unwrap();
+    assert_eq!(exclude_contents, "first.log\nsecond.log\n");
+}


### PR DESCRIPTION
This PR adds an "Add to .git/info/exclude" action to the project panel and git panel context menus, immediately below the existing "Add to .gitignore" entry. `.gitignore` is committed and affects every collaborator, while `.git/info/exclude` is per-clone and local-only — useful for paths a developer wants to ignore without forcing the choice on the team (local debug scripts, personal scratchpads, IDE-specific notes).

Reading support for `.git/info/exclude` already landed in #42082; this completes the round-trip by adding the write affordance.

<!-- TODO: drag the project_panel screenshot/GIF here -->

<!-- TODO: drag the git_panel screenshot/GIF here -->

Notes:

- **Implementation**: `Repository::add_path_to_exclude` is essentially copy-pasted from `add_path_to_gitignore` (added in #47377). The append/dedup/newline-handling logic is line-for-line identical, with three differences: the path is computed via `backend.main_repository_path().join(REPO_EXCLUDE)` so it lands in the common gitdir (`<commondir>/info/exclude`), matching the location git itself uses (per `gitrepository-layout(5)`, `info/` in a per-worktree gitdir is ignored when `$GIT_COMMON_DIR` is set) and the location Zed's worktree scanner reads from (`crates/worktree/src/worktree.rs:5207`); `fs.create_dir(parent)` ensures `.git/info/` exists for fresh repos; the error message references `.git/info/exclude`. I did not refactor the shared logic into a helper to keep the change scoped to one feature.

- **Git panel parity**: The git panel entry uses `action_disabled_when(!is_created, ...)` to mirror the existing `Add to .gitignore` semantics — both ignore mechanisms are no-ops for tracked files (would need `git rm --cached` first), so the constraint is the same.

- **Toast inconsistency carried forward**: As noted in #47377, `add_to_gitignore` shows a `StatusToast` in `project_panel` but uses `show_error_toast` in `git_panel`. I mirrored that asymmetry rather than introduce a new one. Happy to follow up to unify in a separate PR.

- **Tests**: Added five integration tests in `project_panel_tests.rs` covering empty file, dedup, missing trailing newline, existing trailing newline, and directory entries. No git_panel test was added because that crate has no test scaffolding today (the existing `add_to_gitignore` git_panel handler is also untested).

Release Notes:

- Added an "Add to .git/info/exclude" action to the project panel and git panel context menus, allowing a path to be ignored locally without modifying `.gitignore`.

Screenshot：
<img width="800" height="520" alt="CleanShot 2026-04-29 at 13 30 03" src="https://github.com/user-attachments/assets/dba62785-dd37-4ba2-b4d8-48cb4486856d" />
