### PR TITLE
Handle OpenAI-compatible quota errors

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -3145,6 +3145,7 @@ impl Thread {
             | AuthenticationError { .. }
             | PermissionError { .. }
             | NoApiKey { .. }
+            | BillingQuotaExceeded { .. }
             | ApiEndpointNotFound { .. }
             | PromptTooLarge { .. } => None,
             // These errors might be transient, so retry them

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -123,6 +123,9 @@ pub(crate) enum ThreadError {
     RateLimitExceeded {
         provider: SharedString,
     },
+    BillingQuotaExceeded {
+        provider: SharedString,
+    },
     ServerOverloaded {
         provider: SharedString,
     },
@@ -167,6 +170,9 @@ impl From<anyhow::Error> for ThreadError {
             use LanguageModelCompletionError::*;
             match lm_error {
                 RateLimitExceeded { provider, .. } => Self::RateLimitExceeded {
+                    provider: provider.to_string().into(),
+                },
+                BillingQuotaExceeded { provider, .. } => Self::BillingQuotaExceeded {
                     provider: provider.to_string().into(),
                 },
                 ServerOverloaded { provider, .. } | ApiInternalServerError { provider, .. } => {
@@ -2972,6 +2978,21 @@ pub(crate) mod tests {
     use crate::thread_metadata_store::ThreadMetadataStore;
 
     use super::*;
+
+    #[test]
+    fn test_thread_error_maps_billing_quota_exceeded() {
+        let error = anyhow::anyhow!(LanguageModelCompletionError::BillingQuotaExceeded {
+            provider: String::from("xAI").into(),
+            message: "No credits remaining for this API key".to_string(),
+        });
+
+        match ThreadError::from(error) {
+            ThreadError::BillingQuotaExceeded { provider } => {
+                assert_eq!(provider.to_string(), "xAI")
+            }
+            error => panic!("Expected BillingQuotaExceeded thread error, got: {error:?}"),
+        }
+    }
 
     #[gpui::test]
     async fn test_drop(cx: &mut TestAppContext) {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1251,6 +1251,11 @@ impl ThreadView {
                     None,
                     format!("{provider}'s rate limit was reached.").into(),
                 ),
+                ThreadError::BillingQuotaExceeded { provider } => (
+                    "billing_quota_exceeded",
+                    None,
+                    format!("{provider}'s API quota or credits are exhausted.").into(),
+                ),
                 ThreadError::ServerOverloaded { provider } => (
                     "server_overloaded",
                     None,
@@ -8264,6 +8269,17 @@ impl ThreadView {
                 .into(),
                 true,
                 true,
+                cx,
+            ),
+            ThreadError::BillingQuotaExceeded { provider } => self.render_error_callout(
+                "Credits or Quota Exhausted",
+                format!(
+                    "{provider}'s API key has exhausted its credits or billing quota. \
+                    Add credits or update billing with {provider}, then try again."
+                )
+                .into(),
+                false,
+                false,
                 cx,
             ),
             ThreadError::ServerOverloaded { provider } => self.render_error_callout(

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -102,6 +102,11 @@ pub enum LanguageModelCompletionError {
         provider: LanguageModelProviderName,
         retry_after: Option<Duration>,
     },
+    #[error("{provider}'s API quota or credits are exhausted: {message}")]
+    BillingQuotaExceeded {
+        provider: LanguageModelProviderName,
+        message: String,
+    },
     #[error("{provider}'s API servers are overloaded right now")]
     ServerOverloaded {
         provider: LanguageModelProviderName,
@@ -193,6 +198,82 @@ impl LanguageModelCompletionError {
         Some((upstream_status, inner_message))
     }
 
+    fn quota_exhaustion_message(message: &str) -> Option<String> {
+        let error_json = serde_json::from_str::<serde_json::Value>(message).ok();
+
+        if let Some(error_json) = error_json.as_ref() {
+            if let Some(code) = Self::error_json_string_field(error_json, "code")
+                .or_else(|| Self::error_json_string_field(error_json, "type"))
+                && Self::is_quota_exhaustion_code(code)
+            {
+                return Some(Self::error_json_message(error_json, message));
+            }
+
+            let error_message = Self::error_json_message(error_json, message);
+            if Self::is_quota_exhaustion_text(&error_message) {
+                return Some(error_message);
+            }
+        } else if Self::is_quota_exhaustion_text(message) {
+            return Some(message.to_string());
+        }
+
+        None
+    }
+
+    fn error_json_string_field<'a>(
+        error_json: &'a serde_json::Value,
+        field: &str,
+    ) -> Option<&'a str> {
+        error_json
+            .get("error")
+            .and_then(|error| error.get(field))
+            .or_else(|| error_json.get(field))
+            .and_then(|value| value.as_str())
+    }
+
+    fn error_json_message(error_json: &serde_json::Value, fallback: &str) -> String {
+        error_json
+            .get("error")
+            .and_then(|error| {
+                error
+                    .get("message")
+                    .and_then(|message| message.as_str())
+                    .or_else(|| error.as_str())
+            })
+            .or_else(|| {
+                error_json
+                    .get("message")
+                    .and_then(|message| message.as_str())
+            })
+            .unwrap_or(fallback)
+            .to_string()
+    }
+
+    fn is_quota_exhaustion_code(code: &str) -> bool {
+        matches!(
+            code.to_ascii_lowercase().as_str(),
+            "billing_hard_limit_reached"
+                | "credits_exhausted"
+                | "insufficient_credits"
+                | "insufficient_quota"
+                | "payment_required"
+        )
+    }
+
+    fn is_quota_exhaustion_text(message: &str) -> bool {
+        let message = message.to_ascii_lowercase();
+        [
+            "credit balance is too low",
+            "insufficient credits",
+            "no credits",
+            "out of credits",
+            "ran out of credits",
+            "run out of credits",
+        ]
+        .iter()
+        .any(|phrase| message.contains(phrase))
+    }
+
     pub fn from_cloud_failure(
         upstream_provider: LanguageModelProviderName,
         code: String,
@@ -244,10 +325,16 @@ impl LanguageModelCompletionError {
             StatusCode::PAYLOAD_TOO_LARGE => Self::PromptTooLarge {
                 tokens: parse_prompt_too_long(&message),
             },
-            StatusCode::TOO_MANY_REQUESTS => Self::RateLimitExceeded {
-                provider,
-                retry_after,
-            },
+            StatusCode::TOO_MANY_REQUESTS => {
+                if let Some(message) = Self::quota_exhaustion_message(&message) {
+                    Self::BillingQuotaExceeded { provider, message }
+                } else {
+                    Self::RateLimitExceeded {
+                        provider,
+                        retry_after,
+                    }
+                }
+            }
             StatusCode::INTERNAL_SERVER_ERROR => Self::ApiInternalServerError { provider, message },
             StatusCode::SERVICE_UNAVAILABLE => Self::ServerOverloaded {
                 provider,
@@ -531,6 +618,58 @@ mod tests {
                 assert_eq!(provider.0, "anthropic");
             }
             _ => panic!("Expected ServerOverloaded error for upstream_http_503"),
+        }
+    }
+
+    #[test]
+    fn test_openai_insufficient_quota_429_is_not_rate_limit() {
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("openai-compatible").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","param":null,"code":"insufficient_quota"}}"#.to_string(),
+            None,
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "openai-compatible's API quota or credits are exhausted: You exceeded your current quota, please check your plan and billing details."
+        );
+    }
+
+    #[test]
+    fn test_openai_compatible_no_credits_429_is_not_rate_limit() {
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("xAI").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":"No credits remaining for this API key"}"#.to_string(),
+            None,
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "xAI's API quota or credits are exhausted: No credits remaining for this API key"
+        );
+    }
+
+    #[test]
+    fn test_openai_rate_limit_429_remains_rate_limit() {
+        let retry_after = Duration::from_secs(30);
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("openai-compatible").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"message":"Requests are too frequent","type":"rate_limit_error","code":"rate_limit_exceeded"}}"#.to_string(),
+            Some(retry_after),
+        );
+
+        match error {
+            LanguageModelCompletionError::RateLimitExceeded {
+                provider,
+                retry_after: Some(actual_retry_after),
+            } => {
+                assert_eq!(provider.0, "openai-compatible");
+                assert_eq!(actual_retry_after, retry_after);
+            }
+            _ => panic!("Expected RateLimitExceeded for a rate limit response, got: {error:?}"),
         }
     }
 


### PR DESCRIPTION
Fixes #54996

## Summary

- Added a distinct `BillingQuotaExceeded` language model error for known OpenAI-compatible 429 quota/credit exhaustion responses.
- Kept true 429 rate-limit responses on the existing retryable rate-limit path.
- Render quota/credit exhaustion as a non-retryable Agent Panel callout and exclude it from automatic retry strategy.

## Root Cause

OpenAI-compatible providers can return HTTP 429 for both rate limits and exhausted credits/quota. Zed mapped every 429 to `RateLimitExceeded`, so exhausted-credit responses were shown as retryable rate limits.

## Validation

- `cargo test -p language_model_core --lib`
- `./script/clippy -p language_model_core`
- `cargo check -p agent --lib`
- Attempted: `cargo test -p agent_ui test_thread_error_maps_billing_quota_exceeded --lib`
  - Blocked locally by the macOS build environment: `xcrun: error: unable to find utility "metal", not a developer tool or in PATH`

Release Notes:

- Fixed OpenAI-compatible provider out-of-credits errors being shown as retryable rate limits.
