### PR TITLE
Reset selection mark mode after an action

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1350,6 +1350,7 @@ pub struct Editor {
     /// Whether we are temporarily displaying a diff other than git's
     temporary_diff_override: bool,
     selection_mark_mode: bool,
+    continue_selection_mark_mode: bool,
     toggle_fold_multiple_buffers: Task<()>,
     _scroll_cursor_center_top_bottom_task: Task<()>,
     serialize_selections: Task<()>,
@@ -2652,6 +2653,7 @@ impl Editor {
             registered_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             selection_mark_mode: false,
+            continue_selection_mark_mode: false,
             toggle_fold_multiple_buffers: Task::ready(()),
             serialize_selections: Task::ready(()),
             serialize_folds: Task::ready(()),
@@ -4097,6 +4099,9 @@ impl Editor {
             state.effects.nav_history = effects.nav_history.or(state.effects.nav_history);
             let (changed, result) = self.selections.change_with(&snapshot, change);
             state.changed |= changed;
+            if self.selection_mark_mode {
+                self.continue_selection_mark_mode = true;
+            }
             return result;
         }
         let mut state = DeferredSelectionEffectsState {
@@ -4112,6 +4117,9 @@ impl Editor {
         };
         let (changed, result) = self.selections.change_with(&snapshot, change);
         state.changed = state.changed || changed;
+        if self.selection_mark_mode {
+            self.continue_selection_mark_mode = true;
+        }
         if self.defer_selection_effects {
             self.deferred_selection_effects_state = Some(state);
         } else {
@@ -20849,7 +20857,22 @@ impl Editor {
             })
         }
         self.selection_mark_mode = true;
+        self.continue_selection_mark_mode = true;
         cx.notify();
+    }
+
+    pub fn reset_mark(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.selection_mark_mode && !self.continue_selection_mark_mode {
+            self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.move_with(&mut |_, sel| {
+                    sel.collapse_to(sel.head(), SelectionGoal::None);
+                });
+            });
+
+            self.selection_mark_mode = false;
+        }
+
+        self.continue_selection_mark_mode = false;
     }
 
     pub fn swap_selection_ends(
@@ -25108,6 +25131,7 @@ impl Editor {
                     }
                 }
 
+                self.selection_mark_mode = false;
                 cx.emit(EditorEvent::BufferEdited);
                 cx.emit(SearchEvent::MatchesInvalidated);
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -37329,6 +37329,69 @@ async fn test_tsx_nested_jsx_member_expression_highlights(cx: &mut TestAppContex
     });
 }
 
+#[gpui::test]
+async fn test_set_mark_not_reset_on_movement(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("aaaa\nbˇb\ncccc");
+    cx.dispatch_action(SetMark);
+    cx.update_editor(|e, window, cx| {
+        assert!(
+            e.key_context(window, cx).contains("selection_mode"),
+            "mark mode should be active after SetMark"
+        );
+    });
+    cx.dispatch_action(MoveRight);
+    cx.update_editor(|e, window, cx| {
+        assert!(
+            e.key_context(window, cx).contains("selection_mode"),
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_set_mark_reset_on_non_movement(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("aaaa\nbˇb\ncccc");
+    cx.dispatch_action(SetMark);
+    cx.update_editor(|e, window, cx| {
+        assert!(
+            e.key_context(window, cx).contains("selection_mode"),
+            "mark mode should be active after SetMark"
+        );
+    });
+    cx.dispatch_action(Cancel);
+    cx.update_editor(|e, window, cx| {
+        assert!(
+            !e.key_context(window, cx).contains("selection_mode"),
+            "mark mode should be reset after non-movement action"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_set_mark_reset_on_buffer_edit(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("helloˇ");
+    cx.dispatch_action(SetMark);
+    cx.update_editor(|e, window, cx| {
+        assert!(
+            e.key_context(window, cx).contains("selection_mode"),
+            "mark mode should be active after SetMark"
+        );
+    });
+    cx.simulate_input("x");
+    cx.update_editor(|e, window, cx| {
+        assert!(
+            !e.key_context(window, cx).contains("selection_mode"),
+            "mark mode should be reset after buffer edit"
+        );
+    });
+    cx.assert_editor_state("helloxˇ");
+}
+
 fn setup_syntax_highlighting(
     language: Arc<Language>,
     cx: &mut EditorTestContext,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12675,6 +12675,7 @@ pub fn register_action<T: Action>(
         if phase == DispatchPhase::Bubble {
             editor.update(cx, |editor, cx| {
                 listener(editor, action, window, cx);
+                editor.reset_mark(window, cx);
             })
         }
     })


### PR DESCRIPTION
* If the editor is in selection mark mode and an action other than movement occurs, the editor needs to exit selection mark mode.
* A movement action will not change the status of selection mark mode. `continue_selection_mark_mode` flag is added to allow such actions to notify that it does not want to change the status.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved: Reset selection mark mode after an action.

**Problem**

Zed has Emacs-like selection mode. It can be activated using set_mark action. However after selection mark mode is activated (e.g. by using ctrl-space), it keeps working until it is canceled (e.g. by using ctrl-g). It would be nice if the selection mark mode can be deactivated automatically after any non-movement action.

**Solution**

Since there are so many supported action, deactivating selection mark mode in every actions would create a big change. In this pull request, a new variable named continue_selection_mark_mode is added to Editor so that movement actions can keep the mode going while all other actions by default deactivate selection mark mode.
