### PR TITLE
agent: Escape tool argument markdown

### DIFF
--- a/crates/agent/src/tools/delete_path_tool.rs
+++ b/crates/agent/src/tools/delete_path_tool.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use settings::Settings;
 use std::path::Path;
 use std::sync::Arc;
-use util::markdown::MarkdownInlineCode;
+use util::markdown::{MarkdownEscaped, MarkdownInlineCode};
 
 /// Deletes the file or directory (and the directory's contents, recursively) at the specified path in the project, and returns confirmation of the deletion.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -66,7 +66,7 @@ impl AgentTool for DeletePathTool {
         _cx: &mut App,
     ) -> SharedString {
         if let Ok(input) = input {
-            format!("Delete “`{}`”", input.path).into()
+            format!("Delete {}", MarkdownEscaped(&input.path)).into()
         } else {
             "Delete path".into()
         }

--- a/crates/agent/src/tools/find_path_tool.rs
+++ b/crates/agent/src/tools/find_path_tool.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use std::{cmp, path::PathBuf, sync::Arc};
+use util::markdown::MarkdownEscaped;
 use util::paths::PathMatcher;
 
 /// Fast file path pattern matching tool that works with any codebase size
@@ -114,7 +115,7 @@ impl AgentTool for FindPathTool {
     ) -> SharedString {
         let mut title = "Find paths".to_string();
         if let Ok(input) = input {
-            title.push_str(&format!(" matching “`{}`”", input.glob));
+            title.push_str(&format!(" matching {}", MarkdownEscaped(&input.glob)));
         }
         title.into()
     }
@@ -214,6 +215,27 @@ mod test {
     use project::{FakeFs, Project};
     use settings::SettingsStore;
     use util::path;
+
+    #[gpui::test]
+    async fn test_initial_title_escapes_markdown_in_glob(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let tool = FindPathTool::new(project);
+
+        let title = cx.update(|cx| {
+            tool.initial_title(
+                Ok(FindPathToolInput {
+                    glob: "__tests__/[a]*.js".to_string(),
+                    offset: 0,
+                }),
+                cx,
+            )
+        });
+
+        assert_eq!(title, "Find paths matching \\_\\_tests\\_\\_/\\[a]\\*.js");
+    }
 
     #[gpui::test]
     async fn test_find_path_tool(cx: &mut TestAppContext) {

--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use settings::Settings;
 use std::{cmp, fmt::Write, sync::Arc};
 use util::RangeExt;
-use util::markdown::MarkdownInlineCode;
+use util::markdown::MarkdownEscaped;
 use util::paths::PathMatcher;
 
 /// Searches the contents of files in the project with a regular expression
@@ -94,7 +94,7 @@ impl AgentTool for GrepTool {
         match input {
             Ok(input) => {
                 let page = input.page();
-                let regex_str = MarkdownInlineCode(&input.regex);
+                let regex = MarkdownEscaped(&input.regex);
                 let case_info = if input.case_sensitive {
                     " (case-sensitive)"
                 } else {
@@ -102,9 +102,9 @@ impl AgentTool for GrepTool {
                 };
 
                 if page > 1 {
-                    format!("Get page {page} of search results for regex {regex_str}{case_info}")
+                    format!("Get page {page} of search results for regex {regex}{case_info}")
                 } else {
-                    format!("Search files for regex {regex_str}{case_info}")
+                    format!("Search files for regex {regex}{case_info}")
                 }
             }
             Err(_) => "Search with regex".into(),
@@ -348,6 +348,29 @@ mod tests {
     use settings::SettingsStore;
     use unindent::Unindent;
     use util::path;
+
+    #[gpui::test]
+    async fn test_initial_title_escapes_markdown_in_regex(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let tool = GrepTool::new(project);
+
+        let title = cx.update(|cx| {
+            tool.initial_title(
+                Ok(GrepToolInput {
+                    regex: "__tests__/[a]*".to_string(),
+                    include_pattern: None,
+                    offset: 0,
+                    case_sensitive: false,
+                }),
+                cx,
+            )
+        });
+
+        assert_eq!(title, "Search files for regex \\_\\_tests\\_\\_/\\[a]\\*");
+    }
 
     #[gpui::test]
     async fn test_grep_tool_with_include_pattern(cx: &mut TestAppContext) {

--- a/crates/agent/src/tools/open_tool.rs
+++ b/crates/agent/src/tools/open_tool.rs
@@ -53,7 +53,7 @@ impl AgentTool for OpenTool {
         _cx: &mut App,
     ) -> SharedString {
         if let Ok(input) = input {
-            format!("Open `{}`", MarkdownEscaped(&input.path_or_url)).into()
+            format!("Open {}", MarkdownEscaped(&input.path_or_url)).into()
         } else {
             "Open file or URL".into()
         }

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 use std::sync::Arc;
-use util::markdown::MarkdownCodeBlock;
+use util::markdown::{MarkdownCodeBlock, MarkdownEscaped};
 
 fn tool_content_err(e: impl std::fmt::Display) -> LanguageModelToolResultContent {
     LanguageModelToolResultContent::from(e.to_string())
@@ -99,12 +99,17 @@ impl AgentTool for ReadFileTool {
         {
             match (input.start_line, input.end_line) {
                 (Some(start), Some(end)) => {
-                    format!("Read file `{path}` (lines {}-{})", start, end,)
+                    format!(
+                        "Read file {} (lines {}-{})",
+                        MarkdownEscaped(&path),
+                        start,
+                        end,
+                    )
                 }
                 (Some(start), None) => {
-                    format!("Read file `{path}` (from line {})", start)
+                    format!("Read file {} (from line {})", MarkdownEscaped(&path), start)
                 }
-                _ => format!("Read file `{path}`"),
+                _ => format!("Read file {}", MarkdownEscaped(&path)),
             }
             .into()
         } else {
@@ -394,6 +399,38 @@ mod test {
             error_text(result.unwrap_err()),
             "root/some_dir is a directory, not a file. Use the list_directory tool to explore directory contents."
         );
+    }
+
+    #[gpui::test]
+    async fn test_initial_title_escapes_markdown_in_path(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/root"),
+            json!({
+                "__tests__": {
+                    "[a]*.js": "",
+                }
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let tool = ReadFileTool::new(project, action_log, true);
+
+        let title = cx.update(|cx| {
+            tool.initial_title(
+                Ok(ReadFileToolInput {
+                    path: "root/__tests__/[a]*.js".to_string(),
+                    start_line: None,
+                    end_line: None,
+                }),
+                cx,
+            )
+        });
+
+        assert_eq!(title, "Read file root/\\_\\_tests\\_\\_/\\[a]\\*.js");
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes #56034

Fixes markdown rendering in Agent panel tool call labels by escaping user/tool-provided argument strings before they are rendered as Markdown.

Tool call titles for file paths, regex patterns, and glob patterns could previously interpret characters like `_`, `*`, and `[` as Markdown syntax. For example, `__tests__/a.js` could render with bold styling instead of plain text.

Covered cases:
- `read_file` paths
- `grep` regex patterns
- `find_path` glob patterns
- `delete_path` paths
- `open` paths/URLs

Added focused regression coverage for markdown-sensitive arguments in `read_file`, `grep`, and `find_path`.

Validation:
- `cargo fmt --package agent --check`
- Targeted `cargo test -p agent test_initial_title_escapes_markdown` was attempted, but did not complete because Cargo spent several minutes fetching pinned git dependencies.

Release Notes:

- Fixed Agent panel tool call labels rendering markdown syntax in file paths and search patterns.