### PR TITLE
dev_container: Fix Dockerfile env escaping

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -25,7 +25,9 @@ use crate::{
         Docker, DockerClient, DockerComposeConfig, DockerComposeService, DockerComposeServiceBuild,
         DockerComposeServicePort, DockerComposeVolume, DockerInspect, DockerPs,
     },
-    features::{DevContainerFeatureJson, FeatureManifest, parse_oci_feature_ref},
+    features::{
+        DevContainerFeatureJson, FeatureManifest, dockerfile_env_instruction, parse_oci_feature_ref,
+    },
     get_oci_token,
     oci::{TokenResponse, download_oci_tarball, get_oci_manifest},
     safe_id_lower,
@@ -704,7 +706,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
 
             if let Some(env) = &self.dev_container().container_env {
                 for (key, value) in env {
-                    extended_dockerfile = format!("{extended_dockerfile}ENV {key}={value}\n");
+                    extended_dockerfile.push_str(&dockerfile_env_instruction(key, value));
                 }
             }
         }
@@ -1541,7 +1543,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         if let Some(env) = &self.dev_container().container_env {
             for (key, value) in env {
-                dockerfile = format!("{dockerfile}ENV {key}={value}\n");
+                dockerfile.push_str(&dockerfile_env_instruction(key, value));
             }
         }
         dockerfile
@@ -5228,6 +5230,113 @@ USER $IMAGE_USER
 # Ensure that /etc/profile does not clobber the existing path
 RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 "#
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[gpui::test]
+    async fn test_update_uid_dockerfile_escapes_container_env_values_with_spaces(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+        env_logger::try_init().ok();
+        let given_devcontainer_contents = r#"
+            {
+              "name": "cli-${devcontainerId}",
+              "image": "test_image:latest",
+              "containerEnv": {
+                "PROMPT_COMMAND": "history -a",
+              },
+            }
+            "#;
+
+        let (test_dependencies, mut devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, given_devcontainer_contents)
+                .await
+                .unwrap();
+
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+
+        let _devcontainer_up = devcontainer_manifest.build_and_run().await.unwrap();
+
+        let files = test_dependencies.fs.files();
+        let uid_dockerfile = files
+            .iter()
+            .find(|f| {
+                f.file_name()
+                    .is_some_and(|s| s.display().to_string() == "updateUID.Dockerfile")
+            })
+            .expect("to be found");
+        let uid_dockerfile = test_dependencies.fs.load(uid_dockerfile).await.unwrap();
+
+        assert!(
+            uid_dockerfile.contains("ENV PROMPT_COMMAND=history\\ -a\n"),
+            "containerEnv values with spaces should be escaped in Dockerfile ENV key=value form: {uid_dockerfile}"
+        );
+        assert!(
+            !uid_dockerfile.contains("ENV PROMPT_COMMAND=history -a\n"),
+            "unescaped spaces in Dockerfile ENV key=value form make docker build parse '-a' as another variable"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_extended_dockerfile_escapes_container_env_values_with_spaces_when_uid_update_disabled(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+        env_logger::try_init().ok();
+        let given_devcontainer_contents = r#"
+            {
+              "name": "cli-${devcontainerId}",
+              "build": {
+                "dockerfile": "Dockerfile",
+              },
+              "updateRemoteUserUID": false,
+              "containerEnv": {
+                "PROMPT_COMMAND": "history -a",
+              },
+            }
+            "#;
+
+        let (test_dependencies, mut devcontainer_manifest) =
+            init_default_devcontainer_manifest(cx, given_devcontainer_contents)
+                .await
+                .unwrap();
+
+        test_dependencies
+            .fs
+            .atomic_write(
+                PathBuf::from(TEST_PROJECT_PATH).join(".devcontainer/Dockerfile"),
+                "FROM test_image:latest".to_string(),
+            )
+            .await
+            .unwrap();
+
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+
+        let _devcontainer_up = devcontainer_manifest.build_and_run().await.unwrap();
+
+        let files = test_dependencies.fs.files();
+        let extended_dockerfile = files
+            .iter()
+            .find(|f| {
+                f.file_name()
+                    .is_some_and(|s| s.display().to_string() == "Dockerfile.extended")
+            })
+            .expect("to be found");
+        let extended_dockerfile = test_dependencies
+            .fs
+            .load(extended_dockerfile)
+            .await
+            .unwrap();
+
+        assert!(
+            extended_dockerfile.contains("ENV PROMPT_COMMAND=history\\ -a\n"),
+            "containerEnv values with spaces should be escaped in Dockerfile ENV key=value form: {extended_dockerfile}"
+        );
+        assert!(
+            !extended_dockerfile.contains("ENV PROMPT_COMMAND=history -a\n"),
+            "unescaped spaces in Dockerfile ENV key=value form make docker build parse '-a' as another variable"
         );
     }
 

--- a/crates/dev_container/src/features.rs
+++ b/crates/dev_container/src/features.rs
@@ -122,7 +122,7 @@ RUN chmod -R 0755 {full_dest} \
         env.sort();
 
         for (key, value) in env {
-            layer = format!("{layer}ENV {key}={value}\n")
+            layer.push_str(&dockerfile_env_instruction(key, value));
         }
         layer
     }
@@ -201,6 +201,29 @@ RUN chmod -R 0755 {full_dest} \
     }
 }
 
+pub(crate) fn dockerfile_env_instruction(key: &str, value: &str) -> String {
+    format!("ENV {key}={}\n", escape_dockerfile_env_value(value))
+}
+
+fn escape_dockerfile_env_value(value: &str) -> String {
+    let mut escaped_value = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            ' ' | '\t' => {
+                escaped_value.push('\\');
+                escaped_value.push(character);
+            }
+            '\\' => escaped_value.push_str("\\\\"),
+            '\'' => escaped_value.push_str("\\'"),
+            '"' => escaped_value.push_str("\\\""),
+            '\n' => escaped_value.push_str("\\n"),
+            '\r' => escaped_value.push_str("\\r"),
+            _ => escaped_value.push(character),
+        }
+    }
+    escaped_value
+}
+
 /// Parses an OCI feature reference string into its components.
 ///
 /// Handles formats like:
@@ -251,4 +274,61 @@ pub(crate) fn parse_oci_feature_ref(input: &str) -> Option<OciFeatureRef> {
         path,
         version,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dockerfile_env_instruction_escapes_values_for_key_value_syntax() {
+        assert_eq!(
+            dockerfile_env_instruction("PROMPT_COMMAND", "history -a"),
+            "ENV PROMPT_COMMAND=history\\ -a\n"
+        );
+        assert_eq!(dockerfile_env_instruction("EMPTY", ""), "ENV EMPTY=\n");
+        assert_eq!(
+            dockerfile_env_instruction("GREETING", "hello \"zed\""),
+            "ENV GREETING=hello\\ \\\"zed\\\"\n"
+        );
+        assert_eq!(
+            dockerfile_env_instruction("SHELL_PROMPT", "don't stop"),
+            "ENV SHELL_PROMPT=don\\'t\\ stop\n"
+        );
+        assert_eq!(
+            dockerfile_env_instruction("WINDOWS_PATH", r"C:\Program Files\Zed"),
+            "ENV WINDOWS_PATH=C:\\\\Program\\ Files\\\\Zed\n"
+        );
+    }
+
+    #[test]
+    fn dockerfile_env_instruction_preserves_dockerfile_environment_references() {
+        assert_eq!(
+            dockerfile_env_instruction("PATH", "/usr/local/go/bin:/go/bin:${PATH}"),
+            "ENV PATH=/usr/local/go/bin:/go/bin:${PATH}\n"
+        );
+    }
+
+    #[test]
+    fn generate_dockerfile_env_escapes_container_env_values_with_spaces_for_features() {
+        let feature = FeatureManifest::new(
+            "go_0".to_string(),
+            PathBuf::from("/tmp/go_0"),
+            DevContainerFeatureJson {
+                container_env: Some(HashMap::from([
+                    (
+                        "PATH".to_string(),
+                        "/usr/local/go/bin:/go/bin:${PATH}".to_string(),
+                    ),
+                    ("PROMPT_COMMAND".to_string(), "history -a".to_string()),
+                ])),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            feature.generate_dockerfile_env(),
+            "ENV PATH=/usr/local/go/bin:/go/bin:${PATH}\nENV PROMPT_COMMAND=history\\ -a\n"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add a shared helper for rendering Dockerfile `ENV` instructions from devcontainer `containerEnv` values.
- Escape Dockerfile token delimiters and quote characters while preserving `${...}` expansion for values such as `PATH`.
- Apply the helper to UID-update Dockerfile generation, extended Dockerfile generation, and feature `containerEnv` generation.

Fixes #55372.

## Root Cause

Devcontainer `containerEnv` values were interpolated directly as `ENV key=value`. Values containing spaces, such as `PROMPT_COMMAND=history -a`, were parsed by Dockerfile tooling as multiple tokens and broke UID-update builds.

## Test Plan

- `cargo test -p dev_container escapes_container_env_values_with_spaces -- --nocapture`
- `git diff --check origin/main...codex/fix-devcontainer-env-escaping`

## Suggested .rules additions

None.

Release Notes:

- Fixed devcontainer builds when `containerEnv` values contain spaces or Dockerfile quote characters.
