### PR TITLE
Add user-configurable mouse and scroll wheel keybindings

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -993,3 +993,28 @@ pub struct ConfirmEditReviewComment {
 pub struct CancelEditReviewComment {
     pub id: usize,
 }
+
+/// Adds a cursor at the current mouse position. Intended for keymap-bound mouse buttons.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct AddCursorAtMouse;
+
+/// Extends the current selection to the mouse position. Intended for keymap-bound mouse buttons.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct ExtendSelectionToMouse;
+
+/// Goes to the definition of the symbol at the current mouse position.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct GoToDefinitionAtMouse;
+
+/// Goes to the type definition of the symbol at the current mouse position.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct GoToTypeDefinitionAtMouse;
+
+/// Starts a columnar (block) selection at the current mouse position.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
+pub struct StartColumnarSelectionAtMouse;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -391,6 +391,11 @@ impl EditorElement {
                 .go_to_type_definition_split(action, window, cx)
                 .detach_and_log_err(cx);
         });
+        register_action(editor, window, Editor::add_cursor_at_mouse);
+        register_action(editor, window, Editor::extend_selection_to_mouse);
+        register_action(editor, window, Editor::go_to_definition_at_mouse);
+        register_action(editor, window, Editor::go_to_type_definition_at_mouse);
+        register_action(editor, window, Editor::start_columnar_selection_at_mouse);
         register_action(editor, window, Editor::open_url);
         register_action(editor, window, Editor::open_selected_filename);
         register_action(editor, window, Editor::fold);

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -1052,6 +1052,122 @@ impl Editor {
         self.go_to_definition_of_kind(GotoDefinitionKind::Type, true, window, cx)
     }
 
+    fn point_for_mouse(&self, window: &Window) -> Option<(Rc<PositionMap>, PointForPosition)> {
+        let position_map = self.last_position_map.clone()?;
+        let mouse_position = window.mouse_position();
+        if !position_map.text_hitbox.contains(&mouse_position) {
+            return None;
+        }
+        let point = position_map.point_for_position(mouse_position);
+        Some((position_map, point))
+    }
+
+    pub fn add_cursor_at_mouse(
+        &mut self,
+        _: &AddCursorAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_, point)) = self.point_for_mouse(window) else {
+            return;
+        };
+        cx.stop_propagation();
+        self.select(
+            SelectPhase::Begin {
+                position: point.previous_valid,
+                add: true,
+                click_count: 1,
+            },
+            window,
+            cx,
+        );
+        self.select(SelectPhase::End, window, cx);
+    }
+
+    pub fn extend_selection_to_mouse(
+        &mut self,
+        _: &ExtendSelectionToMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_, point)) = self.point_for_mouse(window) else {
+            return;
+        };
+        cx.stop_propagation();
+        self.select(
+            SelectPhase::Extend {
+                position: point.previous_valid,
+                click_count: 1,
+            },
+            window,
+            cx,
+        );
+        self.select(SelectPhase::End, window, cx);
+    }
+
+    fn goto_definition_at_mouse_of_kind(
+        &mut self,
+        kind: GotoDefinitionKind,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((position_map, point)) = self.point_for_mouse(window) else {
+            return;
+        };
+        cx.stop_propagation();
+        let display_snapshot = &position_map.snapshot.display_snapshot;
+        let buffer_point = point.previous_valid.to_point(display_snapshot);
+        let anchor = display_snapshot
+            .buffer_snapshot()
+            .anchor_before(buffer_point);
+        self.change_selections(SelectionEffects::default(), window, cx, |s| {
+            s.select_anchor_ranges([anchor..anchor]);
+        });
+        self.select(SelectPhase::End, window, cx);
+        self.go_to_definition_of_kind(kind, false, window, cx)
+            .detach_and_log_err(cx);
+    }
+
+    pub fn go_to_definition_at_mouse(
+        &mut self,
+        _: &GoToDefinitionAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.goto_definition_at_mouse_of_kind(GotoDefinitionKind::Symbol, window, cx);
+    }
+
+    pub fn go_to_type_definition_at_mouse(
+        &mut self,
+        _: &GoToTypeDefinitionAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.goto_definition_at_mouse_of_kind(GotoDefinitionKind::Type, window, cx);
+    }
+
+    pub fn start_columnar_selection_at_mouse(
+        &mut self,
+        _: &StartColumnarSelectionAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_, point)) = self.point_for_mouse(window) else {
+            return;
+        };
+        cx.stop_propagation();
+        self.select(
+            SelectPhase::BeginColumnar {
+                position: point.previous_valid,
+                reset: true,
+                mode: ColumnarMode::FromMouse,
+                goal_column: point.exact_unclipped.column(),
+            },
+            window,
+            cx,
+        );
+    }
+
     pub fn open_url(&mut self, _: &OpenUrl, window: &mut Window, cx: &mut Context<Self>) {
         let selection = self.selections.newest_anchor();
         let head = selection.head();

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -50,8 +50,8 @@
 //!  KeyBinding::new("cmd-k left", pane::SplitLeft, Some("Pane"))
 
 use crate::{
-    Action, ActionRegistry, App, DispatchPhase, EntityId, FocusId, KeyBinding, KeyContext, Keymap,
-    Keystroke, ModifiersChangedEvent, Window,
+    Action, ActionRegistry, App, DispatchPhase, EntityId, FocusId, HitboxId, KeyBinding,
+    KeyContext, Keymap, Keystroke, ModifiersChangedEvent, Window,
 };
 use collections::FxHashMap;
 use smallvec::SmallVec;
@@ -75,6 +75,7 @@ pub(crate) struct DispatchTree {
     nodes: Vec<DispatchNode>,
     focusable_node_ids: FxHashMap<FocusId, DispatchNodeId>,
     view_node_ids: FxHashMap<EntityId, DispatchNodeId>,
+    hitbox_node_ids: FxHashMap<HitboxId, DispatchNodeId>,
     keymap: Rc<RefCell<Keymap>>,
     action_registry: Rc<ActionRegistry>,
 }
@@ -145,6 +146,7 @@ impl DispatchTree {
             nodes: Vec::new(),
             focusable_node_ids: FxHashMap::default(),
             view_node_ids: FxHashMap::default(),
+            hitbox_node_ids: FxHashMap::default(),
             keymap,
             action_registry,
         }
@@ -157,6 +159,7 @@ impl DispatchTree {
         self.nodes.clear();
         self.focusable_node_ids.clear();
         self.view_node_ids.clear();
+        self.hitbox_node_ids.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -221,6 +224,26 @@ impl DispatchTree {
         let node_id = *self.node_stack.last().unwrap();
         self.nodes[node_id.0].focus_id = Some(focus_id);
         self.focusable_node_ids.insert(focus_id, node_id);
+    }
+
+    /// Records that the given hitbox belongs to the currently active dispatch node.
+    ///
+    /// Pointer bindings use this to resolve actions against the dispatch path under the cursor
+    /// instead of the keyboard focus path.
+    pub fn set_active_node_hitbox(&mut self, hitbox_id: HitboxId) {
+        if let Some(node_id) = self.node_stack.last().copied() {
+            self.hitbox_node_ids.insert(hitbox_id, node_id);
+        }
+    }
+
+    /// Look up the dispatch node associated with a hitbox in the current frame.
+    pub fn node_id_for_hitbox(&self, hitbox_id: HitboxId) -> Option<DispatchNodeId> {
+        self.hitbox_node_ids.get(&hitbox_id).copied()
+    }
+
+    /// Associates a hitbox with a remapped dispatch node when reusing a subtree.
+    pub fn associate_hitbox(&mut self, hitbox_id: HitboxId, node_id: DispatchNodeId) {
+        self.hitbox_node_ids.insert(hitbox_id, node_id);
     }
 
     pub fn set_view_id(&mut self, view_id: EntityId) {
@@ -317,6 +340,9 @@ impl DispatchTree {
                 self.view_node_ids.remove(&view_id);
             }
         }
+        // Hitbox-node associations are frame-local, so drop entries that pointed
+        // into the truncated range.
+        self.hitbox_node_ids.retain(|_, node_id| node_id.0 < index);
         self.nodes.truncate(index);
     }
 
@@ -445,7 +471,7 @@ impl DispatchTree {
         }
     }
 
-    fn bindings_for_input(
+    pub(crate) fn bindings_for_input(
         &self,
         input: &[Keystroke],
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
@@ -822,6 +848,68 @@ mod tests {
 
         assert_eq!(result.pending.len(), 1);
         assert!(!result.pending_has_binding);
+    }
+
+    #[test]
+    fn test_pointer_bindings_use_dispatch_path_context() {
+        let mut tree = test_dispatch_tree(vec![
+            KeyBinding::new("ctrl-middleclick", TestAction, Some("Editor")),
+            KeyBinding::new("ctrl-middleclick", SecondaryTestAction, Some("Workspace")),
+        ]);
+
+        let workspace_node = tree.push_node();
+        tree.set_key_context(KeyContext::parse("Workspace").unwrap());
+        let editor_node = tree.push_node();
+        tree.set_key_context(KeyContext::parse("Editor").unwrap());
+
+        let dispatch_path = tree.dispatch_path(editor_node);
+        let (bindings, pending, context_stack) = tree.bindings_for_input(
+            &[Keystroke::parse("ctrl-middleclick").unwrap()],
+            &dispatch_path,
+        );
+
+        assert!(!pending);
+        assert_eq!(context_stack.len(), 2);
+        assert_eq!(bindings.len(), 2);
+        assert!(bindings[0].action.partial_eq(&TestAction));
+        assert!(bindings[1].action.partial_eq(&SecondaryTestAction));
+
+        let dispatch_path = tree.dispatch_path(workspace_node);
+        let (bindings, pending, context_stack) = tree.bindings_for_input(
+            &[Keystroke::parse("ctrl-middleclick").unwrap()],
+            &dispatch_path,
+        );
+
+        assert!(!pending);
+        assert_eq!(context_stack.len(), 1);
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings[0].action.partial_eq(&SecondaryTestAction));
+    }
+
+    #[test]
+    fn test_hitbox_dispatch_node_associations_are_frame_local() {
+        let mut tree = test_dispatch_tree(Vec::new());
+
+        let root_node = tree.push_node();
+        tree.set_active_node_hitbox(crate::HitboxId::test(1));
+        assert_eq!(
+            tree.node_id_for_hitbox(crate::HitboxId::test(1)),
+            Some(root_node)
+        );
+
+        let child_node = tree.push_node();
+        tree.set_active_node_hitbox(crate::HitboxId::test(2));
+        assert_eq!(
+            tree.node_id_for_hitbox(crate::HitboxId::test(2)),
+            Some(child_node)
+        );
+
+        tree.truncate(child_node.0);
+        assert_eq!(
+            tree.node_id_for_hitbox(crate::HitboxId::test(1)),
+            Some(root_node)
+        );
+        assert_eq!(tree.node_id_for_hitbox(crate::HitboxId::test(2)), None);
     }
 
     #[crate::test]

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{Display, Write},
 };
 
-use crate::PlatformKeyboardMapper;
+use crate::{MouseButton, NavigationDirection, PlatformKeyboardMapper, ScrollDelta};
 
 /// This is a helper trait so that we can simplify the implementation of some functions
 pub trait AsKeystroke {
@@ -80,6 +80,11 @@ impl Keystroke {
     /// This method assumes that `self` was typed and `target' is in the keymap, and checks
     /// both possibilities for self against the target.
     pub fn should_match(&self, target: &KeybindingKeystroke) -> bool {
+        // Mouse and scroll keystrokes never participate in IME translation; match exact.
+        if is_pointer_key(&self.key) || is_pointer_key(&target.inner.key) {
+            return target.inner.modifiers == self.modifiers && target.inner.key == self.key;
+        }
+
         #[cfg(not(target_os = "windows"))]
         if let Some(key_char) = self
             .key_char
@@ -121,6 +126,7 @@ impl Keystroke {
         let mut modifiers = Modifiers::none();
         let mut key = None;
         let mut key_char = None;
+        let mut click_prefix: Option<&str> = None;
 
         let mut components = source.split('-').peekable();
         while let Some(component) = components.next() {
@@ -146,6 +152,14 @@ impl Keystroke {
                 } else {
                     modifiers.control = true;
                 };
+                continue;
+            }
+            if component.eq_ignore_ascii_case("double") {
+                click_prefix = Some("double");
+                continue;
+            }
+            if component.eq_ignore_ascii_case("triple") {
+                click_prefix = Some("triple");
                 continue;
             }
 
@@ -208,9 +222,19 @@ impl Keystroke {
             }
         });
 
-        let key = key.ok_or_else(|| InvalidKeystrokeError {
+        let mut key = key.ok_or_else(|| InvalidKeystrokeError {
             keystroke: source.to_owned(),
         })?;
+
+        if let Some(prefix) = click_prefix {
+            // `double`/`triple` are only meaningful in front of a mouse-button key.
+            if !is_mouse_button_key(&key) {
+                return Err(InvalidKeystrokeError {
+                    keystroke: source.to_owned(),
+                });
+            }
+            key = format!("{prefix}{key}");
+        }
 
         Ok(Keystroke {
             modifiers,
@@ -233,6 +257,54 @@ impl Keystroke {
                 || self.modifiers.control
                 || self.modifiers.function
                 || self.modifiers.alt)
+    }
+
+    /// Build a keystroke representing a mouse-button event.
+    /// `click_count` of 2 produces a `doubleleftclick`-style key; 3 → `tripleleftclick`.
+    pub fn from_mouse_button(
+        button: MouseButton,
+        modifiers: Modifiers,
+        click_count: usize,
+    ) -> Self {
+        let base = match button {
+            MouseButton::Left => "leftclick",
+            MouseButton::Right => "rightclick",
+            MouseButton::Middle => "middleclick",
+            MouseButton::Navigate(NavigationDirection::Back) => "backclick",
+            MouseButton::Navigate(NavigationDirection::Forward) => "forwardclick",
+        };
+        let key = match click_count {
+            2 => format!("double{base}"),
+            3 => format!("triple{base}"),
+            _ => base.to_string(),
+        };
+        Keystroke {
+            modifiers,
+            key,
+            key_char: None,
+        }
+    }
+
+    /// Build a keystroke representing a scroll-wheel event, or `None` if the
+    /// scroll delta has no clear vertical direction.
+    pub fn from_scroll(delta: ScrollDelta, modifiers: Modifiers) -> Option<Self> {
+        let dy = match delta {
+            ScrollDelta::Pixels(p) => p.y.0,
+            ScrollDelta::Lines(p) => p.y,
+        };
+        if dy == 0.0 {
+            return None;
+        }
+        let key = if dy > 0.0 {
+            "mousescrollup"
+        } else {
+            "mousescrolldown"
+        };
+        Some(Keystroke {
+            modifiers,
+            key: key.into(),
+            key_char: None,
+        })
     }
 
     /// Returns a new keystroke with the key_char filled.
@@ -375,7 +447,30 @@ impl KeybindingKeystroke {
     }
 }
 
+fn is_mouse_button_key(key: &str) -> bool {
+    matches!(
+        key,
+        "leftclick" | "rightclick" | "middleclick" | "backclick" | "forwardclick"
+    )
+}
+
+fn is_pointer_key(key: &str) -> bool {
+    if matches!(key, "mousescrollup" | "mousescrolldown") {
+        return true;
+    }
+    if is_mouse_button_key(key) {
+        return true;
+    }
+    if let Some((_, rest)) = split_click_prefix(key) {
+        return is_mouse_button_key(rest);
+    }
+    false
+}
+
 fn is_printable_key(key: &str) -> bool {
+    if is_pointer_key(key) {
+        return false;
+    }
     !matches!(
         key,
         "f1" | "f2"
@@ -771,6 +866,68 @@ fn unparse(modifiers: &Modifiers, key: &str) -> String {
     if modifiers.shift {
         result.push_str("shift-");
     }
-    result.push_str(&key);
+    if let Some((prefix, base)) = split_click_prefix(key) {
+        result.push_str(prefix);
+        result.push('-');
+        result.push_str(base);
+    } else {
+        result.push_str(key);
+    }
     result
+}
+
+/// If `key` is a `double`/`triple`-prefixed mouse-button key, return `(prefix, base)`.
+fn split_click_prefix(key: &str) -> Option<(&'static str, &str)> {
+    if let Some(rest) = key.strip_prefix("double") {
+        if is_mouse_button_key(rest) {
+            return Some(("double", rest));
+        }
+    }
+    if let Some(rest) = key.strip_prefix("triple") {
+        if is_mouse_button_key(rest) {
+            return Some(("triple", rest));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mouse_button_keystrokes() {
+        let keystroke = Keystroke::parse("ctrl-middleclick").unwrap();
+        assert!(keystroke.modifiers.control);
+        assert_eq!(keystroke.key, "middleclick");
+        assert_eq!(keystroke.unparse(), "ctrl-middleclick");
+
+        let keystroke = Keystroke::parse("double-leftclick").unwrap();
+        assert_eq!(keystroke.key, "doubleleftclick");
+        assert_eq!(keystroke.unparse(), "double-leftclick");
+
+        let keystroke = Keystroke::parse("triple-rightclick").unwrap();
+        assert_eq!(keystroke.key, "triplerightclick");
+        assert_eq!(keystroke.unparse(), "triple-rightclick");
+    }
+
+    #[test]
+    fn parses_scroll_keystrokes() {
+        let keystroke = Keystroke::parse("ctrl-mousescrollup").unwrap();
+        assert!(keystroke.modifiers.control);
+        assert_eq!(keystroke.key, "mousescrollup");
+        assert_eq!(keystroke.unparse(), "ctrl-mousescrollup");
+
+        let keystroke = Keystroke::parse("alt-mousescrolldown").unwrap();
+        assert!(keystroke.modifiers.alt);
+        assert_eq!(keystroke.key, "mousescrolldown");
+        assert_eq!(keystroke.unparse(), "alt-mousescrolldown");
+    }
+
+    #[test]
+    fn rejects_click_count_prefix_for_non_mouse_buttons() {
+        assert!(Keystroke::parse("double-a").is_err());
+        assert!(Keystroke::parse("double-mousescrollup").is_err());
+        assert!(Keystroke::parse("triple-mousescrolldown").is_err());
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -8,17 +8,17 @@ use crate::{
     EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
     Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
     KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite,
-    MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
-    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
-    Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage,
-    RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
-    SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, Shadow, SharedString, Size,
-    StrikethroughStyle, Style, SubpixelSprite, SubscriberSet, Subscription, SystemWindowTab,
-    SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task, TextRenderingMode, TextStyle,
-    TextStyleRefinement, ThermalState, TransformationMatrix, Underline, UnderlineStyle,
-    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControls, WindowDecorations,
-    WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, profiler, px, rems, size,
-    transparent_black,
+    MouseButton, MouseDownEvent, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels,
+    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
+    PolychromeSprite, Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams,
+    RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
+    SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, ScrollWheelEvent, Shadow,
+    SharedString, Size, StrikethroughStyle, Style, SubpixelSprite, SubscriberSet, Subscription,
+    SystemWindowTab, SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task,
+    TextRenderingMode, TextStyle, TextStyleRefinement, ThermalState, TransformationMatrix,
+    Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance, WindowBounds,
+    WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowTextSystem, point,
+    prelude::*, profiler, px, rems, size, transparent_black,
 };
 
 use anyhow::{Context as _, Result, anyhow};
@@ -620,6 +620,11 @@ impl HitboxId {
 }
 
 impl HitboxId {
+    #[cfg(test)]
+    pub(crate) const fn test(id: u64) -> Self {
+        Self(id)
+    }
+
     /// Checks if the hitbox with this ID is currently hovered. Returns `false` during keyboard
     /// input modality so that keyboard navigation suppresses hover highlights. Except when handling
     /// `ScrollWheelEvent`, this is typically what you want when determining whether to handle mouse
@@ -1054,6 +1059,10 @@ pub struct Window {
     /// The hitbox that has captured the pointer, if any.
     /// While captured, mouse events route to this hitbox regardless of hit testing.
     captured_hitbox: Option<HitboxId>,
+    /// When a `MouseDown` triggered a keymap-bound action, the matching `MouseUp` is
+    /// swallowed so the bound action doesn't also produce a click. Stores the
+    /// `(button, modifiers)` of the consumed press.
+    suppressed_mouse_up: Option<(MouseButton, Modifiers)>,
     #[cfg(any(feature = "inspector", debug_assertions))]
     inspector: Option<Entity<Inspector>>,
     pub(crate) a11y: A11y,
@@ -1756,6 +1765,7 @@ impl Window {
             client_inset: None,
             image_cache_stack: Vec::new(),
             captured_hitbox: None,
+            suppressed_mouse_up: None,
             #[cfg(any(feature = "inspector", debug_assertions))]
             inspector: None,
             a11y: A11y::new(
@@ -3099,6 +3109,23 @@ impl Window {
             self.next_frame.focus = self.focus;
         }
 
+        // Carry over hitbox-node associations from the reused range,
+        // remapping node ids into the new frame's index space.
+        for hitbox in
+            &self.rendered_frame.hitboxes[range.start.hitboxes_index..range.end.hitboxes_index]
+        {
+            if let Some(old_node_id) = self
+                .rendered_frame
+                .dispatch_tree
+                .node_id_for_hitbox(hitbox.id)
+            {
+                let new_node_id = reused_subtree.refresh_node_id(old_node_id);
+                self.next_frame
+                    .dispatch_tree
+                    .associate_hitbox(hitbox.id, new_node_id);
+            }
+        }
+
         self.next_frame.deferred_draws.extend(
             self.rendered_frame.deferred_draws
                 [range.start.deferred_draws_index..range.end.deferred_draws_index]
@@ -4253,6 +4280,11 @@ impl Window {
             behavior,
         };
         self.next_frame.hitboxes.push(hitbox.clone());
+        // Pointer bindings dispatch against the node path under the cursor, so
+        // remember which dispatch node produced each hitbox.
+        self.next_frame
+            .dispatch_tree
+            .set_active_node_hitbox(hitbox.id);
         hitbox
     }
 
@@ -4625,10 +4657,24 @@ impl Window {
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };
 
-        if let Some(any_mouse_event) = event.mouse_event() {
-            self.dispatch_mouse_event(any_mouse_event, cx);
-        } else if let Some(any_key_event) = event.keyboard_event() {
-            self.dispatch_key_event(any_key_event, cx);
+        // Give keymap-bound mouse and scroll actions a chance to run before the normal
+        // mouse listener chain. MouseUp is suppressed when its matching MouseDown
+        // consumed a binding, so dragging logic isn't tripped.
+        let consumed_by_binding = match &event {
+            PlatformInput::MouseDown(mouse_down) => {
+                self.try_dispatch_mouse_button_binding(mouse_down, cx)
+            }
+            PlatformInput::MouseUp(mouse_up) => self.try_consume_suppressed_mouse_up(mouse_up),
+            PlatformInput::ScrollWheel(scroll) => self.try_dispatch_scroll_binding(scroll, cx),
+            _ => false,
+        };
+
+        if !consumed_by_binding {
+            if let Some(any_mouse_event) = event.mouse_event() {
+                self.dispatch_mouse_event(any_mouse_event, cx);
+            } else if let Some(any_key_event) = event.keyboard_event() {
+                self.dispatch_key_event(any_key_event, cx);
+            }
         }
 
         if self.invalidator.update_count() > update_count_before {
@@ -5012,6 +5058,94 @@ impl Window {
                     .focusable_node_id(focus_id)
             })
             .unwrap_or_else(|| self.rendered_frame.dispatch_tree.root_node_id())
+    }
+
+    /// Returns dispatch nodes under the cursor, from frontmost to back.
+    ///
+    /// Hitboxes can be layered: a front hitbox may have no matching pointer binding while a
+    /// hitbox behind it does. Try each associated node in paint order before falling back to focus.
+    fn dispatch_node_ids_at_cursor(&self) -> SmallVec<[DispatchNodeId; 8]> {
+        let dispatch_tree = &self.rendered_frame.dispatch_tree;
+        let mut node_ids = SmallVec::new();
+        for hitbox_id in &self.mouse_hit_test.ids {
+            if let Some(node_id) = dispatch_tree.node_id_for_hitbox(*hitbox_id) {
+                if !node_ids.contains(&node_id) {
+                    node_ids.push(node_id);
+                }
+            }
+        }
+        node_ids
+    }
+
+    /// Resolve and dispatch keymap bindings for a synthesized pointer keystroke against the
+    /// dispatch path under the cursor. Returns whether any binding consumed the event.
+    fn dispatch_pointer_keystroke(&mut self, keystroke: &Keystroke, cx: &mut App) -> bool {
+        let hit_test = self.rendered_frame.hit_test(self.mouse_position());
+        if hit_test != self.mouse_hit_test {
+            self.mouse_hit_test = hit_test;
+            self.reset_cursor_style(cx);
+        }
+
+        let mut node_ids = self.dispatch_node_ids_at_cursor();
+        let focused_node_id = self.focus_node_id_in_rendered_frame(self.focus);
+        if !node_ids.contains(&focused_node_id) {
+            node_ids.push(focused_node_id);
+        }
+
+        let Some((node_id, bindings)) = node_ids.into_iter().find_map(|node_id| {
+            let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
+            let (bindings, _, _) = self
+                .rendered_frame
+                .dispatch_tree
+                .bindings_for_input(std::slice::from_ref(keystroke), &dispatch_path);
+            (!bindings.is_empty()).then_some((node_id, bindings))
+        }) else {
+            return false;
+        };
+
+        for binding in bindings {
+            cx.propagate_event = true;
+            self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
+            if !cx.propagate_event {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn try_dispatch_mouse_button_binding(&mut self, event: &MouseDownEvent, cx: &mut App) -> bool {
+        let keystroke =
+            Keystroke::from_mouse_button(event.button, event.modifiers, event.click_count);
+        if self.dispatch_pointer_keystroke(&keystroke, cx) {
+            // Suppress the matching MouseUp so click handlers don't also fire.
+            self.suppressed_mouse_up = Some((event.button, event.modifiers));
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_dispatch_scroll_binding(&mut self, event: &ScrollWheelEvent, cx: &mut App) -> bool {
+        // Only consider scroll bindings when at least one modifier is held, so plain
+        // scrolling continues to flow through the normal listener chain.
+        if !event.modifiers.modified() {
+            return false;
+        }
+        let Some(keystroke) = Keystroke::from_scroll(event.delta, event.modifiers) else {
+            return false;
+        };
+        self.dispatch_pointer_keystroke(&keystroke, cx)
+    }
+
+    fn try_consume_suppressed_mouse_up(&mut self, event: &MouseUpEvent) -> bool {
+        if let Some((button, modifiers)) = self.suppressed_mouse_up
+            && button == event.button
+            && modifiers == event.modifiers
+        {
+            self.suppressed_mouse_up = None;
+            return true;
+        }
+        false
     }
 
     fn dispatch_action_on_node(


### PR DESCRIPTION
Closes #10647

Replaces #53889 with the approach Conrad and I aligned on: 
unify mouse/scroll into `Keystroke` rather than introducing parallel `MouseStroke`/`ScrollStroke` types, and resolve bindings against the dispatch path under the cursor rather than the keyboard-focus path.

### Design choices worth flagging

- **Probe runs before the mouse listener chain.** A bound mouse action pre-empts the editor's existing modifier-click handlers; if a binding fires, the normal `dispatch_mouse_event` is skipped.
- **MouseUp suppression.** When a `MouseDown` consumed a binding, the matching `MouseUp` (same button + modifiers) is swallowed so click handlers downstream don't double-fire.
- **Scroll bindings only fire with a modifier held.** Unmodified scrolling continues through the normal listener chain, so we don't walk the keymap on every scroll tick.

Are these fine? or do they requries some changes? 

### Other changes

- Mouse buttons and scroll events become `Keystroke` values with special key names: `leftclick`/`rightclick`/`middleclick`/`backclick`/ `forwardclick`, `mousescrollup`/`mousescrolldown`. 
- Click count is encoded in the key (`doubleleftclick`, `tripleleftclick`) so no field  added to `Keystroke`. Naming follows
Conrad's suggestion.
- New `HitboxId → DispatchNodeId` map on `DispatchTree`, populated by `Window::insert_hitbox`, remapped through `reuse_subtree`.
- Five editor actions: `AddCursorAtMouse`, `ExtendSelectionToMouse`, `GoToDefinitionAtMouse`, `GoToTypeDefinitionAtMouse`, `StartColumnarSelectionAtMouse`.

### Example keymap

```json
[
  {
    "context": "Editor",
    "bindings": {
      "alt-leftclick":       "editor::GoToDefinitionAtMouse",
      "shift-leftclick":     "editor::ExtendSelectionToMouse",
      "ctrl-leftclick":      "editor::AddCursorAtMouse",
      "alt-shift-leftclick": "editor::StartColumnarSelectionAtMouse",
      "ctrl-mousescrollup":   "zed::IncreaseBufferFontSize",
      "ctrl-mousescrolldown": "zed::DecreaseBufferFontSize"
    }
  },
]
```

Video 

[Screencast from 2026-04-29 19-48-18.webm](https://github.com/user-attachments/assets/dc835d0f-ff6d-4970-9f8f-1e9c6106254c)

Release Notes:

- Added user-configurable mouse button and scroll wheel keybindings in keymap.json