### PR TITLE
editor: Preserve Markdown frontmatter during rewrap

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13931,7 +13931,6 @@ impl Editor {
                         let line_text_after_indent = buffer
                             .text_for_range(indent_end..line_end)
                             .collect::<String>();
-
                         let is_within_comment_override = buffer
                             .language_scope_at(indent_end)
                             .is_some_and(|scope| scope.override_name() == Some("comment"));
@@ -14047,7 +14046,40 @@ impl Editor {
                 }
             }
 
-            let mut non_blank_rows_iter = (start_row..=end_row)
+            let rewrap_start_row = if language_scope
+                .as_ref()
+                .is_some_and(|scope| scope.language_name().as_ref() == "Markdown")
+            {
+                let line_start = Point::new(start_row, 0);
+                let line_end = Point::new(start_row, buffer.line_len(MultiBufferRow(start_row)));
+                let first_non_blank_line =
+                    buffer.text_for_range(line_start..line_end).collect::<String>();
+                if first_non_blank_line.trim() == "---" {
+                    let mut frontmatter_end_row = None;
+                    for row in start_row.saturating_add(1)..=end_row {
+                        let row_start = Point::new(row, 0);
+                        let row_end = Point::new(row, buffer.line_len(MultiBufferRow(row)));
+                        let row_text = buffer.text_for_range(row_start..row_end).collect::<String>();
+                        if row_text.trim() == "---" {
+                            frontmatter_end_row = Some(row);
+                            break;
+                        }
+                    }
+                    frontmatter_end_row
+                        .map(|row| row.saturating_add(1))
+                        .unwrap_or(start_row)
+                } else {
+                    start_row
+                }
+            } else {
+                start_row
+            };
+
+            if rewrap_start_row > end_row {
+                return Vec::new();
+            }
+
+            let mut non_blank_rows_iter = (rewrap_start_row..=end_row)
                 .filter(|row| !buffer.is_line_blank(MultiBufferRow(*row)))
                 .peekable();
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7941,6 +7941,40 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
+    // Test that Select All rewrap preserves Markdown frontmatter instead of collapsing it into prose.
+    let language_registry = Arc::new(language::LanguageRegistry::test(cx.executor()));
+    language_registry.add(markdown_language.clone());
+    language_registry.add(languages::language("yaml", tree_sitter_yaml::LANGUAGE.into()));
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language_registry(language_registry);
+        buffer.set_language(Some(markdown_language.clone()), cx);
+    });
+    cx.set_state(indoc! {"
+        ˇ---
+        title: Zed
+        date: 2026-05-04
+        ---
+
+        This is a long line of markdown text that should wrap without changing the frontmatter.
+    "});
+    cx.update_editor(|editor, window, cx| {
+        editor.select_all(&SelectAll, window, cx);
+        editor.rewrap(&Rewrap, window, cx);
+    });
+    assert_eq!(
+        cx.display_text(),
+        indoc! {"
+            ---
+            title: Zed
+            date: 2026-05-04
+            ---
+
+            This is a long line of markdown text
+            that should wrap without changing the
+            frontmatter.
+        "}
+    );
+
     // Test that rewrapping boundary works and preserves relative indent for Markdown documents
     assert_rewrap(
         indoc! {"


### PR DESCRIPTION
Fixes #55593

## Summary

- Treat Markdown YAML frontmatter as its own rewrap boundary
- Add regression coverage for selecting and rewrapping an entire Markdown document with frontmatter

## Validation

- `cargo test -p editor test_rewrap -- --nocapture --test-threads=1`

Release Notes:

- Fixed rewrap corrupting Markdown YAML frontmatter after selecting the full document.
