### PR TITLE
tools: Make time-zones more case-insensitive

### DIFF
--- a/crates/agent/src/tools/now_tool.rs
+++ b/crates/agent/src/tools/now_tool.rs
@@ -13,8 +13,10 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput};
 #[schemars(inline)]
 pub enum Timezone {
     /// Use UTC for the datetime.
+    #[serde(alias = "UTC", alias = "Utc")]
     Utc,
     /// Use local time for the datetime.
+    #[serde(alias = "LOCAL", alias = "Local")]
     Local,
 }
 


### PR DESCRIPTION
gpt-5.5 likes to call the `now` tool with upper-case "UTC", leading to this error:

> Failed to receive tool input: tool input was not fully received


Release Notes:

- N/A