### PR TITLE
acp: Show running agent version in configuration

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -49,6 +49,10 @@ pub trait AgentConnection {
 
     fn telemetry_id(&self) -> SharedString;
 
+    fn agent_version(&self) -> Option<SharedString> {
+        None
+    }
+
     fn new_session(
         self: Rc<Self>,
         project: Entity<Project>,

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -413,6 +413,7 @@ fn enqueue_notification<Notif>(
 pub struct AcpConnection {
     id: AgentId,
     telemetry_id: SharedString,
+    agent_version: Option<SharedString>,
     connection: ConnectionTo<Agent>,
     sessions: Rc<RefCell<HashMap<acp::SessionId, AcpSession>>>,
     pending_sessions: Rc<RefCell<HashMap<acp::SessionId, PendingAcpSession>>>,
@@ -900,12 +901,15 @@ impl AcpConnection {
             }
         });
 
-        let telemetry_id = response
-            .agent_info
+        let agent_info = response.agent_info;
+        let telemetry_id = agent_info
+            .as_ref()
             // Use the one the agent provides if we have one
-            .map(|info| info.name.into())
+            .map(|info| SharedString::from(info.name.clone()))
             // Otherwise, just use the name
             .unwrap_or_else(|| agent_id.0.clone());
+        let agent_version = agent_info
+            .and_then(|info| (!info.version.is_empty()).then(|| SharedString::from(info.version)));
 
         let session_list = if response
             .agent_capabilities
@@ -945,6 +949,7 @@ impl AcpConnection {
             agent_server_store,
             connection,
             telemetry_id,
+            agent_version,
             sessions,
             pending_sessions: Rc::new(RefCell::new(HashMap::default())),
             agent_capabilities: response.agent_capabilities,
@@ -978,6 +983,7 @@ impl AcpConnection {
         Self {
             id: AgentId::new("test"),
             telemetry_id: "test".into(),
+            agent_version: None,
             connection,
             sessions,
             pending_sessions: Rc::new(RefCell::new(HashMap::default())),
@@ -1317,6 +1323,10 @@ impl AgentConnection for AcpConnection {
 
     fn telemetry_id(&self) -> SharedString {
         self.telemetry_id.clone()
+    }
+
+    fn agent_version(&self) -> Option<SharedString> {
+        self.agent_version.clone()
     }
 
     fn new_session(
@@ -1982,6 +1992,10 @@ pub mod test_support {
 
         fn telemetry_id(&self) -> SharedString {
             self.inner.telemetry_id()
+        }
+
+        fn agent_version(&self) -> Option<SharedString> {
+            self.inner.agent_version()
         }
 
         fn new_session(

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1135,10 +1135,13 @@ impl AgentConfiguration {
             id: agent_server_name.clone(),
         };
 
-        let connection_status = self
-            .agent_connection_store
-            .read(cx)
-            .connection_status(&agent, cx);
+        let (connection_status, running_version) = {
+            let connection_store = self.agent_connection_store.read(cx);
+            (
+                connection_store.connection_status(&agent, cx),
+                connection_store.agent_version(&agent, cx),
+            )
+        };
 
         let restart_button = matches!(
             connection_status,
@@ -1252,6 +1255,7 @@ impl AgentConfiguration {
 
         AiSettingItem::new(id, display_name, status, source_kind)
             .icon(icon)
+            .when_some(running_version, |this, version| this.detail_label(version))
             .when_some(restart_button, |this, button| this.action(button))
             .when_some(uninstall_button, |this, button| this.action(button))
     }

--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -97,6 +97,13 @@ impl AgentConnectionStore {
             .unwrap_or(AgentConnectionStatus::Disconnected)
     }
 
+    pub fn agent_version(&self, key: &Agent, cx: &App) -> Option<SharedString> {
+        match self.entries.get(key)?.read(cx) {
+            AgentConnectionEntry::Connected(state) => state.connection.agent_version(),
+            AgentConnectionEntry::Connecting { .. } | AgentConnectionEntry::Error { .. } => None,
+        }
+    }
+
     pub fn active_acp_connections(&self, cx: &App) -> Vec<ActiveAcpConnection> {
         self.entries
             .values()


### PR DESCRIPTION
Store the ACP agent version from agent_info and expose it
through AgentConnection so the configuration UI can display it
for connected agents.

Helpful when debugging to know which version is currently running.

<img width="214" height="67" alt="image" src="https://github.com/user-attachments/assets/4f4c0e3c-a621-48fb-98d4-67329db1e62a" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- acp: Show running agent version in the External Agent settings
