### PR TITLE
project: Fix code lens menu filter dropping point-range lenses

### DIFF
--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -666,6 +666,7 @@ mod tests {
     use gpui::TestAppContext;
     use settings::CodeLens;
     use util::path;
+    use workspace::OpenOptions;
 
     use crate::{
         Editor, LSP_REQUEST_DEBOUNCE_TIMEOUT,
@@ -1591,5 +1592,111 @@ mod tests {
             HashSet::from_iter([70, 80, 90]),
             "Only newly visible lenses at the bottom should be resolved, not middle ones"
         );
+    }
+
+    #[gpui::test]
+    async fn test_code_lens_menu_point_range(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+        update_test_editor_settings(cx, &|settings| {
+            settings.code_lens = Some(CodeLens::Menu);
+        });
+
+        let fs = project::FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/dir"),
+            serde_json::json!({ "main_test.go": "package main\n\nfunc TestFoo(t *testing.T) {}\nfunc TestBar(t *testing.T) {}" }),
+        )
+        .await;
+
+        let project = project::Project::test(fs, [path!("/dir").as_ref()], cx).await;
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+        language_registry.add(Arc::new(language::Language::new(
+            language::LanguageConfig {
+                name: "Go".into(),
+                matcher: language::LanguageMatcher {
+                    path_suffixes: vec!["go".to_string()],
+                    ..language::LanguageMatcher::default()
+                },
+                ..language::LanguageConfig::default()
+            },
+            Some(tree_sitter_go::LANGUAGE.into()),
+        )));
+
+        let mut fake_servers = language_registry.register_fake_lsp(
+            "Go",
+            language::FakeLspAdapter {
+                capabilities: lsp::ServerCapabilities {
+                    code_lens_provider: Some(lsp::CodeLensOptions {
+                        resolve_provider: None,
+                    }),
+                    ..lsp::ServerCapabilities::default()
+                },
+                ..language::FakeLspAdapter::default()
+            },
+        );
+
+        let editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_abs_path(
+                    std::path::PathBuf::from(path!("/dir/main_test.go")),
+                    OpenOptions::default(),
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+
+        let fake_server = fake_servers.next().await.unwrap();
+        // gopls emits zero-length point ranges for test/bench lenses: Start == End == {line, col: 0}
+        // https://github.com/golang/tools/blob/master/gopls/internal/golang/code_lens.go#L54
+        fake_server.set_request_handler::<lsp::request::CodeLensRequest, _, _>(|_, _| async {
+            Ok(Some(vec![lsp::CodeLens {
+                range: lsp::Range::new(lsp::Position::new(2, 0), lsp::Position::new(2, 0)),
+                command: Some(lsp::Command {
+                    title: "run test".to_owned(),
+                    command: "gopls.run_tests".to_owned(),
+                    arguments: None,
+                }),
+                data: None,
+            }]))
+        });
+
+        let buffer = editor.read_with(cx, |editor, cx| {
+            editor.buffer().read(cx).as_singleton().unwrap()
+        });
+
+        let has_run_test = |actions: Vec<project::CodeAction>| {
+            actions
+                .iter()
+                .any(|a| a.lsp_action.command().is_some_and(|c| c.title == "run test"))
+        };
+
+        let mut lens_actions_at = |row: u32, col: u32| {
+            let anchor = buffer.read_with(cx, |buffer, _| {
+                buffer
+                    .snapshot()
+                    .anchor_before(language::Point::new(row, col))
+            });
+            project.update(cx, |project, cx| {
+                project.code_lens_actions(&buffer, anchor..anchor, cx)
+            })
+        };
+
+        let actions = lens_actions_at(2, 0).await.unwrap().unwrap_or_default();
+        assert!(has_run_test(actions), "lens must appear at exact point col 0");
+
+        let actions = lens_actions_at(2, 5).await.unwrap().unwrap_or_default();
+        assert!(has_run_test(actions), "lens must appear at col 5 on same row");
+
+        let actions = lens_actions_at(3, 0).await.unwrap().unwrap_or_default();
+        assert!(!has_run_test(actions), "lens must not appear on a different row");
     }
 }

--- a/crates/project/src/lsp_store/code_lens.rs
+++ b/crates/project/src/lsp_store/code_lens.rs
@@ -9,7 +9,7 @@ use futures::{
     future::{Shared, join_all},
 };
 use gpui::{AppContext as _, AsyncApp, Context, Entity, Task};
-use language::{Anchor, Buffer};
+use language::{Anchor, Buffer, ToPoint as _};
 use lsp::LanguageServerId;
 use rpc::{TypedEnvelope, proto};
 use settings::Settings as _;
@@ -435,9 +435,13 @@ impl Project {
                 return Ok(None);
             };
             let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
+            let cursor_point = range.start.to_point(&snapshot);
             tagged.retain(|_, action| {
-                range.start.cmp(&action.range.start, &snapshot).is_ge()
-                    && range.end.cmp(&action.range.end, &snapshot).is_le()
+                let start = action.range.start.to_point(&snapshot);
+                let end = action.range.end.to_point(&snapshot);
+                (cursor_point.row > start.row
+                    || (cursor_point.row == start.row && cursor_point.column >= start.column))
+                    && cursor_point.row <= end.row
             });
             let resolve_tasks = lsp_store.update(cx, |lsp_store, cx| {
                 tagged

--- a/crates/project/src/lsp_store/code_lens.rs
+++ b/crates/project/src/lsp_store/code_lens.rs
@@ -438,10 +438,7 @@ impl Project {
             let cursor_point = range.start.to_point(&snapshot);
             tagged.retain(|_, action| {
                 let start = action.range.start.to_point(&snapshot);
-                let end = action.range.end.to_point(&snapshot);
-                (cursor_point.row > start.row
-                    || (cursor_point.row == start.row && cursor_point.column >= start.column))
-                    && cursor_point.row <= end.row
+                cursor_point.row == start.row && cursor_point.column >= start.column
             });
             let resolve_tasks = lsp_store.update(cx, |lsp_store, cx| {
                 tagged


### PR DESCRIPTION
Makes the cursor-vs-range check row+column-aware so gopls-style zero-length ranges are included in menu for any cursor's position on the same line, not just only at column 0.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55977

Release Notes:

- Fixed `code_lens: "menu"` dropping gopls test lenses when the cursor is past column 0 on a function line
