### PR TITLE
agent_servers: Include stderr in ACP startup exit errors

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1177,6 +1177,7 @@ pub enum LoadError {
     FailedToInstall(SharedString),
     Exited {
         status: ExitStatus,
+        stderr: Option<SharedString>,
     },
     Other(SharedString),
 }
@@ -1195,7 +1196,7 @@ impl Display for LoadError {
                 )
             }
             LoadError::FailedToInstall(msg) => write!(f, "Failed to install: {msg}"),
-            LoadError::Exited { status } => write!(f, "Server exited with status {status}"),
+            LoadError::Exited { status, .. } => write!(f, "Server exited with status {status}"),
             LoadError::Other(msg) => write!(f, "{msg}"),
         }
     }

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -2304,10 +2304,7 @@ pub mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::atomic::{AtomicUsize, Ordering},
-        time::Duration,
-    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
 
@@ -2492,7 +2489,10 @@ mod tests {
             &mut async_cx,
         )
         .fuse();
-        let timeout = cx.background_executor.timer(Duration::from_secs(5)).fuse();
+        let timeout = cx
+            .background_executor
+            .timer(std::time::Duration::from_secs(5))
+            .fuse();
         futures::pin_mut!(startup, timeout);
 
         let result = futures::select! {

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -20,7 +20,7 @@ use project::{AgentId, Project};
 use remote::remote_client::Interactive;
 use serde::Deserialize;
 use std::path::PathBuf;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::{any::Any, cell::RefCell, collections::VecDeque};
@@ -194,6 +194,34 @@ impl AcpDebugLog {
         for sender in &state.subscribers {
             sender.try_send(message.clone()).log_err();
         }
+    }
+
+    fn trailing_stderr(&self) -> Option<String> {
+        let state = self.state.lock().ok()?;
+        let mut lines = state
+            .messages
+            .iter()
+            .rev()
+            .take_while(|message| matches!(&message.message, AcpDebugMessageContent::Stderr { .. }))
+            .filter_map(|message| match &message.message {
+                AcpDebugMessageContent::Stderr { line } if !line.is_empty() => Some(line.as_ref()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        if lines.is_empty() {
+            return None;
+        }
+
+        lines.reverse();
+        Some(lines.join("\n"))
+    }
+}
+
+fn exited_load_error_with_stderr(status: ExitStatus, debug_log: &AcpDebugLog) -> LoadError {
+    LoadError::Exited {
+        status,
+        stderr: debug_log.trailing_stderr().map(SharedString::from),
     }
 }
 
@@ -714,6 +742,7 @@ impl AcpConnection {
         log::trace!("Spawned (pid: {})", child.id());
 
         let sessions = Rc::new(RefCell::new(HashMap::default()));
+        let debug_log = AcpDebugLog::default();
 
         let (release_channel, version): (Option<&str>, String) = cx.update(|cx| {
             (
@@ -729,7 +758,6 @@ impl AcpConnection {
         // Set up the foreground dispatch channel for bridging Send handler
         // closures to the !Send foreground thread.
         let (dispatch_tx, dispatch_rx) = mpsc::unbounded::<ForegroundWork>();
-        let debug_log = AcpDebugLog::default();
 
         let incoming_lines = futures::io::BufReader::new(stdout).lines();
         let tapped_incoming = incoming_lines.inspect({
@@ -756,37 +784,6 @@ impl AcpConnection {
 
         let transport = Lines::new(tapped_outgoing, tapped_incoming);
 
-        // `connect_client_future` installs the production handler set and
-        // hands us back both the connection-future (to run on a background
-        // executor) and a oneshot receiver that produces the
-        // `ConnectionTo<Agent>` once the transport handshake is ready.
-        let (connection_tx, connection_rx) = futures::channel::oneshot::channel();
-        let connection_future =
-            connect_client_future("zed", transport, dispatch_tx.clone(), connection_tx);
-        let io_task = cx.background_spawn(async move {
-            if let Err(err) = connection_future.await {
-                log::error!("ACP connection error: {err}");
-            }
-        });
-
-        let connection: ConnectionTo<Agent> = connection_rx
-            .await
-            .context("Failed to receive ACP connection handle")?;
-
-        // Set up the foreground dispatch loop to process work items from handlers.
-        let dispatch_context = ClientContext {
-            sessions: sessions.clone(),
-            session_list: client_session_list.clone(),
-        };
-        let dispatch_task = cx.spawn({
-            let mut dispatch_rx = dispatch_rx;
-            async move |cx| {
-                while let Some(work) = dispatch_rx.next().await {
-                    work.run(cx, &dispatch_context);
-                }
-            }
-        });
-
         let stderr_task = cx.background_spawn({
             let debug_log = debug_log.clone();
             async move {
@@ -804,17 +801,53 @@ impl AcpConnection {
             }
         });
 
-        let wait_task = cx.spawn({
-            let sessions = sessions.clone();
-            let status_fut = child.status();
-            async move |cx| {
-                let status = status_fut.await?;
-                emit_load_error_to_all_sessions(&sessions, LoadError::Exited { status }, cx);
-                anyhow::Ok(())
+        // `connect_client_future` installs the production handler set and
+        // hands us back both the connection-future (to run on a background
+        // executor) and a oneshot receiver that produces the
+        // `ConnectionTo<Agent>` once the transport handshake is ready.
+        let (connection_tx, connection_rx) = futures::channel::oneshot::channel();
+        let connection_future =
+            connect_client_future("zed", transport, dispatch_tx.clone(), connection_tx);
+        let io_task = cx.background_spawn(async move {
+            if let Err(err) = connection_future.await {
+                log::error!("ACP connection error: {err}");
             }
         });
 
-        let response = into_foreground_future(
+        let connection_rx = async move {
+            connection_rx
+                .await
+                .context("Failed to receive ACP connection handle")
+        }
+        .boxed_local();
+        let status_fut = child.status().boxed_local();
+        let (connection, status_fut) = match futures::future::select(connection_rx, status_fut)
+            .await
+        {
+            futures::future::Either::Left((connection, status_fut)) => (connection?, status_fut),
+            futures::future::Either::Right((status, _connection_rx)) => match status {
+                Ok(status) => return Err(exited_load_error_with_stderr(status, &debug_log).into()),
+                Err(err) => {
+                    return Err(anyhow!("agent server exited before initialization: {err}"));
+                }
+            },
+        };
+
+        // Set up the foreground dispatch loop to process work items from handlers.
+        let dispatch_context = ClientContext {
+            sessions: sessions.clone(),
+            session_list: client_session_list.clone(),
+        };
+        let dispatch_task = cx.spawn({
+            let mut dispatch_rx = dispatch_rx;
+            async move |cx| {
+                while let Some(work) = dispatch_rx.next().await {
+                    work.run(cx, &dispatch_context);
+                }
+            }
+        });
+
+        let initialize_response = into_foreground_future(
             connection.send_request(
                 acp::InitializeRequest::new(acp::ProtocolVersion::V1)
                     .client_capabilities(
@@ -835,11 +868,37 @@ impl AcpConnection {
                     ),
             ),
         )
-        .await?;
+        .map(|response| response.map_err(anyhow::Error::from))
+        .boxed_local();
+        let (response, status_fut) = match futures::future::select(initialize_response, status_fut)
+            .await
+        {
+            futures::future::Either::Left((response, status_fut)) => (response?, status_fut),
+            futures::future::Either::Right((status, _initialize_response)) => match status {
+                Ok(status) => return Err(exited_load_error_with_stderr(status, &debug_log).into()),
+                Err(err) => {
+                    return Err(anyhow!("agent server exited before initialization: {err}"));
+                }
+            },
+        };
 
         if response.protocol_version < MINIMUM_SUPPORTED_VERSION {
             return Err(UnsupportedVersion.into());
         }
+
+        let wait_task = cx.spawn({
+            let sessions = sessions.clone();
+            let debug_log = debug_log.clone();
+            async move |cx| {
+                let status = status_fut.await?;
+                emit_load_error_to_all_sessions(
+                    &sessions,
+                    exited_load_error_with_stderr(status, &debug_log),
+                    cx,
+                );
+                anyhow::Ok(())
+            }
+        });
 
         let telemetry_id = response
             .agent_info
@@ -1881,7 +1940,10 @@ pub mod test_support {
                     while let Ok(status) = exit_rx.recv().await {
                         emit_load_error_to_all_sessions(
                             &connection.sessions,
-                            LoadError::Exited { status },
+                            LoadError::Exited {
+                                status,
+                                stderr: None,
+                            },
                             cx,
                         );
                     }
@@ -2242,7 +2304,10 @@ pub mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
 
     use super::*;
 
@@ -2371,6 +2436,82 @@ mod tests {
             ])
         );
         assert_eq!(task.label, "Login");
+    }
+
+    #[test]
+    fn trailing_stderr_only_uses_final_stderr_block() {
+        let debug_log = AcpDebugLog::default();
+        debug_log.record_line(AcpDebugMessageDirection::Stderr, "stale stderr");
+        debug_log.record_line(
+            AcpDebugMessageDirection::Incoming,
+            r#"{"method":"initialized"}"#,
+        );
+
+        assert_eq!(debug_log.trailing_stderr(), None);
+
+        debug_log.record_line(AcpDebugMessageDirection::Stderr, "recent stderr");
+        assert_eq!(
+            debug_log.trailing_stderr().as_deref(),
+            Some("recent stderr")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[gpui::test]
+    async fn startup_returns_error_when_agent_exits_before_initialization(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let store = settings::SettingsStore::test(cx);
+            cx.set_global(store);
+        });
+        cx.executor().allow_parking();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project = project::Project::example([temp_dir.path()], &mut cx.to_async()).await;
+        let agent_server_store =
+            project.read_with(cx, |project, _| project.agent_server_store().downgrade());
+        let command = AgentServerCommand {
+            path: "/bin/sh".into(),
+            args: vec![
+                "-c".into(),
+                r#"printf '%s\n' 'npm error code ETARGET' 'npm error notarget No matching version found for @agentclientprotocol/claude-agent-acp@0.32.0 with a date before 4/28/2026, 12:11:38 PM.' >&2; exit 1"#.into(),
+            ],
+            env: None,
+        };
+
+        let mut async_cx = cx.to_async();
+        let startup = AcpConnection::stdio(
+            AgentId::new("test-agent"),
+            project,
+            command,
+            agent_server_store,
+            None,
+            None,
+            HashMap::default(),
+            &mut async_cx,
+        )
+        .fuse();
+        let timeout = cx.background_executor.timer(Duration::from_secs(5)).fuse();
+        futures::pin_mut!(startup, timeout);
+
+        let result = futures::select! {
+            result = startup => result,
+            _ = timeout => panic!("timed out waiting for failed ACP startup"),
+        };
+
+        let Err(error) = result else {
+            panic!("expected ACP startup to fail");
+        };
+        let load_error = error
+            .downcast::<LoadError>()
+            .expect("startup failure should preserve the typed load error");
+        match load_error {
+            LoadError::Exited { status, .. } => {
+                assert!(!status.success(), "expected non-zero exit status");
+            }
+            error => panic!("expected exited load error, got: {error:?}"),
+        };
     }
 
     async fn connect_fake_agent(

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -2159,11 +2159,17 @@ impl ConversationView {
                 msg.into(),
                 Some(self.create_copy_button(msg.to_string()).into_any_element()),
             ),
-            LoadError::Exited { status } => (
-                "Failed to Launch",
-                format!("Server exited with status {status}").into(),
-                None,
-            ),
+            LoadError::Exited { status, stderr } => {
+                let mut message = format!("Server exited with status {status}");
+                if let Some(stderr) = stderr {
+                    message.push_str("\n");
+                    message.push_str(stderr);
+                };
+                let action_slot = stderr
+                    .is_some()
+                    .then(|| self.create_copy_button(message.clone()).into_any_element());
+                ("Failed to Launch", message.into(), action_slot)
+            }
             LoadError::Other(msg) => (
                 "Failed to Launch",
                 msg.into(),


### PR DESCRIPTION
Previously, we weren't waiting on the status future early enough so we
would just hang if we weren't able to start the agent process.

I also added the recent stderr logs in there to help the user debug the
issue, since it is likely relevant in these cases.

<img width="902" height="226" alt="image" src="https://github.com/user-attachments/assets/204e42ff-4c9b-49e7-8a6d-ecf7b022fbd0" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- acp: Improve error messages if the ACP agent fails to start.
