### PR TITLE
docs: Clarify search_web tool availability for Zed Pro

### DIFF
--- a/docs/src/ai/tools.md
+++ b/docs/src/ai/tools.md
@@ -61,6 +61,8 @@ Allows the Agent to work through problems, brainstorm ideas, or plan without exe
 
 Searches the web for information, providing results with snippets and links from relevant web pages, useful for accessing real-time information.
 
+> **Note:** The built-in `search_web` tool is only available to [Zed Pro](https://zed.dev/pricing) subscribers. If you're on a free plan, you can get equivalent functionality by connecting an MCP server that provides web search capabilities. See [MCP servers](./mcp.md) for details.
+
 **Example:** Looking up whether a known bug in a dependency has been patched in a recent release, or finding the current API signature for a third-party library when the local docs are out of date.
 
 ## Edit Tools

--- a/docs/src/ai/tools.md
+++ b/docs/src/ai/tools.md
@@ -61,9 +61,9 @@ Allows the Agent to work through problems, brainstorm ideas, or plan without exe
 
 Searches the web for information, providing results with snippets and links from relevant web pages, useful for accessing real-time information.
 
-> **Note:** The built-in `search_web` tool is only available to [Zed Pro](https://zed.dev/pricing) subscribers. If you're on a free plan, you can get equivalent functionality by connecting an MCP server that provides web search capabilities. See [MCP servers](./mcp.md) for details.
-
 **Example:** Looking up whether a known bug in a dependency has been patched in a recent release, or finding the current API signature for a third-party library when the local docs are out of date.
+
+> **Note:** The built-in `search_web` tool is only available to [Zed Pro](https://zed.dev/pricing) subscribers. If you're on a free plan, you can get equivalent functionality by connecting an MCP server that provides web search capabilities. See [MCP servers](./mcp.md) for details.
 
 ## Edit Tools
 

--- a/docs/src/ai/tools.md
+++ b/docs/src/ai/tools.md
@@ -63,7 +63,7 @@ Searches the web for information, providing results with snippets and links from
 
 **Example:** Looking up whether a known bug in a dependency has been patched in a recent release, or finding the current API signature for a third-party library when the local docs are out of date.
 
-> **Note:** The built-in `search_web` tool is only available to [Zed Pro](https://zed.dev/pricing) subscribers. If you're on a free plan, you can get equivalent functionality by connecting an MCP server that provides web search capabilities. See [MCP servers](./mcp.md) for details.
+> **Note:** The built-in `search_web` tool is only available to [Zed Pro](https://zed.dev/pricing) subscribers using the Zed provider. If you're on a free plan or using a different provider, you can get equivalent functionality by connecting an MCP server that provides web search capabilities. See [MCP servers](./mcp.md) for details.
 
 ## Edit Tools
 


### PR DESCRIPTION
Adds a note to the `search_web` tool entry in the AI tools docs clarifying that the built-in tool is only available to Zed Pro subscribers, and pointing free-plan users to MCP servers as an alternative.

Release Notes:

- N/A