### PR TITLE
Auto watch improvements

### DIFF
--- a/crates/collab/tests/integration/auto_watch_tests.rs
+++ b/crates/collab/tests/integration/auto_watch_tests.rs
@@ -228,7 +228,7 @@ async fn test_auto_watch_toggle_off_leaves_tabs_open(
 }
 
 #[gpui::test]
-async fn test_auto_watch_turns_off_when_following_collaborator(
+async fn test_auto_watch_is_disabled_when_following_collaborator(
     executor: BackgroundExecutor,
     user_a: &mut TestAppContext,
     user_b: &mut TestAppContext,

--- a/crates/collab/tests/integration/auto_watch_tests.rs
+++ b/crates/collab/tests/integration/auto_watch_tests.rs
@@ -237,7 +237,7 @@ async fn test_auto_watch_turns_off_when_following_collaborator(
     let mut server = TestServer::start(executor.clone()).await;
     let setup = setup_auto_watch_test(&mut server, user_a, user_b, user_c).await;
     let (workspace_a, user_a) = setup.client_a.build_workspace(&setup.project_a, user_a);
-    let peer_id_b = setup._client_b.peer_id().unwrap();
+    let user_b_peer_id = setup._client_b.peer_id().unwrap();
 
     workspace_a.update_in(user_a, |workspace, window, cx| {
         workspace.toggle_auto_watch(window, cx);
@@ -250,7 +250,7 @@ async fn test_auto_watch_turns_off_when_following_collaborator(
     });
 
     workspace_a.update_in(user_a, |workspace, window, cx| {
-        workspace.follow(peer_id_b, window, cx);
+        workspace.follow(user_b_peer_id, window, cx);
     });
     executor.run_until_parked();
 

--- a/crates/collab/tests/integration/auto_watch_tests.rs
+++ b/crates/collab/tests/integration/auto_watch_tests.rs
@@ -4,7 +4,7 @@ use gpui::{App, BackgroundExecutor, Entity, TestAppContext, TestScreenCaptureSou
 use project::Project;
 use serde_json::json;
 use util::path;
-use workspace::Workspace;
+use workspace::{AutoWatch, Workspace};
 
 use super::TestClient;
 
@@ -224,6 +224,38 @@ async fn test_auto_watch_toggle_off_leaves_tabs_open(
 
     workspace_a.update(user_a, |workspace, cx| {
         assert_active_matches_title(workspace, "user_b's screen", cx);
+    });
+}
+
+#[gpui::test]
+async fn test_auto_watch_turns_off_when_following_collaborator(
+    executor: BackgroundExecutor,
+    user_a: &mut TestAppContext,
+    user_b: &mut TestAppContext,
+    user_c: &mut TestAppContext,
+) {
+    let mut server = TestServer::start(executor.clone()).await;
+    let setup = setup_auto_watch_test(&mut server, user_a, user_b, user_c).await;
+    let (workspace_a, user_a) = setup.client_a.build_workspace(&setup.project_a, user_a);
+    let peer_id_b = setup._client_b.peer_id().unwrap();
+
+    workspace_a.update_in(user_a, |workspace, window, cx| {
+        workspace.toggle_auto_watch(window, cx);
+    });
+    start_screen_share(user_b).await;
+    executor.run_until_parked();
+
+    workspace_a.update(user_a, |workspace, cx| {
+        assert_active_matches_title(workspace, "user_b's screen", cx);
+    });
+
+    workspace_a.update_in(user_a, |workspace, window, cx| {
+        workspace.follow(peer_id_b, window, cx);
+    });
+    executor.run_until_parked();
+
+    workspace_a.update(user_a, |workspace, _cx| {
+        assert_eq!(*workspace.auto_watch_state(), AutoWatch::Off);
     });
 }
 

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2913,6 +2913,13 @@ impl CollabPanel {
                 if show_auto_watch || show_copy {
                     Some(
                         h_flex()
+                            .when_some(channel_link, |this, channel_link| {
+                                this.child(
+                                    CopyButton::new("copy-channel-link", channel_link)
+                                        .visible_on_hover("section-header")
+                                        .tooltip_label("Copy Channel Link"),
+                                )
+                            })
                             .when(has_auto_watch_flag, |this| {
                                 this.child(
                                     IconButton::new(
@@ -2950,13 +2957,6 @@ impl CollabPanel {
                                                 .ok();
                                         },
                                     )),
-                                )
-                            })
-                            .when_some(channel_link, |this, channel_link| {
-                                this.child(
-                                    CopyButton::new("copy-channel-link", channel_link)
-                                        .visible_on_hover("section-header")
-                                        .tooltip_label("Copy Channel Link"),
                                 )
                             })
                             .into_any_element(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5742,6 +5742,7 @@ impl Workspace {
             .insert(pane.downgrade(), leader_id);
         self.unfollow(leader_id, window, cx);
         self.unfollow_in_pane(&pane, window, cx);
+        self.auto_watch = AutoWatch::Off;
         self.follower_states.insert(
             leader_id,
             FollowerState {


### PR DESCRIPTION
Just a few tweaks to [Auto Watch](https://github.com/zed-industries/zed/pull/54839).

- Swapped the positions of the Copy Channel Link button and the Auto Watch button. The UI still needs a design pass, but I think it’s less awkward now that the Auto Watch button is no longer dangling by itself when engaged.

   Before:

   <img width="324" height="61" alt="SCR-20260507-obsu" src="https://github.com/user-attachments/assets/c967dfe1-9026-4a1d-a399-b735303f2de0" />

   After:

   <img width="373" height="77" alt="SCR-20260507-obzs" src="https://github.com/user-attachments/assets/607e15a5-e50c-4a8e-b22c-327f2e7b8ab5" />

- Turned Auto Watch off when following another collaborator. Following is already disengaged when Auto Watch is enabled, and now Auto Watch is disengaged when following starts. This makes the two modes fully mutually exclusive, which I think is what we want.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
