### PR TITLE
client: Pass x-zed-system-id header in get_authenticated_user()

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -229,9 +229,11 @@ impl UserStore {
                         | Status::Reauthenticated
                         | Status::Connected { .. } => {
                             if let Some(user_id) = client.user_id() {
+                                let system_id =
+                                    client.telemetry().system_id().map(|id| id.to_string());
                                 let response = client
                                     .cloud_client()
-                                    .get_authenticated_user()
+                                    .get_authenticated_user(system_id)
                                     .await
                                     .log_err();
 
@@ -912,15 +914,19 @@ impl UserStore {
         cx.spawn(async move |cx| {
             match message {
                 MessageToClient::UserUpdated => {
-                    let cloud_client = cx
+                    let (cloud_client, system_id) = cx
                         .update(|cx| {
                             this.read_with(cx, |this, _cx| {
-                                this.client.upgrade().map(|client| client.cloud_client())
+                                this.client.upgrade().map(|client| {
+                                    let system_id =
+                                        client.telemetry().system_id().map(|id| id.to_string());
+                                    (client.cloud_client(), system_id)
+                                })
                             })
                         })?
                         .ok_or(anyhow::anyhow!("Failed to get Cloud client"))?;
 
-                    let response = cloud_client.get_authenticated_user().await?;
+                    let response = cloud_client.get_authenticated_user(system_id).await?;
                     cx.update(|cx| {
                         this.update(cx, |this, cx| {
                             this.update_authenticated_user(response, cx);

--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -74,15 +74,20 @@ impl CloudApiClient {
 
     pub async fn get_authenticated_user(
         &self,
+        system_id: Option<String>,
     ) -> Result<GetAuthenticatedUserResponse, ClientApiError> {
-        let request = self.build_request(
-            Request::builder().method(Method::GET).uri(
+        let request_builder = Request::builder()
+            .method(Method::GET)
+            .uri(
                 self.http_client
                     .build_zed_cloud_url("/client/users/me")?
                     .as_ref(),
-            ),
-            AsyncBody::default(),
-        )?;
+            )
+            .when_some(system_id, |builder, system_id| {
+                builder.header(ZED_SYSTEM_ID_HEADER_NAME, system_id)
+            });
+
+        let request = self.build_request(request_builder, AsyncBody::default())?;
 
         let mut response = self.http_client.send(request).await?;
 


### PR DESCRIPTION
We are going to drive current organization selection with server side state, so we need to know which installation we are on so the server can return the correct currently selected organization. Next step will be using the organization from the response and removing the locally persisted current organization id.

Part of CLO-716

Release Notes:

- N/A