### PR TITLE
Fix redundant hover and go-to-definition LSP requests on mouse move

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -358,6 +358,7 @@ pub fn show_link_definition(
     } else {
         editor.hide_hovered_link(cx)
     }
+    hovered_link_state.last_trigger_point = trigger_point.clone();
     let project = editor.project.clone();
     let provider = editor.semantics_provider.clone();
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -298,6 +298,14 @@ fn show_hover(
     editor.hover_state.closest_mouse_distance = None;
 
     if !ignore_timeout {
+        // Don't request again if the location is the same as the previous request
+        if let Some(triggered_from) = &editor.hover_state.triggered_from
+            && triggered_from
+                .cmp(&anchor, &snapshot.buffer_snapshot())
+                .is_eq()
+        {
+            return None;
+        }
         if same_info_hover(editor, &snapshot, anchor)
             || same_diagnostic_hover(editor, &snapshot, anchor)
             || editor.hover_state.diagnostic_popover.is_some()
@@ -309,14 +317,7 @@ fn show_hover(
         }
     }
 
-    // Don't request again if the location is the same as the previous request
-    if let Some(triggered_from) = &editor.hover_state.triggered_from
-        && triggered_from
-            .cmp(&anchor, &snapshot.buffer_snapshot())
-            .is_eq()
-    {
-        return None;
-    }
+    editor.hover_state.triggered_from = Some(anchor);
 
     let hover_popover_delay = EditorSettings::get_global(cx).hover_popover_delay.0;
     let all_diagnostics_active = editor.all_diagnostics_active();


### PR DESCRIPTION
When holding a modifier key (Ctrl/Cmd) and hovering the mouse over code, Zed would flood the language server with duplicate `textDocument/hover` and `textDocument/definition` requests at the same buffer position. This was especially noticeable with slower language servers, where dozens of identical requests would pile up.

Two bugs were responsible:

**Hover (`hover_popover.rs`):** The `triggered_from` field on `HoverState` was designed to deduplicate hover requests at the same position, but it was never actually set — making the check dead code. Additionally, when the LSP returned a `null` hover response, subsequent mouse move events at the same position would re-enter `show_hover`, call `hide_hover` (which cleared `triggered_from`), and then pass the deduplication check, firing another request.

Fixed by:
- Actually setting `triggered_from` after the deduplication checks pass.
- Moving the `triggered_from` check before the `hide_hover` call so it isn't cleared before it can be evaluated.

**Go-to-definition (`hover_links.rs`):** When a go-to-definition request was in flight and the mouse moved to a new position, `last_trigger_point` was never updated to reflect the new position. This meant that if the mouse stayed at the new position (or moved within the same token), every subsequent mouse move event would fail the `last_trigger_point == trigger_point` check and spawn a redundant task — because it was still comparing against the original position from when the state was first created.

Fixed by updating `last_trigger_point` to the current trigger point whenever a new request is launched.

Release Notes:

- Fixed editor flooding the language server with duplicate hover and go-to-definition requests while holding Ctrl/Cmd.