### PR TITLE
Automate updating the Guild board whenever a PR is merged

### DIFF
--- a/.github/workflows/guild_shipped_backfill.yml
+++ b/.github/workflows/guild_shipped_backfill.yml
@@ -1,0 +1,283 @@
+name: Guild Shipped Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (log changes without making them)"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+env:
+  GUILD_CONTRIBUTORS: |
+    0x-pankaj
+    11happy
+    AidanV
+    AmaanBilwar
+    CCXLV
+    HiteshRohira
+    MostlyKIGuess
+    OmChillure
+    Palanikannan1437
+    SeanDunford
+    Shivansh-25
+    SkandaBhat
+    Steven-Weng
+    TwistingTwists
+    YEDASAVG
+    Ziqi-Yang
+    alanpjohn
+    arjunkomath
+    austincummings
+    ayushk-1801
+    claiwe
+    criticic
+    ddoemonn
+    dibashthapa
+    dongdong867
+    emamulandalib
+    eureka928
+    feitreim
+    hagz0r
+    iam-liam
+    iksuddle
+    implabinash
+    imumesh18
+    ishaksebsib
+    lingyaochu
+    loadingalias
+    marcocondrache
+    mchisolm0
+    nairadithya
+    nihalxkumar
+    notJoon
+    polyesterswing
+    prayanshchh
+    prertik
+    razeghi71
+    rgbkrk
+    sarmadgulzar
+    seanstrom
+    th0jensen
+    theonly1me
+    tommyming
+    virajbhartiya
+
+jobs:
+  backfill:
+    name: Backfill Guild PRs to Project
+    runs-on: namespace-profile-2x4-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@bef1eaf1c0ac2b148ee2a0a74c65fbe6db0631f1
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - name: Backfill merged PRs to project
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            console.log(dryRun ? 'DRY RUN — no changes will be made\n' : 'LIVE MODE — changes will be applied\n');
+
+            const contributors = process.env.GUILD_CONTRIBUTORS
+              .split('\n')
+              .map(c => c.trim())
+              .filter(c => c.length > 0);
+
+            console.log(`Found ${contributors.length} guild contributors`);
+
+            const projectQuery = await github.graphql(`
+              query {
+                organization(login: "zed-industries") {
+                  projectV2(number: 74) {
+                    id
+                  }
+                }
+              }
+            `);
+            const projectId = projectQuery.organization.projectV2.id;
+
+            const fieldQuery = await github.graphql(`
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { projectId });
+
+            const statusField = fieldQuery.node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) throw new Error('Could not find Status field on project');
+
+            const shippedOption = statusField.options.find(o => o.name === 'Shipped by the Guild');
+            if (!shippedOption) throw new Error('Could not find "Shipped by the Guild" option in Status field');
+
+            const statusFieldId = statusField.id;
+            const shippedOptionId = shippedOption.id;
+
+            // Load all project items upfront for issue removal lookups
+            let projectItems = [];
+            let hasNextPage = true;
+            let cursor = null;
+
+            while (hasNextPage) {
+              const q = cursor
+                ? `query($projectId: ID!, $cursor: String!) {
+                    node(id: $projectId) { ... on ProjectV2 { items(first: 100, after: $cursor) {
+                      nodes { id content { ... on Issue { number } } }
+                      pageInfo { hasNextPage endCursor }
+                    } } }
+                  }`
+                : `query($projectId: ID!) {
+                    node(id: $projectId) { ... on ProjectV2 { items(first: 100) {
+                      nodes { id content { ... on Issue { number } } }
+                      pageInfo { hasNextPage endCursor }
+                    } } }
+                  }`;
+
+              const vars = cursor ? { projectId, cursor } : { projectId };
+              const result = await github.graphql(q, vars);
+              projectItems = projectItems.concat(result.node.items.nodes);
+              hasNextPage = result.node.items.pageInfo.hasNextPage;
+              cursor = result.node.items.pageInfo.endCursor;
+            }
+
+            console.log(`Loaded ${projectItems.length} existing items from project\n`);
+
+            let totalPRsAdded = 0;
+            let totalIssuesRemoved = 0;
+            let totalFailed = 0;
+
+            for (const contributor of contributors) {
+              console.log(`\nSearching PRs for: ${contributor}`);
+              const query = `repo:zed-industries/zed is:pr is:merged author:${contributor} merged:>=2026-03-02`;
+
+              let page = 1;
+              let hasMore = true;
+
+              while (hasMore) {
+                const searchResults = await github.rest.search.issuesAndPullRequests({
+                  q: query,
+                  per_page: 100,
+                  page: page,
+                });
+
+                const items = searchResults.data.items;
+                console.log(`  Page ${page}: ${items.length} PRs found`);
+
+                for (const item of items) {
+                  try {
+                    const pr = await github.rest.pulls.get({
+                      owner: 'zed-industries',
+                      repo: 'zed',
+                      pull_number: item.number,
+                    });
+
+                    if (dryRun) {
+                      console.log(`  [DRY RUN] Would add PR #${item.number}: ${item.title}`);
+                    } else {
+                      const addResult = await github.graphql(`
+                        mutation($projectId: ID!, $contentId: ID!) {
+                          addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                            item { id }
+                          }
+                        }
+                      `, { projectId, contentId: pr.data.node_id });
+
+                      const itemId = addResult.addProjectV2ItemById.item.id;
+
+                      await github.graphql(`
+                        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                          updateProjectV2ItemFieldValue(input: {
+                            projectId: $projectId
+                            itemId: $itemId
+                            fieldId: $fieldId
+                            value: { singleSelectOptionId: $optionId }
+                          }) {
+                            projectV2Item { id }
+                          }
+                        }
+                      `, { projectId, itemId, fieldId: statusFieldId, optionId: shippedOptionId });
+
+                      console.log(`  ✓ Added PR #${item.number}: ${item.title}`);
+                    }
+                    totalPRsAdded++;
+
+                    // Check for issues closed by this PR
+                    const closingQuery = await github.graphql(`
+                      query($owner: String!, $repo: String!, $prNumber: Int!) {
+                        repository(owner: $owner, name: $repo) {
+                          pullRequest(number: $prNumber) {
+                            closingIssuesReferences(first: 50) {
+                              nodes { number title }
+                            }
+                          }
+                        }
+                      }
+                    `, { owner: 'zed-industries', repo: 'zed', prNumber: item.number });
+
+                    const closedIssues = closingQuery.repository.pullRequest.closingIssuesReferences.nodes;
+                    for (const issue of closedIssues) {
+                      const match = projectItems.find(pi => pi.content && pi.content.number === issue.number);
+                      if (!match) continue;
+
+                      if (dryRun) {
+                        console.log(`  [DRY RUN] Would remove issue #${issue.number} ("${issue.title}") from project`);
+                      } else {
+                        await github.graphql(`
+                          mutation($projectId: ID!, $itemId: ID!) {
+                            deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) {
+                              deletedItemId
+                            }
+                          }
+                        `, { projectId, itemId: match.id });
+                        console.log(`  ✓ Removed issue #${issue.number} ("${issue.title}") from project`);
+                      }
+                      totalIssuesRemoved++;
+                    }
+                  } catch (err) {
+                    totalFailed++;
+                    console.log(`  ✗ PR #${item.number}: ${err.message}`);
+                  }
+                }
+
+                hasMore = items.length === 100;
+                page++;
+              }
+
+              // Rate limit delay between contributors
+              await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+
+            console.log(`\n===== SUMMARY =====`);
+            console.log(`Mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`);
+            console.log(`PRs ${dryRun ? 'to add' : 'added'}: ${totalPRsAdded}`);
+            console.log(`Issues ${dryRun ? 'to remove' : 'removed'}: ${totalIssuesRemoved}`);
+            console.log(`Failures: ${totalFailed}`);

--- a/.github/workflows/guild_shipped_tracker.yml
+++ b/.github/workflows/guild_shipped_tracker.yml
@@ -1,0 +1,233 @@
+name: Guild Shipped Tracker
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+env:
+  GUILD_CONTRIBUTORS: |
+    0x-pankaj
+    11happy
+    AidanV
+    AmaanBilwar
+    CCXLV
+    HiteshRohira
+    MostlyKIGuess
+    OmChillure
+    Palanikannan1437
+    SeanDunford
+    Shivansh-25
+    SkandaBhat
+    Steven-Weng
+    TwistingTwists
+    YEDASAVG
+    Ziqi-Yang
+    alanpjohn
+    arjunkomath
+    austincummings
+    ayushk-1801
+    claiwe
+    criticic
+    ddoemonn
+    dibashthapa
+    dongdong867
+    emamulandalib
+    eureka928
+    feitreim
+    hagz0r
+    iam-liam
+    iksuddle
+    implabinash
+    imumesh18
+    ishaksebsib
+    lingyaochu
+    loadingalias
+    marcocondrache
+    mchisolm0
+    nairadithya
+    nihalxkumar
+    notJoon
+    polyesterswing
+    prayanshchh
+    prertik
+    razeghi71
+    rgbkrk
+    sarmadgulzar
+    seanstrom
+    th0jensen
+    theonly1me
+    tommyming
+    virajbhartiya
+
+jobs:
+  track-guild-shipped:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.repository == 'zed-industries/zed' &&
+      github.event.pull_request.merged_at >= '2026-03-02'
+    runs-on: namespace-profile-2x4-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@bef1eaf1c0ac2b148ee2a0a74c65fbe6db0631f1
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - name: Add PR to Guild project and set status
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const guildContributors = process.env.GUILD_CONTRIBUTORS
+              .split('\n')
+              .map(c => c.trim().toLowerCase())
+              .filter(c => c.length > 0);
+
+            const prAuthor = context.payload.pull_request.user.login.toLowerCase();
+            if (!guildContributors.includes(prAuthor)) {
+              console.log(`${prAuthor} is not a guild contributor. Skipping.`);
+              return;
+            }
+
+            console.log(`${prAuthor} is a guild contributor. Adding PR #${context.payload.pull_request.number} to project...`);
+
+            const projectResult = await github.graphql(`
+              query {
+                organization(login: "zed-industries") {
+                  projectV2(number: 74) {
+                    id
+                  }
+                }
+              }
+            `);
+            const projectId = projectResult.organization.projectV2.id;
+
+            const addResult = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            `, {
+              projectId,
+              contentId: context.payload.pull_request.node_id
+            });
+            const itemId = addResult.addProjectV2ItemById.item.id;
+
+            const fieldsResult = await github.graphql(`
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { projectId });
+
+            const statusField = fieldsResult.node.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) throw new Error('Status field not found in project');
+
+            const shippedOption = statusField.options.find(o => o.name === 'Shipped by the Guild');
+            if (!shippedOption) throw new Error('"Shipped by the Guild" option not found in Status field');
+
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId,
+                  itemId: $itemId,
+                  fieldId: $fieldId,
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `, {
+              projectId,
+              itemId,
+              fieldId: statusField.id,
+              optionId: shippedOption.id
+            });
+
+            console.log(`Added PR #${context.payload.pull_request.number} to "Shipped by the Guild"`);
+
+            // Remove issues closed by this PR from the project
+            const prNumber = context.payload.pull_request.number;
+            const closingIssuesQuery = await github.graphql(`
+              query($owner: String!, $repo: String!, $prNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $prNumber) {
+                    closingIssuesReferences(first: 50) {
+                      nodes {
+                        number
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            `, { owner: 'zed-industries', repo: 'zed', prNumber });
+
+            const closedIssues = closingIssuesQuery.repository.pullRequest.closingIssuesReferences.nodes;
+            if (closedIssues.length === 0) return;
+
+            // Load project items once for lookup
+            let projectItems = [];
+            let hasNextPage = true;
+            let cursor = null;
+
+            while (hasNextPage) {
+              const q = cursor
+                ? `query($projectId: ID!, $cursor: String!) {
+                    node(id: $projectId) { ... on ProjectV2 { items(first: 100, after: $cursor) {
+                      nodes { id content { ... on Issue { number } } }
+                      pageInfo { hasNextPage endCursor }
+                    } } }
+                  }`
+                : `query($projectId: ID!) {
+                    node(id: $projectId) { ... on ProjectV2 { items(first: 100) {
+                      nodes { id content { ... on Issue { number } } }
+                      pageInfo { hasNextPage endCursor }
+                    } } }
+                  }`;
+
+              const vars = cursor ? { projectId, cursor } : { projectId };
+              const result = await github.graphql(q, vars);
+              projectItems = projectItems.concat(result.node.items.nodes);
+              hasNextPage = result.node.items.pageInfo.hasNextPage;
+              cursor = result.node.items.pageInfo.endCursor;
+            }
+
+            for (const issue of closedIssues) {
+              const match = projectItems.find(pi => pi.content && pi.content.number === issue.number);
+              if (!match) continue;
+
+              try {
+                await github.graphql(`
+                  mutation($projectId: ID!, $itemId: ID!) {
+                    deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) {
+                      deletedItemId
+                    }
+                  }
+                `, { projectId, itemId: match.id });
+                console.log(`Removed issue #${issue.number} ("${issue.title}") from project`);
+              } catch (err) {
+                console.log(`Failed to remove issue #${issue.number}: ${err.message}`);
+              }
+            }

--- a/.github/workflows/populate_bug_bashers.yml
+++ b/.github/workflows/populate_bug_bashers.yml
@@ -1,0 +1,151 @@
+name: Populate Bug Bashers Board
+
+on:
+  schedule:
+    # Runs every 6 hours
+    - cron: "0 */6 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  populate-board:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and add issues to project board
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectNumber = 74;
+            const targetColumnName = 'Bug Bashers';
+
+            // Calculate date 30 days ago
+            const thirtyDaysAgo = new Date();
+            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+            const dateFilter = thirtyDaysAgo.toISOString().split('T')[0];
+
+            // Search for open issues with state:reproducible created in last 30 days
+            const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:state:reproducible created:>=${dateFilter}`;
+
+            console.log(`Searching with query: ${searchQuery}`);
+
+            const issues = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: searchQuery,
+              per_page: 100
+            });
+
+            console.log(`Found ${issues.length} issues with state:reproducible`);
+
+            // Filter issues based on additional criteria
+            const filteredIssues = issues.filter(issue => {
+              const labels = issue.labels.map(l => l.name.toLowerCase());
+
+              // Exclude if has priority:p0 or priority:p1
+              if (labels.includes('priority:p0') || labels.includes('priority:p1')) {
+                console.log(`Excluding ${issue.number}: has p0/p1 priority`);
+                return false;
+              }
+
+              // Exclude if has any label containing "ai"
+              if (labels.some(label => label.includes('ai'))) {
+                console.log(`Excluding ${issue.number}: has AI-related label`);
+                return false;
+              }
+
+              // Must have frequency:always, frequency:common, or a label containing ".contrib"
+              const hasRequiredFrequency = labels.includes('frequency:always') ||
+                                           labels.includes('frequency:common') ||
+                                           labels.some(label => label.includes('.contrib'));
+
+              if (!hasRequiredFrequency) {
+                console.log(`Excluding ${issue.number}: missing required frequency/contrib label`);
+                return false;
+              }
+
+              return true;
+            });
+
+            console.log(`${filteredIssues.length} issues match all criteria`);
+
+            // Get the project ID using GraphQL
+            const projectQuery = `
+              query($owner: String!, $number: Int!) {
+                organization(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                    field(name: "Status") {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const projectData = await github.graphql(projectQuery, {
+              owner: context.repo.owner,
+              number: projectNumber
+            });
+
+            const projectId = projectData.organization.projectV2.id;
+            const statusField = projectData.organization.projectV2.field;
+            const targetOption = statusField.options.find(opt => opt.name === targetColumnName);
+
+            if (!targetOption) {
+              throw new Error(`Column "${targetColumnName}" not found in project`);
+            }
+
+            console.log(`Project ID: ${projectId}, Target column: ${targetOption.id}`);
+
+            // Add each issue to the project
+            for (const issue of filteredIssues) {
+              try {
+                // Add item to project
+                const addMutation = `
+                  mutation($projectId: ID!, $contentId: ID!) {
+                    addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                      item { id }
+                    }
+                  }
+                `;
+
+                const addResult = await github.graphql(addMutation, {
+                  projectId: projectId,
+                  contentId: issue.node_id
+                });
+
+                const itemId = addResult.addProjectV2ItemById.item.id;
+
+                // Set the status column
+                const updateMutation = `
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { singleSelectOptionId: $optionId }
+                    }) {
+                      projectV2Item { id }
+                    }
+                  }
+                `;
+
+                await github.graphql(updateMutation, {
+                  projectId: projectId,
+                  itemId: itemId,
+                  fieldId: statusField.id,
+                  optionId: targetOption.id
+                });
+
+                console.log(`Added issue #${issue.number} to project board`);
+              } catch (error) {
+                // Item might already exist in project, which is fine
+                console.log(`Note for issue #${issue.number}: ${error.message}`);
+              }
+            }
+
+            console.log('Done!');


### PR DESCRIPTION
Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A

Note: only PRs merged from March 2, 2026 onwards should be included in these actions.

Two yml files:
#1. guild_shipped_tracker.yml - goal is to have a github action run automatically once a PR from a Guild member is merged. The action will add the merged PR to the "Shipped by the Guild" column on the Guild board (project 74) and remove the closed issue from the Bug Bashers column. 

#2. guild_shipped_backfill.yml - backfill action to clean up the board and add any existing merged PRs from a Guild member onto the "Shipped by the Guild" column, and clean up the Bug Bashers column by removing any issues that are closed by the merged PR.