### PR TITLE
Add paragraph-based navigation to terminal's vi mode

### DIFF
--- a/crates/terminal/src/alacritty.rs
+++ b/crates/terminal/src/alacritty.rs
@@ -355,6 +355,8 @@ impl ViMotion {
             Self::WordRight => AlacViMotion::WordRight,
             Self::WordRightEnd => AlacViMotion::WordRightEnd,
             Self::Bracket => AlacViMotion::Bracket,
+            Self::ParagraphUp => AlacViMotion::ParagraphUp,
+            Self::ParagraphDown => AlacViMotion::ParagraphDown,
         }
     }
 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -96,6 +96,8 @@ enum ViMotion {
     WordRight,
     WordRightEnd,
     Bracket,
+    ParagraphUp,
+    ParagraphDown,
 }
 
 #[derive(Clone, Debug)]
@@ -1922,6 +1924,8 @@ impl Terminal {
             "H" => Some(ViMotion::High),
             "M" => Some(ViMotion::Middle),
             "L" => Some(ViMotion::Low),
+            "{" if keystroke.modifiers.shift => Some(ViMotion::ParagraphUp),
+            "}" if keystroke.modifiers.shift => Some(ViMotion::ParagraphDown),
             _ => None,
         };
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1924,8 +1924,8 @@ impl Terminal {
             "H" => Some(ViMotion::High),
             "M" => Some(ViMotion::Middle),
             "L" => Some(ViMotion::Low),
-            "{" if keystroke.modifiers.shift => Some(ViMotion::ParagraphUp),
-            "}" if keystroke.modifiers.shift => Some(ViMotion::ParagraphDown),
+            "{" => Some(ViMotion::ParagraphUp),
+            "}" => Some(ViMotion::ParagraphDown),
             _ => None,
         };
 


### PR DESCRIPTION
Alacritty has default keyboard shortcuts to navigate between paragraphs in vi mode:

- shift-{: `ParagraphUp`
- shift-}: `ParagraphDown`

This change unlocks them to use in Zed's terminal. The keybindings can be easily overridden via keymap.yml like that:

```yaml
{
    "context": "Terminal && vi_mode",
    "bindings": {
        "ctrl-up": ["terminal::SendKeystroke", "shift-{"],
        "ctrl-down": ["terminal::SendKeystroke", "shift-}"],
    }
}
```

Release Notes:

- Added support for navigating up or down paragraphs in the terminal, when vim vi mode is enabled, with `shift-{` and `shift-}`, respectively.
