### PR TITLE
project_panel: Escape filenames in delete confirmations

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -67,6 +67,7 @@ use ui::{
 };
 use util::{
     ResultExt, TakeUntilExt, TryFutureExt, maybe,
+    markdown::MarkdownInlineCode,
     paths::{PathStyle, compare_paths},
     rel_path::{RelPath, RelPathBuf},
 };
@@ -2357,7 +2358,7 @@ impl ProjectPanel {
                             ""
                         };
 
-                        format!("{message_start} {path}?{unsaved_warning}")
+                        format!("{message_start} {}?{unsaved_warning}", MarkdownInlineCode(&path))
                     }
                     _ => {
                         const CUTOFF_POINT: usize = 10;
@@ -2365,7 +2366,7 @@ impl ProjectPanel {
                             let truncated_path_counts = file_paths.len() - CUTOFF_POINT;
                             let mut paths = file_paths
                                 .iter()
-                                .map(|(_, _, path)| path.clone())
+                                .map(|(_, _, path)| MarkdownInlineCode(path).to_string())
                                 .take(CUTOFF_POINT)
                                 .collect::<Vec<_>>();
                             paths.truncate(CUTOFF_POINT);

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2106,6 +2106,41 @@ async fn test_copy_and_cut_write_to_system_clipboard(cx: &mut gpui::TestAppConte
     );
 }
 
+
+#[gpui::test]
+async fn test_delete_prompt_escapes_markdown_in_file_name(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "__somefile__": "",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/__somefile__", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.delete(&Delete { skip_prompt: false }, window, cx)
+    });
+    let (message, detail) = cx
+        .pending_prompt()
+        .expect("delete should show a confirmation prompt");
+
+    assert_eq!(message, "Are you sure you want to permanently delete `__somefile__`?");
+    assert_eq!(detail, "This cannot be undone.");
+}
+
 #[gpui::test]
 async fn test_remove_opened_file(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);


### PR DESCRIPTION
Fixes #55651

## Summary

- Escape file names before inserting them into Markdown delete/trash confirmation prompts
- Add a project panel test covering Markdown-like file names such as `__somefile__`

## Validation

- `cargo test -p project_panel project_panel_tests::test_delete_prompt_escapes_markdown_in_file_name -- --exact --nocapture`

Release Notes:

- Fixed delete and trash confirmation prompts rendering Markdown-like filenames as formatting.
