### PR TITLE
Revert "Enable Vim/Helix keybindings when the base keymap is set to None"

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2074,16 +2074,16 @@ fn reload_keymaps(cx: &mut App, mut user_key_bindings: Vec<KeyBinding>) {
 
 pub fn load_default_keymap(cx: &mut App) {
     let base_keymap = *BaseKeymap::get_global(cx);
-    if base_keymap != BaseKeymap::None {
-        cx.bind_keys(
-            KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, Some(KeybindSource::Default), cx).unwrap(),
-        );
+    if base_keymap == BaseKeymap::None {
+        return;
+    }
 
-        if let Some(asset_path) = base_keymap.asset_path() {
-            cx.bind_keys(
-                KeymapFile::load_asset(asset_path, Some(KeybindSource::Base), cx).unwrap(),
-            );
-        }
+    cx.bind_keys(
+        KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, Some(KeybindSource::Default), cx).unwrap(),
+    );
+
+    if let Some(asset_path) = base_keymap.asset_path() {
+        cx.bind_keys(KeymapFile::load_asset(asset_path, Some(KeybindSource::Base), cx).unwrap());
     }
 
     if VimModeSetting::get_global(cx).0 || vim_mode_setting::HelixModeSetting::get_global(cx).0 {


### PR DESCRIPTION
Reverts zed-industries/zed#54899

Release notes:

- Reverted the "none" keymap to be literally nothing