### PR TITLE
eval_cli: Set global filesystem in eval CLI init

### DIFF
--- a/crates/eval_cli/src/headless.rs
+++ b/crates/eval_cli/src/headless.rs
@@ -70,6 +70,7 @@ pub fn init(cx: &mut App) -> Arc<AgentCliAppState> {
         git_binary_path,
         cx.background_executor().clone(),
     ));
+    <dyn fs::Fs>::set_global(fs.clone(), cx);
 
     let mut languages = LanguageRegistry::new(cx.background_executor().clone());
     languages.set_language_server_download_dir(paths::languages_dir().clone());


### PR DESCRIPTION
Some dependency started requiring this, so fixing some runtime errors.

Release Notes:

- N/A
