### PR TITLE
Add test_env_file setting to load .env files into test tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17684,6 +17684,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
+ "dotenvy",
  "futures 0.3.32",
  "gpui",
  "hex",

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -8,6 +8,7 @@ use gpui::{App, Entity, Task};
 use gpui::{AsyncApp, FutureExt};
 use language::Buffer;
 use language::Language;
+use language::language_settings::LanguageSettings;
 use lsp::LanguageServerId;
 use lsp::LanguageServerName;
 use project::LanguageServerToQuery;
@@ -15,6 +16,7 @@ use project::LocationLink;
 use project::Project;
 use project::TaskSourceKind;
 use project::lsp_store::lsp_ext_command::GetLspRunnables;
+use project::test_env_file::load_test_env_files;
 use task::ResolvedTask;
 use task::TaskContext;
 use text::BufferId;
@@ -89,9 +91,27 @@ async fn lsp_task_context(
         })
         .await;
 
+    let test_env_paths = cx.update(|cx| {
+        LanguageSettings::for_buffer(buffer.read(cx), cx)
+            .test_env_file
+            .clone()
+    });
+    let fs = cx.update(|cx| worktree_store.read(cx).fs());
+    let test_env = match (
+        test_env_paths.as_ref(),
+        worktree_abs_path.as_deref(),
+        fs.as_ref(),
+    ) {
+        (Some(paths), Some(root), Some(fs)) => load_test_env_files(paths, root, fs).await,
+        _ => HashMap::default(),
+    };
+
+    let mut merged_project_env = project_env.unwrap_or_default();
+    merged_project_env.extend(test_env);
+
     Some(TaskContext {
         cwd: worktree_abs_path.map(|p| p.to_path_buf()),
-        project_env: project_env.unwrap_or_default(),
+        project_env: merged_project_env,
         ..TaskContext::default()
     })
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -19,7 +19,8 @@ pub use settings::{
     AutoIndentMode, CompletionSettingsContent, EditPredictionDataCollectionChoice,
     EditPredictionPromptFormat, EditPredictionProvider, EditPredictionsMode, FormatOnSave,
     Formatter, FormatterList, InlayHintKind, LanguageSettingsContent, LineEndingSetting,
-    LspInsertMode, RewrapBehavior, ShowWhitespaceSetting, SoftWrap, WordsCompletionMode,
+    LspInsertMode, RewrapBehavior, ShowWhitespaceSetting, SoftWrap, TestEnvFilePaths,
+    WordsCompletionMode,
 };
 use settings::{RegisterSetting, Settings, SettingsLocation, SettingsStore, merge_from::MergeFrom};
 use shellexpand;
@@ -89,6 +90,8 @@ pub struct LanguageSettings {
     pub line_ending: LineEndingSetting,
     /// How to perform a buffer format.
     pub formatter: settings::FormatterList,
+    /// Paths to `.env` files loaded into the env of test runs for this language.
+    pub test_env_file: Option<TestEnvFilePaths>,
     /// Zed's Prettier integration settings.
     pub prettier: PrettierSettings,
     /// Whether to automatically close JSX tags.
@@ -700,6 +703,7 @@ impl settings::Settings for AllLanguageSettings {
                 ensure_final_newline_on_save: settings.ensure_final_newline_on_save.unwrap(),
                 line_ending: settings.line_ending.unwrap(),
                 formatter: settings.formatter.unwrap(),
+                test_env_file: settings.test_env_file.clone(),
                 prettier: PrettierSettings {
                     allowed: prettier.allowed.unwrap(),
                     parser: prettier.parser.filter(|parser| !parser.is_empty()),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -18,6 +18,7 @@ pub mod project_settings;
 pub mod search;
 pub mod task_inventory;
 pub mod task_store;
+pub mod test_env_file;
 pub mod telemetry_snapshot;
 pub mod terminals;
 pub mod toolchain_store;

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -9,6 +9,7 @@ use fs::Fs;
 use gpui::{App, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::{
     ContextLocation, ContextProvider as _, LanguageToolchainStore, Location,
+    language_settings::LanguageSettings,
     proto::{deserialize_anchor, serialize_anchor},
 };
 use rpc::{AnyProtoClient, TypedEnvelope, proto};
@@ -19,7 +20,7 @@ use util::ResultExt;
 
 use crate::{
     BasicContextProvider, Inventory, ProjectEnvironment, buffer_store::BufferStore,
-    git_store::GitStore, worktree_store::WorktreeStore,
+    git_store::GitStore, test_env_file::load_test_env_files, worktree_store::WorktreeStore,
 };
 
 // platform-dependent warning
@@ -329,6 +330,20 @@ fn local_task_context_for_location(
             })
             .await;
 
+        let test_env_paths = cx.update(|cx| {
+            LanguageSettings::for_buffer(location.buffer.read(cx), cx)
+                .test_env_file
+                .clone()
+        });
+        let test_env = match (
+            test_env_paths.as_ref(),
+            worktree_abs_path.as_deref(),
+            fs.as_ref(),
+        ) {
+            (Some(paths), Some(root), Some(fs)) => load_test_env_files(paths, root, fs).await,
+            _ => HashMap::default(),
+        };
+
         let mut task_variables = cx
             .update(|cx| {
                 combine_task_variables(
@@ -347,8 +362,11 @@ fn local_task_context_for_location(
         // Remove all custom entries starting with _, as they're not intended for use by the end user.
         task_variables.sweep();
 
+        let mut merged_project_env = project_env.unwrap_or_default();
+        merged_project_env.extend(test_env);
+
         Ok(Some(TaskContext {
-            project_env: project_env.unwrap_or_default(),
+            project_env: merged_project_env,
             cwd: worktree_abs_path.map(|p| p.to_path_buf()),
             task_variables,
         }))
@@ -367,6 +385,10 @@ fn remote_task_context_for_location(
 ) -> Task<anyhow::Result<Option<TaskContext>>> {
     cx.spawn(async move |cx| {
         // We need to gather a client context, as the headless one may lack certain information (e.g. tree-sitter parsing is disabled there, so symbols are not available).
+        // The remote host fills `project_env` (including any `test_env_file` entries it
+        // applied via `local_task_context_for_location`) and serializes it back through
+        // the `proto::TaskContextForLocation` response, so this path inherits the env
+        // file transitively and does not need its own hook.
         let mut remote_context = cx
             .update(|cx| {
                 let worktree_root = worktree_root(&worktree_store, &location, cx);

--- a/crates/project/src/test_env_file.rs
+++ b/crates/project/src/test_env_file.rs
@@ -1,0 +1,167 @@
+//! Loader for the per-language `test_env_file` setting.
+//!
+//! Resolves the configured path(s) against the buffer's worktree root, reads
+//! each file via the project's `Fs`, and returns a key/value map ready to be
+//! merged into a `TaskContext.project_env`. Missing files are silently
+//! skipped; per-line parse errors are logged but do not abort the load.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use collections::HashMap;
+use fs::Fs;
+use settings::TestEnvFilePaths;
+use task::parse_env_file;
+
+pub async fn load_test_env_files(
+    paths: &TestEnvFilePaths,
+    worktree_root: &Path,
+    fs: &Arc<dyn Fs>,
+) -> HashMap<String, String> {
+    let mut result = HashMap::default();
+    for raw in paths.as_ref() {
+        let resolved = resolve_path(raw, worktree_root);
+        if !fs.is_file(&resolved).await {
+            continue;
+        }
+        match fs.open_sync(&resolved).await {
+            Ok(reader) => {
+                let (env, warnings) = parse_env_file(reader);
+                for warning in &warnings {
+                    log::warn!("test_env_file {}: {warning}", resolved.display());
+                }
+                result.extend(env);
+            }
+            Err(err) => {
+                log::warn!(
+                    "test_env_file {}: failed to read: {err}",
+                    resolved.display()
+                );
+            }
+        }
+    }
+    result
+}
+
+fn resolve_path(raw: &str, worktree_root: &Path) -> PathBuf {
+    let worktree_str = worktree_root.to_string_lossy();
+    let expanded = raw
+        .replace("${ZED_WORKTREE_ROOT}", &worktree_str)
+        .replace("$ZED_WORKTREE_ROOT", &worktree_str);
+    let expanded = shellexpand::tilde(&expanded).into_owned();
+    let path = PathBuf::from(expanded);
+    if path.is_absolute() {
+        path
+    } else {
+        worktree_root.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fs::FakeFs;
+    use gpui::TestAppContext;
+    use serde_json::json;
+
+    fn paths_from(values: &[&str]) -> TestEnvFilePaths {
+        if values.len() == 1 {
+            TestEnvFilePaths::Single(values[0].to_string())
+        } else {
+            TestEnvFilePaths::Multiple(values.iter().map(|s| s.to_string()).collect())
+        }
+    }
+
+    #[gpui::test]
+    async fn loads_env_from_single_file(cx: &mut TestAppContext) {
+        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
+        fs.as_fake()
+            .insert_tree(
+                "/project",
+                json!({ ".env": "FOO=bar\nBAZ=qux\n" }),
+            )
+            .await;
+
+        let env = load_test_env_files(&paths_from(&[".env"]), Path::new("/project"), &fs).await;
+
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(env.get("BAZ").map(String::as_str), Some("qux"));
+    }
+
+    #[gpui::test]
+    async fn missing_file_returns_empty(cx: &mut TestAppContext) {
+        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
+        fs.as_fake()
+            .insert_tree("/project", json!({}))
+            .await;
+
+        let env = load_test_env_files(&paths_from(&[".env"]), Path::new("/project"), &fs).await;
+
+        assert!(env.is_empty());
+    }
+
+    #[gpui::test]
+    async fn layered_files_later_overrides_earlier(cx: &mut TestAppContext) {
+        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
+        fs.as_fake()
+            .insert_tree(
+                "/project",
+                json!({
+                    ".env": "SHARED=base\nOVERRIDDEN=base\n",
+                    ".env.local": "OVERRIDDEN=local\nLOCAL_ONLY=yes\n",
+                }),
+            )
+            .await;
+
+        let env = load_test_env_files(
+            &paths_from(&[".env", ".env.local"]),
+            Path::new("/project"),
+            &fs,
+        )
+        .await;
+
+        assert_eq!(env.get("SHARED").map(String::as_str), Some("base"));
+        assert_eq!(env.get("OVERRIDDEN").map(String::as_str), Some("local"));
+        assert_eq!(env.get("LOCAL_ONLY").map(String::as_str), Some("yes"));
+    }
+
+    #[gpui::test]
+    async fn resolves_zed_worktree_root_variable(cx: &mut TestAppContext) {
+        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
+        fs.as_fake()
+            .insert_tree(
+                "/project",
+                json!({ ".env": "FOO=bar\n" }),
+            )
+            .await;
+
+        let env = load_test_env_files(
+            &paths_from(&["$ZED_WORKTREE_ROOT/.env"]),
+            Path::new("/project"),
+            &fs,
+        )
+        .await;
+
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+    }
+
+    #[gpui::test]
+    async fn absolute_path_used_as_is(cx: &mut TestAppContext) {
+        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
+        fs.as_fake()
+            .insert_tree(
+                "/elsewhere",
+                json!({ "shared.env": "FOO=bar\n" }),
+            )
+            .await;
+
+        let env = load_test_env_files(
+            &paths_from(&["/elsewhere/shared.env"]),
+            Path::new("/project"),
+            &fs,
+        )
+        .await;
+
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+    }
+}

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -609,6 +609,7 @@ impl VsCodeSettings {
                 .read_u32("editor.tabSize")
                 .and_then(|n| NonZeroU32::new(n)),
             tasks: None,
+            test_env_file: None,
             use_auto_surround: self.read_enum("editor.autoSurround", |s| match s {
                 "languageDefined" | "quotes" | "brackets" => Some(true),
                 "never" => Some(false),

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -462,6 +462,17 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: auto
     pub formatter: Option<FormatterList>,
+    /// Path(s) to `.env` file(s) loaded into the environment of test runs
+    /// triggered through Zed's runnable code-lenses (gutter Run, "Run test",
+    /// LSP-driven runnables). Accepts a single path string or an array of
+    /// paths; when an array is given, later entries override earlier ones.
+    /// Relative paths resolve against the buffer's worktree root.
+    /// `$ZED_WORKTREE_ROOT` and `~` are expanded. Missing files are silently
+    /// skipped. Variables from the file override variables inherited from the
+    /// project shell environment.
+    ///
+    /// Default: none
+    pub test_env_file: Option<TestEnvFilePaths>,
     /// Zed's Prettier integration settings.
     /// Allows to enable/disable formatting with Prettier
     /// and configure default Prettier, used when no project-level Prettier installation is found.
@@ -942,6 +953,26 @@ pub enum LineEndingSetting {
     /// Normalize line endings to CRLF (`\r\n`) during format and save.
     #[strum(serialize = "Enforce CRLF")]
     EnforceCrlf,
+}
+
+/// Paths to `.env` files loaded into the environment of test runs.
+///
+/// Either a single path or an array of paths. When an array is given, the
+/// files are applied in order and later entries override earlier ones.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, MergeFrom)]
+#[serde(untagged)]
+pub enum TestEnvFilePaths {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl AsRef<[String]> for TestEnvFilePaths {
+    fn as_ref(&self) -> &[String] {
+        match self {
+            Self::Single(single) => std::slice::from_ref(single),
+            Self::Multiple(v) => v,
+        }
+    }
 }
 
 /// Controls which formatters should be used when formatting code.

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true
+dotenvy.workspace = true
 futures.workspace = true
 gpui.workspace = true
 hex.workspace = true

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -5,6 +5,7 @@ mod debug_format;
 mod serde_helpers;
 pub mod static_source;
 mod task_template;
+mod test_env_file;
 mod vscode_debug_format;
 mod vscode_format;
 
@@ -26,6 +27,7 @@ pub use task_template::{
     DebugArgsRequest, HideStrategy, RevealStrategy, SaveStrategy, TaskHook, TaskTemplate,
     TaskTemplates, substitute_variables_in_map, substitute_variables_in_str,
 };
+pub use test_env_file::parse_env_file;
 pub use util::shell::{Shell, ShellKind};
 pub use util::shell_builder::ShellBuilder;
 pub use vscode_debug_format::VsCodeDebugTaskFile;

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -1102,4 +1102,69 @@ mod tests {
         };
         assert!(task.unknown_variables().is_empty());
     }
+
+    /// Locks the merge order in `resolve_task` that the `test_env_file` feature
+    /// relies on: `project_env` (shell + .env file content extended in by the
+    /// orchestrator in `project::test_env_file`) is the baseline, then
+    /// `template.env` overrides those, and finally task variables — which all
+    /// live in the `ZED_*` namespace per `VariableName::Display` — are added on
+    /// top. If anyone refactors the merge order, this test catches the
+    /// regression.
+    #[test]
+    fn test_resolve_task_env_precedence() {
+        let template = TaskTemplate {
+            label: "precedence".to_string(),
+            command: "true".to_string(),
+            env: HashMap::from_iter([
+                ("FROM_TEMPLATE".to_string(), "template".to_string()),
+                ("OVERRIDDEN_BY_TEMPLATE".to_string(), "template".to_string()),
+                ("ZED_WORKTREE_ROOT".to_string(), "template".to_string()),
+            ]),
+            ..TaskTemplate::default()
+        };
+
+        let project_env = HashMap::from_iter([
+            ("FROM_PROJECT_ENV".to_string(), "project".to_string()),
+            ("OVERRIDDEN_BY_TEMPLATE".to_string(), "project".to_string()),
+        ]);
+
+        let task_variables = TaskVariables::from_iter([(
+            VariableName::WorktreeRoot,
+            "/from-task-variable/".to_string(),
+        )]);
+
+        let cx = TaskContext {
+            cwd: None,
+            task_variables,
+            project_env,
+        };
+
+        let resolved = template
+            .resolve_task(TEST_ID_BASE, &cx)
+            .expect("template should resolve")
+            .resolved;
+
+        assert_eq!(
+            resolved.env.get("FROM_PROJECT_ENV").map(String::as_str),
+            Some("project"),
+            "project_env entries with no override should reach the resolved task"
+        );
+        assert_eq!(
+            resolved.env.get("FROM_TEMPLATE").map(String::as_str),
+            Some("template"),
+            "template.env entries should reach the resolved task"
+        );
+        assert_eq!(
+            resolved.env.get("OVERRIDDEN_BY_TEMPLATE").map(String::as_str),
+            Some("template"),
+            "template.env should win over project_env (this is what makes \
+             tasks.json env: blocks reliably override .env file content)"
+        );
+        assert_eq!(
+            resolved.env.get("ZED_WORKTREE_ROOT").map(String::as_str),
+            Some("/from-task-variable/"),
+            "$ZED_* task variables are appended last and should win even \
+             when template.env tries to set them"
+        );
+    }
 }

--- a/crates/task/src/test_env_file.rs
+++ b/crates/task/src/test_env_file.rs
@@ -1,0 +1,94 @@
+//! Parser for the per-language `test_env_file` setting.
+//!
+//! Reads `.env`-formatted content into a key/value map. Lines that fail to
+//! parse are collected as warnings; the rest of the file still applies.
+
+use collections::HashMap;
+use std::io::Read;
+
+/// Parse a `.env`-formatted reader into a key/value map plus a list of
+/// human-readable warnings for lines that failed to parse.
+///
+/// Variable expansion (`${VAR}`) inside the file is performed by `dotenvy`
+/// against environment variables already set in the current process at the
+/// time of parsing. Callers that need expansion against an arbitrary base
+/// environment must seed that environment into the process, or rely on the
+/// inherited project shell env.
+pub fn parse_env_file<R: Read>(reader: R) -> (HashMap<String, String>, Vec<String>) {
+    let mut env = HashMap::default();
+    let mut warnings = Vec::new();
+    for entry in dotenvy::from_read_iter(reader) {
+        match entry {
+            Ok((key, value)) => {
+                env.insert(key, value);
+            }
+            Err(err) => warnings.push(err.to_string()),
+        }
+    }
+    (env, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> (HashMap<String, String>, Vec<String>) {
+        parse_env_file(input.as_bytes())
+    }
+
+    #[test]
+    fn parses_basic_kv() {
+        let (env, warnings) = parse("FOO=bar\nBAZ=qux\n");
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(env.get("BAZ").map(String::as_str), Some("qux"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn ignores_comments_and_blank_lines() {
+        let (env, warnings) = parse("# a comment\n\nFOO=bar\n# another\n");
+        assert_eq!(env.len(), 1);
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn handles_export_prefix() {
+        let (env, warnings) = parse("export FOO=bar\n");
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn handles_quoted_values() {
+        let (env, warnings) = parse("FOO=\"hello world\"\nBAR='single quoted'\n");
+        assert_eq!(env.get("FOO").map(String::as_str), Some("hello world"));
+        assert_eq!(env.get("BAR").map(String::as_str), Some("single quoted"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn malformed_line_collected_as_warning_parsing_continues() {
+        let (env, warnings) = parse("VALID=ok\nthis is not a kv pair\nALSO_VALID=yes\n");
+        assert_eq!(env.get("VALID").map(String::as_str), Some("ok"));
+        assert_eq!(env.get("ALSO_VALID").map(String::as_str), Some("yes"));
+        assert!(
+            !warnings.is_empty(),
+            "expected a warning for the malformed line"
+        );
+    }
+
+    #[test]
+    fn later_keys_in_same_file_override_earlier() {
+        let (env, warnings) = parse("FOO=first\nFOO=second\n");
+        assert_eq!(env.get("FOO").map(String::as_str), Some("second"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn empty_input_produces_empty_map() {
+        let (env, warnings) = parse("");
+        assert!(env.is_empty());
+        assert!(warnings.is_empty());
+    }
+}

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2898,10 +2898,45 @@ The following settings can be overridden for each specific language:
 - [`whitespace_map`](#whitespace-map)
 - [`soft_wrap`](#soft-wrap)
 - [`tab_size`](#tab-size)
+- [`test_env_file`](#test-env-file)
 - [`use_autoclose`](#use-autoclose)
 - [`always_treat_brackets_as_autoclosed`](#always-treat-brackets-as-autoclosed)
 
 These values take in the same options as the root-level settings with the same name.
+
+### Test Env File
+
+- Description: Path or list of paths to `.env`-formatted file(s) loaded into the environment of test runs triggered through Zed's runnable code-lenses (gutter Run, "Run test", LSP-driven runnables) for this language.
+- Setting: `test_env_file`
+- Default: `null`
+
+Relative paths resolve against the buffer's worktree root. The token `$ZED_WORKTREE_ROOT` is expanded to the same root, and `~` is expanded to the home directory. Missing files are silently skipped. When multiple paths are configured, files are applied in order and later entries override earlier ones. Variables defined in the file override variables inherited from the project shell environment.
+
+DAP-driven debug runs use a separate envFile mechanism configured per debug scenario; this setting does not affect them.
+
+Example — single file:
+
+```json [settings]
+{
+  "languages": {
+    "Go": {
+      "test_env_file": "$ZED_WORKTREE_ROOT/.env"
+    }
+  }
+}
+```
+
+Example — layered files (later overrides earlier):
+
+```json [settings]
+{
+  "languages": {
+    "Go": {
+      "test_env_file": [".env", ".env.local"]
+    }
+  }
+}
+```
 
 ### Document Symbols
 

--- a/test-env-file-plan.md
+++ b/test-env-file-plan.md
@@ -1,0 +1,190 @@
+# Plan: `test_env_file` per-language setting
+
+## Goal
+
+Per-language setting that injects environment variables from a `.env` file into the test process before running tests via Zed's runnable code-lenses (gutter Run, "Run test", "Run package", LSP-driven runnables).
+
+```json
+{ "languages": { "Go": { "test_env_file": "$ZED_WORKTREE_ROOT/.env" } } }
+```
+
+DAP-driven debug runs are **already** covered by Zed's existing per-debug-config envFile mechanism (`crates/dap_adapters/src/go.rs:598`) and are out of scope here.
+
+---
+
+## Architecture (locked)
+
+The setting is wired through `TaskContext.project_env`. When the editor builds a `TaskContext` for a buffer, we read the buffer-language's `test_env_file`, parse and resolve it, and **extend** `project_env` with the file contents. The existing `resolve_task()` merge order in `crates/task/src/task_template.rs:251-269` then handles precedence automatically:
+
+```
+inherited_shell_env  ◀ extended by ▶  .env file
+                                            │
+                         resolve_task ──── extend(template.env)
+                                            │
+                                expand_$ZED_*_variables
+                                            │
+                         resolve_task ──── extend(task_variables)
+```
+
+Final precedence: `inherited_shell < .env file < tasks.json template.env < $ZED_* task variables`.
+
+No changes to the `task` crate. No changes to `workspace::tasks::schedule_resolved_task`. All wiring lives in the editor crate where `TaskContext` is constructed.
+
+**Tag filter is not applied.** Because `TaskContext` is shared across all runnables of a buffer, the file is loaded for every runnable of a language with `test_env_file` set, including `go-main` etc. This is an accepted leak — adding a tag filter is a follow-up if it bites in practice.
+
+---
+
+## Implementation steps
+
+### 1. Settings field — `crates/settings_content/src/language.rs`
+
+Add to `LanguageSettingsContent` (line 397+), following the existing `FormatterList` pattern (line 949) and `PathHyperlinkRegex` pattern (`terminal.rs:486`):
+
+```rust
+#[serde(default)]
+pub test_env_file: Option<TestEnvFilePaths>,
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum TestEnvFilePaths {
+    Single(String),
+    Multiple(Vec<String>),
+}
+```
+
+Mirror in the resolved settings type at `crates/language/src/language_settings.rs`. JSON schema is auto-generated.
+
+### 2. `.env` parser module — `crates/task/src/test_env_file.rs` (new)
+
+```rust
+pub fn load_env_files(
+    paths: &[String],
+    worktree_root: &Path,
+    inherited_env: &HashMap<String, String>,
+) -> (HashMap<String, String>, Vec<EnvFileWarning>);
+```
+
+- Resolve each path:
+  - Expand `$ZED_WORKTREE_ROOT` to `worktree_root`.
+  - Expand `~` to home.
+  - Relative paths resolve against `worktree_root`.
+  - Allow `..` and follow symlinks (no sandboxing).
+- Skip non-existent paths silently.
+- Parse via `dotenvy::from_read_iter()` — same call already used in `dap_adapters/src/go.rs:598`. `${VAR}` expansion against `inherited_env ∪ already-parsed-keys` happens in dotenvy.
+- Layered files: iterate paths in order, later entries overwrite earlier (`HashMap::extend`).
+- Collect parse errors as `EnvFileWarning { path, line, message }` — never panic, never abort.
+
+### 3. Hook helper — `crates/editor/src/runnables.rs` (private fn)
+
+```rust
+fn extend_project_env_with_test_env_file(
+    project_env: &mut HashMap<String, String>,
+    buffer: &Buffer,
+    cx: &App,
+) -> Vec<EnvFileWarning>;
+```
+
+- Read `language_settings(buffer.language(), buffer.file(), cx).test_env_file`.
+- If `None` → return immediately, no-op.
+- Resolve worktree root for the buffer.
+- Call `task::test_env_file::load_env_files(...)`.
+- `project_env.extend(file_env)` — file > shell.
+- Return warnings for the caller to surface (or drop, see step 4).
+
+### 4. Wire into 3 `TaskContext` construction sites
+
+| File | Line | Site |
+|---|---|---|
+| `crates/editor/runnables.rs` | 311 | `build_tasks_context` (gutter Run, code-lens) |
+| `crates/editor/code_lens.rs` | 101 | LSP code-lens-derived contexts |
+| `crates/editor/lsp_ext.rs` | 86-94 | LSP runnable contexts (rust-analyzer "Run test" etc.) |
+
+In each site: after `project_env` is populated from project shell-env, call the helper from step 3. Net change: ~3 lines per site.
+
+Warnings: `code_lens.rs` and `lsp_ext.rs` paths drop them silently for the first cut. `runnables.rs` (the user-visible gutter Run) surfaces them via a non-blocking workspace notification — only if the warning vec is non-empty, only once per session per file path (dedupe by path).
+
+### 5. Tests
+
+#### Unit (`crates/task/src/test_env_file.rs`)
+
+```rust
+#[test] fn parses_basic_kv() { ... }
+#[test] fn ignores_comments() { ... }
+#[test] fn handles_export_prefix() { ... }
+#[test] fn handles_quoted_values() { ... }
+#[test] fn expands_var_against_inherited_env() { ... }
+#[test] fn layered_files_later_overrides_earlier() { ... }
+#[test] fn missing_file_returns_empty_no_error() { ... }
+#[test] fn malformed_line_collected_as_warning() { ... }
+#[test] fn file_overrides_shell() { ... }
+```
+
+#### Integration (`crates/editor/src/runnables.rs` test module, `#[gpui::test]` + `FakeFs`)
+
+```rust
+test_env_file_loads_into_resolved_task_env
+test_no_setting_means_no_change
+test_missing_file_silently_skipped
+test_layered_files_apply_in_order
+test_template_env_overrides_file
+test_zed_task_variables_override_file
+```
+
+### 6. Docs — `docs/src/configuring-zed.md`
+
+One paragraph in the language-specific settings section, with a JSON example. No security warning. No `${workspaceFolder}` mention. Note that DAP debug runs use a separate mechanism.
+
+### 7. Release notes & PR
+
+PR title: `Add test_env_file language setting to load .env into test runs`
+
+```
+Release Notes:
+
+- Added the `test_env_file` per-language setting that loads a `.env` file into the environment of test runs.
+```
+
+---
+
+## Decisions locked
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Scope | Per-language (`LanguageSettingsContent`) |
+| 2 | Test-task filter | None — applied to all runnables of the language |
+| 3 | Hook layer | Extend `TaskContext.project_env` at construction sites |
+| 4a | Path variable | `$ZED_WORKTREE_ROOT` only, no native `${workspaceFolder}` |
+| 4b | Relative paths | Resolved against buffer's worktree root |
+| 4c | Multi-worktree | Per-buffer-worktree, automatic |
+| 4d | `..` / symlinks | Allowed, no sandboxing |
+| 5 | Precedence | `file > shell`, `template.env > file`, `$ZED_* > everything` |
+| 6 | Setting shape | `Option<TestEnvFilePaths>` with untagged `Single | Multiple`, mirrors `FormatterList` |
+| 7a | Settings layers | User + project-local (free via `LanguageSettingsContent`) |
+| 7b | Merge | Replace (default `MergeFrom`) |
+| 7c | `.gitignore` validation | None |
+
+---
+
+## Out of scope
+
+- DAP debug runs — already have their own envFile via `dap_adapters/src/go.rs:598`.
+- File watcher / hot reload — read-on-launch is sufficient, files are tiny.
+- General `env_file` for non-test tasks (user-defined `tasks.json` already has `env`).
+- `${workspaceFolder}` alias — Zed-native pattern is `$ZED_WORKTREE_ROOT`.
+- Per-test-target overrides.
+- Encrypted formats (sops, 1Password).
+- Tag-based filter to restrict to test-tagged runnables — leak to `*-main`/`*-bench` is accepted.
+
+---
+
+## Order of work
+
+Single PR containing all of: setting field, parser, hook helper, three call-site wirings, unit tests, integration tests, docs, release notes.
+
+Suggested commit order inside the branch (for reviewer ergonomics, not required to merge separately):
+
+1. Setting field in `LanguageSettingsContent` + mirrored resolved type.
+2. Parser module `crates/task/src/test_env_file.rs` + unit tests.
+3. Helper in `crates/editor/src/runnables.rs` + wire-up at 3 `TaskContext` construction sites.
+4. Integration tests.
+5. Docs + release notes.


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Feature request: [56045](https://github.com/zed-industries/zed/discussions/56045)

Release Notes:

- Added `test_env_file` per-language setting that loads a `.env` file into the environment of test runner tasks.