### PR TITLE
agent_ui: Skip layout backfill when AI is disabled

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -511,7 +511,7 @@ fn maybe_backfill_editor_layout(fs: Arc<dyn Fs>, is_new_install: bool, cx: &mut 
             .is_some();
 
     if !already_backfilled {
-        if !is_new_install {
+        if !is_new_install && !DisableAiSettings::get_global(cx).disable_ai {
             AgentSettings::backfill_editor_layout(fs, cx);
         }
 


### PR DESCRIPTION
Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54568

Release Notes:
- Fixed: agent layout is no longer backfilled on startup when
  `disable_ai` is true. The parallel agents announcement in
  `auto_update_ui` already guards against this — the backfill
  now applies the same check for consistency.