### PR TITLE
git_graph: Fix search bar Vim key handling

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1536,4 +1536,18 @@
       "ctrl-shift-backspace": "worktree_picker::DeleteWorktree",
     },
   },
+  {
+    "context": "GitGraph",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
+  {
+    "context": "GitGraphSearchBar > Editor",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1627,4 +1627,18 @@
       "escape": "notebook::EnterCommandMode",
     },
   },
+  {
+    "context": "GitGraph",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
+  {
+    "context": "GitGraphSearchBar > Editor",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
 ]

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1553,4 +1553,18 @@
       "escape": "notebook::EnterCommandMode",
     },
   },
+  {
+    "context": "GitGraph",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
+  {
+    "context": "GitGraphSearchBar > Editor",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
 ]

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1036,6 +1036,20 @@
   {
     "context": "GitGraph",
     "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
+  {
+    "context": "GitGraphSearchBar > Editor",
+    "bindings": {
+      "tab": "git_graph::FocusNextTabStop",
+      "shift-tab": "git_graph::FocusPreviousTabStop",
+    },
+  },
+  {
+    "context": "GitGraph && !GitGraphSearchBar",
+    "bindings": {
       "j": "vim::MenuSelectNext",
       "k": "vim::MenuSelectPrevious",
       "shift-g": "menu::SelectLast",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3536,6 +3536,10 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn show_cursor(&mut self, cx: &mut Context<Self>) {
+        self.blink_manager.update(cx, BlinkManager::show_cursor);
+    }
+
     pub fn cursor_shape(&self) -> CursorShape {
         self.cursor_shape
     }

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1116,7 +1116,7 @@ impl GitGraph {
 
         let table_interaction_state = cx.new(|cx| {
             let mut state = TableInteractionState::new(cx);
-            state.focus_handle = state.focus_handle.tab_index(2).tab_stop(true);
+            state.focus_handle = state.focus_handle.tab_index(1).tab_stop(true);
             state
         });
 
@@ -1610,6 +1610,14 @@ impl GitGraph {
         self.search(query, cx);
     }
 
+    fn refresh_search_editor_if_focused(&self, window: &Window, cx: &mut Context<Self>) {
+        self.search_state.editor.update(cx, |editor, cx| {
+            if editor.is_focused(window) {
+                cx.notify();
+            }
+        });
+    }
+
     fn focus_next_tab_stop(
         &mut self,
         _: &FocusNextTabStop,
@@ -1617,6 +1625,7 @@ impl GitGraph {
         cx: &mut Context<Self>,
     ) {
         window.focus_next(cx);
+        self.refresh_search_editor_if_focused(window, cx);
         cx.stop_propagation();
         cx.notify();
     }
@@ -1628,6 +1637,7 @@ impl GitGraph {
         cx: &mut Context<Self>,
     ) {
         window.focus_prev(cx);
+        self.refresh_search_editor_if_focused(window, cx);
         cx.stop_propagation();
         cx.notify();
     }
@@ -1830,6 +1840,9 @@ impl GitGraph {
 
         h_flex()
             .key_context("GitGraphSearchBar")
+            .tab_index(1)
+            .tab_group()
+            .tab_stop(false)
             .w_full()
             .p_1p5()
             .gap_1p5()
@@ -2956,6 +2969,9 @@ impl Render for GitGraph {
                                             })
                                             .child(
                                                 div()
+                                                    .tab_index(2)
+                                                    .tab_group()
+                                                    .tab_stop(false)
                                                     .w(DefiniteLength::Fraction(table_fraction))
                                                     .h_full()
                                                     .min_w_0()

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -282,6 +282,10 @@ actions!(
         OpenCommitView,
         /// Focuses the search field.
         FocusSearch,
+        /// Focuses the next git graph tab stop.
+        FocusNextTabStop,
+        /// Focuses the previous git graph tab stop.
+        FocusPreviousTabStop,
     ]
 );
 
@@ -1110,7 +1114,11 @@ impl GitGraph {
             editor
         });
 
-        let table_interaction_state = cx.new(|cx| TableInteractionState::new(cx));
+        let table_interaction_state = cx.new(|cx| {
+            let mut state = TableInteractionState::new(cx);
+            state.focus_handle = state.focus_handle.tab_index(2).tab_stop(true);
+            state
+        });
 
         let column_widths = if matches!(log_source, LogSource::Path(_)) {
             cx.new(|_cx| {
@@ -1602,6 +1610,28 @@ impl GitGraph {
         self.search(query, cx);
     }
 
+    fn focus_next_tab_stop(
+        &mut self,
+        _: &FocusNextTabStop,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus_next(cx);
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    fn focus_previous_tab_stop(
+        &mut self,
+        _: &FocusPreviousTabStop,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus_prev(cx);
+        cx.stop_propagation();
+        cx.notify();
+    }
+
     fn select_entry(
         &mut self,
         idx: usize,
@@ -1783,7 +1813,12 @@ impl GitGraph {
 
     fn render_search_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let color = cx.theme().colors();
-        let query_focus_handle = self.search_state.editor.focus_handle(cx);
+        let query_focus_handle = self
+            .search_state
+            .editor
+            .focus_handle(cx)
+            .tab_index(1)
+            .tab_stop(true);
         let search_options = {
             let mut options = SearchOptions::NONE;
             options.set(
@@ -1794,6 +1829,7 @@ impl GitGraph {
         };
 
         h_flex()
+            .key_context("GitGraphSearchBar")
             .w_full()
             .p_1p5()
             .gap_1p5()
@@ -1806,6 +1842,7 @@ impl GitGraph {
                     .min_w_0()
                     .px_1p5()
                     .gap_1()
+                    .track_focus(&query_focus_handle)
                     .border_1()
                     .border_color(color.border_variant)
                     .rounded_md()
@@ -2811,6 +2848,8 @@ impl Render for GitGraph {
                             let hovered_entry_idx = self.hovered_entry_idx;
                             let weak_self = cx.weak_entity();
                             let focus_handle = self.focus_handle.clone();
+                            let table_focus_handle =
+                                self.table_interaction_state.read(cx).focus_handle.clone();
 
                             let graph_canvas = div()
                                 .id("graph-canvas")
@@ -2840,7 +2879,9 @@ impl Render for GitGraph {
                                 .map_row(move |(index, row), window, cx| {
                                     let is_selected = selected_entry_idx == Some(index);
                                     let is_hovered = hovered_entry_idx == Some(index);
-                                    let is_focused = focus_handle.is_focused(window);
+                                    let table_focus_handle = table_focus_handle.clone();
+                                    let is_focused = focus_handle.is_focused(window)
+                                        || table_focus_handle.is_focused(window);
                                     let weak = weak_self.clone();
                                     let weak_for_hover = weak.clone();
 
@@ -2873,6 +2914,7 @@ impl Render for GitGraph {
                                         })
                                         .on_click(move |event, window, cx| {
                                             let click_count = event.click_count();
+                                            table_focus_handle.focus(window, cx);
                                             weak.update(cx, |this, cx| {
                                                 this.select_entry(
                                                     index,
@@ -2955,15 +2997,20 @@ impl Render for GitGraph {
             }))
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(|this, _: &FocusSearch, window, cx| {
-                this.search_state
-                    .editor
-                    .update(cx, |editor, cx| editor.focus_handle(cx).focus(window, cx));
+                {
+                    let this = &mut *this;
+                    this.search_state
+                        .editor
+                        .update(cx, |editor, cx| editor.focus_handle(cx).focus(window, cx));
+                };
             }))
             .on_action(cx.listener(Self::select_first))
             .on_action(cx.listener(Self::select_prev))
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::select_last))
             .on_action(cx.listener(Self::confirm))
+            .on_action(cx.listener(Self::focus_next_tab_stop))
+            .on_action(cx.listener(Self::focus_previous_tab_stop))
             .on_action(cx.listener(|this, _: &SelectNextMatch, _window, cx| {
                 this.select_next_match(cx);
             }))

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1610,10 +1610,11 @@ impl GitGraph {
         self.search(query, cx);
     }
 
-    fn refresh_search_editor_if_focused(&self, window: &Window, cx: &mut Context<Self>) {
+    fn activate_search_editor_if_focused(&self, window: &mut Window, cx: &mut Context<Self>) {
         self.search_state.editor.update(cx, |editor, cx| {
             if editor.is_focused(window) {
-                cx.notify();
+                editor.select_all(&Default::default(), window, cx);
+                editor.show_cursor(cx);
             }
         });
     }
@@ -1625,7 +1626,7 @@ impl GitGraph {
         cx: &mut Context<Self>,
     ) {
         window.focus_next(cx);
-        self.refresh_search_editor_if_focused(window, cx);
+        self.activate_search_editor_if_focused(window, cx);
         cx.stop_propagation();
         cx.notify();
     }
@@ -1637,7 +1638,7 @@ impl GitGraph {
         cx: &mut Context<Self>,
     ) {
         window.focus_prev(cx);
-        self.refresh_search_editor_if_focused(window, cx);
+        self.activate_search_editor_if_focused(window, cx);
         cx.stop_propagation();
         cx.notify();
     }
@@ -3013,12 +3014,10 @@ impl Render for GitGraph {
             }))
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(|this, _: &FocusSearch, window, cx| {
-                {
-                    let this = &mut *this;
-                    this.search_state
-                        .editor
-                        .update(cx, |editor, cx| editor.focus_handle(cx).focus(window, cx));
-                };
+                this.search_state
+                    .editor
+                    .update(cx, |editor, cx| editor.focus_handle(cx).focus(window, cx));
+                this.activate_search_editor_if_focused(window, cx);
             }))
             .on_action(cx.listener(Self::select_first))
             .on_action(cx.listener(Self::select_prev))


### PR DESCRIPTION
#53609 introduced a regression where Git Graph keybindings could take precedence over the search bar. As a result, typing characters like `j` or `k` in the search field could move the table selection instead of updating the search query.

This PR fixes that regression by scoping Vim table navigation bindings away from the search bar. It also adds dedicated `tab` and `shift-tab` handling for Git Graph focus traversal, with the search bar and graph table participating as separate tab groups.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
