### PR TITLE
worktree: Fix .git/info/exclude not loaded in git worktrees

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5568,7 +5568,9 @@ async fn discover_ancestor_git_repo(
                 };
             }
 
-            let repo_exclude_abs_path = ancestor_dot_git.join(REPO_EXCLUDE);
+            let dot_git_arc: Arc<Path> = Arc::from(ancestor_dot_git.as_path());
+            let (_, common_dir) = discover_git_paths(&dot_git_arc, fs.as_ref()).await;
+            let repo_exclude_abs_path = common_dir.join(REPO_EXCLUDE);
             if let Ok(repo_exclude) = build_gitignore(&repo_exclude_abs_path, fs.as_ref()).await {
                 exclude = Some(Arc::new(repo_exclude));
             }

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -2933,6 +2933,81 @@ async fn test_repo_exclude(executor: BackgroundExecutor, cx: &mut TestAppContext
     });
 }
 
+#[gpui::test]
+async fn test_repo_exclude_in_git_worktree(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+
+    // Set up the main repository with info/exclude
+    let main_repo = Path::new(path!("/main-repo"));
+    fs.insert_tree(
+        main_repo,
+        json!({
+            ".git": {
+                "info": {
+                    "exclude": ".env.*"
+                },
+                "worktrees": {
+                    "my-branch": {
+                        "commondir": "../../"
+                    }
+                }
+            },
+        }),
+    )
+    .await;
+
+    // Set up the git worktree: .git is a file pointing to the main repo
+    let worktree_dir = Path::new(path!("/worktree"));
+    fs.insert_tree(
+        worktree_dir,
+        json!({
+            ".git": "gitdir: /main-repo/.git/worktrees/my-branch",
+            ".env.local": "secret=1234",
+            "README.md": "# Hello",
+            "src": {
+                "main.rs": "fn main() {}",
+            },
+        }),
+    )
+    .await;
+
+    let worktree = Worktree::local(
+        worktree_dir,
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    // .env.local should be ignored via the main repo's info/exclude
+    worktree.update(cx, |worktree, _cx| {
+        let expected_excluded_paths = [];
+        let expected_ignored_paths = [".env.local"];
+        let expected_tracked_paths = ["README.md", "src/main.rs"];
+        let expected_included_paths = [];
+
+        check_worktree_entries(
+            worktree,
+            &expected_excluded_paths,
+            &expected_ignored_paths,
+            &expected_tracked_paths,
+            &expected_included_paths,
+        );
+    });
+}
+
 #[track_caller]
 fn check_worktree_entries(
     tree: &Worktree,


### PR DESCRIPTION
In a git worktree, `.git` is a file (containing `gitdir: ...`) rather than a directory. The initial scan in `discover_ancestor_git_repo()` naively joined `info/exclude` onto the `.git` path, which produced a nonsensical path when `.git` was a file. Use `discover_git_paths()` to resolve the common directory first, matching what the rest of the worktree code already does.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [-] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes NA

Release Notes:

- git: Fix .git/info/exclude not loaded in git worktrees 
