### PR TITLE
editor: Add path to context

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2931,15 +2931,15 @@ impl Editor {
         }
 
         if let Some(singleton_buffer) = self.buffer.read(cx).as_singleton() {
-            if let Some(extension) = singleton_buffer.read(cx).file().and_then(|file| {
-                Some(
-                    file.full_path(cx)
-                        .extension()?
-                        .to_string_lossy()
-                        .to_lowercase(),
-                )
+            if let Some((extension, path)) = singleton_buffer.read(cx).file().and_then(|file| {
+                let full = file.full_path(cx);
+                Some((
+                    full.extension()?.to_string_lossy().to_lowercase(),
+                    full.to_string_lossy().into_owned(),
+                ))
             }) {
                 key_context.set("extension", extension);
+                key_context.set("path", path);
             }
         } else {
             key_context.add("multibuffer");

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -393,6 +393,18 @@ impl KeyBindingContextPredicate {
                 let (predicate, source) = Self::parse_expr(source, PRECEDENCE_NOT)?;
                 Ok((KeyBindingContextPredicate::Not(Box::new(predicate)), source))
             }
+            '\'' => {
+                let s = &source[1..];
+                let end = s
+                    .find('\'')
+                    .context("unterminated string in context predicate")?;
+                let value = &s[..end];
+                source = skip_whitespace(&s[end + 1..]);
+                Ok((
+                    KeyBindingContextPredicate::Identifier(value.to_string().into()),
+                    source,
+                ))
+            }
             _ if is_identifier_char(next) => {
                 let len = source
                     .find(|c: char| !is_identifier_char(c) && !is_vim_operator_char(c))


### PR DESCRIPTION
Hello,

This PR enables keybindings to match against the path of the file opened in the editor.

The main motivation is to use `GIT_EDITOR='zed --wait'` and then when doing interactive rebase we can have a set of custom keybindings for the list of actions: p for pick, r for reword, etc. that match on `path == '.git/rebase-merge/git-rebase-todo'`.

Combined with tasks, I can use [`gitu`](https://github.com/altsem/gitu) or [`lazygit`](https://github.com/jesseduffield/lazygit) from within zed (as demoed in your blog), and truly have all my git workflow inside zed (I know you've been working hard on git integration in zed, but some habits refuse to die, specifically [_magit habit_](https://docs.magit.vc/)).

I looked into your issues and discussions to see if it's something already discussed, but I found nothing. You may have some other concerns or plans about it, and if so, I'd like to help.

I should've asked on these channels before maybe, but TBH this so simple that I am seriously considering maintaining a fork of zed just for that, since AFAICT extensions are not expressive enough to achieve this.

This PR is at a bare minimum (the path is not normalized, no tests, etc.), waiting your feedback. I don't want to commit to something if rejected.

Any guidance would be really appreciated.

Thanks for the snappiest, most comfortable editor out there!

# Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

# Release Notes:

- N/A