### PR TITLE
markdown: Prevent stack overflow in HTML minifier

### DIFF
--- a/crates/markdown/src/html/html_minifier.rs
+++ b/crates/markdown/src/html/html_minifier.rs
@@ -3,6 +3,7 @@ use html5ever::{
     tendril::{Tendril, TendrilSink, fmt::UTF8},
 };
 use markup5ever_rcdom::{Node, NodeData, RcDom};
+use stacksafe::stacksafe;
 use std::{cell::RefCell, io, rc::Rc, str};
 
 #[derive(Default)]
@@ -50,6 +51,7 @@ where
         self.minify_node(&None, &dom.document)
     }
 
+    #[stacksafe]
     fn minify_node<'b>(&mut self, ctx: &'b Option<Context>, node: &'b Node) -> io::Result<()> {
         match &node.data {
             NodeData::Text { contents } => {
@@ -320,6 +322,7 @@ where
     }
 
     #[allow(clippy::needless_pass_by_value)]
+    #[stacksafe]
     fn minify_children(&mut self, ctx: &Option<Context>, node: &Node) -> io::Result<()> {
         let children = node.children.borrow();
         let l = children.len();

--- a/crates/markdown/src/html/html_parser.rs
+++ b/crates/markdown/src/html/html_parser.rs
@@ -810,6 +810,24 @@ mod tests {
     use gpui::TextAlign;
 
     #[test]
+    fn parses_deeply_nested_html_without_stack_overflow() {
+        let depth = 2_000;
+        let mut markdown = String::new();
+
+        for index in 0..depth {
+            markdown.push_str(&format!("<details><summary>L{index}</summary>\n"));
+        }
+        markdown.push_str("leaf\n");
+        for _ in 0..depth {
+            markdown.push_str("</details>\n");
+        }
+
+        let parsed = parse_html_block(&markdown, 0..markdown.len()).unwrap();
+
+        assert!(!parsed.children.is_empty());
+    }
+
+    #[test]
     fn parses_html_styled_text() {
         let parsed = parse_html_block(
             "<p>Some text <strong>strong</strong> <a href=\"https://example.com\">link</a></p>",


### PR DESCRIPTION
## Summary

- Make recursive HTML minifier traversal stack-safe.
- Add a regression test for deeply nested HTML in Markdown input.

Fixes #55390.

## Root Cause

Deeply nested raw HTML in Markdown could overflow the stack during HTML minification before Markdown parsing returned.

## Test Plan

- `CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p markdown --lib --features gpui_platform/runtime_shaders html::html_parser::tests::parses_deeply_nested_html_without_stack_overflow -- --exact --nocapture`
- `git diff --check origin/main...codex/fix-markdown-html-minifier`

## Suggested .rules additions

None.

Release Notes:

- Fixed a crash when opening Markdown files containing deeply nested HTML.
