### PR TITLE
edit_prediction: Add DeepSeek FIM provider

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1703,6 +1703,11 @@
       "prompt_format": "infer",
       "max_output_tokens": 64,
     },
+    "deepseek_fim": {
+      "api_url": "",
+      "model": "",
+      "max_output_tokens": 256,
+    },
     // Controls whether Zed may collect training data when using Zed's Edit Predictions.
     // Data is only captured when the project is detected as open source.
     // Possible values:

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -585,7 +585,8 @@ fn update_command_palette_filter(cx: &mut App) {
                 | EditPredictionProvider::Codestral
                 | EditPredictionProvider::Ollama
                 | EditPredictionProvider::OpenAiCompatibleApi
-                | EditPredictionProvider::Mercury => {
+                | EditPredictionProvider::Mercury
+                | EditPredictionProvider::DeepseekFim => {
                     filter.show_namespace("edit_prediction");
                     filter.hide_namespace("copilot");
                     filter.show_action_types(edit_prediction_actions.iter());

--- a/crates/edit_prediction/src/deepseek_fim.rs
+++ b/crates/edit_prediction/src/deepseek_fim.rs
@@ -1,0 +1,328 @@
+use crate::{
+    EditPredictionId, EditPredictionModelInput, cursor_excerpt,
+    prediction::EditPredictionResult,
+};
+use anyhow::{Context as _, Result, anyhow};
+use futures::AsyncReadExt as _;
+use gpui::{App, AppContext as _, Entity, Global, SharedString, Task, http_client};
+use language::{
+    Anchor, Buffer, BufferSnapshot, ToOffset, ToPoint as _,
+    language_settings::all_language_settings,
+};
+use language_model::{ApiKeyState, EnvVar, env_var};
+use serde::Serialize;
+use std::{path::Path, sync::Arc, time::Instant};
+use zeta_prompt::{ZetaPromptInput, compute_editable_and_context_ranges};
+
+const DEEPSEEK_FIM_API_URL: &str = "https://api.deepseek.com/beta";
+const FIM_CONTEXT_TOKENS: usize = 512;
+
+pub static DEEPSEEK_API_KEY_ENV_VAR: std::sync::LazyLock<EnvVar> = env_var!("DEEPSEEK_API_KEY");
+
+struct GlobalDeepseekFimApiKey(Entity<ApiKeyState>);
+
+impl Global for GlobalDeepseekFimApiKey {}
+
+pub fn deepseek_fim_api_url(cx: &App) -> SharedString {
+    all_language_settings(None, cx)
+        .edit_predictions
+        .deepseek_fim
+        .as_ref()
+        .map(|settings| settings.api_url.clone())
+        .unwrap_or_else(|| DEEPSEEK_FIM_API_URL.into())
+        .into()
+}
+
+pub fn deepseek_fim_api_key_state(cx: &mut App) -> Entity<ApiKeyState> {
+    if let Some(global) = cx.try_global::<GlobalDeepseekFimApiKey>() {
+        return global.0.clone();
+    }
+
+    let entity = cx.new(|cx| {
+        ApiKeyState::new(deepseek_fim_api_url(cx), DEEPSEEK_API_KEY_ENV_VAR.clone())
+    });
+    cx.set_global(GlobalDeepseekFimApiKey(entity.clone()));
+    entity
+}
+
+fn load_deepseek_fim_api_token(
+    cx: &mut App,
+) -> Task<Result<(), language_model::AuthenticateError>> {
+    let credentials_provider = zed_credentials_provider::global(cx);
+    let api_url = deepseek_fim_api_url(cx);
+    deepseek_fim_api_key_state(cx).update(cx, |key_state, cx| {
+        key_state.load_if_needed(api_url, |s| s, credentials_provider, cx)
+    })
+}
+
+pub fn load_deepseek_fim_api_key(cx: &mut App) -> Option<Arc<str>> {
+    _ = load_deepseek_fim_api_token(cx);
+    let url = deepseek_fim_api_url(cx);
+    deepseek_fim_api_key_state(cx).read(cx).key(&url)
+}
+
+#[derive(Debug, Serialize)]
+struct DeepseekFimRequest {
+    model: String,
+    prompt: String,
+    suffix: String,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    stop: Vec<String>,
+}
+
+struct DeepseekFimRequestOutput {
+    request_id: String,
+    edits: Vec<(std::ops::Range<Anchor>, Arc<str>)>,
+    snapshot: BufferSnapshot,
+    inputs: ZetaPromptInput,
+    buffer: Entity<Buffer>,
+}
+
+pub fn request_prediction(
+    EditPredictionModelInput {
+        buffer,
+        snapshot,
+        position,
+        events,
+        ..
+    }: EditPredictionModelInput,
+    cx: &mut App,
+) -> Task<Result<Option<EditPredictionResult>>> {
+    let settings = &all_language_settings(None, cx).edit_predictions;
+
+    let Some(settings) = settings.deepseek_fim.clone() else {
+        return Task::ready(Err(anyhow!("DeepseekFim edit prediction settings not configured")));
+    };
+
+    let full_path: Arc<Path> = snapshot
+        .file()
+        .map(|file| file.full_path(cx))
+        .unwrap_or_else(|| "untitled".into())
+        .into();
+
+    let http_client = cx.http_client();
+    let cursor_point = position.to_point(&snapshot);
+    let request_start = cx.background_executor().now();
+    let api_key = load_deepseek_fim_api_key(cx);
+
+    let result = cx.background_spawn(async move {
+        let cursor_offset = cursor_point.to_offset(&snapshot);
+        let (excerpt_point_range, excerpt_offset_range, cursor_offset_in_excerpt) =
+            cursor_excerpt::compute_cursor_excerpt(&snapshot, cursor_offset);
+        let cursor_excerpt: Arc<str> = snapshot
+            .text_for_range(excerpt_point_range.clone())
+            .collect::<String>()
+            .into();
+        let syntax_ranges =
+            cursor_excerpt::compute_syntax_ranges(&snapshot, cursor_offset, &excerpt_offset_range);
+        let (editable_range, _) = compute_editable_and_context_ranges(
+            &cursor_excerpt,
+            cursor_offset_in_excerpt,
+            &syntax_ranges,
+            FIM_CONTEXT_TOKENS,
+            0,
+        );
+
+        let inputs = ZetaPromptInput {
+            events,
+            related_files: Some(Vec::new()),
+            active_buffer_diagnostics: Vec::new(),
+            cursor_offset_in_excerpt: cursor_offset - excerpt_offset_range.start,
+            cursor_path: full_path.clone(),
+            excerpt_start_row: Some(excerpt_point_range.start.row),
+            cursor_excerpt,
+            excerpt_ranges: Default::default(),
+            syntax_ranges: None,
+            in_open_source_repo: false,
+            can_collect_data: false,
+            repo_url: None,
+        };
+
+        let editable_text = &inputs.cursor_excerpt[editable_range.clone()];
+        let cursor_in_editable = cursor_offset_in_excerpt.saturating_sub(editable_range.start);
+        let prefix = editable_text[..cursor_in_editable].to_string();
+        let suffix = editable_text[cursor_in_editable..].to_string();
+        let stop_tokens = get_fim_stop_tokens();
+
+        let max_tokens = settings.max_output_tokens;
+
+        let request = DeepseekFimRequest {
+            model: settings.model.clone(),
+            prompt: prefix,
+            suffix,
+            max_tokens,
+            temperature: Some(0.2),
+            stop: stop_tokens,
+        };
+
+        let request_body = serde_json::to_string(&request)?;
+        let mut http_request_builder = http_client::Request::builder()
+            .method(http_client::Method::POST)
+            .uri(format!("{}/completions", settings.api_url))
+            .header("Content-Type", "application/json");
+
+        if let Some(api_key) = api_key {
+            http_request_builder =
+                http_request_builder.header("Authorization", format!("Bearer {}", api_key));
+        }
+
+        let http_request =
+            http_request_builder.body(http_client::AsyncBody::from(request_body))?;
+
+        let mut response = http_client.send(http_request).await?;
+        let status = response.status();
+
+        if !status.is_success() {
+            let mut body = String::new();
+            response.body_mut().read_to_string(&mut body).await?;
+            anyhow::bail!("DeepseekFim API error: {} - {}", status, body);
+        }
+
+        let mut body = String::new();
+        response.body_mut().read_to_string(&mut body).await?;
+
+        let parsed: cloud_llm_client::predict_edits_v3::RawCompletionResponse =
+            serde_json::from_str(&body).context("Failed to parse DeepseekFim completion response")?;
+        let text = parsed
+            .choices
+            .into_iter()
+            .next()
+            .map(|choice| choice.text)
+            .unwrap_or_default();
+
+        let response_received_at = Instant::now();
+
+        log::debug!(
+            "deepseek_fim: completion received ({:.2}s)",
+            (response_received_at - request_start).as_secs_f64()
+        );
+
+        let completion: Arc<str> = text.into();
+        let edits = if completion.is_empty() {
+            vec![]
+        } else {
+            let cursor_offset = cursor_point.to_offset(&snapshot);
+            let anchor = snapshot.anchor_after(cursor_offset);
+            vec![(anchor..anchor, completion)]
+        };
+
+        anyhow::Ok(DeepseekFimRequestOutput {
+            request_id: parsed.id,
+            edits,
+            snapshot,
+            inputs,
+            buffer,
+        })
+    });
+
+    cx.spawn(async move |cx: &mut gpui::AsyncApp| {
+        let output = result.await.context("deepseek_fim fim edit prediction failed")?;
+        anyhow::Ok(Some(
+            EditPredictionResult::new(
+                EditPredictionId(output.request_id.into()),
+                &output.buffer,
+                &output.snapshot,
+                output.edits.into(),
+                None,
+                output.inputs,
+                None,
+                cx.background_executor().now() - request_start,
+                cx,
+            )
+            .await,
+        ))
+    })
+}
+
+fn get_fim_stop_tokens() -> Vec<String> {
+    vec![
+        "<|endoftext|>".to_string(),
+        "<|file_separator|>".to_string(),
+        "<|fim_pad|>".to_string(),
+        "<|fim_prefix|>".to_string(),
+        "<|fim_middle|>".to_string(),
+        "<|fim_suffix|>".to_string(),
+        "<fim_prefix>".to_string(),
+        "<fim_middle>".to_string(),
+        "<fim_suffix>".to_string(),
+        "<PRE>".to_string(),
+        "<SUF>".to_string(),
+        "<MID>".to_string(),
+        "[PREFIX]".to_string(),
+        "[SUFFIX]".to_string(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deepseek_fim_request_serialization() {
+        let request = DeepseekFimRequest {
+            model: "deepseek-v4-pro".to_string(),
+            prompt: "def fib(a):\n    ".to_string(),
+            suffix: "\n    return fib(a-1) + fib(a-2)".to_string(),
+            max_tokens: 128,
+            temperature: Some(0.2),
+            stop: vec!["<|endoftext|>".to_string()],
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["model"], "deepseek-v4-pro");
+        assert_eq!(parsed["prompt"], "def fib(a):\n    ");
+        assert_eq!(parsed["suffix"], "\n    return fib(a-1) + fib(a-2)");
+        assert_eq!(parsed["max_tokens"], 128);
+        assert_eq!(parsed["temperature"], 0.2);
+        assert_eq!(parsed["stop"], serde_json::json!(["<|endoftext|>"]));
+    }
+
+    #[test]
+    fn test_deepseek_fim_response_deserialization() {
+        // Sample response from the actual DeepSeek FIM beta endpoint
+        let response_json = r#"{
+            "id": "00000000-0000-0000-0000-000000000000",
+            "choices": [
+                {
+                    "text": "if a < 2:\n        return a",
+                    "index": 0,
+                    "logprobs": null,
+                    "finish_reason": "stop"
+                }
+            ],
+            "created": 0,
+            "model": "deepseek-v4-pro",
+            "system_fingerprint": "fp_redacted",
+            "object": "text_completion",
+            "usage": {
+                "prompt_tokens": 23,
+                "completion_tokens": 9,
+                "total_tokens": 32,
+                "prompt_tokens_details": {
+                    "cached_tokens": 0
+                },
+                "completion_tokens_details": {
+                    "reasoning_tokens": 0
+                },
+                "prompt_cache_hit_tokens": 0,
+                "prompt_cache_miss_tokens": 23
+            }
+        }"#;
+
+        let response: cloud_llm_client::predict_edits_v3::RawCompletionResponse =
+            serde_json::from_str(response_json).unwrap();
+
+        assert_eq!(response.id, "00000000-0000-0000-0000-000000000000");
+        assert_eq!(response.model, "deepseek-v4-pro");
+        assert_eq!(response.choices.len(), 1);
+        assert_eq!(response.choices[0].text, "if a < 2:\n        return a");
+        assert_eq!(response.choices[0].finish_reason.as_deref(), Some("stop"));
+        assert_eq!(response.usage.prompt_tokens, 23);
+        assert_eq!(response.usage.completion_tokens, 9);
+        assert_eq!(response.usage.total_tokens, 32);
+    }
+}

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -62,6 +62,7 @@ use thiserror::Error;
 use util::{RangeExt as _, ResultExt as _};
 
 pub mod cursor_excerpt;
+pub mod deepseek_fim;
 pub mod example_spec;
 pub mod fim;
 mod license_detection;
@@ -173,6 +174,7 @@ pub enum EditPredictionModel {
     Zeta,
     Fim { format: EditPredictionPromptFormat },
     Mercury,
+    DeepseekFim,
 }
 
 #[derive(Clone)]
@@ -949,6 +951,9 @@ impl EditPredictionStore {
                     }
                 }
             }
+            EditPredictionModel::DeepseekFim => {
+                edit_prediction_types::EditPredictionIconSet::new(IconName::AiDeepSeek)
+            }
         }
     }
 
@@ -1521,7 +1526,7 @@ impl EditPredictionStore {
                     zeta::edit_prediction_accepted(self, current_prediction, cx)
                 }
             }
-            EditPredictionModel::Fim { .. } => {}
+            EditPredictionModel::Fim { .. } | EditPredictionModel::DeepseekFim => {}
         }
     }
 
@@ -1882,7 +1887,7 @@ impl EditPredictionStore {
                     cx,
                 );
             }
-            EditPredictionModel::Fim { .. } => {}
+            EditPredictionModel::Fim { .. } | EditPredictionModel::DeepseekFim => {}
         }
     }
 
@@ -2110,7 +2115,8 @@ fn is_ep_store_provider(provider: EditPredictionProvider) -> bool {
         EditPredictionProvider::Zed
         | EditPredictionProvider::Mercury
         | EditPredictionProvider::Ollama
-        | EditPredictionProvider::OpenAiCompatibleApi => true,
+        | EditPredictionProvider::OpenAiCompatibleApi
+        | EditPredictionProvider::DeepseekFim => true,
         EditPredictionProvider::None
         | EditPredictionProvider::Copilot
         | EditPredictionProvider::Codestral => false,
@@ -2145,7 +2151,9 @@ impl EditPredictionStore {
 
         let (needs_acceptance_tracking, max_pending_predictions) =
             match all_language_settings(None, cx).edit_predictions.provider {
-                EditPredictionProvider::Zed | EditPredictionProvider::Mercury => (true, 2),
+                EditPredictionProvider::Zed
+                | EditPredictionProvider::Mercury
+                | EditPredictionProvider::DeepseekFim => (true, 2),
                 EditPredictionProvider::Ollama => (false, 1),
                 EditPredictionProvider::OpenAiCompatibleApi => (false, 2),
                 EditPredictionProvider::None
@@ -2412,6 +2420,7 @@ impl EditPredictionStore {
                 self.mercury
                     .request_prediction(inputs, self.credentials_provider.clone(), cx)
             }
+            EditPredictionModel::DeepseekFim => deepseek_fim::request_prediction(inputs, cx),
         };
 
         cx.spawn(async move |this, cx| {

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -323,6 +323,55 @@ impl Render for EditPredictionButton {
                         .with_handle(self.popover_menu_handle.clone()),
                 )
             }
+            EditPredictionProvider::DeepseekFim => {
+                let enabled = self.editor_enabled.unwrap_or(true);
+                let this = cx.weak_entity();
+
+                div().child(
+                    PopoverMenu::new("deepseek-fim")
+                        .menu(move |window, cx| {
+                            this.update(cx, |this, cx| {
+                                this.build_edit_prediction_context_menu(
+                                    EditPredictionProvider::DeepseekFim,
+                                    window,
+                                    cx,
+                                )
+                            })
+                            .ok()
+                        })
+                        .anchor(Anchor::BottomRight)
+                        .trigger_with_tooltip(
+                            IconButton::new("deepseek-fim-icon", IconName::AiDeepSeek)
+                                .shape(IconButtonShape::Square)
+                                .when(!enabled, |this| {
+                                    this.indicator(Indicator::dot().color(Color::Ignored))
+                                        .indicator_border_color(Some(
+                                            cx.theme().colors().status_bar_background,
+                                        ))
+                                }),
+                            move |_window, cx| {
+                                let settings = all_language_settings(None, cx);
+                                let tooltip_meta =
+                                    match settings.edit_predictions.deepseek_fim.as_ref() {
+                                        Some(settings)
+                                            if !settings.model.trim().is_empty() =>
+                                        {
+                                            format!("Powered by DeepSeek FIM ({})", settings.model)
+                                        }
+                                        _ => "Powered by DeepSeek FIM".to_string(),
+                                    };
+
+                                Tooltip::with_meta(
+                                    "Edit Prediction",
+                                    Some(&ToggleMenu),
+                                    tooltip_meta,
+                                    cx,
+                                )
+                            },
+                        )
+                        .with_handle(self.popover_menu_handle.clone()),
+                )
+            }
             provider @ (EditPredictionProvider::Zed | EditPredictionProvider::Mercury) => {
                 let enabled = self.editor_enabled.unwrap_or(true);
                 let file = self.file.clone();
@@ -1475,6 +1524,17 @@ pub fn get_available_providers(cx: &mut App) -> Vec<EditPredictionProvider> {
         .is_some()
     {
         providers.push(EditPredictionProvider::OpenAiCompatibleApi);
+    }
+
+    if edit_prediction::deepseek_fim::deepseek_fim_api_key_state(cx)
+        .read(cx)
+        .has_key()
+        || all_language_settings(None, cx)
+            .edit_predictions
+            .deepseek_fim
+            .is_some()
+    {
+        providers.push(EditPredictionProvider::DeepseekFim);
     }
 
     if edit_prediction::mercury::mercury_api_token(cx)

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -477,6 +477,8 @@ pub struct EditPredictionSettings {
     /// Settings specific to Ollama.
     pub ollama: Option<OpenAiCompatibleEditPredictionSettings>,
     pub open_ai_compatible_api: Option<OpenAiCompatibleEditPredictionSettings>,
+    /// Settings specific to DeepSeek FIM.
+    pub deepseek_fim: Option<OpenAiCompatibleEditPredictionSettings>,
     pub examples_dir: Option<Arc<Path>>,
     /// Controls whether training data collection is enabled.
     ///
@@ -834,6 +836,23 @@ impl settings::Settings for AllLanguageSettings {
                 prompt_format: openai_compatible_settings.prompt_format.unwrap(),
             });
 
+        let deepseek_fim_settings = edit_predictions
+            .deepseek_fim
+            .and_then(|deepseek_fim| {
+                deepseek_fim.model.filter(|model| !model.is_empty()).map(|model| {
+                    OpenAiCompatibleEditPredictionSettings {
+                        model,
+                        max_output_tokens: deepseek_fim.max_output_tokens.unwrap_or(256),
+                        api_url: deepseek_fim
+                            .api_url
+                            .filter(|url| !url.is_empty())
+                            .map(|url| url.into())
+                            .unwrap_or_else(|| "https://api.deepseek.com/beta".into()),
+                        prompt_format: settings::EditPredictionPromptFormat::DeepseekCoder,
+                    }
+                })
+            });
+
         let mut file_types: FxHashMap<Arc<str>, (GlobSet, Vec<String>)> = FxHashMap::default();
 
         for (language, patterns) in all_languages.file_types.iter().flatten() {
@@ -871,6 +890,7 @@ impl settings::Settings for AllLanguageSettings {
                 codestral: codestral_settings,
                 ollama: ollama_settings,
                 open_ai_compatible_api: openai_compatible_settings,
+                deepseek_fim: deepseek_fim_settings,
                 examples_dir: edit_predictions.examples_dir,
                 allow_data_collection: edit_predictions.allow_data_collection.unwrap_or_default(),
             },

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -87,6 +87,7 @@ pub enum EditPredictionProvider {
     Codestral,
     Ollama,
     OpenAiCompatibleApi,
+    DeepseekFim,
     Mercury,
 }
 
@@ -99,6 +100,7 @@ impl EditPredictionProvider {
             | EditPredictionProvider::Codestral
             | EditPredictionProvider::Ollama
             | EditPredictionProvider::OpenAiCompatibleApi
+            | EditPredictionProvider::DeepseekFim
             | EditPredictionProvider::Mercury => false,
         }
     }
@@ -112,6 +114,7 @@ impl EditPredictionProvider {
             EditPredictionProvider::None => None,
             EditPredictionProvider::Ollama => Some("Ollama"),
             EditPredictionProvider::OpenAiCompatibleApi => Some("OpenAI-Compatible API"),
+            EditPredictionProvider::DeepseekFim => Some("DeepSeek FIM"),
         }
     }
 }
@@ -137,6 +140,8 @@ pub struct EditPredictionSettingsContent {
     pub ollama: Option<OllamaEditPredictionSettingsContent>,
     /// Settings specific to using custom OpenAI-compatible servers for edit prediction.
     pub open_ai_compatible_api: Option<CustomEditPredictionProviderSettingsContent>,
+    /// Settings specific to DeepSeek FIM.
+    pub deepseek_fim: Option<DeepseekFimEditPredictionSettingsContent>,
     /// The directory where manually captured edit prediction examples are stored.
     pub examples_dir: Option<Arc<Path>>,
     /// Controls whether Zed may collect training data when using Zed's Edit Predictions.
@@ -147,6 +152,23 @@ pub struct EditPredictionSettingsContent {
     /// - `"yes"`: allow data collection for files in open-source projects.
     /// - `"no"`: never allow data collection.
     pub allow_data_collection: Option<EditPredictionDataCollectionChoice>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct DeepseekFimEditPredictionSettingsContent {
+    /// Api URL to use for completions.
+    ///
+    /// Default: "https://api.deepseek.com/beta"
+    pub api_url: Option<String>,
+    /// The name of the model.
+    ///
+    /// Default: "deepseek-v4-pro"
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    ///
+    /// Default: 256
+    pub max_output_tokens: Option<u32>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -1,6 +1,7 @@
 use codestral::{CODESTRAL_API_URL, codestral_api_key_state, codestral_api_url};
 use edit_prediction::{
     ApiKeyState,
+    deepseek_fim::{deepseek_fim_api_key_state, deepseek_fim_api_url},
     mercury::{MERCURY_CREDENTIALS_URL, mercury_api_token},
     open_ai_compatible::{open_ai_compatible_api_token, open_ai_compatible_api_url},
 };
@@ -82,6 +83,30 @@ pub(crate) fn render_edit_prediction_setup_page(
                     settings_window
                         .render_sub_page_items_section(
                             open_ai_compatible_settings().iter().enumerate(),
+                            true,
+                            window,
+                            cx,
+                        )
+                        .into_any_element(),
+                ),
+                window,
+                cx,
+            )
+            .into_any_element(),
+        ),
+        Some(
+            render_api_key_provider(
+                IconName::AiDeepSeek,
+                "DeepSeek FIM",
+                ApiKeyDocs::Link {
+                    dashboard_url: "https://platform.deepseek.com/api_keys".into(),
+                },
+                deepseek_fim_api_key_state(cx),
+                |cx| deepseek_fim_api_url(cx),
+                Some(
+                    settings_window
+                        .render_sub_page_items_section(
+                            deepseek_fim_settings().iter().enumerate(),
                             true,
                             window,
                             cx,
@@ -714,6 +739,107 @@ fn codestral_settings() -> Box<[SettingsPageItem]> {
                 placeholder: Some("codestral-latest"),
                 ..Default::default()
             })),
+            files: USER,
+        }),
+    ])
+}
+
+fn deepseek_fim_settings() -> Box<[SettingsPageItem]> {
+    Box::new([
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "API URL",
+            description: "The URL of the DeepSeek FIM API.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .deepseek_fim
+                        .as_ref()?
+                        .api_url
+                        .as_ref()
+                },
+                write: |settings, value, _app: &App| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .deepseek_fim
+                        .get_or_insert_default()
+                        .api_url = value;
+                },
+                json_path: Some("edit_predictions.deepseek_fim.api_url"),
+            }),
+            metadata: Some(Box::new(SettingsFieldMetadata {
+                placeholder: Some("https://api.deepseek.com/beta"),
+                ..Default::default()
+            })),
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "Model",
+            description: "The model string to pass to DeepSeek FIM.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .deepseek_fim
+                        .as_ref()?
+                        .model
+                        .as_ref()
+                },
+                write: |settings, value, _app: &App| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .deepseek_fim
+                        .get_or_insert_default()
+                        .model = value;
+                },
+                json_path: Some("edit_predictions.deepseek_fim.model"),
+            }),
+            metadata: Some(Box::new(SettingsFieldMetadata {
+                placeholder: Some("deepseek-v4-pro"),
+                ..Default::default()
+            })),
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "Max Output Tokens",
+            description: "The maximum number of tokens to generate.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .deepseek_fim
+                        .as_ref()?
+                        .max_output_tokens
+                        .as_ref()
+                },
+                write: |settings, value, _app: &App| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .deepseek_fim
+                        .get_or_insert_default()
+                        .max_output_tokens = value;
+                },
+                json_path: Some("edit_predictions.deepseek_fim.max_output_tokens"),
+            }),
+            metadata: None,
             files: USER,
         }),
     ])

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -147,6 +147,13 @@ fn edit_prediction_provider_config_for_settings(cx: &App) -> Option<EditPredicti
         EditPredictionProvider::Mercury => Some(EditPredictionProviderConfig::Zed(
             EditPredictionModel::Mercury,
         )),
+        EditPredictionProvider::DeepseekFim => {
+            if settings.deepseek_fim.is_some() {
+                Some(EditPredictionProviderConfig::Zed(EditPredictionModel::DeepseekFim))
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -183,6 +190,7 @@ impl EditPredictionProviderConfig {
                 EditPredictionModel::Zeta => "Zeta",
                 EditPredictionModel::Fim { .. } => "FIM",
                 EditPredictionModel::Mercury => "Mercury",
+                EditPredictionModel::DeepseekFim => "DeepSeek FIM",
             },
         }
     }


### PR DESCRIPTION
Summary:

- Add a DeepSeek FIM edit prediction provider that sends prefix/suffix completion requests to the DeepSeek beta completions endpoint.
- Add DeepSeek FIM settings, defaults, provider registry wiring, setup-page controls, provider availability, and status-bar UI.
- Add focused serialization/deserialization tests for the DeepSeek FIM request and response shapes.

Tests:

- cargo test -p edit_prediction deepseek_fim

Release Notes:

- Added DeepSeek FIM as an edit prediction provider.