### PR TITLE
javascript, typescript: Inject GLSL and WGSL syntax in comment-labeled template literals

### DIFF
--- a/crates/grammars/src/javascript/injections.scm
+++ b/crates/grammars/src/javascript/injections.scm
@@ -142,3 +142,25 @@
   ])
   (#match? @_ecma_comment "^\\/\\*\\s*(css)\\s*\\*\\/")
   (#set! injection.language "css"))
+
+; '/* glsl */' or '/*glsl*/'
+(((comment) @_ecma_comment
+  [
+    (string
+      (string_fragment) @injection.content)
+    (template_string
+      (string_fragment) @injection.content)
+  ])
+  (#match? @_ecma_comment "^\\/\\*\\s*glsl\\s*\\*\\/")
+  (#set! injection.language "glsl"))
+
+; '/* wgsl */' or '/*wgsl*/'
+(((comment) @_ecma_comment
+  [
+    (string
+      (string_fragment) @injection.content)
+    (template_string
+      (string_fragment) @injection.content)
+  ])
+  (#match? @_ecma_comment "^\\/\\*\\s*wgsl\\s*\\*\\/")
+  (#set! injection.language "WGSL/WESL"))

--- a/crates/grammars/src/typescript/injections.scm
+++ b/crates/grammars/src/typescript/injections.scm
@@ -197,3 +197,25 @@
   ])
   (#match? @_ecma_comment "^\\/\\*\\s*(css)\\s*\\*\\/")
   (#set! injection.language "css"))
+
+; '/* glsl */' or '/*glsl*/'
+(((comment) @_ecma_comment
+  [
+    (string
+      (string_fragment) @injection.content)
+    (template_string
+      (string_fragment) @injection.content)
+  ])
+  (#match? @_ecma_comment "^\\/\\*\\s*glsl\\s*\\*\\/")
+  (#set! injection.language "glsl"))
+
+; '/* wgsl */' or '/*wgsl*/'
+(((comment) @_ecma_comment
+  [
+    (string
+      (string_fragment) @injection.content)
+    (template_string
+      (string_fragment) @injection.content)
+  ])
+  (#match? @_ecma_comment "^\\/\\*\\s*wgsl\\s*\\*\\/")
+  (#set! injection.language "WGSL/WESL"))


### PR DESCRIPTION
Extends the existing ECMAScript comment-label injection system to support GLSL and WGSL shader languages inside JS/TS strings and template literals.

The pattern `/* language */` before a string is already used for `html`, `sql`, `graphql`, and `css`. This adds the same support for two shader languages commonly embedded as strings in WebGL/WebGPU code:

before:
<img width="460" height="300" alt="Screenshot 2026-04-30 at 23 07 05" src="https://github.com/user-attachments/assets/8952eddc-2f53-42ea-b086-7a0b63dceb10" />

after:
<img width="460" height="300" alt="Screenshot 2026-04-30 at 23 07 39" src="https://github.com/user-attachments/assets/93bf536a-9df4-438b-af7b-382efda196ca" />

Syntax highlighting activates when the corresponding extension is installed:
- GLSL: the built-in `glsl` extension
- WGSL: the community extension [`wgsl-wesl-zed`](https://github.com/lucascompython/wgsl-wesl-zed) (language name `WGSL/WESL`)

Both `/*glsl*/` and `/* glsl */` forms are accepted (same behavior as the existing patterns).

Release Notes:

- Added `/*glsl*/` and `/*wgsl*/` comment-label syntax injection for JavaScript and TypeScript template literals