### PR TITLE
Fix multibuffer initialization based on RHS state

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -583,8 +583,13 @@ impl SplittableEditor {
         };
         let project = workspace.read(cx).project().clone();
 
+        let is_rhs_singleton = self.rhs_multibuffer.read(cx).is_singleton();
         let lhs_multibuffer = cx.new(|cx| {
-            let mut multibuffer = MultiBuffer::new(Capability::ReadOnly);
+            let mut multibuffer = if is_rhs_singleton {
+                MultiBuffer::without_headers(Capability::ReadOnly)
+            } else {
+                MultiBuffer::new(Capability::ReadOnly)
+            };
             multibuffer.set_all_diff_hunks_expanded(cx);
             multibuffer
         });


### PR DESCRIPTION
This update modifies the initialization of the left-hand side multibuffer in the SplittableEditor. It now checks if the right-hand side multibuffer is a singleton and uses a `MultiBuffer::without_headers` instead.


Before Screenshot:
<img width="1624" height="1030" alt="Screenshot 2026-05-07 at 7 30 16 PM" src="https://github.com/user-attachments/assets/3d963703-309c-42e4-b2be-fe64bd9c0a06" />

After Screenshot:
<img width="1624" height="1030" alt="Screenshot 2026-05-07 at 7 32 48 PM" src="https://github.com/user-attachments/assets/51668319-6a34-47df-b8b1-8bf58b86407e" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)



Release Notes:
- Optimized multibuffer creation by conditionally using headers based on RHS state.
