### PR TITLE
Add OpenCode to provider autocomplete enum

### DIFF
--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -429,6 +429,7 @@ impl JsonSchema for LanguageModelProviderSetting {
                         "mistral",
                         "ollama",
                         "openai",
+                        "opencode",
                         "openrouter",
                         "vercel_ai_gateway",
                         "x_ai",


### PR DESCRIPTION
The `opencode` built-in provider is registered in the language model registry
but missing from the JSON schema enum in `LanguageModelProviderSetting`.

<img width="724" height="399" alt="image" src="https://github.com/user-attachments/assets/33da4626-eb44-443e-b656-65533b3a85f1" />
<br>
OpenCode is one of the "first class" providers, so I was surprised it was missing from the auto-complete for the provider fields in the settings file.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Release Notes

- N/A
