### PR TITLE
sidebar: Fix unread indicator being cleared on collapse

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1009,7 +1009,6 @@ impl Sidebar {
         let mut entries = Vec::new();
         let mut notified_threads = previous.notified_threads;
         let mut current_session_ids: HashSet<acp::SessionId> = HashSet::new();
-        let mut current_thread_ids: HashSet<agent_ui::ThreadId> = HashSet::new();
         let mut project_header_indices: Vec<usize> = Vec::new();
         let mut seen_thread_ids: HashSet<agent_ui::ThreadId> = HashSet::new();
 
@@ -1362,7 +1361,6 @@ impl Sidebar {
                     if let Some(sid) = thread.metadata.session_id.clone() {
                         current_session_ids.insert(sid);
                     }
-                    current_thread_ids.insert(thread.metadata.thread_id);
                     entries.push(thread.into());
                 }
             } else {
@@ -1385,16 +1383,17 @@ impl Sidebar {
                     if let Some(sid) = &thread.metadata.session_id {
                         current_session_ids.insert(sid.clone());
                     }
-                    current_thread_ids.insert(thread.metadata.thread_id);
                     entries.push(thread.into());
                 }
             }
         }
 
-        notified_threads.retain(|id| current_thread_ids.contains(id));
+        // Collapsed groups don't load threads, so retain against the global store rather than rebuilt entries.
+        let thread_store = ThreadMetadataStore::global(cx).read(cx);
+        notified_threads.retain(|id| thread_store.entry(*id).is_some_and(|m| !m.archived));
 
         self.thread_last_accessed
-            .retain(|id, _| current_thread_ids.contains(id));
+            .retain(|id, _| thread_store.entry(*id).is_some_and(|m| !m.archived));
 
         self.contents = SidebarContents {
             entries,

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -773,6 +773,64 @@ async fn test_collapse_and_expand_group(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_collapse_preserves_unread_indicator(cx: &mut TestAppContext) {
+    let project = init_test_project("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_n_test_threads(1, &project, cx).await;
+
+    let project_group_key = project.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    let thread_id = sidebar.read_with(cx, |s, _| {
+        s.contents
+            .entries
+            .iter()
+            .find_map(|e| match e {
+                ListEntry::Thread(t) => Some(t.metadata.thread_id),
+                _ => None,
+            })
+            .expect("expected one thread entry")
+    });
+
+    sidebar.update_in(cx, |s, _, _| {
+        s.contents.notified_threads.insert(thread_id);
+    });
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            //
+            "v [my-project]",
+            "  Thread 1 (!)",
+        ]
+    );
+
+    sidebar.update_in(cx, |s, window, cx| {
+        s.toggle_collapse(&project_group_key, window, cx);
+    });
+    cx.run_until_parked();
+
+    sidebar.update_in(cx, |s, window, cx| {
+        s.toggle_collapse(&project_group_key, window, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            //
+            "v [my-project]",
+            "  Thread 1 (!)",
+        ]
+    );
+}
+
+#[gpui::test]
 async fn test_collapse_state_survives_worktree_key_change(cx: &mut TestAppContext) {
     // When a worktree is added to a project, the project group key changes.
     // The sidebar's collapsed/expanded state is keyed by ProjectGroupKey, so


### PR DESCRIPTION
## Context

In the agents (parallel-agents) sidebar, an unread indicator (blue dot) on a thread disappears after the user collapses its project group and expands it again, even though the thread has not been viewed.

`Sidebar::rebuild_contents` collects every thread it renders into a local `current_thread_ids` set, then runs:

```rust
notified_threads.retain(|id| current_thread_ids.contains(id));
self.thread_last_accessed.retain(|id, _| current_thread_ids.contains(id));
```

When a group is collapsed, `should_load_threads` is `false` and the group's threads are never added to `current_thread_ids` — so the retain calls drop the unread marker and last-accessed timestamp for every thread in the collapsed group. On expand the threads come back, but the unread state is already gone.

The fix re-keys both retains against the global `ThreadMetadataStore`, so notification/access state is only cleaned up when a thread is actually deleted or archived. `current_thread_ids` is no longer needed and is removed.

A regression test (`test_collapse_preserves_unread_indicator`) reproduces the original sequence — notify a thread, toggle the group collapsed and back — and asserts the `(!)` marker survives.

### Side effect, intentional

After this change unread state also persists for threads in groups that are temporarily inaccessible (e.g. a remote workspace that has disconnected) — `ThreadMetadataStore` keeps those entries until they are archived or deleted, so the retain predicate keeps their state across reconnect/refresh. This matches the reported user expectation that an unread indicator only goes away when the user reads or removes the thread.

## How to reproduce

1. Open the agents sidebar with at least one project group containing a thread that has an unread indicator (blue dot — appears when a background thread completes while not focused).
2. Collapse the project group containing that thread (click the group header).
3. Expand the same group again.
4. Observe that the blue dot has disappeared, even though the thread was never opened.

<img width="336" height="281" alt="bug-1-unread-visible" src="https://github.com/user-attachments/assets/08d98700-8509-4134-851a-06b891715ccf" />
<img width="336" height="281" alt="bug-2-group-collapsed" src="https://github.com/user-attachments/assets/669614f2-4996-44ae-a20e-b6d2d039f405" />
<img width="336" height="281" alt="bug-3-after-expand-unread-lost" src="https://github.com/user-attachments/assets/dae0d746-4e12-411f-a6bd-2d3a656ec5db" />

<!-- Drop bug-1-unread-visible.png, bug-2-group-collapsed.png, bug-3-after-expand-unread-lost.png here -->

## After the fix

Same steps as above — the blue dot is preserved across collapse/expand.

<img width="338" height="281" alt="fix-3-after-expand-unread-preserved" src="https://github.com/user-attachments/assets/e9fb194b-05b5-4a64-a88b-f69846dea53c" />
<img width="338" height="281" alt="fix-2-group-collapsed" src="https://github.com/user-attachments/assets/bae97e5e-28be-4e43-a1a8-a5c37316e4b5" />
<img width="338" height="281" alt="fix-1-unread-visible" src="https://github.com/user-attachments/assets/086e42b9-fedc-478b-814f-3510abc97ac6" />


<!-- Drop fix-after-expand-unread-preserved.png here -->

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed agent thread unread indicator disappearing after collapsing and expanding its sidebar group.