### PR TITLE
open_ai: Fix parsing response if token use info is unspecified

### DIFF
--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -429,10 +429,13 @@ impl OpenAiEventMapper {
         event: ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let mut events = Vec::new();
-        if let Some(usage) = event.usage {
+        if let Some(usage) = event.usage
+            && let Some(prompt_tokens) = usage.prompt_tokens
+            && let Some(completion_tokens) = usage.completion_tokens
+        {
             events.push(Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
-                input_tokens: usage.prompt_tokens,
-                output_tokens: usage.completion_tokens,
+                input_tokens: prompt_tokens,
+                output_tokens: completion_tokens,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
             })));

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -519,9 +519,9 @@ pub struct FunctionChunk {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Usage {
-    pub prompt_tokens: u64,
-    pub completion_tokens: u64,
-    pub total_tokens: u64,
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
I tried to use google cloud to test gemma4 and compare with the result of ollama. it had response such as

```json
{"choices":[{"delta":{"content":"Hello","reasoning_content":null,"role":null,"tool_calls":null},"finish_reason":null,"index":0,"logprobs":null,"matched_stop":null}],"created":1778081610,"id":"KV_7adz7Ov20xN8Py-angQ8","model":"google/gemma-4-26b-a4b-it-maas","object":"chat.completion.chunk","usage":{"extra_properties":{"google":{"traffic_type":"ON_DEMAND"}}}}
```

(notice that, while "usage" is present, it does not have any of the usual value)

Eventually, I had some more issue when parsing the response (unrelated to this), so I decided to try the google ai endpoint, with its own set of issue.

Those simple change should only loosen the accepted format, so no new compatibility error are expected (but I haven’t tried with other provider)

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) (no change)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Improved open-ai compatibility when token usage info is absent
