### PR TITLE
terminal_view: Preserve spaced task arguments

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1797,6 +1797,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_prepare_task_preserves_spaced_arguments() {
+        let input = SpawnInTerminal {
+            command: Some("echo".to_string()),
+            args: vec!["test2 test3".to_string()],
+            ..SpawnInTerminal::default()
+        };
+        let shell = Shell::Program("sh".to_owned());
+
+        let result = prepare_task_for_spawn(&input, &shell, false);
+
+        assert_eq!(result.command, Some("sh".to_string()));
+        assert_eq!(result.args, vec!["-i".to_string(), "-c".to_string(), "echo 'test2 test3'".to_string()]);
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_prepare_script_like_task() {

--- a/crates/util/src/shell_builder.rs
+++ b/crates/util/src/shell_builder.rs
@@ -140,7 +140,11 @@ impl ShellBuilder {
         if let Some(task_command) = task_command {
             let mut combined_command = task_args.iter().fold(task_command, |mut command, arg| {
                 command.push(' ');
-                command.push_str(&self.kind.to_shell_variable(arg));
+                let shell_variable = self.kind.to_shell_variable(arg);
+                command.push_str(&match self.kind.try_quote(&shell_variable) {
+                    Some(shell_variable) => shell_variable,
+                    None => Cow::Owned(shell_variable),
+                });
                 command
             });
             if self.redirect_stdin {
@@ -323,5 +327,17 @@ mod test {
 
         assert_eq!(program, "fish");
         assert_eq!(args, vec!["-i", "-c", "echo oo"]);
+    }
+
+    #[test]
+    fn build_no_quote_preserves_spaced_arguments() {
+        let shell = Shell::Program("sh".to_owned());
+        let shell_builder = ShellBuilder::new(&shell, false);
+
+        let (program, args) = shell_builder
+            .build_no_quote(Some("echo".into()), &["test2 test3".to_string()]);
+
+        assert_eq!(program, "sh");
+        assert_eq!(args, vec!["-i", "-c", "echo 'test2 test3'"]);
     }
 }


### PR DESCRIPTION
Fixes #55482

## Summary

- Preserve task arguments containing spaces when building shell commands
- Add regression tests for shell command construction and terminal task preparation

## Validation

- `cargo test -p util shell_builder::test::build_no_quote_preserves_spaced_arguments -- --exact --nocapture`
- `cargo test -p terminal_view terminal_panel::tests::test_prepare_task_preserves_spaced_arguments -- --exact --nocapture`

Release Notes:

- Fixed task arguments containing spaces being split when tasks are run.
