### PR TITLE
git_panel: Fix commit message text behind `Open Commit Modal` button

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4525,7 +4525,7 @@ impl GitPanel {
                             .when(self.commit_editor_expanded, |this| {
                                 this.flex_1().min_h_0().pb(footer_size)
                             })
-                            .pr_6()
+                            .pr_2p5()
                             .on_action(|&zed_actions::editor::MoveUp, _, cx| {
                                 cx.stop_propagation();
                             })
@@ -4535,7 +4535,7 @@ impl GitPanel {
                             .child(EditorElement::new(&self.commit_editor, panel_editor_style)),
                     )
                     .child(
-                        h_flex()
+                        v_flex()
                             .absolute()
                             .top_2()
                             .right_2()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4525,7 +4525,7 @@ impl GitPanel {
                             .when(self.commit_editor_expanded, |this| {
                                 this.flex_1().min_h_0().pb(footer_size)
                             })
-                            .pr_2p5()
+                            .pr_6()
                             .on_action(|&zed_actions::editor::MoveUp, _, cx| {
                                 cx.stop_propagation();
                             })


### PR DESCRIPTION
This PR fixes an issue where the your commit message inside the git panel commit editor could be behind the `Open Commit Modal` button.

**Before**
<img width="391" height="180" alt="Screenshot 2026-05-03 at 18 11 33" src="https://github.com/user-attachments/assets/f9c68665-ca82-4fb0-80e1-d501891f5ef5" />

**After**
<img width="359" height="179" alt="Screenshot 2026-05-05 at 18 18 58" src="https://github.com/user-attachments/assets/1ff610c7-5758-4446-9666-67c194b1d3f9" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fix git commit message editor text could be behind the `Open Commit Modal` button
