### PR TITLE
git_ui: Add an option to show all files/changes in the tree view git panel together instead of tracked/untracked

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -223,17 +223,15 @@ fn git_panel_context_menu(
                 Some(Box::new(ToggleTreeView)),
                 move |window, cx| window.dispatch_action(Box::new(ToggleTreeView), cx),
             )
-            .when(!state.tree_view, |this| {
-                this.entry(
-                    if state.sort_by_path {
-                        "Sort by Status"
-                    } else {
-                        "Sort by Path"
-                    },
-                    Some(Box::new(ToggleSortByPath)),
-                    move |window, cx| window.dispatch_action(Box::new(ToggleSortByPath), cx),
-                )
-            })
+            .entry(
+                if state.sort_by_path {
+                    "Sort by Status"
+                } else {
+                    "Sort by Path"
+                },
+                Some(Box::new(ToggleSortByPath)),
+                move |window, cx| window.dispatch_action(Box::new(ToggleSortByPath), cx),
+            )
     })
 }
 
@@ -3568,7 +3566,7 @@ impl GitPanel {
 
         let sort_by_path = GitPanelSettings::get_global(cx).sort_by_path;
         let is_tree_view = matches!(self.view_mode, GitPanelViewMode::Tree(_));
-        let group_by_status = is_tree_view || !sort_by_path;
+        let group_by_status = !sort_by_path;
 
         if let Some(active_repo) = self.active_repository.as_ref() {
             let access = active_repo.update(cx, |active_repo, cx| active_repo.access(cx));
@@ -3729,12 +3727,14 @@ impl GitPanel {
                         continue;
                     }
 
-                    push_entry(
-                        self,
-                        GitListEntry::Header(GitHeaderEntry { header: section }),
-                        true,
-                        Some(&mut tree_state.logical_indices),
-                    );
+                    if group_by_status {
+                        push_entry(
+                            self,
+                            GitListEntry::Header(GitHeaderEntry { header: section }),
+                            true,
+                            Some(&mut tree_state.logical_indices),
+                        );
+                    }
 
                     for (entry, is_visible) in
                         tree_state.build_tree_entries(section, entries, &mut seen_directories)
@@ -8020,6 +8020,110 @@ mod tests {
                 .and_then(|entry| entry.status_entry())
                 .expect("selected entry should be a status entry");
             assert_eq!(selected_entry.repo_path, repo_path("foobar.py"));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_tree_view_with_sort_by_path(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "src": {
+                    "a.rs": "fn a() {}",
+                },
+                "b.rs": "fn b() {}",
+            }),
+        )
+        .await;
+
+        fs.set_status_for_repo(
+            path!("/project/.git").as_ref(),
+            &[
+                ("src/a.rs", StatusCode::Modified.worktree()),
+                ("b.rs", FileStatus::Untracked),
+            ],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        // Enable tree view AND sort by path
+        cx.update(|_window, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.git_panel.get_or_insert_default().tree_view = Some(true);
+                    settings.git_panel.get_or_insert_default().sort_by_path = Some(true);
+                })
+            });
+        });
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        panel.read_with(cx, |panel, _| {
+            // Check that we don't have any headers
+            assert!(panel
+                .entries
+                .iter()
+                .all(|e| !matches!(e, GitListEntry::Header(_))));
+
+            // Check that we have the expected tree structure
+            // 1. Directory "src"
+            // 2. TreeStatus "src/a.rs"
+            // 3. TreeStatus "b.rs"
+            // Note: tree_state.logical_indices should contain indices to these.
+
+            let state = panel
+                .view_mode
+                .tree_state()
+                .expect("tree view state should exist");
+            assert_eq!(state.logical_indices.len(), 3);
+
+            let entry0 = &panel.entries[state.logical_indices[0]];
+            assert!(matches!(entry0, GitListEntry::Directory(dir) if dir.name == "src"));
+
+            let entry1 = &panel.entries[state.logical_indices[1]];
+            if let GitListEntry::TreeStatus(status) = entry1 {
+                assert_eq!(status.entry.repo_path, repo_path("src/a.rs"));
+            } else {
+                panic!("Expected TreeStatus for src/a.rs");
+            }
+
+            let entry2 = &panel.entries[state.logical_indices[2]];
+            if let GitListEntry::TreeStatus(status) = entry2 {
+                assert_eq!(status.entry.repo_path, repo_path("b.rs"));
+            } else {
+                panic!("Expected TreeStatus for b.rs");
+            }
         });
     }
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #[49818](https://github.com/zed-industries/zed/discussions/49818)



Key changes:
- Modified `update_visible_entries` in `git_panel.rs` to make `group_by_status` dependent only on `sort_by_path`, even in tree view.
- Suppressed section headers in tree view when `group_by_status` is false.
- Exposed the "Sort by Path/Status" toggle in the tree view context menu.
- Added a new test case `test_tree_view_with_sort_by_path` to verify the unified tree structure.

Release Notes:

- Added an option to show all files/changes in the tree view git panel together, instead of the split between tracked/untracked.
