### PR TITLE
git_panel: Fix empty state label not align to center

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4824,7 +4824,13 @@ impl GitPanel {
     }
 
     fn render_no_changes_ui(&self, cx: &Context<Self>) -> Vec<AnyElement> {
-        let mut elements: Vec<AnyElement> = vec!["No changes to commit".into_any_element()];
+        let mut elements: Vec<AnyElement> = vec![
+            div()
+                .self_stretch()
+                .text_center()
+                .child("No changes to commit")
+                .into_any_element(),
+        ];
 
         if self.changes_count == 0 && !self.is_on_main_branch(cx) {
             elements.push(
@@ -4906,7 +4912,11 @@ impl GitPanel {
         let worktree_count = self.project.read(cx).visible_worktrees(cx).count();
         if worktree_count > 0 && self.active_repository.is_none() {
             vec![
-                "No Git Repositories".into_any_element(),
+                div()
+                    .self_stretch()
+                    .text_center()
+                    .child("No Git Repositories")
+                    .into_any_element(),
                 panel_filled_button("Initialize Repository")
                     .tooltip(Tooltip::for_action_title_in(
                         "git init",


### PR DESCRIPTION
When the git panel is too narrow for "No changes to commit" or "No Git Repositories" to fit on a single line, the wrapped lines were start-aligned while the button below remained centered, breaking the visual stack.

This wraps each label in a stretched, text-centered `div`, matching the pattern already used by `render_unsafe_repo_ui` in the same file. The bare string is kept (no `Label`) so the parent `v_flex`'s `text_color(Color::Placeholder)` continues to apply unchanged.

### Repository detect

| As-is | To-be |
| --- | --- |
| <img width="400" src="https://github.com/user-attachments/assets/d4388d15-057f-4ea2-ac02-528aa165578a" /> | <img width="400" src="https://github.com/user-attachments/assets/a7901061-9ff2-4bbc-b135-728089d6f43e" /> |

### Repository not detect

| As-is | To-be |
| --- | --- |
| <img width="400" src="https://github.com/user-attachments/assets/cc41387a-108e-43c1-848e-f7241dd33c73" /> | <img width="400" src="https://github.com/user-attachments/assets/c8a2f263-9fe4-450f-9d54-174bfa68e483" /> |



Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes N/A

Release Notes:

- git_panel: Fixed empty state labels in the git panel becoming left-aligned when wrapped to multiple lines