### PR TITLE
Respect editing config when sending messages in agent panel

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1113,9 +1113,28 @@
     },
   },
   {
-    "context": "MessageEditor > Editor && VimControl",
+    "context": "MessageEditor > Editor && VimControl && vim_mode == normal",
     "bindings": {
       "enter": "agent::Chat",
+    },
+  },
+  {
+    "context": "MessageEditor > Editor && VimControl && vim_mode == helix_normal",
+    "bindings": {
+      "enter": "agent::Chat",
+    },
+  },
+  {
+    "context": "MessageEditor > Editor && VimControl && vim_mode == insert && !use_modifier_to_send",
+    "bindings": {
+      "enter": "agent::Chat",
+    },
+  },
+  {
+    "context": "MessageEditor > Editor && VimControl && vim_mode == insert && use_modifier_to_send",
+    "bindings": {
+      "ctrl-enter": "agent::Chat",
+      "enter": "editor::Newline",
     },
   },
 


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/47398

Vim/Helix mode unconditionally binds Enter to send:
```json
{
  "context": "MessageEditor > Editor && VimControl",
  "bindings": { "enter": "agent::Chat" }
}
```
This binding fires whenever `VimControl` is in the key context (despite the name, also applies to helix insert mode) ignoring `use_modifier_to_send`.

In vim.json:1071, the binding context is "MessageEditor > Editor && VimControl", which matches all vim/helix modes including insert mode. It doesn't check use_modifier_to_send or vim_mode.

This commit splits the binding into mode-aware variants, mirroring how the default keymaps handle use_modifier_to_send:

#### Behavior after this commit

In normal mode, Enter should always send (this matches current vim-mode behavior where Enter in normal mode sends):

```
  {
    "context": "MessageEditor > Editor && VimControl && vim_mode == normal",
    "bindings": { "enter": "agent::Chat" }
  }
```

In insert mode without use_modifier_to_send, Enter sends (current default behavior):

```
  {
    "context": "MessageEditor > Editor && VimControl && vim_mode == insert && !use_modifier_to_send",
    "bindings": { "enter": "agent::Chat" }
  }
```

In insert mode with use_modifier_to_send, Ctrl+Enter sends, Enter inserts newline:

```
  {
    "context": "MessageEditor > Editor && VimControl && vim_mode == insert && use_modifier_to_send",
    "bindings": {
      "ctrl-enter": "agent::Chat",
      "enter": "editor::Newline"
    }
  }
```

This also applies to helix normal mode (vim_mode == helix_normal), where Enter sends.

The use_modifier_to_send key context is already propagated correctly by MessageEditor::extend_key_context() at message_editor.rs:1652, so no Rust changes are needed.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior (**Not applicable**)
- [x] Performance impact has been considered and is acceptable  (**Not applicable**)

Closes #47398 

Release Notes:

- Fixed `enter` key behavior in agent panel when in vim/helix insert mode
