### PR TITLE
language: Refresh diagnostic endpoints on every seek

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -5626,8 +5626,8 @@ impl<'a> BufferChunks<'a> {
             }
 
             highlights.captures.set_byte_range(self.range.clone());
-            self.initialize_diagnostic_endpoints();
         }
+        self.initialize_diagnostic_endpoints();
     }
 
     fn initialize_diagnostic_endpoints(&mut self) {


### PR DESCRIPTION
Hoists the call out of the `highlights` branch so it always runs after a seek (it’s [already internally guarded](https://github.com/zed-industries/zed/blob/5dd9082d05/crates/language/src/buffer.rs#L5633-L5636) on `diagnostic_endpoints` being `Some`, so it’s a no-op when diagnostics are off). This keeps diagnostic state fresh across seeks triggered by `BlockChunks::advance` past code-lens blocks, so short `Unnecessary` regions wholly inside the post-block range now dim correctly.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55975.

Release Notes:

- Fixed unnecessary-code dim sometimes disappearing when `code_lens` and `semantic_tokens: "full"` are both enabled
