### PR TITLE
auto_update: Add NixOS rsync install hint

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -81,6 +81,11 @@ fn linux_rsync_install_hint() -> &'static str {
             || distribution_id == "almalinux"
     }) {
         Some("Install it with: sudo dnf install rsync")
+    } else if distribution_ids
+        .iter()
+        .any(|distribution_id| distribution_id == "nixos")
+    {
+        Some("Install pkgs.rsync from nixpkgs")
     } else {
         None
     };


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

NixOS users who are missing rsync get a generic "Please install rsync using your package manager" message.

Release Notes:

- Improved auto update error message for NixOS users missing rsync