### PR TITLE
Improve grouping of worktrees by repo in recent projects

### DIFF
--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -200,27 +200,30 @@ fn migrate_thread_remote_connections(cx: &mut App, migration_task: Task<anyhow::
             return Ok(());
         }
 
-        let recent_workspaces = workspace_db.recent_project_workspaces(fs.as_ref()).await?;
+        let recent_workspaces = workspace_db
+            .recent_project_workspaces_ungrouped(fs.as_ref())
+            .await?;
 
         let mut local_path_lists = HashSet::<PathList>::default();
         let mut remote_path_lists = HashMap::<PathList, RemoteConnectionOptions>::default();
 
         recent_workspaces
             .iter()
-            .filter(|(_, location, path_list, _)| {
-                !path_list.is_empty() && matches!(location, &SerializedWorkspaceLocation::Local)
+            .filter(|workspace| {
+                !workspace.paths.is_empty()
+                    && matches!(workspace.location, SerializedWorkspaceLocation::Local)
             })
-            .for_each(|(_, _, path_list, _)| {
-                local_path_lists.insert(path_list.clone());
+            .for_each(|workspace| {
+                local_path_lists.insert(workspace.paths.clone());
             });
 
-        for (_, location, path_list, _) in recent_workspaces {
-            match location {
+        for workspace in recent_workspaces {
+            match workspace.location {
                 SerializedWorkspaceLocation::Remote(remote_connection)
-                    if !local_path_lists.contains(&path_list) =>
+                    if !local_path_lists.contains(&workspace.paths) =>
                 {
                     remote_path_lists
-                        .entry(path_list)
+                        .entry(workspace.paths)
                         .or_insert(remote_connection);
                 }
                 _ => {}

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -39,8 +39,8 @@ use ui_input::ErasedEditor;
 use util::ResultExt;
 use util::paths::PathExt;
 use workspace::{
-    CloseWindow, ModalView, PathList, SerializedWorkspaceLocation, Workspace, WorkspaceDb,
-    WorkspaceId, resolve_worktree_workspaces,
+    CloseWindow, ModalView, PathList, RecentWorkspace, SerializedWorkspaceLocation, Workspace,
+    WorkspaceDb, WorkspaceId,
 };
 
 use zed_actions::agents_sidebar::FocusSidebarFilter;
@@ -1127,7 +1127,6 @@ impl ProjectPickerModal {
                 .await
                 .log_err()
                 .unwrap_or_default();
-            let workspaces = resolve_worktree_workspaces(workspaces, fs.as_ref()).await;
             this.update_in(cx, move |this, window, cx| {
                 this.picker.update(cx, move |picker, cx| {
                     picker.delegate.workspaces = workspaces;
@@ -1182,12 +1181,7 @@ struct ProjectPickerDelegate {
     archive_view: WeakEntity<ThreadsArchiveView>,
     current_workspace_id: Option<WorkspaceId>,
     sibling_workspace_ids: HashSet<WorkspaceId>,
-    workspaces: Vec<(
-        WorkspaceId,
-        SerializedWorkspaceLocation,
-        PathList,
-        DateTime<Utc>,
-    )>,
+    workspaces: Vec<RecentWorkspace>,
     filtered_entries: Vec<ProjectPickerEntry>,
     selected_index: usize,
     focus_handle: FocusHandle,
@@ -1332,9 +1326,10 @@ impl PickerDelegate for ProjectPickerDelegate {
             .workspaces
             .iter()
             .enumerate()
-            .filter(|(_, (id, _, _, _))| self.is_sibling_workspace(*id))
-            .map(|(id, (_, _, paths, _))| {
-                let combined_string = paths
+            .filter(|(_, workspace)| self.is_sibling_workspace(workspace.workspace_id))
+            .map(|(id, workspace)| {
+                let combined_string = workspace
+                    .identity_paths
                     .ordered_paths()
                     .map(|path| path.compact().to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
@@ -1364,11 +1359,13 @@ impl PickerDelegate for ProjectPickerDelegate {
             .workspaces
             .iter()
             .enumerate()
-            .filter(|(_, (id, _, _, _))| {
-                !self.is_current_workspace(*id) && !self.is_sibling_workspace(*id)
+            .filter(|(_, workspace)| {
+                !self.is_current_workspace(workspace.workspace_id)
+                    && !self.is_sibling_workspace(workspace.workspace_id)
             })
-            .map(|(id, (_, _, paths, _))| {
-                let combined_string = paths
+            .map(|(id, workspace)| {
+                let combined_string = workspace
+                    .identity_paths
                     .ordered_paths()
                     .map(|path| path.compact().to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
@@ -1406,8 +1403,8 @@ impl PickerDelegate for ProjectPickerDelegate {
             entries.push(ProjectPickerEntry::Header("This Window".into()));
 
             if is_empty_query {
-                for (id, (workspace_id, _, _, _)) in self.workspaces.iter().enumerate() {
-                    if self.is_sibling_workspace(*workspace_id) {
+                for (id, workspace) in self.workspaces.iter().enumerate() {
+                    if self.is_sibling_workspace(workspace.workspace_id) {
                         entries.push(ProjectPickerEntry::Workspace(StringMatch {
                             candidate_id: id,
                             score: 0.0,
@@ -1433,9 +1430,9 @@ impl PickerDelegate for ProjectPickerDelegate {
             entries.push(ProjectPickerEntry::Header("Recent Projects".into()));
 
             if is_empty_query {
-                for (id, (workspace_id, _, _, _)) in self.workspaces.iter().enumerate() {
-                    if !self.is_current_workspace(*workspace_id)
-                        && !self.is_sibling_workspace(*workspace_id)
+                for (id, workspace) in self.workspaces.iter().enumerate() {
+                    if !self.is_current_workspace(workspace.workspace_id)
+                        && !self.is_sibling_workspace(workspace.workspace_id)
                     {
                         entries.push(ProjectPickerEntry::Workspace(StringMatch {
                             candidate_id: id,
@@ -1468,11 +1465,11 @@ impl PickerDelegate for ProjectPickerDelegate {
             Some(ProjectPickerEntry::Workspace(hit)) => hit.candidate_id,
             _ => return,
         };
-        let Some((_workspace_id, _location, paths, _)) = self.workspaces.get(candidate_id) else {
+        let Some(workspace) = self.workspaces.get(candidate_id) else {
             return;
         };
 
-        self.update_working_directories_and_unarchive(paths.clone(), window, cx);
+        self.update_working_directories_and_unarchive(workspace.paths.clone(), window, cx);
         cx.emit(DismissEvent);
     }
 
@@ -1504,9 +1501,11 @@ impl PickerDelegate for ProjectPickerDelegate {
                     .into_any_element(),
             ),
             ProjectPickerEntry::Workspace(hit) => {
-                let (_, location, paths, _) = self.workspaces.get(hit.candidate_id)?;
+                let workspace = self.workspaces.get(hit.candidate_id)?;
+                let location = &workspace.location;
 
-                let ordered_paths: Vec<_> = paths
+                let ordered_paths: Vec<_> = workspace
+                    .identity_paths
                     .ordered_paths()
                     .map(|p| p.compact().to_string_lossy().to_string())
                     .collect();
@@ -1514,7 +1513,8 @@ impl PickerDelegate for ProjectPickerDelegate {
                 let tooltip_path: SharedString = ordered_paths.join("\n").into();
 
                 let mut path_start_offset = 0;
-                let match_labels: Vec<_> = paths
+                let match_labels: Vec<_> = workspace
+                    .identity_paths
                     .ordered_paths()
                     .map(|p| p.compact())
                     .map(|path| {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -60,26 +60,6 @@ pub const GRAPH_CHUNK_SIZE: usize = 1000;
 /// Default value for the `git.worktree_directory` setting.
 pub const DEFAULT_WORKTREE_DIRECTORY: &str = "../worktrees";
 
-/// Determine the original (main) repository's working directory.
-///
-/// For linked worktrees, `common_dir` differs from `repository_dir` and
-/// points to the main repo's `.git` directory, so we can derive the main
-/// repo's working directory from it. For normal repos and submodules,
-/// `common_dir` equals `repository_dir`, and the original repo is simply
-/// `work_directory` itself.
-pub fn original_repo_path(
-    work_directory: &Path,
-    common_dir: &Path,
-    repository_dir: &Path,
-) -> PathBuf {
-    if common_dir != repository_dir {
-        original_repo_path_from_common_dir(common_dir)
-            .unwrap_or_else(|| work_directory.to_path_buf())
-    } else {
-        work_directory.to_path_buf()
-    }
-}
-
 /// Given the git common directory (from `commondir()`), derive the original
 /// repository's working directory.
 ///

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -7916,14 +7916,17 @@ impl Repository {
 }
 
 /// If `path` is a git linked worktree checkout, resolves it to the main
-/// repository's working directory path. Returns `None` if `path` is a normal
-/// repository, not a git repo, or if resolution fails.
+/// repository's identity path. For regular linked worktrees this is the main
+/// repository's working directory; for linked worktrees backed by a bare repo
+/// such as `.bare`, this is the parent project directory users think of as the
+/// repository root. Returns `None` if `path` is a normal repository, not a git
+/// repo, or if resolution fails.
 ///
 /// Resolution works by:
 /// 1. Reading the `.git` file to get the `gitdir:` pointer
 /// 2. Following that to the worktree-specific git directory
 /// 3. Reading the `commondir` file to find the shared `.git` directory
-/// 4. Deriving the main repo's working directory from the common dir
+/// 4. Deriving the main repo's identity path from the common dir
 pub async fn resolve_git_worktree_to_main_repo(fs: &dyn Fs, path: &Path) -> Option<PathBuf> {
     let dot_git = path.join(".git");
     let metadata = fs.metadata(&dot_git).await.ok()??;
@@ -7940,7 +7943,7 @@ pub async fn resolve_git_worktree_to_main_repo(fs: &dyn Fs, path: &Path) -> Opti
         .canonicalize(&gitdir_abs.join(commondir_content.trim()))
         .await
         .ok()?;
-    git::repository::original_repo_path_from_common_dir(&common_dir)
+    Some(repo_identity_path(&common_dir).to_path_buf())
 }
 
 /// Validates that the resolved worktree directory is acceptable:

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6226,6 +6226,21 @@ impl ProjectGroupKey {
     pub fn host(&self) -> Option<RemoteConnectionOptions> {
         self.host.clone()
     }
+
+    pub fn matches(&self, other: &ProjectGroupKey) -> bool {
+        self.paths == other.paths
+            && if let (
+                Some(RemoteConnectionOptions::Ssh(left)),
+                Some(RemoteConnectionOptions::Ssh(right)),
+            ) = (&self.host, &other.host)
+            {
+                left.host == right.host
+                    && left.port == right.port
+                    && left.username == right.username
+            } else {
+                self.host == other.host
+            }
+    }
 }
 
 pub fn path_suffix(path: &Path, detail: usize) -> String {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -108,7 +108,7 @@ pub use prettier_store::PrettierStore;
 use project_settings::{ProjectSettings, SettingsObserver, SettingsObserverEvent};
 #[cfg(target_os = "windows")]
 use remote::wsl_path_to_windows_path;
-use remote::{RemoteClient, RemoteConnectionOptions};
+use remote::{RemoteClient, RemoteConnectionOptions, same_remote_connection_identity};
 use rpc::{
     AnyProtoClient, ErrorCode,
     proto::{LanguageServerPromptResponse, REMOTE_SERVER_PROJECT_ID},
@@ -6229,17 +6229,7 @@ impl ProjectGroupKey {
 
     pub fn matches(&self, other: &ProjectGroupKey) -> bool {
         self.paths == other.paths
-            && if let (
-                Some(RemoteConnectionOptions::Ssh(left)),
-                Some(RemoteConnectionOptions::Ssh(right)),
-            ) = (&self.host, &other.host)
-            {
-                left.host == right.host
-                    && left.port == right.port
-                    && left.username == right.username
-            } else {
-                self.host == other.host
-            }
+            && same_remote_connection_identity(self.host.as_ref(), other.host.as_ref())
     }
 }
 

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1667,6 +1667,35 @@ mod resolve_worktree_tests {
     }
 
     #[gpui::test]
+    async fn test_resolve_git_worktree_bare_repo_identity_path(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/monty/.bare",
+            json!({
+                "worktrees": {
+                    "feature-a": {
+                        "commondir": "../../",
+                        "HEAD": "ref: refs/heads/feature-a"
+                    }
+                }
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            "/monty/feature-a",
+            json!({
+                ".git": "gitdir: /monty/.bare/worktrees/feature-a",
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        let result =
+            resolve_git_worktree_to_main_repo(fs.as_ref(), Path::new("/monty/feature-a")).await;
+        assert_eq!(result, Some(PathBuf::from("/monty")));
+    }
+
+    #[gpui::test]
     async fn test_resolve_git_worktree_no_git_returns_none(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -2115,15 +2115,19 @@ impl RecentProjectsDelegate {
         if let Some(ProjectPickerEntry::RecentProject(selected_match)) =
             self.filtered_entries.get(ix)
         {
-            let workspace_id = self.workspaces[selected_match.candidate_id].workspace_id;
+            let recent_workspace = self.workspaces[selected_match.candidate_id].clone();
             let fs = self
                 .workspace
                 .upgrade()
                 .map(|ws| ws.read(cx).app_state().fs.clone());
             let db = WorkspaceDb::global(cx);
             cx.spawn_in(window, async move |this, cx| {
-                db.delete_workspace_by_id(workspace_id).await.log_err();
                 let Some(fs) = fs else { return };
+                let deleted_workspace_ids = db
+                    .delete_recent_workspace_group(&recent_workspace)
+                    .await
+                    .log_err()
+                    .unwrap_or_default();
                 let workspaces = db
                     .recent_project_workspaces(fs.as_ref())
                     .await
@@ -2138,8 +2142,11 @@ impl RecentProjectsDelegate {
                     // After deleting a project, we want to update the history manager to reflect the change.
                     // But we do not emit a update event when user opens a project, because it's handled in `workspace::load_workspace`.
                     if let Some(history_manager) = HistoryManager::global(cx) {
-                        history_manager
-                            .update(cx, |this, cx| this.delete_history(workspace_id, cx));
+                        history_manager.update(cx, |this, cx| {
+                            for workspace_id in &deleted_workspace_ids {
+                                this.delete_history(*workspace_id, cx);
+                            }
+                        });
                     }
                 })
                 .ok();

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -47,7 +47,7 @@ use ui::{
 use util::{ResultExt, paths::PathExt};
 use workspace::{
     HistoryManager, ModalView, MultiWorkspace, OpenMode, OpenOptions, OpenVisible, PathList,
-    SerializedWorkspaceLocation, Workspace, WorkspaceDb, WorkspaceId,
+    RecentWorkspace, SerializedWorkspaceLocation, Workspace, WorkspaceDb, WorkspaceId,
     notifications::DetachAndPromptErr, with_active_or_new_workspace,
 };
 use zed_actions::{OpenDevContainer, OpenRecent, OpenRemote};
@@ -102,13 +102,13 @@ pub async fn get_recent_projects(
 
     let filtered: Vec<_> = workspaces
         .into_iter()
-        .filter(|(id, _, _, _)| Some(*id) != current_workspace_id)
-        .filter(|(_, location, _, _)| matches!(location, SerializedWorkspaceLocation::Local))
+        .filter(|workspace| Some(workspace.workspace_id) != current_workspace_id)
+        .filter(|workspace| matches!(workspace.location, SerializedWorkspaceLocation::Local))
         .collect();
 
     let mut all_paths: Vec<PathBuf> = filtered
         .iter()
-        .flat_map(|(_, _, path_list, _)| path_list.paths().iter().cloned())
+        .flat_map(|workspace| workspace.identity_paths.paths().iter().cloned())
         .collect();
     all_paths.sort();
     all_paths.dedup();
@@ -121,9 +121,9 @@ pub async fn get_recent_projects(
 
     let entries: Vec<RecentProjectEntry> = filtered
         .into_iter()
-        .map(|(workspace_id, _, path_list, timestamp)| {
-            let paths: Vec<PathBuf> = path_list.paths().to_vec();
-            let ordered_paths: Vec<&PathBuf> = path_list.ordered_paths().collect();
+        .map(|workspace| {
+            let paths: Vec<PathBuf> = workspace.paths.paths().to_vec();
+            let ordered_paths: Vec<&PathBuf> = workspace.identity_paths.ordered_paths().collect();
 
             let name = ordered_paths
                 .iter()
@@ -145,8 +145,8 @@ pub async fn get_recent_projects(
                 name: SharedString::from(name),
                 full_path: SharedString::from(full_path),
                 paths,
-                workspace_id,
-                timestamp,
+                workspace_id: workspace.workspace_id,
+                timestamp: workspace.timestamp,
             }
         })
         .collect();
@@ -614,7 +614,6 @@ impl RecentProjects {
                 .await
                 .log_err()
                 .unwrap_or_default();
-            let workspaces = workspace::resolve_worktree_workspaces(workspaces, fs.as_ref()).await;
             this.update_in(cx, move |this, window, cx| {
                 this.picker.update(cx, move |picker, cx| {
                     picker.delegate.set_workspaces(workspaces);
@@ -773,11 +772,9 @@ impl RecentProjects {
             if let Some(ProjectPickerEntry::RecentProject(hit)) =
                 picker.delegate.filtered_entries.get(ix)
             {
-                if let Some((_, location, paths, _)) =
-                    picker.delegate.workspaces.get(hit.candidate_id)
-                {
-                    if matches!(location, SerializedWorkspaceLocation::Local) {
-                        let paths_to_add = paths.paths().to_vec();
+                if let Some(workspace) = picker.delegate.workspaces.get(hit.candidate_id) {
+                    if matches!(workspace.location, SerializedWorkspaceLocation::Local) {
+                        let paths_to_add = workspace.paths.paths().to_vec();
                         picker
                             .delegate
                             .add_paths_to_project(paths_to_add, window, cx);
@@ -812,12 +809,7 @@ pub struct RecentProjectsDelegate {
     workspace: WeakEntity<Workspace>,
     open_folders: Vec<OpenFolderEntry>,
     window_project_groups: Vec<ProjectGroupKey>,
-    workspaces: Vec<(
-        WorkspaceId,
-        SerializedWorkspaceLocation,
-        PathList,
-        DateTime<Utc>,
-    )>,
+    workspaces: Vec<RecentWorkspace>,
     filtered_entries: Vec<ProjectPickerEntry>,
     selected_index: usize,
     render_paths: bool,
@@ -860,20 +852,12 @@ impl RecentProjectsDelegate {
         }
     }
 
-    pub fn set_workspaces(
-        &mut self,
-        workspaces: Vec<(
-            WorkspaceId,
-            SerializedWorkspaceLocation,
-            PathList,
-            DateTime<Utc>,
-        )>,
-    ) {
+    pub fn set_workspaces(&mut self, workspaces: Vec<RecentWorkspace>) {
         self.workspaces = workspaces;
         let has_non_local_recent = !self
             .workspaces
             .iter()
-            .all(|(_, location, _, _)| matches!(location, SerializedWorkspaceLocation::Local));
+            .all(|workspace| matches!(workspace.location, SerializedWorkspaceLocation::Local));
         self.has_any_non_local_projects =
             self.project_connection_options.is_some() || has_non_local_recent;
     }
@@ -987,9 +971,10 @@ impl PickerDelegate for RecentProjectsDelegate {
             .workspaces
             .iter()
             .enumerate()
-            .filter(|(_, (id, _, paths, _))| self.is_valid_recent_candidate(*id, paths, cx))
-            .map(|(id, (_, _, paths, _))| {
-                let combined_string = paths
+            .filter(|(_, workspace)| self.is_valid_recent_candidate(workspace, cx))
+            .map(|(id, workspace)| {
+                let combined_string = workspace
+                    .identity_paths
                     .ordered_paths()
                     .map(|path| path.compact().to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
@@ -1063,8 +1048,8 @@ impl PickerDelegate for RecentProjectsDelegate {
             entries.push(ProjectPickerEntry::Header("Recent Projects".into()));
 
             if is_empty_query {
-                for (id, (workspace_id, _, paths, _)) in self.workspaces.iter().enumerate() {
-                    if self.is_valid_recent_candidate(*workspace_id, paths, cx) {
+                for (id, workspace) in self.workspaces.iter().enumerate() {
+                    if self.is_valid_recent_candidate(workspace, cx) {
                         entries.push(ProjectPickerEntry::RecentProject(StringMatch {
                             candidate_id: id,
                             score: 0.0,
@@ -1149,20 +1134,15 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let Some(workspace) = self.workspace.upgrade() else {
                     return;
                 };
-                let Some((
-                    candidate_workspace_id,
-                    candidate_workspace_location,
-                    candidate_workspace_paths,
-                    _,
-                )) = self.workspaces.get(selected_match.candidate_id)
+                let Some(candidate_workspace) = self.workspaces.get(selected_match.candidate_id)
                 else {
                     return;
                 };
 
                 let replace_current_window = self.create_new_window == secondary;
-                let candidate_workspace_id = *candidate_workspace_id;
-                let candidate_workspace_location = candidate_workspace_location.clone();
-                let candidate_workspace_paths = candidate_workspace_paths.clone();
+                let candidate_workspace_id = candidate_workspace.workspace_id;
+                let candidate_workspace_location = candidate_workspace.location.clone();
+                let candidate_workspace_paths = candidate_workspace.paths.clone();
 
                 workspace.update(cx, |workspace, cx| {
                     if workspace.database_id() == Some(candidate_workspace_id) {
@@ -1497,10 +1477,13 @@ impl PickerDelegate for RecentProjectsDelegate {
                 )
             }
             ProjectPickerEntry::RecentProject(hit) => {
-                let (_, location, paths, _) = self.workspaces.get(hit.candidate_id)?;
+                let workspace = self.workspaces.get(hit.candidate_id)?;
+                let location = &workspace.location;
+                let raw_paths = &workspace.paths;
+                let identity_paths = &workspace.identity_paths;
                 let is_local = matches!(location, SerializedWorkspaceLocation::Local);
-                let paths_to_add = paths.paths().to_vec();
-                let ordered_paths: Vec<_> = paths
+                let paths_to_add = raw_paths.paths().to_vec();
+                let ordered_paths: Vec<_> = identity_paths
                     .ordered_paths()
                     .map(|p| p.compact().to_string_lossy().to_string())
                     .collect();
@@ -1517,7 +1500,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                 };
 
                 let mut path_start_offset = 0;
-                let (match_labels, paths): (Vec<_>, Vec<_>) = paths
+                let (match_labels, paths): (Vec<_>, Vec<_>) = identity_paths
                     .ordered_paths()
                     .map(|p| p.compact())
                     .map(|path| {
@@ -1891,8 +1874,11 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 Some(ProjectPickerEntry::RecentProject(hit)) => self
                                     .workspaces
                                     .get(hit.candidate_id)
-                                    .map(|(_, loc, ..)| {
-                                        matches!(loc, SerializedWorkspaceLocation::Local)
+                                    .map(|workspace| {
+                                        matches!(
+                                            workspace.location,
+                                            SerializedWorkspaceLocation::Local
+                                        )
                                     })
                                     .unwrap_or(false),
                                 _ => false,
@@ -2129,8 +2115,7 @@ impl RecentProjectsDelegate {
         if let Some(ProjectPickerEntry::RecentProject(selected_match)) =
             self.filtered_entries.get(ix)
         {
-            let (workspace_id, _, _, _) = &self.workspaces[selected_match.candidate_id];
-            let workspace_id = *workspace_id;
+            let workspace_id = self.workspaces[selected_match.candidate_id].workspace_id;
             let fs = self
                 .workspace
                 .upgrade()
@@ -2143,8 +2128,6 @@ impl RecentProjectsDelegate {
                     .recent_project_workspaces(fs.as_ref())
                     .await
                     .unwrap_or_default();
-                let workspaces =
-                    workspace::resolve_worktree_workspaces(workspaces, fs.as_ref()).await;
                 this.update_in(cx, move |picker, window, cx| {
                     picker.delegate.set_workspaces(workspaces);
                     picker
@@ -2209,10 +2192,10 @@ impl RecentProjectsDelegate {
         false
     }
 
-    fn is_in_current_window_groups(&self, paths: &PathList) -> bool {
+    fn is_in_current_window_groups(&self, workspace: &RecentWorkspace) -> bool {
         self.window_project_groups
             .iter()
-            .any(|key| key.path_list() == paths)
+            .any(|key| key == &workspace.project_group_key())
     }
 
     fn is_open_folder(&self, paths: &PathList) -> bool {
@@ -2233,13 +2216,12 @@ impl RecentProjectsDelegate {
 
     fn is_valid_recent_candidate(
         &self,
-        workspace_id: WorkspaceId,
-        paths: &PathList,
+        workspace: &RecentWorkspace,
         cx: &mut Context<Picker<Self>>,
     ) -> bool {
-        !self.is_current_workspace(workspace_id, cx)
-            && !self.is_in_current_window_groups(paths)
-            && !self.is_open_folder(paths)
+        !self.is_current_workspace(workspace.workspace_id, cx)
+            && !self.is_in_current_window_groups(workspace)
+            && !self.is_open_folder(&workspace.paths)
     }
 }
 

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -2195,7 +2195,7 @@ impl RecentProjectsDelegate {
     fn is_in_current_window_groups(&self, workspace: &RecentWorkspace) -> bool {
         self.window_project_groups
             .iter()
-            .any(|key| key == &workspace.project_group_key())
+            .any(|key| key.matches(&workspace.project_group_key()))
     }
 
     fn is_open_folder(&self, paths: &PathList) -> bool {

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -195,7 +195,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                     && !self
                         .window_project_groups
                         .iter()
-                        .any(|key| key == &workspace.project_group_key())
+                        .any(|key| key.matches(&workspace.project_group_key()))
             })
             .map(|(id, workspace)| {
                 let combined_string = workspace

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use fuzzy_nucleo::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
@@ -16,8 +15,8 @@ use ui::{ButtonLike, KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*}
 use ui_input::ErasedEditor;
 use util::{ResultExt, paths::PathExt};
 use workspace::{
-    MultiWorkspace, OpenMode, OpenOptions, PathList, ProjectGroupKey, SerializedWorkspaceLocation,
-    Workspace, WorkspaceDb, WorkspaceId, notifications::DetachAndPromptErr,
+    MultiWorkspace, OpenMode, OpenOptions, ProjectGroupKey, RecentWorkspace,
+    SerializedWorkspaceLocation, Workspace, WorkspaceDb, notifications::DetachAndPromptErr,
 };
 
 use zed_actions::OpenRemote;
@@ -74,8 +73,6 @@ impl SidebarRecentProjects {
                     .await
                     .log_err()
                     .unwrap_or_default();
-                let workspaces =
-                    workspace::resolve_worktree_workspaces(workspaces, fs.as_ref()).await;
                 this.update_in(cx, move |this, window, cx| {
                     this.picker.update(cx, move |picker, cx| {
                         picker.delegate.set_workspaces(workspaces);
@@ -116,12 +113,7 @@ impl Render for SidebarRecentProjects {
 pub struct SidebarRecentProjectsDelegate {
     workspace: WeakEntity<Workspace>,
     window_project_groups: Vec<ProjectGroupKey>,
-    workspaces: Vec<(
-        WorkspaceId,
-        SerializedWorkspaceLocation,
-        PathList,
-        DateTime<Utc>,
-    )>,
+    workspaces: Vec<RecentWorkspace>,
     filtered_workspaces: Vec<StringMatch>,
     selected_index: usize,
     has_any_non_local_projects: bool,
@@ -129,18 +121,10 @@ pub struct SidebarRecentProjectsDelegate {
 }
 
 impl SidebarRecentProjectsDelegate {
-    pub fn set_workspaces(
-        &mut self,
-        workspaces: Vec<(
-            WorkspaceId,
-            SerializedWorkspaceLocation,
-            PathList,
-            DateTime<Utc>,
-        )>,
-    ) {
+    pub fn set_workspaces(&mut self, workspaces: Vec<RecentWorkspace>) {
         self.has_any_non_local_projects = workspaces
             .iter()
-            .any(|(_, location, _, _)| !matches!(location, SerializedWorkspaceLocation::Local));
+            .any(|workspace| !matches!(workspace.location, SerializedWorkspaceLocation::Local));
         self.workspaces = workspaces;
     }
 }
@@ -206,15 +190,16 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
             .workspaces
             .iter()
             .enumerate()
-            .filter(|(_, (id, _, paths, _))| {
-                Some(*id) != current_workspace_id
+            .filter(|(_, workspace)| {
+                Some(workspace.workspace_id) != current_workspace_id
                     && !self
                         .window_project_groups
                         .iter()
-                        .any(|key| key.path_list() == paths)
+                        .any(|key| key == &workspace.project_group_key())
             })
-            .map(|(id, (_, _, paths, _))| {
-                let combined_string = paths
+            .map(|(id, workspace)| {
+                let combined_string = workspace
+                    .identity_paths
                     .ordered_paths()
                     .map(|path| path.compact().to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
@@ -251,9 +236,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
         let Some(hit) = self.filtered_workspaces.get(self.selected_index) else {
             return;
         };
-        let Some((_, location, candidate_workspace_paths, _)) =
-            self.workspaces.get(hit.candidate_id)
-        else {
+        let Some(recent_workspace) = self.workspaces.get(hit.candidate_id) else {
             return;
         };
 
@@ -261,10 +244,10 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
             return;
         };
 
-        match location {
+        match &recent_workspace.location {
             SerializedWorkspaceLocation::Local => {
                 if let Some(handle) = window.window_handle().downcast::<MultiWorkspace>() {
-                    let paths = candidate_workspace_paths.paths().to_vec();
+                    let paths = recent_workspace.paths.paths().to_vec();
                     cx.defer(move |cx| {
                         if let Some(task) = handle
                             .update(cx, |multi_workspace, window, cx| {
@@ -290,7 +273,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                         crate::RemoteSettings::get_global(cx)
                             .fill_connection_options_from_settings(connection);
                     };
-                    let paths = candidate_workspace_paths.paths().to_vec();
+                    let paths = recent_workspace.paths.paths().to_vec();
                     cx.spawn_in(window, async move |_, cx| {
                         open_remote_project(connection.clone(), paths, app_state, open_options, cx)
                             .await
@@ -326,14 +309,15 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let hit = self.filtered_workspaces.get(ix)?;
-        let (_, location, paths, _) = self.workspaces.get(hit.candidate_id)?;
+        let workspace = self.workspaces.get(hit.candidate_id)?;
 
-        let ordered_paths: Vec<_> = paths
+        let ordered_paths: Vec<_> = workspace
+            .identity_paths
             .ordered_paths()
             .map(|p| p.compact().to_string_lossy().to_string())
             .collect();
 
-        let tooltip_path: SharedString = match &location {
+        let tooltip_path: SharedString = match &workspace.location {
             SerializedWorkspaceLocation::Remote(options) => {
                 let host = options.display_name();
                 if ordered_paths.len() == 1 {
@@ -346,7 +330,8 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
         };
 
         let mut path_start_offset = 0;
-        let match_labels: Vec<_> = paths
+        let match_labels: Vec<_> = workspace
+            .identity_paths
             .ordered_paths()
             .map(|p| p.compact())
             .map(|path| {
@@ -357,7 +342,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
             })
             .collect();
 
-        let prefix = match &location {
+        let prefix = match &workspace.location {
             SerializedWorkspaceLocation::Remote(options) => {
                 Some(SharedString::from(options.display_name()))
             }
@@ -371,7 +356,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
             active: false,
         };
 
-        let icon = icon_for_remote_connection(match location {
+        let icon = icon_for_remote_connection(match &workspace.location {
             SerializedWorkspaceLocation::Local => None,
             SerializedWorkspaceLocation::Remote(options) => Some(options),
         });

--- a/crates/workspace/src/history_manager.rs
+++ b/crates/workspace/src/history_manager.rs
@@ -49,9 +49,12 @@ impl HistoryManager {
                 .unwrap_or_default()
                 .into_iter()
                 .rev()
-                .filter_map(|(id, location, paths, _timestamp)| {
-                    if matches!(location, SerializedWorkspaceLocation::Local) {
-                        Some(HistoryManagerEntry::new(id, &paths))
+                .filter_map(|workspace| {
+                    if matches!(workspace.location, SerializedWorkspaceLocation::Local) {
+                        Some(HistoryManagerEntry::new(
+                            workspace.workspace_id,
+                            &workspace.paths,
+                        ))
                     } else {
                         None
                     }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -5258,20 +5258,17 @@ mod tests {
 
         let t0 = Utc::now();
 
-        let result = vec![
-            local_recent_workspace(
-                WorkspaceId(1),
-                PathList::new(&["/foo/my-feature"]),
-                t0,
-                fs.as_ref(),
-            )
-            .await,
-        ];
+        let result = local_recent_workspace(
+            WorkspaceId(1),
+            PathList::new(&["/foo/my-feature"]),
+            t0,
+            fs.as_ref(),
+        )
+        .await;
 
         // Bare-backed worktrees should resolve to the repo identity path, which
         // is the parent directory users think of as the project root.
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].identity_paths.paths(), &[PathBuf::from("/foo")]);
+        assert_eq!(result.identity_paths.paths(), &[PathBuf::from("/foo")]);
     }
 
     #[gpui::test]
@@ -5281,7 +5278,7 @@ mod tests {
         let fs = fs::FakeFs::new(cx.executor());
 
         fs.insert_tree(
-            "/monty",
+            "/the-project",
             json!({
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
@@ -5298,7 +5295,7 @@ mod tests {
         .await;
 
         fs.insert_tree(
-            "/monty/feature-a",
+            "/the-project/feature-a",
             json!({
                 ".git": "gitdir: ../.bare/worktrees/feature-a\n",
                 "src": { "lib.rs": "" }
@@ -5309,11 +5306,16 @@ mod tests {
         let t0 = Utc::now() - chrono::Duration::hours(1);
         let t1 = Utc::now();
         let workspaces = vec![
-            local_recent_workspace(WorkspaceId(1), PathList::new(&["/monty"]), t0, fs.as_ref())
-                .await,
+            local_recent_workspace(
+                WorkspaceId(1),
+                PathList::new(&["/the-project"]),
+                t0,
+                fs.as_ref(),
+            )
+            .await,
             local_recent_workspace(
                 WorkspaceId(2),
-                PathList::new(&["/monty/feature-a"]),
+                PathList::new(&["/the-project/feature-a"]),
                 t1,
                 fs.as_ref(),
             )
@@ -5323,7 +5325,10 @@ mod tests {
         let result = dedupe_recent_workspaces(workspaces);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].identity_paths.paths(), &[PathBuf::from("/monty")]);
+        assert_eq!(
+            result[0].identity_paths.paths(),
+            &[PathBuf::from("/the-project")]
+        );
         assert_eq!(result[0].workspace_id, WorkspaceId(2));
         assert_eq!(result[0].timestamp, t1);
     }
@@ -5335,7 +5340,7 @@ mod tests {
             WorkspaceDb::open_test_db("test_recent_project_workspaces_preserve_reopen_paths").await;
 
         fs.insert_tree(
-            "/monty",
+            "/the-project",
             json!({
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
@@ -5352,7 +5357,7 @@ mod tests {
         .await;
 
         fs.insert_tree(
-            "/monty/feature-a",
+            "/the-project/feature-a",
             json!({
                 ".git": "gitdir: ../.bare/worktrees/feature-a\n",
                 "src": { "lib.rs": "" }
@@ -5362,14 +5367,14 @@ mod tests {
 
         db.save_workspace(workspace_with(
             1,
-            &[Path::new("/monty")],
+            &[Path::new("/the-project")],
             empty_pane_group(),
             None,
         ))
         .await;
         db.save_workspace(workspace_with(
             2,
-            &[Path::new("/monty/feature-a")],
+            &[Path::new("/the-project/feature-a")],
             empty_pane_group(),
             None,
         ))
@@ -5387,11 +5392,11 @@ mod tests {
         assert_eq!(recents[0].workspace_id, WorkspaceId(2));
         assert_eq!(
             recents[0].paths.paths(),
-            &[PathBuf::from("/monty/feature-a")]
+            &[PathBuf::from("/the-project/feature-a")]
         );
         assert_eq!(
             recents[0].identity_paths.paths(),
-            &[PathBuf::from("/monty")]
+            &[PathBuf::from("/the-project")]
         );
     }
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2051,6 +2051,50 @@ impl WorkspaceDb {
         ))
     }
 
+    pub async fn delete_recent_workspace_group(
+        &self,
+        target: &RecentWorkspace,
+    ) -> Result<Vec<WorkspaceId>> {
+        let target_paths = &target.identity_paths;
+        let target_remote_connection = match &target.location {
+            SerializedWorkspaceLocation::Local => None,
+            SerializedWorkspaceLocation::Remote(connection) => {
+                Some(remote_connection_identity(connection))
+            }
+        };
+
+        let remote_connections = self.remote_connections()?;
+
+        let mut workspace_ids = Vec::new();
+        for (workspace_id, paths, identity_paths, remote_connection_id, _, _) in
+            self.recent_workspaces()?
+        {
+            let remote_connection = if let Some(id) = remote_connection_id {
+                let Some(connection_options) = remote_connections.get(&id) else {
+                    continue;
+                };
+                Some(remote_connection_identity(connection_options))
+            } else {
+                None
+            };
+            if remote_connection == target_remote_connection
+                && &identity_paths.unwrap_or(paths) == target_paths
+            {
+                workspace_ids.push(workspace_id);
+            }
+        }
+
+        futures::future::join_all(
+            workspace_ids
+                .iter()
+                .copied()
+                .map(|workspace_id| self.delete_workspace_by_id(workspace_id)),
+        )
+        .await;
+
+        Ok(workspace_ids)
+    }
+
     // Deletes workspace rows that can no longer be restored from. Remote workspaces whose
     // connection was removed, and (on Windows) workspaces pointing at WSL paths, are cleaned
     // up immediately. Local workspaces with no valid paths on disk are kept for seven days
@@ -2644,10 +2688,9 @@ async fn resolve_local_workspace_identity(fs: &dyn Fs, paths: &PathList) -> Opti
 fn dedupe_recent_workspaces(
     workspaces: impl IntoIterator<Item = RecentWorkspace>,
 ) -> Vec<RecentWorkspace> {
-    let mut seen: collections::HashMap<(Option<RemoteConnectionIdentity>, Vec<PathBuf>), usize> =
-        collections::HashMap::default();
+    let mut indices_by_key: HashMap<(Option<RemoteConnectionIdentity>, Vec<PathBuf>), usize> =
+        HashMap::default();
     let mut result: Vec<RecentWorkspace> = Vec::new();
-
     for workspace in workspaces {
         let location_identity = match &workspace.location {
             SerializedWorkspaceLocation::Local => None,
@@ -2656,12 +2699,12 @@ fn dedupe_recent_workspaces(
             }
         };
         let key = (location_identity, workspace.identity_paths.paths().to_vec());
-        if let Some(&existing_index) = seen.get(&key) {
+        if let Some(&existing_index) = indices_by_key.get(&key) {
             if workspace.timestamp > result[existing_index].timestamp {
                 result[existing_index] = workspace;
             }
         } else {
-            seen.insert(key, result.len());
+            indices_by_key.insert(key, result.len());
             result.push(workspace);
         }
     }
@@ -5451,6 +5494,74 @@ mod tests {
         assert_eq!(recents.len(), 2);
         assert_eq!(recents[0].workspace_id, WorkspaceId(2));
         assert_eq!(recents[1].workspace_id, WorkspaceId(1));
+    }
+
+    #[gpui::test]
+    async fn test_delete_recent_workspace_group_removes_all_matching_rows(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db = WorkspaceDb::open_test_db(
+            "test_delete_recent_workspace_group_removes_all_matching_rows",
+        )
+        .await;
+
+        fs.insert_tree(
+            "/the-group",
+            json!({
+                ".git": "gitdir: ./.bare\n",
+                ".bare": {
+                    "worktrees": {
+                        "feature-a": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature-a"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        fs.insert_tree(
+            "/the-group/feature-a",
+            json!({
+                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+                "src": { "lib.rs": "" }
+            }),
+        )
+        .await;
+
+        db.save_workspace(SerializedWorkspace {
+            identity_paths: Some(PathList::new(&["/the-group"])),
+            ..workspace_with(1, &[Path::new("/the-group")], empty_pane_group(), None)
+        })
+        .await;
+        db.save_workspace(SerializedWorkspace {
+            identity_paths: Some(PathList::new(&["/the-group"])),
+            ..workspace_with(
+                2,
+                &[Path::new("/the-group/feature-a")],
+                empty_pane_group(),
+                None,
+            )
+        })
+        .await;
+        db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:00".to_owned())
+            .await
+            .unwrap();
+        db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+            .await
+            .unwrap();
+
+        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        assert_eq!(recents.len(), 1);
+
+        let deleted = db.delete_recent_workspace_group(&recents[0]).await.unwrap();
+        assert_eq!(deleted, vec![WorkspaceId(2), WorkspaceId(1)]);
+
+        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        assert!(recents.is_empty());
     }
 
     #[gpui::test]

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -21,6 +21,7 @@ use db::{
 };
 use gpui::{Axis, Bounds, Task, WindowBounds, WindowId, point, size};
 use project::{
+    ProjectGroupKey,
     bookmark_store::SerializedBookmark,
     debugger::breakpoint_store::{BreakpointState, SourceBreakpoint},
     trusted_worktrees::{DbTrustedPaths, RemoteHostLocation},
@@ -1032,6 +1033,10 @@ impl Domain for WorkspaceDb {
                 ON UPDATE CASCADE
             );
         ),
+        sql!(
+            ALTER TABLE workspaces ADD COLUMN identity_paths TEXT;
+            ALTER TABLE workspaces ADD COLUMN identity_paths_order TEXT;
+        ),
     ];
 
     // Allow recovering from bad migration that was initially shipped to nightly
@@ -1084,6 +1089,8 @@ impl WorkspaceDb {
             workspace_id,
             paths,
             paths_order,
+            identity_paths,
+            identity_paths_order,
             window_bounds,
             display,
             centered_layout,
@@ -1093,6 +1100,8 @@ impl WorkspaceDb {
             WorkspaceId,
             String,
             String,
+            Option<String>,
+            Option<String>,
             Option<SerializedWindowBounds>,
             Option<Uuid>,
             Option<bool>,
@@ -1104,6 +1113,8 @@ impl WorkspaceDb {
                     workspace_id,
                     paths,
                     paths_order,
+                    identity_paths,
+                    identity_paths_order,
                     window_state,
                     window_x,
                     window_y,
@@ -1141,6 +1152,12 @@ impl WorkspaceDb {
             paths,
             order: paths_order,
         });
+        let identity_paths = identity_paths.map(|paths| {
+            PathList::deserialize(&SerializedPathList {
+                paths,
+                order: identity_paths_order.unwrap_or_default(),
+            })
+        });
 
         let remote_connection_options = if let Some(remote_connection_id) = remote_connection_id {
             self.remote_connection(remote_connection_id)
@@ -1157,6 +1174,7 @@ impl WorkspaceDb {
                 None => SerializedWorkspaceLocation::Local,
             },
             paths,
+            identity_paths,
             center_group: self
                 .get_center_pane_group(workspace_id)
                 .context("Getting center group")
@@ -1181,6 +1199,8 @@ impl WorkspaceDb {
         let (
             paths,
             paths_order,
+            identity_paths,
+            identity_paths_order,
             window_bounds,
             display,
             centered_layout,
@@ -1190,6 +1210,8 @@ impl WorkspaceDb {
         ): (
             String,
             String,
+            Option<String>,
+            Option<String>,
             Option<SerializedWindowBounds>,
             Option<Uuid>,
             Option<bool>,
@@ -1201,6 +1223,8 @@ impl WorkspaceDb {
                 SELECT
                     paths,
                     paths_order,
+                    identity_paths,
+                    identity_paths_order,
                     window_state,
                     window_x,
                     window_y,
@@ -1231,6 +1255,12 @@ impl WorkspaceDb {
             paths,
             order: paths_order,
         });
+        let identity_paths = identity_paths.map(|paths| {
+            PathList::deserialize(&SerializedPathList {
+                paths,
+                order: identity_paths_order.unwrap_or_default(),
+            })
+        });
 
         let remote_connection_id = remote_connection_id.map(|id| RemoteConnectionId(id as u64));
         let remote_connection_options = if let Some(remote_connection_id) = remote_connection_id {
@@ -1248,6 +1278,7 @@ impl WorkspaceDb {
                 None => SerializedWorkspaceLocation::Local,
             },
             paths,
+            identity_paths,
             center_group: self
                 .get_center_pane_group(workspace_id)
                 .context("Getting center group")
@@ -1416,10 +1447,9 @@ impl WorkspaceDb {
         ret
     }
 
-    /// Saves a workspace using the worktree roots. Will garbage collect any workspaces
-    /// that used this workspace previously
     pub(crate) async fn save_workspace(&self, workspace: SerializedWorkspace) {
         let paths = workspace.paths.serialize();
+        let identity_paths = workspace.identity_paths.map(|paths| paths.serialize());
         log::debug!("Saving workspace at location: {:?}", workspace.location);
         self.write(move |conn| {
             conn.with_savepoint("update_worktrees", || {
@@ -1535,6 +1565,8 @@ impl WorkspaceDb {
                         workspace_id,
                         paths,
                         paths_order,
+                        identity_paths,
+                        identity_paths_order,
                         remote_connection_id,
                         left_dock_visible,
                         left_dock_active_panel,
@@ -1549,23 +1581,25 @@ impl WorkspaceDb {
                         window_id,
                         timestamp
                     )
-                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, CURRENT_TIMESTAMP)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, CURRENT_TIMESTAMP)
                     ON CONFLICT DO
                     UPDATE SET
                         paths = ?2,
                         paths_order = ?3,
-                        remote_connection_id = ?4,
-                        left_dock_visible = ?5,
-                        left_dock_active_panel = ?6,
-                        left_dock_zoom = ?7,
-                        right_dock_visible = ?8,
-                        right_dock_active_panel = ?9,
-                        right_dock_zoom = ?10,
-                        bottom_dock_visible = ?11,
-                        bottom_dock_active_panel = ?12,
-                        bottom_dock_zoom = ?13,
-                        session_id = ?14,
-                        window_id = ?15,
+                        identity_paths = ?4,
+                        identity_paths_order = ?5,
+                        remote_connection_id = ?6,
+                        left_dock_visible = ?7,
+                        left_dock_active_panel = ?8,
+                        left_dock_zoom = ?9,
+                        right_dock_visible = ?10,
+                        right_dock_active_panel = ?11,
+                        right_dock_zoom = ?12,
+                        bottom_dock_visible = ?13,
+                        bottom_dock_active_panel = ?14,
+                        bottom_dock_zoom = ?15,
+                        session_id = ?16,
+                        window_id = ?17,
                         timestamp = CURRENT_TIMESTAMP
                 );
                 let mut prepared_query = conn.exec_bound(query)?;
@@ -1573,6 +1607,8 @@ impl WorkspaceDb {
                     workspace.id,
                     paths.paths.clone(),
                     paths.order.clone(),
+                    identity_paths.as_ref().map(|paths| paths.paths.clone()),
+                    identity_paths.as_ref().map(|paths| paths.order.clone()),
                     remote_connection_id,
                     workspace.docks,
                     workspace.session_id,
@@ -1747,6 +1783,7 @@ impl WorkspaceDb {
         Vec<(
             WorkspaceId,
             PathList,
+            Option<PathList>,
             Option<RemoteConnectionId>,
             Option<String>,
             DateTime<Utc>,
@@ -1756,10 +1793,25 @@ impl WorkspaceDb {
             .recent_workspaces_query()?
             .into_iter()
             .map(
-                |(id, paths, order, remote_connection_id, session_id, timestamp)| {
+                |(
+                    id,
+                    paths,
+                    order,
+                    identity_paths,
+                    identity_paths_order,
+                    remote_connection_id,
+                    session_id,
+                    timestamp,
+                )| {
                     (
                         id,
                         PathList::deserialize(&SerializedPathList { paths, order }),
+                        identity_paths.map(|paths| {
+                            PathList::deserialize(&SerializedPathList {
+                                paths,
+                                order: identity_paths_order.unwrap_or_default(),
+                            })
+                        }),
                         remote_connection_id.map(RemoteConnectionId),
                         session_id,
                         parse_timestamp(&timestamp),
@@ -1770,8 +1822,8 @@ impl WorkspaceDb {
     }
 
     query! {
-        fn recent_workspaces_query() -> Result<Vec<(WorkspaceId, String, String, Option<u64>, Option<String>, String)>> {
-            SELECT workspace_id, paths, paths_order, remote_connection_id, session_id, timestamp
+        fn recent_workspaces_query() -> Result<Vec<(WorkspaceId, String, String, Option<String>, Option<String>, Option<u64>, Option<String>, String)>> {
+            SELECT workspace_id, paths, paths_order, identity_paths, identity_paths_order, remote_connection_id, session_id, timestamp
             FROM workspaces
             WHERE
                 paths IS NOT NULL OR
@@ -1944,31 +1996,26 @@ impl WorkspaceDb {
         any_dir
     }
 
-    // Returns the recent project workspaces suitable for showing in the recent-projects UI.
-    // Scratch workspaces (no paths) are filtered out - they aren't really "projects" and
-    // are restored separately by `last_session_workspace_locations`.
-    pub async fn recent_project_workspaces(
+    // Returns the raw recent workspace history. Scratch workspaces (no paths) are filtered
+    // out because they are restored separately by `last_session_workspace_locations`.
+    pub async fn recent_project_workspaces_ungrouped(
         &self,
         fs: &dyn Fs,
-    ) -> Result<
-        Vec<(
-            WorkspaceId,
-            SerializedWorkspaceLocation,
-            PathList,
-            DateTime<Utc>,
-        )>,
-    > {
+    ) -> Result<Vec<RecentWorkspace>> {
         let remote_connections = self.remote_connections()?;
         let mut result = Vec::new();
-        for (id, paths, remote_connection_id, _session_id, timestamp) in self.recent_workspaces()? {
+        for (id, paths, identity_paths_hint, remote_connection_id, _session_id, timestamp) in
+            self.recent_workspaces()?
+        {
             if let Some(remote_connection_id) = remote_connection_id {
                 if let Some(connection_options) = remote_connections.get(&remote_connection_id) {
-                    result.push((
-                        id,
-                        SerializedWorkspaceLocation::Remote(connection_options.clone()),
-                        paths,
+                    result.push(RecentWorkspace {
+                        workspace_id: id,
+                        location: SerializedWorkspaceLocation::Remote(connection_options.clone()),
+                        paths: paths.clone(),
+                        identity_paths: identity_paths_hint.unwrap_or(paths),
                         timestamp,
-                    ));
+                    });
                 }
                 continue;
             }
@@ -1978,10 +2025,30 @@ impl WorkspaceDb {
             }
 
             if Self::all_paths_exist_with_a_directory(paths.paths(), fs).await {
-                result.push((id, SerializedWorkspaceLocation::Local, paths, timestamp));
+                let identity_paths = resolve_local_workspace_identity(fs, &paths)
+                    .await
+                    .or(identity_paths_hint)
+                    .unwrap_or_else(|| paths.clone());
+                result.push(RecentWorkspace {
+                    workspace_id: id,
+                    location: SerializedWorkspaceLocation::Local,
+                    paths,
+                    identity_paths,
+                    timestamp,
+                });
             }
         }
+
         Ok(result)
+    }
+
+    // Returns the recent project workspaces suitable for recent-project UIs.
+    // Entries are deduplicated by git worktree identity, but preserve the original
+    // serialized paths for reopening.
+    pub async fn recent_project_workspaces(&self, fs: &dyn Fs) -> Result<Vec<RecentWorkspace>> {
+        Ok(dedupe_recent_workspaces(
+            self.recent_project_workspaces_ungrouped(fs).await?,
+        ))
     }
 
     // Deletes workspace rows that can no longer be restored from. Remote workspaces whose
@@ -1998,7 +2065,9 @@ impl WorkspaceDb {
         let remote_connections = self.remote_connections()?;
         let now = Utc::now();
         let mut workspaces_to_delete = Vec::new();
-        for (id, paths, remote_connection_id, session_id, timestamp) in self.recent_workspaces()? {
+        for (id, paths, _identity_paths_hint, remote_connection_id, session_id, timestamp) in
+            self.recent_workspaces()?
+        {
             if let Some(session_id) = session_id.as_deref() {
                 if session_id == current_session_id || Some(session_id) == last_session_id {
                     continue;
@@ -2038,17 +2107,7 @@ impl WorkspaceDb {
         Ok(())
     }
 
-    pub async fn last_workspace(
-        &self,
-        fs: &dyn Fs,
-    ) -> Result<
-        Option<(
-            WorkspaceId,
-            SerializedWorkspaceLocation,
-            PathList,
-            DateTime<Utc>,
-        )>,
-    > {
+    pub async fn last_workspace(&self, fs: &dyn Fs) -> Result<Option<RecentWorkspace>> {
         Ok(self.recent_project_workspaces(fs).await?.into_iter().next())
     }
 
@@ -2536,80 +2595,74 @@ VALUES {placeholders};"#
     }
 }
 
-type WorkspaceEntry = (
-    WorkspaceId,
-    SerializedWorkspaceLocation,
-    PathList,
-    DateTime<Utc>,
-);
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecentWorkspace {
+    pub workspace_id: WorkspaceId,
+    pub location: SerializedWorkspaceLocation,
+    pub paths: PathList,
+    pub identity_paths: PathList,
+    pub timestamp: DateTime<Utc>,
+}
 
-/// Resolves workspace entries whose paths are git linked worktree checkouts
-/// to their main repository paths.
-///
-/// For each workspace entry:
-/// - If any path is a linked worktree checkout, all worktree paths in that
-///   entry are resolved to their main repository paths, producing a new
-///   `PathList`.
-/// - The resolved entry is then deduplicated against existing entries: if a
-///   workspace with the same paths already exists, the entry with the most
-///   recent timestamp is kept.
-pub async fn resolve_worktree_workspaces(
-    workspaces: impl IntoIterator<Item = WorkspaceEntry>,
-    fs: &dyn Fs,
-) -> Vec<WorkspaceEntry> {
-    // First pass: resolve worktree paths to main repo paths concurrently.
-    let resolved = futures::future::join_all(workspaces.into_iter().map(|entry| async move {
-        let paths = entry.2.paths();
-        if paths.is_empty() {
-            return entry;
-        }
+impl RecentWorkspace {
+    pub fn project_group_key(&self) -> ProjectGroupKey {
+        let host = match &self.location {
+            SerializedWorkspaceLocation::Local => None,
+            SerializedWorkspaceLocation::Remote(options) => Some(options.clone()),
+        };
+        ProjectGroupKey::new(host, self.identity_paths.clone())
+    }
+}
 
-        // Resolve each path concurrently
-        let resolved_paths = futures::future::join_all(
-            paths
-                .iter()
-                .map(|path| project::git_store::resolve_git_worktree_to_main_repo(fs, path)),
-        )
-        .await;
-
-        // If no paths were resolved, this entry is not a worktree — keep as-is
-        if resolved_paths.iter().all(|r| r.is_none()) {
-            return entry;
-        }
-
-        // Build new path list, substituting resolved paths
-        let new_paths: Vec<PathBuf> = paths
+async fn resolve_local_workspace_identity(fs: &dyn Fs, paths: &PathList) -> Option<PathList> {
+    let raw_paths = paths.paths();
+    let resolved_paths = futures::future::join_all(
+        raw_paths
             .iter()
-            .zip(resolved_paths.iter())
-            .map(|(original, resolved)| {
-                resolved
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_else(|| original.clone())
-            })
-            .collect();
-
-        let new_path_refs: Vec<&Path> = new_paths.iter().map(|p| p.as_path()).collect();
-        (entry.0, entry.1, PathList::new(&new_path_refs), entry.3)
-    }))
+            .map(|path| project::git_store::resolve_git_worktree_to_main_repo(fs, path)),
+    )
     .await;
 
-    // Second pass: deduplicate by PathList.
-    // When two entries resolve to the same paths, keep the one with the
-    // more recent timestamp.
-    let mut seen: collections::HashMap<Vec<PathBuf>, usize> = collections::HashMap::default();
-    let mut result: Vec<WorkspaceEntry> = Vec::new();
+    if resolved_paths.iter().all(|resolved| resolved.is_none()) {
+        return None;
+    }
 
-    for entry in resolved {
-        let key: Vec<PathBuf> = entry.2.paths().to_vec();
-        if let Some(&existing_idx) = seen.get(&key) {
-            // Keep the entry with the more recent timestamp
-            if entry.3 > result[existing_idx].3 {
-                result[existing_idx] = entry;
+    let resolved_paths: Vec<PathBuf> = raw_paths
+        .iter()
+        .zip(resolved_paths.iter())
+        .map(|(original, resolved)| {
+            resolved
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| original.clone())
+        })
+        .collect();
+    let resolved_path_refs: Vec<&Path> = resolved_paths.iter().map(PathBuf::as_path).collect();
+    Some(PathList::new(&resolved_path_refs))
+}
+
+fn dedupe_recent_workspaces(
+    workspaces: impl IntoIterator<Item = RecentWorkspace>,
+) -> Vec<RecentWorkspace> {
+    let mut seen: collections::HashMap<(Option<RemoteConnectionIdentity>, Vec<PathBuf>), usize> =
+        collections::HashMap::default();
+    let mut result: Vec<RecentWorkspace> = Vec::new();
+
+    for workspace in workspaces {
+        let location_identity = match &workspace.location {
+            SerializedWorkspaceLocation::Local => None,
+            SerializedWorkspaceLocation::Remote(connection) => {
+                Some(remote_connection_identity(connection))
+            }
+        };
+        let key = (location_identity, workspace.identity_paths.paths().to_vec());
+        if let Some(&existing_index) = seen.get(&key) {
+            if workspace.timestamp > result[existing_index].timestamp {
+                result[existing_index] = workspace;
             }
         } else {
             seen.insert(key, result.len());
-            result.push(entry);
+            result.push(workspace);
         }
     }
 
@@ -2796,6 +2849,7 @@ mod tests {
         let workspace = SerializedWorkspace {
             id,
             paths: PathList::new(&["/tmp"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -2952,6 +3006,7 @@ mod tests {
         let workspace = SerializedWorkspace {
             id,
             paths: PathList::new(&["/tmp"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3001,6 +3056,7 @@ mod tests {
         let workspace_without_breakpoint = SerializedWorkspace {
             id,
             paths: PathList::new(&["/tmp"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3100,6 +3156,7 @@ mod tests {
         let mut workspace_1 = SerializedWorkspace {
             id: WorkspaceId(1),
             paths: PathList::new(&["/tmp", "/tmp2"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3116,6 +3173,7 @@ mod tests {
         let workspace_2 = SerializedWorkspace {
             id: WorkspaceId(2),
             paths: PathList::new(&["/tmp"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3224,6 +3282,7 @@ mod tests {
         let workspace = SerializedWorkspace {
             id: WorkspaceId(5),
             paths: PathList::new(&["/tmp", "/tmp2"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group,
             window_bounds: Default::default(),
@@ -3259,6 +3318,7 @@ mod tests {
         let workspace_1 = SerializedWorkspace {
             id: WorkspaceId(1),
             paths: PathList::new(&["/tmp", "/tmp2"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3275,6 +3335,7 @@ mod tests {
         let mut workspace_2 = SerializedWorkspace {
             id: WorkspaceId(2),
             paths: PathList::new(&["/tmp"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3318,6 +3379,7 @@ mod tests {
         let mut workspace_3 = SerializedWorkspace {
             id: WorkspaceId(3),
             paths: PathList::new(&["/tmp2", "/tmp"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3357,6 +3419,7 @@ mod tests {
         let workspace_1 = SerializedWorkspace {
             id: WorkspaceId(1),
             paths: PathList::new(&["/tmp1"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3373,6 +3436,7 @@ mod tests {
         let workspace_2 = SerializedWorkspace {
             id: WorkspaceId(2),
             paths: PathList::new(&["/tmp2"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3389,6 +3453,7 @@ mod tests {
         let workspace_3 = SerializedWorkspace {
             id: WorkspaceId(3),
             paths: PathList::new(&["/tmp3"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3405,6 +3470,7 @@ mod tests {
         let workspace_4 = SerializedWorkspace {
             id: WorkspaceId(4),
             paths: PathList::new(&["/tmp4"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3430,6 +3496,7 @@ mod tests {
         let workspace_5 = SerializedWorkspace {
             id: WorkspaceId(5),
             paths: PathList::default(),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Remote(
                 db.remote_connection(connection_id).unwrap(),
             ),
@@ -3448,6 +3515,7 @@ mod tests {
         let workspace_6 = SerializedWorkspace {
             id: WorkspaceId(6),
             paths: PathList::new(&["/tmp6c", "/tmp6b", "/tmp6a"]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3506,6 +3574,7 @@ mod tests {
         SerializedWorkspace {
             id: WorkspaceId(4),
             paths: PathList::new(paths),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: center_group.clone(),
             window_bounds: Default::default(),
@@ -3548,6 +3617,7 @@ mod tests {
         .map(|(id, paths, window_id)| SerializedWorkspace {
             id: WorkspaceId(id),
             paths: PathList::new(paths.as_slice()),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -3646,6 +3716,7 @@ mod tests {
         SerializedWorkspace {
             id: WorkspaceId(id as i64),
             paths: PathList::new(paths),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group,
             window_bounds: Default::default(),
@@ -3657,6 +3728,48 @@ mod tests {
             session_id: session_id.map(|s| s.to_owned()),
             window_id: Some(id),
             user_toolchains: Default::default(),
+        }
+    }
+
+    fn remote_workspace_with(id: u64, host: &str, paths: &[&Path]) -> SerializedWorkspace {
+        SerializedWorkspace {
+            id: WorkspaceId(id as i64),
+            paths: PathList::new(paths),
+            identity_paths: None,
+            location: SerializedWorkspaceLocation::Remote(RemoteConnectionOptions::Ssh(
+                SshConnectionOptions {
+                    host: host.into(),
+                    ..Default::default()
+                },
+            )),
+            center_group: empty_pane_group(),
+            window_bounds: Default::default(),
+            display: Default::default(),
+            docks: Default::default(),
+            bookmarks: Default::default(),
+            breakpoints: Default::default(),
+            centered_layout: false,
+            session_id: None,
+            window_id: Some(id),
+            user_toolchains: Default::default(),
+        }
+    }
+
+    async fn local_recent_workspace(
+        workspace_id: WorkspaceId,
+        paths: PathList,
+        timestamp: DateTime<Utc>,
+        fs: &dyn Fs,
+    ) -> RecentWorkspace {
+        let identity_paths = resolve_local_workspace_identity(fs, &paths)
+            .await
+            .unwrap_or_else(|| paths.clone());
+        RecentWorkspace {
+            workspace_id,
+            location: SerializedWorkspaceLocation::Local,
+            paths,
+            identity_paths,
+            timestamp,
         }
     }
 
@@ -3680,7 +3793,9 @@ mod tests {
 
         let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
         assert!(
-            recents.iter().all(|(id, ..)| *id != WorkspaceId(1)),
+            recents
+                .iter()
+                .all(|workspace| workspace.workspace_id != WorkspaceId(1)),
             "scratch-only workspace must not appear in the recent-projects UI"
         );
     }
@@ -3883,6 +3998,7 @@ mod tests {
         .map(|(id, remote_connection, window_id)| SerializedWorkspace {
             id: WorkspaceId(id),
             paths: PathList::default(),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Remote(remote_connection),
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -4245,6 +4361,7 @@ mod tests {
         let workspace = SerializedWorkspace {
             id,
             paths: PathList::new(empty_paths),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: None,
@@ -4322,6 +4439,7 @@ mod tests {
             db.save_workspace(SerializedWorkspace {
                 id: WorkspaceId(*id),
                 paths: PathList::new(&[*dir]),
+                identity_paths: None,
                 location: SerializedWorkspaceLocation::Local,
                 center_group: Default::default(),
                 window_bounds: Default::default(),
@@ -4608,6 +4726,7 @@ mod tests {
         db.save_workspace(SerializedWorkspace {
             id: workspace2_db_id,
             paths: PathList::new(&[&dir]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -4704,6 +4823,7 @@ mod tests {
         db.save_workspace(SerializedWorkspace {
             id: ws1_id,
             paths: PathList::new(&[dir1.path()]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -4721,6 +4841,7 @@ mod tests {
         db.save_workspace(SerializedWorkspace {
             id: ws2_id,
             paths: PathList::new(&[dir2.path()]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -4800,6 +4921,7 @@ mod tests {
         db.save_workspace(SerializedWorkspace {
             id: workspace2_db_id,
             paths: PathList::new(&[&dir]),
+            identity_paths: None,
             location: SerializedWorkspaceLocation::Local,
             center_group: Default::default(),
             window_bounds: Default::default(),
@@ -4957,7 +5079,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_resolve_worktree_workspaces(cx: &mut gpui::TestAppContext) {
+    async fn test_recent_workspace_identity_deduplication(cx: &mut gpui::TestAppContext) {
         let fs = fs::FakeFs::new(cx.executor());
 
         // Main repo with a linked worktree entry
@@ -5012,64 +5134,59 @@ mod tests {
         let t3 = Utc::now() - chrono::Duration::hours(1);
 
         let workspaces = vec![
-            // 1: Main checkout of /repo (opened earlier)
-            (
-                WorkspaceId(1),
-                SerializedWorkspaceLocation::Local,
-                PathList::new(&["/repo"]),
-                t0,
-            ),
-            // 2: Linked worktree of /repo (opened more recently)
-            //    Should dedup with #1; more recent timestamp wins.
-            (
+            local_recent_workspace(WorkspaceId(1), PathList::new(&["/repo"]), t0, fs.as_ref())
+                .await,
+            local_recent_workspace(
                 WorkspaceId(2),
-                SerializedWorkspaceLocation::Local,
                 PathList::new(&["/worktree"]),
                 t1,
-            ),
-            // 3: Mixed-path workspace: one root is a linked worktree,
-            //    the other is a normal repo. The worktree path should be
-            //    resolved; the normal path kept as-is.
-            (
+                fs.as_ref(),
+            )
+            .await,
+            local_recent_workspace(
                 WorkspaceId(3),
-                SerializedWorkspaceLocation::Local,
                 PathList::new(&["/other-repo", "/worktree"]),
                 t2,
-            ),
-            // 4: Non-git project — passed through unchanged.
-            (
+                fs.as_ref(),
+            )
+            .await,
+            local_recent_workspace(
                 WorkspaceId(4),
-                SerializedWorkspaceLocation::Local,
                 PathList::new(&["/plain-project"]),
                 t3,
-            ),
+                fs.as_ref(),
+            )
+            .await,
         ];
 
-        let result = resolve_worktree_workspaces(workspaces, fs.as_ref()).await;
+        let result = dedupe_recent_workspaces(workspaces);
 
         // Should have 3 entries: #1 and #2 deduped into one, plus #3 and #4.
         assert_eq!(result.len(), 3);
 
         // First entry: /repo — deduplicated from #1 and #2.
         // Keeps the position of #1 (first seen), but with #2's later timestamp.
-        assert_eq!(result[0].2.paths(), &[PathBuf::from("/repo")]);
-        assert_eq!(result[0].3, t1);
+        assert_eq!(result[0].identity_paths.paths(), &[PathBuf::from("/repo")]);
+        assert_eq!(result[0].timestamp, t1);
 
         // Second entry: mixed-path workspace with worktree resolved.
         // /worktree → /repo, so paths become [/other-repo, /repo] (sorted).
         assert_eq!(
-            result[1].2.paths(),
+            result[1].identity_paths.paths(),
             &[PathBuf::from("/other-repo"), PathBuf::from("/repo")]
         );
-        assert_eq!(result[1].0, WorkspaceId(3));
+        assert_eq!(result[1].workspace_id, WorkspaceId(3));
 
         // Third entry: non-git project, unchanged.
-        assert_eq!(result[2].2.paths(), &[PathBuf::from("/plain-project")]);
-        assert_eq!(result[2].0, WorkspaceId(4));
+        assert_eq!(
+            result[2].identity_paths.paths(),
+            &[PathBuf::from("/plain-project")]
+        );
+        assert_eq!(result[2].workspace_id, WorkspaceId(4));
     }
 
     #[gpui::test]
-    async fn test_resolve_worktree_workspaces_bare_repo(cx: &mut gpui::TestAppContext) {
+    async fn test_recent_workspace_identity_for_bare_repo(cx: &mut gpui::TestAppContext) {
         let fs = fs::FakeFs::new(cx.executor());
 
         // Bare repo at /foo/.bare (commondir doesn't end with .git)
@@ -5098,19 +5215,242 @@ mod tests {
 
         let t0 = Utc::now();
 
-        let workspaces = vec![(
-            WorkspaceId(1),
-            SerializedWorkspaceLocation::Local,
-            PathList::new(&["/foo/my-feature"]),
-            t0,
-        )];
+        let result = vec![
+            local_recent_workspace(
+                WorkspaceId(1),
+                PathList::new(&["/foo/my-feature"]),
+                t0,
+                fs.as_ref(),
+            )
+            .await,
+        ];
 
-        let result = resolve_worktree_workspaces(workspaces, fs.as_ref()).await;
-
-        // The worktree path must be preserved unchanged — /foo/.bare is a bare repo
-        // and cannot serve as a working-tree root, so resolution must return None.
+        // Bare-backed worktrees should resolve to the repo identity path, which
+        // is the parent directory users think of as the project root.
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].2.paths(), &[PathBuf::from("/foo/my-feature")]);
+        assert_eq!(result[0].identity_paths.paths(), &[PathBuf::from("/foo")]);
+    }
+
+    #[gpui::test]
+    async fn test_recent_workspace_identity_deduplicates_main_and_linked_worktree(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+
+        fs.insert_tree(
+            "/monty",
+            json!({
+                ".git": "gitdir: ./.bare\n",
+                ".bare": {
+                    "worktrees": {
+                        "feature-a": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature-a"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        fs.insert_tree(
+            "/monty/feature-a",
+            json!({
+                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+                "src": { "lib.rs": "" }
+            }),
+        )
+        .await;
+
+        let t0 = Utc::now() - chrono::Duration::hours(1);
+        let t1 = Utc::now();
+        let workspaces = vec![
+            local_recent_workspace(WorkspaceId(1), PathList::new(&["/monty"]), t0, fs.as_ref())
+                .await,
+            local_recent_workspace(
+                WorkspaceId(2),
+                PathList::new(&["/monty/feature-a"]),
+                t1,
+                fs.as_ref(),
+            )
+            .await,
+        ];
+
+        let result = dedupe_recent_workspaces(workspaces);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].identity_paths.paths(), &[PathBuf::from("/monty")]);
+        assert_eq!(result[0].workspace_id, WorkspaceId(2));
+        assert_eq!(result[0].timestamp, t1);
+    }
+
+    #[gpui::test]
+    async fn test_recent_project_workspaces_preserve_reopen_paths(cx: &mut gpui::TestAppContext) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db =
+            WorkspaceDb::open_test_db("test_recent_project_workspaces_preserve_reopen_paths").await;
+
+        fs.insert_tree(
+            "/monty",
+            json!({
+                ".git": "gitdir: ./.bare\n",
+                ".bare": {
+                    "worktrees": {
+                        "feature-a": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature-a"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        fs.insert_tree(
+            "/monty/feature-a",
+            json!({
+                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+                "src": { "lib.rs": "" }
+            }),
+        )
+        .await;
+
+        db.save_workspace(workspace_with(
+            1,
+            &[Path::new("/monty")],
+            empty_pane_group(),
+            None,
+        ))
+        .await;
+        db.save_workspace(workspace_with(
+            2,
+            &[Path::new("/monty/feature-a")],
+            empty_pane_group(),
+            None,
+        ))
+        .await;
+        db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:00".to_owned())
+            .await
+            .unwrap();
+        db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+            .await
+            .unwrap();
+
+        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+
+        assert_eq!(recents.len(), 1);
+        assert_eq!(recents[0].workspace_id, WorkspaceId(2));
+        assert_eq!(
+            recents[0].paths.paths(),
+            &[PathBuf::from("/monty/feature-a")]
+        );
+        assert_eq!(
+            recents[0].identity_paths.paths(),
+            &[PathBuf::from("/monty")]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_recent_project_workspaces_remote_identity_hint(cx: &mut gpui::TestAppContext) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db =
+            WorkspaceDb::open_test_db("test_recent_project_workspaces_remote_identity_hint").await;
+
+        let workspace = remote_workspace_with(1, "example.com", &[Path::new("/repo/feature-a")]);
+        db.save_workspace(SerializedWorkspace {
+            identity_paths: Some(PathList::new(&["/repo"])),
+            ..workspace
+        })
+        .await;
+
+        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+
+        assert_eq!(recents.len(), 1);
+        assert_eq!(
+            recents[0].paths.paths(),
+            &[PathBuf::from("/repo/feature-a")]
+        );
+        assert_eq!(recents[0].identity_paths.paths(), &[PathBuf::from("/repo")]);
+    }
+
+    #[gpui::test]
+    async fn test_recent_project_workspaces_remote_paths_do_not_use_local_fs_identity(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db = WorkspaceDb::open_test_db(
+            "test_recent_project_workspaces_remote_paths_do_not_use_local_fs_identity",
+        )
+        .await;
+
+        fs.insert_tree(
+            "/repo",
+            json!({
+                ".git": "gitdir: ./.bare\n",
+                ".bare": {
+                    "worktrees": {
+                        "feature-a": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature-a"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            "/repo/feature-a",
+            json!({
+                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+                "src": { "lib.rs": "" }
+            }),
+        )
+        .await;
+
+        db.save_workspace(remote_workspace_with(
+            1,
+            "example.com",
+            &[Path::new("/repo/feature-a")],
+        ))
+        .await;
+
+        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+
+        assert_eq!(recents.len(), 1);
+        assert_eq!(
+            recents[0].identity_paths.paths(),
+            &[PathBuf::from("/repo/feature-a")]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_recent_project_workspaces_do_not_dedupe_remote_hosts(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db =
+            WorkspaceDb::open_test_db("test_recent_project_workspaces_do_not_dedupe_remote_hosts")
+                .await;
+
+        db.save_workspace(remote_workspace_with(1, "host-a", &[Path::new("/repo")]))
+            .await;
+        db.save_workspace(remote_workspace_with(2, "host-b", &[Path::new("/repo")]))
+            .await;
+        db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:00".to_owned())
+            .await
+            .unwrap();
+        db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+            .await
+            .unwrap();
+
+        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+
+        assert_eq!(recents.len(), 2);
+        assert_eq!(recents[0].workspace_id, WorkspaceId(2));
+        assert_eq!(recents[1].workspace_id, WorkspaceId(1));
     }
 
     #[gpui::test]

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -130,6 +130,13 @@ pub(crate) struct SerializedWorkspace {
     pub(crate) id: WorkspaceId,
     pub(crate) location: SerializedWorkspaceLocation,
     pub(crate) paths: PathList,
+    /// The workspace's main worktree paths at the time this workspace was saved.
+    ///
+    /// These paths are used for grouping, deduping, and display in recent-workspace
+    /// UIs. They are not authoritative for reopening the workspace, because they may
+    /// become stale if the repository layout changes after the save. Use `paths` when
+    /// reopening the workspace.
+    pub(crate) identity_paths: Option<PathList>,
     pub(crate) center_group: SerializedPaneGroup,
     pub(crate) window_bounds: Option<SerializedWindowBounds>,
     pub(crate) centered_layout: bool,

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -1,11 +1,10 @@
 use crate::{
-    NewFile, Open, OpenMode, PathList, SerializedWorkspaceLocation, ToggleWorkspaceSidebar,
-    Workspace, WorkspaceId,
+    NewFile, Open, OpenMode, PathList, RecentWorkspace, SerializedWorkspaceLocation,
+    ToggleWorkspaceSidebar, Workspace,
     item::{Item, ItemEvent},
     persistence::WorkspaceDb,
 };
 use agent_settings::AgentSettings;
-use chrono::{DateTime, Utc};
 use git::Clone as GitClone;
 use gpui::{
     Action, App, Context, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
@@ -242,14 +241,7 @@ pub struct WelcomePage {
     workspace: WeakEntity<Workspace>,
     focus_handle: FocusHandle,
     fallback_to_recent_projects: bool,
-    recent_workspaces: Option<
-        Vec<(
-            WorkspaceId,
-            SerializedWorkspaceLocation,
-            PathList,
-            DateTime<Utc>,
-        )>,
-    >,
+    recent_workspaces: Option<Vec<RecentWorkspace>>,
 }
 
 impl WelcomePage {
@@ -310,14 +302,11 @@ impl WelcomePage {
         cx: &mut Context<Self>,
     ) {
         if let Some(recent_workspaces) = &self.recent_workspaces {
-            if let Some((_workspace_id, location, paths, _timestamp)) =
-                recent_workspaces.get(action.index)
-            {
-                let is_local = matches!(location, SerializedWorkspaceLocation::Local);
+            if let Some(workspace) = recent_workspaces.get(action.index) {
+                let is_local = matches!(workspace.location, SerializedWorkspaceLocation::Local);
 
                 if is_local {
-                    let paths = paths.clone();
-                    let paths = paths.paths().to_vec();
+                    let paths = workspace.paths.paths().to_vec();
                     self.workspace
                         .update(cx, |workspace, cx| {
                             workspace
@@ -433,8 +422,13 @@ impl Render for WelcomePage {
             .flatten()
             .take(5)
             .enumerate()
-            .map(|(index, (_, loc, paths, _))| {
-                self.render_recent_project(index, first_section_entries + index, loc, paths)
+            .map(|(index, workspace)| {
+                self.render_recent_project(
+                    index,
+                    first_section_entries + index,
+                    &workspace.location,
+                    &workspace.identity_paths,
+                )
             })
             .collect::<Vec<_>>();
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -84,15 +84,15 @@ pub use pane_group::{
     ActivePaneDecorator, HANDLE_HITBOX_SIZE, Member, PaneAxis, PaneGroup, PaneRenderContext,
     SplitDirection,
 };
-use persistence::{SerializedWindowBounds, model::SerializedWorkspace};
 pub use persistence::{
-    WorkspaceDb, delete_unloaded_items,
+    RecentWorkspace, WorkspaceDb, delete_unloaded_items,
     model::{
         DockData, DockStructure, ItemId, MultiWorkspaceState, SerializedMultiWorkspace,
         SerializedProjectGroup, SerializedWorkspaceLocation, SessionWorkspace,
     },
-    read_serialized_multi_workspaces, resolve_worktree_workspaces,
+    read_serialized_multi_workspaces,
 };
+use persistence::{SerializedWindowBounds, model::SerializedWorkspace};
 use postage::stream::Stream;
 use project::{
     DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
@@ -6857,11 +6857,13 @@ impl Workspace {
                 let center_group = build_serialized_pane_group(&self.center.root, window, cx);
                 let docks = build_serialized_docks(self, window, cx);
                 let window_bounds = Some(SerializedWindowBounds(window.window_bounds()));
+                let identity_paths_hint = self.project_group_key(cx).path_list().clone();
 
                 let serialized_workspace = SerializedWorkspace {
                     id: database_id,
                     location,
                     paths,
+                    identity_paths: Some(identity_paths_hint),
                     center_group,
                     window_bounds,
                     display: Default::default(),
@@ -8947,7 +8949,7 @@ pub async fn last_opened_workspace_location(
         .await
         .log_err()
         .flatten()
-        .map(|(id, location, paths, _timestamp)| (id, location, paths))
+        .map(|workspace| (workspace.workspace_id, workspace.location, workspace.paths))
 }
 
 pub async fn last_session_workspace_locations(
@@ -9068,7 +9070,7 @@ pub async fn apply_restored_multiworkspace_state(
                     && let Some(common_dir) =
                         project::discover_root_repo_common_dir(path, fs.as_ref()).await
                 {
-                    let main_path = common_dir.parent().unwrap_or(&common_dir);
+                    let main_path = project::repo_identity_path(&common_dir);
                     resolved_paths.push(main_path.to_path_buf());
                 } else {
                     resolved_paths.push(path.to_path_buf());


### PR DESCRIPTION
* Perform grouping even for repositories that have no main worktree
* Enable grouping for remote projects
* Delete entire project groups when deleting via the recent project picker

Release Notes:

- Fixed a bug where each linked worktree appeared as its own entry in recent projects for repositories without main worktrees
- Fixed a bug where deleting projects from the recent projects sometimes appeared to have no effect.
