### PR TITLE
helix: Add keybinding for tab switcher toggle

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -527,6 +527,7 @@
       "space w d": "pane::SplitDown", // not a helix default
 
       // Space mode
+      "space b": "tab_switcher::ToggleAll",
       "space f": "file_finder::Toggle",
       "space k": "editor::Hover",
       "space s": "outline::Toggle",


### PR DESCRIPTION
Add support for Helix' buffer picker that is opened via `space b` by default.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability



Closes https://github.com/zed-industries/zed/issues/55867
