### PR TITLE
agent: Fix create-directory tool icon

### DIFF
--- a/crates/agent/src/tools/create_directory_tool.rs
+++ b/crates/agent/src/tools/create_directory_tool.rs
@@ -191,11 +191,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_create_directory_tool_kind_is_edit() {
-        assert_eq!(CreateDirectoryTool::kind(), acp::ToolKind::Edit);
-    }
-
     #[gpui::test]
     async fn test_create_directory_symlink_escape_requests_authorization(cx: &mut TestAppContext) {
         init_test(cx);

--- a/crates/agent/src/tools/create_directory_tool.rs
+++ b/crates/agent/src/tools/create_directory_tool.rs
@@ -54,7 +54,7 @@ impl AgentTool for CreateDirectoryTool {
     const NAME: &'static str = "create_directory";
 
     fn kind() -> acp::ToolKind {
-        acp::ToolKind::Read
+        acp::ToolKind::Edit
     }
 
     fn initial_title(
@@ -189,6 +189,11 @@ mod tests {
             settings.tool_permissions.default = settings::ToolPermissionMode::Allow;
             AgentSettings::override_global(settings, cx);
         });
+    }
+
+    #[test]
+    fn test_create_directory_tool_kind_is_edit() {
+        assert_eq!(CreateDirectoryTool::kind(), acp::ToolKind::Edit);
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7318,6 +7318,15 @@ impl ThreadView {
                 .size(IconSize::Small)
                 .color(Color::Muted)
                 .into_any_element()
+        } else if tool_call
+            .tool_name
+            .as_ref()
+            .is_some_and(|tool_name| tool_name == "create_directory")
+        {
+            Icon::new(IconName::FolderOpenAdd)
+                .size(IconSize::Small)
+                .color(Color::Muted)
+                .into_any_element()
         } else {
             Icon::new(match tool_call.kind {
                 acp::ToolKind::Read => IconName::ToolSearch,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7318,15 +7318,6 @@ impl ThreadView {
                 .size(IconSize::Small)
                 .color(Color::Muted)
                 .into_any_element()
-        } else if tool_call
-            .tool_name
-            .as_ref()
-            .is_some_and(|tool_name| tool_name == "create_directory")
-        {
-            Icon::new(IconName::FolderOpenAdd)
-                .size(IconSize::Small)
-                .color(Color::Muted)
-                .into_any_element()
         } else {
             Icon::new(match tool_call.kind {
                 acp::ToolKind::Read => IconName::ToolSearch,


### PR DESCRIPTION
Fixes #55436

  The create-directory agent tool was classified as a read tool, which caused
  the agent UI to render it with the search icon.

  This PR marks `create_directory` as an edit tool and gives it a folder-add
  icon in the conversation tool card. Creating a directory mutates the project,
  so treating it as an edit tool better matches the behavior and avoids the
  misleading search icon.

  Validation:
  - `cargo build -p zed`
  - `cargo test -p agent test_create_directory_tool_kind_is_edit -- --nocapture`
  - `git diff --check`
  - Manually verified in a local dev build that asking the agent to create `tmp-
  zed-icon-test-dir` shows a folder icon instead of a search icon, and that the
  directory is created successfully.

  Self-Review Checklist:

  - [x] I've reviewed my own diff for quality, security, and reliability
  - [x] Unsafe blocks (if any) have justifying comments
  - [x] The content is consistent with the [UI/UX checklist](https://github.com/
  zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
  - [x] Tests cover the new/changed behavior
  - [x] Performance impact has been considered and is acceptable

  Release Notes:

  - Fixed create-directory agent tool cards showing a search icon.

<img width="593" height="281" alt="07547c9f-2cf2-432b-8c0f-86f336dce3c5" src="https://github.com/user-attachments/assets/a5a277ee-56c5-4801-a7d8-27c347222169" />
<img width="594" height="157" alt="2b3f2b62-4782-42f1-a20d-c26f9cfe8940" src="https://github.com/user-attachments/assets/37845785-5145-4701-9060-1dd1bdb60801" />
