### PR TITLE
editor: respect `go_to_definition_scroll_strategy` when jumping to reference

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -25556,12 +25556,10 @@ impl Editor {
                             if has_file && !is_project_file {
                                 editor.set_read_only(true);
                             }
-                            let autoscroll = match scroll_offset {
-                                Some(scroll_offset) => {
-                                    Autoscroll::top_relative(scroll_offset as ScrollOffset)
-                                }
-                                None => Autoscroll::newest(),
-                            };
+                            let autoscroll = Autoscroll::for_go_to_definition(
+                                scroll_offset.map(|offset| offset as ScrollOffset),
+                                cx,
+                            );
                             let nav_history = editor.nav_history.take();
                             let multibuffer_snapshot = editor.buffer().read(cx).snapshot(cx);
                             let Some(buffer_snapshot) = multibuffer_snapshot.as_singleton() else {


### PR DESCRIPTION
Fix https://github.com/zed-industries/zed/issues/55741

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
