### PR TITLE
Fix micromamba powershell activation

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1259,7 +1259,7 @@ fn micromamba_shell_name(kind: ShellKind) -> &'static str {
         ShellKind::Csh => "csh",
         ShellKind::Fish => "fish",
         ShellKind::Nushell => "nu",
-        ShellKind::PowerShell => "powershell",
+        ShellKind::PowerShell | ShellKind::Pwsh => "powershell",
         ShellKind::Cmd => "cmd.exe",
         // default / catch-all:
         _ => "posix",
@@ -1470,9 +1470,17 @@ impl ToolchainLister for PythonToolchainProvider {
                     // Activate micromamba shell in the child shell
                     // [required for micromamba]
                     if manager == "micromamba" {
-                        let shell = micromamba_shell_name(shell);
-                        activation_script
-                            .push(format!(r#"eval "$({manager} shell hook --shell {shell})""#));
+                        match shell {
+                            ShellKind::PowerShell | ShellKind::Pwsh => {
+                                activation_script.push(format!(r#"(& {manager} shell hook --shell powershell) | Out-String | Invoke-Expression"#));
+                            }
+                            _ => {
+                                let shell_name = micromamba_shell_name(shell);
+                                activation_script.push(format!(
+                                    r#"eval "$({manager} shell hook --shell {shell_name})""#
+                                ));
+                            }
+                        }
                     }
 
                     if let Some(name) = &toolchain.environment.name {


### PR DESCRIPTION
Powershell does not support eval, furthermore pwsh is also a "powershell" shell for micromamba.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fixes micromamba powershell activation
