### PR TITLE
agent: Simplify tool schemas for enums

### DIFF
--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -94,10 +94,7 @@ pub struct EditFileToolInput {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EditFileMode {
-    /// Overwrite the file with new content (replacing any existing content).
-    /// If the file does not exist, it will be created.
     Write,
-    /// Make granular edits to an existing file
     Edit,
 }
 

--- a/crates/agent/src/tools/now_tool.rs
+++ b/crates/agent/src/tools/now_tool.rs
@@ -12,10 +12,8 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput};
 #[serde(rename_all = "snake_case")]
 #[schemars(inline)]
 pub enum Timezone {
-    /// Use UTC for the datetime.
     #[serde(alias = "UTC", alias = "Utc")]
     Utc,
-    /// Use local time for the datetime.
     #[serde(alias = "LOCAL", alias = "Local")]
     Local,
 }
@@ -24,7 +22,7 @@ pub enum Timezone {
 /// Only use this tool when the user specifically asks for it or the current task would benefit from knowing the current datetime.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct NowToolInput {
-    /// The timezone to use for the datetime.
+    /// The timezone to use for the datetime. Use `utc` for UTC, or `local` for the system's local time.
     timezone: Timezone,
 }
 


### PR DESCRIPTION
Previously schemars generated oneOf variants for these enums (because we added inline comments), making the schemas more complicated than they had to be.

E.g. `edit_file` `mode`

Before:
```json
{
  "mode": {
    "description": "The mode of operation on the file. Possible values:\n- 'write': Replace the entire contents of the file. If the file doesn't exist, it will be created. Requires 'content' field.\n- 'edit': Make granular edits to an existing file. Requires 'edits' field.\n\nWhen a file already exists or you just created it, prefer editing it as opposed to recreating it from scratch.",
    "oneOf": [
      {
        "description": "Overwrite the file with new content (replacing any existing content).\nIf the file does not exist, it will be created.",
        "type": "string",
        "const": "write"
      },
      {
        "description": "Make granular edits to an existing file",
        "type": "string",
        "const": "edit"
      }
    ]
  }
}
```

After:
```json
{
  "mode": {
    "description": "The mode of operation on the file. Possible values:\n- 'write': Replace the entire contents of the file. If the file doesn't exist, it will be created. Requires 'content' field.\n- 'edit': Make granular edits to an existing file. Requires 'edits' field.\n\nWhen a file already exists or you just created it, prefer editing it as opposed to recreating it from scratch.",
    "type": "string",
    "enum": ["write", "edit"]
  }
}
```

Release Notes:

- N/A
