### PR TITLE
git_graph: Fix mouse cursor not switching to cursor pointer in git graph

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -2811,6 +2811,7 @@ impl Render for GitGraph {
                                 .id("graph-canvas")
                                 .size_full()
                                 .overflow_hidden()
+                                .cursor_pointer()
                                 .child(
                                     div()
                                         .size_full()
@@ -2846,6 +2847,7 @@ impl Render for GitGraph {
                                     };
 
                                     row.h(row_height)
+                                        .cursor_pointer()
                                         .when(is_selected, |row| row.bg(selected_bg))
                                         .when(is_hovered && !is_selected, |row| row.bg(hover_bg))
                                         .on_hover(move |&is_hovered, _, cx| {


### PR DESCRIPTION
This PR calls 'cursor_pointer()' on the appropriate UI elements. It is a very small change, but it is my first time contributing, so please let me know if I have made any mistakes.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55218

Release Notes:

- Fixed the mouse cursor not switching to cursor pointer when hovering commit rows in the git graph