### PR TITLE
Fix devcontainer ENV value quoting

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -26,7 +26,7 @@ use crate::{
         DockerComposeServicePort, DockerComposeVolume, DockerInspect, DockerPs,
     },
     features::{DevContainerFeatureJson, FeatureManifest, parse_oci_feature_ref},
-    get_oci_token,
+    format_dockerfile_env_line, get_oci_token,
     oci::{TokenResponse, download_oci_tarball, get_oci_manifest},
     safe_id_lower,
 };
@@ -704,7 +704,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
 
             if let Some(env) = &self.dev_container().container_env {
                 for (key, value) in env {
-                    extended_dockerfile = format!("{extended_dockerfile}ENV {key}={value}\n");
+                    extended_dockerfile.push_str(&format_dockerfile_env_line(key, value));
                 }
             }
         }
@@ -1541,7 +1541,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         if let Some(env) = &self.dev_container().container_env {
             for (key, value) in env {
-                dockerfile = format!("{dockerfile}ENV {key}={value}\n");
+                dockerfile.push_str(&format_dockerfile_env_line(key, value));
             }
         }
         dockerfile
@@ -3348,6 +3348,38 @@ mod test {
         );
 
         assert_eq!(replaced, "before one:two after");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[gpui::test]
+    async fn test_update_uid_dockerfile_escapes_container_env_values_with_spaces(
+        cx: &mut TestAppContext,
+    ) {
+        let (_, devcontainer_manifest) = init_default_devcontainer_manifest(
+            cx,
+            r#"
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "remoteUser": "vscode",
+    "containerEnv": {
+        "PROMPT_COMMAND": "history -a"
+    }
+}
+            "#,
+        )
+        .await
+        .unwrap();
+
+        let dockerfile = devcontainer_manifest.generate_update_uid_dockerfile();
+
+        assert!(
+            dockerfile.contains("ENV PROMPT_COMMAND=\"history -a\"\n"),
+            "containerEnv values with spaces should be quoted in Dockerfile ENV lines: {dockerfile}"
+        );
+        assert!(
+            !dockerfile.contains("ENV PROMPT_COMMAND=history -a\n"),
+            "unescaped spaces make Docker parse '-a' as a separate ENV assignment"
+        );
     }
 
     #[gpui::test]

--- a/crates/dev_container/src/features.rs
+++ b/crates/dev_container/src/features.rs
@@ -7,7 +7,7 @@ use serde_json_lenient::Value;
 use crate::{
     devcontainer_api::DevContainerError,
     devcontainer_json::{FeatureOptions, MountDefinition},
-    safe_id_upper,
+    format_dockerfile_env_line, safe_id_upper,
 };
 
 /// Parsed components of an OCI feature reference such as
@@ -122,7 +122,7 @@ RUN chmod -R 0755 {full_dest} \
         env.sort();
 
         for (key, value) in env {
-            layer = format!("{layer}ENV {key}={value}\n")
+            layer.push_str(&format_dockerfile_env_line(key, value));
         }
         layer
     }

--- a/crates/dev_container/src/lib.rs
+++ b/crates/dev_container/src/lib.rs
@@ -75,6 +75,35 @@ pub(crate) fn safe_id_lower(input: &str) -> String {
 pub(crate) fn safe_id_upper(input: &str) -> String {
     get_safe_id(input).to_uppercase()
 }
+
+pub(crate) fn format_dockerfile_env_line(key: &str, value: &str) -> String {
+    format!("ENV {key}={}\n", escape_dockerfile_env_value(value))
+}
+
+fn escape_dockerfile_env_value(value: &str) -> std::borrow::Cow<'_, str> {
+    if value
+        .chars()
+        .all(|character| !character.is_whitespace() && character != '"' && character != '\\')
+    {
+        return std::borrow::Cow::Borrowed(value);
+    }
+
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '"' | '\\' => {
+                escaped.push('\\');
+                escaped.push(character);
+            }
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            other => escaped.push(other),
+        }
+    }
+    escaped.push('"');
+    std::borrow::Cow::Owned(escaped)
+}
 fn get_safe_id(input: &str) -> String {
     let replaced: String = input
         .chars()
@@ -1675,8 +1704,24 @@ mod tests {
 
     use crate::{
         DevContainerTemplatesResponse, devcontainer_templates_repository,
-        get_deserializable_oci_blob, ghcr_registry,
+        format_dockerfile_env_line, get_deserializable_oci_blob, ghcr_registry,
     };
+
+    #[test]
+    fn test_format_dockerfile_env_line_quotes_values_that_need_escaping() {
+        assert_eq!(
+            format_dockerfile_env_line("PROMPT_COMMAND", "history -a"),
+            "ENV PROMPT_COMMAND=\"history -a\"\n"
+        );
+        assert_eq!(
+            format_dockerfile_env_line("PATH", "/usr/local/go/bin:/go/bin:${PATH}"),
+            "ENV PATH=/usr/local/go/bin:/go/bin:${PATH}\n"
+        );
+        assert_eq!(
+            format_dockerfile_env_line("QUOTE", "a\"b"),
+            "ENV QUOTE=\"a\\\"b\"\n"
+        );
+    }
 
     #[gpui::test]
     async fn test_get_devcontainer_templates() {


### PR DESCRIPTION
Fixes #55372

Summary:
- Added a shared formatter for Dockerfile `ENV` lines generated by devcontainer code.
- Quote/escape `containerEnv` values when they contain whitespace, quotes, or backslashes.
- Use the formatter for both feature-generated env layers and devcontainer `containerEnv` layers, including the UID-update Dockerfile path.

Root cause:
- Devcontainer Dockerfile generation wrote `ENV {key}={value}` directly. Values like `history -a` were emitted as `ENV PROMPT_COMMAND=history -a`, which Docker parses as an invalid extra assignment token.

Validation:
- `cargo test -p dev_container test_update_uid_dockerfile_escapes_container_env_values_with_spaces -- --nocapture`
- `cargo test -p dev_container test_format_dockerfile_env_line_quotes_values_that_need_escaping -- --nocapture`
- `cargo test -p dev_container`
- `cargo fmt --package dev_container --check`
- `CARGO=/home/rc/.cargo/bin/cargo ./script/clippy -p dev_container`

Release Notes:

- Fixed devcontainer startup failures when `containerEnv` values contain spaces.
