### PR TITLE
Fix IME not working after virtual desktop switching on Wayland

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -319,9 +319,11 @@ impl WaylandClientStatePtr {
         let client = self.get_client();
         let mut state = client.borrow_mut();
         let Some(text_input) = state.text_input.take() else {
+            log::debug!("enable_ime: no text input available");
             return;
         };
 
+        log::debug!("enable_ime: enabling text input");
         text_input.enable();
         text_input.set_content_type(ContentHint::None, ContentPurpose::Normal);
         if let Some(window) = state.keyboard_focused_window.clone() {
@@ -1418,15 +1420,21 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 this.handle_keyboard_layout_change();
             }
             wl_keyboard::Event::Enter { surface, .. } => {
+                log::debug!("keyboard: Enter event for surface {:?}", surface.id());
                 state.keyboard_focused_window = get_window(&mut state, &surface.id());
                 state.enter_token = Some(());
 
                 if let Some(window) = state.keyboard_focused_window.clone() {
                     drop(state);
                     window.set_focused(true);
+                    // Enable IME when keyboard enters the surface, similar to X11 behavior.
+                    // This helps with virtual desktop switching where the text input
+                    // might not receive an Enter event.
+                    this.enable_ime();
                 }
             }
             wl_keyboard::Event::Leave { surface, .. } => {
+                log::debug!("keyboard: Leave event for surface {:?}", surface.id());
                 let keyboard_focused_window = get_window(&mut state, &surface.id());
                 state.keyboard_focused_window = None;
                 state.enter_token.take();
@@ -1614,10 +1622,12 @@ impl Dispatch<zwp_text_input_v3::ZwpTextInputV3, ()> for WaylandClientStatePtr {
         let mut state = client.borrow_mut();
         match event {
             zwp_text_input_v3::Event::Enter { .. } => {
+                log::debug!("text_input: Enter event");
                 drop(state);
                 this.enable_ime();
             }
             zwp_text_input_v3::Event::Leave { .. } => {
+                log::debug!("text_input: Leave event");
                 drop(state);
                 this.disable_ime();
             }


### PR DESCRIPTION
Closes #54975

## Problem
IME stops working in Zed after switching virtual desktops on KDE/Wayland. Users can only type ASCII characters until they click away from Zed and back.

## Solution
Enable IME when the window gains keyboard focus, not just when the text input protocol sends an Enter event. This matches X11 behavior and works around compositor bugs.

## Changes
- Call `enable_ime()` in the Wayland keyboard Enter event handler
- Add debug logging for IME events


## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable



Release Notes:

- Fixed IME not working after switching virtual desktops on Wayland
