### PR TITLE
git_ui: Refresh stash entries when opening picker

### DIFF
--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -85,9 +85,12 @@ impl StashList {
         cx: &mut Context<Self>,
     ) -> Self {
         let mut _subscriptions = Vec::new();
-        let stash_request = repository
-            .clone()
-            .map(|repository| repository.read_with(cx, |repo, _| repo.cached_stash()));
+        let stash_entries = repository
+            .as_ref()
+            .map(|repository| {
+                repository.read_with(cx, |repo, _| repo.cached_stash().entries.to_vec())
+            })
+            .unwrap_or_default();
 
         if let Some(repo) = repository.clone() {
             _subscriptions.push(
@@ -109,33 +112,29 @@ impl StashList {
             )
         }
 
-        cx.spawn_in(window, async move |this, cx| {
-            let stash_entries = stash_request
-                .map(|git_stash| git_stash.entries.to_vec())
-                .unwrap_or_default();
-
-            this.update_in(cx, |this, window, cx| {
-                this.picker.update(cx, |picker, cx| {
-                    picker.delegate.all_stash_entries = Some(stash_entries);
-                    picker.refresh(window, cx);
-                })
-            })?;
-
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
-
-        let delegate = StashListDelegate::new(repository, workspace, window, cx);
+        let delegate = StashListDelegate::new(repository.clone(), workspace, window, cx);
         let picker = cx.new(|cx| {
             Picker::uniform_list(delegate, window, cx)
                 .show_scrollbar(true)
                 .modal(!embedded)
         });
         let picker_focus_handle = picker.focus_handle(cx);
-        picker.update(cx, |picker, _| {
+        picker.update(cx, |picker, cx| {
             picker.delegate.focus_handle = picker_focus_handle.clone();
             picker.delegate.show_footer = !embedded;
+            picker.delegate.all_stash_entries = Some(stash_entries);
+            picker.refresh(window, cx);
         });
+
+        if let Some(repository) = repository {
+            cx.spawn_in(window, async move |_, cx| {
+                repository
+                    .update(cx, |repository, cx| repository.refresh_stash_entries(cx))
+                    .await?;
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
 
         Self {
             picker,
@@ -697,11 +696,16 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use git::{Oid, stash::StashEntry};
+    use git::{
+        Oid,
+        stash::{GitStash, StashEntry},
+    };
     use gpui::{TestAppContext, VisualTestContext, rems};
     use picker::PickerDelegate;
     use project::{FakeFs, Project};
+    use serde_json::json;
     use settings::SettingsStore;
+    use util::path;
     use workspace::MultiWorkspace;
 
     fn init_test(cx: &mut TestAppContext) {
@@ -779,6 +783,77 @@ mod tests {
 
         workspace.update(cx, |workspace, cx| {
             assert!(workspace.active_modal::<StashList>(cx).is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_stash_picker_refreshes_stale_cache_on_open(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "file.txt": "content",
+            }),
+        )
+        .await;
+        fs.with_git_state(path!("/project/.git").as_ref(), false, |state| {
+            state.stash_entries = GitStash {
+                entries: vec![stash_entry(0, "before external rename", Some("main"))].into(),
+            };
+        })
+        .unwrap();
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        let repository =
+            project.read_with(cx, |project, cx| project.active_repository(cx).unwrap());
+
+        repository.read_with(cx, |repository, _| {
+            assert_eq!(
+                repository.cached_stash().entries[0].message,
+                "before external rename"
+            );
+        });
+        fs.with_git_state(path!("/project/.git").as_ref(), false, |state| {
+            state.stash_entries = GitStash {
+                entries: vec![stash_entry(0, "after external rename", Some("main"))].into(),
+            };
+        })
+        .unwrap();
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let cx = &mut VisualTestContext::from_window(*multi_workspace, cx);
+        let workspace = multi_workspace
+            .update(cx, |workspace, _, _| workspace.workspace().clone())
+            .unwrap();
+        let stash_list = workspace.update_in(cx, |workspace, window, cx| {
+            let weak_workspace = workspace.weak_handle();
+            let repository = repository.clone();
+
+            workspace.toggle_modal(window, cx, move |window, cx| {
+                StashList::new(Some(repository), weak_workspace, rems(34.), window, cx)
+            });
+
+            workspace.active_modal::<StashList>(cx).unwrap()
+        });
+
+        cx.run_until_parked();
+
+        stash_list.update(cx, |stash_list, cx| {
+            let entries = stash_list
+                .picker
+                .read(cx)
+                .delegate
+                .all_stash_entries
+                .as_ref()
+                .unwrap();
+            assert_eq!(entries[0].message, "after external rename");
         });
     }
 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4699,6 +4699,45 @@ impl Repository {
         self.snapshot.stash_entries.clone()
     }
 
+    pub fn refresh_stash_entries(&mut self, cx: &mut Context<Self>) -> Task<anyhow::Result<()>> {
+        let this = cx.weak_entity();
+        let updates_tx = self
+            .git_store()
+            .and_then(|git_store| match &git_store.read(cx).state {
+                GitStoreState::Local { downstream, .. } => downstream
+                    .as_ref()
+                    .map(|downstream| downstream.updates_tx.clone()),
+                _ => None,
+            });
+
+        let rx = self.send_job(None, move |git_repo, mut cx| async move {
+            let RepositoryState::Local(LocalRepositoryState { backend, .. }) = git_repo else {
+                return Ok(());
+            };
+
+            let stash_entries = backend.stash_entries().await?;
+            let snapshot = this.update(&mut cx, |this, cx| {
+                if this.snapshot.stash_entries == stash_entries {
+                    None
+                } else {
+                    this.snapshot.stash_entries = stash_entries;
+                    cx.emit(RepositoryEvent::StashEntriesChanged);
+                    Some(this.snapshot.clone())
+                }
+            })?;
+
+            if let (Some(snapshot), Some(updates_tx)) = (snapshot, updates_tx) {
+                updates_tx
+                    .unbounded_send(DownstreamUpdate::UpdateRepository(snapshot))
+                    .ok();
+            }
+
+            Ok(())
+        });
+
+        cx.spawn(|_, _: &mut AsyncApp| async move { rx.await? })
+    }
+
     pub fn repo_path_to_project_path(&self, path: &RepoPath, cx: &App) -> Option<ProjectPath> {
         let git_store = self.git_store.upgrade()?;
         let worktree_store = git_store.read(cx).worktree_store.read(cx);


### PR DESCRIPTION
## Summary

- Refresh stash entries when opening the stash picker.
- Add a regression test for externally renamed stashes that mutate outside Zed's cached stash snapshot.

Fixes #55234.

## Root Cause

The stash picker initialized from cached stash entries and only updated after a `StashEntriesChanged` event. External stash metadata changes can leave the worktree status unchanged, so the cached stash name stayed stale until a broader refresh happened.

## Test Plan

- `cargo test -p git_ui stash_picker::tests::test_stash_picker_refreshes_stale_cache_on_open -- --nocapture`
- `cargo test -p git_ui stash_picker::tests -- --nocapture`

## Suggested .rules additions

None.

Release Notes:

- Fixed stale stash names in the stash picker after external stash renames.
