### PR TITLE
Fix split diff not activating with DiffViewStyle::Split setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -324,8 +324,8 @@
   // switches to unified mode and switches back when the editor is wide
   // enough. Set to 0 to disable automatic switching.
   //
-  // Default: 100
-  "minimum_split_diff_width": 100,
+  // Default: 68
+  "minimum_split_diff_width": 68,
   // Show method signatures in the editor, when inside parentheses.
   "auto_signature_help": false,
   // Whether to show the signature help after completion or a bracket pair inserted.

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use buffer_diff::{BufferDiff, BufferDiffSnapshot};
+use log::info;
 use collections::HashMap;
 
 use gpui::{
@@ -1273,6 +1274,7 @@ impl SplittableEditor {
             DiffViewStyle::Unified => {}
             DiffViewStyle::Split => {
                 if self.too_narrow_for_split && is_split {
+                    info!("split diff deactivated: editor width ({:.0}px) below minimum_split_diff_width threshold ({:.0}px = {} em-widths). Set minimum_split_diff_width to 0 in settings to disable auto-switching.", width.as_f32(), min_width.as_f32(), min_ems);
                     self.unsplit(window, cx);
                 } else if !self.too_narrow_for_split && !is_split {
                     self.split(window, cx);

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1298,6 +1298,10 @@ impl SplittableEditor {
 
 #[cfg(test)]
 impl SplittableEditor {
+    fn simulate_width_changed(&mut self, width: Pixels, window: &mut Window, cx: &mut Context<Self>) {
+        self.width_changed(width, window, cx);
+    }
+
     fn check_invariants(&self, quiesced: bool, cx: &mut App) {
         use text::Bias;
 
@@ -6202,5 +6206,52 @@ mod tests {
             editor.is_some(),
             "SplittableEditor should be able to act as Editor"
         );
+    }
+
+    #[gpui::test]
+    async fn test_width_changed_auto_split_and_unsplit(cx: &mut gpui::TestAppContext) {
+        let (editor, cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Split).await;
+        cx.run_until_parked();
+
+        // After init with Split style, deferred split() should have run
+        let is_split = editor.read_with(cx, |e, _| e.is_split());
+        assert!(is_split, "should start split after deferred init");
+
+        // Simulate a very narrow width — should auto-unsplit
+        editor.update_in(cx, |editor, window, cx| {
+            editor.simulate_width_changed(px(100.0), window, cx);
+        });
+        cx.run_until_parked();
+
+        let is_split = editor.read_with(cx, |e, _| e.is_split());
+        assert!(!is_split, "should unsplit when too narrow");
+        let too_narrow = editor.read_with(cx, |e, _| e.too_narrow_for_split);
+        assert!(too_narrow, "too_narrow_for_split should be true");
+
+        // Widen again — should auto-re-split
+        editor.update_in(cx, |editor, window, cx| {
+            editor.simulate_width_changed(px(3000.0), window, cx);
+        });
+        cx.run_until_parked();
+
+        let is_split = editor.read_with(cx, |e, _| e.is_split());
+        assert!(is_split, "should re-split when wide enough");
+        let too_narrow = editor.read_with(cx, |e, _| e.too_narrow_for_split);
+        assert!(!too_narrow, "too_narrow_for_split should be false");
+    }
+
+    #[gpui::test]
+    async fn test_width_changed_does_not_unsplit_unified(cx: &mut gpui::TestAppContext) {
+        let (editor, cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Unified).await;
+        cx.run_until_parked();
+
+        // Unified mode should never split, regardless of width
+        editor.update_in(cx, |editor, window, cx| {
+            editor.simulate_width_changed(px(3000.0), window, cx);
+        });
+        cx.run_until_parked();
+
+        let is_split = editor.read_with(cx, |e, _| e.is_split());
+        assert!(!is_split, "unified mode should stay unified even when wide");
     }
 }

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -255,7 +255,7 @@ pub struct EditorSettingsContent {
     /// switches to unified mode and switches back when the editor is wide
     /// enough. Set to 0 to disable automatic switching.
     ///
-    /// Default: 100
+    /// Default: 68
     pub minimum_split_diff_width: Option<f32>,
 }
 


### PR DESCRIPTION
## Summary

- The `minimum_split_diff_width` default of 100 em-widths (~500-600px at typical font sizes) was too aggressive, causing `width_changed()` to auto-unsplit immediately after construction's deferred `split()` call, silently reverting to unified mode even when `DiffViewStyle` was set to `Split`.
- Lowered the default from 100 to 68 em-widths (~340-400px), allowing split diffs to activate in typical editor panel widths.
- Added a `log::info` message when auto-unsplit happens so users can diagnose why split diff isn't active and learn how to disable auto-switching (`minimum_split_diff_width: 0`).

**Root cause:** When `SplittableEditor` is constructed with `DiffViewStyle::Split`, it defers a `split()` call via `window.defer()`. On the first render, a `canvas` element detects the width and also defers `width_changed()`. Since the constructor's defer runs first, `split()` succeeds, but `width_changed()` then fires and — finding the panel narrower than 100 em-widths — immediately calls `unsplit()`, undoing the split. Most editor panels are narrower than 100 em-widths, so users with `DiffViewStyle: Split` would always see unified diffs.

## Test plan

- [x] `cargo check -p editor` — compiles clean
- [x] `cargo test -p editor -- split` — 40 passed, 0 failed
- [x] `cargo clippy -p editor -- -D warnings` — no warnings
- [ ] Set `Diff View Style` to `Split` in settings, open a git diff (Project Diff), verify split view appears
- [ ] Resize window narrow enough to trigger auto-switch — verify unified mode activates and log message appears
- [ ] Resize back — verify split mode re-activates automatically

Release Notes:

- Fixed split diff not activating when `Diff View Style` is set to `Split` by lowering the `minimum_split_diff_width` default from 100 to 68 columns