### PR TITLE
Add GPT-5.5 and GPT-5.5 pro to models docs

### DIFF
--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -35,11 +35,11 @@ Zed's plans offer hosted versions of major LLMs with higher rate limits than dir
 |                        | Anthropic | Output              | $5.00                        | $5.50                   |
 |                        | Anthropic | Input - Cache Write | $1.25                        | $1.375                  |
 |                        | Anthropic | Input - Cache Read  | $0.10                        | $0.11                   |
-| GPT-5.5 pro            | OpenAI    | Input               | $60.00                       | $66.00                  |
-|                        | OpenAI    | Output              | $360.00                      | $396.00                 |
+| GPT-5.5 pro            | OpenAI    | Input               | $30.00                       | $33.00                  |
+|                        | OpenAI    | Output              | $180.00                      | $198.00                 |
 | GPT-5.5                | OpenAI    | Input               | $5.00                        | $5.50                   |
 |                        | OpenAI    | Output              | $30.00                       | $33.00                  |
-|                        | OpenAI    | Cached Input        | $0.05                        | $0.055                  |
+|                        | OpenAI    | Cached Input        | $0.50                        | $0.55                   |
 | GPT-5.4 pro            | OpenAI    | Input               | $30.00                       | $33.00                  |
 |                        | OpenAI    | Output              | $180.00                      | $198.00                 |
 | GPT-5.4                | OpenAI    | Input               | $2.50                        | $2.75                   |

--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -1,13 +1,13 @@
 ---
 title: AI Models and Pricing - Zed
-description: AI models available via Zed Pro including Claude, GPT-5.4, Gemini 3.1 Pro, and Grok. Pricing, context windows, and tool call support.
+description: AI models available via Zed Pro including Claude, GPT-5.5, Gemini 3.1 Pro, and Grok. Pricing, context windows, and tool call support.
 ---
 
 # Models
 
 Zed's plans offer hosted versions of major LLMs with higher rate limits than direct API access. Model availability is updated regularly. To use your own API keys instead, see [LLM Providers](./llm-providers.md). For general setup, see [Configuration](./configuration.md).
 
-> **Note:** Claude Opus models and GPT-5.4 pro are not available on the [Student plan](./plans-and-usage.md#student).
+> **Note:** Claude Opus models, GPT-5.4 pro, and GPT-5.5 pro are not available on the [Student plan](./plans-and-usage.md#student).
 
 | Model                  | Provider  | Token Type          | Provider Price per 1M tokens | Zed Price per 1M tokens |
 | ---------------------- | --------- | ------------------- | ---------------------------- | ----------------------- |
@@ -35,6 +35,11 @@ Zed's plans offer hosted versions of major LLMs with higher rate limits than dir
 |                        | Anthropic | Output              | $5.00                        | $5.50                   |
 |                        | Anthropic | Input - Cache Write | $1.25                        | $1.375                  |
 |                        | Anthropic | Input - Cache Read  | $0.10                        | $0.11                   |
+| GPT-5.5 pro            | OpenAI    | Input               | $60.00                       | $66.00                  |
+|                        | OpenAI    | Output              | $360.00                      | $396.00                 |
+| GPT-5.5                | OpenAI    | Input               | $5.00                        | $5.50                   |
+|                        | OpenAI    | Output              | $30.00                       | $33.00                  |
+|                        | OpenAI    | Cached Input        | $0.05                        | $0.055                  |
 | GPT-5.4 pro            | OpenAI    | Input               | $30.00                       | $33.00                  |
 |                        | OpenAI    | Output              | $180.00                      | $198.00                 |
 | GPT-5.4                | OpenAI    | Input               | $2.50                        | $2.75                   |
@@ -102,6 +107,8 @@ A context window is the maximum span of text and code an LLM can consider at onc
 | Claude Sonnet 4.5           | Anthropic | 200k                      |
 | Claude Sonnet 4.6           | Anthropic | 1M                        |
 | Claude Haiku 4.5            | Anthropic | 200k                      |
+| GPT-5.5 pro                 | OpenAI    | 1M                        |
+| GPT-5.5                     | OpenAI    | 1M                        |
 | GPT-5.4 pro                 | OpenAI    | 400k                      |
 | GPT-5.4                     | OpenAI    | 400k                      |
 | GPT-5.3-Codex               | OpenAI    | 400k                      |

--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -107,8 +107,8 @@ A context window is the maximum span of text and code an LLM can consider at onc
 | Claude Sonnet 4.5           | Anthropic | 200k                      |
 | Claude Sonnet 4.6           | Anthropic | 1M                        |
 | Claude Haiku 4.5            | Anthropic | 200k                      |
-| GPT-5.5 pro                 | OpenAI    | 1M                        |
-| GPT-5.5                     | OpenAI    | 1M                        |
+| GPT-5.5 pro                 | OpenAI    | 400k                      |
+| GPT-5.5                     | OpenAI    | 400k                      |
 | GPT-5.4 pro                 | OpenAI    | 400k                      |
 | GPT-5.4                     | OpenAI    | 400k                      |
 | GPT-5.3-Codex               | OpenAI    | 400k                      |


### PR DESCRIPTION
Adds GPT-5.5 and GPT-5.5 pro to the models docs page, following the same structure as #53344.

Release Notes:

- N/A