### PR TITLE
agent: Remove streaming edit feature flag

### DIFF
--- a/crates/agent/src/tests/edit_file_thread_test.rs
+++ b/crates/agent/src/tests/edit_file_thread_test.rs
@@ -210,11 +210,6 @@ async fn test_streaming_edit_json_parse_error_does_not_cause_unsaved_changes(
     super::init_test(cx);
     super::always_allow_tools(cx);
 
-    // Enable the streaming edit file tool feature flag.
-    cx.update(|cx| {
-        cx.update_flags(true, vec!["streaming-edit-file-tool".to_string()]);
-    });
-
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
         path!("/project"),

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
-use feature_flags::{
-    FeatureFlagAppExt as _, StreamingEditFileToolFeatureFlag, UpdatePlanToolFeatureFlag,
-};
+use feature_flags::{FeatureFlagAppExt as _, UpdatePlanToolFeatureFlag};
 
 use agent_client_protocol::schema as acp;
 use agent_settings::{
@@ -2866,8 +2864,7 @@ impl Thread {
             }
         }
 
-        let use_streaming_edit_tool =
-            cx.has_flag::<StreamingEditFileToolFeatureFlag>() && model.supports_streaming_tools();
+        let use_streaming_edit_tool = model.supports_streaming_tools();
 
         let mut tools = self
             .tools

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -47,18 +47,6 @@ impl FeatureFlag for DiffReviewFeatureFlag {
 }
 register_feature_flag!(DiffReviewFeatureFlag);
 
-pub struct StreamingEditFileToolFeatureFlag;
-
-impl FeatureFlag for StreamingEditFileToolFeatureFlag {
-    const NAME: &'static str = "streaming-edit-file-tool";
-    type Value = PresenceFlag;
-
-    fn enabled_for_staff() -> bool {
-        true
-    }
-}
-register_feature_flag!(StreamingEditFileToolFeatureFlag);
-
 pub struct UpdatePlanToolFeatureFlag;
 
 impl FeatureFlag for UpdatePlanToolFeatureFlag {


### PR DESCRIPTION
We already enabled the feature flag, but that only applies to logged in
users. Going to make sure that everyone gets the new tool as long as the
model supports it.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- agent: Improve edit tool performance for models that support streaming tool calls.
