### PR TITLE
docs: Add Tailwind LSP configuration section for Go (Templ)

### DIFF
--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -234,3 +234,26 @@ In such case Zed won't spawn a new instance of Delve, as it opts to use an exist
 - Tree-sitter:
   [tree-sitter-go-work](https://github.com/d1y/tree-sitter-go-work)
 - Language Server: N/A
+
+## Using the Tailwind CSS Language Server with Templ
+
+[Templ](https://github.com/a-h/templ) is an HTML templating language for Go. Templ files are not recognised as HTML by default, so the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) needs to be told to treat them as HTML and where to look for class names. With the [Templ extension](https://github.com/makifdb/zed-templ) installed, add the following to your `settings.json`:
+
+```json [settings]
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "includeLanguages": {
+          "templ": "html"
+        },
+        "experimental": {
+          "classRegex": ["class=\"([^\"]*)\"", "className=\"([^\"]*)\""]
+        }
+      }
+    }
+  }
+}
+```
+
+With these settings you'll get Tailwind completions inside `class="..."` (and `className="..."`) attributes in `.templ` files.

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -248,7 +248,7 @@ In such case Zed won't spawn a new instance of Delve, as it opts to use an exist
           "templ": "html"
         },
         "experimental": {
-          "classRegex": ["class=\"([^\"]*)\"", "className=\"([^\"]*)\""]
+          "classRegex": ["class=\"([^\"]*)\""]
         }
       }
     }
@@ -256,4 +256,4 @@ In such case Zed won't spawn a new instance of Delve, as it opts to use an exist
 }
 ```
 
-With these settings you'll get Tailwind completions inside `class="..."` (and `className="..."`) attributes in `.templ` files.
+With these settings you'll get Tailwind completions inside `class="..."` attributes in `.templ` files.

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -261,6 +261,6 @@ To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS lan
 }
 ```
 
-> Note: You need to enable the language server for Templ, tell it to treat .templ files as HTML (they are not recognised as HTML by default)
+> Note: Unlike other languages, you need to tell Tailwind to treat `.templ` files as HTML explicitly.
 
 This gives you Tailwind CSS completions inside `class="..."` attributes in your `.templ` files.

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -237,10 +237,15 @@ In such case Zed won't spawn a new instance of Delve, as it opts to use an exist
 
 ## Using the Tailwind CSS Language Server with Templ
 
-[Templ](https://github.com/a-h/templ) is an HTML templating language for Go. Templ files are not recognised as HTML by default, so the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) needs to be told to treat them as HTML and where to look for class names. With the [Templ extension](https://github.com/makifdb/zed-templ) installed, add the following to your `settings.json`:
+To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in [Templ](https://github.com/a-h/templ) files, you need to enable the language server for Templ and configure where it should look for CSS classes by adding the following to your `settings.json`:
 
 ```json [settings]
 {
+  "languages": {
+    "Templ": {
+      "language_servers": ["tailwindcss-language-server", "..."]
+    }
+  },
   "lsp": {
     "tailwindcss-language-server": {
       "settings": {
@@ -256,4 +261,6 @@ In such case Zed won't spawn a new instance of Delve, as it opts to use an exist
 }
 ```
 
-With these settings you'll get Tailwind completions inside `class="..."` attributes in `.templ` files.
+> Note: You need to enable the language server for Templ, tell it to treat .templ files as HTML (they are not recognised as HTML by default)
+
+This gives you Tailwind CSS completions inside `class="..."` attributes in your `.templ` files.

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -15,6 +15,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [CSS](./css.md)
 - [ERB](./ruby.md#using-the-tailwind-css-language-server-with-ruby)
 - [Gleam](./gleam.md#using-the-tailwind-css-language-server-with-gleam)
+- [Go (Templ)](./go.md#using-the-tailwind-css-language-server-with-templ)
 - [HEEx](./elixir.md#using-the-tailwind-css-language-server-with-heex-templates)
 - [HTML](./html.md#using-the-tailwind-css-language-server-with-html)
 - [TypeScript](./typescript.md#using-the-tailwind-css-language-server-with-typescript)


### PR DESCRIPTION
Document how to configure the Tailwind CSS language server for Go (Templ).

Ref #43969.

Release Notes:

- N/A