### PR TITLE
google_ai: Make streamed full thinking text be properly recognized

### DIFF
--- a/crates/google_ai/src/completion.rs
+++ b/crates/google_ai/src/completion.rs
@@ -27,7 +27,10 @@ pub fn into_google(
             .flat_map(|content| match content {
                 MessageContent::Text(text) => {
                     if !text.is_empty() {
-                        vec![Part::TextPart(TextPart { text })]
+                        vec![Part::TextPart(TextPart {
+                            text,
+                            thought: false,
+                        })]
                     } else {
                         vec![]
                     }
@@ -37,7 +40,7 @@ pub fn into_google(
                     signature: Some(signature),
                 } => {
                     if !signature.is_empty() {
-                        vec![Part::ThoughtPart(crate::ThoughtPart {
+                        vec![Part::ThoughtSignaturePart(crate::ThoughtSignaturePart {
                             thought: true,
                             thought_signature: signature,
                         })]
@@ -45,8 +48,18 @@ pub fn into_google(
                         vec![]
                     }
                 }
-                MessageContent::Thinking { .. } => {
-                    vec![]
+                MessageContent::Thinking {
+                    text,
+                    signature: None,
+                } => {
+                    if !text.is_empty() {
+                        vec![Part::TextPart(TextPart {
+                            text,
+                            thought: true,
+                        })]
+                    } else {
+                        vec![]
+                    }
                 }
                 MessageContent::RedactedThinking(_) => vec![],
                 MessageContent::Image(image) => {
@@ -266,7 +279,14 @@ impl GoogleEventMapper {
                     .into_iter()
                     .for_each(|part| match part {
                         Part::TextPart(text_part) => {
-                            events.push(Ok(LanguageModelCompletionEvent::Text(text_part.text)))
+                            if text_part.thought {
+                                events.push(Ok(LanguageModelCompletionEvent::Thinking {
+                                    text: text_part.text,
+                                    signature: None,
+                                }))
+                            } else {
+                                events.push(Ok(LanguageModelCompletionEvent::Text(text_part.text)))
+                            }
                         }
                         Part::InlineDataPart(_) => {}
                         Part::FunctionCallPart(function_call_part) => {
@@ -294,7 +314,7 @@ impl GoogleEventMapper {
                             )));
                         }
                         Part::FunctionResponsePart(_) => {}
-                        Part::ThoughtPart(part) => {
+                        Part::ThoughtSignaturePart(part) => {
                             events.push(Ok(LanguageModelCompletionEvent::Thinking {
                                 text: "(Encrypted thought)".to_string(), // TODO: Can we populate this from thought summaries?
                                 signature: Some(part.thought_signature),

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -170,13 +170,15 @@ pub enum Part {
     InlineDataPart(InlineDataPart),
     FunctionCallPart(FunctionCallPart),
     FunctionResponsePart(FunctionResponsePart),
-    ThoughtPart(ThoughtPart),
+    ThoughtSignaturePart(ThoughtSignaturePart),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TextPart {
     pub text: String,
+    #[serde(default)]
+    pub thought: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -210,7 +212,7 @@ pub struct FunctionResponsePart {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ThoughtPart {
+pub struct ThoughtSignaturePart {
     pub thought: bool,
     pub thought_signature: String,
 }


### PR DESCRIPTION
When using gemma4, google ai does not hide the thought process, and transmit it as text with the "thought" value set to true (as for "encrypted" thought). This fix it.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) (no UI change)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable (no change expected)

Release Notes:

- Google AI: Fixed complete though process parsing, such as for Gemma4