### PR TITLE
eval_cli: Update eval_cli toolchain and pin harbor

### DIFF
--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -56,7 +56,6 @@ file_icons.workspace = true
 fs.workspace = true
 futures.workspace = true
 git.workspace = true
-git_ui.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 gpui_tokio.workspace = true
@@ -124,6 +123,7 @@ clock = { workspace = true, features = ["test-support"] }
 db = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 eval_utils.workspace = true
+git_ui.workspace = true
 gpui = { workspace = true, "features" = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 indoc.workspace = true

--- a/crates/eval_cli/.gitignore
+++ b/crates/eval_cli/.gitignore
@@ -1,3 +1,4 @@
 **/jobs
 **/*.egg-info
 **/__pycache__
+uv.lock

--- a/crates/eval_cli/Dockerfile
+++ b/crates/eval_cli/Dockerfile
@@ -7,12 +7,12 @@
 # Or use the helper script:
 #   crates/eval_cli/script/build-linux
 
-FROM rust:1.94.1 AS builder
+FROM rust:1.95.0 AS builder
 
 WORKDIR /app
 
     # Pre-install the toolchain specified in rust-toolchain.toml so it is cached.
-RUN rustup toolchain install 1.94.1 --profile minimal \
+RUN rustup toolchain install 1.95.0 --profile minimal \
     --component rustfmt --component clippy --component rust-analyzer --component rust-src \
     --target wasm32-wasip2 --target wasm32-unknown-unknown --target x86_64-unknown-linux-musl --target x86_64-unknown-linux-gnu
 

--- a/crates/eval_cli/zed_eval/pyproject.toml
+++ b/crates/eval_cli/zed_eval/pyproject.toml
@@ -3,7 +3,7 @@ name = "zed-eval"
 version = "0.1.0"
 description = "Harbor agent wrapper for Zed's eval-cli"
 requires-python = ">=3.12"
-dependencies = ["harbor"]
+dependencies = ["harbor==0.6.4"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
Move `git_ui` to `agent_ui` test dependencies
and bump the eval CLI Docker image to Rust 1.95.0 while pinning
the Python `harbor` dependency to 0.6.4

Release Notes:

- N/A