### PR TITLE
opencode: Remove Ling 2.6 Flash Free model

### DIFF
--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -123,8 +123,6 @@ pub enum Model {
     DeepSeekV4Pro,
     #[serde(rename = "deepseek-v4-flash")]
     DeepSeekV4Flash,
-    #[serde(rename = "ling-2.6-flash-free")]
-    Ling2_6FlashFree,
     #[serde(rename = "hy3-preview-free")]
     Hy3PreviewFree,
     #[serde(rename = "minimax-m2.5")]
@@ -217,7 +215,6 @@ impl Model {
             Self::MiniMaxM2_5Free
             | Self::Nemotron3SuperFree
             | Self::BigPickle
-            | Self::Ling2_6FlashFree
             | Self::Hy3PreviewFree => &[OpenCodeSubscription::Free],
 
             // Custom models get their subscription from settings, not from here
@@ -263,7 +260,6 @@ impl Model {
 
             Self::DeepSeekV4Pro => "deepseek-v4-pro",
             Self::DeepSeekV4Flash => "deepseek-v4-flash",
-            Self::Ling2_6FlashFree => "ling-2.6-flash-free",
             Self::Hy3PreviewFree => "hy3-preview-free",
             Self::MiniMaxM2_5 => "minimax-m2.5",
             Self::MiniMaxM2_5Free => "minimax-m2.5-free",
@@ -320,7 +316,6 @@ impl Model {
 
             Self::DeepSeekV4Pro => "DeepSeek V4 Pro",
             Self::DeepSeekV4Flash => "DeepSeek V4 Flash",
-            Self::Ling2_6FlashFree => "Ling 2.6 Flash Free",
             Self::Hy3PreviewFree => "Hy3 Preview Free",
             Self::MiniMaxM2_5 => "MiniMax M2.5",
             Self::MiniMaxM2_5Free => "MiniMax M2.5 Free",
@@ -401,7 +396,6 @@ impl Model {
             | Self::DeepSeekV4Flash
             | Self::BigPickle
             | Self::Nemotron3SuperFree
-            | Self::Ling2_6FlashFree
             | Self::Hy3PreviewFree => ApiProtocol::OpenAiChat,
 
             Self::Custom { protocol, .. } => *protocol,
@@ -468,7 +462,6 @@ impl Model {
             Self::BigPickle => 200_000,
             Self::Nemotron3SuperFree => 204_800,
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => 1_000_000,
-            Self::Ling2_6FlashFree => 262_100,
             Self::Hy3PreviewFree => 256_000,
 
             Self::Custom { max_tokens, .. } => *max_tokens,
@@ -521,7 +514,6 @@ impl Model {
             Self::MimoV2_5Pro | Self::MimoV2_5 | Self::MimoV2Pro | Self::MimoV2Omni => {
                 Some(128_000)
             }
-            Self::Ling2_6FlashFree => Some(32_800),
             Self::Hy3PreviewFree => Some(64_000),
 
             Self::Custom {
@@ -589,7 +581,6 @@ impl Model {
             | Self::DeepSeekV4Flash
             | Self::BigPickle
             | Self::Nemotron3SuperFree
-            | Self::Ling2_6FlashFree
             | Self::Hy3PreviewFree => false,
 
             Self::Custom { protocol, .. } => matches!(


### PR DESCRIPTION
Remove the "Ling 2.6 Flash Free" model from the OpenCode provider's built-in
model list, as it is no longer available via the API. Attempting to use it
returns the following error:

```
invalid request format to OpenCode's API: {"error":{"message":"Error from provider: Ling-2.6-flash is no longer available as a free model. It has transitioned to a paid model. Continue using it here: https://openrouter.ai/inclusionai/ling-2.6-flash","code":404},"user_id":"user_2..."}
```

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Removed Ling 2.6 Flash Free model from the OpenCode provider