### PR TITLE
Fix git diff stats and generated commit messages

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -676,6 +676,68 @@ struct BulkStaging {
     anchor: RepoPath,
 }
 
+#[derive(Default)]
+struct CommitMessageThinkingBlockSanitizer {
+    pending: String,
+    in_thinking_block: bool,
+}
+
+impl CommitMessageThinkingBlockSanitizer {
+    const START_TAG: &'static str = "<think>";
+    const END_TAG: &'static str = "</think>";
+
+    fn sanitize_chunk(&mut self, chunk: &str) -> String {
+        self.pending.push_str(chunk);
+        let mut sanitized = String::new();
+
+        loop {
+            if self.in_thinking_block {
+                if let Some(end_tag_start) = self.pending.find(Self::END_TAG) {
+                    let after_end_tag = end_tag_start + Self::END_TAG.len();
+                    self.pending.drain(..after_end_tag);
+                    self.in_thinking_block = false;
+                    continue;
+                }
+
+                let suffix_len = Self::partial_tag_suffix_len(&self.pending, Self::END_TAG);
+                let keep_from = self.pending.len() - suffix_len;
+                self.pending.drain(..keep_from);
+                return sanitized;
+            }
+
+            if let Some(start_tag_start) = self.pending.find(Self::START_TAG) {
+                sanitized.push_str(&self.pending[..start_tag_start]);
+                let after_start_tag = start_tag_start + Self::START_TAG.len();
+                self.pending.drain(..after_start_tag);
+                self.in_thinking_block = true;
+                continue;
+            }
+
+            let suffix_len = Self::partial_tag_suffix_len(&self.pending, Self::START_TAG);
+            let emit_len = self.pending.len() - suffix_len;
+            sanitized.push_str(&self.pending[..emit_len]);
+            self.pending.drain(..emit_len);
+            return sanitized;
+        }
+    }
+
+    fn finish(&mut self) -> String {
+        if self.in_thinking_block {
+            self.pending.clear();
+            String::new()
+        } else {
+            std::mem::take(&mut self.pending)
+        }
+    }
+
+    fn partial_tag_suffix_len(text: &str, tag: &str) -> usize {
+        (1..tag.len())
+            .rev()
+            .find(|&suffix_len| text.ends_with(&tag[..suffix_len]))
+            .unwrap_or(0)
+    }
+}
+
 const MAX_PANEL_EDITOR_LINES: usize = 6;
 
 pub(crate) fn commit_message_editor(
@@ -2771,9 +2833,15 @@ impl GitPanel {
                             })?;
                         }
 
+                        let mut sanitizer = CommitMessageThinkingBlockSanitizer::default();
+                        let mut stream_failed = false;
                         while let Some(message) = messages.stream.next().await {
                             match message {
                                 Ok(text) => {
+                                    let text = sanitizer.sanitize_chunk(&text);
+                                    if text.is_empty() {
+                                        continue;
+                                    }
                                     this.update(cx, |this, cx| {
                                         this.commit_message_buffer(cx).update(cx, |buffer, cx| {
                                             let insert_position = buffer.anchor_before(buffer.len());
@@ -2783,9 +2851,24 @@ impl GitPanel {
                                 }
                                 Err(e) => {
                                     Self::show_commit_message_error(&this, &e, cx);
+                                    stream_failed = true;
                                     break;
                                 }
                             }
+                        }
+
+                        if stream_failed {
+                            return anyhow::Ok(());
+                        }
+
+                        let text = sanitizer.finish();
+                        if !text.is_empty() {
+                            this.update(cx, |this, cx| {
+                                this.commit_message_buffer(cx).update(cx, |buffer, cx| {
+                                    let insert_position = buffer.anchor_before(buffer.len());
+                                    buffer.edit([(insert_position..insert_position, text)], None, cx);
+                                });
+                            })?;
                         }
                     }
                     Err(e) => {
@@ -6893,6 +6976,29 @@ mod tests {
         assert_eq!(
             message,
             "Your local changes to the following files would be overwritten by merge"
+        );
+    }
+
+    #[test]
+    fn test_commit_message_thinking_block_sanitizer_handles_chunk_boundaries() {
+        let mut sanitizer = CommitMessageThinkingBlockSanitizer::default();
+        let mut sanitized = String::new();
+
+        for chunk in [
+            "Fix generated ",
+            "commit<th",
+            "ink>Need to reason",
+            " about the diff</thi",
+            "nk> messages\n\nPreserve <thi",
+            "s literal text",
+        ] {
+            sanitized.push_str(&sanitizer.sanitize_chunk(chunk));
+        }
+        sanitized.push_str(&sanitizer.finish());
+
+        assert_eq!(
+            sanitized,
+            "Fix generated commit messages\n\nPreserve <this literal text"
         );
     }
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1763,6 +1763,36 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_new_files_are_counted_as_added_lines(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "new.txt": "first\nsecond\nthird\n",
+            }),
+        )
+        .await;
+
+        fs.set_head_and_index_for_repo(Path::new(path!("/project/.git")), &[]);
+
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let diff = cx.new_window_entity(|window, cx| {
+            ProjectDiff::new(project.clone(), workspace, window, cx)
+        });
+        cx.run_until_parked();
+
+        diff.read_with(cx, |diff, cx| {
+            assert_eq!(diff.calculate_changed_lines(cx), (3, 0));
+        });
+    }
+
+    #[gpui::test]
     async fn test_save_after_restore(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -104,9 +104,12 @@ impl TextDiffView {
 
         let source_buffer_snapshot = source_buffer.read(cx).snapshot();
         let mut clipboard_text = diff_data.clipboard_text.clone();
+        let selected_text = source_buffer_snapshot
+            .text_for_range(expanded_selection_range.clone())
+            .collect::<String>();
 
-        if !clipboard_text.ends_with("\n") {
-            clipboard_text.push_str("\n");
+        if selected_text.ends_with('\n') && !clipboard_text.ends_with('\n') {
+            clipboard_text.push('\n');
         }
 
         let workspace = workspace.weak_handle();
@@ -548,6 +551,23 @@ mod tests {
             ),
             "Clipboard ↔ text.txt @ L1:1-3",
             &format!("Clipboard ↔ {} @ L1:1-3", path!("test/text.txt")),
+            cx,
+        )
+        .await;
+    }
+
+    #[gpui::test]
+    async fn test_diffing_clipboard_against_final_line_without_trailing_newline_is_clean(
+        cx: &mut TestAppContext,
+    ) {
+        base_test(
+            path!("/test"),
+            path!("/test/text.txt"),
+            "a",
+            "«aˇ»",
+            "ˇa",
+            "Clipboard ↔ text.txt @ L1:1-2",
+            &format!("Clipboard ↔ {} @ L1:1-2", path!("test/text.txt")),
             cx,
         )
         .await;

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -7396,10 +7396,11 @@ impl Repository {
                 let Some(this) = this.upgrade() else {
                     return Ok(());
                 };
-                let RepositoryState::Local(LocalRepositoryState { backend, .. }) = state else {
+                let RepositoryState::Local(LocalRepositoryState { backend, fs, .. }) = state else {
                     bail!("not a local repository")
                 };
-                let snapshot = compute_snapshot(this.clone(), backend.clone(), &mut cx).await?;
+                let snapshot =
+                    compute_snapshot(this.clone(), backend.clone(), fs.clone(), &mut cx).await?;
                 this.update(&mut cx, |this, cx| {
                     this.clear_pending_ops(cx);
                 });
@@ -7622,7 +7623,7 @@ impl Repository {
                         mem::take(&mut this.paths_needing_status_update),
                     )
                 })?;
-                let RepositoryState::Local(LocalRepositoryState { backend, .. }) = state else {
+                let RepositoryState::Local(LocalRepositoryState { backend, fs, .. }) = state else {
                     bail!("not a local repository")
                 };
 
@@ -7654,13 +7655,22 @@ impl Repository {
 
                         let diff_stats: HashMap<RepoPath, DiffStat> =
                             HashMap::from_iter(diff_stats.entries.into_iter().cloned());
+                        let work_directory_abs_path = prev_snapshot.work_directory_abs_path.clone();
 
                         let mut changed_path_statuses = Vec::new();
                         let prev_statuses = prev_snapshot.statuses_by_path.clone();
                         let mut cursor = prev_statuses.cursor::<PathProgress>(());
 
                         for (repo_path, status) in &*statuses.entries {
-                            let current_diff_stat = diff_stats.get(repo_path).copied();
+                            let mut current_diff_stat = diff_stats.get(repo_path).copied();
+                            if current_diff_stat.is_none() && status.is_created() {
+                                current_diff_stat = created_file_diff_stat(
+                                    &fs,
+                                    &work_directory_abs_path,
+                                    repo_path,
+                                )
+                                .await;
+                            }
 
                             changed_paths.remove(repo_path);
                             if cursor.seek_forward(&PathTarget::Path(repo_path), Bias::Left)
@@ -8274,6 +8284,7 @@ mod tests {
     use super::*;
     use crate::Project;
     use fs::FakeFs;
+    use git::repository::repo_path;
     use gpui::TestAppContext;
     use gpui::proptest::prelude::*;
     use rand::{SeedableRng, rngs::StdRng};
@@ -8285,6 +8296,45 @@ mod tests {
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_untracked_files_get_added_line_diff_stat(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {},
+                "existing.txt": "changed\n",
+                "new.txt": "first\nsecond\nthird\n",
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            Path::new("/project/.git"),
+            &[("existing.txt", "original\n".into())],
+        );
+
+        let project = Project::test(fs, [Path::new("/project")], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let repository = project.read_with(cx, |project, cx| {
+            project.git_store().read(cx).active_repository().unwrap()
+        });
+
+        repository.read_with(cx, |repository, _| {
+            assert_eq!(
+                repository.diff_stat_for_path(&repo_path("new.txt")),
+                Some(DiffStat {
+                    added: 3,
+                    deleted: 0,
+                }),
+            );
         });
     }
 
@@ -8604,6 +8654,32 @@ mod tests {
     }
 }
 
+fn added_line_count(text: &str) -> u32 {
+    text.lines().count().try_into().unwrap_or(u32::MAX)
+}
+
+async fn created_file_diff_stat(
+    fs: &Arc<dyn Fs>,
+    work_directory_abs_path: &Path,
+    repo_path: &RepoPath,
+) -> Option<DiffStat> {
+    let path = work_directory_abs_path.join(repo_path.as_std_path());
+    let text = match fs.load(&path).await {
+        Ok(text) => text,
+        Err(error) => {
+            log::debug!(
+                "failed to compute diff stat for created file {}: {error:#}",
+                repo_path.display(PathStyle::local())
+            );
+            return None;
+        }
+    };
+    Some(DiffStat {
+        added: added_line_count(&text),
+        deleted: 0,
+    })
+}
+
 /// This snapshot computes the repository state on the foreground thread while
 /// running the git commands on the background thread. We update branch, head,
 /// remotes, and worktrees first so the UI can react sooner, then compute file
@@ -8611,6 +8687,7 @@ mod tests {
 async fn compute_snapshot(
     this: Entity<Repository>,
     backend: Arc<dyn GitRepository>,
+    fs: Arc<dyn Fs>,
     cx: &mut AsyncApp,
 ) -> Result<RepositorySnapshot> {
     let (id, work_directory_abs_path, prev_snapshot) = this.update(cx, |this, _| {
@@ -8730,19 +8807,23 @@ async fn compute_snapshot(
     let diff_stat_map: HashMap<&RepoPath, DiffStat> =
         diff_stats.entries.iter().map(|(p, s)| (p, *s)).collect();
     let mut conflicted_paths = Vec::new();
-    let statuses_by_path = SumTree::from_iter(
-        statuses.entries.iter().map(|(repo_path, status)| {
-            if status.is_conflicted() {
-                conflicted_paths.push(repo_path.clone());
-            }
-            StatusEntry {
-                repo_path: repo_path.clone(),
-                status: *status,
-                diff_stat: diff_stat_map.get(repo_path).copied(),
-            }
-        }),
-        (),
-    );
+    let mut status_entries = Vec::with_capacity(statuses.entries.len());
+    for (repo_path, status) in statuses.entries.iter() {
+        if status.is_conflicted() {
+            conflicted_paths.push(repo_path.clone());
+        }
+        let mut diff_stat = diff_stat_map.get(repo_path).copied();
+        if diff_stat.is_none() && status.is_created() {
+            diff_stat =
+                created_file_diff_stat(&fs, &snapshot.work_directory_abs_path, repo_path).await;
+        }
+        status_entries.push(StatusEntry {
+            repo_path: repo_path.clone(),
+            status: *status,
+            diff_stat,
+        });
+    }
+    let statuses_by_path = SumTree::from_iter(status_entries, ());
 
     let merge_details = cx
         .background_spawn({


### PR DESCRIPTION
## Summary

- Fix untracked/new files so the git project diff can show `+N` added lines instead of a blank stat.
- Preserve clean clipboard-selection diffs for final-line selections without forcing an extra trailing newline.
- Strip streamed `<think>...</think>` blocks from AI-generated commit messages while preserving normal text across chunk boundaries.

Closes #54266.
Closes #49204.
Closes #50989.

## Test Plan

- `cargo fmt --package project --package git_ui -- --check`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' ./script/cargo test -p project test_untracked_files_get_added_line_diff_stat -- --nocapture`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' ./script/cargo test -p git_ui test_commit_message_thinking_block_sanitizer_handles_chunk_boundaries -- --nocapture`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' ./script/cargo test -p git_ui test_diffing_clipboard_against_final_line_without_trailing_newline_is_clean -- --nocapture`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' ./script/cargo test -p git_ui test_new_files_are_counted_as_added_lines -- --nocapture`

Release Notes:

- Fixed git diff and generated commit message edge cases.
