### PR TITLE
agent_ui: Trigger @-mention menu after opening brackets

### DIFF
--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1670,11 +1670,7 @@ impl MentionCompletion {
         supported_modes: &[PromptContextType],
     ) -> Option<Self> {
         // Find the rightmost '@' that has a boundary before it and no whitespace immediately after.
-        // A boundary is the start of the line, whitespace, or an opening bracket so that
-        // bracketed mentions like `(@file)`, `[@file]`, and `{@file}` open the completion menu.
-        // We deliberately do not treat every non-word character as a boundary because `@fetch`
-        // arguments are URLs that frequently contain '@' (e.g. `https://example.com/@org/repo`),
-        // and `/` would otherwise cause the inner '@' to be picked instead of the leading `@fetch`.
+        // A boundary is the start of the line, whitespace, or an opening bracket.
         let mut last_mention_start = None;
         for (idx, _) in line.rmatch_indices('@') {
             // No whitespace immediately after '@'.

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1669,10 +1669,15 @@ impl MentionCompletion {
         offset_to_line: usize,
         supported_modes: &[PromptContextType],
     ) -> Option<Self> {
-        // Find the rightmost '@' that has a word boundary before it and no whitespace immediately after
+        // Find the rightmost '@' that has a boundary before it and no whitespace immediately after.
+        // A boundary is the start of the line, whitespace, or an opening bracket so that
+        // bracketed mentions like `(@file)`, `[@file]`, and `{@file}` open the completion menu.
+        // We deliberately do not treat every non-word character as a boundary because `@fetch`
+        // arguments are URLs that frequently contain '@' (e.g. `https://example.com/@org/repo`),
+        // and `/` would otherwise cause the inner '@' to be picked instead of the leading `@fetch`.
         let mut last_mention_start = None;
         for (idx, _) in line.rmatch_indices('@') {
-            // No whitespace immediately after '@'
+            // No whitespace immediately after '@'.
             if line[idx + 1..]
                 .chars()
                 .next()
@@ -1681,12 +1686,11 @@ impl MentionCompletion {
                 continue;
             }
 
-            // Must be a word boundary before '@'
             if idx > 0
                 && line[..idx]
                     .chars()
                     .last()
-                    .is_some_and(|c| !c.is_whitespace())
+                    .is_some_and(|c| !c.is_whitespace() && !matches!(c, '(' | '[' | '{'))
             {
                 continue;
             }
@@ -2544,6 +2548,39 @@ mod tests {
                 argument: Some("https://example.com/@".to_string()),
             }),
             "Should parse URL ending with @ (even if URL is incomplete)"
+        );
+
+        // Bracketed mentions: opening brackets count as a boundary before '@' so
+        // typing `(@`, `[@`, or `{@` still opens the completion menu.
+
+        assert_eq!(
+            MentionCompletion::try_parse("(@", 0, &supported_modes),
+            Some(MentionCompletion {
+                source_range: 1..2,
+                mode: None,
+                argument: None,
+            }),
+            "Should parse mention immediately after '('"
+        );
+
+        assert_eq!(
+            MentionCompletion::try_parse("[@", 0, &supported_modes),
+            Some(MentionCompletion {
+                source_range: 1..2,
+                mode: None,
+                argument: None,
+            }),
+            "Should parse mention immediately after '['"
+        );
+
+        assert_eq!(
+            MentionCompletion::try_parse("{@", 0, &supported_modes),
+            Some(MentionCompletion {
+                source_range: 1..2,
+                mode: None,
+                argument: None,
+            }),
+            "Should parse mention immediately after '{{'"
         );
     }
 


### PR DESCRIPTION
Typing `@` immediately after `(`, `[`, or `{` did not open the Agent Panel’s @-mention completion menu, so `(@file)`, `[@file]`, and `{@file}` were unusable. This has been bothering me for quite some time now. Overall, I believe this is a QoL improvement, albeit a small one.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Fixed the Agent Panel’s @-mention menu not appearing when `@` immediately follows `(`, `[`, or `{`.
