### PR TITLE
agent_ui: Add per-tool enable/disable for MCP servers

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1584,6 +1584,193 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_mcp_tools_individually_disabled(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    // Set up a profile with enable_all_context_servers=true but one tool explicitly disabled.
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "tool_permissions": { "default": "allow" },
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {
+                            EchoTool::NAME: true,
+                        },
+                        "context_servers": {
+                            "test_server": {
+                                "tools": {
+                                    "allowed_tool": true,
+                                    "blocked_tool": false
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    // Register a context server with two tools.
+    let _mcp_tool_calls = setup_context_server(
+        "test_server",
+        vec![
+            context_server::types::Tool {
+                name: "allowed_tool".into(),
+                title: None,
+                description: Some("An allowed tool".into()),
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: None,
+                annotations: None,
+            },
+            context_server::types::Tool {
+                name: "blocked_tool".into(),
+                title: None,
+                description: Some("A blocked tool".into()),
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: None,
+                annotations: None,
+            },
+        ],
+        &context_server_store,
+        cx,
+    );
+
+    let events = thread.update(cx, |thread, cx| {
+        thread.send(UserMessageId::new(), ["Hey"], cx).unwrap()
+    });
+    cx.run_until_parked();
+
+    // Only the allowed tool should appear in the completion request.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_names = tool_names_for_completion(&completion);
+    assert!(
+        tool_names.contains(&"allowed_tool".to_string()),
+        "allowed_tool should be present, got: {:?}",
+        tool_names
+    );
+    assert!(
+        !tool_names.contains(&"blocked_tool".to_string()),
+        "blocked_tool should NOT be present, got: {:?}",
+        tool_names
+    );
+
+    fake_model.send_last_completion_stream_text_chunk("OK");
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
+async fn test_mcp_tools_all_disabled_by_default(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    // Set up a profile with enable_all_context_servers=false and only one tool enabled.
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "tool_permissions": { "default": "allow" },
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": false,
+                        "tools": {
+                            EchoTool::NAME: true,
+                        },
+                        "context_servers": {
+                            "test_server": {
+                                "tools": {
+                                    "enabled_tool": true
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    // Register a context server with two tools.
+    let _mcp_tool_calls = setup_context_server(
+        "test_server",
+        vec![
+            context_server::types::Tool {
+                name: "enabled_tool".into(),
+                title: None,
+                description: Some("An enabled tool".into()),
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: None,
+                annotations: None,
+            },
+            context_server::types::Tool {
+                name: "not_enabled_tool".into(),
+                title: None,
+                description: Some("Not explicitly enabled".into()),
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: None,
+                annotations: None,
+            },
+        ],
+        &context_server_store,
+        cx,
+    );
+
+    let events = thread.update(cx, |thread, cx| {
+        thread.send(UserMessageId::new(), ["Hey"], cx).unwrap()
+    });
+    cx.run_until_parked();
+
+    // Only the explicitly enabled tool should appear.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_names = tool_names_for_completion(&completion);
+    assert!(
+        tool_names.contains(&"enabled_tool".to_string()),
+        "enabled_tool should be present, got: {:?}",
+        tool_names
+    );
+    assert!(
+        !tool_names.contains(&"not_enabled_tool".to_string()),
+        "not_enabled_tool should NOT be present, got: {:?}",
+        tool_names
+    );
+
+    fake_model.send_last_completion_stream_text_chunk("OK");
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
 async fn test_mcp_tool_multi_content_response(cx: &mut TestAppContext) {
     let ThreadTest {
         model,

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -117,11 +117,19 @@ impl AgentProfileSettings {
     }
 
     pub fn is_context_server_tool_enabled(&self, server_id: &str, tool_name: &str) -> bool {
-        self.enable_all_context_servers
-            || self
-                .context_servers
+        if self.enable_all_context_servers {
+            // All enabled by default; only disabled if explicitly set to false
+            self.context_servers
+                .get(server_id)
+                .and_then(|preset| preset.tools.get(tool_name))
+                .copied()
+                .unwrap_or(true)
+        } else {
+            // None enabled by default; only enabled if explicitly set to true
+            self.context_servers
                 .get(server_id)
                 .is_some_and(|preset| preset.tools.get(tool_name) == Some(&true))
+        }
     }
 
     pub fn save_to_settings(

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -208,3 +208,102 @@ impl From<settings::ContextServerPresetContent> for ContextServerPreset {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile_with_all_servers_enabled() -> AgentProfileSettings {
+        let mut context_servers = IndexMap::default();
+        let mut tools = IndexMap::default();
+        tools.insert(Arc::from("enabled_tool"), true);
+        tools.insert(Arc::from("disabled_tool"), false);
+        context_servers.insert(Arc::from("my_server"), ContextServerPreset { tools });
+
+        AgentProfileSettings {
+            name: "Test".into(),
+            tools: IndexMap::default(),
+            enable_all_context_servers: true,
+            context_servers,
+            default_model: None,
+        }
+    }
+
+    fn profile_with_all_servers_disabled() -> AgentProfileSettings {
+        let mut context_servers = IndexMap::default();
+        let mut tools = IndexMap::default();
+        tools.insert(Arc::from("enabled_tool"), true);
+        tools.insert(Arc::from("disabled_tool"), false);
+        context_servers.insert(Arc::from("my_server"), ContextServerPreset { tools });
+
+        AgentProfileSettings {
+            name: "Test".into(),
+            tools: IndexMap::default(),
+            enable_all_context_servers: false,
+            context_servers,
+            default_model: None,
+        }
+    }
+
+    #[test]
+    fn test_enable_all_servers_respects_explicit_false() {
+        let profile = profile_with_all_servers_enabled();
+
+        // Explicitly enabled tool is enabled
+        assert!(profile.is_context_server_tool_enabled("my_server", "enabled_tool"));
+
+        // Explicitly disabled tool is disabled even with enable_all_context_servers=true
+        assert!(!profile.is_context_server_tool_enabled("my_server", "disabled_tool"));
+
+        // Tool with no explicit entry defaults to enabled
+        assert!(profile.is_context_server_tool_enabled("my_server", "unlisted_tool"));
+
+        // Tool on an unknown server defaults to enabled
+        assert!(profile.is_context_server_tool_enabled("unknown_server", "any_tool"));
+    }
+
+    #[test]
+    fn test_disable_all_servers_requires_explicit_true() {
+        let profile = profile_with_all_servers_disabled();
+
+        // Explicitly enabled tool is enabled
+        assert!(profile.is_context_server_tool_enabled("my_server", "enabled_tool"));
+
+        // Explicitly disabled tool is disabled
+        assert!(!profile.is_context_server_tool_enabled("my_server", "disabled_tool"));
+
+        // Tool with no explicit entry defaults to disabled
+        assert!(!profile.is_context_server_tool_enabled("my_server", "unlisted_tool"));
+
+        // Tool on an unknown server defaults to disabled
+        assert!(!profile.is_context_server_tool_enabled("unknown_server", "any_tool"));
+    }
+
+    #[test]
+    fn test_enable_all_servers_no_server_preset() {
+        let profile = AgentProfileSettings {
+            name: "Test".into(),
+            tools: IndexMap::default(),
+            enable_all_context_servers: true,
+            context_servers: IndexMap::default(),
+            default_model: None,
+        };
+
+        // With no server presets at all, everything defaults to enabled
+        assert!(profile.is_context_server_tool_enabled("any_server", "any_tool"));
+    }
+
+    #[test]
+    fn test_disable_all_servers_no_server_preset() {
+        let profile = AgentProfileSettings {
+            name: "Test".into(),
+            tools: IndexMap::default(),
+            enable_all_context_servers: false,
+            context_servers: IndexMap::default(),
+            default_model: None,
+        };
+
+        // With no server presets at all, everything defaults to disabled
+        assert!(!profile.is_context_server_tool_enabled("any_server", "any_tool"));
+    }
+}

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -7,6 +7,7 @@ mod tool_picker;
 use std::{ops::Range, rc::Rc, sync::Arc};
 
 use agent::ContextServerRegistry;
+use agent_settings::AgentSettings;
 use anyhow::Result;
 use cloud_api_types::Plan;
 use collections::HashMap;
@@ -673,6 +674,28 @@ impl AgentConfiguration {
             .tools_for_server(&context_server_id)
             .count();
 
+        let enabled_tool_count = if is_running {
+            let settings = AgentSettings::get_global(cx);
+            settings
+                .profiles
+                .get(&settings.default_profile)
+                .map(|profile| {
+                    self.context_server_registry
+                        .read(cx)
+                        .tools_for_server(&context_server_id)
+                        .filter(|tool| {
+                            profile.is_context_server_tool_enabled(
+                                &context_server_id.0,
+                                &tool.name(),
+                            )
+                        })
+                        .count()
+                })
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
         let source = if provided_by_extension {
             AiSettingItemSource::Extension
         } else {
@@ -741,16 +764,19 @@ impl AgentConfiguration {
                                     .detach();
                                 }
                             }
-                        }).when(tool_count > 0, |this| this.entry("View Tools", None, {
+                        }).when(tool_count > 0, |this| this.entry("Configure Tools", None, {
                             let context_server_id = context_server_id.clone();
                             let context_server_registry = context_server_registry.clone();
                             let workspace = workspace.clone();
+                            let fs = fs.clone();
                             move |window, cx| {
                                 let context_server_id = context_server_id.clone();
+                                let fs = fs.clone();
                                 workspace.update(cx, |workspace, cx| {
                                     ConfigureContextServerToolsModal::toggle(
                                         context_server_id,
                                         context_server_registry.clone(),
+                                        fs,
                                         workspace,
                                         window,
                                         cx,
@@ -920,15 +946,16 @@ impl AgentConfiguration {
             None
         };
 
-        let tool_label = if is_running {
-            Some(if tool_count == 1 {
-                SharedString::from("1 tool")
-            } else {
-                SharedString::from(format!("{} tools", tool_count))
-            })
+        let tool_label = if is_running && tool_count > 0 {
+            Some(SharedString::from(format!(
+                "{}/{} tools",
+                enabled_tool_count, tool_count
+            )))
         } else {
             None
         };
+
+        let context_server_id_for_tools = context_server_id.clone();
 
         AiSettingItem::new(item_id, display_name, status, source)
             .action(context_server_configuration_menu)
@@ -975,7 +1002,37 @@ impl AgentConfiguration {
                     }
                 }),
             )
-            .when_some(tool_label, |this, label| this.detail_label(label))
+            .when_some(tool_label, |this, label| {
+                this.detail_element(
+                    Button::new("tool-count-btn", label)
+                        .style(ButtonStyle::Subtle)
+                        .label_size(LabelSize::Small)
+                        .color(Color::Muted)
+                        .on_click({
+                            let context_server_id = context_server_id_for_tools.clone();
+                            let context_server_registry = self.context_server_registry.clone();
+                            let workspace = self.workspace.clone();
+                            let fs = self.fs.clone();
+                            move |_event, window, cx| {
+                                let context_server_id = context_server_id.clone();
+                                let context_server_registry = context_server_registry.clone();
+                                let fs = fs.clone();
+                                workspace
+                                    .update(cx, |workspace, cx| {
+                                        ConfigureContextServerToolsModal::toggle(
+                                            context_server_id,
+                                            context_server_registry,
+                                            fs,
+                                            workspace,
+                                            window,
+                                            cx,
+                                        );
+                                    })
+                                    .ok();
+                            }
+                        }),
+                )
+            })
             .when_some(details, |this, details| this.details(details))
     }
 

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
@@ -1,45 +1,66 @@
+use std::sync::Arc;
+
 use agent::ContextServerRegistry;
+use agent_settings::{AgentProfileId, AgentSettings};
 use collections::HashMap;
 use context_server::ContextServerId;
+use fs::Fs;
 use gpui::{
-    DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ScrollHandle, Window, prelude::*,
+    DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ScrollHandle, SharedString, Window,
+    prelude::*,
 };
-use ui::{Divider, DividerColor, Modal, ModalHeader, WithScrollbar, prelude::*};
+use settings::{
+    AgentProfileContent, ContextServerPresetContent, Settings, SettingsStore,
+    update_settings_file,
+};
+use ui::{
+    Button, ButtonStyle, Checkbox, Divider, DividerColor, LabelSize, Modal, ModalHeader,
+    WithScrollbar, prelude::*,
+};
 use workspace::{ModalView, Workspace};
 
 pub struct ConfigureContextServerToolsModal {
     context_server_id: ContextServerId,
     context_server_registry: Entity<ContextServerRegistry>,
+    fs: Arc<dyn Fs>,
     focus_handle: FocusHandle,
     expanded_tools: HashMap<SharedString, bool>,
     scroll_handle: ScrollHandle,
+    _settings_subscription: gpui::Subscription,
 }
 
 impl ConfigureContextServerToolsModal {
     fn new(
         context_server_id: ContextServerId,
         context_server_registry: Entity<ContextServerRegistry>,
+        fs: Arc<dyn Fs>,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let settings_subscription =
+            cx.observe_global::<SettingsStore>(|_this, cx| cx.notify());
+
         Self {
             context_server_id,
             context_server_registry,
+            fs,
             focus_handle: cx.focus_handle(),
             expanded_tools: HashMap::default(),
             scroll_handle: ScrollHandle::new(),
+            _settings_subscription: settings_subscription,
         }
     }
 
     pub fn toggle(
         context_server_id: ContextServerId,
         context_server_registry: Entity<ContextServerRegistry>,
+        fs: Arc<dyn Fs>,
         workspace: &mut Workspace,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
         workspace.toggle_modal(window, cx, |window, cx| {
-            Self::new(context_server_id, context_server_registry, window, cx)
+            Self::new(context_server_id, context_server_registry, fs, window, cx)
         });
     }
 
@@ -47,30 +68,189 @@ impl ConfigureContextServerToolsModal {
         cx.emit(DismissEvent)
     }
 
+    fn active_profile_and_settings(
+        &self,
+        cx: &App,
+    ) -> Option<(AgentProfileId, agent_settings::AgentProfileSettings)> {
+        let settings = AgentSettings::get_global(cx);
+        let profile_id = settings.default_profile.clone();
+        let profile = settings.profiles.get(&profile_id)?.clone();
+        Some((profile_id, profile))
+    }
+
+    fn is_tool_enabled(&self, tool_name: &str, cx: &App) -> bool {
+        let settings = AgentSettings::get_global(cx);
+        let Some(profile) = settings.profiles.get(&settings.default_profile) else {
+            return false;
+        };
+        profile.is_context_server_tool_enabled(&self.context_server_id.0, tool_name)
+    }
+
+    fn toggle_tool(&self, tool_name: SharedString, cx: &mut Context<Self>) {
+        let Some((profile_id, profile_settings)) = self.active_profile_and_settings(cx) else {
+            return;
+        };
+
+        let is_currently_enabled =
+            profile_settings.is_context_server_tool_enabled(&self.context_server_id.0, &tool_name);
+        let server_id: Arc<str> = self.context_server_id.0.clone();
+
+        update_settings_file(self.fs.clone(), cx, {
+            let profile_id = profile_id.clone();
+            let tool_name: Arc<str> = tool_name.as_ref().into();
+            move |settings, _cx| {
+                let profiles = settings
+                    .agent
+                    .get_or_insert_default()
+                    .profiles
+                    .get_or_insert_default();
+                let profile = profiles
+                    .entry(profile_id.0)
+                    .or_insert_with(|| AgentProfileContent {
+                        name: profile_settings.name.into(),
+                        tools: profile_settings.tools,
+                        enable_all_context_servers: Some(
+                            profile_settings.enable_all_context_servers,
+                        ),
+                        context_servers: profile_settings
+                            .context_servers
+                            .into_iter()
+                            .map(|(id, preset)| {
+                                (
+                                    id,
+                                    ContextServerPresetContent {
+                                        tools: preset.tools,
+                                    },
+                                )
+                            })
+                            .collect(),
+                        default_model: profile_settings.default_model.clone(),
+                    });
+
+                let preset = profile.context_servers.entry(server_id).or_default();
+                *preset.tools.entry(tool_name).or_default() = !is_currently_enabled;
+            }
+        });
+    }
+
+    fn set_all_tools(&self, enabled: bool, cx: &mut Context<Self>) {
+        let Some((profile_id, profile_settings)) = self.active_profile_and_settings(cx) else {
+            return;
+        };
+
+        let tool_names: Vec<SharedString> = self
+            .context_server_registry
+            .read(cx)
+            .tools_for_server(&self.context_server_id)
+            .map(|tool| tool.name())
+            .collect();
+
+        let server_id: Arc<str> = self.context_server_id.0.clone();
+
+        update_settings_file(self.fs.clone(), cx, {
+            let profile_id = profile_id.clone();
+            move |settings, _cx| {
+                let profiles = settings
+                    .agent
+                    .get_or_insert_default()
+                    .profiles
+                    .get_or_insert_default();
+                let profile = profiles
+                    .entry(profile_id.0)
+                    .or_insert_with(|| AgentProfileContent {
+                        name: profile_settings.name.into(),
+                        tools: profile_settings.tools,
+                        enable_all_context_servers: Some(
+                            profile_settings.enable_all_context_servers,
+                        ),
+                        context_servers: profile_settings
+                            .context_servers
+                            .into_iter()
+                            .map(|(id, preset)| {
+                                (
+                                    id,
+                                    ContextServerPresetContent {
+                                        tools: preset.tools,
+                                    },
+                                )
+                            })
+                            .collect(),
+                        default_model: profile_settings.default_model.clone(),
+                    });
+
+                let preset = profile.context_servers.entry(server_id).or_default();
+                for tool_name in tool_names {
+                    let name: Arc<str> = tool_name.as_ref().into();
+                    *preset.tools.entry(name).or_default() = enabled;
+                }
+            }
+        });
+    }
+
+    fn enabled_count(&self, cx: &App) -> usize {
+        self.context_server_registry
+            .read(cx)
+            .tools_for_server(&self.context_server_id)
+            .filter(|tool| self.is_tool_enabled(&tool.name(), cx))
+            .count()
+    }
+
     fn render_modal_content(
         &self,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let tools = self
+        let tools: Vec<_> = self
             .context_server_registry
             .read(cx)
             .tools_for_server(&self.context_server_id)
-            .collect::<Vec<_>>();
+            .collect();
+
+        let total_count = tools.len();
+        let enabled_count = self.enabled_count(cx);
+        let all_enabled = enabled_count == total_count;
 
         div()
             .size_full()
             .pb_2()
             .child(
+                h_flex()
+                    .px_3()
+                    .py_1p5()
+                    .justify_between()
+                    .child(
+                        Label::new(format!("{}/{} enabled", enabled_count, total_count))
+                            .color(Color::Muted)
+                            .size(LabelSize::Small),
+                    )
+                    .child(
+                        Button::new(
+                            "toggle-all",
+                            if all_enabled {
+                                "Disable All"
+                            } else {
+                                "Enable All"
+                            },
+                        )
+                        .style(ButtonStyle::Subtle)
+                        .label_size(LabelSize::Small)
+                        .on_click(cx.listener(move |this, _event, _window, cx| {
+                            this.set_all_tools(!all_enabled, cx);
+                        })),
+                    ),
+            )
+            .child(Divider::horizontal().color(DividerColor::Border))
+            .child(
                 v_flex()
                     .id("modal_content")
                     .px_2()
-                    .gap_1()
-                    .max_h_128()
+                    .gap_0p5()
+                    .max_h_96()
                     .overflow_y_scroll()
                     .track_scroll(&self.scroll_handle)
                     .children(tools.iter().enumerate().flat_map(|(index, tool)| {
                         let tool_name = tool.name();
+                        let is_enabled = self.is_tool_enabled(&tool_name, cx);
                         let is_expanded = self
                             .expanded_tools
                             .get(tool_name.as_ref())
@@ -83,6 +263,12 @@ impl ConfigureContextServerToolsModal {
                             IconName::ChevronDown
                         };
 
+                        let selection: ToggleState = if is_enabled {
+                            ToggleState::Selected
+                        } else {
+                            ToggleState::Unselected
+                        };
+
                         let mut items = vec![
                             v_flex()
                                 .child(
@@ -92,35 +278,60 @@ impl ConfigureContextServerToolsModal {
                                         .pl_1()
                                         .pr_2()
                                         .w_full()
-                                        .justify_between()
+                                        .items_center()
+                                        .gap_1p5()
                                         .rounded_sm()
                                         .hover(|s| s.bg(cx.theme().colors().element_hover))
                                         .child(
-                                            Label::new(tool_name.clone())
-                                                .buffer_font(cx)
-                                                .size(LabelSize::Small),
+                                            Checkbox::new(
+                                                format!("tool-toggle-{}", index),
+                                                selection,
+                                            )
+                                            .on_click(cx.listener({
+                                                let tool_name = tool_name.clone();
+                                                move |this, _state, _window, cx| {
+                                                    this.toggle_tool(tool_name.clone(), cx);
+                                                }
+                                            })),
                                         )
                                         .child(
-                                            Icon::new(icon)
-                                                .size(IconSize::Small)
-                                                .color(Color::Muted),
-                                        )
-                                        .on_click(cx.listener({
-                                            move |this, _event, _window, _cx| {
-                                                let current = this
-                                                    .expanded_tools
-                                                    .get(tool_name.as_ref())
-                                                    .copied()
-                                                    .unwrap_or(false);
-                                                this.expanded_tools
-                                                    .insert(tool_name.clone(), !current);
-                                                _cx.notify();
-                                            }
-                                        })),
+                                            h_flex()
+                                                .id(format!("tool-expand-{}", index))
+                                                .flex_1()
+                                                .min_w_0()
+                                                .justify_between()
+                                                .child(
+                                                    Label::new(tool_name.clone())
+                                                        .buffer_font(cx)
+                                                        .size(LabelSize::Small),
+                                                )
+                                                .child(
+                                                    Icon::new(icon)
+                                                        .size(IconSize::Small)
+                                                        .color(Color::Muted),
+                                                )
+                                                .on_click(cx.listener({
+                                                    let tool_name = tool_name.clone();
+                                                    move |this, _event, _window, cx| {
+                                                        let current = this
+                                                            .expanded_tools
+                                                            .get(tool_name.as_ref())
+                                                            .copied()
+                                                            .unwrap_or(false);
+                                                        this.expanded_tools
+                                                            .insert(tool_name.clone(), !current);
+                                                        cx.notify();
+                                                    }
+                                                })),
+                                        ),
                                 )
                                 .when(is_expanded, |this| {
                                     this.child(
-                                        Label::new(tool.description()).color(Color::Muted).mx_1(),
+                                        Label::new(tool.description())
+                                            .color(Color::Muted)
+                                            .size(LabelSize::Small)
+                                            .mx_1()
+                                            .ml_6(),
                                     )
                                 })
                                 .into_any_element(),
@@ -155,6 +366,18 @@ impl EventEmitter<DismissEvent> for ConfigureContextServerToolsModal {}
 
 impl Render for ConfigureContextServerToolsModal {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let enabled_count = self.enabled_count(cx);
+        let total_count = self
+            .context_server_registry
+            .read(cx)
+            .tools_for_server(&self.context_server_id)
+            .count();
+
+        let headline = format!(
+            "{} — {}/{} tools enabled",
+            self.context_server_id.0, enabled_count, total_count
+        );
+
         div()
             .key_context("ContextServerToolsModal")
             .occlude()
@@ -166,7 +389,7 @@ impl Render for ConfigureContextServerToolsModal {
                 Modal::new("configure-context-server-tools", None::<ScrollHandle>)
                     .header(
                         ModalHeader::new()
-                            .headline(format!("Tools from {}", self.context_server_id.0))
+                            .headline(headline)
                             .show_dismiss_button(true),
                     )
                     .child(self.render_modal_content(window, cx)),

--- a/crates/ui/src/components/ai/ai_setting_item.rs
+++ b/crates/ui/src/components/ai/ai_setting_item.rs
@@ -74,6 +74,7 @@ pub struct AiSettingItem {
     icon: Option<AnyElement>,
     label: SharedString,
     detail_label: Option<SharedString>,
+    detail_element: Option<AnyElement>,
     actions: Vec<AnyElement>,
     details: Option<AnyElement>,
 }
@@ -92,6 +93,7 @@ impl AiSettingItem {
             icon: None,
             label: label.into(),
             detail_label: None,
+            detail_element: None,
             actions: Vec::new(),
             details: None,
         }
@@ -104,6 +106,11 @@ impl AiSettingItem {
 
     pub fn detail_label(mut self, detail: impl Into<SharedString>) -> Self {
         self.detail_label = Some(detail.into());
+        self
+    }
+
+    pub fn detail_element(mut self, element: impl IntoElement) -> Self {
+        self.detail_element = Some(element.into_any_element());
         self
     }
 
@@ -127,6 +134,7 @@ impl RenderOnce for AiSettingItem {
             icon,
             label,
             detail_label,
+            detail_element,
             actions,
             details,
         } = self;
@@ -221,12 +229,18 @@ impl RenderOnce for AiSettingItem {
                                             .color(Color::Muted),
                                     ),
                             )
-                            .when_some(detail_label, |this, detail| {
-                                this.child(
-                                    Label::new(detail)
-                                        .color(Color::Muted)
-                                        .size(LabelSize::Small),
-                                )
+                            .map(|this| {
+                                if let Some(element) = detail_element {
+                                    this.child(element)
+                                } else if let Some(detail) = detail_label {
+                                    this.child(
+                                        Label::new(detail)
+                                            .color(Color::Muted)
+                                            .size(LabelSize::Small),
+                                    )
+                                } else {
+                                    this
+                                }
                             }),
                     )
                     .when(!actions.is_empty(), |this| {


### PR DESCRIPTION
This PR makes it possible to selectively enable/disable individual tools from MCP servers directly from the agent configuration panel.

## Problem

The existing "View Tools" modal was read-only — you could see which tools a server provided but couldn't toggle them. The only way to configure per-tool settings was through the Manage Profiles modal (buried several clicks deep) or manual JSON editing.

Additionally, `is_context_server_tool_enabled` had a logic bug: when `enable_all_context_servers` was `true`, the `||` short-circuited and per-tool `false` entries were silently ignored. Users could uncheck tools in the ToolPicker UI, but those changes had no effect.

## Solution

- **Configure Tools modal**: The read-only tools viewer now has checkboxes per tool, an Enable All/Disable All button, and an "X/Y enabled" count. Changes persist immediately to settings.
- **Clickable tool count**: The "N tools" label on each MCP server row is now a clickable button showing "X/Y tools" (enabled/total). Clicking it opens the configure modal.
- **Fix `is_context_server_tool_enabled`**: When `enable_all_context_servers` is `true`, tools now default to enabled but respect explicit `false` entries. When `false`, tools require explicit `true`.

## Screenshots

#### MCP Server List

<img width="394" height="170" alt="mcp-list" src="https://github.com/user-attachments/assets/b05facbc-6c8a-4f4d-bc1e-cd2fc7277d5c" />

#### MCP Configure Tools

<img width="506" height="431" alt="mcp-tools" src="https://github.com/user-attachments/assets/3db6862d-3e10-4862-9cd7-741114f95aea" />

---

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added per-tool enable/disable UI for MCP servers in the agent configuration panel
- Fixed `is_context_server_tool_enabled` ignoring explicit `false` entries when `enable_all_context_servers` was `true`
