### PR TITLE
editor: Don't bypass show_edit_predictions when navigating diagnostics

### DIFF
--- a/crates/editor/src/diagnostics.rs
+++ b/crates/editor/src/diagnostics.rs
@@ -192,8 +192,8 @@ impl Editor {
         });
         self.activate_diagnostics(buffer_id, diagnostic, window, cx);
         self.refresh_edit_prediction(
-            false,
             true,
+            false,
             EditPredictionRequestTrigger::DiagnosticNavigation,
             window,
             cx,


### PR DESCRIPTION
`go_to_diagnostic_impl` was calling `refresh_edit_prediction(false, true)` with `user_requested = true`, which skips the `should_show_edit_predictions` check inside `refresh_edit_prediction` (`crates/editor/src/editor.rs`).

As a result, navigating between diagnostics in a buffer where the user has set `show_edit_predictions: false` would still trigger `EditPredictionProvider::refresh`. With the Zed provider this fans out into many `textDocument/definition` and `textDocument/typeDefinition` LSP requests for every identifier near the cursor (`RelatedExcerptStore::fetch_excerpts`), which is surprising for users who have explicitly disabled edit predictions for that language.

Jumping to a diagnostic is a navigation action, not a request for an edit prediction, so pass `user_requested = false` and enable debouncing here.

Release Notes:

- Fixed diagnostic navigation triggering unnecessary LSP requests when edit predictions are disabled.