### PR TITLE
Fix standalone modifier sequences not being flushed after timeout

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -261,6 +261,13 @@ impl Keystroke {
         }
         self
     }
+
+    /// Returns whether the key itself is a modifier
+    pub fn is_modifier_key(&self) -> bool {
+         matches!(self.key.as_str(),
+             "shift" | "control" | "alt" | "platform" | "function"
+        )
+    }
 }
 
 impl KeybindingKeystroke {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5922,3 +5922,116 @@ pub fn outline(
         border_style,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        App, Context, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding, Render,
+        TestApp, Window, div
+    };
+    use std::time::Duration;
+
+    actions!(window_test, [TestAction]);
+
+    struct TestView {
+        focus_handle: FocusHandle,
+        action_count: usize,
+    }
+
+    impl TestView {
+        fn new(_window: &mut Window, cx: &mut Context<Self>) -> Self {
+            Self {
+                focus_handle: cx.focus_handle(),
+                action_count: 0,
+            }
+        }
+    }
+
+    impl Focusable for TestView {
+        fn focus_handle(&self, _cx: &App) -> FocusHandle {
+            self.focus_handle.clone()
+        }
+    }
+
+    impl Render for TestView {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div().key_context("test")
+                .track_focus(&self.focus_handle)
+                .on_action(cx.listener(|this: &mut TestView, _: &TestAction, _, _| {
+                    this.action_count += 1;
+                }))
+        }
+    }
+
+    #[test]
+    fn test_standalone_modifier_sequences_timeout(){
+        let mut app = TestApp::new();
+        app.update(|cx| {
+            cx.bind_keys(vec![KeyBinding::new(
+                "shift shift",
+                TestAction,
+                Some("test"),
+            )]);
+        });
+        let mut window = app.open_window(TestView::new);
+        window.update(|view, window, cx| {
+            window.focus(&view.focus_handle(cx), cx);
+        });
+        window.simulate_keystroke("shift");
+        window.update(|_, window, _| {
+            let keystroke = window
+                .pending_input_keystrokes()
+                .expect("standalone modifier should start a pending sequence");
+            assert_eq!(
+                keystroke.iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+                vec!["shift"]);
+        });
+        // Advance time beyond the key sequence timeout to trigger flush
+        app.advance_clock(Duration::from_secs(2));
+        app.run_until_parked();
+
+        window.update(|view, window, _| {
+            assert!(
+                !window.has_pending_keystrokes(),
+                "pending standalone modifier sequence should be flushed when the timeout fires"
+            );
+            assert_eq!(
+                view.action_count, 0,
+                "a single shift should not dispatch the two-stroke binding"
+            );
+        });
+    }
+
+    #[test]
+    fn test_standalone_modifier_sequence_dispatches_before_timeout() {
+        let mut app = TestApp::new();
+        app.update(|cx| {
+            cx.bind_keys(vec![KeyBinding::new(
+                "shift shift",
+                TestAction,
+                Some("test"),
+            )]);
+        });
+        let mut window = app.open_window(TestView::new);
+        window.update(|view, window, cx| {
+            window.focus(&view.focus_handle(cx), cx);
+        });
+        window.simulate_keystroke("shift");
+        window.update(|_, window, _| {
+            assert!(window.has_pending_keystrokes());
+        });
+        window.simulate_keystroke("shift");
+        window.update(|view, window, _| {
+            assert!(
+                !window.has_pending_keystrokes(),
+                "matched binding should clear pending input"
+            );
+            assert_eq!(
+                view.action_count, 1,
+                "second shift should dispatch the shift-shift binding"
+            );
+        });
+    }
+}

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4523,9 +4523,10 @@ impl Window {
                     accepts
                 });
 
+            let standalone_modifier =
+                matches!(currently_pending.keystrokes.as_slice(), [keystroke] if keystroke.is_modifier_key());
             currently_pending.needs_timeout |=
-                match_result.pending_has_binding || text_input_requires_timeout;
-
+                match_result.pending_has_binding || text_input_requires_timeout || standalone_modifier;
             if currently_pending.needs_timeout {
                 currently_pending.timer = Some(self.spawn(cx, async move |cx| {
                     cx.background_executor.timer(Duration::from_secs(1)).await;


### PR DESCRIPTION
### Summary
Standalone modifier keys were not timing out, causing them to linger in pending state and incorrectly form multi-stroke sequences (e.g. triggering `shift shift` after IME switching).

### Details

Standalone modifier keystrokes (e.g. `shift`) were not participating in the key sequence timeout lifecycle, causing them to remain in the pending input state indefinitely.

In Chinese IME, `shift` is commonly used to toggle between EN and ZH modes.
A typical workflow is:
1. Tap `shift` to switch to Chinese input
2. Type some Chinese text
3. Tap `shift` again to switch back to English

However, due to the missing timeout behavior, the first `shift` remains in the pending sequence.
As a result, the second `shift` is interpreted as `shift shift`, which incorrectly triggers the command palette.

### Reproduction
1. Use the following keymap, or enable the JetBrains keymap:
```json
[
  {
    "bindings": {
      "shift shift": "command_palette::Toggle",
    },
  }
]
```

2. Press the `shift` key twice with an interval greater than the timeout (1 second)
3. The command palette is toggled (unexpected; it should not be triggered)

### Fix

If the pending input sequence contains only a standalone modifier, mark it as requiring a timeout, so it is flushed after the timeout.

### Test
Tests are added to cover:
- timeout flushing of standalone modifiers
- successful dispatch when the sequence completes before timeout


---
Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

~~Closes #ISSUE~~

Release Notes:

- Fixed standalone modifier keys no longer linger in the pending input state indefinitely. This prevents them from incorrectly forming multi-stroke shortcuts after long intervals