### PR TITLE
git_ui: Add Git Panel entry click behavior setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -962,9 +962,16 @@
     //
     // Default: false
     "collapse_untracked_diff": false,
-    /// Whether to show entries with tree or flat view in the panel
-    ///
-    /// Default: false
+    // What clicking a file entry in the Git panel should do.
+    // `diff` opens the Git diff view for that file.
+    // `open` opens the file directly in the editor.
+    //
+    // Choices: diff, open
+    // Default: diff
+    "entry_click_behavior": "diff",
+    // Whether to show entries with tree or flat view in the panel
+    //
+    // Default: false
     "tree_view": false,
     // Whether the git panel should open on startup.
     //

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -61,7 +61,7 @@ use project::{
 use prompt_store::{BuiltInPrompt, PromptId, PromptStore, RULES_FILE_NAMES};
 use proto::RpcError;
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsStore, StatusStyle};
+use settings::{EntryClickBehavior, Settings, SettingsStore, StatusStyle};
 use smallvec::SmallVec;
 use std::future::Future;
 use std::ops::Range;
@@ -5620,8 +5620,15 @@ impl GitPanel {
                     if event.click_count() > 1 || event.modifiers().secondary() {
                         this.open_file(&Default::default(), window, cx)
                     } else {
-                        this.open_diff(&Default::default(), window, cx);
-                        this.focus_handle.focus(window, cx);
+                        match GitPanelSettings::get_global(cx).entry_click_behavior {
+                            EntryClickBehavior::Diff => {
+                                this.open_diff(&Default::default(), window, cx);
+                                this.focus_handle.focus(window, cx);
+                            }
+                            EntryClickBehavior::Open => {
+                                this.open_file(&Default::default(), window, cx)
+                            }
+                        }
                     }
                 })
             })

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -2,7 +2,7 @@ use editor::{EditorSettings, ui_scrollbar_settings_from_raw};
 use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{RegisterSetting, Settings, StatusStyle};
+use settings::{EntryClickBehavior, RegisterSetting, Settings, StatusStyle};
 use ui::{
     px,
     scrollbars::{ScrollbarVisibility, ShowScrollbar},
@@ -26,6 +26,7 @@ pub struct GitPanelSettings {
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
     pub collapse_untracked_diff: bool,
+    pub entry_click_behavior: EntryClickBehavior,
     pub tree_view: bool,
     pub diff_stats: bool,
     pub show_count_badge: bool,
@@ -73,6 +74,7 @@ impl Settings for GitPanelSettings {
             fallback_branch_name: git_panel.fallback_branch_name.unwrap(),
             sort_by_path: git_panel.sort_by_path.unwrap(),
             collapse_untracked_diff: git_panel.collapse_untracked_diff.unwrap(),
+            entry_click_behavior: git_panel.entry_click_behavior.unwrap(),
             tree_view: git_panel.tree_view.unwrap(),
             diff_stats: git_panel.diff_stats.unwrap(),
             show_count_badge: git_panel.show_count_badge.unwrap(),

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -691,6 +691,13 @@ pub struct GitPanelSettingsContent {
     /// Default: false
     pub collapse_untracked_diff: Option<bool>,
 
+    /// What clicking a file entry in the Git panel should do.
+    /// `diff` opens the Git diff view for that file.
+    /// `open` opens the file directly in the editor.
+    ///
+    /// Default: diff
+    pub entry_click_behavior: Option<EntryClickBehavior>,
+
     /// Whether to show entries with tree or flat view in the panel
     ///
     /// Default: false
@@ -737,6 +744,29 @@ pub enum StatusStyle {
     #[default]
     Icon,
     LabelColor,
+}
+
+#[derive(
+    Default,
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EntryClickBehavior {
+    /// Open the Git diff view for the clicked file entry.
+    #[default]
+    Diff,
+    /// Open the clicked file entry directly in the editor.
+    Open,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5627,6 +5627,28 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Entry Click Behavior",
+                description: "Choose whether clicking a file entry opens its Git diff view or opens the file directly in the editor.",
+                field: Box::new(SettingField {
+                    json_path: Some("git_panel.entry_click_behavior"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_panel
+                            .as_ref()?
+                            .entry_click_behavior
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .entry_click_behavior = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Tree View",
                 description: "Enable to show entries in tree view list, disable to show in flat view list.",
                 field: Box::new(SettingField {


### PR DESCRIPTION
## Summary
- add a `git_panel.entry_click_behavior` setting so Git Panel clicks can either open the diff view or open the file directly
- keep the existing default behavior by leaving `diff` as the default, while allowing users to opt into `open`
- document the setting and its `diff`/`open` meanings in the settings schema and defaults

I often wish I could just click the file without having to right-click + open, or deal with the somewhat flaky double-click. I think letting users choose what click does by default seems reasonable? If not, happy to open an issue first where we can discuss it. First time contributor; sorry if I missed anything!

EDIT: Looking more at the double-click, I wonder if this should also toggle what double click does? meaning if we set single-click to `open`, then we should set double-click to `diff`?

## Related
- Related to #51712

## Testing
- `cargo fmt --all`
- Could not run targeted `cargo test -p git_ui ...` in this environment because Cargo dependency fetches require GitHub SSH authentication

Release Notes:

- Improved Git Panel settings by adding a click behavior option for opening diffs or files directly.