### PR TITLE
gpui: Defer platform callbacks while app is borrowed

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -70,11 +70,14 @@ mod visual_test_context;
 /// The duration for which futures returned from [Context::on_app_quit] can run before the application fully quits.
 pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
 
+type DeferredAppUpdate = Box<dyn FnOnce(&mut App)>;
+
 /// Temporary(?) wrapper around [`RefCell<App>`] to help us debug any double borrows.
 /// Strongly consider removing after stabilization.
 #[doc(hidden)]
 pub struct AppCell {
     app: RefCell<App>,
+    deferred_updates: RefCell<Vec<DeferredAppUpdate>>,
 }
 
 impl AppCell {
@@ -85,7 +88,10 @@ impl AppCell {
             let thread_id = std::thread::current().id();
             eprintln!("borrowed {thread_id:?}");
         }
-        AppRef(self.app.borrow())
+        AppRef {
+            app: Some(self.app.borrow()),
+            app_cell: self,
+        }
     }
 
     #[doc(hidden)]
@@ -95,7 +101,10 @@ impl AppCell {
             let thread_id = std::thread::current().id();
             eprintln!("borrowed {thread_id:?}");
         }
-        AppRefMut(self.app.borrow_mut())
+        AppRefMut {
+            app: self.app.borrow_mut(),
+            deferred_updates: &self.deferred_updates,
+        }
     }
 
     #[doc(hidden)]
@@ -105,16 +114,54 @@ impl AppCell {
             let thread_id = std::thread::current().id();
             eprintln!("borrowed {thread_id:?}");
         }
-        Ok(AppRefMut(self.app.try_borrow_mut()?))
+        Ok(AppRefMut {
+            app: self.app.try_borrow_mut()?,
+            deferred_updates: &self.deferred_updates,
+        })
+    }
+}
+
+fn drain_deferred_updates(app: &mut App, deferred_updates: &RefCell<Vec<DeferredAppUpdate>>) {
+    loop {
+        let updates = {
+            let mut deferred_updates = deferred_updates.borrow_mut();
+            std::mem::take(&mut *deferred_updates)
+        };
+
+        if updates.is_empty() {
+            break;
+        }
+
+        for update in updates {
+            update(app);
+        }
     }
 }
 
 #[doc(hidden)]
-#[derive(Deref, DerefMut)]
-pub struct AppRef<'a>(Ref<'a, App>);
+pub struct AppRef<'a> {
+    app: Option<Ref<'a, App>>,
+    app_cell: &'a AppCell,
+}
+
+impl Deref for AppRef<'_> {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        match self.app.as_ref() {
+            Some(app) => app,
+            None => unreachable!("AppRef dereferenced after drop"),
+        }
+    }
+}
 
 impl Drop for AppRef<'_> {
     fn drop(&mut self) {
+        self.app.take();
+        if let Ok(mut app) = self.app_cell.app.try_borrow_mut() {
+            drain_deferred_updates(&mut app, &self.app_cell.deferred_updates);
+        }
+
         if option_env!("TRACK_THREAD_BORROWS").is_some() {
             let thread_id = std::thread::current().id();
             eprintln!("dropped borrow from {thread_id:?}");
@@ -124,10 +171,17 @@ impl Drop for AppRef<'_> {
 
 #[doc(hidden)]
 #[derive(Deref, DerefMut)]
-pub struct AppRefMut<'a>(RefMut<'a, App>);
+pub struct AppRefMut<'a> {
+    #[deref]
+    #[deref_mut]
+    app: RefMut<'a, App>,
+    deferred_updates: &'a RefCell<Vec<DeferredAppUpdate>>,
+}
 
 impl Drop for AppRefMut<'_> {
     fn drop(&mut self) {
+        drain_deferred_updates(&mut self.app, self.deferred_updates);
+
         if option_env!("TRACK_THREAD_BORROWS").is_some() {
             let thread_id = std::thread::current().id();
             eprintln!("dropped {thread_id:?}");
@@ -764,34 +818,33 @@ impl App {
                 #[cfg(any(test, feature = "leak-detection"))]
                 _ref_counts,
             }),
+            deferred_updates: RefCell::new(Vec::new()),
         });
 
         init_app_menus(platform.as_ref(), &app.borrow());
         SystemWindowTabController::init(&mut app.borrow_mut());
 
         platform.on_keyboard_layout_change(Box::new({
-            let app = Rc::downgrade(&app);
+            let cx = app.borrow().to_async();
             move || {
-                if let Some(app) = app.upgrade() {
-                    let cx = &mut app.borrow_mut();
+                cx.update_or_defer(|cx| {
                     cx.keyboard_layout = cx.platform.keyboard_layout();
                     cx.keyboard_mapper = cx.platform.keyboard_mapper();
                     cx.keyboard_layout_observers
                         .clone()
                         .retain(&(), move |callback| (callback)(cx));
-                }
+                });
             }
         }));
 
         platform.on_thermal_state_change(Box::new({
-            let app = Rc::downgrade(&app);
+            let cx = app.borrow().to_async();
             move || {
-                if let Some(app) = app.upgrade() {
-                    let cx = &mut app.borrow_mut();
+                cx.update_or_defer(|cx| {
                     cx.thermal_state_observers
                         .clone()
                         .retain(&(), move |callback| (callback)(cx));
-                }
+                });
             }
         }));
 

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -166,6 +166,17 @@ impl AsyncApp {
         lock.update(f)
     }
 
+    /// Updates the app immediately if it is not borrowed, otherwise defers the update until the current borrow ends.
+    pub fn update_or_defer(&self, f: impl FnOnce(&mut App) + 'static) {
+        let app = self.app();
+
+        if let Ok(mut app) = app.try_borrow_mut() {
+            app.update(f);
+        } else {
+            app.deferred_updates.borrow_mut().push(Box::new(f));
+        }
+    }
+
     /// Arrange for the given callback to be invoked whenever the given entity emits an event of a given type.
     /// The callback is provided a handle to the emitting entity and a reference to the emitted event.
     pub fn subscribe<T, Event>(

--- a/crates/gpui/src/platform/app_menu.rs
+++ b/crates/gpui/src/platform/app_menu.rs
@@ -332,9 +332,7 @@ pub(crate) fn init_app_menus(platform: &dyn Platform, cx: &App) {
     platform.on_will_open_app_menu(Box::new({
         let cx = cx.to_async();
         move || {
-            if let Some(app) = cx.app.upgrade() {
-                app.borrow_mut().update(|cx| cx.clear_pending_keystrokes());
-            }
+            cx.update_or_defer(|cx| cx.clear_pending_keystrokes());
         }
     }));
 
@@ -351,9 +349,8 @@ pub(crate) fn init_app_menus(platform: &dyn Platform, cx: &App) {
     platform.on_app_menu_action(Box::new({
         let cx = cx.to_async();
         move |action| {
-            if let Some(app) = cx.app.upgrade() {
-                app.borrow_mut().update(|cx| cx.dispatch_action(action));
-            }
+            let action = action.boxed_clone();
+            cx.update_or_defer(move |cx| cx.dispatch_action(&*action));
         }
     }));
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1327,10 +1327,12 @@ impl Window {
 
         platform_window.on_close(Box::new({
             let window_id = handle.window_id();
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move || {
-                let _ = handle.update(&mut cx, |_, window, _| window.remove_window());
-                let _ = cx.update(|cx| {
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, _| window.remove_window())
+                        .log_err();
                     SystemWindowTabController::remove_tab(cx, window_id);
                 });
             }
@@ -1427,67 +1429,79 @@ impl Window {
             }
         }));
         platform_window.on_resize(Box::new({
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move |_, _| {
-                handle
-                    .update(&mut cx, |_, window, cx| window.bounds_changed(cx))
-                    .log_err();
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, cx| window.bounds_changed(cx))
+                        .log_err();
+                });
             }
         }));
         platform_window.on_moved(Box::new({
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move || {
-                handle
-                    .update(&mut cx, |_, window, cx| window.bounds_changed(cx))
-                    .log_err();
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, cx| window.bounds_changed(cx))
+                        .log_err();
+                });
             }
         }));
         platform_window.on_appearance_changed(Box::new({
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move || {
-                handle
-                    .update(&mut cx, |_, window, cx| window.appearance_changed(cx))
-                    .log_err();
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, cx| window.appearance_changed(cx))
+                        .log_err();
+                });
             }
         }));
         platform_window.on_button_layout_changed(Box::new({
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move || {
-                handle
-                    .update(&mut cx, |_, window, cx| window.button_layout_changed(cx))
-                    .log_err();
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, cx| window.button_layout_changed(cx))
+                        .log_err();
+                });
             }
         }));
         platform_window.on_active_status_change(Box::new({
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move |active| {
-                handle
-                    .update(&mut cx, |_, window, cx| {
-                        window.active.set(active);
-                        window.modifiers = window.platform_window.modifiers();
-                        window.capslock = window.platform_window.capslock();
-                        window
-                            .activation_observers
-                            .clone()
-                            .retain(&(), |callback| callback(window, cx));
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, cx| {
+                            window.active.set(active);
+                            window.modifiers = window.platform_window.modifiers();
+                            window.capslock = window.platform_window.capslock();
+                            window
+                                .activation_observers
+                                .clone()
+                                .retain(&(), |callback| callback(window, cx));
 
-                        window.bounds_changed(cx);
-                        window.refresh();
+                            window.bounds_changed(cx);
+                            window.refresh();
 
-                        SystemWindowTabController::update_last_active(cx, window.handle.id);
-                    })
-                    .log_err();
+                            SystemWindowTabController::update_last_active(cx, window.handle.id);
+                        })
+                        .log_err();
+                });
             }
         }));
         platform_window.on_hover_status_change(Box::new({
-            let mut cx = cx.to_async();
+            let cx = cx.to_async();
             move |active| {
-                handle
-                    .update(&mut cx, |_, window, _| {
-                        window.hovered.set(active);
-                        window.refresh();
-                    })
-                    .log_err();
+                cx.update_or_defer(move |cx| {
+                    handle
+                        .update(cx, |_, window, _| {
+                            window.hovered.set(active);
+                            window.refresh();
+                        })
+                        .log_err();
+                });
             }
         }));
         platform_window.on_input({


### PR DESCRIPTION
This is just meant to show a possible direction to fix these reentrancy crashes, not ready to merge.

### Summary

Fixes crashes caused by platform callbacks reentering GPUI while the app is already borrowed.

On Windows, reading from the clipboard can reenter our window procedure. In Sentry, this happened while GPUI was rendering: `GetClipboardData` reentered wndproc, delivered `WM_DESTROY`, and ran the window close callback. That callback tried to update GPUI while the app was already borrowed, causing `RefCell already borrowed`.

This adds `AsyncApp::update_or_defer`, which runs an app update immediately when possible and queues it when the app is currently borrowed. Void platform/window callbacks that mutate GPUI now use this path.

### Self-Review Checklist

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

### Release Notes:

- Fixed crashes caused by platform callbacks reentering GPUI while the app is already updating.
