### PR TITLE
languages: Highlight `default` as `keyword.control` in JS/TS/TSX files

### DIFF
--- a/crates/grammars/src/javascript/highlights.scm
+++ b/crates/grammars/src/javascript/highlights.scm
@@ -249,7 +249,6 @@
   "async"
   "debugger"
   "declare"
-  "default"
   "delete"
   "extends"
   "get"
@@ -298,6 +297,7 @@
   "case"
   "catch"
   "continue"
+  "default"
   "do"
   "else"
   "finally"
@@ -310,9 +310,6 @@
   "while"
   "yield"
 ] @keyword.control
-
-(switch_default
-  "default" @keyword.control)
 
 (template_substitution
   "${" @punctuation.special

--- a/crates/grammars/src/tsx/highlights.scm
+++ b/crates/grammars/src/tsx/highlights.scm
@@ -270,7 +270,6 @@
   "async"
   "debugger"
   "declare"
-  "default"
   "delete"
   "extends"
   "get"
@@ -322,6 +321,7 @@
   "case"
   "catch"
   "continue"
+  "default"
   "do"
   "else"
   "finally"
@@ -334,9 +334,6 @@
   "while"
   "yield"
 ] @keyword.control
-
-(switch_default
-  "default" @keyword.control)
 
 (template_substitution
   "${" @punctuation.special

--- a/crates/grammars/src/typescript/highlights.scm
+++ b/crates/grammars/src/typescript/highlights.scm
@@ -389,7 +389,6 @@
   "async"
   "debugger"
   "declare"
-  "default"
   "delete"
   "extends"
   "get"
@@ -441,6 +440,7 @@
   "case"
   "catch"
   "continue"
+  "default"
   "do"
   "else"
   "finally"
@@ -453,6 +453,3 @@
   "while"
   "yield"
 ] @keyword.control
-
-(switch_default
-  "default" @keyword.control)


### PR DESCRIPTION
`default` was grouped under the generic `@keyword` capture in the tree-sitter highlights queries for JavaScript, TypeScript, and TSX, with a separate `(switch_default "default" @keyword.control)` query that promoted it to `@keyword.control` only inside `switch ... default:` blocks. As a result, `default` in `export default ...` was tokenized as `@keyword`, while `default` in `switch (x) { default: }` was tokenized as `@keyword.control`.

It should be `@keyword.control` everywhere -- same as `return`, `yield`, `throw`, `break`, etcetera, which were already correctly classified. This matches the TextMate scope convention (which lists `default` as a `keyword.control` example) and VSCode’s behavior (`keyword.control.default.tsx` -- see linked issue for screenshot).

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #55924.

Release Notes:

- Fixed `default` keyword not being highlighted as `keyword.control` in JavaScript, TypeScript, and TSX files
