### PR TITLE
workspace: Open new windows on the focused display

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1995,6 +1995,16 @@ impl Workspace {
                 } else {
                     let window_bounds_override = window_bounds_env_override();
 
+                    let active_display = cx.update(|cx| {
+                        cx.active_window().and_then(|handle| {
+                            cx.update_window(handle, |_, window, app| {
+                                window.display(app).and_then(|d| d.uuid().ok())
+                            })
+                            .ok()
+                            .flatten()
+                        })
+                    });
+
                     let (window_bounds, display) = if let Some(bounds) = window_bounds_override {
                         (Some(WindowBounds::Windowed(bounds)), None)
                     } else if let Some(workspace) = serialized_workspace.as_ref()
@@ -2003,6 +2013,8 @@ impl Workspace {
                     {
                         // Reopening an existing workspace - restore its saved bounds
                         (Some(bounds.0), Some(display))
+                    } else if let Some(display) = active_display {
+                        (None, Some(display))
                     } else if let Some((display, bounds)) =
                         persistence::read_default_window_bounds(&kvp)
                     {


### PR DESCRIPTION
## summary

when you have zed fullscreen on a secondary display and hit cmd-shift-n, the new window pops up on your primary display instead of the actively focused display.

the cause is that `Workspace::new_local`'s new-window path only consults the last-saved default bounds when picking a display. it never looks at where the user currently is.

this change adds an "active display" branch into the priority chain, right after the serialized-workspace branch:

1. `ZED_WINDOW_BOUNDS` env override
2. saved bounds for a serialized workspace being reopened
3. **the focused window's display** *(new)*
4. last-saved global default bounds
5. gpui's `default_bounds()` cascade

when the active-display branch fires we drop the saved size/position and let gpui cascade defaults on the new display, since the old bounds were sized for whatever display the user was on before.

## test plan

- [x] `cargo check -p workspace`
- [x] `./script/clippy -p workspace`
- [x] manual: with zed fullscreen on a secondary display, cmd-shift-n opens the new window on that display
- [ ] reopening a serialized workspace still restores its saved bounds/display
- [ ] first window after a fresh launch (no focused window) still falls back to the saved default

Release Notes:

- fixed new windows opening on the primary display when the focused window was on a secondary display
