### PR TITLE
editor: Stop word movement at isolated punctuation

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -446,7 +446,7 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
         // Make alt-right skip punctuation to respect VSCode behaviour. For example: |.hello goes to .hello|
         if is_first_iteration
             && classifier.is_punctuation(left)
-            && !classifier.is_punctuation(right)
+            && !right.is_whitespace()
             && right != '\n'
         {
             is_first_iteration = false;
@@ -1163,6 +1163,7 @@ mod tests {
         assert("helloˇ.---..ˇtest", cx);
         assert("testˇ.--ˇ test", cx);
         assert("oneˇ,;:!?ˇtwo", cx);
+        assert("foo ˇ.ˇ bar", cx);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes #55601

## Summary

- Adjust word-end movement so isolated punctuation is treated as a stop instead of being skipped with the following word
- Keep the existing behavior that moves through leading punctuation before a word

## Validation

- `cargo test -p editor movement::tests::test_next_word_end -- --exact --nocapture`
- `cargo test -p editor movement::tests::test_previous_word_start -- --exact --nocapture`

Release Notes:

- Fixed word movement skipping isolated punctuation characters.
