### PR TITLE
Fix Vim visual block gj/gk on wrapped lines

### DIFF
--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -259,7 +259,7 @@ impl Vim {
             };
 
             if vim.mode == Mode::VisualBlock {
-                vim.visual_block_motion(true, editor, window, cx, &mut move_cursor);
+                vim.visual_block_motion(true, true, editor, window, cx, &mut move_cursor);
             } else {
                 editor.change_selections(
                     SelectionEffects::no_scroll().nav_history(false),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1255,7 +1255,7 @@ impl Vim {
         self.update_editor(cx, |vim, editor, cx| {
             if last_mode != Mode::VisualBlock && last_mode.is_visual() && mode == Mode::VisualBlock
             {
-                vim.visual_block_motion(true, editor, window, cx, &mut |_, point, goal| {
+                vim.visual_block_motion(true, true, editor, window, cx, &mut |_, point, goal| {
                     Some((point, goal))
                 })
             }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -227,9 +227,15 @@ impl Vim {
                     }
                 )
             {
-                let is_up_or_down = matches!(motion, Motion::Up { .. } | Motion::Down { .. });
+                let (preserve_goal, skip_wrapped_rows) = match motion {
+                    Motion::Up { display_lines } | Motion::Down { display_lines } => {
+                        (true, !display_lines)
+                    }
+                    _ => (false, false),
+                };
                 vim.visual_block_motion(
-                    is_up_or_down,
+                    preserve_goal,
+                    skip_wrapped_rows,
                     editor,
                     window,
                     cx,
@@ -299,6 +305,7 @@ impl Vim {
     pub fn visual_block_motion(
         &mut self,
         preserve_goal: bool,
+        skip_wrapped_rows: bool,
         editor: &mut Editor,
         window: &mut Window,
         cx: &mut Context<Editor>,
@@ -416,9 +423,15 @@ impl Vim {
 
                 // Find the next or previous buffer row where the `row` should
                 // be moved to, so that wrapped lines are skipped.
-                row = map
-                    .start_of_relative_buffer_row(DisplayPoint::new(row, 0), direction)
-                    .row();
+                if skip_wrapped_rows {
+                    row = map
+                        .start_of_relative_buffer_row(DisplayPoint::new(row, 0), direction)
+                        .row();
+                } else if going_up {
+                    row = row - 1;
+                } else {
+                    row = row + 1;
+                }
             }
 
             s.select(selections);
@@ -934,7 +947,10 @@ impl Vim {
 }
 #[cfg(test)]
 mod test {
+    use gpui::UpdateGlobal;
     use indoc::indoc;
+    use language::language_settings::SoftWrap;
+    use settings::SettingsStore;
     use workspace::item::Item;
 
     use crate::{
@@ -1651,6 +1667,31 @@ mod test {
             «1ˇ»2345678901234567890
             "
         });
+    }
+
+    #[gpui::test]
+    async fn test_visual_block_wrapped_display_line_motions(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.project.all_languages.defaults.soft_wrap = Some(SoftWrap::Bounded);
+                    settings
+                        .project
+                        .all_languages
+                        .defaults
+                        .preferred_line_length = Some(12);
+                });
+            })
+        });
+
+        cx.set_state("ˇ12345678901234567890", Mode::Normal);
+        cx.simulate_keystrokes("ctrl-v g j");
+        cx.assert_state("«1ˇ»23456789012«3ˇ»4567890", Mode::VisualBlock);
+
+        cx.set_state("123456789012«3ˇ»4567890", Mode::VisualBlock);
+        cx.simulate_keystrokes("g k");
+        cx.assert_state("«1ˇ»23456789012«3ˇ»4567890", Mode::VisualBlock);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #55128

Release Notes:

- Fixed a Vim mode hang when moving a one-character-wide visual block selection through soft-wrapped display lines with `gj` or `gk`.

## Summary

This updates visual block motion to distinguish logical-line motions (`j`/`k`) from display-line motions (`gj`/`gk`) when soft wrap is active:

- Logical up/down visual block movement keeps the previous behavior and skips wrapped display rows.
- Display-line up/down movement now traverses wrapped display rows instead of forcing movement to the next/previous buffer row.
- Existing non-motion call sites preserve the previous skip-wrapped-row behavior.

## Testing

- `cargo fmt --check`
- `cargo check -p vim`
- `git diff --check`
- `cargo test -p vim test_visual_block_wrapped_display_line_motions --lib -- --nocapture`
- `cargo test -p vim test_visual_block_wrapping_selection --lib -- --nocapture`
- `cargo test -p vim test_visual_block --lib -- --nocapture`

Additional note: `cargo test -p vim --lib` in parallel produced unrelated transient asset/keymap failures; rerunning those affected tests individually passed. A serial full run exceeded the local 10-minute command window and was stopped.
