### PR TITLE
settings: Fix inverted VS Code import for `files.simpleDialog.enable`

### DIFF
--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1033,7 +1033,7 @@ impl VsCodeSettings {
             restore_on_startup: None,
             window_decorations: None,
             show_call_status_icon: None,
-            use_system_path_prompts: self.read_bool("files.simpleDialog.enable"),
+            use_system_path_prompts: self.read_bool("files.simpleDialog.enable").map(|b| !b),
             use_system_prompts: None,
             use_system_window_tabs: self.read_bool("window.nativeTabs"),
             when_closing_with_no_tabs: self.read_bool("window.closeWhenEmpty").map(|b| {


### PR DESCRIPTION
Seems to have been introduced in https://github.com/zed-industries/zed/commit/1fbe1e351246dd54577324e9632c6f9a48bc6ece. These settings actually mean the opposite:

> Whether to use the system provided dialogs for Open and Save As. When set to false, Zed will use the built-in keyboard-first pickers.

> Enables the simple file dialog for opening and saving files and folders. The simple file dialog replaces the system file dialog when enabled.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

~~Closes #ISSUE~~

Release Notes:

- Fixed import of VSCode setting `files.simpleDialog.enable` being inverted
