### PR TITLE
workspace: Retain previous project when opening with sidebar closed

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1957,6 +1957,9 @@ impl MultiWorkspace {
                 }
 
                 let create_task = this.update_in(cx, |this, window, cx| {
+                    if empty_workspace.is_none() {
+                        this.retain_active_workspace(cx);
+                    }
                     this.find_or_create_local_workspace(
                         PathList::new(&paths),
                         None,

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -259,6 +259,87 @@ async fn test_open_directory_in_empty_workspace_does_not_open_sidebar(cx: &mut T
 }
 
 #[gpui::test]
+async fn test_open_project_retains_previous_workspace_when_sidebar_is_closed(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let app_state = cx.update(AppState::test);
+    let fs = app_state.fs.as_fake();
+    fs.insert_tree(path!("/project_a"), json!({ "file_a.txt": "" }))
+        .await;
+    fs.insert_tree(path!("/project_b"), json!({ "file_b.txt": "" }))
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+    window
+        .read_with(cx, |mw, _cx| {
+            assert!(!mw.sidebar_open(), "sidebar should start closed");
+        })
+        .unwrap();
+
+    let workspace_a = window
+        .update(cx, |mw, window, cx| {
+            mw.open_project(
+                vec![PathBuf::from(path!("/project_a"))],
+                OpenMode::Activate,
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let workspace_b = window
+        .update(cx, |mw, window, cx| {
+            mw.open_project(
+                vec![PathBuf::from(path!("/project_b"))],
+                OpenMode::Activate,
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_ne!(workspace_a, workspace_b);
+    window
+        .update(cx, |mw, _window, cx| {
+            assert!(!mw.sidebar_open(), "sidebar should still be closed");
+            assert_eq!(
+                mw.project_group_keys(),
+                vec![ProjectGroupKey::new(
+                    None,
+                    PathList::new(&[path!("/project_a")])
+                )]
+            );
+            mw.open_sidebar(cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    window
+        .read_with(cx, |mw, _cx| {
+            assert!(mw.sidebar_open());
+            assert_eq!(mw.workspaces().count(), 2);
+            assert_eq!(
+                mw.project_group_keys(),
+                vec![
+                    ProjectGroupKey::new(None, PathList::new(&[path!("/project_b")])),
+                    ProjectGroupKey::new(None, PathList::new(&[path!("/project_a")])),
+                ]
+            );
+        })
+        .unwrap();
+}
+
+#[gpui::test]
 async fn test_project_group_keys_duplicate_not_added(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.executor());


### PR DESCRIPTION
Closes #55169

Ensures that opening a project with the workspace sidebar closed retains the previously active non-empty workspace before activating the newly opened project. This prevents the previous project from disappearing when the sidebar is opened later.

Added a regression test covering the closed-sidebar flow: open project A, open project B, then open the sidebar and verify both project groups are present.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed projects disappearing from the workspace sidebar when opening multiple projects while the sidebar is closed
