### PR TITLE
git_graph: Deduplicate queued commit preview jobs

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -11,8 +11,8 @@ use git::{
     Oid, RunHook,
     blame::Blame,
     repository::{
-        AskPassDelegate, Branch, CommitData, CommitDataReader, CommitDetails, CommitOptions,
-        CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRepository,
+        AskPassDelegate, Branch, CommitData, CommitDataReader, CommitDetails, CommitDiff,
+        CommitOptions, CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRepository,
         GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource, PushOptions, RefEdit,
         Remote, RepoPath, ResetMode, SearchCommitArgs, Worktree,
     },
@@ -26,7 +26,7 @@ use gpui::{AsyncApp, BackgroundExecutor, SharedString, Task};
 use ignore::gitignore::GitignoreBuilder;
 use parking_lot::Mutex;
 use rope::Rope;
-use std::{path::PathBuf, sync::Arc, sync::atomic::AtomicBool};
+use std::{path::PathBuf, sync::Arc, sync::atomic::AtomicBool, time::Duration};
 use text::LineEnding;
 use util::{paths::PathStyle, rel_path::RelPath};
 
@@ -77,6 +77,10 @@ pub struct FakeGitRepositoryState {
     pub graph_commits: Vec<Arc<InitialGraphCommitData>>,
     pub commit_data: HashMap<Oid, FakeCommitDataEntry>,
     pub stash_entries: GitStash,
+    pub worktrees: Vec<Worktree>,
+    pub commit_diffs: HashMap<String, CommitDiff>,
+    pub commit_load_delay_ms: HashMap<String, u64>,
+    pub commit_load_calls: Vec<String>,
 }
 
 impl FakeGitRepositoryState {
@@ -101,6 +105,10 @@ impl FakeGitRepositoryState {
             commit_data: Default::default(),
             commit_history: Vec::new(),
             stash_entries: Default::default(),
+            worktrees: Vec::new(),
+            commit_diffs: Default::default(),
+            commit_load_delay_ms: Default::default(),
+            commit_load_calls: Default::default(),
         }
     }
 }
@@ -196,10 +204,32 @@ impl GitRepository for FakeGitRepository {
 
     fn load_commit(
         &self,
-        _commit: String,
+        commit: String,
         _cx: AsyncApp,
     ) -> BoxFuture<'_, Result<git::repository::CommitDiff>> {
-        async { Ok(git::repository::CommitDiff { files: Vec::new() }) }.boxed()
+        let executor = self.executor.clone();
+        let fut = self.with_state_async(false, move |state| {
+            state.commit_load_calls.push(commit.clone());
+            let delay_ms = state
+                .commit_load_delay_ms
+                .get(&commit)
+                .copied()
+                .unwrap_or_default();
+            let diff = state
+                .commit_diffs
+                .get(&commit)
+                .cloned()
+                .context("commit diff not configured")?;
+            Ok((delay_ms, diff))
+        });
+        async move {
+            let (delay_ms, diff) = fut.await?;
+            if delay_ms > 0 {
+                executor.timer(Duration::from_millis(delay_ms)).await;
+            }
+            Ok(diff)
+        }
+        .boxed()
     }
 
     fn set_index_text(

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2395,6 +2395,46 @@ impl FakeFs {
         .unwrap();
     }
 
+    pub fn set_commit_diff_for_repo(
+        &self,
+        dot_git: &Path,
+        commit: &str,
+        files: Vec<(String, Option<String>, Option<String>, bool)>,
+    ) {
+        self.with_git_state(dot_git, true, |state| {
+            state.commit_diffs.insert(
+                commit.to_string(),
+                git::repository::CommitDiff {
+                    files: files
+                        .into_iter()
+                        .map(
+                            |(path, old_text, new_text, is_binary)| git::repository::CommitFile {
+                                path: repo_path(&path),
+                                old_text,
+                                new_text,
+                                is_binary,
+                            },
+                        )
+                        .collect(),
+                },
+            );
+        })
+        .unwrap();
+    }
+
+    pub fn set_commit_load_delay_for_repo(&self, dot_git: &Path, commit: &str, delay: Duration) {
+        self.with_git_state(dot_git, true, |state| {
+            state
+                .commit_load_delay_ms
+                .insert(commit.to_string(), delay.as_millis() as u64);
+        })
+        .unwrap();
+    }
+
+    pub fn commit_load_calls_for_repo(&self, dot_git: &Path) -> Vec<String> {
+        self.with_git_state(dot_git, false, |state| state.commit_load_calls.clone())
+            .unwrap()
+    }
     /// Put the given git repository into a state with the given status,
     /// by mutating the head, index, and unmerged state.
     pub fn set_status_for_repo(&self, dot_git: &Path, statuses: &[(&str, FileStatus)]) {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -475,7 +475,23 @@ pub struct CommitDetails {
     pub author_name: SharedString,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct FileHistoryEntry {
+    pub sha: SharedString,
+    pub subject: SharedString,
+    pub message: SharedString,
+    pub commit_timestamp: i64,
+    pub author_name: SharedString,
+    pub author_email: SharedString,
+}
+
+#[derive(Debug, Clone)]
+pub struct FileHistory {
+    pub entries: Vec<FileHistoryEntry>,
+    pub path: RepoPath,
+}
+
+#[derive(Debug, Clone)]
 pub struct CommitDiff {
     pub files: Vec<CommitFile>,
 }
@@ -487,7 +503,7 @@ pub enum CommitFileStatus {
     Deleted,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommitFile {
     pub path: RepoPath,
     pub old_text: Option<String>,

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1736,7 +1736,7 @@ impl GitGraph {
             return;
         };
 
-        let diff_receiver = repository.update(cx, |repo, _| repo.load_commit_diff(sha));
+        let diff_receiver = repository.update(cx, |repo, _| repo.load_commit_diff_preview(sha));
 
         self._commit_diff_task = Some(cx.spawn(async move |this, cx| {
             if let Ok(Ok(diff)) = diff_receiver.await {
@@ -4913,6 +4913,113 @@ mod tests {
                 LogSource::Path(tracked2_repo_path)
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_commit_preview_jobs_replace_queued_preview_requests(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {},
+                "file.txt": "content",
+            }),
+        )
+        .await;
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let oid1 = Oid::random(&mut rng);
+        let oid2 = Oid::random(&mut rng);
+        let oid3 = Oid::random(&mut rng);
+
+        fs.set_graph_commits(
+            Path::new("/project/.git"),
+            vec![
+                Arc::new(InitialGraphCommitData {
+                    sha: oid1,
+                    parents: smallvec![oid2],
+                    ref_names: vec!["HEAD".into()],
+                }),
+                Arc::new(InitialGraphCommitData {
+                    sha: oid2,
+                    parents: smallvec![oid3],
+                    ref_names: vec![],
+                }),
+                Arc::new(InitialGraphCommitData {
+                    sha: oid3,
+                    parents: smallvec![],
+                    ref_names: vec![],
+                }),
+            ],
+        );
+
+        fs.set_commit_diff_for_repo(
+            Path::new("/project/.git"),
+            &oid1.to_string(),
+            vec![("one.txt".into(), None, Some("one".into()), false)],
+        );
+        fs.set_commit_diff_for_repo(
+            Path::new("/project/.git"),
+            &oid2.to_string(),
+            vec![("two.txt".into(), None, Some("two".into()), false)],
+        );
+        fs.set_commit_diff_for_repo(
+            Path::new("/project/.git"),
+            &oid3.to_string(),
+            vec![("three.txt".into(), None, Some("three".into()), false)],
+        );
+        fs.set_commit_load_delay_for_repo(
+            Path::new("/project/.git"),
+            &oid1.to_string(),
+            std::time::Duration::from_millis(200),
+        );
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        cx.run_until_parked();
+
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+
+        let workspace_weak =
+            multi_workspace.read_with(&*cx, |multi, _| multi.workspace().downgrade());
+        let git_graph = cx.new_window_entity(|window, cx| {
+            GitGraph::new(project.clone(), workspace_weak, window, cx)
+        });
+        cx.run_until_parked();
+
+        git_graph.update_in(&mut *cx, |this, window, cx| {
+            this.select_first(&SelectFirst, window, cx);
+        });
+        cx.run_until_parked();
+
+        git_graph.update_in(&mut *cx, |this, window, cx| {
+            this.select_next(&SelectNext, window, cx);
+            this.select_next(&SelectNext, window, cx);
+        });
+        cx.run_until_parked();
+
+        cx.executor()
+            .advance_clock(std::time::Duration::from_millis(250));
+        cx.run_until_parked();
+
+        let load_calls = fs.commit_load_calls_for_repo(Path::new("/project/.git"));
+        assert_eq!(
+            load_calls,
+            vec![oid1.to_string(), oid3.to_string()],
+            "queued preview requests should keep only the latest pending commit diff job",
+        );
+
+        let selected_preview_path = git_graph.read_with(&*cx, |graph, _| {
+            graph
+                .selected_commit_diff
+                .as_ref()
+                .and_then(|diff| diff.files.first())
+                .map(|file| file.path.as_unix_str().to_string())
+        });
+        assert_eq!(selected_preview_path.as_deref(), Some("three.txt"));
     }
 
     #[gpui::test]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -379,7 +379,7 @@ pub struct Repository {
     // For a local repository, holds paths that have had worktree events since the last status scan completed,
     // and that should be examined during the next status scan.
     paths_needing_status_update: Vec<Vec<RepoPath>>,
-    job_sender: mpsc::UnboundedSender<GitJob>,
+    job_sender: GitJobQueue,
     active_jobs: HashMap<JobId, JobInfo>,
     job_debug_queue: job_debug_queue::GitJobDebugQueue,
     pending_ops: SumTree<PendingOps>,
@@ -391,12 +391,7 @@ pub struct Repository {
     commit_data_handler: CommitDataHandlerState,
     commit_data: HashMap<Oid, CommitDataState>,
     refetch_repo_state: Arc<
-        dyn Fn(
-            &mut Context<Self>,
-        ) -> (
-            mpsc::UnboundedSender<GitJob>,
-            Shared<Task<Result<RepositoryState, String>>>,
-        ),
+        dyn Fn(&mut Context<Self>) -> (GitJobQueue, Shared<Task<Result<RepositoryState, String>>>),
     >,
 }
 
@@ -512,6 +507,65 @@ pub struct GitJob {
     id: JobId,
     job: Box<dyn FnOnce(RepositoryState, &mut AsyncApp) -> Task<()>>,
     key: Option<GitJobKey>,
+    dedup: GitJobDedup,
+}
+
+#[derive(Clone)]
+struct GitJobQueue {
+    jobs: Arc<Mutex<VecDeque<GitJob>>>,
+    wake_tx: mpsc::UnboundedSender<()>,
+}
+
+impl GitJobQueue {
+    fn new() -> (Self, mpsc::UnboundedReceiver<()>) {
+        let (wake_tx, wake_rx) = mpsc::unbounded();
+        (
+            Self {
+                jobs: Arc::new(Mutex::new(VecDeque::new())),
+                wake_tx,
+            },
+            wake_rx,
+        )
+    }
+
+    fn push(&self, job: GitJob) -> Vec<JobId> {
+        let mut removed_job_ids = Vec::new();
+        {
+            let mut jobs = self.jobs.lock();
+            if matches!(job.dedup, GitJobDedup::Enqueue)
+                && let Some(key) = job.key.as_ref()
+            {
+                let mut retained_jobs = VecDeque::with_capacity(jobs.len());
+                while let Some(queued_job) = jobs.pop_front() {
+                    if queued_job.key.as_ref() == Some(key) {
+                        removed_job_ids.push(queued_job.id);
+                    } else {
+                        retained_jobs.push_back(queued_job);
+                    }
+                }
+                *jobs = retained_jobs;
+            }
+            jobs.push_back(job);
+        }
+
+        self.wake_tx.unbounded_send(()).ok();
+        removed_job_ids
+    }
+
+    fn pop(&self) -> Option<GitJob> {
+        self.jobs.lock().pop_front()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.wake_tx.is_closed()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GitJobDedup {
+    None,
+    Dequeue,
+    Enqueue,
 }
 
 #[derive(PartialEq, Eq)]
@@ -520,6 +574,7 @@ enum GitJobKey {
     ReloadBufferDiffBases,
     RefreshStatuses,
     ReloadGitState,
+    LoadCommitDiffPreview,
 }
 
 impl GitStore {
@@ -4805,49 +4860,53 @@ impl Repository {
         let (result_tx, result_rx) = futures::channel::oneshot::channel();
         let job_id = post_inc(&mut self.job_id);
         let this = self.this.clone();
-
         let key_label = key.as_ref().map(format_job_key);
         self.job_debug_queue.add(job_id, description, key_label);
-
-        self.job_sender
-            .unbounded_send(GitJob {
-                id: job_id,
-                key,
-                job: Box::new(move |state, cx: &mut AsyncApp| {
-                    let job = job(state, cx.clone());
-                    cx.spawn(async move |cx| {
-                        this.update(cx, |this, cx| {
-                            this.job_debug_queue.mark_running(job_id);
-                            if let Some(s) = status {
-                                this.active_jobs.insert(
-                                    job_id,
-                                    JobInfo {
-                                        start: Instant::now(),
-                                        message: s,
-                                    },
-                                );
-                            }
-                            cx.notify();
-                        })
-                        .ok();
-
-                        let result = job.await;
-
-                        this.update(cx, |this, cx| {
-                            this.job_debug_queue.mark_complete(
+        let dedup = match &key {
+            Some(GitJobKey::LoadCommitDiffPreview) => GitJobDedup::Enqueue,
+            Some(_) => GitJobDedup::Dequeue,
+            None => GitJobDedup::None,
+        };
+        let removed_job_ids = self.job_sender.push(GitJob {
+            id: job_id,
+            key,
+            dedup,
+            job: Box::new(move |state, cx: &mut AsyncApp| {
+                let job = job(state, cx.clone());
+                cx.spawn(async move |cx| {
+                    this.update(cx, |this, cx| {
+                        this.job_debug_queue.mark_running(job_id);
+                        if let Some(s) = status {
+                            this.active_jobs.insert(
                                 job_id,
-                                job_debug_queue::CompletedJobStatus::Finished,
+                                JobInfo {
+                                    start: Instant::now(),
+                                    message: s,
+                                },
                             );
-                            this.active_jobs.remove(&job_id);
-                            cx.notify();
-                        })
-                        .ok();
-
-                        result_tx.send(result).ok();
+                        }
+                        cx.notify();
                     })
-                }),
-            })
-            .ok();
+                    .ok();
+
+                    let result = job.await;
+
+                    this.update(cx, |this, cx| {
+                        this.job_debug_queue
+                            .mark_complete(job_id, job_debug_queue::CompletedJobStatus::Finished);
+                        this.active_jobs.remove(&job_id);
+                        cx.notify();
+                    })
+                    .ok();
+
+                    result_tx.send(result).ok();
+                })
+            }),
+        });
+        for removed_job_id in removed_job_ids {
+            self.job_debug_queue
+                .mark_complete(removed_job_id, job_debug_queue::CompletedJobStatus::Skipped);
+        }
         result_rx
     }
 
@@ -5144,6 +5203,49 @@ impl Repository {
         })
     }
 
+    pub fn load_commit_diff_preview(
+        &mut self,
+        commit: String,
+    ) -> oneshot::Receiver<Result<CommitDiff>> {
+        let id = self.id;
+        self.send_keyed_job(
+            "load_commit_diff_preview",
+            Some(GitJobKey::LoadCommitDiffPreview),
+            None,
+            move |git_repo, cx| async move {
+                match git_repo {
+                    RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
+                        backend.load_commit(commit, cx).await
+                    }
+                    RepositoryState::Remote(RemoteRepositoryState {
+                        client, project_id, ..
+                    }) => {
+                        let response = client
+                            .request(proto::LoadCommitDiff {
+                                project_id: project_id.0,
+                                repository_id: id.to_proto(),
+                                commit,
+                            })
+                            .await?;
+                        Ok(CommitDiff {
+                            files: response
+                                .files
+                                .into_iter()
+                                .map(|file| {
+                                    Ok(CommitFile {
+                                        path: RepoPath::from_proto(&file.path)?,
+                                        old_text: file.old_text,
+                                        new_text: file.new_text,
+                                        is_binary: file.is_binary,
+                                    })
+                                })
+                                .collect::<Result<Vec<_>>>()?,
+                        })
+                    }
+                }
+            },
+        )
+    }
     pub fn get_graph_data(
         &self,
         log_source: LogSource,
@@ -7793,8 +7895,9 @@ impl Repository {
     fn spawn_local_git_worker(
         state: Shared<Task<Result<LocalRepositoryState, String>>>,
         cx: &mut Context<Self>,
-    ) -> mpsc::UnboundedSender<GitJob> {
-        let (job_tx, mut job_rx) = mpsc::unbounded::<GitJob>();
+    ) -> GitJobQueue {
+        let (job_queue, mut wake_rx) = GitJobQueue::new();
+        let worker_queue = job_queue.clone();
 
         cx.spawn(async move |this, cx| {
             let state = state.await.map_err(|err| anyhow::anyhow!(err))?;
@@ -7808,17 +7911,14 @@ impl Repository {
                 .await;
             }
             let state = RepositoryState::Local(state);
-            let mut jobs = VecDeque::new();
             loop {
-                while let Ok(next_job) = job_rx.try_recv() {
-                    jobs.push_back(next_job);
-                }
-
-                if let Some(job) = jobs.pop_front() {
-                    if let Some(current_key) = &job.key
-                        && jobs
-                            .iter()
-                            .any(|other_job| other_job.key.as_ref() == Some(current_key))
+                if let Some(job) = worker_queue.pop() {
+                    if matches!(job.dedup, GitJobDedup::Dequeue)
+                        && let Some(current_key) = &job.key
+                        && worker_queue.jobs.lock().iter().any(|other_job| {
+                            other_job.key.as_ref() == Some(current_key)
+                                && matches!(other_job.dedup, GitJobDedup::Dequeue)
+                        })
                     {
                         let skipped_job_id = job.id;
                         this.update(cx, |repo, _| {
@@ -7831,38 +7931,36 @@ impl Repository {
                         continue;
                     }
                     (job.job)(state.clone(), cx).await;
-                } else if let Some(job) = job_rx.next().await {
-                    jobs.push_back(job);
-                } else {
+                } else if wake_rx.next().await.is_none() {
                     break;
+                } else {
+                    continue;
                 }
             }
             anyhow::Ok(())
         })
         .detach_and_log_err(cx);
 
-        job_tx
+        job_queue
     }
 
     fn spawn_remote_git_worker(
         state: RemoteRepositoryState,
         cx: &mut Context<Self>,
-    ) -> mpsc::UnboundedSender<GitJob> {
-        let (job_tx, mut job_rx) = mpsc::unbounded::<GitJob>();
+    ) -> GitJobQueue {
+        let (job_queue, mut wake_rx) = GitJobQueue::new();
+        let worker_queue = job_queue.clone();
 
         cx.spawn(async move |this, cx| {
             let state = RepositoryState::Remote(state);
-            let mut jobs = VecDeque::new();
             loop {
-                while let Ok(next_job) = job_rx.try_recv() {
-                    jobs.push_back(next_job);
-                }
-
-                if let Some(job) = jobs.pop_front() {
-                    if let Some(current_key) = &job.key
-                        && jobs
-                            .iter()
-                            .any(|other_job| other_job.key.as_ref() == Some(current_key))
+                if let Some(job) = worker_queue.pop() {
+                    if matches!(job.dedup, GitJobDedup::Dequeue)
+                        && let Some(current_key) = &job.key
+                        && worker_queue.jobs.lock().iter().any(|other_job| {
+                            other_job.key.as_ref() == Some(current_key)
+                                && matches!(other_job.dedup, GitJobDedup::Dequeue)
+                        })
                     {
                         let skipped_job_id = job.id;
                         this.update(cx, |repo, _| {
@@ -7875,17 +7973,17 @@ impl Repository {
                         continue;
                     }
                     (job.job)(state.clone(), cx).await;
-                } else if let Some(job) = job_rx.next().await {
-                    jobs.push_back(job);
-                } else {
+                } else if wake_rx.next().await.is_none() {
                     break;
+                } else {
+                    continue;
                 }
             }
             anyhow::Ok(())
         })
         .detach_and_log_err(cx);
 
-        job_tx
+        job_queue
     }
 
     fn load_staged_text(
@@ -8229,6 +8327,7 @@ fn format_job_key(key: &GitJobKey) -> SharedString {
         GitJobKey::ReloadBufferDiffBases => "ReloadBufferDiffBases".into(),
         GitJobKey::RefreshStatuses => "RefreshStatuses".into(),
         GitJobKey::ReloadGitState => "ReloadGitState".into(),
+        GitJobKey::LoadCommitDiffPreview => "LoadCommitDiffPreview".into(),
     }
 }
 


### PR DESCRIPTION
## Summary

Keep git graph commit previews on the shared git worker, but stop queued preview requests from piling up during rapid keyboard navigation.

This changes commit preview jobs to use enqueue-time deduplication while leaving existing keyed git jobs on their current dequeue-time deduplication behavior.

Closes #56145

## Testing

- git diff --check
- cargo check -p git_graph --tests reaches an unrelated existing compile error in crates/remote_connection/src/remote_connection.rs for RemoteConnectionOptions::Mock(_)

Release Notes:

- Improved git graph commit preview responsiveness during rapid keyboard navigation