### PR TITLE
open_path_prompt: Add multi-select support to path picker

### DIFF
--- a/crates/open_path_prompt/Cargo.toml
+++ b/crates/open_path_prompt/Cargo.toml
@@ -10,6 +10,7 @@ file_icons.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+menu.workspace = true
 picker.workspace = true
 project.workspace = true
 schemars.workspace = true

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -8,17 +8,19 @@ use file_icons::FileIcons;
 use futures::channel::oneshot;
 use fuzzy::{CharBag, StringMatch, StringMatchCandidate};
 use gpui::{HighlightStyle, StyledText, Task};
+use menu;
 use picker::{Picker, PickerDelegate};
 use project::{DirectoryItem, DirectoryLister};
 use settings::Settings;
 use std::{
+    collections::HashSet,
     path::{self, Path, PathBuf},
     sync::{
         Arc,
         atomic::{self, AtomicBool},
     },
 };
-use ui::{Context, LabelLike, ListItem, Window};
+use ui::{Context, KeyBinding, LabelLike, ListItem, Window};
 use ui::{HighlightedLabel, ListItemSpacing, prelude::*};
 use util::{
     maybe,
@@ -42,6 +44,7 @@ pub struct OpenPathDelegate {
     render_footer:
         Arc<dyn Fn(&mut Window, &mut Context<Picker<Self>>) -> Option<AnyElement> + 'static>,
     hidden_entries: bool,
+    selected_paths: HashSet<PathBuf>,
 }
 
 impl OpenPathDelegate {
@@ -70,6 +73,7 @@ impl OpenPathDelegate {
             replace_prompt: Task::ready(()),
             render_footer: Arc::new(|_, _| None),
             hidden_entries: false,
+            selected_paths: HashSet::new(),
         }
     }
 
@@ -147,6 +151,28 @@ impl OpenPathDelegate {
                 }))
                 .collect(),
             DirectoryState::None { .. } => Vec::new(),
+        }
+    }
+
+    fn resolve_entry_path(&self, candidate: &CandidateInfo, cx: &App) -> Option<PathBuf> {
+        match &self.directory_state {
+            DirectoryState::List { parent_path, .. } => {
+                let path =
+                    if parent_path == &self.prompt_root && candidate.path.string.is_empty() {
+                        PathBuf::from(&self.prompt_root)
+                    } else {
+                        Path::new(self.lister.resolve_tilde(parent_path, cx).as_ref())
+                            .join(&candidate.path.string)
+                    };
+                Some(path)
+            }
+            _ => None,
+        }
+    }
+
+    fn toggle_selected_path(&mut self, path: PathBuf) {
+        if !self.selected_paths.remove(&path) {
+            self.selected_paths.insert(path);
         }
     }
 
@@ -608,23 +634,32 @@ impl PickerDelegate for OpenPathDelegate {
         )
     }
 
-    fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+    fn confirm(&mut self, secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         let Some(candidate) = self.get_entry(self.selected_index) else {
             return;
         };
 
         match &self.directory_state {
             DirectoryState::None { .. } => return,
-            DirectoryState::List { parent_path, .. } => {
-                let confirmed_path =
-                    if parent_path == &self.prompt_root && candidate.path.string.is_empty() {
-                        PathBuf::from(&self.prompt_root)
-                    } else {
-                        Path::new(self.lister.resolve_tilde(parent_path, cx).as_ref())
-                            .join(&candidate.path.string)
-                    };
+            DirectoryState::List { .. } => {
+                let Some(resolved) = self.resolve_entry_path(&candidate, cx) else {
+                    return;
+                };
+
+                if secondary {
+                    self.toggle_selected_path(resolved);
+                    cx.notify();
+                    return;
+                }
+
+                let mut paths: Vec<PathBuf> =
+                    self.selected_paths.drain().collect();
+                if paths.is_empty() {
+                    paths.push(resolved);
+                }
+
                 if let Some(tx) = self.tx.take() {
-                    tx.send(Some(vec![confirmed_path])).ok();
+                    tx.send(Some(paths)).ok();
                 }
             }
             DirectoryState::Create {
@@ -743,6 +778,9 @@ impl PickerDelegate for OpenPathDelegate {
 
         match &self.directory_state {
             DirectoryState::List { parent_path, .. } => {
+                let is_multi_selected = self
+                    .resolve_entry_path(&candidate, cx)
+                    .map_or(false, |path| self.selected_paths.contains(&path));
                 let (label, indices) = if is_current_dir_candidate {
                     ("open this directory".to_string(), vec![])
                 } else if *parent_path == self.prompt_root {
@@ -761,7 +799,11 @@ impl PickerDelegate for OpenPathDelegate {
                         .spacing(ListItemSpacing::Sparse)
                         .start_slot::<Icon>(file_icon)
                         .inset(true)
-                        .toggle_state(selected)
+                        .toggle_state(selected || is_multi_selected)
+                        .end_slot::<Icon>(
+                            is_multi_selected
+                                .then(|| Icon::new(IconName::Check).color(Color::Accent)),
+                        )
                         .child(HighlightedLabel::new(label, indices)),
                 )
             }
@@ -837,7 +879,37 @@ impl PickerDelegate for OpenPathDelegate {
         window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Option<AnyElement> {
-        (self.render_footer)(window, cx)
+        if let Some(element) = (self.render_footer)(window, cx) {
+            return Some(element);
+        }
+
+        if matches!(self.directory_state, DirectoryState::List { .. }) {
+            let selected_count = self.selected_paths.len();
+            let label = if selected_count > 0 {
+                format!("{selected_count} selected")
+            } else {
+                "Select multiple".to_string()
+            };
+            return Some(
+                h_flex()
+                    .w_full()
+                    .p_1p5()
+                    .border_t_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .child(
+                        Button::new("multi-select-hint", label)
+                            .key_binding(KeyBinding::for_action(
+                                &menu::SecondaryConfirm,
+                                cx,
+                            ))
+                            .style(ButtonStyle::Subtle)
+                            .disabled(true),
+                    )
+                    .into_any_element(),
+            );
+        }
+
+        None
     }
 
     fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {

--- a/crates/open_path_prompt/src/open_path_prompt_tests.rs
+++ b/crates/open_path_prompt/src/open_path_prompt_tests.rs
@@ -482,3 +482,81 @@ fn collect_match_candidates(
 ) -> Vec<String> {
     picker.update(cx, |f, _| f.delegate.collect_match_candidates())
 }
+
+#[gpui::test]
+async fn test_open_path_prompt_multi_select(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/root"),
+            json!({
+                "dir1": {},
+                "dir2": {},
+                "dir3": {},
+                "file1": "F1",
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+
+    let (tx, rx) = futures::channel::oneshot::channel();
+    let lister = project::DirectoryLister::Project(project.clone());
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    let picker = workspace.update_in(cx, |_, window, cx| {
+        let delegate = OpenPathDelegate::new(tx, lister.clone(), false, cx).show_hidden();
+        cx.new(|cx| {
+            let picker = Picker::uniform_list(delegate, window, cx)
+                .width(rems(34.))
+                .modal(false);
+            let query = lister.default_query(cx);
+            picker.set_query(&query, window, cx);
+            picker
+        })
+    });
+
+    insert_query(path!("/root/"), &picker, cx).await;
+
+    // Secondary confirm (ctrl/cmd+enter) on dir1 toggles it into the selection set.
+    picker.update_in(cx, |picker, window, cx| {
+        picker.delegate.set_selected_index(1, window, cx);
+        picker.delegate.confirm(true, window, cx);
+    });
+    picker.update(cx, |picker, _| {
+        assert_eq!(picker.delegate.selected_paths.len(), 1);
+        assert!(picker.delegate.selected_paths.iter().any(|p| p.ends_with("dir1")));
+    });
+
+    // Secondary confirm on dir3 adds it to the selection set.
+    picker.update_in(cx, |picker, window, cx| {
+        picker.delegate.set_selected_index(3, window, cx);
+        picker.delegate.confirm(true, window, cx);
+    });
+    picker.update(cx, |picker, _| {
+        assert_eq!(picker.delegate.selected_paths.len(), 2);
+    });
+
+    // Secondary confirm on dir1 again removes it from the selection set.
+    picker.update_in(cx, |picker, window, cx| {
+        picker.delegate.set_selected_index(1, window, cx);
+        picker.delegate.confirm(true, window, cx);
+    });
+    picker.update(cx, |picker, _| {
+        assert_eq!(picker.delegate.selected_paths.len(), 1);
+        assert!(picker.delegate.selected_paths.iter().any(|p| p.ends_with("dir3")));
+    });
+
+    // Regular confirm sends all selected paths.
+    picker.update_in(cx, |picker, window, cx| {
+        picker.delegate.confirm(false, window, cx);
+    });
+
+    let paths = rx.await.unwrap().unwrap();
+    assert_eq!(paths.len(), 1);
+    assert!(paths[0].ends_with("dir3"));
+}


### PR DESCRIPTION
Please treat this as proposal. Happy to iterate on this/cancel

Add the ability to select multiple folders in the open path prompt using ctrl+enter / cmd+enter to toggle items, then enter to confirm.

Selected items display a checkmark icon and highlighted state. When confirming with items toggled, all selected paths are sent. Without any toggled items, the behavior is unchanged (single selection).

This is particularly useful for SSH/remote sessions where the native OS file picker is not available and users need to add multiple folders to a project.

Please find image refs attached

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
  - None created 
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
  - I've follower the description. I decided to skip the point on cancelling out of selection in favor of user retrying the same dialog. This is simpler then having multiple cancellation tiers
- [x] Tests cover the new/changed behavior
  - Tests generated with AI
- [x] Performance impact has been considered and is acceptable
  - Should not apply


Closes #ISSUE

Release Notes:

- Added ability to pick multiple projects in path picker

<img width="515" height="144" alt="Screenshot 2026-05-04 at 13 07 56" src="https://github.com/user-attachments/assets/78536313-f48a-4b89-8492-31a961839917" />
<img width="608" height="286" alt="Screenshot 2026-05-04 at 13 07 45" src="https://github.com/user-attachments/assets/bbb1b663-ad1a-4c3b-baa6-c63dfa73798f" />
<img width="592" height="273" alt="Screenshot 2026-05-04 at 13 07 24" src="https://github.com/user-attachments/assets/376f6a38-6ded-4f22-b9d9-ef212f48958e" />
