### PR TITLE
settings: Disable Prettier for Python by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2257,6 +2257,9 @@
           "name": "ruff",
         },
       },
+      "prettier": {
+        "allowed": false,
+      },
       "debuggers": ["Debugpy"],
       "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."],
     },


### PR DESCRIPTION
Prettier has no built-in Python parser and should not run on Python files.
This mirrors the existing pattern used for C and C++ files and was explicitly
requested by a maintainer in #48600.

Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #48600

Release Notes:
- Fixed Python files being affected by prettier by explicitly disabling it, matching the existing behavior for C and C++ files