### PR TITLE
sidebar: Don't do anything on cmd-click if project is already active

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -4182,6 +4182,9 @@ impl Sidebar {
             .and_then(|mw| mw.read(cx).last_active_workspace_for_group(key, cx))
             .or_else(|| self.workspace_for_group(key, cx));
         if let Some(workspace) = workspace {
+            if self.is_active_workspace(&workspace, cx) {
+                return;
+            }
             self.activate_workspace(&workspace, window, cx);
         } else {
             self.open_workspace_for_group(key, window, cx);


### PR DESCRIPTION
Prevent flashing the currently selected thread upon cmd-clicking the active project's header.

Release Notes:

- Fixed a bug where a thread within the currently active project would flash upon cmd-clicking the project header.
