### PR TITLE
sidebar: Make placeholder text clearer

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -635,7 +635,7 @@ impl Sidebar {
 
         let filter_editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
-            editor.set_placeholder_text("Search…", window, cx);
+            editor.set_placeholder_text("Search threads…", window, cx);
             editor
         });
 


### PR DESCRIPTION
Changes the sidebar filter editor placeholder from "Search…" to "Search threads…" to make it clear what is being searched.

Release Notes:

- Improved sidebar search placeholder text to read "Search threads…" instead of "Search…"