### PR TITLE
Fix creating branch with base in remote

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2753,10 +2753,11 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
         let branch_name = envelope.payload.branch_name;
+        let base_branch = envelope.payload.base_branch;
 
         repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.create_branch(branch_name, None)
+                repository_handle.create_branch(branch_name, base_branch)
             })
             .await??;
 
@@ -7033,6 +7034,7 @@ impl Repository {
                             project_id: project_id.0,
                             repository_id: id.to_proto(),
                             branch_name,
+                            base_branch,
                         })
                         .await?;
 

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -180,6 +180,7 @@ message GitCreateBranch {
   reserved 2;
   uint64 repository_id = 3;
   string branch_name = 4;
+  optional string base_branch = 5;
 }
 
 message GitChangeBranch {


### PR DESCRIPTION
To support branch create with base branch, added extra optional field in GitCreateBranch proto.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #43985

Release Notes:

- git:  Fixed remote branch creation based on default branch
