### PR TITLE
Fix git graph file diff view opening wrong file if a previous one is already open

### DIFF
--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -201,7 +201,12 @@ impl CommitView {
                                     .is_some_and(|view| view.read(cx).commit.sha == commit_sha)
                             });
                             if let Some(ix) = ix {
-                                pane.activate_item(ix, true, true, window, cx);
+                                let existing = pane.items()
+                                        .filter_map(|item| item.downcast::<CommitView>())
+                                        .find(|view| view.read(cx).commit.sha == commit_sha).unwrap();
+
+                                pane.remove_item(existing.item_id(), false, false, window, cx);
+                                pane.add_item(Box::new(commit_view), true, true, Some(ix), window, cx);
                             } else {
                                 pane.add_item(Box::new(commit_view), true, true, None, window, cx);
                             }

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -201,12 +201,21 @@ impl CommitView {
                                     .is_some_and(|view| view.read(cx).commit.sha == commit_sha)
                             });
                             if let Some(ix) = ix {
-                                let existing = pane.items()
-                                        .filter_map(|item| item.downcast::<CommitView>())
-                                        .find(|view| view.read(cx).commit.sha == commit_sha).unwrap();
+                                let existing = pane
+                                    .items()
+                                    .filter_map(|item| item.downcast::<CommitView>())
+                                    .find(|view| view.read(cx).commit.sha == commit_sha)
+                                    .unwrap();
 
                                 pane.remove_item(existing.item_id(), false, false, window, cx);
-                                pane.add_item(Box::new(commit_view), true, true, Some(ix), window, cx);
+                                pane.add_item(
+                                    Box::new(commit_view),
+                                    true,
+                                    true,
+                                    Some(ix),
+                                    window,
+                                    cx,
+                                );
                             } else {
                                 pane.add_item(Box::new(commit_view), true, true, None, window, cx);
                             }


### PR DESCRIPTION
Fixed the portion of the open() function of the CommitView struct that checked to see if the commit view was already open in a tab. Previously, it did not account for files being filtered, and called pane.activate_item() when it found a matching commit SHA open. Now, the pane item is deleted and replaced with the new CommitView, respecting the position of the tab. This allows for the filtered files to be updated and work according to the expectations laid out in the mentioned issue. 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55446

Release Notes:

- Fix git graph file diff view opening wrong file if a previous one is already open
