### PR TITLE
keymap: Avoid format-vs-rules collision in JetBrains overlay

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -191,6 +191,17 @@
   { "context": "Diagnostics > Editor", "bindings": { "alt-6": "pane::CloseActiveItem" } },
   { "context": "OutlinePanel", "bindings": { "alt-7": "workspace::CloseActiveDock" } },
   {
+    // `ctrl-alt-l` is bound to `editor::Format` (jetbrains "Reformat Code") in
+    // the Editor context above, which collides with the default
+    // `agent::OpenRulesLibrary` binding. Mirror the windows keymap and use
+    // `shift-alt-l` instead so the menu hint and the action stay in sync.
+    "context": "AgentPanel",
+    "bindings": {
+      "ctrl-alt-l": null,
+      "shift-alt-l": "agent::OpenRulesLibrary",
+    },
+  },
+  {
     "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel",
     "bindings": {
       "escape": "editor::ToggleFocus",

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -195,6 +195,17 @@
   { "context": "Diagnostics > Editor", "bindings": { "cmd-6": "pane::CloseActiveItem" } },
   { "context": "OutlinePanel", "bindings": { "cmd-7": "workspace::CloseActiveDock" } },
   {
+    // `cmd-alt-l` is bound to `editor::Format` (jetbrains "Reformat Code") in
+    // the Editor context above, which collides with the default
+    // `agent::OpenRulesLibrary` binding. Mirror the windows keymap and use
+    // `shift-alt-l` instead so the menu hint and the action stay in sync.
+    "context": "AgentPanel",
+    "bindings": {
+      "cmd-alt-l": null,
+      "shift-alt-l": "agent::OpenRulesLibrary",
+    },
+  },
+  {
     "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel",
     "bindings": {
       "escape": "editor::ToggleFocus",


### PR DESCRIPTION
the jetbrains overlay binds `ctrl-alt-l` (linux) / `cmd-alt-l` (macos) to `editor::Format` (jetbrains "reformat code"), which collides with the default `agent::OpenRulesLibrary` binding. the agent panel shows the conflicting key as the rules tooltip but pressing it formats the buffer instead of opening rules. mirrors the windows keymap by switching the linux/macos overlays to `shift-alt-l` in the AgentPanel context (with the colliding key explicitly null-ed), so the hint and the action stay in sync.

closes #49764.

Release Notes:

- Fixed the JetBrains keymap so the agent panel "Rules" entry uses `shift-alt-l` and no longer flickers a non-functional `ctrl-alt-l` / `cmd-alt-l` shortcut.