### PR TITLE
Add OpenAI Codex provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11811,6 +11811,7 @@ name = "open_ai"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "collections",
  "futures 0.3.32",
  "http_client",
@@ -11821,8 +11822,10 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "serde_json",
+ "sha2",
  "strum 0.27.2",
  "thiserror 2.0.17",
+ "url",
 ]
 
 [[package]]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2336,6 +2336,7 @@
     "openai": {
       "api_url": "https://api.openai.com/v1",
     },
+    "openai_codex": {},
     "openai_compatible": {},
     "opencode": {
       "api_url": "https://opencode.ai/zen",

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -25,6 +25,7 @@ use crate::provider::lmstudio::LmStudioLanguageModelProvider;
 pub use crate::provider::mistral::MistralLanguageModelProvider;
 use crate::provider::ollama::OllamaLanguageModelProvider;
 use crate::provider::open_ai::OpenAiLanguageModelProvider;
+use crate::provider::open_ai_codex::OpenAiCodexLanguageModelProvider;
 use crate::provider::open_ai_compatible::OpenAiCompatibleLanguageModelProvider;
 use crate::provider::open_router::OpenRouterLanguageModelProvider;
 use crate::provider::opencode::OpenCodeLanguageModelProvider;
@@ -243,6 +244,14 @@ fn register_language_model_providers(
     );
     registry.register_provider(
         Arc::new(OpenAiLanguageModelProvider::new(
+            client.http_client(),
+            credentials_provider.clone(),
+            cx,
+        )),
+        cx,
+    );
+    registry.register_provider(
+        Arc::new(OpenAiCodexLanguageModelProvider::new(
             client.http_client(),
             credentials_provider.clone(),
             cx,

--- a/crates/language_models/src/provider.rs
+++ b/crates/language_models/src/provider.rs
@@ -8,6 +8,7 @@ pub mod lmstudio;
 pub mod mistral;
 pub mod ollama;
 pub mod open_ai;
+pub mod open_ai_codex;
 pub mod open_ai_compatible;
 pub mod open_router;
 pub mod opencode;

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -313,29 +313,7 @@ impl LanguageModel for OpenAiLanguageModel {
     }
 
     fn supports_images(&self) -> bool {
-        use open_ai::Model;
-        match &self.model {
-            Model::FourOmniMini
-            | Model::FourPointOneNano
-            | Model::Five
-            | Model::FiveCodex
-            | Model::FiveMini
-            | Model::FiveNano
-            | Model::FivePointOne
-            | Model::FivePointTwo
-            | Model::FivePointTwoCodex
-            | Model::FivePointThreeCodex
-            | Model::FivePointFour
-            | Model::FivePointFourPro
-            | Model::FivePointFive
-            | Model::FivePointFivePro
-            | Model::O1
-            | Model::O3 => true,
-            Model::ThreePointFiveTurbo | Model::Four | Model::FourTurbo | Model::O3Mini => false,
-            Model::Custom {
-                supports_images, ..
-            } => *supports_images,
-        }
+        self.model.supports_images()
     }
 
     fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {

--- a/crates/language_models/src/provider/open_ai_codex.rs
+++ b/crates/language_models/src/provider/open_ai_codex.rs
@@ -1,0 +1,666 @@
+use anyhow::{Context as _, Result, anyhow};
+use collections::BTreeMap;
+use credentials_provider::CredentialsProvider;
+use futures::{FutureExt, StreamExt, future::BoxFuture};
+use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, Window};
+use http_client::HttpClient;
+use language_model::{
+    AuthenticateError, IconOrSvg, LanguageModel, LanguageModelCompletionError,
+    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
+    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
+    LanguageModelRequest, LanguageModelToolChoice, RateLimiter,
+};
+use open_ai::codex::{
+    CODEX_API_URL, CODEX_OAUTH_CREDENTIALS_KEY, CodexOAuthSession, create_codex_authorization_flow,
+    exchange_codex_authorization_code, now_ms, parse_codex_authorization_callback_path,
+    refresh_codex_session,
+};
+use open_ai::responses::{
+    Request as ResponseRequest, ResponseInputContent, ResponseInputItem, ResponseTextConfig,
+    ResponseTextVerbosity, StreamEvent, stream_codex_response,
+};
+use settings::Settings;
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::Arc,
+    time::Duration,
+};
+use strum::IntoEnumIterator;
+use ui::{Button, ButtonStyle, ConfiguredApiCard, TintColor, prelude::*};
+use util::ResultExt;
+
+use crate::provider::open_ai::{OpenAiResponseEventMapper, into_open_ai_response};
+
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openai-codex");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("OpenAI Codex");
+
+const OAUTH_CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct OpenAiCodexSettings {
+    pub available_models: Vec<settings::OpenAiCodexAvailableModel>,
+}
+
+pub struct OpenAiCodexLanguageModelProvider {
+    http_client: Arc<dyn HttpClient>,
+    state: Entity<State>,
+}
+
+pub struct State {
+    session: Option<CodexOAuthSession>,
+    credentials_provider: Arc<dyn CredentialsProvider>,
+    http_client: Arc<dyn HttpClient>,
+}
+
+impl State {
+    fn is_authenticated(&self) -> bool {
+        self.session.is_some()
+    }
+
+    fn authenticate(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
+        let credentials_provider = self.credentials_provider.clone();
+        let http_client = self.http_client.clone();
+        cx.spawn(async move |this, cx| {
+            match load_codex_session(credentials_provider.clone(), http_client, cx).await {
+                Ok(Some(session)) => {
+                    this.update(cx, |this, cx| {
+                        this.session = Some(session);
+                        cx.notify();
+                    })
+                    .map_err(AuthenticateError::Other)?;
+                    Ok(())
+                }
+                Ok(None) => Err(AuthenticateError::CredentialsNotFound),
+                Err(error) => Err(AuthenticateError::Other(error)),
+            }
+        })
+    }
+
+    fn login(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
+        let credentials_provider = self.credentials_provider.clone();
+        let http_client = self.http_client.clone();
+        cx.spawn(async move |this, cx| {
+            let flow = create_codex_authorization_flow().map_err(AuthenticateError::Other)?;
+            let code_task = cx.background_spawn(wait_for_authorization_code(flow.state.clone()));
+            cx.update(|cx| cx.open_url(&flow.url));
+            let code = code_task.await.map_err(AuthenticateError::Other)?;
+            let session =
+                exchange_codex_authorization_code(http_client.as_ref(), &code, &flow.verifier)
+                    .await
+                    .map_err(AuthenticateError::Other)?;
+            store_codex_session(credentials_provider.as_ref(), &session, cx)
+                .await
+                .map_err(AuthenticateError::Other)?;
+            this.update(cx, |this, cx| {
+                this.session = Some(session);
+                cx.notify();
+            })
+            .map_err(AuthenticateError::Other)?;
+            Ok(())
+        })
+    }
+
+    fn authenticated_session(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<CodexOAuthSession, LanguageModelCompletionError>> {
+        let credentials_provider = self.credentials_provider.clone();
+        let http_client = self.http_client.clone();
+        cx.spawn(async move |this, cx| {
+            let Some(session) = load_codex_session(credentials_provider, http_client, cx)
+                .await
+                .map_err(LanguageModelCompletionError::Other)?
+            else {
+                return Err(LanguageModelCompletionError::NoApiKey {
+                    provider: PROVIDER_NAME,
+                });
+            };
+
+            this.update(cx, |this, cx| {
+                this.session = Some(session.clone());
+                cx.notify();
+            })
+            .map_err(LanguageModelCompletionError::Other)?;
+
+            Ok(session)
+        })
+    }
+
+    fn reset_credentials(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
+        let credentials_provider = self.credentials_provider.clone();
+        cx.spawn(async move |this, cx| {
+            credentials_provider
+                .delete_credentials(CODEX_OAUTH_CREDENTIALS_KEY, cx)
+                .await?;
+            this.update(cx, |this, cx| {
+                this.session = None;
+                cx.notify();
+            })
+        })
+    }
+}
+
+impl OpenAiCodexLanguageModelProvider {
+    pub fn new(
+        http_client: Arc<dyn HttpClient>,
+        credentials_provider: Arc<dyn CredentialsProvider>,
+        cx: &mut App,
+    ) -> Self {
+        let state = cx.new(|_| State {
+            session: None,
+            credentials_provider,
+            http_client: http_client.clone(),
+        });
+
+        Self { http_client, state }
+    }
+
+    fn create_language_model(&self, model: open_ai::Model) -> Arc<dyn LanguageModel> {
+        Arc::new(OpenAiCodexLanguageModel {
+            id: LanguageModelId::from(model.id().to_string()),
+            model,
+            state: self.state.clone(),
+            http_client: self.http_client.clone(),
+            request_limiter: RateLimiter::new(4),
+        })
+    }
+
+    fn settings(cx: &App) -> &OpenAiCodexSettings {
+        &crate::AllLanguageModelSettings::get_global(cx).openai_codex
+    }
+}
+
+impl LanguageModelProviderState for OpenAiCodexLanguageModelProvider {
+    type ObservableEntity = State;
+
+    fn observable_entity(&self) -> Option<Entity<Self::ObservableEntity>> {
+        Some(self.state.clone())
+    }
+}
+
+impl LanguageModelProvider for OpenAiCodexLanguageModelProvider {
+    fn id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn icon(&self) -> IconOrSvg {
+        IconOrSvg::Icon(IconName::AiOpenAi)
+    }
+
+    fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(open_ai::Model::FiveCodex))
+    }
+
+    fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(open_ai::Model::FiveCodex))
+    }
+
+    fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
+        let mut models = BTreeMap::default();
+
+        for model in open_ai::Model::iter() {
+            if !matches!(model, open_ai::Model::Custom { .. }) {
+                models.insert(model.id().to_string(), model);
+            }
+        }
+
+        for model in &Self::settings(cx).available_models {
+            models.insert(
+                model.name.clone(),
+                open_ai::Model::Custom {
+                    name: model.name.clone(),
+                    display_name: model.display_name.clone(),
+                    max_tokens: model.max_tokens,
+                    max_output_tokens: model.max_output_tokens,
+                    max_completion_tokens: model.max_completion_tokens,
+                    reasoning_effort: Some(model.reasoning_effort),
+                    supports_chat_completions: false,
+                    supports_images: model.supports_images,
+                },
+            );
+        }
+
+        models
+            .into_values()
+            .map(|model| self.create_language_model(model))
+            .collect()
+    }
+
+    fn is_authenticated(&self, cx: &App) -> bool {
+        self.state.read(cx).is_authenticated()
+    }
+
+    fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {
+        self.state.update(cx, |state, cx| state.authenticate(cx))
+    }
+
+    fn configuration_view(
+        &self,
+        _target_agent: language_model::ConfigurationViewTargetAgent,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> AnyView {
+        cx.new(|cx| ConfigurationView::new(self.state.clone(), window, cx))
+            .into()
+    }
+
+    fn reset_credentials(&self, cx: &mut App) -> Task<Result<()>> {
+        self.state
+            .update(cx, |state, cx| state.reset_credentials(cx))
+    }
+}
+
+pub struct OpenAiCodexLanguageModel {
+    id: LanguageModelId,
+    model: open_ai::Model,
+    state: Entity<State>,
+    http_client: Arc<dyn HttpClient>,
+    request_limiter: RateLimiter,
+}
+
+impl OpenAiCodexLanguageModel {
+    fn stream_response(
+        &self,
+        mut request: ResponseRequest,
+        cx: &AsyncApp,
+    ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<StreamEvent>>>> {
+        let http_client = self.http_client.clone();
+        let state = self.state.clone();
+        let session_task =
+            cx.update(|cx| state.update(cx, |state, cx| state.authenticated_session(cx)));
+
+        request.store = Some(false);
+        request.instructions = take_system_instructions(&mut request.input);
+        request.include = vec!["reasoning.encrypted_content".to_string()];
+        request.text = Some(ResponseTextConfig {
+            verbosity: ResponseTextVerbosity::Low,
+        });
+
+        let future = self.request_limiter.stream(async move {
+            let session = session_task.await?;
+            let provider_name = PROVIDER_NAME.0.to_string();
+            let user_agent = codex_user_agent();
+            let request = stream_codex_response(
+                http_client.as_ref(),
+                &provider_name,
+                CODEX_API_URL,
+                &session.access_token,
+                &session.account_id,
+                &user_agent,
+                request,
+            );
+            let response = request.await?;
+            Ok(response)
+        });
+
+        async move { Ok(future.await?.boxed()) }.boxed()
+    }
+}
+
+impl LanguageModel for OpenAiCodexLanguageModel {
+    fn id(&self) -> LanguageModelId {
+        self.id.clone()
+    }
+
+    fn name(&self) -> LanguageModelName {
+        LanguageModelName::from(self.model.display_name().to_string())
+    }
+
+    fn provider_id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn provider_name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn supports_tools(&self) -> bool {
+        true
+    }
+
+    fn supports_images(&self) -> bool {
+        self.model.supports_images()
+    }
+
+    fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
+        matches!(
+            choice,
+            LanguageModelToolChoice::Auto
+                | LanguageModelToolChoice::Any
+                | LanguageModelToolChoice::None
+        )
+    }
+
+    fn supports_streaming_tools(&self) -> bool {
+        true
+    }
+
+    fn supports_thinking(&self) -> bool {
+        self.model.reasoning_effort().is_some()
+    }
+
+    fn supports_split_token_display(&self) -> bool {
+        true
+    }
+
+    fn telemetry_id(&self) -> String {
+        format!("openai-codex/{}", self.model.id())
+    }
+
+    fn max_token_count(&self) -> u64 {
+        self.model.max_token_count()
+    }
+
+    fn max_output_tokens(&self) -> Option<u64> {
+        self.model.max_output_tokens()
+    }
+
+    fn stream_completion(
+        &self,
+        request: LanguageModelRequest,
+        cx: &AsyncApp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            futures::stream::BoxStream<
+                'static,
+                Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+            >,
+            LanguageModelCompletionError,
+        >,
+    > {
+        let request = into_open_ai_response(
+            request,
+            self.model.id(),
+            self.model.supports_parallel_tool_calls(),
+            self.model.supports_prompt_cache_key(),
+            self.max_output_tokens(),
+            self.model.reasoning_effort(),
+        );
+        let completions = self.stream_response(request, cx);
+        async move {
+            let mapper = OpenAiResponseEventMapper::new();
+            Ok(mapper.map_stream(completions.await?).boxed())
+        }
+        .boxed()
+    }
+}
+
+fn take_system_instructions(input: &mut Vec<ResponseInputItem>) -> Option<String> {
+    let mut instructions = Vec::new();
+    let mut next_input = Vec::with_capacity(input.len());
+
+    for item in input.drain(..) {
+        match item {
+            ResponseInputItem::Message(message) if message.role == open_ai::Role::System => {
+                for content in message.content {
+                    if let ResponseInputContent::Text { text } = content
+                        && !text.trim().is_empty()
+                    {
+                        instructions.push(text);
+                    }
+                }
+            }
+            item => next_input.push(item),
+        }
+    }
+
+    *input = next_input;
+
+    if instructions.is_empty() {
+        None
+    } else {
+        Some(instructions.join("\n\n"))
+    }
+}
+
+struct ConfigurationView {
+    state: Entity<State>,
+    load_credentials_task: Option<Task<()>>,
+    login_task: Option<Task<()>>,
+    last_error: Option<SharedString>,
+}
+
+impl ConfigurationView {
+    fn new(state: Entity<State>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        cx.observe(&state, |_, _, cx| {
+            cx.notify();
+        })
+        .detach();
+
+        let load_credentials_task = Some(cx.spawn_in(window, {
+            let state = state.clone();
+            async move |this, cx| {
+                let result = state.update(cx, |state, cx| state.authenticate(cx)).await;
+                this.update(cx, |this, cx| {
+                    if let Err(AuthenticateError::Other(error)) = result {
+                        this.last_error = Some(error.to_string().into());
+                    }
+                    this.load_credentials_task = None;
+                    cx.notify();
+                })
+                .log_err();
+            }
+        }));
+
+        Self {
+            state,
+            load_credentials_task,
+            login_task: None,
+            last_error: None,
+        }
+    }
+
+    fn login(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let state = self.state.clone();
+        self.last_error = None;
+        self.login_task = Some(cx.spawn_in(window, async move |this, cx| {
+            let result = state.update(cx, |state, cx| state.login(cx)).await;
+            this.update(cx, |this, cx| {
+                if let Err(error) = result {
+                    this.last_error = Some(error.to_string().into());
+                }
+                this.login_task = None;
+                cx.notify();
+            })
+            .log_err();
+        }));
+        cx.notify();
+    }
+
+    fn reset_credentials(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let state = self.state.clone();
+        self.login_task = Some(cx.spawn_in(window, async move |this, cx| {
+            let result = state
+                .update(cx, |state, cx| state.reset_credentials(cx))
+                .await;
+            this.update(cx, |this, cx| {
+                if let Err(error) = result {
+                    this.last_error = Some(error.to_string().into());
+                }
+                this.login_task = None;
+                cx.notify();
+            })
+            .log_err();
+        }));
+        cx.notify();
+    }
+}
+
+impl Render for ConfigurationView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let is_authenticated = self.state.read(cx).is_authenticated();
+        let is_busy = self.login_task.is_some();
+
+        v_flex()
+            .gap_2()
+            .when_some(self.last_error.clone(), |this, error| {
+                this.child(Label::new(error).size(LabelSize::Small).color(Color::Error))
+            })
+            .map(|this| {
+                if is_authenticated {
+                    this.child(
+                        ConfiguredApiCard::new("Signed in with ChatGPT for Codex").on_click(
+                            cx.listener(|this, _, window, cx| this.reset_credentials(window, cx)),
+                        ),
+                    )
+                } else {
+                    this.child(
+                        Label::new(
+                            "Sign in with ChatGPT to use Codex models through your ChatGPT plan.",
+                        )
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                    )
+                    .child(
+                        Button::new(
+                            "openai-codex-sign-in",
+                            if is_busy {
+                                "Signing in…"
+                            } else {
+                                "Sign in with ChatGPT"
+                            },
+                        )
+                        .style(ButtonStyle::Tinted(TintColor::Accent))
+                        .full_width()
+                        .disabled(is_busy)
+                        .on_click(cx.listener(|this, _, window, cx| this.login(window, cx))),
+                    )
+                }
+            })
+            .into_any_element()
+    }
+}
+
+async fn load_codex_session(
+    credentials_provider: Arc<dyn CredentialsProvider>,
+    http_client: Arc<dyn HttpClient>,
+    cx: &AsyncApp,
+) -> Result<Option<CodexOAuthSession>> {
+    let Some((_, bytes)) = credentials_provider
+        .read_credentials(CODEX_OAUTH_CREDENTIALS_KEY, cx)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    let mut session: CodexOAuthSession =
+        serde_json::from_slice(&bytes).context("failed to parse OpenAI Codex credentials")?;
+    if session.expires_at_ms <= now_ms() + Duration::from_secs(60).as_millis() as u64 {
+        session = refresh_codex_session(http_client.as_ref(), &session.refresh_token).await?;
+        store_codex_session(credentials_provider.as_ref(), &session, cx).await?;
+    }
+    Ok(Some(session))
+}
+
+async fn store_codex_session(
+    credentials_provider: &dyn CredentialsProvider,
+    session: &CodexOAuthSession,
+    cx: &AsyncApp,
+) -> Result<()> {
+    let bytes = serde_json::to_vec(session)?;
+    credentials_provider
+        .write_credentials(CODEX_OAUTH_CREDENTIALS_KEY, "oauth", &bytes, cx)
+        .await
+}
+
+async fn wait_for_authorization_code(state: String) -> Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:1455")
+        .context("failed to start OpenAI Codex OAuth callback server on 127.0.0.1:1455")?;
+    listener.set_nonblocking(true)?;
+    let started_at = std::time::Instant::now();
+    let mut stream = loop {
+        match listener.accept() {
+            Ok((stream, _)) => break stream,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if started_at.elapsed() >= OAUTH_CALLBACK_TIMEOUT {
+                    return Err(anyhow!("Timed out waiting for OpenAI Codex OAuth callback"));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    };
+    stream.set_nonblocking(false)?;
+    let mut buffer = [0_u8; 4096];
+    let bytes_read = stream.read(&mut buffer)?;
+    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let request_line = request
+        .lines()
+        .next()
+        .ok_or_else(|| anyhow!("OAuth callback did not include an HTTP request line"))?;
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| anyhow!("OAuth callback request line was malformed"))?;
+    let code = parse_codex_authorization_callback_path(path, &state);
+    let (status, body) = if code.is_ok() {
+        (
+            "200 OK",
+            "OpenAI Codex authentication completed. You can close this window.",
+        )
+    } else {
+        ("400 Bad Request", "OpenAI Codex authentication failed.")
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {status}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )?;
+
+    code
+}
+
+fn codex_user_agent() -> String {
+    format!(
+        "Zed ({}/{}; language_models {})",
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use open_ai::responses::ResponseMessageItem;
+
+    #[test]
+    fn extracts_system_messages_as_instructions() {
+        let mut input = vec![
+            ResponseInputItem::Message(ResponseMessageItem {
+                role: open_ai::Role::System,
+                content: vec![ResponseInputContent::Text {
+                    text: "First instruction".to_string(),
+                }],
+            }),
+            ResponseInputItem::Message(ResponseMessageItem {
+                role: open_ai::Role::User,
+                content: vec![ResponseInputContent::Text {
+                    text: "User message".to_string(),
+                }],
+            }),
+            ResponseInputItem::Message(ResponseMessageItem {
+                role: open_ai::Role::System,
+                content: vec![ResponseInputContent::Text {
+                    text: "Second instruction".to_string(),
+                }],
+            }),
+        ];
+
+        assert_eq!(
+            take_system_instructions(&mut input).as_deref(),
+            Some("First instruction\n\nSecond instruction")
+        );
+        assert_eq!(input.len(), 1);
+        assert!(matches!(
+            &input[0],
+            ResponseInputItem::Message(message) if message.role == open_ai::Role::User
+        ));
+    }
+}

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -7,8 +7,9 @@ use crate::provider::{
     anthropic::AnthropicSettings, bedrock::AmazonBedrockSettings, cloud::ZedDotDevSettings,
     deepseek::DeepSeekSettings, google::GoogleSettings, lmstudio::LmStudioSettings,
     mistral::MistralSettings, ollama::OllamaSettings, open_ai::OpenAiSettings,
-    open_ai_compatible::OpenAiCompatibleSettings, open_router::OpenRouterSettings,
-    opencode::OpenCodeSettings, vercel_ai_gateway::VercelAiGatewaySettings, x_ai::XAiSettings,
+    open_ai_codex::OpenAiCodexSettings, open_ai_compatible::OpenAiCompatibleSettings,
+    open_router::OpenRouterSettings, opencode::OpenCodeSettings,
+    vercel_ai_gateway::VercelAiGatewaySettings, x_ai::XAiSettings,
 };
 
 #[derive(Debug, RegisterSetting)]
@@ -23,6 +24,7 @@ pub struct AllLanguageModelSettings {
     pub opencode: OpenCodeSettings,
     pub open_router: OpenRouterSettings,
     pub openai: OpenAiSettings,
+    pub openai_codex: OpenAiCodexSettings,
     pub openai_compatible: HashMap<Arc<str>, OpenAiCompatibleSettings>,
     pub vercel_ai_gateway: VercelAiGatewaySettings,
     pub x_ai: XAiSettings,
@@ -44,6 +46,7 @@ impl settings::Settings for AllLanguageModelSettings {
         let opencode = language_models.opencode.unwrap();
         let open_router = language_models.open_router.unwrap();
         let openai = language_models.openai.unwrap();
+        let openai_codex = language_models.openai_codex.unwrap();
         let openai_compatible = language_models.openai_compatible.unwrap();
         let vercel_ai_gateway = language_models.vercel_ai_gateway.unwrap();
         let x_ai = language_models.x_ai.unwrap();
@@ -99,6 +102,9 @@ impl settings::Settings for AllLanguageModelSettings {
             openai: OpenAiSettings {
                 api_url: openai.api_url.unwrap(),
                 available_models: openai.available_models.unwrap_or_default(),
+            },
+            openai_codex: OpenAiCodexSettings {
+                available_models: openai_codex.available_models.unwrap_or_default(),
             },
             openai_compatible: openai_compatible
                 .into_iter()

--- a/crates/open_ai/Cargo.toml
+++ b/crates/open_ai/Cargo.toml
@@ -17,6 +17,7 @@ schemars = ["dep:schemars"]
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 collections.workspace = true
 futures.workspace = true
 http_client.workspace = true
@@ -26,8 +27,10 @@ schemars = { workspace = true, optional = true }
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/open_ai/src/codex.rs
+++ b/crates/open_ai/src/codex.rs
@@ -1,0 +1,260 @@
+use anyhow::{Result, anyhow};
+use base64::Engine as _;
+use futures::AsyncReadExt as _;
+use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const CODEX_API_URL: &str = "https://chatgpt.com/backend-api";
+pub const CODEX_OAUTH_CREDENTIALS_KEY: &str = "openai-codex-oauth";
+
+// These must match the OpenAI Codex CLI OAuth app's registered redirect URI.
+pub const CODEX_CLI_OAUTH_REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
+
+const CODEX_OAUTH_CALLBACK_PATH: &str = "/auth/callback";
+const CODEX_CLI_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const OAUTH_SCOPE: &str = "openid profile email offline_access";
+const JWT_CLAIM_PATH: &str = "https://api.openai.com/auth";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CodexOAuthSession {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at_ms: u64,
+    pub account_id: String,
+}
+
+#[derive(Debug)]
+pub struct CodexAuthorizationFlow {
+    pub verifier: String,
+    pub state: String,
+    pub url: String,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    expires_in: u64,
+}
+
+pub fn create_codex_authorization_flow() -> Result<CodexAuthorizationFlow> {
+    let verifier = random_urlsafe(32);
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(Sha256::digest(verifier.as_bytes()));
+    let state = random_urlsafe(16);
+    let mut url = url::Url::parse(AUTHORIZE_URL)?;
+    url.query_pairs_mut()
+        .append_pair("response_type", "code")
+        .append_pair("client_id", CODEX_CLI_CLIENT_ID)
+        .append_pair("redirect_uri", CODEX_CLI_OAUTH_REDIRECT_URI)
+        .append_pair("scope", OAUTH_SCOPE)
+        .append_pair("code_challenge", &challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("state", &state)
+        .append_pair("id_token_add_organizations", "true")
+        .append_pair("codex_cli_simplified_flow", "true")
+        .append_pair("originator", "zed");
+    Ok(CodexAuthorizationFlow {
+        verifier,
+        state,
+        url: url.to_string(),
+    })
+}
+
+pub async fn exchange_codex_authorization_code(
+    http_client: &dyn HttpClient,
+    code: &str,
+    verifier: &str,
+) -> Result<CodexOAuthSession> {
+    token_request(
+        http_client,
+        &[
+            ("grant_type", "authorization_code"),
+            ("client_id", CODEX_CLI_CLIENT_ID),
+            ("code", code),
+            ("code_verifier", verifier),
+            ("redirect_uri", CODEX_CLI_OAUTH_REDIRECT_URI),
+        ],
+    )
+    .await
+}
+
+pub async fn refresh_codex_session(
+    http_client: &dyn HttpClient,
+    refresh_token: &str,
+) -> Result<CodexOAuthSession> {
+    token_request(
+        http_client,
+        &[
+            ("grant_type", "refresh_token"),
+            ("client_id", CODEX_CLI_CLIENT_ID),
+            ("refresh_token", refresh_token),
+        ],
+    )
+    .await
+}
+
+pub fn parse_codex_authorization_callback_path(path: &str, expected_state: &str) -> Result<String> {
+    let url = url::Url::parse(&format!("http://localhost{path}"))?;
+    let callback_state = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "state").then_some(value.into_owned()));
+    let code = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "code").then_some(value.into_owned()));
+
+    match (
+        url.path() == CODEX_OAUTH_CALLBACK_PATH,
+        callback_state.as_deref() == Some(expected_state),
+        code,
+    ) {
+        (true, true, Some(code)) => Ok(code),
+        (false, _, _) => Err(anyhow!("OAuth callback route did not match /auth/callback")),
+        (true, false, _) => Err(anyhow!(
+            "OAuth callback state did not match the login request"
+        )),
+        (true, true, None) => Err(anyhow!(
+            "OAuth callback did not include an authorization code"
+        )),
+    }
+}
+
+async fn token_request(
+    http_client: &dyn HttpClient,
+    params: &[(&str, &str)],
+) -> Result<CodexOAuthSession> {
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(params.iter().copied())
+        .finish();
+    let request = HttpRequest::builder()
+        .method(Method::POST)
+        .uri(TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(AsyncBody::from(body))?;
+
+    let mut response = http_client.send(request).await?;
+    let mut body = String::new();
+    response.body_mut().read_to_string(&mut body).await?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "OpenAI Codex OAuth token request failed: {} {}",
+            response.status(),
+            body
+        ));
+    }
+
+    let token: TokenResponse = serde_json::from_str(&body)?;
+    let account_id = extract_codex_account_id(&token.access_token)?;
+    Ok(CodexOAuthSession {
+        access_token: token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at_ms: now_ms() + token.expires_in * 1000,
+        account_id,
+    })
+}
+
+fn extract_codex_account_id(access_token: &str) -> Result<String> {
+    let payload = access_token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| anyhow!("OpenAI Codex access token is not a JWT"))?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload))?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded)?;
+    json.get(JWT_CLAIM_PATH)
+        .and_then(|auth| auth.get("chatgpt_account_id"))
+        .and_then(|account_id| account_id.as_str())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("OpenAI Codex access token did not include a ChatGPT account ID"))
+}
+
+fn random_urlsafe(bytes_len: usize) -> String {
+    let mut bytes = vec![0; bytes_len];
+    rand::rng().fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub fn now_ms() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as u64,
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_chatgpt_account_id_from_access_token() -> Result<()> {
+        let payload = serde_json::json!({
+            JWT_CLAIM_PATH: {
+                "chatgpt_account_id": "account-id"
+            }
+        });
+        let token = format!(
+            "header.{}.signature",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string())
+        );
+
+        assert_eq!(extract_codex_account_id(&token)?, "account-id");
+        Ok(())
+    }
+
+    #[test]
+    fn builds_codex_authorization_flow() -> Result<()> {
+        let flow = create_codex_authorization_flow()?;
+        let url = url::Url::parse(&flow.url)?;
+        let query = url
+            .query_pairs()
+            .collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(url.as_str().split('?').next(), Some(AUTHORIZE_URL));
+        assert_eq!(
+            query.get("client_id").map(|value| value.as_ref()),
+            Some(CODEX_CLI_CLIENT_ID)
+        );
+        assert_eq!(
+            query.get("redirect_uri").map(|value| value.as_ref()),
+            Some(CODEX_CLI_OAUTH_REDIRECT_URI)
+        );
+        assert_eq!(
+            query
+                .get("code_challenge_method")
+                .map(|value| value.as_ref()),
+            Some("S256")
+        );
+        assert_eq!(
+            query.get("state").map(|value| value.as_ref()),
+            Some(flow.state.as_str())
+        );
+        assert!(!flow.verifier.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn parses_codex_authorization_callback_path() -> Result<()> {
+        assert_eq!(
+            parse_codex_authorization_callback_path(
+                "/auth/callback?code=authorization-code&state=expected-state",
+                "expected-state",
+            )?,
+            "authorization-code"
+        );
+
+        assert!(
+            parse_codex_authorization_callback_path(
+                "/auth/callback?code=authorization-code&state=other-state",
+                "expected-state",
+            )
+            .is_err()
+        );
+        Ok(())
+    }
+}

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -212,6 +212,8 @@ pub fn into_open_ai_response(
 
     ResponseRequest {
         model: model_id.into(),
+        store: None,
+        instructions: None,
         input: input_items,
         stream,
         temperature,
@@ -237,6 +239,8 @@ pub fn into_open_ai_response(
             effort,
             summary: Some(crate::responses::ReasoningSummaryMode::Auto),
         }),
+        include: Vec::new(),
+        text: None,
     }
 }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -1,4 +1,5 @@
 pub mod batches;
+pub mod codex;
 pub mod completion;
 pub mod responses;
 
@@ -279,6 +280,31 @@ impl Model {
                 ..
             } => !*supports_chat_completions,
             _ => true,
+        }
+    }
+
+    pub fn supports_images(&self) -> bool {
+        match self {
+            Self::FourOmniMini
+            | Self::FourPointOneNano
+            | Self::Five
+            | Self::FiveCodex
+            | Self::FiveMini
+            | Self::FiveNano
+            | Self::FivePointOne
+            | Self::FivePointTwo
+            | Self::FivePointTwoCodex
+            | Self::FivePointThreeCodex
+            | Self::FivePointFour
+            | Self::FivePointFourPro
+            | Self::FivePointFive
+            | Self::FivePointFivePro
+            | Self::O1
+            | Self::O3 => true,
+            Self::ThreePointFiveTurbo | Self::Four | Self::FourTurbo | Self::O3Mini => false,
+            Self::Custom {
+                supports_images, ..
+            } => *supports_images,
         }
     }
 

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -9,6 +9,10 @@ use crate::{ReasoningEffort, RequestError, Role, ToolChoice};
 #[derive(Serialize, Debug)]
 pub struct Request {
     pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub input: Vec<ResponseInputItem>,
     #[serde(default)]
@@ -29,6 +33,72 @@ pub struct Request {
     pub prompt_cache_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<ResponseTextConfig>,
+}
+
+#[derive(Serialize, Debug)]
+struct CodexRequest {
+    model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    store: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    input: Vec<ResponseInputItem>,
+    #[serde(default)]
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<ToolDefinition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<ReasoningConfig>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    include: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<ResponseTextConfig>,
+}
+
+impl From<Request> for CodexRequest {
+    fn from(request: Request) -> Self {
+        Self {
+            model: request.model,
+            store: request.store,
+            instructions: request.instructions,
+            input: request.input,
+            stream: request.stream,
+            temperature: request.temperature,
+            parallel_tool_calls: request.parallel_tool_calls,
+            tool_choice: request.tool_choice,
+            tools: request.tools,
+            prompt_cache_key: request.prompt_cache_key,
+            reasoning: request.reasoning,
+            include: request.include,
+            text: request.text,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct ResponseTextConfig {
+    pub verbosity: ResponseTextVerbosity,
+}
+
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ResponseTextVerbosity {
+    Low,
+    Medium,
+    High,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -333,35 +403,7 @@ pub async fn stream_response(
     let mut response = client.send(request).await?;
     if response.status().is_success() {
         if is_streaming {
-            let reader = BufReader::new(response.into_body());
-            Ok(reader
-                .lines()
-                .filter_map(|line| async move {
-                    match line {
-                        Ok(line) => {
-                            let line = line
-                                .strip_prefix("data: ")
-                                .or_else(|| line.strip_prefix("data:"))?;
-                            if line == "[DONE]" || line.is_empty() {
-                                None
-                            } else {
-                                match serde_json::from_str::<StreamEvent>(line) {
-                                    Ok(event) => Some(Ok(event)),
-                                    Err(error) => {
-                                        log::error!(
-                                            "Failed to parse OpenAI responses stream event: `{}`\nResponse: `{}`",
-                                            error,
-                                            line,
-                                        );
-                                        Some(Err(anyhow!(error)))
-                                    }
-                                }
-                            }
-                        }
-                        Err(error) => Some(Err(anyhow!(error))),
-                    }
-                })
-                .boxed())
+            Ok(stream_events_from_body(response.into_body()))
         } else {
             let mut body = String::new();
             response
@@ -471,5 +513,146 @@ pub async fn stream_response(
             body,
             headers: response.headers().clone(),
         })
+    }
+}
+
+pub async fn stream_codex_response(
+    client: &dyn HttpClient,
+    provider_name: &str,
+    api_url: &str,
+    access_token: &str,
+    account_id: &str,
+    user_agent: &str,
+    request: Request,
+) -> Result<BoxStream<'static, Result<StreamEvent>>, RequestError> {
+    let uri = format!("{}/codex/responses", api_url.trim_end_matches('/'));
+    if request.max_output_tokens.is_some() {
+        log::debug!("OpenAI Codex API does not support max_output_tokens; omitting it");
+    }
+    if request.top_p.is_some() {
+        log::debug!("OpenAI Codex API does not support top_p; omitting it");
+    }
+
+    let mut request_builder = HttpRequest::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header("Content-Type", "application/json")
+        .header("Accept", "text/event-stream")
+        .header("OpenAI-Beta", "responses=experimental")
+        .header("Authorization", format!("Bearer {}", access_token.trim()))
+        .header("chatgpt-account-id", account_id)
+        .header("originator", "zed")
+        .header("User-Agent", user_agent);
+
+    if let Some(prompt_cache_key) = request.prompt_cache_key.as_deref() {
+        request_builder = request_builder
+            .header("session_id", prompt_cache_key)
+            .header("x-client-request-id", prompt_cache_key);
+    }
+
+    let is_streaming = request.stream;
+    let request = CodexRequest::from(request);
+    let request = request_builder
+        .body(AsyncBody::from(
+            serde_json::to_string(&request).map_err(|e| RequestError::Other(e.into()))?,
+        ))
+        .map_err(|e| RequestError::Other(e.into()))?;
+
+    let mut response = client.send(request).await?;
+    if response.status().is_success() {
+        if is_streaming {
+            Ok(stream_events_from_body(response.into_body()))
+        } else {
+            Err(RequestError::Other(anyhow!(
+                "{provider_name} only supports streaming responses"
+            )))
+        }
+    } else {
+        let mut body = String::new();
+        response
+            .body_mut()
+            .read_to_string(&mut body)
+            .await
+            .map_err(|e| RequestError::Other(e.into()))?;
+
+        Err(RequestError::HttpResponseError {
+            provider: provider_name.to_owned(),
+            status_code: response.status(),
+            body,
+            headers: response.headers().clone(),
+        })
+    }
+}
+
+fn stream_events_from_body(body: AsyncBody) -> BoxStream<'static, Result<StreamEvent>> {
+    let reader = BufReader::new(body);
+    reader
+        .lines()
+        .filter_map(|line| async move {
+            match line {
+                Ok(line) => {
+                    let line = line
+                        .strip_prefix("data: ")
+                        .or_else(|| line.strip_prefix("data:"))?;
+                    if line == "[DONE]" || line.is_empty() {
+                        None
+                    } else {
+                        match serde_json::from_str::<StreamEvent>(line) {
+                            Ok(event) => Some(Ok(event)),
+                            Err(error) => {
+                                log::error!(
+                                    "Failed to parse OpenAI responses stream event: `{}`\nResponse: `{}`",
+                                    error,
+                                    line,
+                                );
+                                Some(Err(anyhow!(error)))
+                            }
+                        }
+                    }
+                }
+                Err(error) => Some(Err(anyhow!(error))),
+            }
+        })
+        .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_request_omits_unsupported_responses_parameters() -> Result<()> {
+        let request = Request {
+            model: "gpt-5-codex".to_string(),
+            store: Some(false),
+            instructions: Some("instructions".to_string()),
+            input: vec![ResponseInputItem::Message(ResponseMessageItem {
+                role: Role::User,
+                content: vec![ResponseInputContent::Text {
+                    text: "prompt".to_string(),
+                }],
+            })],
+            stream: true,
+            temperature: Some(0.1),
+            top_p: Some(0.9),
+            max_output_tokens: Some(128),
+            parallel_tool_calls: Some(true),
+            tool_choice: Some(ToolChoice::Auto),
+            tools: Vec::new(),
+            prompt_cache_key: Some("session-id".to_string()),
+            reasoning: None,
+            include: vec!["reasoning.encrypted_content".to_string()],
+            text: Some(ResponseTextConfig {
+                verbosity: ResponseTextVerbosity::Low,
+            }),
+        };
+
+        let value = serde_json::to_value(CodexRequest::from(request))?;
+
+        assert_eq!(value["model"], "gpt-5-codex");
+        assert_eq!(value["instructions"], "instructions");
+        assert!(value.get("max_output_tokens").is_none());
+        assert!(value.get("top_p").is_none());
+        Ok(())
     }
 }

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -20,6 +20,7 @@ pub struct AllLanguageModelSettingsContent {
     pub opencode: Option<OpenCodeSettingsContent>,
     pub open_router: Option<OpenRouterSettingsContent>,
     pub openai: Option<OpenAiSettingsContent>,
+    pub openai_codex: Option<OpenAiCodexSettingsContent>,
     pub openai_compatible: Option<HashMap<Arc<str>, OpenAiCompatibleSettingsContent>>,
     pub vercel_ai_gateway: Option<VercelAiGatewaySettingsContent>,
     pub x_ai: Option<XAiSettingsContent>,
@@ -242,6 +243,25 @@ pub struct MistralAvailableModel {
 pub struct OpenAiSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<OpenAiAvailableModel>>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
+pub struct OpenAiCodexSettingsContent {
+    pub available_models: Option<Vec<OpenAiCodexAvailableModel>>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct OpenAiCodexAvailableModel {
+    pub name: String,
+    pub display_name: Option<String>,
+    pub max_tokens: u64,
+    pub max_output_tokens: Option<u64>,
+    pub max_completion_tokens: Option<u64>,
+    pub reasoning_effort: language_model_core::ReasoningEffort,
+    #[serde(default = "default_true")]
+    pub supports_images: bool,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
## Summary

- Add an OpenAI Codex language model provider that authenticates through the Codex OAuth flow and uses ChatGPT Codex backend responses.
- Share OpenAI Responses stream parsing and model capability metadata so Codex stays aligned with the existing OpenAI provider where the protocols overlap.

Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Related discussions:
- https://github.com/zed-industries/zed/discussions/49965
- https://github.com/zed-industries/zed/discussions/53836

Release Notes:

- Added OpenAI Codex as a language model provider.
