### PR TITLE
gpui_wgpu: don't crash if the GL backend panics during init

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -160,15 +160,72 @@ impl WgpuContext {
         ))
     }
 
+    /// Build the `wgpu::Instance` used for adapter selection and surface
+    /// creation.
+    ///
+    /// On Linux, `wgpu`'s GL backend eagerly initializes EGL inside
+    /// `wgpu::Instance::new`. With NVIDIA's proprietary driver, that
+    /// initialization can panic inside
+    /// `khronos_egl::Instance::get_platform_display`: the driver returns
+    /// `EGL_NO_DISPLAY` without setting an EGL error, and the binding then
+    /// unwraps the resulting `Option<Error>` and aborts the process (and on
+    /// some systems takes the X session with it). This has been seen with
+    /// `EGL_EXT_platform_xcb` advertised but not actually usable on the
+    /// proprietary NVIDIA driver. See
+    /// https://github.com/zed-industries/zed/issues/52944.
+    ///
+    /// We catch the unwind, drop the GL backend, and retry with the remaining
+    /// backends. Vulkan does not consult the display handle during init, so
+    /// the retry succeeds whenever a usable Vulkan ICD is present (which is
+    /// the path Zed used before the move to wgpu v29 anyway).
     #[cfg(not(target_family = "wasm"))]
     pub fn instance(display: Box<dyn wgpu::wgt::WgpuHasDisplayHandle>) -> wgpu::Instance {
-        wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::VULKAN | wgpu::Backends::GL,
-            flags: wgpu::InstanceFlags::default(),
-            backend_options: wgpu::BackendOptions::default(),
-            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
-            display: Some(display),
-        })
+        let backends = wgpu::Backends::VULKAN | wgpu::Backends::GL;
+
+        // `Box<dyn ...>` is not `UnwindSafe`; we never observe the descriptor
+        // again on the unwinding path, so asserting unwind safety here is
+        // sound.
+        let attempt = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends,
+                flags: wgpu::InstanceFlags::default(),
+                backend_options: wgpu::BackendOptions::default(),
+                memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+                display: Some(display),
+            })
+        }));
+
+        match attempt {
+            Ok(instance) => instance,
+            Err(payload) => {
+                let msg = panic_payload_str(&payload);
+                let fallback = backends - wgpu::Backends::GL;
+                if fallback.is_empty() {
+                    log::error!(
+                        "wgpu::Instance::new panicked during backend init and no \
+                         non-GL backend is available to fall back to: {msg}"
+                    );
+                    std::panic::resume_unwind(payload);
+                }
+                log::warn!(
+                    "wgpu::Instance::new panicked during backend init ({msg}); \
+                     retrying without the GL backend. This is typically caused by a \
+                     buggy EGL implementation, most commonly NVIDIA's proprietary \
+                     driver on X11/XCB (issue #52944)."
+                );
+                // The original boxed display handle was moved into the
+                // panicking call and is gone. The non-GL backends do not need
+                // it for instance creation; Vulkan obtains a display via
+                // `create_surface` later.
+                wgpu::Instance::new(wgpu::InstanceDescriptor {
+                    backends: fallback,
+                    flags: wgpu::InstanceFlags::default(),
+                    backend_options: wgpu::BackendOptions::default(),
+                    memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+                    display: None,
+                })
+            }
+        }
     }
 
     pub fn check_compatible_with_surface(&self, surface: &wgpu::Surface<'_>) -> anyhow::Result<()> {
@@ -413,6 +470,18 @@ impl WgpuContext {
     }
 }
 
+/// Best-effort string extraction from a panic payload, for logging.
+#[cfg(not(target_family = "wasm"))]
+fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> &str {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 fn parse_pci_id(id: &str) -> anyhow::Result<u32> {
     let mut id = id.trim();
@@ -432,7 +501,28 @@ fn parse_pci_id(id: &str) -> anyhow::Result<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_pci_id;
+    use super::{panic_payload_str, parse_pci_id};
+
+    #[test]
+    fn test_panic_payload_str_static_str() {
+        let payload = std::panic::catch_unwind(|| panic!("static str payload"))
+            .expect_err("panic should propagate");
+        assert_eq!(panic_payload_str(&payload), "static str payload");
+    }
+
+    #[test]
+    fn test_panic_payload_str_owned_string() {
+        let payload = std::panic::catch_unwind(|| panic!("owned: {}", 42))
+            .expect_err("panic should propagate");
+        assert_eq!(panic_payload_str(&payload), "owned: 42");
+    }
+
+    #[test]
+    fn test_panic_payload_str_unknown_type() {
+        let payload = std::panic::catch_unwind(|| std::panic::panic_any(123u32))
+            .expect_err("panic should propagate");
+        assert_eq!(panic_payload_str(&payload), "<non-string panic payload>");
+    }
 
     #[test]
     fn test_parse_device_id() {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #52944

Release Notes:

- Linux: Fixed a startup crash on systems where the GL/EGL backend aborts during `wgpu::Instance::new` (most commonly NVIDIA's proprietary driver on X11/XCB); Zed now logs a warning and falls back to Vulkan instead of taking the host down with it.

---

#### What's happening

Since 0.230.0 (the wgpu v29 bump in `a7c9c24f40`), `WgpuContext::instance` passes Zed's display handle into `wgpu::InstanceDescriptor::display`. On X11, gpui_linux supplies an XCB handle. Inside `wgpu::Instance::new`, the GL backend's `Instance::init` (`wgpu-hal/src/gles/egl.rs`) tries `eglGetPlatformDisplay(EGL_PLATFORM_XCB_EXT, ...)` whenever `EGL_EXT_platform_xcb` is advertised. NVIDIA's proprietary driver advertises the extension but the call returns `EGL_NO_DISPLAY` *without* setting an EGL error. The `khronos-egl` 6.0 binding then unwraps the `Option<Error>` returned by `eglGetError`, which is `None`, and panics:

```
panicked at khronos-egl-6.0.0/src/lib.rs:1779:26:
called `Option::unwrap()` on a `None` value
```

Because that panic happens inside `wgpu::Instance::new` (before any adapter exists), there's nothing the call site can recover from in the normal `Result` channel. Diagnosis credit goes to @k4yt3x in https://github.com/zed-industries/zed/issues/52944#issuecomment-4174330935 (and the follow-up in #52944#issuecomment-4174348183).

#### Why not just drop the GL backend

That's the workaround posted on the issue and it does unblock affected users, but it also removes GL as a fallback for everyone, including users on systems where Vulkan isn't viable (very old/odd hardware, software rasterizers, certain remote-display setups). I'd rather keep the multi-backend default and degrade gracefully on the configurations that are actually broken.

#### What this PR does

`WgpuContext::instance` wraps the `wgpu::Instance::new` call in `catch_unwind`. If it panics and GL is one of multiple requested backends, we log a warning explaining the likely cause and retry with `Backends::VULKAN`. The original `Box<dyn WgpuHasDisplayHandle>` is moved into the failed call and is gone, but Vulkan does not consult the display handle during init (it picks one up later through `create_surface`), so passing `display: None` on the retry is fine. If GL is the *only* backend requested, we re-raise the original panic rather than silently swallowing it.

`AssertUnwindSafe` is used because `Box<dyn ...>` isn't `UnwindSafe`; the descriptor is consumed before we'd ever observe its state on the failure path, and there's no shared mutable state across the boundary.

#### Tests

Added unit tests for the small `panic_payload_str` helper covering the `&'static str`, `String`, and unknown-payload-type cases. Reproducing the actual EGL panic in CI requires NVIDIA + X11 hardware, which isn't feasible here; the catch_unwind plumbing itself is exercised by the helper tests.

#### How I verified

- `cargo check -p gpui_wgpu --no-default-features` clean
- `cargo test -p gpui_wgpu --lib --no-default-features` -> 7 passed, 0 failed
- `cargo clippy -p gpui_wgpu --no-default-features --lib --tests -- -D warnings` clean
- `cargo fmt -p gpui_wgpu --check` clean