### PR TITLE
Make error notifications copyable

### DIFF
--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -138,7 +138,7 @@ use gpui::{AppContext, AsyncApp, SharedString, Task, WeakEntity};
 use project::{ProjectPath, WorktreeId};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::VecDeque, sync::Arc};
-use ui::App;
+use ui::{App, Severity};
 use workspace::{
     Workspace,
     notifications::{NotificationId, simple_message_notification::MessageNotification},
@@ -550,7 +550,11 @@ impl Inner {
                     NotificationId::Named(SharedString::new_static("project_panel_undo"));
 
                 workspace.show_notification(notification_id, cx, move |cx| {
-                    cx.new(|cx| MessageNotification::new(error, cx).with_title(title))
+                    cx.new(|cx| {
+                        MessageNotification::new(error, cx)
+                            .severity(Severity::Error)
+                            .with_title(title)
+                    })
                 })
             })
             .ok();

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -728,6 +728,8 @@ pub mod simple_message_notification {
         show_suppress_button: bool,
         title: Option<SharedString>,
         scroll_handle: ScrollHandle,
+        copyable_text: Option<SharedString>,
+        severity: Severity,
     }
 
     impl Focusable for MessageNotification {
@@ -747,9 +749,11 @@ pub mod simple_message_notification {
             S: Into<SharedString>,
         {
             let message = message.into();
+            let copyable = message.clone();
             Self::new_from_builder(cx, move |_, _| {
                 Label::new(message.clone()).into_any_element()
             })
+            .copyable_text(copyable)
         }
 
         pub fn new_from_builder<F>(cx: &mut App, content: F) -> MessageNotification
@@ -773,7 +777,22 @@ pub mod simple_message_notification {
                 title: None,
                 focus_handle: cx.focus_handle(),
                 scroll_handle: ScrollHandle::new(),
+                copyable_text: None,
+                severity: Severity::Info,
             }
+        }
+
+        pub fn severity(mut self, severity: Severity) -> Self {
+            self.severity = severity;
+            self
+        }
+
+        pub fn copyable_text<S>(mut self, text: S) -> Self
+        where
+            S: Into<SharedString>,
+        {
+            self.copyable_text = Some(text.into());
+            self
         }
 
         pub fn primary_message<S>(mut self, message: S) -> Self
@@ -913,6 +932,17 @@ pub mod simple_message_notification {
                 .with_suffix(
                     h_flex()
                         .gap_1()
+                        .when_some(
+                            matches!(self.severity, Severity::Error | Severity::Warning)
+                                .then(|| self.copyable_text.clone())
+                                .flatten(),
+                            |this, text| {
+                                this.child(
+                                    ui::CopyButton::new("copy-notification-message", text)
+                                        .tooltip_label("Copy Message"),
+                                )
+                            },
+                        )
                         .children(self.primary_message.iter().map(|message| {
                             let mut button = Button::new(message.clone(), message.clone())
                                 .label_size(LabelSize::Small)

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -728,7 +728,7 @@ pub mod simple_message_notification {
         show_suppress_button: bool,
         title: Option<SharedString>,
         scroll_handle: ScrollHandle,
-        copyable_text: Option<SharedString>,
+        text_to_copy: Option<SharedString>,
         severity: Severity,
     }
 
@@ -749,11 +749,11 @@ pub mod simple_message_notification {
             S: Into<SharedString>,
         {
             let message = message.into();
-            let copyable = message.clone();
+            let text_to_copy = message.clone();
             Self::new_from_builder(cx, move |_, _| {
                 Label::new(message.clone()).into_any_element()
             })
-            .copyable_text(copyable)
+            .text_to_copy(text_to_copy)
         }
 
         pub fn new_from_builder<F>(cx: &mut App, content: F) -> MessageNotification
@@ -777,7 +777,7 @@ pub mod simple_message_notification {
                 title: None,
                 focus_handle: cx.focus_handle(),
                 scroll_handle: ScrollHandle::new(),
-                copyable_text: None,
+                text_to_copy: None,
                 severity: Severity::Info,
             }
         }
@@ -787,11 +787,11 @@ pub mod simple_message_notification {
             self
         }
 
-        pub fn copyable_text<S>(mut self, text: S) -> Self
+        pub fn text_to_copy<S>(mut self, text: S) -> Self
         where
             S: Into<SharedString>,
         {
-            self.copyable_text = Some(text.into());
+            self.text_to_copy = Some(text.into());
             self
         }
 
@@ -934,7 +934,7 @@ pub mod simple_message_notification {
                         .gap_1()
                         .when_some(
                             matches!(self.severity, Severity::Error | Severity::Warning)
-                                .then(|| self.copyable_text.clone())
+                                .then(|| self.text_to_copy.clone())
                                 .flatten(),
                             |this, text| {
                                 this.child(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8137,6 +8137,7 @@ fn notify_if_database_failed(window: WindowHandle<MultiWorkspace>, cx: &mut Asyn
                         |cx| {
                             cx.new(|cx| {
                                 MessageNotification::new("Failed to load the database file.", cx)
+                                    .severity(Severity::Error)
                                     .primary_message("File an Issue")
                                     .primary_icon(IconName::Plus)
                                     .primary_on_click(|window, cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1720,6 +1720,7 @@ fn open_log_file(workspace: &mut Workspace, window: &mut Window, cx: &mut Contex
                                         ),
                                         cx,
                                     )
+                                    .severity(Severity::Error)
                                 })
                             },
                         );
@@ -1797,6 +1798,7 @@ fn notify_settings_errors(result: settings::SettingsParseResult, is_user: bool, 
                 show_app_notification(id, cx, move |cx| {
                     cx.new(|cx| {
                         MessageNotification::new(format!("Invalid user settings file\n{error}"), cx)
+                            .severity(Severity::Error)
                             .primary_message("Open Settings File")
                             .primary_icon(IconName::Settings)
                             .primary_on_click(|window, cx| {
@@ -1833,6 +1835,7 @@ fn notify_settings_errors(result: settings::SettingsParseResult, is_user: bool, 
                             ),
                             cx,
                         )
+                        .severity(Severity::Error)
                         .primary_message("Open Settings File")
                         .primary_icon(IconName::Settings)
                         .primary_on_click(|window, cx| {
@@ -1991,6 +1994,7 @@ fn show_keymap_file_json_error(
     show_app_notification(notification_id, cx, move |cx| {
         cx.new(|cx| {
             MessageNotification::new(message.clone(), cx)
+                .severity(Severity::Error)
                 .primary_message("Open Keymap File")
                 .primary_icon(IconName::Settings)
                 .primary_on_click(|window, cx| {


### PR DESCRIPTION
## Summary

Adds a copy button to simple message notifications marked as error or warning, so error text can be copied. Addresses #55430.

## Test Plan

- Run cargo fmt --check
- Run ./script/clippy
- Manually verified error notifications show a copy button.
- Manually verified info notifications, such as extension suggestions, do not show a copy button.


## Screenshot
<img width="451" height="109" alt="image" src="https://github.com/user-attachments/assets/783185cf-9500-4c98-9bf2-1ddb3be646be" />

## Release Notes:

- Added a copy button to error notifications.
