### PR TITLE
Update panel dock default values in settings docs

### DIFF
--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -84,7 +84,7 @@ pub struct AgentSettingsContent {
     pub button: Option<bool>,
     /// Where to dock the agent panel.
     ///
-    /// Default: right
+    /// Default: left
     pub dock: Option<DockPosition>,
     /// Whether the agent panel should use flexible (proportional) sizing.
     ///

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -647,7 +647,7 @@ pub struct GitPanelSettingsContent {
     pub button: Option<bool>,
     /// Where to dock the panel.
     ///
-    /// Default: left
+    /// Default: right
     pub dock: Option<DockPosition>,
     /// Default width of the panel in pixels.
     ///
@@ -756,7 +756,7 @@ pub struct PanelSettingsContent {
     pub button: Option<bool>,
     /// Where to dock the panel.
     ///
-    /// Default: left
+    /// Default: right
     pub dock: Option<DockPosition>,
     /// Default width of the panel in pixels.
     ///
@@ -998,7 +998,7 @@ pub struct OutlinePanelSettingsContent {
     pub default_width: Option<f32>,
     /// The position of outline panel
     ///
-    /// Default: left
+    /// Default: right
     pub dock: Option<DockSide>,
     /// Whether to show file icons in the outline panel.
     ///

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -705,7 +705,7 @@ pub struct ProjectPanelSettingsContent {
     pub default_width: Option<f32>,
     /// The position of project panel
     ///
-    /// Default: left
+    /// Default: right
     pub dock: Option<DockSide>,
     /// Spacing between worktree entries in the project panel.
     ///


### PR DESCRIPTION
The [Parallel Agents release](https://zed.dev/blog/parallel-agents) introduced a new default layout: the agent panel now docks on the left, while the project, git, outline, and collaboration panels now dock on the right. The rustdoc comments in `crates/settings_content` were not updated to reflect this change.

This PR corrects the `Default:` values in the following structs:

- `ProjectPanelSettingsContent.dock`: `left` → `right`
- `GitPanelSettingsContent.dock`: `left` → `right`
- `PanelSettingsContent.dock` (collaboration panel): `left` → `right`
- `OutlinePanelSettingsContent.dock`: `left` → `right`
- `AgentSettingsContent.dock`: `right` → `left`

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
