### PR TITLE
Fix mismatched excerpts in split agent diff

### DIFF
--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -173,19 +173,17 @@ impl AgentDiffPane {
                 .map(|diff_hunk| diff_hunk.buffer_range.to_point(&snapshot))
                 .collect::<Vec<_>>();
 
-            let (was_empty, is_excerpt_newly_added) =
-                self.multibuffer.update(cx, |multibuffer, cx| {
-                    let was_empty = multibuffer.is_empty();
-                    let is_excerpt_newly_added = multibuffer.update_excerpts_for_path(
-                        path_key.clone(),
-                        buffer.clone(),
-                        diff_hunk_ranges,
-                        multibuffer_context_lines(cx),
-                        cx,
-                    );
-                    multibuffer.add_diff(diff_handle.clone(), cx);
-                    (was_empty, is_excerpt_newly_added)
-                });
+            let was_empty = self.multibuffer.read(cx).is_empty();
+            let is_excerpt_newly_added = self.editor.update(cx, |editor, cx| {
+                editor.update_excerpts_for_path(
+                    path_key.clone(),
+                    buffer.clone(),
+                    diff_hunk_ranges,
+                    multibuffer_context_lines(cx),
+                    diff_handle.clone(),
+                    cx,
+                )
+            });
 
             let rhs_editor = self.editor.read(cx).rhs_editor().clone();
             rhs_editor.update(cx, |editor, cx| {
@@ -216,9 +214,9 @@ impl AgentDiffPane {
             });
         }
 
-        self.multibuffer.update(cx, |multibuffer, cx| {
+        self.editor.update(cx, |editor, cx| {
             for buffer_id in buffers_to_delete {
-                multibuffer.remove_excerpts_for_buffer(buffer_id, cx);
+                editor.remove_excerpts_for_buffer(buffer_id, cx);
             }
         });
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1280,6 +1280,18 @@ impl SplittableEditor {
             }
         }
     }
+
+    pub fn remove_excerpts_for_buffer(
+        &mut self,
+        buffer_id: BufferId,
+        cx: &mut Context<'_, SplittableEditor>,
+    ) {
+        let snapshot = self.rhs_multibuffer.read(cx).snapshot(cx);
+        let Some(path) = snapshot.path_for_buffer(buffer_id) else {
+            return;
+        };
+        self.remove_excerpts_for_path(path.clone(), cx);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed excerpts not matching in the agent diff when in the split view.