### PR TITLE
agent_ui: Add external file/directory context via + menu

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4114,6 +4114,21 @@ impl ThreadView {
                         }),
                 )
                 .item(
+                    ContextMenuEntry::new("External File")
+                        .icon(IconName::FolderOpen)
+                        .icon_color(Color::Muted)
+                        .icon_size(IconSize::XSmall)
+                        .handler({
+                            let message_editor = message_editor.clone();
+                            move |window, cx| {
+                                message_editor.focus_handle(cx).focus(window, cx);
+                                message_editor.update(cx, |editor, cx| {
+                                    editor.add_external_files_from_picker(window, cx);
+                                });
+                            }
+                        }),
+                )
+                .item(
                     ContextMenuEntry::new("Symbols")
                         .icon(IconName::Code)
                         .icon_color(Color::Muted)

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1495,6 +1495,72 @@ impl MessageEditor {
             .detach_and_log_err(cx);
     }
 
+    pub fn add_external_files_from_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let editor = self.editor.clone();
+        let mention_set = self.mention_set.clone();
+        let workspace = self.workspace.clone();
+        let supports_images = self.session_capabilities.read().supports_images();
+
+        let paths_receiver = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: true,
+            directories: true,
+            multiple: true,
+            prompt: Some("Select External Files or Directories".into()),
+        });
+
+        window
+            .spawn(cx, async move |cx| {
+                let paths = match paths_receiver.await {
+                    Ok(Ok(Some(paths))) => paths,
+                    _ => return Ok::<(), anyhow::Error>(()),
+                };
+
+                let Some(workspace) = workspace.upgrade() else {
+                    return Ok(());
+                };
+
+                for path in paths {
+                    let resolve_task = cx.update({
+                        let workspace = workspace.clone();
+                        let path = path.clone();
+                        move |_, cx| {
+                            let project = workspace.read(cx).project().clone();
+                            Workspace::project_path_for_path(project, &path, false, cx)
+                        }
+                    })?;
+
+                    if let Some((_added_worktree, project_path)) = resolve_task.await.log_err() {
+                        let mention_task = cx.update({
+                            let editor = editor.clone();
+                            let mention_set = mention_set.clone();
+                            let workspace = workspace.clone();
+                            move |window, cx| {
+                                let project = workspace.read(cx).project().clone();
+                                insert_mention_for_project_path(
+                                    &project_path,
+                                    MentionInsertPosition::EndOfBuffer,
+                                    &editor,
+                                    &mention_set,
+                                    &project,
+                                    &workspace,
+                                    supports_images,
+                                    window,
+                                    cx,
+                                )
+                            }
+                        })?;
+
+                        if let Some(task) = mention_task {
+                            task.await;
+                        }
+                    }
+                }
+
+                Ok(())
+            })
+            .detach_and_log_err(cx);
+    }
+
     pub fn set_read_only(&mut self, read_only: bool, cx: &mut Context<Self>) {
         self.editor.update(cx, |message_editor, cx| {
             message_editor.set_read_only(read_only);


### PR DESCRIPTION
## Summary

- Adds an **"External File"** option to the Agent Panel's `+` context menu
- Opens a native system file picker that accepts both files and directories
- Selected paths are resolved via `Workspace::project_path_for_path` (creates temporary worktrees), then inserted as context mentions
- Follows the same async pattern as `add_images_from_picker` and `insert_dragged_files`

Closes #56015

## Test plan

- [ ] Open the Agent Panel and click the `+` button
- [ ] Verify "External File" appears between "Files & Directories" and "Symbols"
- [ ] Select a file from outside the current project — verify it appears as context
- [ ] Select a directory from outside the project — verify it works
- [ ] Select multiple files at once — verify all appear
- [ ] Cancel the picker — verify no errors

Release Notes:

- Added "External File" option in Agent Panel's + context menu to attach files and directories from outside the current project as context