### PR TITLE
agent: Allow model to provide stringified `timezone` in `now` tool

### DIFF
--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -30,6 +30,33 @@ mod web_search_tool;
 
 use crate::AgentTool;
 use language_model::{LanguageModelRequestTool, LanguageModelToolSchemaFormat};
+use serde::{
+    Deserialize, Deserializer,
+    de::{DeserializeOwned, Error as _},
+};
+
+/// Deserialize a value that may have been provided as a JSON-encoded string
+/// instead of the structured value. Some models occasionally stringify nested
+/// arguments, so we accept either form.
+pub(crate) fn deserialize_maybe_stringified<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ValueOrJsonString<T> {
+        Value(T),
+        String(String),
+    }
+
+    match ValueOrJsonString::<T>::deserialize(deserializer)? {
+        ValueOrJsonString::Value(value) => Ok(value),
+        ValueOrJsonString::String(string) => serde_json::from_str::<T>(&string).map_err(|error| {
+            D::Error::custom(format!("failed to parse stringified value: {error}"))
+        }),
+    }
+}
 
 pub use apply_code_action_tool::*;
 pub use context_server_registry::*;

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -2,6 +2,7 @@ mod reindent;
 mod streaming_fuzzy_matcher;
 mod streaming_parser;
 
+use super::deserialize_maybe_stringified;
 use super::restore_file_from_disk_tool::RestoreFileFromDiskTool;
 use super::save_file_tool::SaveFileTool;
 use crate::ToolInputPayload;
@@ -24,10 +25,7 @@ use language_model::LanguageModelToolResultContent;
 use project::lsp_store::{FormatTrigger, LspFormatTarget};
 use project::{AgentLocation, Project, ProjectPath};
 use schemars::JsonSchema;
-use serde::{
-    Deserialize, Deserializer, Serialize,
-    de::{DeserializeOwned, Error as _},
-};
+use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -132,26 +130,6 @@ pub struct PartialEdit {
     pub old_text: Option<String>,
     #[serde(default)]
     pub new_text: Option<String>,
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum ValueOrJsonString<T> {
-    Value(T),
-    String(String),
-}
-
-fn deserialize_maybe_stringified<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-where
-    T: DeserializeOwned,
-    D: Deserializer<'de>,
-{
-    match ValueOrJsonString::<T>::deserialize(deserializer)? {
-        ValueOrJsonString::Value(value) => Ok(value),
-        ValueOrJsonString::String(string) => serde_json::from_str::<T>(&string).map_err(|error| {
-            D::Error::custom(format!("failed to parse stringified value: {error}"))
-        }),
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/agent/src/tools/now_tool.rs
+++ b/crates/agent/src/tools/now_tool.rs
@@ -6,6 +6,7 @@ use gpui::{App, SharedString, Task};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::deserialize_maybe_stringified;
 use crate::{AgentTool, ToolCallEventStream, ToolInput};
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -23,6 +24,7 @@ pub enum Timezone {
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct NowToolInput {
     /// The timezone to use for the datetime. Use `utc` for UTC, or `local` for the system's local time.
+    #[serde(deserialize_with = "deserialize_maybe_stringified")]
     timezone: Timezone,
 }
 
@@ -60,5 +62,30 @@ impl AgentTool for NowTool {
             };
             Ok(format!("The current datetime is {now}."))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+    use serde_json::json;
+
+    #[gpui::test]
+    async fn test_stringified_timezone_input_succeeds(cx: &mut TestAppContext) {
+        let tool = Arc::new(NowTool);
+        let (mut sender, input) = ToolInput::<NowToolInput>::test();
+        let (event_stream, _receiver) = ToolCallEventStream::test();
+        let task = cx.update(|cx| tool.clone().run(input, event_stream, cx));
+
+        sender.send_full(json!({
+            "timezone": "\"utc\""
+        }));
+
+        let result = task.await.unwrap();
+        assert!(
+            result.starts_with("The current datetime is "),
+            "unexpected output: {result}"
+        );
     }
 }


### PR DESCRIPTION
See https://github.com/zed-industries/zed/issues/55186#issuecomment-4376114420

I think the recent changes to the tool schema in #55763 will make this more unlikely, but does not hurt to allow the model to provide `"utc"`.

Release Notes:

- N/A
