### PR TITLE
workspace: Add action to move the active item to a new window

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1354,6 +1354,10 @@ pub struct Editor {
     _scroll_cursor_center_top_bottom_task: Task<()>,
     serialize_selections: Task<()>,
     serialize_folds: Task<()>,
+    /// Bound to the window the editor currently lives in. Replaced (rather
+    /// than detached) on `added_to_workspace` so the editor follows window
+    /// changes — see [`crate::items::Item::added_to_workspace`].
+    _window_activation_subscription: Option<Subscription>,
     mouse_cursor_hidden: bool,
     minimap: Option<Entity<Self>>,
     hide_mouse_mode: HideMouseMode,
@@ -2615,22 +2619,13 @@ impl Editor {
                         cx.observe_global_in::<SettingsStore>(window, Self::settings_changed),
                         cx.observe_global_in::<GlobalTheme>(window, Self::theme_changed),
                         observe_buffer_font_size_adjustment(cx, |_, cx| cx.notify()),
-                        cx.observe_window_activation(window, |editor, window, cx| {
-                            let active = window.is_window_active();
-                            editor.blink_manager.update(cx, |blink_manager, cx| {
-                                if active {
-                                    blink_manager.enable(cx);
-                                } else {
-                                    blink_manager.disable(cx);
-                                }
-                            });
-                            if active {
-                                editor.show_mouse_cursor(cx);
-                            }
-                        }),
                     ]
                 })
                 .unwrap_or_default(),
+            // Set lazily by `added_to_workspace`; binding it here would lock
+            // the editor to its construction-time window and leak when the
+            // editor is later moved to another window.
+            _window_activation_subscription: None,
             runnables: RunnableData::new(),
             pull_diagnostics_task: Task::ready(()),
             colors: None,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1027,6 +1027,34 @@ impl Item for Editor {
             .detach();
         }
 
+        // The window-activation observer is bound to a specific window, so it
+        // has to follow the editor when it moves between windows (e.g. via
+        // `MoveActiveItemToNewWindow`). Replacing the field drops any prior
+        // subscription, keeping exactly one live observer per editor.
+        self.show_mouse_cursor(cx);
+        let blink_manager = self.blink_manager.clone();
+        blink_manager.update(cx, |blink_manager, cx| {
+            if window.is_window_active() {
+                blink_manager.enable(cx);
+            } else {
+                blink_manager.disable(cx);
+            }
+        });
+        self._window_activation_subscription =
+            Some(cx.observe_window_activation(window, |editor, window, cx| {
+                let active = window.is_window_active();
+                editor.blink_manager.update(cx, |blink_manager, cx| {
+                    if active {
+                        blink_manager.enable(cx);
+                    } else {
+                        blink_manager.disable(cx);
+                    }
+                });
+                if active {
+                    editor.show_mouse_cursor(cx);
+                }
+            }));
+
         // Load persisted folds if this editor doesn't already have folds.
         // This handles manually-opened files (not workspace restoration).
         let display_snapshot = self

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1,7 +1,7 @@
 use crate::{
-    CloseWindow, NewCenterTerminal, NewFile, NewTerminal, OpenInTerminal, OpenOptions,
-    OpenTerminal, OpenVisible, SplitDirection, ToggleFileFinder, ToggleProjectSymbols, ToggleZoom,
-    Workspace, WorkspaceItemBuilder, ZoomIn, ZoomOut,
+    CloseWindow, MoveActiveItemToNewWindow, NewCenterTerminal, NewFile, NewTerminal,
+    OpenInTerminal, OpenOptions, OpenTerminal, OpenVisible, SplitDirection, ToggleFileFinder,
+    ToggleProjectSymbols, ToggleZoom, Workspace, WorkspaceItemBuilder, ZoomIn, ZoomOut,
     focus_follows_mouse::FocusFollowsMouse as _,
     invalid_item_view::InvalidItemView,
     item::{
@@ -3376,6 +3376,15 @@ impl Pane {
                         } else {
                             menu = menu.map(pin_tab_entries);
                         }
+
+                        menu = menu.separator().entry(
+                            "Move to New Window",
+                            Some(MoveActiveItemToNewWindow.boxed_clone()),
+                            window.handler_for(&pane, move |pane, window, cx| {
+                                pane.activate_item(ix, true, true, window, cx);
+                                window.dispatch_action(MoveActiveItemToNewWindow.boxed_clone(), cx);
+                            }),
+                        );
                     };
 
                     // Add custom item-specific actions

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -283,6 +283,17 @@ actions!(
         FollowNextCollaborator,
         /// Moves the focused panel to the next position.
         MoveFocusedPanelToNextPosition,
+        /// Moves the active item out of its pane and into its own window.
+        ///
+        /// Works for tabs in the center pane group and items inside dock panels
+        /// (any panel whose `Panel::pane()` returns `Some`). The detached window
+        /// is a normal `Workspace` sharing the same `Project`; state continuity
+        /// comes from sharing the underlying `Entity<T>` directly.
+        MoveActiveItemToNewWindow,
+        /// In a window opened via `MoveActiveItemToNewWindow`, returns the
+        /// active item back to the source workspace's active pane and closes
+        /// the detached window.
+        ReattachActiveItemToSourceWindow,
         /// Creates a new file.
         NewFile,
         /// Creates a new file in a vertical split.
@@ -1398,6 +1409,15 @@ pub struct Workspace {
     multi_workspace: Option<WeakEntity<MultiWorkspace>>,
     active_worktree_creation: ActiveWorktreeCreation,
     deferred_save_items: Vec<Box<dyn WeakItemHandle>>,
+    /// Set when this workspace was opened by `MoveActiveItemToNewWindow`.
+    /// Reattach uses this to send the active item back to the source pane.
+    detached_from: Option<DetachedFrom>,
+}
+
+#[derive(Clone)]
+struct DetachedFrom {
+    workspace: WeakEntity<Workspace>,
+    pane: WeakEntity<Pane>,
 }
 
 impl EventEmitter<Event> for Workspace {}
@@ -1830,6 +1850,7 @@ impl Workspace {
             open_in_dev_container: false,
             _dev_container_task: None,
             deferred_save_items: Vec::new(),
+            detached_from: None,
         }
     }
 
@@ -5144,6 +5165,119 @@ impl Workspace {
         );
     }
 
+    /// Detaches the active item of the focused pane (center pane or a dock-panel's
+    /// inner pane) into a new OS window. The new window contains a fresh
+    /// `Workspace` sharing this workspace's `Project`; the item itself is moved
+    /// (not cloned) and continues to share its underlying entity, so PTYs,
+    /// buffers, and undo history are preserved.
+    pub fn move_active_item_to_new_window(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let source_pane = self.focused_pane(window, cx);
+        let Some(item) = source_pane.read(cx).active_item() else {
+            return;
+        };
+        let item_id = item.item_id();
+        let project = self.project.clone();
+        let app_state = self.app_state.clone();
+        let detached_from = DetachedFrom {
+            workspace: self.weak_self.clone(),
+            pane: source_pane.downgrade(),
+        };
+        let item = item.boxed_clone();
+
+        // The action handler runs inside the source workspace's update closure,
+        // which means the source workspace is currently borrowed. Building a new
+        // window synchronously here would paint before `Pane::AddItem` events
+        // are dispatched, so any element on the moved item would still see the
+        // source workspace as its owner — and reading it would double-lease.
+        // Defer the whole transfer until the current update completes.
+        window.defer(cx, move |window, cx| {
+            let options = (app_state.build_window_options)(None, cx);
+            let result = cx.open_window(options, {
+                let item = item.boxed_clone();
+                move |window, cx| {
+                    let workspace =
+                        cx.new(|cx| Workspace::new(None, project, app_state, window, cx));
+                    workspace.update(cx, |workspace, cx| {
+                        workspace.detached_from = Some(detached_from);
+                        let pane = workspace.active_pane.clone();
+                        pane.update(cx, |pane, cx| {
+                            pane.add_item(item, true, true, None, window, cx);
+                        });
+                    });
+                    cx.new(|cx| MultiWorkspace::new(workspace, window, cx))
+                }
+            });
+
+            let window_handle = match result {
+                Ok(handle) => handle,
+                Err(error) => {
+                    log::error!("failed to open detached item window: {error:#}");
+                    return;
+                }
+            };
+
+            // Production `build_window_options` returns `show: false, focus: false`
+            // so the platform doesn't reveal the window until we explicitly ask.
+            window_handle
+                .update(cx, |_, window, _| window.activate_window())
+                .log_err();
+
+            source_pane.update(cx, |pane, cx| {
+                pane.remove_item(item_id, false, false, window, cx);
+            });
+        });
+    }
+
+    /// Returns the active item to its source workspace and closes this window.
+    /// Has no effect if this workspace was not opened via
+    /// `MoveActiveItemToNewWindow` or if the source no longer exists.
+    pub fn reattach_active_item_to_source_window(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(detached_from) = self.detached_from.clone() else {
+            return;
+        };
+
+        let source_workspace = match detached_from.workspace.upgrade() {
+            Some(workspace) => workspace,
+            None => {
+                window.remove_window();
+                return;
+            }
+        };
+
+        let source_pane = detached_from
+            .pane
+            .upgrade()
+            .or_else(|| Some(source_workspace.read(cx).active_pane.clone()));
+        let Some(source_pane) = source_pane else {
+            window.remove_window();
+            return;
+        };
+
+        let detached_pane = self.active_pane.clone();
+        let Some(active_item) = detached_pane.read(cx).active_item() else {
+            window.remove_window();
+            return;
+        };
+        let item_id = active_item.item_id();
+
+        let destination_index = source_pane.read(cx).items_len();
+        move_item(
+            &detached_pane,
+            &source_pane,
+            item_id,
+            destination_index,
+            true,
+            window,
+            cx,
+        );
+
+        window.remove_window();
+    }
+
     pub fn bounding_box_for_pane(&self, pane: &Entity<Pane>) -> Option<Bounds<Pixels>> {
         self.center.bounding_box_for_pane(pane)
     }
@@ -5839,9 +5973,27 @@ impl Workspace {
             title = "empty project".to_string();
         }
 
-        let active_project_path = self.active_item(cx).and_then(|item| item.project_path(cx));
+        let active_item = self.active_item(cx);
+        let active_project_path = active_item.as_ref().and_then(|item| item.project_path(cx));
 
-        if let Some(path) = active_project_path.as_ref() {
+        // Detached single-item windows share the project name with their
+        // source workspace. Suffix with the item's tab text so the user can
+        // tell them apart in the dock — and it's strictly better than the
+        // path-based fallback for items without a path (e.g. terminals).
+        // Falls back to the path-based suffix if the item provides no tab
+        // text, so a detached editor never ends up titled less than its
+        // pre-detach window.
+        let detached_tab_text = self
+            .detached_from
+            .as_ref()
+            .and_then(|_| active_item.as_ref())
+            .map(|item| item.tab_content_text(0, cx))
+            .filter(|text| !text.is_empty());
+
+        if let Some(tab_text) = detached_tab_text {
+            title.push_str(" — ");
+            title.push_str(tab_text.as_ref());
+        } else if let Some(path) = active_project_path.as_ref() {
             let filename = path.path.file_name().or_else(|| {
                 Some(
                     project
@@ -7142,6 +7294,16 @@ impl Workspace {
             .on_action(cx.listener(
                 |workspace, action: &MoveItemToPaneInDirection, window, cx| {
                     workspace.move_item_to_pane_in_direction(action, window, cx)
+                },
+            ))
+            .on_action(
+                cx.listener(|workspace, _: &MoveActiveItemToNewWindow, window, cx| {
+                    workspace.move_active_item_to_new_window(window, cx);
+                }),
+            )
+            .on_action(cx.listener(
+                |workspace, _: &ReattachActiveItemToSourceWindow, window, cx| {
+                    workspace.reattach_active_item_to_source_window(window, cx);
                 },
             ))
             .on_action(cx.listener(|workspace, _: &SwapPaneLeft, _, cx| {
@@ -15598,5 +15760,104 @@ mod tests {
         });
         let path = workspace.read_with(cx, |workspace, cx| workspace.most_recent_active_path(cx));
         assert_eq!(path, None);
+    }
+
+    #[gpui::test]
+    async fn test_move_active_item_to_new_window(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item = cx.new(|cx| TestItem::new(cx));
+        let item_id = item.entity_id();
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.move_active_item_to_new_window(window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |workspace, cx| {
+            let source_pane = workspace.active_pane().read(cx);
+            assert_eq!(
+                source_pane.items_len(),
+                0,
+                "source pane should no longer hold the item"
+            );
+        });
+
+        let detached_window = cx
+            .windows()
+            .into_iter()
+            .find_map(|handle| handle.downcast::<MultiWorkspace>())
+            .expect("detached MultiWorkspace window should exist");
+
+        detached_window
+            .update(cx, |multi_workspace, _, cx| {
+                let workspace = multi_workspace.workspace().read(cx);
+                let pane = workspace.active_pane().read(cx);
+                assert_eq!(pane.items_len(), 1, "detached pane should hold one item");
+                assert_eq!(
+                    pane.active_item().expect("active item").item_id(),
+                    item_id,
+                    "the moved item should be active in the detached pane",
+                );
+                assert!(
+                    workspace.detached_from.is_some(),
+                    "detached workspace should remember its source",
+                );
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_reattach_active_item_to_source_window(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item = cx.new(|cx| TestItem::new(cx));
+        let item_id = item.entity_id();
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.move_active_item_to_new_window(window, cx);
+        });
+        cx.run_until_parked();
+
+        let detached_window = cx
+            .windows()
+            .into_iter()
+            .find_map(|handle| handle.downcast::<MultiWorkspace>())
+            .expect("detached MultiWorkspace window should exist");
+
+        detached_window
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    workspace.reattach_active_item_to_source_window(window, cx);
+                });
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |workspace, cx| {
+            let source_pane = workspace.active_pane().read(cx);
+            assert_eq!(source_pane.items_len(), 1, "item should be back in source");
+            assert_eq!(
+                source_pane.active_item().expect("active item").item_id(),
+                item_id,
+            );
+        });
     }
 }


### PR DESCRIPTION
## Problem

Multi-monitor users want to put a single editor tab or terminal on a second display without giving up Zed's project context. Today the only way is to open another full project window, losing the shared `Entity<Project>` and forcing duplicate workspaces.

There's been steady demand for it:

- [#9662 _Open editor tabs in a secondary window_](https://github.com/zed-industries/zed/issues/9662) — opened Mar 2024, **306 👍 / 27 👀**, the staff ranked it among the most-requested feature gaps.
- [#5229](https://github.com/zed-industries/zed/issues/5229) — same shape, longer-running thread.
- The previous attempt ([#50197](https://github.com/zed-industries/zed/pull/50197)) kept drawing comments months after it was closed — 20 👍 / 10 ❤️ / 4 🚀 on the PR, plus unsolicited "any update?" pings from `jmevel`, `marcoafm26`, `leferi99`. It was closed for the wrong architecture (`WorkspaceSatellite`), not the wrong feature. Cameron's close note: _"Multi-window in general is definitely something that we're keen to support."_

This PR is the rewrite against that feedback.

## Prior art

The interaction model exists in every major editor:

- **VS Code** — _Move Editor into New Window_ (and _View → Editor Layout → Move Editor into New Window_).
- **JetBrains IDEs** — _Window → Detach Tab_.
- **Sublime Text / Atom** — drag a tab off the tab bar.

Zed adapts the same UX: a tab (or any item that lives in a `Pane`) can be moved into its own window, and brought back. The new window is a real `Workspace` over the same `Project`, so all the existing workspace machinery (sidebar, dock, project-switcher) works inside it.

## What this does

Adds two actions:

- `workspace::MoveActiveItemToNewWindow` — moves the focused pane's active item into its own window.
- `workspace::ReattachActiveItemToSourceWindow` — sends the item back to its source pane and closes the detached window.

Surfaces:

| Surface                                     | Coverage                                                   |
| ------------------------------------------- | ---------------------------------------------------------- |
| Tab right-click menu — "Move to New Window" | Center pane, dock panels with tab strips (terminal, agent) |
| Command palette                             | Both actions, all surfaces                                 |
| Default keybinding                          | None — users bind their own                                |

The detached window's title suffix is the moved item's tab text (`myproject — main.rs`, `myproject — Terminal: zsh`) so it's distinguishable in the macOS Dock and `cmd+~` switcher.

## Why this approach

Cameron's review of #50197 surfaced three structural critiques. Each is addressed by the architecture here:

1. _"Satellite windows are the wrong model — a second window should be a normal `Workspace`."_
   The detached window is a normal `MultiWorkspace + Workspace` sharing the source's `Entity<Project>`. No new top-level types. `MultiWorkspace::new` is reused unchanged.
2. _"GPUI now lets entities be shared across windows directly — proxy machinery is unnecessary."_
   The item's underlying entity (`Entity<Editor>`, `Entity<TerminalView>`, `Entity<Terminal>`) is referenced from views in both windows. State continuity is by entity sharing, not by serialisation: PTYs keep running, buffers keep their undo history.
3. _"Don't special-case panels — should also work for tabs and integrate with the multi-window infrastructure."_
   `Workspace::focused_pane` resolves the source pane uniformly across the center pane group and any panel that exposes `Panel::pane()`. The action is the same code path for tabs and dock-panel items, and it sits next to `MoveProjectToNewWindow` in the same action family.

No `WorkspaceSatellite`. No sqlite round-trip. No changes to `MultiWorkspace::new`, the `Dock`, or the `Panel` trait.

## What this doesn't do

- **Persistence** — detached windows are ephemeral; closing one destroys it. The follow-up extends the existing sqlite-backed `MultiWorkspace` persistence.
- **Drag-out detach** — drag-a-tab-out-of-the-titlebar isn't wired up. The design supports it via the same `move_active_item_to_new_window` entry point.
- **Chromeless windows** — the detached window has the full normal chrome (sidebar, dock, title bar). The user can drag more items in; it becomes a real second workspace over the same project. This was deliberate: a `chromeless: bool` flag would re-introduce the panel/satellite-style special-casing #50197 was rejected for.

## Cross-cuts

| Concern                        | Status                                                                                                                                                                                                                                      |
| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Vim mode**                   | No vim keybindings overridden. The actions are `workspace::*`-namespaced; vim doesn't intercept. State (mode, register, marks) is held on the editor's entity and follows the move.                                                         |
| **Remote / collab projects**   | The shared `Entity<Project>` is the same regardless of local/remote, so collab/SSH projects should work without changes. I haven't tested on collab — happy to do so before merge if a maintainer can confirm a test setup.                  |
| **Workspace trust**            | The detached `Workspace` shares the same `Entity<Project>`, so trusted-worktree state is inherited automatically. No new trust surface introduced.                                                                                          |
| **Settings / themes / keymap** | No new settings. No theme changes. No default keybinding. The detached window inherits the active theme, so light and dark mode are covered by construction.                                                                                |
| **Accessibility**              | Command palette covers every case. Tab right-click covers center-pane tabs and dock panels with internal tab strips. Panels without a tab strip rely on the command palette — easy to add per-panel menu entries in a follow-up if desired. |
| **Performance**                | Action runs on user input; not in any render or input-event hot path.                                                                                                                                                                       |
| **Platforms**                  | macOS verified end-to-end. The feature uses only `cx.open_window`, which is cross-platform, so Linux and Windows should work — I haven't been able to test them. Happy to do so before merge if it's a blocker.                             |

## Editor coexistence

State that lives on the editor's entity follows the move automatically because the entity is the same across windows:

- Multi-buffer items (project search, find-all-references) — entity-shared, preserved.
- Dirty state, undo history, folds — `MultiBuffer`/`Editor` state, preserved.
- LSP popovers / hover state — re-attached via the editor's normal lifecycle on `added_to_workspace`.
- Inline blocks, edit predictions, gutter elements — held on the editor entity, follow the move.

Manual repro covered: editor with unsaved changes, editor with active find-all-results, terminal running `tail -f`. Everything keeps state. LSP popovers / find-all matrix-testing pending.

## Incidental fixes

Three supporting changes — two required for the feature, one pre-existing latent bug surfaced during testing.

1. **Required — defer window creation.** The action handler runs inside the source workspace's `update`. Building the new window synchronously means the source workspace is borrowed while the new window paints, and any element on the moved item that touches the source workspace would double-lease. The actual panic stack from manual testing fingered `debugger_ui::register_action_renderer` (`crates/debugger_ui/src/debugger_ui.rs:269`) reading `editor.workspace()`. `window.defer(cx, ...)` lets the source's update finish first.
2. **Required — `window.activate_window()` after `cx.open_window`.** Production `build_window_options` returns `show: false, focus: false`, so without an explicit `activate_window` the new window is created but never revealed.
3. **Pre-existing latent bug — editor's window-activation observer never followed the editor between windows** (`crates/editor/src/items.rs`; new `_window_activation_subscription: Option<Subscription>` field on `Editor`). The observer was registered once at construction against the editor's first window. The detach feature was the first thing to actually move editors between windows and exposed it, but the same bug would surface for any future feature that does so (split-window UX, follow-mode revisions, etc.). Replacing the field on `added_to_workspace` rather than detaching keeps exactly one live observer per editor and resets `mouse_cursor_hidden` for the new window.

Happy to split this into a precursor PR if you'd prefer to land it independently.

## Files changed

| File                                | Change                                                                                                                                                                                                                                                                                                            |
| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `crates/workspace/src/workspace.rs` | New `MoveActiveItemToNewWindow` and `ReattachActiveItemToSourceWindow` actions; `Workspace::move_active_item_to_new_window` and `Workspace::reattach_active_item_to_source_window`; `detached_from: Option<DetachedFrom>` field; window-title suffix for detached workspaces; action handler wiring; 2 unit tests |
| `crates/workspace/src/pane.rs`      | "Move to New Window" entry in the tab right-click menu                                                                                                                                                                                                                                                            |
| `crates/editor/src/editor.rs`       | `_window_activation_subscription: Option<Subscription>` field; removed the construction-time observer                                                                                                                                                                                                             |
| `crates/editor/src/items.rs`        | `Editor::added_to_workspace` re-registers the window-activation observer for the current window and resets `mouse_cursor_hidden`                                                                                                                                                                                  |

## Demo

https://github.com/user-attachments/assets/3cabd87a-e369-4f5b-9abf-fd240d26ae36

The recording walks through:

1. Open multiple editor tabs, detach one, reattach.
2. Same flow with a terminal pane.
3. Detach several windows, show the macOS Window menu listing them as `zed — <item>`.
4. Reattach everything.

## Tests

- `crates/workspace/src/workspace.rs::tests::test_move_active_item_to_new_window` — verifies the source pane is empty and the detached window holds the item with `detached_from` set.
- `crates/workspace/src/workspace.rs::tests::test_reattach_active_item_to_source_window` — verifies reattach returns the item to the source pane.
- `cargo nextest run -p workspace --lib` — 196 pass.
- `cargo nextest run -p editor --lib` — 723 pass (no regressions from the editor subscription change).
- `./script/clippy -p workspace -p editor -p gpui` — clean.

Release Notes:

- Added action to move the active tab or dock-panel item into its own window