### PR TITLE
ollama: Fix thinking being also sent as content

### DIFF
--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -381,11 +381,14 @@ impl OllamaLanguageModel {
                     }
                 }
                 Role::Assistant => {
-                    let content = msg.string_contents();
+                    let mut text_content = String::new();
                     let mut thinking = None;
                     let mut tool_calls = Vec::new();
                     for content in msg.content.into_iter() {
                         match content {
+                            MessageContent::Text(text) => {
+                                text_content.push_str(&text);
+                            }
                             MessageContent::Thinking { text, .. } if !text.is_empty() => {
                                 thinking = Some(text)
                             }
@@ -402,7 +405,7 @@ impl OllamaLanguageModel {
                         }
                     }
                     messages.push(ChatMessage::Assistant {
-                        content,
+                        content: text_content,
                         tool_calls: Some(tool_calls),
                         images: if images.is_empty() {
                             None


### PR DESCRIPTION
"msg.string_contents();" return more than just content. It also return tool result (which need special handling, and should be emitted from the tool role) and thinking (which need already implemented special handling).

This resulted in thinking being sent as content, which apparently ollama’s gemma4 parser didn’t handled well, and caused a number of issue that manifested by 1. outputting end of though token where unappropriate and 2. repeating things endlessly

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) (no UI/UX impact)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable (a quick review, without benchmark, show that this should be at least as fast as the previous code. This is called only exceptionally anyway.)

Closes #55537

Release Notes:

- Fixed "thinking" text being badly formatted when sent to Ollama
