### PR TITLE
git_ui: Disable push button while pushing

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -644,6 +644,7 @@ pub struct GitPanel {
     changes_count: usize,
     new_staged_count: usize,
     pending_commit: Option<Task<()>>,
+    pending_push: Option<Task<()>>,
     amend_pending: bool,
     original_commit_message: Option<String>,
     signoff_enabled: bool,
@@ -832,6 +833,7 @@ impl GitPanel {
                 new_staged_count: 0,
                 changes_count: 0,
                 pending_commit: None,
+                pending_push: None,
                 amend_pending: false,
                 original_commit_message: None,
                 signoff_enabled: false,
@@ -3047,7 +3049,7 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.can_push_and_pull(cx) {
+        if !self.can_push_and_pull(cx) || self.pending_push.is_some() {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -3073,7 +3075,7 @@ impl GitPanel {
         };
         let remote = self.get_remote(select_remote, true, window, cx);
 
-        cx.spawn_in(window, async move |this, cx| {
+        let push_work = cx.spawn_in(window, async move |this, cx| -> anyhow::Result<()> {
             let remote = match remote.await {
                 Ok(Some(remote)) => remote,
                 Ok(None) => {
@@ -3126,11 +3128,26 @@ impl GitPanel {
                     log::error!("Error while pushing {:?}", e);
                     this.show_error_toast(action.name(), e, cx)
                 }
-            })?;
+            })
+            .ok();
 
             anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+        });
+
+        let task = cx.spawn(async move |this, cx| {
+            let result = push_work.await;
+            this.update(cx, |this, cx| {
+                this.pending_push.take();
+                if let Err(e) = result {
+                    this.show_error_toast("push", e, cx);
+                }
+                cx.notify();
+            })
+            .ok();
+        });
+
+        self.pending_push = Some(task);
+        cx.notify();
     }
 
     /// Updates git's configuration, adding the directory of the current
@@ -4396,6 +4413,7 @@ impl GitPanel {
                         &branch,
                         focus_handle,
                         true,
+                        self.pending_push.is_some(),
                     ))
                 })
                 .into_any_element(),
@@ -8427,6 +8445,75 @@ mod tests {
             assert_eq!(style.text.font_size.to_pixels(window.rem_size()), px(20.0));
 
             Editor::single_line(window, cx)
+        });
+    }
+
+    #[gpui::test]
+    async fn test_push_is_noop_when_pending(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "file.rs": "fn main() {}",
+            }),
+        )
+        .await;
+        fs.set_branch_name(path!("/project/.git").as_ref(), Some("main"));
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+        cx.run_until_parked();
+
+        panel.read_with(cx, |panel, cx| {
+            assert!(
+                panel.active_repository.is_some(),
+                "test setup: no active repository"
+            );
+            assert!(
+                panel
+                    .active_repository
+                    .as_ref()
+                    .unwrap()
+                    .read(cx)
+                    .branch
+                    .is_some(),
+                "test setup: no branch on repository"
+            );
+        });
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.pending_push = Some(cx.spawn(async |_, _| {}));
+            panel.push(false, false, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(cx, |panel, _| {
+            assert!(
+                panel.pending_push.is_some(),
+                "push() should be a no-op when a push is already in progress"
+            );
         });
     }
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -634,6 +634,7 @@ pub struct GitPanel {
     changes_count: usize,
     new_staged_count: usize,
     pending_commit: Option<Task<()>>,
+    pending_push: Option<Task<()>>,
     amend_pending: bool,
     original_commit_message: Option<String>,
     signoff_enabled: bool,
@@ -819,6 +820,7 @@ impl GitPanel {
                 new_staged_count: 0,
                 changes_count: 0,
                 pending_commit: None,
+                pending_push: None,
                 amend_pending: false,
                 original_commit_message: None,
                 signoff_enabled: false,
@@ -3079,7 +3081,7 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.can_push_and_pull(cx) {
+        if !self.can_push_and_pull(cx) || self.pending_push.is_some() {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -3105,7 +3107,7 @@ impl GitPanel {
         };
         let remote = self.get_remote(select_remote, true, window, cx);
 
-        cx.spawn_in(window, async move |this, cx| {
+        let push_work = cx.spawn_in(window, async move |this, cx| -> anyhow::Result<()> {
             let remote = match remote.await {
                 Ok(Some(remote)) => remote,
                 Ok(None) => {
@@ -3150,11 +3152,26 @@ impl GitPanel {
                     log::error!("Error while pushing {:?}", e);
                     this.show_error_toast(action.name(), e, cx)
                 }
-            })?;
+            })
+            .ok();
 
             anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+        });
+
+        let task = cx.spawn(async move |this, cx| {
+            let result = push_work.await;
+            this.update(cx, |this, cx| {
+                this.pending_push.take();
+                if let Err(e) = result {
+                    this.show_error_toast("push", e, cx);
+                }
+                cx.notify();
+            })
+            .ok();
+        });
+
+        self.pending_push = Some(task);
+        cx.notify();
     }
 
     pub fn create_pull_request(&self, window: &mut Window, cx: &mut Context<Self>) {
@@ -4329,6 +4346,7 @@ impl GitPanel {
                         &branch,
                         focus_handle,
                         true,
+                        self.pending_push.is_some(),
                     ))
                 })
                 .into_any_element(),
@@ -8136,6 +8154,75 @@ mod tests {
             assert!(
                 context.contains("ChangesList"),
                 "should have ChangesList context after re-focusing changes list"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_push_is_noop_when_pending(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "file.rs": "fn main() {}",
+            }),
+        )
+        .await;
+        fs.set_branch_name(path!("/project/.git").as_ref(), Some("main"));
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+        cx.run_until_parked();
+
+        panel.read_with(cx, |panel, cx| {
+            assert!(
+                panel.active_repository.is_some(),
+                "test setup: no active repository"
+            );
+            assert!(
+                panel
+                    .active_repository
+                    .as_ref()
+                    .unwrap()
+                    .read(cx)
+                    .branch
+                    .is_some(),
+                "test setup: no branch on repository"
+            );
+        });
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.pending_push = Some(cx.spawn(async |_, _| {}));
+            panel.push(false, false, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(cx, |panel, _| {
+            assert!(
+                panel.pending_push.is_some(),
+                "push() should be a no-op when a push is already in progress"
             );
         });
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8387,7 +8387,6 @@ mod tests {
     }
 
     #[gpui::test]
-<<<<<<< HEAD
     async fn test_fill_commit_editor_toggle(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.background_executor.clone());
@@ -8453,8 +8452,6 @@ mod tests {
     }
 
     #[gpui::test]
-=======
->>>>>>> 9c020a6c6c60726f7886a195eabd682eb321c1af
     async fn test_push_is_noop_when_pending(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3148,7 +3148,6 @@ impl GitPanel {
 
         self.pending_push = Some(task);
         cx.notify();
-<<<<<<< HEAD
     }
 
     /// Updates git's configuration, adding the directory of the current

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -679,6 +679,7 @@ fn render_remote_button(
     branch: &Branch,
     keybinding_target: Option<FocusHandle>,
     show_fetch_button: bool,
+    pending_push: bool,
 ) -> Option<impl IntoElement> {
     let id = id.into();
     let upstream = branch.upstream.as_ref();
@@ -695,6 +696,7 @@ fn render_remote_button(
                 keybinding_target,
                 id,
                 ahead,
+                pending_push,
             )),
             (ahead, behind) => Some(remote_button::render_pull_button(
                 keybinding_target,
@@ -717,9 +719,10 @@ fn render_remote_button(
 mod remote_button {
     use gpui::{Action, Anchor, AnyView, ClickEvent, FocusHandle};
     use ui::{
-        App, ButtonCommon, Clickable, ContextMenu, ElementId, FluentBuilder, Icon, IconName,
-        IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle, ParentElement,
-        PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div, h_flex, rems,
+        App, ButtonCommon, Clickable, ContextMenu, Disableable, ElementId, FluentBuilder, Icon,
+        IconName, IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle,
+        ParentElement, PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div,
+        h_flex, rems,
     };
 
     pub fn render_fetch_button(
@@ -732,6 +735,7 @@ mod remote_button {
             0,
             0,
             Some(IconName::ArrowCircle),
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Fetch), cx);
@@ -752,13 +756,16 @@ mod remote_button {
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
         ahead: u32,
+        pending_push: bool,
     ) -> SplitButton {
+        let push_text = if pending_push { "Pushing..." } else { "Push" };
         split_button(
             id,
-            "Push",
+            push_text,
             ahead as usize,
             0,
             None,
+            pending_push,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
@@ -787,6 +794,7 @@ mod remote_button {
             ahead as usize,
             behind as usize,
             None,
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Pull), cx);
@@ -813,6 +821,7 @@ mod remote_button {
             0,
             0,
             Some(IconName::ExpandUp),
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
@@ -839,6 +848,7 @@ mod remote_button {
             0,
             0,
             Some(IconName::ExpandUp),
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
@@ -913,6 +923,7 @@ mod remote_button {
         ahead_count: usize,
         behind_count: usize,
         left_icon: Option<IconName>,
+        pending_push: bool,
         keybinding_target: Option<FocusHandle>,
         left_on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
         tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
@@ -937,6 +948,7 @@ mod remote_button {
             format!("split-button-left-{}", id).into(),
         ))
         .layer(ui::ElevationIndex::ModalSurface)
+        .disabled(pending_push)
         .size(ui::ButtonSize::Compact)
         .when(should_render_counts, |this| {
             this.child(

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -639,6 +639,7 @@ fn render_remote_button(
     branch: &Branch,
     keybinding_target: Option<FocusHandle>,
     show_fetch_button: bool,
+    pending_push: bool,
 ) -> Option<impl IntoElement> {
     let id = id.into();
     let upstream = branch.upstream.as_ref();
@@ -655,6 +656,7 @@ fn render_remote_button(
                 keybinding_target,
                 id,
                 ahead,
+                pending_push,
             )),
             (ahead, behind) => Some(remote_button::render_pull_button(
                 keybinding_target,
@@ -677,9 +679,10 @@ fn render_remote_button(
 mod remote_button {
     use gpui::{Action, AnyView, ClickEvent, Corner, FocusHandle};
     use ui::{
-        App, ButtonCommon, Clickable, ContextMenu, ElementId, FluentBuilder, Icon, IconName,
-        IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle, ParentElement,
-        PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div, h_flex, rems,
+        App, ButtonCommon, Clickable, ContextMenu, Disableable, ElementId, FluentBuilder, Icon,
+        IconName, IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle,
+        ParentElement, PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div,
+        h_flex, rems,
     };
 
     pub fn render_fetch_button(
@@ -692,6 +695,7 @@ mod remote_button {
             0,
             0,
             Some(IconName::ArrowCircle),
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Fetch), cx);
@@ -712,13 +716,16 @@ mod remote_button {
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
         ahead: u32,
+        pending_push: bool,
     ) -> SplitButton {
+        let push_text = if pending_push { "Pushing..." } else { "Push" };
         split_button(
             id,
-            "Push",
+            push_text,
             ahead as usize,
             0,
             None,
+            pending_push,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
@@ -747,6 +754,7 @@ mod remote_button {
             ahead as usize,
             behind as usize,
             None,
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Pull), cx);
@@ -773,6 +781,7 @@ mod remote_button {
             0,
             0,
             Some(IconName::ExpandUp),
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
@@ -799,6 +808,7 @@ mod remote_button {
             0,
             0,
             Some(IconName::ExpandUp),
+            false,
             keybinding_target.clone(),
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
@@ -873,6 +883,7 @@ mod remote_button {
         ahead_count: usize,
         behind_count: usize,
         left_icon: Option<IconName>,
+        pending_push: bool,
         keybinding_target: Option<FocusHandle>,
         left_on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
         tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
@@ -897,6 +908,7 @@ mod remote_button {
             format!("split-button-left-{}", id).into(),
         ))
         .layer(ui::ElevationIndex::ModalSurface)
+        .disabled(pending_push)
         .size(ui::ButtonSize::Compact)
         .when(should_render_counts, |this| {
             this.child(


### PR DESCRIPTION
Disables the push button while it is already pushing. From discussion topic here: https://github.com/zed-industries/zed/discussions/45195.

This code follows the existing conventions in place for `pending_commits` and copies it for a new `pending_push`

Existing behaviour: When you click the push button, you can keep clicking it and its not clear that it is actually pushing, aside from the status bar at the bottom which is easy to miss.

https://github.com/user-attachments/assets/188260ff-4ed2-4354-bdd0-e77361ea4d78

After this change: 
Button becomes disabled while pushing.

https://github.com/user-attachments/assets/6695b10c-5570-4c90-9fef-f81111a01f82



Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

Disabled 'git push' button when git is currently pushing. 
