### PR TITLE
ci: Create releases with the Zed Zippy identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,13 @@ jobs:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
     runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
+    - id: generate-token
+      name: steps::authenticate_as_zippy
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+      with:
+        app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}
+        private-key: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
+        permission-contents: write
     - name: steps::checkout_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       with:
@@ -289,7 +296,7 @@ jobs:
     - name: release::create_draft_release::create_release
       run: script/create-draft-release target/release-notes.md
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
     timeout-minutes: 60
   compliance_check:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -1,11 +1,11 @@
-use gh_workflow::{Event, Expression, Push, Run, Step, Use, Workflow, ctx::Context};
+use gh_workflow::{Event, Expression, Level, Push, Run, Step, Use, Workflow, ctx::Context};
 use indoc::formatdoc;
 
 use crate::tasks::workflows::{
     run_bundling::{bundle_linux, bundle_mac, bundle_windows, upload_artifact},
     run_tests,
     runners::{self, Arch, Platform},
-    steps::{self, FluentBuilder, NamedJob, dependant_job, named, release_job},
+    steps::{self, FluentBuilder, NamedJob, TokenPermissions, dependant_job, named, release_job},
     vars::{self, JobOutput, StepOutput, assets},
 };
 
@@ -471,10 +471,14 @@ fn create_draft_release() -> NamedJob {
         )
     }
 
-    fn create_release() -> Step<Run> {
+    fn create_release(token: StepOutput) -> Step<Run> {
         named::bash("script/create-draft-release target/release-notes.md")
-            .add_env(("GITHUB_TOKEN", vars::GITHUB_TOKEN))
+            .add_env(("GITHUB_TOKEN", token.to_string()))
     }
+
+    let (authenticate_step, token) = steps::authenticate_as_zippy()
+        .with_permissions([(TokenPermissions::Contents, Level::Write)])
+        .into();
 
     named::job(
         release_job(&[])
@@ -483,6 +487,7 @@ fn create_draft_release() -> NamedJob {
             // is able to diff between the current and previous tag.
             //
             // 25 was chosen arbitrarily.
+            .add_step(authenticate_step)
             .add_step(
                 steps::checkout_repo()
                     .with_custom_fetch_depth(25)
@@ -491,7 +496,7 @@ fn create_draft_release() -> NamedJob {
             .add_step(steps::script("script/determine-release-channel"))
             .add_step(steps::script("mkdir -p target/"))
             .add_step(generate_release_notes())
-            .add_step(create_release()),
+            .add_step(create_release(token)),
     )
 }
 


### PR DESCRIPTION
Just a small QoL, the change here will make it so that under https://github.com/zed-industries/zed/releases/tag/v1.0.1 the releases will show as created by zed-zippy and not github-actions.

Release Notes:

- N/A
