### PR TITLE
deepseek: Add `tool_choice` field to DeepSeek request model

### DIFF
--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -126,6 +126,8 @@ pub struct Request {
     pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<ToolDefinition>,
 }
@@ -156,6 +158,14 @@ pub enum ResponseFormat {
     Text,
     #[serde(rename = "json_object")]
     JsonObject,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolChoice {
+    None,
+    Auto,
+    Required,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -450,6 +450,11 @@ pub fn into_deepseek(
             None
         },
         response_format: None,
+        tool_choice: request.tool_choice.map(|choice| match choice {
+            LanguageModelToolChoice::Auto => deepseek::ToolChoice::Auto,
+            LanguageModelToolChoice::Any => deepseek::ToolChoice::Required,
+            LanguageModelToolChoice::None => deepseek::ToolChoice::None,
+        }),
         tools: request
             .tools
             .into_iter()


### PR DESCRIPTION
Release Notes:

- N/A

reference: https://api-docs.deepseek.com/api/create-chat-completion/
