### PR TITLE
collab: Simplify contributor setup in `test_channel_requires_zed_cla`

### DIFF
--- a/crates/collab/src/db/queries/contributors.rs
+++ b/crates/collab/src/db/queries/contributors.rs
@@ -3,30 +3,10 @@ use super::*;
 impl Database {
     /// Records that a given user has signed the CLA.
     #[cfg(feature = "test-support")]
-    pub async fn add_contributor(
-        &self,
-        github_login: &str,
-        github_user_id: i32,
-        github_email: Option<&str>,
-        github_name: Option<&str>,
-        github_user_created_at: DateTimeUtc,
-        initial_channel_id: Option<ChannelId>,
-    ) -> Result<()> {
+    pub async fn add_contributor(&self, user_id: UserId) -> Result<()> {
         self.transaction(|tx| async move {
-            let user = self
-                .update_or_create_user_by_github_account_tx(
-                    github_login,
-                    github_user_id,
-                    github_email,
-                    github_name,
-                    github_user_created_at.naive_utc(),
-                    initial_channel_id,
-                    &tx,
-                )
-                .await?;
-
             contributor::Entity::insert(contributor::ActiveModel {
-                user_id: ActiveValue::Set(user.id),
+                user_id: ActiveValue::Set(user_id),
                 signed_at: ActiveValue::NotSet,
             })
             .on_conflict(

--- a/crates/collab/tests/integration/channel_guest_tests.rs
+++ b/crates/collab/tests/integration/channel_guest_tests.rs
@@ -1,6 +1,5 @@
 use crate::TestServer;
 use call::ActiveCall;
-use chrono::Utc;
 use collab::db::ChannelId;
 use editor::Editor;
 use gpui::{BackgroundExecutor, TestAppContext};
@@ -183,14 +182,6 @@ async fn test_channel_guest_promotion(cx_a: &mut TestAppContext, cx_b: &mut Test
 #[gpui::test]
 async fn test_channel_requires_zed_cla(cx_a: &mut TestAppContext, cx_b: &mut TestAppContext) {
     let mut server = TestServer::start(cx_a.executor()).await;
-
-    server
-        .app_state
-        .db
-        .update_or_create_user_by_github_account("user_b", 100, None, None, Utc::now(), None)
-        .await
-        .unwrap();
-
     let client_a = server.create_client(cx_a, "user_a").await;
     let client_b = server.create_client(cx_b, "user_b").await;
     let active_call_a = cx_a.read(ActiveCall::global);
@@ -288,10 +279,17 @@ async fn test_channel_requires_zed_cla(cx_a: &mut TestAppContext, cx_b: &mut Tes
     });
 
     // User B signs the zed CLA.
+    let user_b = server
+        .app_state
+        .db
+        .get_user_by_github_login("user_b")
+        .await
+        .unwrap()
+        .expect("user_b not found");
     server
         .app_state
         .db
-        .add_contributor("user_b", 100, None, None, Utc::now(), None)
+        .add_contributor(user_b.id)
         .await
         .unwrap();
 


### PR DESCRIPTION
This PR updates the `test_channel_requires_zed_cla` test to simplify the setup for denoting that a user has signed the CLA.

Since the user already exists in the database, we can just create the corresponding record without needing to worry about upserting.

Release Notes:

- N/A
