### PR TITLE
language_tools: Add timestamps to LSP logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13418,6 +13418,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "buffer_diff",
+ "chrono",
  "circular-buffer",
  "client",
  "clock",

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -715,11 +715,12 @@ fn send_toggle_log_message(
 }
 
 fn log_contents<T: Message>(lines: &VecDeque<T>, level: <T as Message>::Level) -> String {
-    lines
-        .iter()
-        .filter(|message| message.should_include(level))
-        .flat_map(|message| [message.as_ref(), "\n"])
-        .collect()
+    let mut contents = String::new();
+    for message in lines.iter().filter(|message| message.should_include(level)) {
+        contents.push_str(&message.display_text());
+        contents.push('\n');
+    }
+    contents
 }
 
 impl Render for LspLogView {

--- a/crates/language_tools/src/lsp_log_view_tests.rs
+++ b/crates/language_tools/src/lsp_log_view_tests.rs
@@ -101,8 +101,33 @@ async fn test_lsp_log_view(cx: &mut TestAppContext) {
                 }
             }]
         );
-        assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");
+        assert_timestamped_log_line(
+            view.editor.read(cx).text(cx).as_str(),
+            "hello from the server",
+        );
     });
+}
+
+fn assert_timestamped_log_line(actual: &str, message: &str) {
+    let Some(line) = actual.strip_suffix('\n') else {
+        panic!("log line should end with newline: {actual:?}");
+    };
+    let Some((timestamp, rest)) = line
+        .strip_prefix('[')
+        .and_then(|line| line.split_once("] "))
+    else {
+        panic!("log line should start with a bracketed timestamp: {actual:?}");
+    };
+
+    assert_eq!(rest, message);
+    assert_eq!(timestamp.len(), "HH:MM:SS".len());
+    assert!(timestamp.chars().enumerate().all(|(index, character)| {
+        if index == 2 || index == 5 {
+            character == ':'
+        } else {
+            character.is_ascii_digit()
+        }
+    }));
 }
 
 fn init_test(cx: &mut gpui::TestAppContext) {

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -42,6 +42,7 @@ async-channel.workspace = true
 base64.workspace = true
 buffer_diff.workspace = true
 circular-buffer.workspace = true
+chrono.workspace = true
 client.workspace = true
 clock.workspace = true
 collections.workspace = true

--- a/crates/project/src/lsp_store/log_store.rs
+++ b/crates/project/src/lsp_store/log_store.rs
@@ -1,5 +1,6 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{borrow::Cow, collections::VecDeque, sync::Arc};
 
+use chrono::Local;
 use collections::HashMap;
 use futures::{StreamExt, channel::mpsc};
 use gpui::{App, AppContext as _, Context, Entity, EventEmitter, Global, Subscription, WeakEntity};
@@ -51,8 +52,13 @@ struct ProjectState {
 
 pub trait Message: AsRef<str> {
     type Level: Copy + std::fmt::Debug;
+
     fn should_include(&self, _: Self::Level) -> bool {
         true
+    }
+
+    fn display_text(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.as_ref())
     }
 }
 
@@ -60,6 +66,17 @@ pub trait Message: AsRef<str> {
 pub struct LogMessage {
     message: String,
     typ: MessageType,
+    timestamp: String,
+}
+
+impl LogMessage {
+    fn new(message: String, typ: MessageType) -> Self {
+        Self {
+            message,
+            typ,
+            timestamp: Local::now().format("%H:%M:%S").to_string(),
+        }
+    }
 }
 
 impl AsRef<str> for LogMessage {
@@ -81,6 +98,10 @@ impl Message for LogMessage {
             (_, MessageType::INFO) => false,
             _ => true,
         }
+    }
+
+    fn display_text(&self) -> Cow<'_, str> {
+        Cow::Owned(format!("[{}] {}", self.timestamp, self.message))
     }
 }
 
@@ -431,7 +452,7 @@ impl LogStore {
             );
         } else if let Some(new_message) = Self::push_new_message(
             log_lines,
-            LogMessage { message, typ },
+            LogMessage::new(message, typ),
             language_server_state.log_level,
         ) {
             self.emit_event(
@@ -507,7 +528,7 @@ impl LogStore {
         }
         let visible = message.should_include(current_severity);
 
-        let visible_message = visible.then(|| message.as_ref().to_string());
+        let visible_message = visible.then(|| message.display_text().into_owned());
         log_lines.push_back(message);
         visible_message
     }


### PR DESCRIPTION
## Summary

- Store a timestamp with each LSP log message.
- Render LSP log lines with their timestamp in the language tools log view.
- Update the focused LSP log view test to cover timestamp display.

Fixes #55296.

## Root Cause

LSP logs kept only message text and type, so the log view joined raw messages without the timestamp that users expect from diagnostic logs.

## Test Plan

- `cargo test -p language_tools test_lsp_log_view -- --nocapture`
- `cargo test -p language_tools lsp_log_view_tests -- --nocapture`

## Suggested .rules additions

None.

Release Notes:

- Fixed missing timestamps in LSP log output.
