### PR TITLE
zed: Do not upload crashes that lack an associated release

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -266,6 +266,10 @@ async fn upload_minidump(
     minidump: Vec<u8>,
     metadata: &crashes::CrashInfo,
 ) -> Result<()> {
+    if metadata.init.commit_sha == "no sha" {
+        log::warn!("No commit sha set, skipping minidump upload");
+        return Ok(());
+    }
     let mut form = Form::new()
         .part(
             "upload_file_minidump",


### PR DESCRIPTION
We will not have any debug data for these anyways (and usually this indicates someone else made a built that somehow points to our sentry endpoint ...)

Release Notes:

- N/A or Added/Fixed/Improved ...
