### PR TITLE
collab: Decouple session principal from `User` database model

### DIFF
--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -74,7 +74,7 @@ pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl Into
             .await?
             .with_context(|| format!("user {user_id} not found"))?;
 
-        req.extensions_mut().insert(Principal::User(user));
+        req.extensions_mut().insert(Principal::User(user.into()));
         return Ok::<_, Error>(next.run(req).await);
     }
 

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -37,7 +37,6 @@ use worktree_settings_file::LocalSettingsKind;
 
 pub use ids::*;
 pub use sea_orm::ConnectOptions;
-pub use tables::user::Model as User;
 pub use tables::*;
 
 #[cfg(feature = "test-support")]

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -60,7 +60,10 @@ impl Database {
     }
 
     /// Returns a user by GitHub login. There are no access checks here, so this should only be used internally.
-    pub async fn get_user_by_github_login(&self, github_login: &str) -> Result<Option<User>> {
+    pub async fn get_user_by_github_login(
+        &self,
+        github_login: &str,
+    ) -> Result<Option<user::Model>> {
         self.transaction(|tx| async move {
             Ok(user::Entity::find()
                 .filter(user::Column::GithubLogin.eq(github_login))
@@ -78,7 +81,7 @@ impl Database {
         github_name: Option<&str>,
         github_user_created_at: DateTimeUtc,
         initial_channel_id: Option<ChannelId>,
-    ) -> Result<User> {
+    ) -> Result<user::Model> {
         self.transaction(|tx| async move {
             self.update_or_create_user_by_github_account_tx(
                 github_login,
@@ -103,7 +106,7 @@ impl Database {
         github_user_created_at: NaiveDateTime,
         initial_channel_id: Option<ChannelId>,
         tx: &DatabaseTransaction,
-    ) -> Result<User> {
+    ) -> Result<user::Model> {
         if let Some(existing_user) = self
             .get_user_by_github_user_id_or_github_login(github_user_id, github_login, tx)
             .await?
@@ -156,7 +159,7 @@ impl Database {
         github_user_id: i32,
         github_login: &str,
         tx: &DatabaseTransaction,
-    ) -> Result<Option<User>> {
+    ) -> Result<Option<user::Model>> {
         if let Some(user_by_github_user_id) = user::Entity::find()
             .filter(user::Column::GithubUserId.eq(github_user_id))
             .one(tx)
@@ -178,7 +181,7 @@ impl Database {
 
     /// get_all_users returns the next page of users. To get more call again with
     /// the same limit and the page incremented by 1.
-    pub async fn get_all_users(&self, page: u32, limit: u32) -> Result<Vec<User>> {
+    pub async fn get_all_users(&self, page: u32, limit: u32) -> Result<Vec<user::Model>> {
         self.transaction(|tx| async move {
             Ok(user::Entity::find()
                 .order_by_asc(user::Column::GithubLogin)
@@ -207,7 +210,11 @@ impl Database {
     }
 
     /// Find users where github_login ILIKE name_query.
-    pub async fn fuzzy_search_users(&self, name_query: &str, limit: u32) -> Result<Vec<User>> {
+    pub async fn fuzzy_search_users(
+        &self,
+        name_query: &str,
+        limit: u32,
+    ) -> Result<Vec<user::Model>> {
         self.transaction(|tx| async {
             let tx = tx;
             let like_string = Self::fuzzy_like_string(name_query);

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -19,6 +19,17 @@ pub struct Model {
     pub created_at: NaiveDateTime,
 }
 
+impl From<Model> for crate::entities::User {
+    fn from(user: Model) -> Self {
+        crate::entities::User {
+            id: user.id,
+            github_login: user.github_login,
+            admin: user.admin,
+            connected_once: user.connected_once,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
     #[sea_orm(has_one = "super::room_participant::Entity")]

--- a/crates/collab/src/entities.rs
+++ b/crates/collab/src/entities.rs
@@ -1,0 +1,3 @@
+mod user;
+
+pub use user::*;

--- a/crates/collab/src/entities/user.rs
+++ b/crates/collab/src/entities/user.rs
@@ -1,0 +1,9 @@
+use crate::db::UserId;
+
+#[derive(Debug, Clone)]
+pub struct User {
+    pub id: UserId,
+    pub github_login: String,
+    pub admin: bool,
+    pub connected_once: bool,
+}

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod db;
+pub mod entities;
 pub mod env;
 pub mod executor;
 pub mod rpc;

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1,12 +1,13 @@
 mod connection_pool;
 
 use crate::api::{CloudflareIpCountryHeader, SystemIdHeader};
+use crate::entities::User;
 use crate::{
     AppState, Error, Result, auth,
     db::{
         self, BufferId, Capability, Channel, ChannelId, ChannelRole, ChannelsForUser, Database,
         InviteMemberResult, MembershipUpdated, NotificationId, ProjectId, RejoinedProject,
-        RemoveChannelMemberResult, RespondToChannelInvite, RoomId, ServerId, SharedThreadId, User,
+        RemoveChannelMemberResult, RespondToChannelInvite, RoomId, ServerId, SharedThreadId,
         UserId,
     },
     executor::Executor,

--- a/crates/collab/tests/integration/test_server.rs
+++ b/crates/collab/tests/integration/test_server.rs
@@ -294,7 +294,7 @@ impl TestServer {
                         cx.background_spawn(server.handle_connection(
                             server_conn,
                             client_name,
-                            Principal::User(user),
+                            Principal::User(user.into()),
                             ZedVersion(semver::Version::new(1, 0, 0)),
                             Some("test".to_string()),
                             None,


### PR DESCRIPTION
This PR decouples the session principal in Collab from the `User` database model.

We have introduced a new `User` domain entity that we use for the principal. Currently we just construct it from the database model, but this separation will make it easier to remove reliance on reading the database directly soon.

Release Notes:

- N/A
