### PR TITLE
Add ability to set font options for inlay hints

### DIFF
--- a/crates/collab/tests/integration/editor_tests.rs
+++ b/crates/collab/tests/integration/editor_tests.rs
@@ -2551,6 +2551,9 @@ async fn test_inlay_hint_refresh_is_forwarded(
                         show_other_hints: Some(false),
                         show_background: Some(false),
                         toggle_on_modifiers_press: None,
+                        font_family: None,
+                        font_weight: None,
+                        font_features: None,
                     })
             });
         });
@@ -2569,6 +2572,9 @@ async fn test_inlay_hint_refresh_is_forwarded(
                         show_other_hints: Some(true),
                         show_background: Some(false),
                         toggle_on_modifiers_press: None,
+                        font_family: None,
+                        font_weight: None,
+                        font_features: None,
                     })
             });
         });

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1409,7 +1409,7 @@ pub struct HighlightedChunk<'a> {
     pub text: &'a str,
     pub style: Option<HighlightStyle>,
     pub is_tab: bool,
-    pub is_inlay: bool,
+    pub inlay_type: Option<InlayId>,
     pub replacement: Option<ChunkReplacement>,
 }
 
@@ -1424,7 +1424,8 @@ impl<'a> HighlightedChunk<'a> {
         let style = self.style;
         let is_tab = self.is_tab;
         let renderer = self.replacement;
-        let is_inlay = self.is_inlay;
+        let inlay_type = self.inlay_type;
+
         iter::from_fn(move || {
             let mut prefix_len = 0;
             while let Some(&chunk) = chunks.peek() {
@@ -1442,7 +1443,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style,
                         is_tab,
-                        is_inlay,
+                        inlay_type,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1468,7 +1469,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style: Some(invisible_style),
                         is_tab: false,
-                        is_inlay,
+                        inlay_type,
                         replacement: Some(ChunkReplacement::Str(replacement.into())),
                     });
                 } else {
@@ -1491,7 +1492,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style: Some(invisible_style),
                         is_tab: false,
-                        is_inlay,
+                        inlay_type,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1504,7 +1505,7 @@ impl<'a> HighlightedChunk<'a> {
                     text: remainder,
                     style,
                     is_tab,
-                    is_inlay,
+                    inlay_type,
                     replacement: renderer.clone(),
                 })
             } else {
@@ -1867,7 +1868,7 @@ impl DisplaySnapshot {
                         // For color inlays, blend the color with the editor background
                         // if the color has transparency (alpha < 1.0)
                         color: chunk_highlight.color.map(|color| {
-                            if chunk.is_inlay && !color.is_opaque() {
+                            if chunk.inlay_type.is_some() && !color.is_opaque() {
                                 editor_style.background.blend(color)
                             } else {
                                 color
@@ -1880,7 +1881,7 @@ impl DisplaySnapshot {
                     }
                 });
 
-                let diagnostic_highlight = if chunk.is_inlay {
+                let diagnostic_highlight = if chunk.inlay_type.is_some() {
                     current_diagnostic_underline.map(|underline| HighlightStyle {
                         underline: Some(underline),
                         ..Default::default()
@@ -1930,7 +1931,7 @@ impl DisplaySnapshot {
                     text: chunk.text,
                     style,
                     is_tab: chunk.is_tab,
-                    is_inlay: chunk.is_inlay,
+                    inlay_type: chunk.inlay_type,
                     replacement: chunk.renderer.map(ChunkReplacement::Renderer),
                 }
                 .highlight_invisibles(editor_style)
@@ -4272,7 +4273,7 @@ pub mod tests {
             text: pilot_emoji,
             style: None,
             is_tab: false,
-            is_inlay: false,
+            inlay_type: None,
             replacement: None,
         };
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1410,7 +1410,7 @@ pub struct HighlightedChunk<'a> {
     pub text: &'a str,
     pub style: Option<HighlightStyle>,
     pub is_tab: bool,
-    pub is_inlay: bool,
+    pub inlay_type: Option<InlayId>,
     pub replacement: Option<ChunkReplacement>,
 }
 
@@ -1424,7 +1424,8 @@ impl<'a> HighlightedChunk<'a> {
         let style = self.style;
         let is_tab = self.is_tab;
         let renderer = self.replacement;
-        let is_inlay = self.is_inlay;
+        let inlay_type = self.inlay_type;
+
         iter::from_fn(move || {
             if text.is_empty() {
                 return None;
@@ -1444,7 +1445,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style,
                         is_tab,
-                        is_inlay,
+                        inlay_type,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1468,7 +1469,7 @@ impl<'a> HighlightedChunk<'a> {
                     text: invisible_text,
                     style: Some(invisible_style),
                     is_tab: false,
-                    is_inlay,
+                    inlay_type,
                     replacement: match replacement(ch) {
                         Some(replacement) => {
                             Some(ChunkReplacement::Str(SharedString::from(replacement)))
@@ -1483,7 +1484,7 @@ impl<'a> HighlightedChunk<'a> {
                 text: remainder,
                 style,
                 is_tab,
-                is_inlay,
+                inlay_type,
                 replacement: renderer.clone(),
             })
         })
@@ -1871,7 +1872,7 @@ impl DisplaySnapshot {
                         // For color inlays, blend the color with the editor background
                         // if the color has transparency (alpha < 1.0)
                         color: chunk_highlight.color.map(|color| {
-                            if chunk.is_inlay && !color.is_opaque() {
+                            if chunk.inlay_type.is_some() && !color.is_opaque() {
                                 editor_style.background.blend(color)
                             } else {
                                 color
@@ -1884,7 +1885,7 @@ impl DisplaySnapshot {
                     }
                 });
 
-                let diagnostic_highlight = if chunk.is_inlay {
+                let diagnostic_highlight = if chunk.inlay_type.is_some() {
                     current_diagnostic_underline.map(|underline| HighlightStyle {
                         underline: Some(underline),
                         ..Default::default()
@@ -1934,7 +1935,7 @@ impl DisplaySnapshot {
                     text: chunk.text,
                     style,
                     is_tab: chunk.is_tab,
-                    is_inlay: chunk.is_inlay,
+                    inlay_type: chunk.inlay_type,
                     replacement: chunk.renderer.map(ChunkReplacement::Renderer),
                 }
                 .highlight_invisibles(editor_style)
@@ -4471,7 +4472,7 @@ pub mod tests {
             text: pilot_emoji,
             style: None,
             is_tab: false,
-            is_inlay: false,
+            inlay_type: None,
             replacement: None,
         };
 

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1414,8 +1414,8 @@ pub struct Chunk<'a> {
     pub underline: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Whether this chunk of text was originally a tab character.
-    pub is_inlay: bool,
+    /// The type of inlay associated with this chunk, if any.
+    pub inlay_type: Option<InlayId>,
     /// An optional recipe for how the chunk should be presented.
     pub renderer: Option<ChunkRenderer>,
     /// Bitmap of tab character locations in chunk
@@ -1608,7 +1608,7 @@ impl<'a> Iterator for FoldChunks<'a> {
                 diagnostic_severity: chunk.diagnostic_severity,
                 is_unnecessary: chunk.is_unnecessary,
                 is_tab: chunk.is_tab,
-                is_inlay: chunk.is_inlay,
+                inlay_type: inlay_chunk.inlay_id,
                 underline: chunk.underline,
                 renderer: inlay_chunk.renderer,
             });

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1427,8 +1427,8 @@ pub struct Chunk<'a> {
     pub underline: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Whether this chunk of text was originally a tab character.
-    pub is_inlay: bool,
+    /// The type of inlay associated with this chunk, if any.
+    pub inlay_type: Option<InlayId>,
     /// An optional recipe for how the chunk should be presented.
     pub renderer: Option<ChunkRenderer>,
     /// Bitmap of tab character locations in chunk
@@ -1621,7 +1621,7 @@ impl<'a> Iterator for FoldChunks<'a> {
                 diagnostic_severity: chunk.diagnostic_severity,
                 is_unnecessary: chunk.is_unnecessary,
                 is_tab: chunk.is_tab,
-                is_inlay: chunk.is_inlay,
+                inlay_type: inlay_chunk.inlay_id,
                 underline: chunk.underline,
                 renderer: inlay_chunk.renderer,
             });

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -240,6 +240,8 @@ pub struct InlayChunks<'a> {
 #[derive(Clone)]
 pub struct InlayChunk<'a> {
     pub chunk: Chunk<'a>,
+    /// The inlay this chunk belongs to, if any.
+    pub inlay_id: Option<InlayId>,
     /// Whether the inlay should be customly rendered.
     pub renderer: Option<ChunkRenderer>,
 }
@@ -318,6 +320,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         newlines,
                         ..chunk.clone()
                     },
+                    inlay_id: None,
                     renderer: None,
                 }
             }
@@ -476,9 +479,9 @@ impl<'a> Iterator for InlayChunks<'a> {
                         tabs: new_tabs,
                         newlines: new_newlines,
                         highlight_style,
-                        is_inlay: true,
                         ..Chunk::default()
                     },
+                    inlay_id: Some(inlay.id),
                     renderer,
                 }
             }
@@ -2438,7 +2441,7 @@ mod tests {
         // Verify the highlighted portion includes the complete ellipsis character
         let highlighted_chunks: Vec<_> = chunks
             .iter()
-            .filter(|c| c.chunk.highlight_style.is_some() && c.chunk.is_inlay)
+            .filter(|c| c.chunk.highlight_style.is_some() && c.inlay_id.is_some())
             .collect();
 
         assert_eq!(highlighted_chunks.len(), 1);
@@ -2561,7 +2564,7 @@ mod tests {
             // Verify that the highlighted portion matches expectations
             let highlighted_text: String = chunks
                 .iter()
-                .filter(|c| c.chunk.highlight_style.is_some() && c.chunk.is_inlay)
+                .filter(|c| c.chunk.highlight_style.is_some() && c.inlay_id.is_some())
                 .map(|c| c.chunk.text)
                 .collect();
             assert_eq!(

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -240,6 +240,8 @@ pub struct InlayChunks<'a> {
 #[derive(Clone)]
 pub struct InlayChunk<'a> {
     pub chunk: Chunk<'a>,
+    /// The inlay this chunk belongs to, if any.
+    pub inlay_id: Option<InlayId>,
     /// Whether the inlay should be customly rendered.
     pub renderer: Option<ChunkRenderer>,
 }
@@ -318,6 +320,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         newlines,
                         ..chunk.clone()
                     },
+                    inlay_id: None,
                     renderer: None,
                 }
             }
@@ -476,9 +479,9 @@ impl<'a> Iterator for InlayChunks<'a> {
                         tabs: new_tabs,
                         newlines: new_newlines,
                         highlight_style,
-                        is_inlay: true,
                         ..Chunk::default()
                     },
+                    inlay_id: Some(inlay.id),
                     renderer,
                 }
             }
@@ -2528,7 +2531,7 @@ mod tests {
         // Verify the highlighted portion includes the complete ellipsis character
         let highlighted_chunks: Vec<_> = chunks
             .iter()
-            .filter(|c| c.chunk.highlight_style.is_some() && c.chunk.is_inlay)
+            .filter(|c| c.chunk.highlight_style.is_some() && c.inlay_id.is_some())
             .collect();
 
         assert_eq!(highlighted_chunks.len(), 1);
@@ -2651,7 +2654,7 @@ mod tests {
             // Verify that the highlighted portion matches expectations
             let highlighted_text: String = chunks
                 .iter()
-                .filter(|c| c.chunk.highlight_style.is_some() && c.chunk.is_inlay)
+                .filter(|c| c.chunk.highlight_style.is_some() && c.inlay_id.is_some())
                 .map(|c| c.chunk.text)
                 .collect();
             assert_eq!(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9749,6 +9749,8 @@ impl Editor {
     }
 
     fn settings_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.style = None;
+
         let new_language_settings = self.fetch_applicable_language_settings(cx);
         let language_settings_changed = new_language_settings != self.applicable_language_settings;
         self.applicable_language_settings = new_language_settings;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -530,7 +530,9 @@ pub struct EditorStyle {
     pub syntax: Arc<SyntaxTheme>,
     pub status: StatusColors,
     pub inlay_hints_style: HighlightStyle,
+    pub inlay_hints_font: gpui::Font,
     pub edit_prediction_styles: EditPredictionStyles,
+    pub edit_prediction_font: gpui::Font,
     pub unnecessary_code_fade: f32,
     pub show_underlines: bool,
 }
@@ -551,10 +553,12 @@ impl Default for EditorStyle {
             // style and retrieve them directly from the theme.
             status: StatusColors::dark(),
             inlay_hints_style: HighlightStyle::default(),
+            inlay_hints_font: TextStyle::default().font(),
             edit_prediction_styles: EditPredictionStyles {
                 insertion: HighlightStyle::default(),
                 whitespace: HighlightStyle::default(),
             },
+            edit_prediction_font: TextStyle::default().font(),
             unnecessary_code_fade: Default::default(),
             show_underlines: true,
         }
@@ -10884,7 +10888,9 @@ impl Editor {
             syntax: cx.theme().syntax().clone(),
             status: cx.theme().status().clone(),
             inlay_hints_style: make_inlay_hints_style(cx),
+            inlay_hints_font: settings.inlay_hints_font.clone(),
             edit_prediction_styles: make_suggestion_styles(cx),
+            edit_prediction_font: settings.edit_predictions_font.clone(),
             unnecessary_code_fade: settings.unnecessary_code_fade,
             show_underlines: self.diagnostics_enabled(),
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -530,7 +530,9 @@ pub struct EditorStyle {
     pub syntax: Arc<SyntaxTheme>,
     pub status: StatusColors,
     pub inlay_hints_style: HighlightStyle,
+    pub inlay_hints_font: gpui::Font,
     pub edit_prediction_styles: EditPredictionStyles,
+    pub edit_prediction_font: gpui::Font,
     pub unnecessary_code_fade: f32,
     pub show_underlines: bool,
 }
@@ -551,10 +553,12 @@ impl Default for EditorStyle {
             // style and retrieve them directly from the theme.
             status: StatusColors::dark(),
             inlay_hints_style: HighlightStyle::default(),
+            inlay_hints_font: TextStyle::default().font(),
             edit_prediction_styles: EditPredictionStyles {
                 insertion: HighlightStyle::default(),
                 whitespace: HighlightStyle::default(),
             },
+            edit_prediction_font: TextStyle::default().font(),
             unnecessary_code_fade: Default::default(),
             show_underlines: true,
         }
@@ -11318,7 +11322,9 @@ impl Editor {
             syntax: cx.theme().syntax().clone(),
             status: cx.theme().status().clone(),
             inlay_hints_style: make_inlay_hints_style(cx),
+            inlay_hints_font: settings.inlay_hints_font.clone(),
             edit_prediction_styles: make_suggestion_styles(cx),
+            edit_prediction_font: settings.edit_predictions_font.clone(),
             unnecessary_code_fade: settings.unnecessary_code_fade,
             show_underlines: self.diagnostics_enabled(),
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10118,6 +10118,8 @@ impl Editor {
     }
 
     fn settings_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.style = None;
+
         let new_language_settings = self.fetch_applicable_language_settings(cx);
         let language_settings_changed = new_language_settings != self.applicable_language_settings;
         self.applicable_language_settings = new_language_settings;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7078,7 +7078,7 @@ impl LineWithInvisibles {
             text: "\n",
             style: None,
             is_tab: false,
-            is_inlay: false,
+            inlay_type: None,
             replacement: None,
         }]) {
             if let Some(replacement) = highlighted_chunk.replacement {
@@ -7245,7 +7245,7 @@ impl LineWithInvisibles {
                             strikethrough: text_style.strikethrough,
                         });
 
-                        if editor_mode.is_full() && !highlighted_chunk.is_inlay {
+                        if editor_mode.is_full() && highlighted_chunk.inlay_type.is_none() {
                             // Line wrap pads its contents with fake whitespaces,
                             // avoid printing them
                             let is_soft_wrapped = is_row_soft_wrapped(row);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -47,7 +47,7 @@ use gpui::{
     GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
     ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
     ParentElement, Pixels, ScrollHandle, ShapedLine, SharedString, Size,
-    StatefulInteractiveElement, Style, Styled, StyledText, TaskExt, TextAlign, TextRun,
+    StatefulInteractiveElement, Style, Styled, StyledText, TaskExt, TextAlign, TextRun, TextStyle,
     TextStyleRefinement, WeakEntity, Window, div, fill, outline, pattern_slash, point, px, quad,
     relative, size, solid_background, transparent_black,
 };
@@ -63,6 +63,7 @@ use multi_buffer::{
 };
 
 use project::{
+    InlayId,
     debugger::breakpoint_store::{Breakpoint, BreakpointSessionState},
     project_settings::ProjectSettings,
 };
@@ -7042,6 +7043,18 @@ impl fmt::Debug for LineFragment {
 }
 
 impl LineWithInvisibles {
+    fn font_for_chunk(
+        inlay_type: Option<InlayId>,
+        text_style: &TextStyle,
+        editor_style: &EditorStyle,
+    ) -> gpui::Font {
+        match inlay_type {
+            Some(InlayId::EditPrediction(_)) => editor_style.edit_prediction_font.clone(),
+            Some(_) => editor_style.inlay_hints_font.clone(),
+            None => text_style.font(),
+        }
+    }
+
     fn from_chunks<'a>(
         chunks: impl Iterator<Item = HighlightedChunk<'a>>,
         editor_style: &EditorStyle,
@@ -7161,7 +7174,11 @@ impl LineWithInvisibles {
 
                         let run = TextRun {
                             len: x.len(),
-                            font: text_style.font(),
+                            font: Self::font_for_chunk(
+                                highlighted_chunk.inlay_type,
+                                &text_style,
+                                editor_style,
+                            ),
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -7238,7 +7255,11 @@ impl LineWithInvisibles {
 
                         styles.push(TextRun {
                             len: line_chunk.len(),
-                            font: text_style.font(),
+                            font: Self::font_for_chunk(
+                                highlighted_chunk.inlay_type,
+                                &text_style,
+                                editor_style,
+                            ),
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -47,7 +47,7 @@ use gpui::{
     GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
     ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
     ParentElement, Pixels, ScrollHandle, ShapedLine, SharedString, Size,
-    StatefulInteractiveElement, Style, Styled, StyledText, TaskExt, TextAlign, TextRun,
+    StatefulInteractiveElement, Style, Styled, StyledText, TaskExt, TextAlign, TextRun, TextStyle,
     TextStyleRefinement, WeakEntity, Window, div, fill, outline, pattern_slash, point, px, quad,
     relative, size, solid_background, transparent_black,
 };
@@ -63,6 +63,7 @@ use multi_buffer::{
 };
 
 use project::{
+    InlayId,
     debugger::breakpoint_store::{Breakpoint, BreakpointSessionState},
     project_settings::{InlineBlameLocation, ProjectSettings},
 };
@@ -7080,6 +7081,18 @@ impl fmt::Debug for LineFragment {
 }
 
 impl LineWithInvisibles {
+    fn font_for_chunk(
+        inlay_type: Option<InlayId>,
+        text_style: &TextStyle,
+        editor_style: &EditorStyle,
+    ) -> gpui::Font {
+        match inlay_type {
+            Some(InlayId::EditPrediction(_)) => editor_style.edit_prediction_font.clone(),
+            Some(_) => editor_style.inlay_hints_font.clone(),
+            None => text_style.font(),
+        }
+    }
+
     fn from_chunks<'a>(
         chunks: impl Iterator<Item = HighlightedChunk<'a>>,
         editor_style: &EditorStyle,
@@ -7199,7 +7212,11 @@ impl LineWithInvisibles {
 
                         let run = TextRun {
                             len: x.len(),
-                            font: text_style.font(),
+                            font: Self::font_for_chunk(
+                                highlighted_chunk.inlay_type,
+                                &text_style,
+                                editor_style,
+                            ),
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -7276,7 +7293,11 @@ impl LineWithInvisibles {
 
                         styles.push(TextRun {
                             len: line_chunk.len(),
-                            font: text_style.font(),
+                            font: Self::font_for_chunk(
+                                highlighted_chunk.inlay_type,
+                                &text_style,
+                                editor_style,
+                            ),
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7116,7 +7116,7 @@ impl LineWithInvisibles {
             text: "\n",
             style: None,
             is_tab: false,
-            is_inlay: false,
+            inlay_type: None,
             replacement: None,
         }]) {
             if let Some(replacement) = highlighted_chunk.replacement {
@@ -7283,7 +7283,7 @@ impl LineWithInvisibles {
                             strikethrough: text_style.strikethrough,
                         });
 
-                        if editor_mode.is_full() && !highlighted_chunk.is_inlay {
+                        if editor_mode.is_full() && highlighted_chunk.inlay_type.is_none() {
                             // Line wrap pads its contents with fake whitespaces,
                             // avoid printing them
                             let is_soft_wrapped = is_row_soft_wrapped(row);

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1697,6 +1697,9 @@ mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1706,6 +1706,9 @@ mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1934,6 +1934,9 @@ mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -2501,6 +2501,9 @@ mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -1043,6 +1043,9 @@ pub mod tests {
                 show_other_hints: Some(allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         let (_, editor, fake_server) = prepare_test_objects(cx, |fake_server, file_with_hints| {
@@ -1237,6 +1240,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1347,6 +1353,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1596,6 +1605,9 @@ pub mod tests {
                 show_other_hints: Some(allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1761,6 +1773,9 @@ pub mod tests {
                     show_other_hints: Some(new_allowed_hint_kinds.contains(&None)),
                     show_background: Some(false),
                     toggle_on_modifiers_press: None,
+                    font_family: None,
+                    font_weight: None,
+                    font_features: None,
                 })
             });
             cx.executor().run_until_parked();
@@ -1808,6 +1823,9 @@ pub mod tests {
                 show_other_hints: Some(another_allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -1881,6 +1899,9 @@ pub mod tests {
                 show_other_hints: Some(final_allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -1955,6 +1976,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -2317,6 +2341,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -2933,6 +2960,9 @@ let c = 3;"#
                 show_other_hints: Some(false),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3126,6 +3156,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -3165,6 +3198,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3276,6 +3312,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3358,6 +3397,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -3424,6 +3466,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3650,6 +3695,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -4595,6 +4643,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -1048,6 +1048,9 @@ pub mod tests {
                 show_other_hints: Some(allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         let (_, editor, fake_server) = prepare_test_objects(cx, |fake_server, file_with_hints| {
@@ -1322,6 +1325,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1478,6 +1484,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1728,6 +1737,9 @@ pub mod tests {
                 show_other_hints: Some(allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1893,6 +1905,9 @@ pub mod tests {
                     show_other_hints: Some(new_allowed_hint_kinds.contains(&None)),
                     show_background: Some(false),
                     toggle_on_modifiers_press: None,
+                    font_family: None,
+                    font_weight: None,
+                    font_features: None,
                 })
             });
             cx.executor().run_until_parked();
@@ -1940,6 +1955,9 @@ pub mod tests {
                 show_other_hints: Some(another_allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -2013,6 +2031,9 @@ pub mod tests {
                 show_other_hints: Some(final_allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -2087,6 +2108,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -2571,6 +2595,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3187,6 +3214,9 @@ let c = 3;"#
                 show_other_hints: Some(false),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3380,6 +3410,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -3419,6 +3452,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3530,6 +3566,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3612,6 +3651,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -3678,6 +3720,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3904,6 +3949,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -4835,6 +4883,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -554,8 +554,6 @@ pub struct Chunk<'a> {
     pub is_unnecessary: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Whether this chunk of text was originally an inlay.
-    pub is_inlay: bool,
     /// Whether to underline the corresponding text range in the editor.
     pub underline: bool,
 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -558,8 +558,6 @@ pub struct Chunk<'a> {
     pub is_unnecessary: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Whether this chunk of text was originally an inlay.
-    pub is_inlay: bool,
     /// Whether to underline the corresponding text range in the editor.
     pub underline: bool,
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -531,6 +531,8 @@ impl VsCodeSettings {
     }
 
     fn default_language_settings_content(&self) -> LanguageSettingsContent {
+        let (inlay_hints_font_family, _) = self.read_fonts("editor.inlayHints.fontFamily");
+
         LanguageSettingsContent {
             allow_rewrap: None,
             always_treat_brackets_as_autoclosed: None,
@@ -579,7 +581,21 @@ impl VsCodeSettings {
                 enabled: self.read_bool("editor.guides.indentation"),
                 ..Default::default()
             }),
-            inlay_hints: None,
+            inlay_hints: if self.read_string("editor.inalyHints.enabled").is_some() {
+                Some(InlayHintSettingsContent {
+                    enabled: self.read_enum("editor.inlayHints.enabled", |s| {
+                        Some(match s {
+                            "on" => true,
+                            "onUnlessPressed" => true,
+                            _ => false,
+                        })
+                    }),
+                    font_family: inlay_hints_font_family,
+                    ..Default::default()
+                })
+            } else {
+                None
+            },
             jsx_tag_auto_close: None,
             language_servers: None,
             semantic_tokens: self
@@ -658,6 +674,8 @@ impl VsCodeSettings {
             .read_value("cursor.general.globalCursorIgnoreList")?
             .as_array()?;
 
+        let (edit_prediction_font_family, _) = self.read_fonts("editor.inlineSuggest.fontFamily");
+
         skip_default(EditPredictionSettingsContent {
             disabled_globs: skip_default(
                 disabled_globs
@@ -666,6 +684,7 @@ impl VsCodeSettings {
                     .map(|s| s.to_string())
                     .collect(),
             ),
+            font_family: edit_prediction_font_family,
             ..Default::default()
         })
     }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -535,6 +535,8 @@ impl VsCodeSettings {
     }
 
     fn default_language_settings_content(&self) -> LanguageSettingsContent {
+        let (inlay_hints_font_family, _) = self.read_fonts("editor.inlayHints.fontFamily");
+
         LanguageSettingsContent {
             allow_rewrap: None,
             always_treat_brackets_as_autoclosed: None,
@@ -583,7 +585,21 @@ impl VsCodeSettings {
                 enabled: self.read_bool("editor.guides.indentation"),
                 ..Default::default()
             }),
-            inlay_hints: None,
+            inlay_hints: if self.read_string("editor.inalyHints.enabled").is_some() {
+                Some(InlayHintSettingsContent {
+                    enabled: self.read_enum("editor.inlayHints.enabled", |s| {
+                        Some(match s {
+                            "on" => true,
+                            "onUnlessPressed" => true,
+                            _ => false,
+                        })
+                    }),
+                    font_family: inlay_hints_font_family,
+                    ..Default::default()
+                })
+            } else {
+                None
+            },
             jsx_tag_auto_close: None,
             language_servers: None,
             semantic_tokens: self
@@ -666,6 +682,8 @@ impl VsCodeSettings {
             .read_value("cursor.general.globalCursorIgnoreList")?
             .as_array()?;
 
+        let (edit_prediction_font_family, _) = self.read_fonts("editor.inlineSuggest.fontFamily");
+
         skip_default(EditPredictionSettingsContent {
             disabled_globs: skip_default(
                 disabled_globs
@@ -674,6 +692,7 @@ impl VsCodeSettings {
                     .map(|s| s.to_string())
                     .collect(),
             ),
+            font_family: edit_prediction_font_family,
             ..Default::default()
         })
     }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 use settings_macros::{MergeFrom, with_fallible_options};
 use std::sync::Arc;
 
-use crate::{DocumentFoldingRanges, DocumentSymbols, ExtendingVec, SemanticTokens, merge_from};
+use crate::{
+    DocumentFoldingRanges, DocumentSymbols, ExtendingVec, FontFamilyName, FontFeaturesContent,
+    FontWeightContent, SemanticTokens, merge_from,
+};
 
 /// The state of the modifier keys at some point in time
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
@@ -173,6 +176,18 @@ pub struct EditPredictionSettingsContent {
     /// - `"yes"`: allow data collection for files in open-source projects.
     /// - `"no"`: never allow data collection.
     pub allow_data_collection: Option<EditPredictionDataCollectionChoice>,
+    /// The name of a font to use for rendering edit predictions.
+    ///
+    /// Defaults to inlay hints' font family.
+    pub font_family: Option<FontFamilyName>,
+    /// The weight of the editor font in CSS units from 100 to 900.
+    ///
+    /// Defaults to inlay hints' font weight.
+    pub font_weight: Option<FontWeightContent>,
+    /// The OpenType features to enable for rendering edit predictions.
+    ///
+    /// Defaults to inlay hints' font features.
+    pub font_features: Option<FontFeaturesContent>,
 }
 
 #[with_fallible_options]
@@ -729,7 +744,7 @@ pub struct JsxTagAutoCloseSettingsContent {
 
 /// The settings for inlay hints.
 #[with_fallible_options]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
 pub struct InlayHintSettingsContent {
     /// Global switch to toggle hints on and off.
     ///
@@ -776,6 +791,18 @@ pub struct InlayHintSettingsContent {
     ///
     /// Default: null
     pub toggle_on_modifiers_press: Option<ModifiersContent>,
+    /// The name of a font to use for rendering inlay hints.
+    ///
+    /// Defaults to buffer's font family.
+    pub font_family: Option<FontFamilyName>,
+    /// The weight of the editor font in CSS units from 100 to 900.
+    ///
+    /// Defaults to buffer's font weight.
+    pub font_weight: Option<FontWeightContent>,
+    /// The OpenType features to enable for rendering inlay hints.
+    ///
+    /// Defaults to buffer's font features.
+    pub font_features: Option<FontFeaturesContent>,
 }
 
 /// The kind of an inlay hint.

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -7,7 +7,8 @@ use settings_macros::{MergeFrom, with_fallible_options};
 use std::sync::Arc;
 
 use crate::{
-    DelayMs, DocumentFoldingRanges, DocumentSymbols, ExtendingSet, SemanticTokens, merge_from,
+    DelayMs, DocumentFoldingRanges, DocumentSymbols, ExtendingSet, FontFamilyName,
+    FontFeaturesContent, FontWeightContent, SemanticTokens, merge_from,
 };
 
 /// The state of the modifier keys at some point in time
@@ -159,6 +160,18 @@ pub struct EditPredictionSettingsContent {
     /// - `"yes"`: allow data collection for files in open-source projects.
     /// - `"no"`: never allow data collection.
     pub allow_data_collection: Option<EditPredictionDataCollectionChoice>,
+    /// The name of a font to use for rendering edit predictions.
+    ///
+    /// Defaults to inlay hints' font family.
+    pub font_family: Option<FontFamilyName>,
+    /// The weight of the editor font in CSS units from 100 to 900.
+    ///
+    /// Defaults to inlay hints' font weight.
+    pub font_weight: Option<FontWeightContent>,
+    /// The OpenType features to enable for rendering edit predictions.
+    ///
+    /// Defaults to inlay hints' font features.
+    pub font_features: Option<FontFeaturesContent>,
 }
 
 #[with_fallible_options]
@@ -815,7 +828,7 @@ pub struct JsxTagAutoCloseSettingsContent {
 
 /// The settings for inlay hints.
 #[with_fallible_options]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
 pub struct InlayHintSettingsContent {
     /// Global switch to toggle hints on and off.
     ///
@@ -862,6 +875,18 @@ pub struct InlayHintSettingsContent {
     ///
     /// Default: null
     pub toggle_on_modifiers_press: Option<ModifiersContent>,
+    /// The name of a font to use for rendering inlay hints.
+    ///
+    /// Defaults to buffer's font family.
+    pub font_family: Option<FontFamilyName>,
+    /// The weight of the editor font in CSS units from 100 to 900.
+    ///
+    /// Defaults to buffer's font weight.
+    pub font_weight: Option<FontWeightContent>,
+    /// The OpenType features to enable for rendering inlay hints.
+    ///
+    /// Defaults to buffer's font features.
+    pub font_features: Option<FontFeaturesContent>,
 }
 
 /// The kind of an inlay hint.

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -52,6 +52,14 @@ pub struct ThemeSettings {
     ///
     /// The terminal font family can be overridden using it's own setting.
     pub buffer_font: Font,
+    /// The font used for inlay hints.
+    ///
+    /// Falls back to the buffer font if unset.
+    pub inlay_hints_font: Font,
+    /// The font used for edit predictions.
+    ///
+    /// Falls back to the inlay hints font if unset.
+    pub edit_predictions_font: Font,
     /// The agent font size. Determines the size of text in the agent panel. Falls back to the UI font size if unset.
     agent_ui_font_size: Option<Pixels>,
     /// The agent buffer font size. Determines the size of user messages in the agent panel.
@@ -710,9 +718,64 @@ fn font_fallbacks_from_settings(
 
 impl settings::Settings for ThemeSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
+        let project_content = &content.project;
         let content = &content.theme;
         let theme_selection: ThemeSelection = content.theme.clone().unwrap().into();
         let icon_theme_selection: IconThemeSelection = content.icon_theme.clone().unwrap().into();
+
+        let buffer_font_family = content.buffer_font_family.as_ref().unwrap();
+
+        let buffer_font_features = content.buffer_font_features.clone().unwrap();
+        let buffer_font_fallbacks =
+            font_fallbacks_from_settings(content.buffer_font_fallbacks.clone());
+        let buffer_font_weight = content.buffer_font_weight.unwrap();
+
+        // Inlay hints work in an "inheritance" manner. Base level is buffer options
+        // They can then be overridden by inlay hints options
+        // Then the underlying inlay hint type, which only edit predictions are
+        // supported for this currently.
+        // buffer > inlay hints > inlay type
+        let inlay_content = project_content
+            .all_languages
+            .defaults
+            .inlay_hints
+            .clone()
+            .unwrap_or_default();
+
+        let edit_prediction_content = project_content
+            .all_languages
+            .edit_predictions
+            .clone()
+            .unwrap_or_default();
+
+        let buffer_font_size = content.buffer_font_size.unwrap();
+
+        // buffer -> inlay hints fallback
+        let inlay_hints_font_family = inlay_content
+            .font_family
+            .as_ref()
+            .unwrap_or(buffer_font_family);
+        let inlay_hints_font_weight = inlay_content.font_weight.unwrap_or(buffer_font_weight);
+        let inlay_hints_font_features = inlay_content
+            .font_features
+            .clone()
+            .unwrap_or_else(|| buffer_font_features.clone());
+
+        // inlay hints -> edit predictions fallback
+        let edit_pred_font_family = edit_prediction_content
+            .font_family
+            .as_ref()
+            .or(inlay_content.font_family.as_ref())
+            .unwrap_or(buffer_font_family);
+        let edit_pred_font_weight = edit_prediction_content
+            .font_weight
+            .or(inlay_content.font_weight)
+            .unwrap_or(buffer_font_weight);
+        let edit_pred_font_features = edit_prediction_content
+            .font_features
+            .or(inlay_content.font_features.clone())
+            .unwrap_or_else(|| buffer_font_features.clone());
+
         Self {
             ui_font_size: clamp_font_size(content.ui_font_size.unwrap().into_gpui()),
             ui_font: Font {
@@ -722,20 +785,28 @@ impl settings::Settings for ThemeSettings {
                 weight: content.ui_font_weight.unwrap().into_gpui(),
                 style: Default::default(),
             },
-            buffer_font: Font {
-                family: content
-                    .buffer_font_family
-                    .as_ref()
-                    .unwrap()
-                    .0
-                    .clone()
-                    .into(),
-                features: content.buffer_font_features.clone().unwrap().into_gpui(),
-                fallbacks: font_fallbacks_from_settings(content.buffer_font_fallbacks.clone()),
-                weight: content.buffer_font_weight.unwrap().into_gpui(),
+            inlay_hints_font: Font {
+                family: inlay_hints_font_family.0.clone().into(),
+                features: inlay_hints_font_features.into_gpui(),
+                fallbacks: buffer_font_fallbacks.clone(),
+                weight: inlay_hints_font_weight.into_gpui(),
                 style: FontStyle::default(),
             },
-            buffer_font_size: clamp_font_size(content.buffer_font_size.unwrap().into_gpui()),
+            edit_predictions_font: Font {
+                family: edit_pred_font_family.0.clone().into(),
+                features: edit_pred_font_features.into_gpui(),
+                fallbacks: buffer_font_fallbacks.clone(),
+                weight: edit_pred_font_weight.into_gpui(),
+                style: FontStyle::default(),
+            },
+            buffer_font: Font {
+                family: buffer_font_family.0.clone().into(),
+                features: buffer_font_features.into_gpui(),
+                fallbacks: buffer_font_fallbacks,
+                weight: buffer_font_weight.into_gpui(),
+                style: FontStyle::default(),
+            },
+            buffer_font_size: clamp_font_size(buffer_font_size.into_gpui()),
             buffer_line_height: content.buffer_line_height.unwrap().into(),
             agent_ui_font_size: content.agent_ui_font_size.map(|s| s.into_gpui()),
             agent_buffer_font_size: content.agent_buffer_font_size.map(|s| s.into_gpui()),

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -833,3 +833,117 @@ impl settings::Settings for ThemeSettings {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::UpdateGlobal;
+    use settings::{EditPredictionSettingsContent, InlayHintSettingsContent, SettingsStore};
+
+    fn init_cx(cx: &mut gpui::App) {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+    }
+
+    #[gpui::test]
+    fn test_inlay_hints_font_falls_back_to_buffer_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.inlay_hints_font.family, settings.buffer_font.family,
+            "inlay hints font should fall back to buffer font when unset"
+        );
+    }
+
+    #[gpui::test]
+    fn test_inlay_hints_font_overrides_buffer_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.inlay_hints =
+                    Some(InlayHintSettingsContent {
+                        font_family: Some(FontFamilyName("Lilex".into())),
+                        ..Default::default()
+                    });
+            });
+        });
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.inlay_hints_font.family,
+            SharedString::from("Lilex")
+        );
+        assert_ne!(
+            settings.inlay_hints_font.family, settings.buffer_font.family,
+            "inlay hints font should differ from buffer font when explicitly set"
+        );
+    }
+
+    #[gpui::test]
+    fn test_edit_predictions_font_falls_back_through_inlay_to_buffer(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.edit_predictions_font.family, settings.buffer_font.family,
+            "edit predictions font should fall back to buffer font when neither inlay nor edit prediction font is set"
+        );
+    }
+
+    #[gpui::test]
+    fn test_edit_predictions_font_falls_back_to_inlay_hints_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.inlay_hints =
+                    Some(InlayHintSettingsContent {
+                        font_family: Some(FontFamilyName("Lilex".into())),
+                        ..Default::default()
+                    });
+            });
+        });
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.edit_predictions_font.family, settings.inlay_hints_font.family,
+            "edit predictions font should inherit from inlay hints font when not explicitly set"
+        );
+    }
+
+    #[gpui::test]
+    fn test_edit_predictions_font_overrides_inlay_hints_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.inlay_hints =
+                    Some(InlayHintSettingsContent {
+                        font_family: Some(FontFamilyName("Lilex".into())),
+                        ..Default::default()
+                    });
+                settings.project.all_languages.edit_predictions =
+                    Some(EditPredictionSettingsContent {
+                        font_family: Some(FontFamilyName("Courier".into())),
+                        ..Default::default()
+                    });
+            });
+        });
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.inlay_hints_font.family,
+            SharedString::from("Lilex")
+        );
+        assert_eq!(
+            settings.edit_predictions_font.family,
+            SharedString::from("Courier")
+        );
+        assert_ne!(
+            settings.edit_predictions_font.family, settings.inlay_hints_font.family,
+            "edit predictions font should differ from inlay hints font when both are explicitly set"
+        );
+    }
+}

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -55,6 +55,14 @@ pub struct ThemeSettings {
     /// The agent UI font family. Determines the family of response text in the agent panel.
     /// Falls back to the UI font family if unset.
     agent_ui_font_family: Option<SharedString>,
+    /// The font used for inlay hints.
+    ///
+    /// Falls back to the buffer font if unset.
+    pub inlay_hints_font: Font,
+    /// The font used for edit predictions.
+    ///
+    /// Falls back to the inlay hints font if unset.
+    pub edit_predictions_font: Font,
     /// The agent font size. Determines the size of text in the agent panel. Falls back to the UI font size if unset.
     agent_ui_font_size: Option<Pixels>,
     /// The agent buffer font family. Determines the family of user messages in the agent panel.
@@ -703,9 +711,64 @@ fn font_fallbacks_from_settings(
 
 impl settings::Settings for ThemeSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
+        let project_content = &content.project;
         let content = &content.theme;
         let theme_selection: ThemeSelection = content.theme.clone().unwrap().into();
         let icon_theme_selection: IconThemeSelection = content.icon_theme.clone().unwrap().into();
+
+        let buffer_font_family = content.buffer_font_family.as_ref().unwrap();
+
+        let buffer_font_features = content.buffer_font_features.clone().unwrap();
+        let buffer_font_fallbacks =
+            font_fallbacks_from_settings(content.buffer_font_fallbacks.clone());
+        let buffer_font_weight = content.buffer_font_weight.unwrap();
+
+        // Inlay hints work in an "inheritance" manner. Base level is buffer options
+        // They can then be overridden by inlay hints options
+        // Then the underlying inlay hint type, which only edit predictions are
+        // supported for this currently.
+        // buffer > inlay hints > inlay type
+        let inlay_content = project_content
+            .all_languages
+            .defaults
+            .inlay_hints
+            .clone()
+            .unwrap_or_default();
+
+        let edit_prediction_content = project_content
+            .all_languages
+            .edit_predictions
+            .clone()
+            .unwrap_or_default();
+
+        let buffer_font_size = content.buffer_font_size.unwrap();
+
+        // buffer -> inlay hints fallback
+        let inlay_hints_font_family = inlay_content
+            .font_family
+            .as_ref()
+            .unwrap_or(buffer_font_family);
+        let inlay_hints_font_weight = inlay_content.font_weight.unwrap_or(buffer_font_weight);
+        let inlay_hints_font_features = inlay_content
+            .font_features
+            .clone()
+            .unwrap_or_else(|| buffer_font_features.clone());
+
+        // inlay hints -> edit predictions fallback
+        let edit_pred_font_family = edit_prediction_content
+            .font_family
+            .as_ref()
+            .or(inlay_content.font_family.as_ref())
+            .unwrap_or(buffer_font_family);
+        let edit_pred_font_weight = edit_prediction_content
+            .font_weight
+            .or(inlay_content.font_weight)
+            .unwrap_or(buffer_font_weight);
+        let edit_pred_font_features = edit_prediction_content
+            .font_features
+            .or(inlay_content.font_features.clone())
+            .unwrap_or_else(|| buffer_font_features.clone());
+
         Self {
             ui_font_size: clamp_font_size(content.ui_font_size.unwrap().into_gpui()),
             ui_font: Font {
@@ -715,20 +778,28 @@ impl settings::Settings for ThemeSettings {
                 weight: content.ui_font_weight.unwrap().into_gpui(),
                 style: Default::default(),
             },
-            buffer_font: Font {
-                family: content
-                    .buffer_font_family
-                    .as_ref()
-                    .unwrap()
-                    .0
-                    .clone()
-                    .into(),
-                features: content.buffer_font_features.clone().unwrap().into_gpui(),
-                fallbacks: font_fallbacks_from_settings(content.buffer_font_fallbacks.clone()),
-                weight: content.buffer_font_weight.unwrap().into_gpui(),
+            inlay_hints_font: Font {
+                family: inlay_hints_font_family.0.clone().into(),
+                features: inlay_hints_font_features.into_gpui(),
+                fallbacks: buffer_font_fallbacks.clone(),
+                weight: inlay_hints_font_weight.into_gpui(),
                 style: FontStyle::default(),
             },
-            buffer_font_size: clamp_font_size(content.buffer_font_size.unwrap().into_gpui()),
+            edit_predictions_font: Font {
+                family: edit_pred_font_family.0.clone().into(),
+                features: edit_pred_font_features.into_gpui(),
+                fallbacks: buffer_font_fallbacks.clone(),
+                weight: edit_pred_font_weight.into_gpui(),
+                style: FontStyle::default(),
+            },
+            buffer_font: Font {
+                family: buffer_font_family.0.clone().into(),
+                features: buffer_font_features.into_gpui(),
+                fallbacks: buffer_font_fallbacks,
+                weight: buffer_font_weight.into_gpui(),
+                style: FontStyle::default(),
+            },
+            buffer_font_size: clamp_font_size(buffer_font_size.into_gpui()),
             buffer_line_height: buffer_line_height_from_settings(
                 content.buffer_line_height.unwrap(),
             ),

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -836,3 +836,117 @@ impl settings::Settings for ThemeSettings {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::UpdateGlobal;
+    use settings::{EditPredictionSettingsContent, InlayHintSettingsContent, SettingsStore};
+
+    fn init_cx(cx: &mut gpui::App) {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+    }
+
+    #[gpui::test]
+    fn test_inlay_hints_font_falls_back_to_buffer_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.inlay_hints_font.family, settings.buffer_font.family,
+            "inlay hints font should fall back to buffer font when unset"
+        );
+    }
+
+    #[gpui::test]
+    fn test_inlay_hints_font_overrides_buffer_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.inlay_hints =
+                    Some(InlayHintSettingsContent {
+                        font_family: Some(FontFamilyName("Lilex".into())),
+                        ..Default::default()
+                    });
+            });
+        });
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.inlay_hints_font.family,
+            SharedString::from("Lilex")
+        );
+        assert_ne!(
+            settings.inlay_hints_font.family, settings.buffer_font.family,
+            "inlay hints font should differ from buffer font when explicitly set"
+        );
+    }
+
+    #[gpui::test]
+    fn test_edit_predictions_font_falls_back_through_inlay_to_buffer(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.edit_predictions_font.family, settings.buffer_font.family,
+            "edit predictions font should fall back to buffer font when neither inlay nor edit prediction font is set"
+        );
+    }
+
+    #[gpui::test]
+    fn test_edit_predictions_font_falls_back_to_inlay_hints_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.inlay_hints =
+                    Some(InlayHintSettingsContent {
+                        font_family: Some(FontFamilyName("Lilex".into())),
+                        ..Default::default()
+                    });
+            });
+        });
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.edit_predictions_font.family, settings.inlay_hints_font.family,
+            "edit predictions font should inherit from inlay hints font when not explicitly set"
+        );
+    }
+
+    #[gpui::test]
+    fn test_edit_predictions_font_overrides_inlay_hints_font(cx: &mut gpui::App) {
+        init_cx(cx);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.inlay_hints =
+                    Some(InlayHintSettingsContent {
+                        font_family: Some(FontFamilyName("Lilex".into())),
+                        ..Default::default()
+                    });
+                settings.project.all_languages.edit_predictions =
+                    Some(EditPredictionSettingsContent {
+                        font_family: Some(FontFamilyName("Courier".into())),
+                        ..Default::default()
+                    });
+            });
+        });
+
+        let settings = ThemeSettings::get_global(cx);
+        assert_eq!(
+            settings.inlay_hints_font.family,
+            SharedString::from("Lilex")
+        );
+        assert_eq!(
+            settings.edit_predictions_font.family,
+            SharedString::from("Courier")
+        );
+        assert_ne!(
+            settings.edit_predictions_font.family, settings.inlay_hints_font.family,
+            "edit predictions font should differ from inlay hints font when both are explicitly set"
+        );
+    }
+}

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -645,7 +645,10 @@ For the case of "open", regular selection behavior can be achieved by holding `a
       "**/*.crt",
       "**/.dev.vars",
       "**/secrets.yml"
-    ]
+    ],
+    "font_family": null,
+    "font_weight": null,
+    "font_features": null
   }
 ```
 
@@ -2856,7 +2859,10 @@ Run the {#action icon_theme_selector::Toggle} action in the command palette to s
     "show_background": false,
     "edit_debounce_ms": 700,
     "scroll_debounce_ms": 50,
-    "toggle_on_modifiers_press": null
+    "toggle_on_modifiers_press": null,
+    "font_family": null,
+    "font_weight": null,
+    "font_features": null
   }
 }
 ```

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -679,7 +679,10 @@ For the case of "open", regular selection behavior can be achieved by holding `a
       "**/*.crt",
       "**/.dev.vars",
       "**/secrets.yml"
-    ]
+    ],
+    "font_family": null,
+    "font_weight": null,
+    "font_features": null
   }
 ```
 
@@ -3028,7 +3031,10 @@ Run the {#action icon_theme_selector::Toggle} action in the command palette to s
     "show_background": false,
     "edit_debounce_ms": 700,
     "scroll_debounce_ms": 50,
-    "toggle_on_modifiers_press": null
+    "toggle_on_modifiers_press": null,
+    "font_family": null,
+    "font_weight": null,
+    "font_features": null
   }
 }
 ```


### PR DESCRIPTION
Allows setting of the font options (family, features, weight) for all inlay hints and for edit predictions in particular.

VS code has similar functionality and we also migrate VS code settings over.

Inspired by VS code and https://monaspace.githubnext.com/

<img width="435" height="119" alt="image" src="https://github.com/user-attachments/assets/8662961e-0936-4410-acf9-bf2e5b72399e" />

https://github.com/user-attachments/assets/f4ca8ea2-dccf-45d0-aad9-ed5911ffde5d

This is a second attempt at implementing this, similar approach but reusing existing enums.

Font size was skipped again because it's a separate effort to implement that appears to be more complex given how we construct text runs for lines.

- [X] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #15716

Release Notes:

- Inlay hints font options are configurable independently from buffer font
- Edit predictions font options are configurable independently from inlay hints font
