### PR TITLE
workspace: Prompt to save unsaved buffers when opening a new project

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -94,6 +94,10 @@ pub enum SaveIntent {
     SaveAs,
     /// prompt "you have unsaved changes" before writing
     Close,
+    /// like `Close`, but skips hot-exit serialization; used when the workspace
+    /// is being replaced by a new project, where session-DB content would not
+    /// be restored under the new workspace id
+    CloseReplace,
     /// write all dirty files, don't prompt on conflict
     Overwrite,
     /// skip all save-related behavior
@@ -2371,7 +2375,7 @@ impl Pane {
                 }
             }
         } else if is_dirty && (can_save || can_save_as) {
-            if save_intent == SaveIntent::Close {
+            if matches!(save_intent, SaveIntent::Close | SaveIntent::CloseReplace) {
                 let will_autosave = cx.update(|_window, cx| {
                     item.can_autosave(cx)
                         && item.workspace_settings(cx).autosave.should_save_on_close()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3305,9 +3305,14 @@ impl Workspace {
                 }
             }
 
+            let save_intent = if close_intent == CloseIntent::ReplaceWindow {
+                SaveIntent::CloseReplace
+            } else {
+                SaveIntent::Close
+            };
             let save_result = this
                 .update_in(cx, |this, window, cx| {
-                    this.save_all_internal(SaveIntent::Close, window, cx)
+                    this.save_all_internal(save_intent, window, cx)
                 })?
                 .await;
 
@@ -3507,6 +3512,10 @@ impl Workspace {
             } else {
                 dirty_items
             };
+
+            if save_intent == SaveIntent::CloseReplace && !dirty_items.is_empty() {
+                workspace.update(cx, |_, cx| cx.emit(Event::Activate))?;
+            }
 
             for (pane, item) in dirty_items {
                 let (singleton, project_entry_ids) = cx.update(|_, cx| {
@@ -11507,6 +11516,47 @@ mod tests {
         let task = workspace.update_in(cx, |w, window, cx| {
             w.prepare_to_close(CloseIntent::CloseWindow, window, cx)
         });
+        assert!(task.await.unwrap());
+    }
+
+    // Regression test for https://github.com/zed-industries/zed/issues/55726:
+    // when the workspace is being *replaced* (not closed/quit), dirty serializable
+    // items must still be prompted rather than silently hot-exit'd.
+    #[gpui::test]
+    async fn test_replace_window_prompts_for_serializable_dirty_items(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            register_serializable_item::<TestItem>(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item = cx.new(|cx| {
+            TestItem::new(cx)
+                .with_dirty(true)
+                .with_serialize(|| Some(Task::ready(Ok(()))))
+        });
+        workspace.update_in(cx, |w, window, cx| {
+            w.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        let task = workspace.update_in(cx, |w, window, cx| {
+            w.prepare_to_close(CloseIntent::ReplaceWindow, window, cx)
+        });
+        cx.executor().run_until_parked();
+
+        // Unlike CloseWindow (which uses hot-exit), ReplaceWindow must prompt
+        // because the new workspace will have a different id and the serialized
+        // content would not be restored.
+        assert!(
+            cx.has_pending_prompt(),
+            "expected a save prompt when replacing workspace with serializable dirty item"
+        );
+        cx.simulate_prompt_answer("Don't Save");
         assert!(task.await.unwrap());
     }
 


### PR DESCRIPTION
## Context

Closes #55726

When Zed starts with an untitled buffer, the user types content, then opens a file or project, the typed content disappears silently with no save prompt.

**Root cause:** `prepare_to_close(CloseIntent::ReplaceWindow)` called `save_all_internal(SaveIntent::Close)`. That function has a hot-exit path: for each dirty item it first attempts to serialize the content into the session DB.
For a real `Editor` with `restore_unsaved_buffers = true` (the default), this serialization succeeds and the item is removed from the pending list, so no "Save / Don't Save / Cancel" prompt is ever shown.

Hot-exit is intentional for `CloseWindow` and `Quit`, the same workspace id is restored on next launch, so the content comes back. For `ReplaceWindow` the workspace is replaced with a brand-new id, so the serialized content is never
restored and is effectively lost.

**Fix:** add `SaveIntent::CloseReplace`, used only for `ReplaceWindow`. It bypasses the hot-exit serialization block in `save_all_internal`, so all dirty items fall through to the per-item `save_item` prompt ("Save / Don't Save /
Cancel") unchanged. `Event::Activate` is also emitted before the prompt loop so the workspace is brought into focus first (matching existing `SaveIntent::Close` behaviour).

Video of the manual test below :

[Screencast from 2026-05-06 02-19-09.webm](https://github.com/user-attachments/assets/318798c4-78ce-4610-b74d-20a2c7762954)

## How to Review

- **`crates/workspace/src/pane.rs`** : 
new `SaveIntent::CloseReplace` variant (after `Close`); `save_item` prompt condition extended to include it so the per-item "Save / Don't Save / Cancel" dialog fires.

- **`crates/workspace/src/workspace.rs`** : 
`prepare_to_close` now selects `SaveIntent::CloseReplace` when `close_intent == CloseIntent::ReplaceWindow`
  `save_all_internal` emits `Event::Activate` before the `save_item` loop for `CloseReplace` (the hot-exit block already handled this for `SaveIntent::Close`)
regression test `test_replace_window_prompts_for_serializable_dirty_items` exercises the exact path the bug was on a serializable dirty item plus `CloseIntent::ReplaceWindow`.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed unsaved content in untitled buffers being silently discarded when opening a new project

