### PR TITLE
vim: Keep cursor position when using `gw`

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -255,8 +255,8 @@
       "g ~": "vim::PushOppositeCase",
       "g ?": "vim::PushRot13",
       // "g ?": "vim::PushRot47",
-      "g w": "vim::PushRewrap",
-      "g q": "vim::PushRewrap",
+      "g w": ["vim::PushRewrap", { "keep_cursor": true }],
+      "g q": ["vim::PushRewrap", { "keep_cursor": false }],
       "insert": "vim::InsertBefore",
       "] d": "editor::GoToDiagnostic",
       "[ d": "editor::GoToPreviousDiagnostic",
@@ -321,8 +321,8 @@
       "g shift-r": ["vim::Paste", { "preserve_clipboard": true }],
       "g c": "vim::ToggleComments",
       "g b": "vim::ToggleBlockComments",
-      "g q": "vim::Rewrap",
-      "g w": "vim::Rewrap",
+      "g q": ["vim::Rewrap", { "keep_cursor": false }],
+      "g w": ["vim::Rewrap", { "keep_cursor": true }],
       "g ?": "vim::ConvertToRot13",
       // "g ?": "vim::ConvertToRot47",
       "\"": "vim::PushRegister",
@@ -547,7 +547,7 @@
       "]": ["vim::PushHelixNext", { "around": true }],
       "[": ["vim::PushHelixPrevious", { "around": true }],
       "ctrl-s": "editor::SaveLocation",
-      "g q": "vim::PushRewrap",
+      "g q": ["vim::PushRewrap", { "keep_cursor": false }],
     },
   },
   {
@@ -943,7 +943,7 @@
       "space w j": "workspace::ActivatePaneDown",
       "space w k": "workspace::ActivatePaneUp",
       "space w l": "workspace::ActivatePaneRight",
-	  "space w q": "pane::CloseActiveItem",
+      "space w q": "pane::CloseActiveItem",
     },
   },
   {
@@ -1056,8 +1056,8 @@
       "ctrl-d": "git_graph::ScrollDown",
       "ctrl-u": "git_graph::ScrollUp",
       "shift-g": "menu::SelectLast",
-      "g g": "menu::SelectFirst"
-    }
+      "g g": "menu::SelectFirst",
+    },
   },
   {
     "context": "GitPanel && ChangesList && !GitBranchSelector",

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1735,15 +1735,22 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         )
         .range(wrap_count),
         VimCommand::new(("j", "oin"), JoinLines).range(select_range),
-        VimCommand::new(("reflow", ""), Rewrap { line_length: None })
-            .range(select_range)
-            .args(|_action, args| {
-                args.parse::<usize>().map_or(None, |length| {
-                    Some(Box::new(Rewrap {
-                        line_length: Some(length),
-                    }))
-                })
-            }),
+        VimCommand::new(
+            ("reflow", ""),
+            Rewrap {
+                line_length: None,
+                keep_cursor: false,
+            },
+        )
+        .range(select_range)
+        .args(|_action, args| {
+            args.parse::<usize>().map_or(None, |length| {
+                Some(Box::new(Rewrap {
+                    line_length: Some(length),
+                    keep_cursor: false,
+                }))
+            })
+        }),
         VimCommand::new(("fo", "ld"), editor::actions::FoldSelectedRanges).range(act_on_range),
         VimCommand::new(("foldo", "pen"), editor::actions::UnfoldLines)
             .bang(editor::actions::UnfoldRecursive)

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -403,7 +403,9 @@ impl Vim {
                 window,
                 cx,
             ),
-            Some(Operator::Rewrap) => self.rewrap_motion(motion, times, forced_motion, window, cx),
+            Some(Operator::Rewrap { keep_cursor }) => {
+                self.rewrap_motion(motion, times, keep_cursor, forced_motion, window, cx)
+            }
             Some(Operator::Outdent) => self.indent_motion(
                 motion,
                 times,
@@ -510,7 +512,9 @@ impl Vim {
                 Some(Operator::ShellCommand) => {
                     self.shell_command_object(object, around, window, cx);
                 }
-                Some(Operator::Rewrap) => self.rewrap_object(object, around, times, window, cx),
+                Some(Operator::Rewrap { keep_cursor }) => {
+                    self.rewrap_object(object, around, keep_cursor, times, window, cx)
+                }
                 Some(Operator::Lowercase) => {
                     self.convert_object(object, around, ConvertTarget::LowerCase, times, window, cx)
                 }
@@ -2118,6 +2122,57 @@ mod test {
         cx.shared_state()
             .await
             .assert_eq("th th\nth th\nth th\nth th\nth th\nˇth th\n");
+    }
+
+    #[gpui::test]
+    async fn test_gw(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.set_neovim_option("textwidth=5").await;
+
+        cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .defaults
+                        .preferred_line_length = Some(5);
+                });
+            })
+        });
+
+        cx.set_shared_state("ˇth th th th th th\n").await;
+        cx.simulate_shared_keystrokes("g w w").await;
+        cx.shared_state().await.assert_eq("ˇth th\nth th\nth th\n");
+
+        cx.set_shared_state("th th th ˇth th th\n").await;
+        cx.simulate_shared_keystrokes("g w w").await;
+        cx.shared_state().await.assert_eq("th th\nth ˇth\nth th\n");
+
+        cx.set_shared_state("ˇth th th th th th\nth th th th th th\n")
+            .await;
+        cx.simulate_shared_keystrokes("v j g w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("th th\nth th\nth th\nˇth th\nth th\nth th\n");
+
+        cx.set_shared_state("th th th ˇth th th\nth th th th th th\n")
+            .await;
+        cx.simulate_shared_keystrokes("v j g w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("th th\nth th\nth th\nth th\nth ˇth\nth th\n");
+
+        cx.set_shared_state("th th th th th th\nth th th ˇth th th\n")
+            .await;
+        cx.simulate_shared_keystrokes("v k b g w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("th th\nˇth th\nth th\nth th\nth th\nth th\n");
+
+        cx.set_shared_state("th «th th thˇ» th th\n").await;
+        cx.simulate_shared_keystrokes("g w").await;
+        cx.shared_state().await.assert_eq("th th\nth tˇh\nth th\n");
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -2163,16 +2163,40 @@ mod test {
             .await
             .assert_eq("th th\nth th\nth th\nth th\nth ˇth\nth th\n");
 
-        cx.set_shared_state("th th th th th th\nth th th ˇth th th\n")
+        cx.set_shared_state("th th th th th th\nth th th tˇh th th\n")
             .await;
         cx.simulate_shared_keystrokes("v k b g w").await;
         cx.shared_state()
             .await
-            .assert_eq("th th\nˇth th\nth th\nth th\nth th\nth th\n");
+            .assert_eq("th th\nth ˇth\nth th\nth th\nth th\nth th\n");
 
-        cx.set_shared_state("th «th th thˇ» th th\n").await;
+        cx.set_shared_state("th «th th thˇ» th th").await;
         cx.simulate_shared_keystrokes("g w").await;
-        cx.shared_state().await.assert_eq("th th\nth tˇh\nth th\n");
+        cx.shared_state().await.assert_eq("th th\nth tˇh\nth th");
+
+        cx.set_shared_state("th ˇth th th th th\n").await;
+        cx.simulate_shared_keystrokes("v e e").await;
+        cx.shared_state().await.assert_eq("th «th thˇ» th th th\n");
+
+        cx.set_shared_state("th ˇth th th th th\n").await;
+        cx.simulate_shared_keystrokes("v e e g w").await;
+        cx.shared_state().await.assert_eq("th th\ntˇh th\nth th\n");
+
+        cx.set_shared_state("th «th thˇ» th th th\n").await;
+        cx.simulate_shared_keystrokes("g w").await;
+        cx.shared_state().await.assert_eq("th th\ntˇh th\nth th\n");
+
+        cx.set_shared_state("th «th \u{1f340}ˇ» th th th\n").await;
+        cx.simulate_shared_keystrokes("g w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("th th\n\u{1f340}ˇ th\nth th\n");
+
+        cx.set_shared_state("th «th th \u{1f340}ˇ» th th\n").await;
+        cx.simulate_shared_keystrokes("g w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("th th\nth ˇ\u{1f340}\nth th\n");
     }
 
     #[gpui::test]

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -1,16 +1,36 @@
 use crate::{Vim, motion::Motion, object::Object, state::Mode};
 use collections::HashMap;
-use editor::{Bias, Editor, RewrapOptions, SelectionEffects, display_map::ToDisplayPoint};
+use editor::{
+    Bias, DisplayPoint, Editor, MultiBufferOffset, RewrapOptions, SelectionEffects,
+    display_map::{DisplaySnapshot, ToDisplayPoint},
+};
 use gpui::{Action, Context, Window};
 use language::SelectionGoal;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use text::Selection;
 
 /// Rewraps the selected text to fit within the line width.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 pub(crate) struct Rewrap {
     pub line_length: Option<usize>,
+    pub keep_cursor: bool,
+}
+
+fn head_offset_for_keep_cursor(
+    display_map: &DisplaySnapshot,
+    selection: &Selection<DisplayPoint>,
+) -> MultiBufferOffset {
+    let off = selection.head().to_offset(display_map, Bias::Left);
+
+    // When the selection isn't reversed, the offset works out to be after the head position. It
+    // needs to be adjusted so that the cursor ends up in the same position as it does in neovim.
+    if selection.reversed {
+        off
+    } else {
+        off.saturating_sub_usize(1)
+    }
 }
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
@@ -22,6 +42,13 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
         vim.update_editor(cx, |vim, editor, cx| {
             editor.transact(window, cx, |editor, window, cx| {
                 let mut positions = vim.save_selection_starts(editor, cx);
+                let display_map = editor.display_snapshot(cx);
+                let mut selection_head_offsets: HashMap<_, _> = editor
+                    .selections
+                    .all_display(&display_map)
+                    .iter()
+                    .map(|s| (s.id, head_offset_for_keep_cursor(&display_map, s)))
+                    .collect();
                 editor.rewrap(
                     RewrapOptions {
                         override_language_settings: true,
@@ -30,15 +57,26 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
                     },
                     cx,
                 );
-                editor.change_selections(Default::default(), window, cx, |s| {
-                    s.move_with(&mut |map, selection| {
-                        if let Some(anchor) = positions.remove(&selection.id) {
-                            let mut point = anchor.to_display_point(map);
-                            *point.column_mut() = 0;
-                            selection.collapse_to(point, SelectionGoal::None);
-                        }
+                if action.keep_cursor {
+                    editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                        s.move_with(&mut |map, selection| {
+                            if let Some(offset) = selection_head_offsets.remove(&selection.id) {
+                                let point = offset.to_display_point(map);
+                                selection.collapse_to(point, SelectionGoal::None);
+                            }
+                        });
                     });
-                });
+                } else {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.move_with(&mut |map, selection| {
+                            if let Some(anchor) = positions.remove(&selection.id) {
+                                let mut point = anchor.to_display_point(map);
+                                *point.column_mut() = 0;
+                                selection.collapse_to(point, SelectionGoal::None);
+                            }
+                        });
+                    });
+                }
             });
         });
         if vim.mode.is_visual() {
@@ -52,6 +90,7 @@ impl Vim {
         &mut self,
         motion: Motion,
         times: Option<usize>,
+        keep_cursor: bool,
         forced_motion: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -60,11 +99,14 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
+                let mut selection_head_offsets: HashMap<_, _> = Default::default();
                 let mut selection_starts: HashMap<_, _> = Default::default();
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
                         let anchor = map.display_point_to_anchor(selection.head(), Bias::Right);
                         selection_starts.insert(selection.id, anchor);
+                        selection_head_offsets
+                            .insert(selection.id, selection.head().to_offset(map, Bias::Right));
                         motion.expand_selection(
                             map,
                             selection,
@@ -81,14 +123,24 @@ impl Vim {
                     },
                     cx,
                 );
-                editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                    s.move_with(&mut |map, selection| {
-                        let anchor = selection_starts.remove(&selection.id).unwrap();
-                        let mut point = anchor.to_display_point(map);
-                        *point.column_mut() = 0;
-                        selection.collapse_to(point, SelectionGoal::None);
+                if keep_cursor {
+                    editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                        s.move_with(&mut |map, selection| {
+                            let offset = selection_head_offsets.remove(&selection.id).unwrap();
+                            let point = offset.to_display_point(map);
+                            selection.collapse_to(point, SelectionGoal::None);
+                        });
                     });
-                });
+                } else {
+                    editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                        s.move_with(&mut |map, selection| {
+                            let anchor = selection_starts.remove(&selection.id).unwrap();
+                            let mut point = anchor.to_display_point(map);
+                            *point.column_mut() = 0;
+                            selection.collapse_to(point, SelectionGoal::None);
+                        });
+                    });
+                }
             });
         });
     }
@@ -97,6 +149,7 @@ impl Vim {
         &mut self,
         object: Object,
         around: bool,
+        keep_cursor: bool,
         times: Option<usize>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -104,11 +157,14 @@ impl Vim {
         self.stop_recording(cx);
         self.update_editor(cx, |_, editor, cx| {
             editor.transact(window, cx, |editor, window, cx| {
+                let mut selection_head_offsets: HashMap<_, _> = Default::default();
                 let mut original_positions: HashMap<_, _> = Default::default();
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
                         let anchor = map.display_point_to_anchor(selection.head(), Bias::Right);
                         original_positions.insert(selection.id, anchor);
+                        selection_head_offsets
+                            .insert(selection.id, selection.head().to_offset(map, Bias::Right));
                         object.expand_selection(map, selection, around, times);
                     });
                 });
@@ -119,14 +175,24 @@ impl Vim {
                     },
                     cx,
                 );
-                editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                    s.move_with(&mut |map, selection| {
-                        let anchor = original_positions.remove(&selection.id).unwrap();
-                        let mut point = anchor.to_display_point(map);
-                        *point.column_mut() = 0;
-                        selection.collapse_to(point, SelectionGoal::None);
+                if keep_cursor {
+                    editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                        s.move_with(&mut |map, selection| {
+                            let offset = selection_head_offsets.remove(&selection.id).unwrap();
+                            let point = offset.to_display_point(map);
+                            selection.collapse_to(point, SelectionGoal::None);
+                        });
                     });
-                });
+                } else {
+                    editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                        s.move_with(&mut |map, selection| {
+                            let anchor = original_positions.remove(&selection.id).unwrap();
+                            let mut point = anchor.to_display_point(map);
+                            *point.column_mut() = 0;
+                            selection.collapse_to(point, SelectionGoal::None);
+                        });
+                    });
+                }
             });
         });
     }

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -3,6 +3,7 @@ use collections::HashMap;
 use editor::{
     Bias, DisplayPoint, Editor, MultiBufferOffset, RewrapOptions, SelectionEffects,
     display_map::{DisplaySnapshot, ToDisplayPoint},
+    movement,
 };
 use gpui::{Action, Context, Window};
 use language::SelectionGoal;
@@ -22,14 +23,14 @@ fn head_offset_for_keep_cursor(
     display_map: &DisplaySnapshot,
     selection: &Selection<DisplayPoint>,
 ) -> MultiBufferOffset {
-    let off = selection.head().to_offset(display_map, Bias::Left);
+    let point = selection.head();
 
     // When the selection isn't reversed, the offset works out to be after the head position. It
     // needs to be adjusted so that the cursor ends up in the same position as it does in neovim.
     if selection.reversed {
-        off
+        point.to_offset(display_map, Bias::Left)
     } else {
-        off.saturating_sub_usize(1)
+        movement::saturating_left(display_map, point).to_offset(display_map, Bias::Left)
     }
 }
 
@@ -61,7 +62,7 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
                     editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
                         s.move_with(&mut |map, selection| {
                             if let Some(offset) = selection_head_offsets.remove(&selection.id) {
-                                let point = offset.to_display_point(map);
+                                let point = map.clip_at_line_end(offset.to_display_point(map));
                                 selection.collapse_to(point, SelectionGoal::None);
                             }
                         });
@@ -127,7 +128,7 @@ impl Vim {
                     editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
                         s.move_with(&mut |map, selection| {
                             let offset = selection_head_offsets.remove(&selection.id).unwrap();
-                            let point = offset.to_display_point(map);
+                            let point = map.clip_at_line_end(offset.to_display_point(map));
                             selection.collapse_to(point, SelectionGoal::None);
                         });
                     });

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -124,7 +124,9 @@ pub enum Operator {
     Indent,
     Outdent,
     AutoIndent,
-    Rewrap,
+    Rewrap {
+        keep_cursor: bool,
+    },
     ShellCommand,
     Lowercase,
     Uppercase,
@@ -1086,7 +1088,8 @@ impl Operator {
             Operator::Indent => ">",
             Operator::AutoIndent => "eq",
             Operator::ShellCommand => "sh",
-            Operator::Rewrap => "gq",
+            Operator::Rewrap { keep_cursor: false } => "gq",
+            Operator::Rewrap { keep_cursor: true } => "gw",
             Operator::ReplaceWithRegister => "gR",
             Operator::Exchange => "cx",
             Operator::Outdent => "<",
@@ -1167,7 +1170,7 @@ impl Operator {
             Operator::Change
             | Operator::Delete
             | Operator::Yank
-            | Operator::Rewrap
+            | Operator::Rewrap { .. }
             | Operator::Indent
             | Operator::Outdent
             | Operator::AutoIndent
@@ -1208,7 +1211,7 @@ impl Operator {
             | Operator::ToggleComments
             | Operator::ToggleBlockComments
             | Operator::ReplaceWithRegister
-            | Operator::Rewrap
+            | Operator::Rewrap { .. }
             | Operator::ShellCommand
             | Operator::AddSurrounds { target: None }
             | Operator::ChangeSurrounds { target: None, .. }

--- a/crates/vim/src/test/neovim_connection.rs
+++ b/crates/vim/src/test/neovim_connection.rs
@@ -210,7 +210,7 @@ impl NeovimConnection {
             .await
             .expect("Could not set nvim cursor position");
 
-        if !selection.is_empty() {
+        if selection.start != selection.end {
             self.nvim
                 .input("v")
                 .await

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -163,6 +163,14 @@ struct PushLiteral {
     prefix: Option<String>,
 }
 
+/// Starts a rewrap operation.
+#[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
+#[action(namespace = vim)]
+#[serde(deny_unknown_fields)]
+struct PushRewrap {
+    keep_cursor: bool,
+}
+
 actions!(
     vim,
     [
@@ -226,8 +234,6 @@ actions!(
         PushOutdent,
         /// Starts an auto-indent operation.
         PushAutoIndent,
-        /// Starts a rewrap operation.
-        PushRewrap,
         /// Starts a shell command operation.
         PushShellCommand,
         /// Converts to lowercase.
@@ -843,8 +849,14 @@ impl Vim {
                 vim.push_operator(Operator::AutoIndent, window, cx)
             });
 
-            Vim::action(editor, cx, |vim, _: &PushRewrap, window, cx| {
-                vim.push_operator(Operator::Rewrap, window, cx)
+            Vim::action(editor, cx, |vim, action: &PushRewrap, window, cx| {
+                vim.push_operator(
+                    Operator::Rewrap {
+                        keep_cursor: action.keep_cursor,
+                    },
+                    window,
+                    cx,
+                )
             });
 
             Vim::action(editor, cx, |vim, _: &PushShellCommand, window, cx| {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -168,6 +168,7 @@ struct PushLiteral {
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
 struct PushRewrap {
+    #[serde(default)]
     keep_cursor: bool,
 }
 

--- a/crates/vim/test_data/test_gw.json
+++ b/crates/vim/test_data/test_gw.json
@@ -1,0 +1,34 @@
+{"SetOption":{"value":"textwidth=5"}}
+{"Put":{"state":"ˇth th th th th th\n"}}
+{"Key":"g"}
+{"Key":"w"}
+{"Key":"w"}
+{"Get":{"state":"ˇth th\nth th\nth th\n","mode":"Normal"}}
+{"Put":{"state":"th th th ˇth th th\n"}}
+{"Key":"g"}
+{"Key":"w"}
+{"Key":"w"}
+{"Get":{"state":"th th\nth ˇth\nth th\n","mode":"Normal"}}
+{"Put":{"state":"ˇth th th th th th\nth th th th th th\n"}}
+{"Key":"v"}
+{"Key":"j"}
+{"Key":"g"}
+{"Key":"w"}
+{"Get":{"state":"th th\nth th\nth th\nˇth th\nth th\nth th\n","mode":"Normal"}}
+{"Put":{"state":"th th th ˇth th th\nth th th th th th\n"}}
+{"Key":"v"}
+{"Key":"j"}
+{"Key":"g"}
+{"Key":"w"}
+{"Get":{"state":"th th\nth th\nth th\nth th\nth ˇth\nth th\n","mode":"Normal"}}
+{"Put":{"state":"th th th th th th\nth th th ˇth th th\n"}}
+{"Key":"v"}
+{"Key":"k"}
+{"Key":"b"}
+{"Key":"g"}
+{"Key":"w"}
+{"Get":{"state":"th th\nˇth th\nth th\nth th\nth th\nth th\n","mode":"Normal"}}
+{"Put":{"state":"th «th th thˇ» th th\n"}}
+{"Key":"g"}
+{"Key":"w"}
+{"Get":{"state":"th th\nth tˇh\nth th\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_gw.json
+++ b/crates/vim/test_data/test_gw.json
@@ -21,14 +21,30 @@
 {"Key":"g"}
 {"Key":"w"}
 {"Get":{"state":"th th\nth th\nth th\nth th\nth ˇth\nth th\n","mode":"Normal"}}
-{"Put":{"state":"th th th th th th\nth th th ˇth th th\n"}}
+{"Put":{"state":"th th th th th th\nth th th tˇh th th\n"}}
 {"Key":"v"}
 {"Key":"k"}
 {"Key":"b"}
 {"Key":"g"}
 {"Key":"w"}
-{"Get":{"state":"th th\nˇth th\nth th\nth th\nth th\nth th\n","mode":"Normal"}}
-{"Put":{"state":"th «th th thˇ» th th\n"}}
+{"Get":{"state":"th th\nth ˇth\nth th\nth th\nth th\nth th\n","mode":"Normal"}}
+{"Put":{"state":"th «th th thˇ» th th"}}
 {"Key":"g"}
 {"Key":"w"}
-{"Get":{"state":"th th\nth tˇh\nth th\n","mode":"Normal"}}
+{"Get":{"state":"th th\nth tˇh\nth th","mode":"Normal"}}
+{"Put":{"state":"th ˇth th th th th\n"}}
+{"Key":"v"}
+{"Key":"e"}
+{"Key":"e"}
+{"Get":{"state":"th «th thˇ» th th th\n","mode":"Visual"}}
+{"Put":{"state":"th ˇth th th th th\n"}}
+{"Key":"v"}
+{"Key":"e"}
+{"Key":"e"}
+{"Key":"g"}
+{"Key":"w"}
+{"Get":{"state":"th th\ntˇh th\nth th\n","mode":"Normal"}}
+{"Put":{"state":"th «th thˇ» th th th\n"}}
+{"Key":"g"}
+{"Key":"w"}
+{"Get":{"state":"th th\nthˇ th\nth th\n","mode":"Normal"}}


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (no unsafe)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #32521

Release Notes:

- Fixed incorrect cursor position after formatting text with gw
