### PR TITLE
fs: Pre-filter the event kind before acquiring global lock and cloning callback handlers

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -1,4 +1,4 @@
-use notify::EventKind;
+use notify::{Event, EventKind};
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -458,6 +458,16 @@ fn handle_poll_event(event: Result<notify::Event, notify::Error>) {
 }
 
 fn handle_event(mode: WatcherMode, event: Result<notify::Event, notify::Error>) {
+    if matches!(
+        event,
+        Ok(Event {
+            kind: EventKind::Access(_),
+            ..
+        })
+    ) {
+        return;
+    }
+
     log::trace!("global handle event for {mode:?}: {event:?}");
 
     let callbacks = {
@@ -472,9 +482,6 @@ fn handle_event(mode: WatcherMode, event: Result<notify::Event, notify::Error>) 
 
     match event {
         Ok(event) => {
-            if matches!(event.kind, EventKind::Access(_)) {
-                return;
-            }
             for callback in callbacks {
                 callback(Ok(&event));
             }


### PR DESCRIPTION
In #54481, the `handle_event` function was altered to check for an `Access` event after the callbacks were acquired via a global state lock. The lock/Vec-collect has enough overhead (or maybe there's enough lock contention?) that the handler isn't performant enough to keep up with the volume of inotify events, and its queue fills up, resulting in [a rescan event getting emitted](https://github.com/notify-rs/notify/blob/79007aefb41d9f853d00656eb768600e3ea41ee0/notify/src/inotify.rs#L304-L306), which presumably results in *more* access events for the file as it's rescanned, which further serve to fill up the inotify queue.

Moving the check for an `Access` event and returning before doing anything remotely expensive seems to resolve the issues I've been having lately. Not sure if it addresses the original issue in #53480 though. 

Longer-term, it might be prudent to do the event handler's heavy-lifting in a separate thread with its own event queue, and let the handler passed to the `notify` crate be just a dumb `tx` sender.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Related to #53480
Fixes #55829 

Release Notes:

- Fixed inotify event queue overflows on linux
