### PR TITLE
agent_ui: Add Copy Last Response button and cycle through prior prompts

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4930,10 +4930,21 @@ impl ThreadView {
                 .shape(ui::IconButtonShape::Square)
                 .icon_size(IconSize::Small)
                 .icon_color(Color::Ignored)
-                .tooltip(Tooltip::text("Scroll To Most Recent User Prompt"))
+                .tooltip(Tooltip::text(
+                    "Scroll To Recent User Prompt (click again for previous)",
+                ))
                 .on_click(cx.listener(move |this, _, _, cx| {
                     this.scroll_to_most_recent_user_prompt(cx);
                 }));
+
+        let copy_last_response = IconButton::new("copy_last_response", IconName::Copy)
+            .shape(ui::IconButtonShape::Square)
+            .icon_size(IconSize::Small)
+            .icon_color(Color::Ignored)
+            .tooltip(Tooltip::text("Copy Last Response"))
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.copy_last_assistant_response(cx);
+            }));
 
         let scroll_to_top = IconButton::new("scroll_to_top", IconName::ArrowUp)
             .shape(ui::IconButtonShape::Square)
@@ -5095,6 +5106,7 @@ impl ThreadView {
 
         container
             .child(open_as_markdown)
+            .child(copy_last_response)
             .child(scroll_to_recent_user_prompt)
             .child(scroll_to_top)
             .into_any_element()
@@ -5106,12 +5118,26 @@ impl ThreadView {
             return;
         }
 
-        // Find the most recent user message and scroll it to the top of the viewport.
-        // (Fallback: if no user message exists, scroll to the bottom.)
-        if let Some(ix) = entries
+        // Walk backwards through user prompts on each click. The first click from
+        // a position below the latest prompt lands on it (preserving the original
+        // "scroll to most recent" behavior); subsequent clicks step to the
+        // previous prompt. After the oldest prompt, wrap around to the latest.
+        let current_top = self.list_state.logical_scroll_top().item_ix;
+        let target = entries
             .iter()
-            .rposition(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)))
-        {
+            .enumerate()
+            .rev()
+            .find(|(ix, entry)| {
+                *ix < current_top && matches!(entry, AgentThreadEntry::UserMessage(_))
+            })
+            .map(|(ix, _)| ix)
+            .or_else(|| {
+                entries
+                    .iter()
+                    .rposition(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)))
+            });
+
+        if let Some(ix) = target {
             self.list_state.scroll_to(ListOffset {
                 item_ix: ix,
                 offset_in_item: px(0.0),
@@ -5119,6 +5145,25 @@ impl ThreadView {
             cx.notify();
         } else {
             self.scroll_to_end(cx);
+        }
+    }
+
+    /// Copy the most recent assistant message in this thread to the system
+    /// clipboard, rendered as Markdown. No-op if the thread has no assistant
+    /// messages yet.
+    pub(crate) fn copy_last_assistant_response(&self, cx: &mut Context<Self>) {
+        let markdown = self
+            .thread
+            .read(cx)
+            .entries()
+            .iter()
+            .rev()
+            .find_map(|entry| match entry {
+                AgentThreadEntry::AssistantMessage(message) => Some(message.to_markdown(cx)),
+                _ => None,
+            });
+        if let Some(markdown) = markdown {
+            cx.write_to_clipboard(ClipboardItem::new_string(markdown));
         }
     }
 


### PR DESCRIPTION
Closes part of #55902.

## Summary

Two small additions to the agent thread toolbar:

1. **Copy Last Response button.** A new icon button (`IconName::Copy`) that copies the most recent assistant message in the active thread to the system clipboard, rendered as Markdown via the existing `AssistantMessage::to_markdown` path. No-op when the thread has no assistant message yet. Sits next to the existing "Open Thread as Markdown" button.

2. **Cycle through prior prompts on the existing scroll-to-recent-prompt button.** The button previously always jumped to the latest user prompt. With this change the first click from anywhere below the latest prompt still lands on it (existing behavior preserved), but subsequent clicks step back to earlier prompts. After the oldest prompt it wraps to the latest. Tooltip updated to reflect the new behavior.

The keyboard actions `ScrollOutputToPreviousMessage` / `ScrollOutputToNextMessage` already exist and are unchanged; this only wires equivalent reverse-stepping into the toolbar button so it's discoverable without a keybind.

## Why

The toolbar already exposes navigation/extraction affordances (open as markdown, scroll to top, scroll to recent prompt). Two of the three asks in #55902 fit that pattern with minimal surface change:

- Copying a long, code-fenced agent response by hand is unreliable across rendered Markdown blocks. A dedicated button removes the manual selection step.
- The existing "jump to last prompt" button is great for navigating *one* level up; cycling lets the same affordance reach any prior prompt without scrolling.

The third ask in #55902 (in-thread search) needs more design and is left for a follow-up PR.

## Test plan

- `cargo check -p agent_ui` is clean.
- Manual:
  - Long thread with multiple user prompts and assistant responses.
  - Click the new copy button → paste into a markdown buffer; the last assistant response (including code fences and `<thinking>` wrappers) round-trips correctly.
  - Click the recent-prompt button repeatedly → scroll position steps from latest prompt to previous prompts and wraps after the oldest.
  - On a thread with zero assistant messages, the copy button is a no-op (does not panic, does not clear clipboard).

## Files

- `crates/agent_ui/src/conversation_view/thread_view.rs`: new `copy_last_assistant_response` method, updated `scroll_to_most_recent_user_prompt` to walk backwards on repeated calls, new toolbar button + updated tooltip.

## Out of scope

- In-thread search (#55902 ②) — separate, larger UI surface.
- Per-message copy buttons on each assistant message (this PR only adds a single "copy last" affordance on the toolbar).
- Keyboard shortcut / Command Palette entry for the copy action (happy to add in a follow-up if desired).

CLA: I'll accept the CLA prompt on this PR.


Release Notes:

- Agent Panel: Added a "Copy Last Response" toolbar button and made the existing "Scroll To Recent User Prompt" button cycle through earlier prompts on repeated clicks.



Release Notes:

- Agent: Added a "Copy Last Response" button and made the existing "Scroll To Recent User Prompt" button cycle backwards through earlier prompts on repeated clicks.
