### PR TITLE
Add Codex ACP skill mentions

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -61,6 +61,10 @@ pub enum MentionUri {
     MergeConflict {
         file_path: String,
     },
+    Skill {
+        name: String,
+        abs_path: PathBuf,
+    },
 }
 
 impl MentionUri {
@@ -225,6 +229,20 @@ impl MentionUri {
                 }
             }
             "http" | "https" => Ok(MentionUri::Fetch { url }),
+            "skill" => {
+                let decoded = decode(path).unwrap_or(Cow::Borrowed(path));
+                Ok(MentionUri::Skill {
+                    name: single_query_param(&url, "name")?
+                        .or_else(|| {
+                            Path::new(decoded.as_ref())
+                                .parent()
+                                .and_then(Path::file_name)
+                                .map(|name| name.to_string_lossy().into_owned())
+                        })
+                        .unwrap_or_else(|| "skill".to_string()),
+                    abs_path: decoded.as_ref().into(),
+                })
+            }
             other => bail!("unrecognized scheme {:?}", other),
         }
     }
@@ -262,6 +280,7 @@ impl MentionUri {
                 ..
             } => selection_name(path.as_deref(), line_range),
             MentionUri::Fetch { url } => url.to_string(),
+            MentionUri::Skill { name, .. } => format!("${name}"),
         }
     }
 
@@ -317,6 +336,7 @@ impl MentionUri {
             MentionUri::Fetch { .. } => IconName::ToolWeb.path().into(),
             MentionUri::GitDiff { .. } => IconName::GitBranch.path().into(),
             MentionUri::MergeConflict { .. } => IconName::GitMergeConflict.path().into(),
+            MentionUri::Skill { .. } => IconName::Sparkle.path().into(),
         }
     }
 
@@ -424,6 +444,12 @@ impl MentionUri {
                 url.query_pairs_mut().append_pair("path", file_path);
                 url
             }
+            MentionUri::Skill { name, abs_path } => {
+                let mut url = Url::parse("skill:///").unwrap();
+                url.set_path(&abs_path.to_string_lossy());
+                url.query_pairs_mut().append_pair("name", name);
+                url
+            }
         }
     }
 }
@@ -432,7 +458,10 @@ pub struct MentionLink<'a>(&'a MentionUri);
 
 impl fmt::Display for MentionLink<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[@{}]({})", self.0.name(), self.0.to_uri())
+        match self.0 {
+            MentionUri::Skill { name, .. } => write!(f, "[${name}]({})", self.0.to_uri()),
+            _ => write!(f, "[@{}]({})", self.0.name(), self.0.to_uri()),
+        }
     }
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -360,6 +360,7 @@ impl UserMessage {
                             )
                             .ok();
                         }
+                        MentionUri::Skill { .. } => {}
                     }
 
                     language_model::MessageContent::Text(uri.as_link().to_string())

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1,6 +1,6 @@
 use std::cmp::Reverse;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -32,6 +32,7 @@ use ui::IconName;
 use ui::prelude::*;
 use util::ResultExt as _;
 use util::paths::PathStyle;
+use util::paths::home_dir;
 use util::rel_path::RelPath;
 use util::truncate_and_remove_front;
 use workspace::Workspace;
@@ -158,6 +159,13 @@ pub(crate) enum Match {
 }
 
 #[derive(Debug, Clone)]
+pub struct SkillMatch {
+    name: SharedString,
+    description: Option<SharedString>,
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
 pub struct BranchDiffMatch {
     pub base_ref: SharedString,
 }
@@ -216,6 +224,9 @@ pub trait PromptCompletionProviderDelegate: Send + Sync + 'static {
 
     fn available_commands(&self, cx: &App) -> Vec<AvailableCommand>;
     fn confirm_command(&self, cx: &mut App);
+    fn supports_skills(&self) -> bool {
+        false
+    }
 }
 
 pub struct PromptCompletionProvider<T: PromptCompletionProviderDelegate> {
@@ -355,6 +366,46 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
             icon_path: Some(icon_path),
             confirm: Some(confirm_completion_callback(
                 rule.title,
+                source_range.start,
+                new_text_len - 1,
+                uri,
+                source,
+                editor,
+                mention_set,
+                workspace,
+            )),
+        }
+    }
+
+    fn completion_for_skill(
+        skill: SkillMatch,
+        source_range: Range<Anchor>,
+        source: Arc<T>,
+        editor: WeakEntity<Editor>,
+        mention_set: WeakEntity<MentionSet>,
+        workspace: Entity<Workspace>,
+        cx: &mut App,
+    ) -> Completion {
+        let uri = MentionUri::Skill {
+            name: skill.name.to_string(),
+            abs_path: skill.path,
+        };
+        let new_text = format!("[{}]({}) ", uri.name(), uri.to_uri());
+        let new_text_len = new_text.len();
+        Completion {
+            replace_range: source_range.clone(),
+            new_text,
+            label: CodeLabel::plain(skill.name.to_string(), None),
+            documentation: skill.description.map(|description| {
+                CompletionDocumentation::MultiLinePlainText(description)
+            }),
+            source: project::CompletionSource::Custom,
+            icon_path: Some(uri.icon_path(cx)),
+            match_start: None,
+            snippet_deduplication_key: None,
+            insert_text_mode: None,
+            confirm: Some(confirm_completion_callback(
+                uri.name().into(),
                 source_range.start,
                 new_text_len - 1,
                 uri,
@@ -860,6 +911,54 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
         })
     }
 
+    fn search_skills(&self, query: String, cx: &mut App) -> Task<Vec<SkillMatch>> {
+        if !self.source.supports_skills() {
+            return Task::ready(Vec::new());
+        }
+
+        let workspace_roots = self
+            .workspace
+            .upgrade()
+            .map(|workspace| {
+                workspace
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let background_executor = cx.background_executor().clone();
+
+        cx.background_spawn(async move {
+            let mut skills = discover_codex_skills(workspace_roots);
+            skills.sort_by(|left, right| left.name.cmp(&right.name));
+
+            if query.is_empty() {
+                skills.truncate(100);
+                return skills;
+            }
+
+            let candidates = skills
+                .iter()
+                .enumerate()
+                .map(|(id, skill)| StringMatchCandidate::new(id, &skill.name))
+                .collect::<Vec<_>>();
+            fuzzy::match_strings(
+                &candidates,
+                &query,
+                false,
+                true,
+                100,
+                &Arc::new(AtomicBool::default()),
+                background_executor,
+            )
+            .await
+            .into_iter()
+            .map(|mat| skills[mat.candidate_id].clone())
+            .collect()
+        })
+    }
+
     fn fetch_branch_diff_match(
         &self,
         workspace: &Entity<Workspace>,
@@ -1245,6 +1344,36 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
         let editor = self.editor.clone();
         let mention_set = self.mention_set.downgrade();
         match state {
+            PromptCompletion::Skill(SkillCompletion { query, .. }) => {
+                let search_task = self.search_skills(query.unwrap_or_default(), cx);
+                cx.spawn(async move |_, cx| {
+                    let matches = search_task.await;
+                    let completions = cx.update(|cx| {
+                        matches
+                            .into_iter()
+                            .map(|skill| {
+                                Self::completion_for_skill(
+                                    skill,
+                                    source_range.clone(),
+                                    source.clone(),
+                                    editor.clone(),
+                                    mention_set.clone(),
+                                    workspace.clone(),
+                                    cx,
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                    });
+
+                    Ok(vec![CompletionResponse {
+                        completions,
+                        display_options: CompletionDisplayOptions {
+                            dynamic_width: true,
+                        },
+                        is_incomplete: true,
+                    }])
+                })
+            }
             PromptCompletion::SlashCommand(SlashCommandCompletion {
                 command, argument, ..
             }) => {
@@ -1585,6 +1714,7 @@ fn confirm_completion_callback<T: PromptCompletionProviderDelegate>(
 enum PromptCompletion {
     SlashCommand(SlashCommandCompletion),
     Mention(MentionCompletion),
+    Skill(SkillCompletion),
 }
 
 impl PromptCompletion {
@@ -1592,6 +1722,7 @@ impl PromptCompletion {
         match self {
             Self::SlashCommand(completion) => completion.source_range.clone(),
             Self::Mention(completion) => completion.source_range.clone(),
+            Self::Skill(completion) => completion.source_range.clone(),
         }
     }
 
@@ -1607,8 +1738,135 @@ impl PromptCompletion {
                 return Some(Self::Mention(mention));
             }
         }
+        if line.contains('$')
+            && let Some(skill) = SkillCompletion::try_parse(line, offset_to_line)
+        {
+            return Some(Self::Skill(skill));
+        }
         SlashCommandCompletion::try_parse(line, offset_to_line).map(Self::SlashCommand)
     }
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct SkillCompletion {
+    source_range: Range<usize>,
+    query: Option<String>,
+}
+
+impl SkillCompletion {
+    fn try_parse(line: &str, offset_to_line: usize) -> Option<Self> {
+        let mut skill_start = None;
+        for (idx, _) in line.rmatch_indices('$') {
+            if line[idx + 1..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_whitespace())
+            {
+                continue;
+            }
+
+            if idx > 0
+                && line[..idx]
+                    .chars()
+                    .last()
+                    .is_some_and(|c| !c.is_whitespace())
+            {
+                continue;
+            }
+
+            skill_start = Some(idx);
+            break;
+        }
+
+        let skill_start = skill_start?;
+        let rest_of_line = &line[skill_start + 1..];
+        let query_text = rest_of_line.split_whitespace().next().unwrap_or_default();
+        let end = skill_start + 1 + query_text.len();
+
+        Some(Self {
+            source_range: skill_start + offset_to_line..end + offset_to_line,
+            query: (!query_text.is_empty()).then(|| query_text.to_string()),
+        })
+    }
+}
+
+fn discover_codex_skills(workspace_roots: Vec<PathBuf>) -> Vec<SkillMatch> {
+    let mut skill_roots = Vec::new();
+
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        skill_roots.push(PathBuf::from(codex_home).join("skills"));
+    } else {
+        skill_roots.push(home_dir().join(".codex").join("skills"));
+    }
+
+    for root in workspace_roots {
+        skill_roots.push(root.join(".codex").join("skills"));
+    }
+
+    let mut skills = Vec::new();
+    for root in skill_roots {
+        collect_codex_skills_from_root(&root, &mut skills);
+    }
+    skills
+}
+
+fn collect_codex_skills_from_root(root: &Path, skills: &mut Vec<SkillMatch>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let skill_path = entry.path().join("SKILL.md");
+        if !skill_path.is_file() {
+            continue;
+        }
+
+        let skill_name = entry.file_name().to_string_lossy().into_owned();
+        let metadata = std::fs::read_to_string(&skill_path)
+            .ok()
+            .map(|content| parse_skill_metadata(&content))
+            .unwrap_or_default();
+        let name = metadata
+            .name
+            .unwrap_or(skill_name)
+            .trim_start_matches('$')
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+
+        skills.push(SkillMatch {
+            name: name.into(),
+            description: metadata.description.map(Into::into),
+            path: skill_path,
+        });
+    }
+}
+
+#[derive(Default)]
+struct SkillMetadata {
+    name: Option<String>,
+    description: Option<String>,
+}
+
+fn parse_skill_metadata(content: &str) -> SkillMetadata {
+    let mut metadata = SkillMetadata::default();
+    for line in content.lines().take(80) {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim().trim_matches('"').trim_matches('\'');
+        match key.trim() {
+            "name" if metadata.name.is_none() && !value.is_empty() => {
+                metadata.name = Some(value.to_string());
+            }
+            "description" if metadata.description.is_none() && !value.is_empty() => {
+                metadata.description = Some(value.to_string());
+            }
+            _ => {}
+        }
+    }
+    metadata
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -9265,6 +9265,7 @@ pub(crate) fn open_link(
             MentionUri::TerminalSelection { .. } => {}
             MentionUri::GitDiff { .. } => {}
             MentionUri::MergeConflict { .. } => {}
+            MentionUri::Skill { .. } => {}
         })
     } else {
         cx.open_url(&url);

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -147,6 +147,7 @@ impl MentionSet {
             MentionUri::GitDiff { base_ref } => {
                 self.confirm_mention_for_git_diff(base_ref.into(), cx)
             }
+            MentionUri::Skill { .. } => Task::ready(Ok(Mention::Link)),
             MentionUri::Selection {
                 abs_path: Some(abs_path),
                 line_range,
@@ -296,6 +297,7 @@ impl MentionSet {
             MentionUri::GitDiff { base_ref } => {
                 self.confirm_mention_for_git_diff(base_ref.into(), cx)
             }
+            MentionUri::Skill { .. } => Task::ready(Ok(Mention::Link)),
             MentionUri::MergeConflict { .. } => {
                 debug_panic!("unexpected merge conflict URI");
                 Task::ready(Err(anyhow!("unexpected merge conflict URI")))

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -112,6 +112,7 @@ struct MessageEditorCompletionDelegate {
     session_capabilities: SharedSessionCapabilities,
     has_thread_store: bool,
     message_editor: WeakEntity<MessageEditor>,
+    supports_skills: bool,
 }
 
 impl PromptCompletionProviderDelegate for MessageEditorCompletionDelegate {
@@ -131,6 +132,10 @@ impl PromptCompletionProviderDelegate for MessageEditorCompletionDelegate {
 
     fn confirm_command(&self, cx: &mut App) {
         let _ = self.message_editor.update(cx, |this, cx| this.send(cx));
+    }
+
+    fn supports_skills(&self) -> bool {
+        self.supports_skills
     }
 }
 
@@ -455,6 +460,7 @@ impl MessageEditor {
                 session_capabilities: session_capabilities.clone(),
                 has_thread_store: thread_store.is_some(),
                 message_editor: cx.weak_entity(),
+                supports_skills: agent_id.0 == "codex-acp",
             },
             editor.downgrade(),
             mention_set.clone(),
@@ -1841,13 +1847,19 @@ impl Addon for MessageEditorAddon {
     }
 }
 
-/// Parses markdown mention links in the format `[@name](uri)` from text.
+/// Parses markdown-backed mentions from text. `@` entries refer to context,
+/// while `$` entries refer to agent skills such as `[$skill](skill://...)`.
 /// Returns a vector of (range, MentionUri) pairs where range is the byte range in the text.
 fn parse_mention_links(text: &str, path_style: PathStyle) -> Vec<(Range<usize>, MentionUri)> {
     let mut mentions = Vec::new();
     let mut search_start = 0;
 
-    while let Some(link_start) = text[search_start..].find("[@") {
+    while let Some(link_start) = text[search_start..]
+        .find("[@")
+        .into_iter()
+        .chain(text[search_start..].find("[$"))
+        .min()
+    {
         let absolute_start = search_start + link_start;
 
         // Find the matching closing bracket for the name, handling nested brackets.

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -189,7 +189,8 @@ fn open_mention_uri(
         | MentionUri::Diagnostics { .. }
         | MentionUri::TerminalSelection { .. }
         | MentionUri::GitDiff { .. }
-        | MentionUri::MergeConflict { .. } => {}
+        | MentionUri::MergeConflict { .. }
+        | MentionUri::Skill { .. } => {}
     });
 }
 


### PR DESCRIPTION
Add Codex ACP skill mentions in the agent composer.

This starts wiring Zed's external Codex agent flow toward Codex skills support by adding a Codex-scoped `$skill` mention path. The editor can now represent selected skills as markdown-backed mention chips using `skill://...` URIs, while keeping `@` reserved for Zed context mentions.

This is related to zed-industries/zed#49057, but does not fully fix it yet. The remaining work is in `codex-acp`: the adapter still needs to discover Codex skills, advertise `/skills`, and translate `skill://...` mentions into Codex-native `UserInput::Skill` items so Codex actually activates selected skills.

Changes:

- Added `MentionUri::Skill` with `skill://...` parsing and serialization.
- Added `$` skill completion parsing, gated to `codex-acp` sessions.
- Added local Codex skill discovery from `CODEX_HOME`/`~/.codex/skills` and workspace `.codex/skills`.
- Serialize selected skills as markdown-backed `$skill` mentions.
- Preserve existing `@` context mention behavior.
- Treat skill mentions as lightweight links in non-skill contexts.

Validation:

- `cargo check -p agent_ui -p acp_thread`
- `git diff --check`

Formatting note:

- `cargo fmt --all -- --check` could not run locally because `cargo-fmt` is not applicable to the active `1.94.1-aarch64-apple-darwin` toolchain, despite rustup reporting `rustfmt` is installed.

Release Notes:

- Improved Codex ACP agent composer support for skill mentions.
