### PR TITLE
settings: Remove hardcoded PHP Prettier parser to honor .prettierrc overrides

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2235,7 +2235,6 @@
       "prettier": {
         "allowed": true,
         "plugins": ["@prettier/plugin-php"],
-        "parser": "php",
       },
     },
     "Plain Text": {


### PR DESCRIPTION
Fixes the default Zed settings hardcoding `"parser": "php"` for the PHP
language's prettier configuration, which caused `.prettierrc` parser
overrides (e.g. `prettier-plugin-blade`) to be silently ignored.

Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #42796

Release Notes:
- Fixed PHP prettier formatting ignoring `.prettierrc` parser overrides (e.g. `prettier-plugin-blade`)