### PR TITLE
editor: Decode escaped characters in hover popover links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5809,6 +5809,7 @@ dependencies = [
  "unicode-width",
  "unindent",
  "url",
+ "urlencoding",
  "util",
  "uuid",
  "vim_mode_setting",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -98,6 +98,7 @@ unindent = { workspace = true, optional = true }
 ui.workspace = true
 ui_input.workspace = true
 url.workspace = true
+urlencoding.workspace = true
 util.workspace = true
 uuid.workspace = true
 vim_mode_setting.workspace = true

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -798,19 +798,36 @@ pub fn diagnostics_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
     }
 }
 
+fn parse_file_link(link: &str) -> Option<(PathBuf, Option<String>)> {
+    if let Ok(uri) = Url::parse(link)
+        && uri.scheme() == "file"
+    {
+        let path = uri.to_file_path().ok().unwrap_or_else(|| {
+            let path_text = uri.path();
+            let decoded_url = urlencoding::decode(path_text)
+                .map(|decoded| decoded.into_owned())
+                .unwrap_or_else(|_| path_text.to_string());
+            PathBuf::from(&decoded_url)
+        });
+        let fragment = uri.fragment().map(ToOwned::to_owned);
+        Some((path, fragment))
+    } else {
+        None
+    }
+}
+
 pub fn open_markdown_url(
     workspace: Option<Entity<Workspace>>,
     link: SharedString,
     window: &mut Window,
     cx: &mut App,
 ) {
-    if let Ok(uri) = Url::parse(&link)
-        && uri.scheme() == "file"
+    if let Some((path, fragment)) = parse_file_link(&link)
         && let Some(workspace) = workspace
     {
         workspace.update(cx, |workspace, cx| {
             let task = workspace.open_abs_path(
-                PathBuf::from(uri.path()),
+                path,
                 OpenOptions {
                     visible: Some(OpenVisible::None),
                     ..Default::default()
@@ -823,7 +840,7 @@ pub fn open_markdown_url(
                 let item = task.await?;
                 // Ruby LSP uses URLs with #L1,1-4,4
                 // we'll just take the first number and assume it's a line number
-                let Some(fragment) = uri.fragment() else {
+                let Some(fragment) = fragment.as_deref() else {
                     return anyhow::Ok(());
                 };
                 let mut accum = 0u32;
@@ -2746,5 +2763,22 @@ mod tests {
                 "No hover info task should be scheduled when hover is disabled"
             );
         });
+    }
+
+    #[test]
+    fn parse_file_links() {
+        assert_eq!(
+            parse_file_link("file:///path/to/file"),
+            Some((PathBuf::from("/path/to/file"), None))
+        );
+        assert_eq!(
+            parse_file_link("file:///path/to/file%20with%20spaces"),
+            Some((PathBuf::from("/path/to/file with spaces"), None))
+        );
+        assert_eq!(
+            parse_file_link("file:///path/to/file#123"),
+            Some((PathBuf::from("/path/to/file"), Some("123".to_string())))
+        );
+        assert_eq!(parse_file_link("http://example.com/"), None,);
     }
 }

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -799,21 +799,18 @@ pub fn diagnostics_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
 }
 
 fn parse_file_link(link: &str) -> Option<(PathBuf, Option<String>)> {
-    if let Ok(uri) = Url::parse(link)
-        && uri.scheme() == "file"
-    {
-        let path = uri.to_file_path().ok().unwrap_or_else(|| {
-            let path_text = uri.path();
-            let decoded_url = urlencoding::decode(path_text)
-                .map(|decoded| decoded.into_owned())
-                .unwrap_or_else(|_| path_text.to_string());
-            PathBuf::from(&decoded_url)
-        });
-        let fragment = uri.fragment().map(ToOwned::to_owned);
-        Some((path, fragment))
-    } else {
-        None
-    }
+    let uri = Url::parse(link).ok().filter(|uri| uri.scheme() == "file")?;
+    let fragment = uri.fragment().map(ToOwned::to_owned);
+    let path = uri.to_file_path().unwrap_or_else(|_| {
+        let encoded = uri.path();
+
+        urlencoding::decode(encoded)
+            .map(Cow::into_owned)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(encoded))
+    });
+
+    Some((path, fragment))
 }
 
 pub fn open_markdown_url(
@@ -840,7 +837,7 @@ pub fn open_markdown_url(
                 let item = task.await?;
                 // Ruby LSP uses URLs with #L1,1-4,4
                 // we'll just take the first number and assume it's a line number
-                let Some(fragment) = fragment.as_deref() else {
+                let Some(fragment) = fragment else {
                     return anyhow::Ok(());
                 };
                 let mut accum = 0u32;
@@ -2766,7 +2763,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_file_links() {
+    fn test_parse_file_links() {
         assert_eq!(
             parse_file_link("file:///path/to/file"),
             Some((PathBuf::from("/path/to/file"), None))


### PR DESCRIPTION
Decodes url escape sequences in hover preview `file:///` links like escaped
spaces in the file path.

I'm working on an LSP and happened to be working with some files in a directory with spaces. When adding Markdown links with `file:///` the `%20` escape for spaces was being included verbatim in the path that Zed tried to open.

I'm reusing the lines from `markdown_preview_view.rs` for decoding. In the existing tests I don't see coverage for `file:///` links. If you'd like some tests for this can you point me to any examples to start from?

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed decoding spaces and other escaped characters in `file://` links used in hover popovers
