### PR TITLE
Fix musl linking failure in bundle-linux by setting CC for musl target

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -88,6 +88,8 @@ cargo build --release --target "${target_triple}" --package zed --package cli
 # from influencing dynamic libraries required by it.
 if [[ "$remote_server_triple" == "$musl_triple" ]]; then
     export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
+    musl_cc_var="CC_$(echo "$remote_server_triple" | tr '-' '_')"
+    export "$musl_cc_var"=musl-gcc
 fi
 cargo build --release --target "${remote_server_triple}" --package remote_server
 


### PR DESCRIPTION
"Assisted by Claude"

The remote_server musl build failed with undefined references to `__isoc23_sscanf` and `__isoc23_strtol` from `aws-lc-sys` because the default C compiler used glibc headers while linking against musl libc. Setting `CC_<target>=musl-gcc` ensures C dependencies compile with musl headers.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Related #24880 #44831 

Release Notes:

- Fixed musl error when building remote server for the default musl triple on linux
