### PR TITLE
agent: Unwrap doc comment paragraphs on tool inputs

### DIFF
--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -35,9 +35,7 @@ use serde::{
     de::{DeserializeOwned, Error as _},
 };
 
-/// Deserialize a value that may have been provided as a JSON-encoded string
-/// instead of the structured value. Some models occasionally stringify nested
-/// arguments, so we accept either form.
+/// Deserialize a value that may have been provided as a JSON-encoded string instead of the structured value. Some models occasionally stringify nested arguments, so we accept either form.
 pub(crate) fn deserialize_maybe_stringified<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: DeserializeOwned,

--- a/crates/agent/src/tools/apply_code_action_tool.rs
+++ b/crates/agent/src/tools/apply_code_action_tool.rs
@@ -12,15 +12,12 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput};
 
 /// Applies a code action previously retrieved by get_code_actions.
 ///
-/// You must call get_code_actions first to get the list of available actions,
-/// then use the number from that list to choose which action to apply.
+/// You must call get_code_actions first to get the list of available actions, then use the number from that list to choose which action to apply.
 ///
-/// After applying a code action, the list is cleared. If you want to apply
-/// another action, call get_code_actions again.
+/// After applying a code action, the list is cleared. If you want to apply another action, call get_code_actions again.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ApplyCodeActionToolInput {
-    /// The 1-based index of the code action to apply, from the list
-    /// returned by get_code_actions.
+    /// The 1-based index of the code action to apply, from the list returned by get_code_actions.
     pub index: u32,
 }
 

--- a/crates/agent/src/tools/copy_path_tool.rs
+++ b/crates/agent/src/tools/copy_path_tool.rs
@@ -18,15 +18,12 @@ use std::path::Path;
 use std::sync::Arc;
 use util::markdown::MarkdownInlineCode;
 
-/// Copies a file or directory in the project, and returns confirmation that the copy succeeded.
-/// Directory contents will be copied recursively.
+/// Copies a file or directory in the project, and returns confirmation that the copy succeeded. Directory contents will be copied recursively.
 ///
-/// This tool should be used when it's desirable to create a copy of a file or directory without modifying the original.
-/// It's much more efficient than doing this by separately reading and then writing the file or directory's contents, so this tool should be preferred over that approach whenever copying is the goal.
+/// This tool should be used when it's desirable to create a copy of a file or directory without modifying the original. It's much more efficient than doing this by separately reading and then writing the file or directory's contents, so this tool should be preferred over that approach whenever copying is the goal.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CopyPathToolInput {
-    /// The source path of the file or directory to copy.
-    /// If a directory is specified, its contents will be copied recursively.
+    /// The source path of the file or directory to copy. If a directory is specified, its contents will be copied recursively.
     ///
     /// <example>
     /// If the project has the following files:

--- a/crates/agent/src/tools/diagnostics_tool.rs
+++ b/crates/agent/src/tools/diagnostics_tool.rs
@@ -15,17 +15,14 @@ use util::markdown::MarkdownInlineCode;
 ///
 /// This tool can be invoked after a series of edits to determine if further edits are necessary, or if the user asks to fix errors or warnings in their codebase.
 ///
-/// When a path is provided, shows all diagnostics for that specific file.
-/// When no path is provided, shows a summary of error and warning counts for all files in the project.
+/// When a path is provided, shows all diagnostics for that specific file. When no path is provided, shows a summary of error and warning counts for all files in the project.
 ///
 /// <example>
-/// To get diagnostics for a specific file:
-/// {
+/// To get diagnostics for a specific file: {
 ///     "path": "src/main.rs"
 /// }
 ///
-/// To get a project-wide diagnostic summary:
-/// {}
+/// To get a project-wide diagnostic summary: {}
 /// </example>
 ///
 /// <guidelines>
@@ -36,8 +33,7 @@ use util::markdown::MarkdownInlineCode;
 pub struct DiagnosticsToolInput {
     /// The path to get diagnostics for. If not provided, returns a project-wide summary.
     ///
-    /// This path should never be absolute, and the first component
-    /// of the path should always be a root directory in a project.
+    /// This path should never be absolute, and the first component of the path should always be a root directory in a project.
     ///
     /// <example>
     /// If the project has the following root directories:

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -49,8 +49,7 @@ pub struct EditFileToolInput {
     /// </example>
     pub path: PathBuf,
 
-    /// List of edit operations to apply sequentially.
-    /// Each edit finds `old_text` in the file and replaces it with `new_text`.
+    /// List of edit operations to apply sequentially. Each edit finds `old_text` in the file and replaces it with `new_text`.
     #[serde(deserialize_with = "deserialize_maybe_stringified")]
     pub edits: Vec<Edit>,
 }
@@ -1871,9 +1870,7 @@ mod tests {
         assert_eq!(input_path, Some(PathBuf::from("root/test.txt")));
     }
 
-    /// When the buffer has unsaved changes and the user picks "Save", the
-    /// pending edits are flushed to disk and the agent's edit then proceeds
-    /// against the just-saved content.
+    /// When the buffer has unsaved changes and the user picks "Save", the pending edits are flushed to disk and the agent's edit then proceeds against the just-saved content.
     #[gpui::test]
     async fn test_streaming_dirty_buffer_save(cx: &mut TestAppContext) {
         let (edit_tool, project, action_log, fs, _thread) =
@@ -1962,9 +1959,7 @@ mod tests {
         assert_eq!(on_disk, "replaced content");
     }
 
-    /// When the buffer has unsaved changes and the user picks "Discard", the
-    /// pending edits are reverted to match disk and the agent's edit then
-    /// proceeds against the on-disk content.
+    /// When the buffer has unsaved changes and the user picks "Discard", the pending edits are reverted to match disk and the agent's edit then proceeds against the on-disk content.
     #[gpui::test]
     async fn test_streaming_dirty_buffer_discard(cx: &mut TestAppContext) {
         let (edit_tool, project, action_log, fs, _thread) =
@@ -2039,10 +2034,7 @@ mod tests {
         assert_eq!(on_disk, "replaced content");
     }
 
-    /// When the buffer is dirty and the user resolves it manually — e.g.
-    /// pressing `cmd-s` while the prompt is visible — the prompt is
-    /// dismissed automatically and the edit proceeds against the saved
-    /// content. The user shouldn't have to also click a button.
+    /// When the buffer is dirty and the user resolves it manually — e.g. pressing `cmd-s` while the prompt is visible — the prompt is dismissed automatically and the edit proceeds against the saved content. The user shouldn't have to also click a button.
     #[gpui::test]
     async fn test_streaming_dirty_buffer_resolved_externally(cx: &mut TestAppContext) {
         let (edit_tool, project, action_log, fs, _thread) =

--- a/crates/agent/src/tools/edit_session.rs
+++ b/crates/agent/src/tools/edit_session.rs
@@ -29,22 +29,17 @@ use ui::SharedString;
 use util::rel_path::RelPath;
 use util::{Deferred, ResultExt};
 
-/// Operating mode used internally by `EditSession`/`Pipeline` to choose between
-/// applying granular edits (the `edit_file` tool) or replacing/creating the
-/// entire file content (the `write_file` tool).
+/// Operating mode used internally by `EditSession`/`Pipeline` to choose between applying granular edits (the `edit_file` tool) or replacing/creating the entire file content (the `write_file` tool).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum EditSessionMode {
     Write,
     Edit,
 }
 
-/// A single edit operation that replaces old text with new text
-/// Properly escape all text fields as valid JSON strings.
-/// Remember to escape special characters like newlines (`\n`) and quotes (`"`) in JSON strings.
+/// A single edit operation that replaces old text with new text Properly escape all text fields as valid JSON strings. Remember to escape special characters like newlines (`\n`) and quotes (`"`) in JSON strings.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Edit {
-    /// The exact text to find in the file. This will be matched using fuzzy matching
-    /// to handle minor differences in whitespace or formatting.
+    /// The exact text to find in the file. This will be matched using fuzzy matching to handle minor differences in whitespace or formatting.
     ///
     /// Be minimal with replacements:
     /// - For unique lines, include only those lines
@@ -910,10 +905,7 @@ fn extract_match(
     }
 }
 
-/// Edits a buffer and reports the edit to the action log in the same effect
-/// cycle. This ensures the action log's subscription handler sees the version
-/// already updated by `buffer_edited`, so it does not misattribute the agent's
-/// edit as a user edit.
+/// Edits a buffer and reports the edit to the action log in the same effect cycle. This ensures the action log's subscription handler sees the version already updated by `buffer_edited`, so it does not misattribute the agent's edit as a user edit.
 fn agent_edit_buffer<I, S, T>(
     buffer: &Entity<Buffer>,
     edits: I,
@@ -962,14 +954,9 @@ async fn ensure_buffer_saved(
     Ok(false)
 }
 
-/// Prompts the user about how to handle a dirty buffer that the agent
-/// wants to edit (`EditSessionMode::Edit`) or overwrite
-/// (`EditSessionMode::Write`), and performs the chosen action so the
-/// edit session can proceed (or returns `Err` to cancel).
+/// Prompts the user about how to handle a dirty buffer that the agent wants to edit (`EditSessionMode::Edit`) or overwrite (`EditSessionMode::Write`), and performs the chosen action so the edit session can proceed (or returns `Err` to cancel).
 ///
-/// If the user resolves the dirty state externally (e.g. cmd-s or
-/// reload) while the prompt is visible, the prompt is dismissed
-/// automatically.
+/// If the user resolves the dirty state externally (e.g. cmd-s or reload) while the prompt is visible, the prompt is dismissed automatically.
 async fn resolve_dirty_buffer(
     buffer: &Entity<Buffer>,
     mode: EditSessionMode,

--- a/crates/agent/src/tools/edit_session/reindent.rs
+++ b/crates/agent/src/tools/edit_session/reindent.rs
@@ -31,8 +31,7 @@ pub fn compute_indent_delta(buffer_indent: LineIndent, query_indent: LineIndent)
     }
 }
 
-/// Synchronous re-indentation adapter. Buffers incomplete lines and applies
-/// an `IndentDelta` to each line's leading whitespace before emitting it.
+/// Synchronous re-indentation adapter. Buffers incomplete lines and applies an `IndentDelta` to each line's leading whitespace before emitting it.
 pub struct Reindenter {
     delta: IndentDelta,
     buffer: String,
@@ -48,8 +47,7 @@ impl Reindenter {
         }
     }
 
-    /// Feed a chunk of text and return the re-indented portion that is
-    /// ready to emit. Incomplete trailing lines are buffered internally.
+    /// Feed a chunk of text and return the re-indented portion that is ready to emit. Incomplete trailing lines are buffered internally.
     pub fn push(&mut self, chunk: &str) -> String {
         self.buffer.push_str(chunk);
         self.drain(false)

--- a/crates/agent/src/tools/edit_session/streaming_fuzzy_matcher.rs
+++ b/crates/agent/src/tools/edit_session/streaming_fuzzy_matcher.rs
@@ -5,8 +5,7 @@ const REPLACEMENT_COST: u32 = 1;
 const INSERTION_COST: u32 = 3;
 const DELETION_COST: u32 = 10;
 
-/// A streaming fuzzy matcher that can process text chunks incrementally
-/// and return the best match found so far at each step.
+/// A streaming fuzzy matcher that can process text chunks incrementally and return the best match found so far at each step.
 pub struct StreamingFuzzyMatcher {
     snapshot: TextBufferSnapshot,
     query_lines: Vec<String>,
@@ -36,13 +35,11 @@ impl StreamingFuzzyMatcher {
 
     /// Push a new chunk of text and get the best match found so far.
     ///
-    /// This method accumulates text chunks and processes complete lines.
-    /// Partial lines are buffered internally until a newline is received.
+    /// This method accumulates text chunks and processes complete lines. Partial lines are buffered internally until a newline is received.
     ///
     /// # Returns
     ///
-    /// Returns `Some(range)` if a match has been found with the accumulated
-    /// query so far, or `None` if no suitable match exists yet.
+    /// Returns `Some(range)` if a match has been found with the accumulated query so far, or `None` if no suitable match exists yet.
     pub fn push(&mut self, chunk: &str, line_hint: Option<u32>) -> Option<Range<usize>> {
         // Add the chunk to our incomplete line buffer
         self.incomplete_line.push_str(chunk);
@@ -67,8 +64,7 @@ impl StreamingFuzzyMatcher {
 
     /// Finish processing and return the final best match(es).
     ///
-    /// This processes any remaining incomplete line before returning the final
-    /// match result.
+    /// This processes any remaining incomplete line before returning the final match result.
     pub fn finish(&mut self) -> Vec<Range<usize>> {
         // Process any remaining incomplete line
         if !self.incomplete_line.is_empty() {

--- a/crates/agent/src/tools/edit_session/streaming_parser.rs
+++ b/crates/agent/src/tools/edit_session/streaming_parser.rs
@@ -39,19 +39,9 @@ struct EditStreamState {
 
 /// Converts incrementally-growing tool call JSON into a stream of chunk events.
 ///
-/// The tool call streaming infrastructure delivers partial JSON objects where
-/// string fields grow over time. This parser compares consecutive partials,
-/// computes the deltas, and emits `EditEvent`s or `WriteEvent`s that downstream
-/// pipeline stages (`StreamingFuzzyMatcher` for old_text, `StreamingDiff` for
-/// new_text) can consume incrementally.
+/// The tool call streaming infrastructure delivers partial JSON objects where string fields grow over time. This parser compares consecutive partials, computes the deltas, and emits `EditEvent`s or `WriteEvent`s that downstream pipeline stages (`StreamingFuzzyMatcher` for old_text, `StreamingDiff` for new_text) can consume incrementally.
 ///
-/// Because partial JSON comes through a fixer (`partial-json-fixer`) that
-/// closes incomplete escape sequences, a string can temporarily contain wrong
-/// trailing characters (e.g. a literal `\` instead of `\n`).  We handle this
-/// by holding back trailing backslash characters in non-finalized chunks: if
-/// a partial string ends with `\` (0x5C), that byte is not emitted until the
-/// next partial confirms or corrects it.  This avoids feeding corrupted bytes
-/// to downstream consumers.
+/// Because partial JSON comes through a fixer (`partial-json-fixer`) that closes incomplete escape sequences, a string can temporarily contain wrong trailing characters (e.g. a literal `\` instead of `\n`).  We handle this by holding back trailing backslash characters in non-finalized chunks: if a partial string ends with `\` (0x5C), that byte is not emitted until the next partial confirms or corrects it.  This avoids feeding corrupted bytes to downstream consumers.
 #[derive(Default, Debug)]
 pub struct StreamingParser {
     edit_states: Vec<EditStreamState>,
@@ -61,9 +51,7 @@ pub struct StreamingParser {
 impl StreamingParser {
     /// Push a new set of partial edits (from edit mode) and return any events.
     ///
-    /// Each call should pass the *entire current* edits array as seen in the
-    /// latest partial input. The parser will diff it against its internal state
-    /// to produce only the new events.
+    /// Each call should pass the *entire current* edits array as seen in the latest partial input. The parser will diff it against its internal state to produce only the new events.
     pub fn push_edits(&mut self, edits: &[PartialEdit]) -> SmallVec<[EditEvent; 4]> {
         let mut events = SmallVec::new();
 
@@ -161,8 +149,7 @@ impl StreamingParser {
 
     /// Push new content and return any events.
     ///
-    /// Each call should pass the *entire current* content string. The parser
-    /// will diff it against its internal state to emit only the new chunk.
+    /// Each call should pass the *entire current* content string. The parser will diff it against its internal state to emit only the new chunk.
     pub fn push_content(&mut self, content: &str) -> SmallVec<[WriteEvent; 1]> {
         let mut events = SmallVec::new();
 
@@ -176,13 +163,9 @@ impl StreamingParser {
         events
     }
 
-    /// Finalize all edits with the complete input. This emits `done: true`
-    /// events for any in-progress old_text or new_text that hasn't been
-    /// finalized yet.
+    /// Finalize all edits with the complete input. This emits `done: true` events for any in-progress old_text or new_text that hasn't been finalized yet.
     ///
-    /// `final_edits` should be the fully deserialized final edits array. The
-    /// parser compares against its tracked state and emits any remaining deltas
-    /// with `done: true`.
+    /// `final_edits` should be the fully deserialized final edits array. The parser compares against its tracked state and emits any remaining deltas with `done: true`.
     pub fn finalize_edits(&mut self, edits: &[Edit]) -> SmallVec<[EditEvent; 4]> {
         let mut events = SmallVec::new();
 
@@ -267,8 +250,7 @@ impl StreamingParser {
         events
     }
 
-    /// When a new edit appears at `index`, finalize the edit at `index - 1`
-    /// by emitting a `NewTextChunk { done: true }` if it hasn't been finalized.
+    /// When a new edit appears at `index`, finalize the edit at `index - 1` by emitting a `NewTextChunk { done: true }` if it hasn't been finalized.
     fn finalize_previous_edit(
         &mut self,
         new_index: usize,
@@ -338,11 +320,7 @@ impl StreamingParser {
     }
 }
 
-/// Returns the byte position up to which it is safe to emit from a partial
-/// string.  If the string ends with a backslash (`\`, 0x5C), that byte is
-/// held back because it may be an artifact of the partial JSON fixer closing
-/// an incomplete escape sequence (e.g. turning a half-received `\n` into `\\`).
-/// The next partial will reveal the correct character.
+/// Returns the byte position up to which it is safe to emit from a partial string.  If the string ends with a backslash (`\`, 0x5C), that byte is held back because it may be an artifact of the partial JSON fixer closing an incomplete escape sequence (e.g. turning a half-received `\n` into `\\`). The next partial will reveal the correct character.
 fn safe_emit_end(text: &str) -> usize {
     if text.as_bytes().last() == Some(&b'\\') {
         text.len() - 1

--- a/crates/agent/src/tools/evals/edit_file.rs
+++ b/crates/agent/src/tools/evals/edit_file.rs
@@ -470,8 +470,7 @@ impl EditToolTest {
         Ok(EditEvalOutput { assertion, sample })
     }
 
-    /// Stream the model completion and extract the first complete tool use
-    /// whose name matches `EditFileTool::NAME`, parsed as `EditFileToolInput`.
+    /// Stream the model completion and extract the first complete tool use whose name matches `EditFileTool::NAME`, parsed as `EditFileToolInput`.
     async fn extract_tool_use(
         &self,
         request: LanguageModelRequest,

--- a/crates/agent/src/tools/evals/terminal_tool.rs
+++ b/crates/agent/src/tools/evals/terminal_tool.rs
@@ -62,15 +62,9 @@ impl CommandAssertion {
         }
     }
 
-    /// Passes when the command is a git command and every git subcommand that
-    /// could block on a pty (pager or editor) is guarded with the appropriate
-    /// environment variable or flag.
+    /// Passes when the command is a git command and every git subcommand that could block on a pty (pager or editor) is guarded with the appropriate environment variable or flag.
     ///
-    /// This is intentionally permissive about *which* git subcommand the model
-    /// chooses — for an indirect prompt like "combine my last 3 commits", the
-    /// model is free to first investigate with `git log` or jump straight to
-    /// `git rebase -i`. Either is fine, as long as whatever it picks won't
-    /// hang on a pager or editor.
+    /// This is intentionally permissive about *which* git subcommand the model chooses — for an indirect prompt like "combine my last 3 commits", the model is free to first investigate with `git log` or jump straight to `git rebase -i`. Either is fine, as long as whatever it picks won't hang on a pager or editor.
     fn git_pty_safe(description: &'static str) -> Self {
         Self::new(description, |input| {
             let cmd = input.command.as_str();
@@ -295,8 +289,7 @@ async fn load_model(
     }))
 }
 
-/// Stream the model completion and extract the first complete tool use whose
-/// name matches `TerminalTool::NAME`, parsed as `TerminalToolInput`.
+/// Stream the model completion and extract the first complete tool use whose name matches `TerminalTool::NAME`, parsed as `TerminalToolInput`.
 async fn extract_tool_use(
     model: &Arc<dyn LanguageModel>,
     request: LanguageModelRequest,

--- a/crates/agent/src/tools/find_path_tool.rs
+++ b/crates/agent/src/tools/find_path_tool.rs
@@ -32,8 +32,7 @@ pub struct FindPathToolInput {
     /// You can get back the first two paths by providing a glob of "*thing*.txt"
     /// </example>
     pub glob: String,
-    /// Optional starting position for paginated results (0-based).
-    /// When not provided, starts from the beginning.
+    /// Optional starting position for paginated results (0-based). When not provided, starts from the beginning.
     #[serde(default)]
     pub offset: usize,
 }

--- a/crates/agent/src/tools/find_references_tool.rs
+++ b/crates/agent/src/tools/find_references_tool.rs
@@ -11,11 +11,9 @@ use serde::{Deserialize, Serialize};
 
 /// Finds all references to a symbol across the project using the language server.
 ///
-/// Returns a list of locations where the symbol is referenced, including file paths,
-/// line numbers, and code snippets for each reference.
+/// Returns a list of locations where the symbol is referenced, including file paths, line numbers, and code snippets for each reference.
 ///
-/// Before using this tool, use read_file or grep to find the exact symbol
-/// name and line number.
+/// Before using this tool, use read_file or grep to find the exact symbol name and line number.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FindReferencesToolInput {
     /// The symbol to find references of.

--- a/crates/agent/src/tools/get_code_actions_tool.rs
+++ b/crates/agent/src/tools/get_code_actions_tool.rs
@@ -12,14 +12,11 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput};
 
 /// Gets the list of available code actions at a symbol location from the language server.
 ///
-/// Code actions include quick fixes, refactorings, and other automated transformations
-/// suggested by the language server (e.g. "Add missing import", "Extract to function").
+/// Code actions include quick fixes, refactorings, and other automated transformations suggested by the language server (e.g. "Add missing import", "Extract to function").
 ///
-/// Returns a numbered list of available actions. Use apply_code_action with the
-/// corresponding number to apply one.
+/// Returns a numbered list of available actions. Use apply_code_action with the corresponding number to apply one.
 ///
-/// Before using this tool, use read_file or grep to find the exact symbol
-/// name and line number.
+/// Before using this tool, use read_file or grep to find the exact symbol name and line number.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GetCodeActionsToolInput {
     /// The symbol to get code actions for.

--- a/crates/agent/src/tools/go_to_definition_tool.rs
+++ b/crates/agent/src/tools/go_to_definition_tool.rs
@@ -11,11 +11,9 @@ use serde::{Deserialize, Serialize};
 
 /// Jumps to the definition of a symbol using the language server.
 ///
-/// Returns the file path and line number of the symbol's definition,
-/// along with a snippet of the source code at that location.
+/// Returns the file path and line number of the symbol's definition, along with a snippet of the source code at that location.
 ///
-/// Before using this tool, use read_file or grep to find the exact symbol
-/// name and line number of a usage you want to navigate from.
+/// Before using this tool, use read_file or grep to find the exact symbol name and line number of a usage you want to navigate from.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GoToDefinitionToolInput {
     /// The symbol to find the definition of.

--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -31,9 +31,7 @@ pub struct GrepToolInput {
     ///
     /// Do NOT specify a path here! This will only be matched against the code **content**.
     pub regex: String,
-    /// A glob pattern for the paths of files to include in the search.
-    /// Supports standard glob patterns like "**/*.rs" or "frontend/src/**/*.ts".
-    /// If omitted, all files in the project will be searched.
+    /// A glob pattern for the paths of files to include in the search. Supports standard glob patterns like "**/*.rs" or "frontend/src/**/*.ts". If omitted, all files in the project will be searched.
     ///
     /// The glob pattern is matched against the full path including the project root directory.
     ///
@@ -43,13 +41,10 @@ pub struct GrepToolInput {
     /// - /a/b/backend
     /// - /c/d/frontend
     ///
-    /// Use "backend/**/*.rs" to search only Rust files in the backend root directory.
-    /// Use "frontend/src/**/*.ts" to search TypeScript files only in the frontend root directory (sub-directory "src").
-    /// Use "**/*.rs" to search Rust files across all root directories.
+    /// Use "backend/**/*.rs" to search only Rust files in the backend root directory. Use "frontend/src/**/*.ts" to search TypeScript files only in the frontend root directory (sub-directory "src"). Use "**/*.rs" to search Rust files across all root directories.
     /// </example>
     pub include_pattern: Option<String>,
-    /// Optional starting position for paginated results (0-based).
-    /// When not provided, starts from the beginning.
+    /// Optional starting position for paginated results (0-based). When not provided, starts from the beginning.
     #[serde(default)]
     pub offset: u32,
     /// Whether the regex is case-sensitive. Defaults to false (case-insensitive).

--- a/crates/agent/src/tools/move_path_tool.rs
+++ b/crates/agent/src/tools/move_path_tool.rs
@@ -37,12 +37,10 @@ pub struct MovePathToolInput {
     /// </example>
     pub source_path: String,
 
-    /// The destination path where the file or directory should be moved/renamed to.
-    /// If the paths are the same except for the filename, then this will be a rename.
+    /// The destination path where the file or directory should be moved/renamed to. If the paths are the same except for the filename, then this will be a rename.
     ///
     /// <example>
-    /// To move "directory1/a/something.txt" to "directory2/b/renamed.txt",
-    /// provide a destination_path of "directory2/b/renamed.txt"
+    /// To move "directory1/a/something.txt" to "directory2/b/renamed.txt", provide a destination_path of "directory2/b/renamed.txt"
     /// </example>
     pub destination_path: String,
 }

--- a/crates/agent/src/tools/now_tool.rs
+++ b/crates/agent/src/tools/now_tool.rs
@@ -19,8 +19,7 @@ pub enum Timezone {
     Local,
 }
 
-/// Returns the current datetime in RFC 3339 format.
-/// Only use this tool when the user specifically asks for it or the current task would benefit from knowing the current datetime.
+/// Returns the current datetime in RFC 3339 format. Only use this tool when the user specifically asks for it or the current task would benefit from knowing the current datetime.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct NowToolInput {
     /// The timezone to use for the datetime. Use `utc` for UTC, or `local` for the system's local time.

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -43,8 +43,7 @@ pub struct ReadFileToolInput {
     /// - /a/b/directory1
     /// - /c/d/directory2
     ///
-    /// If you want to access `file.txt` in `directory1`, you should use the path `directory1/file.txt`.
-    /// If you want to access `file.txt` in `directory2`, you should use the path `directory2/file.txt`.
+    /// If you want to access `file.txt` in `directory1`, you should use the path `directory1/file.txt`. If you want to access `file.txt` in `directory2`, you should use the path `directory2/file.txt`.
     /// </example>
     pub path: String,
     /// Optional line number to start reading on (1-based index)

--- a/crates/agent/src/tools/rename_tool.rs
+++ b/crates/agent/src/tools/rename_tool.rs
@@ -12,12 +12,9 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput};
 
 /// Renames a symbol across the project using the language server.
 ///
-/// This performs a semantic rename, updating all references to the symbol
-/// across all files in the project. The language server determines which
-/// occurrences to rename based on the symbol's type and scope.
+/// This performs a semantic rename, updating all references to the symbol across all files in the project. The language server determines which occurrences to rename based on the symbol's type and scope.
 ///
-/// Before using this tool, use read_file or grep to find the exact symbol
-/// name and line number.
+/// Before using this tool, use read_file or grep to find the exact symbol name and line number.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct RenameToolInput {
     /// The symbol to rename.

--- a/crates/agent/src/tools/symbol_locator.rs
+++ b/crates/agent/src/tools/symbol_locator.rs
@@ -11,16 +11,13 @@ use text::{Anchor, Point};
 
 /// Identifies a specific symbol (declaration or usage) in the source code.
 ///
-/// Use the file path, line number, and symbol name from file outlines, grep results,
-/// or other tool outputs to populate these fields.
+/// Use the file path, line number, and symbol name from file outlines, grep results, or other tool outputs to populate these fields.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SymbolLocator {
-    /// The relative path of the file containing the symbol
-    /// (e.g. "crates/editor/src/editor.rs").
+    /// The relative path of the file containing the symbol (e.g. "crates/editor/src/editor.rs").
     pub file_path: String,
 
-    /// The 1-based line number where the symbol appears.
-    /// Use the line numbers from file outlines or grep results.
+    /// The 1-based line number where the symbol appears. Use the line numbers from file outlines or grep results.
     pub line: u32,
 
     /// The name of the symbol (function name, type name, variable name, etc.)
@@ -104,8 +101,7 @@ impl fmt::Display for LocationDisplay {
     }
 }
 
-/// Searches for `needle` in a char iterator, returning the byte offset of the
-/// first occurrence without collecting the full iterator into a string.
+/// Searches for `needle` in a char iterator, returning the byte offset of the first occurrence without collecting the full iterator into a string.
 ///
 /// Equivalent to [`str::find`]
 fn find_in_char_iter(chars: impl Iterator<Item = char>, needle: &str) -> Option<usize> {
@@ -141,11 +137,7 @@ fn find_in_char_iter(chars: impl Iterator<Item = char>, needle: &str) -> Option<
 impl SymbolLocator {
     /// Resolves this locator into a concrete buffer and position.
     ///
-    /// Opens the file at `file_path`, then searches for `symbol_name` on the
-    /// specified `line`. Returns an error if the file can't be found, the line
-    /// is out of range, or the symbol name doesn't appear on that line.
-    /// If the symbol name appears multiple times on the line, uses the first
-    /// occurrence.
+    /// Opens the file at `file_path`, then searches for `symbol_name` on the specified `line`. Returns an error if the file can't be found, the line is out of range, or the symbol name doesn't appear on that line. If the symbol name appears multiple times on the line, uses the first occurrence.
     pub async fn resolve(
         &self,
         project: &Entity<Project>,

--- a/crates/agent/src/tools/tool_permissions.rs
+++ b/crates/agent/src/tools/tool_permissions.rs
@@ -24,8 +24,7 @@ pub enum SensitiveSettingsKind {
 pub enum ResolvedProjectPath {
     /// The path resolves to a location safely within the project boundaries.
     Safe(ProjectPath),
-    /// The path resolves through a symlink to a location outside the project.
-    /// Agent tools should prompt the user before proceeding with access.
+    /// The path resolves through a symlink to a location outside the project. Agent tools should prompt the user before proceeding with access.
     SymlinkEscape {
         /// The project-relative path (before symlink resolution).
         project_path: ProjectPath,
@@ -34,10 +33,7 @@ pub enum ResolvedProjectPath {
     },
 }
 
-/// Asynchronously canonicalizes the absolute paths of all worktrees in a
-/// project using the provided `Fs`. The returned paths can be passed to
-/// [`resolve_project_path`] and related helpers so that they don't need to
-/// perform blocking filesystem I/O themselves.
+/// Asynchronously canonicalizes the absolute paths of all worktrees in a project using the provided `Fs`. The returned paths can be passed to [`resolve_project_path`] and related helpers so that they don't need to perform blocking filesystem I/O themselves.
 pub async fn canonicalize_worktree_roots<C: gpui::AppContext>(
     project: &Entity<Project>,
     fs: &Arc<dyn Fs>,
@@ -60,15 +56,11 @@ pub async fn canonicalize_worktree_roots<C: gpui::AppContext>(
     canonical_roots
 }
 
-/// Walks up ancestors of `path` to find the deepest one that exists on disk and
-/// can be canonicalized, then reattaches the remaining suffix components.
+/// Walks up ancestors of `path` to find the deepest one that exists on disk and can be canonicalized, then reattaches the remaining suffix components.
 ///
-/// This is needed for paths where the leaf (or intermediate directories) don't
-/// exist yet but an ancestor may be a symlink. For example, when creating
-/// `.zed/settings.json` where `.zed` is a symlink to an external directory.
+/// This is needed for paths where the leaf (or intermediate directories) don't exist yet but an ancestor may be a symlink. For example, when creating `.zed/settings.json` where `.zed` is a symlink to an external directory.
 ///
-/// Note: intermediate directories *can* be symlinks (not just leaf entries),
-/// so we must walk the full ancestor chain. For example:
+/// Note: intermediate directories *can* be symlinks (not just leaf entries), so we must walk the full ancestor chain. For example:
 ///   `ln -s /external/config /project/.zed`
 /// makes `.zed` an intermediate symlink directory.
 async fn canonicalize_with_ancestors(path: &Path, fs: &dyn Fs) -> Option<PathBuf> {
@@ -102,8 +94,7 @@ fn is_within_any_worktree(canonical_path: &Path, canonical_worktree_roots: &[Pat
         .any(|root| canonical_path.starts_with(root))
 }
 
-/// Returns the kind of sensitive settings location this path targets, if any:
-/// either inside a `.zed/` local-settings directory or inside the global config dir.
+/// Returns the kind of sensitive settings location this path targets, if any: either inside a `.zed/` local-settings directory or inside the global config dir.
 pub async fn sensitive_settings_kind(path: &Path, fs: &dyn Fs) -> Option<SensitiveSettingsKind> {
     let local_settings_folder = paths::local_settings_folder_name();
     if path.components().any(|component| {
@@ -131,13 +122,9 @@ pub async fn is_sensitive_settings_path(path: &Path, fs: &dyn Fs) -> bool {
 
 /// Resolves a path within the project, checking for symlink escapes.
 ///
-/// This is the primary entry point for agent tools that need to resolve a
-/// user-provided path string into a validated `ProjectPath`. It combines
-/// path lookup (`find_project_path`) with symlink safety verification.
+/// This is the primary entry point for agent tools that need to resolve a user-provided path string into a validated `ProjectPath`. It combines path lookup (`find_project_path`) with symlink safety verification.
 ///
-/// `canonical_worktree_roots` should be obtained from
-/// [`canonicalize_worktree_roots`] before calling this function so that no
-/// blocking I/O is needed here.
+/// `canonical_worktree_roots` should be obtained from [`canonicalize_worktree_roots`] before calling this function so that no blocking I/O is needed here.
 ///
 /// # Returns
 ///
@@ -230,10 +217,7 @@ pub fn resolve_project_path(
     Ok(ResolvedProjectPath::Safe(project_path))
 }
 
-/// Prompts the user for permission when a path resolves through a symlink to a
-/// location outside the project. This check is an additional gate after
-/// settings-based deny decisions: even if a tool is configured as "always allow,"
-/// a symlink escape still requires explicit user approval.
+/// Prompts the user for permission when a path resolves through a symlink to a location outside the project. This check is an additional gate after settings-based deny decisions: even if a tool is configured as "always allow," a symlink escape still requires explicit user approval.
 pub fn authorize_symlink_access(
     tool_name: &str,
     display_path: &str,
@@ -273,12 +257,9 @@ pub fn authorize_with_sensitive_settings(
     }
 }
 
-/// Creates a single authorization prompt for multiple symlink escapes.
-/// Each escape is a `(display_path, canonical_target)` pair.
+/// Creates a single authorization prompt for multiple symlink escapes. Each escape is a `(display_path, canonical_target)` pair.
 ///
-/// Accepts `&[(&str, PathBuf)]` to match the natural return type of
-/// [`detect_symlink_escape`], avoiding intermediate owned-to-borrowed
-/// conversions at call sites.
+/// Accepts `&[(&str, PathBuf)]` to match the natural return type of [`detect_symlink_escape`], avoiding intermediate owned-to-borrowed conversions at call sites.
 pub fn authorize_symlink_escapes(
     tool_name: &str,
     escapes: &[(&str, PathBuf)],
@@ -309,8 +290,7 @@ pub fn authorize_symlink_escapes(
     event_stream.authorize_always_prompt(title, context, cx)
 }
 
-/// Checks whether a path escapes the project via symlink, without creating
-/// an authorization task. Useful for pre-filtering paths before settings checks.
+/// Checks whether a path escapes the project via symlink, without creating an authorization task. Useful for pre-filtering paths before settings checks.
 pub fn path_has_symlink_escape(
     project: &Project,
     path: impl AsRef<Path>,
@@ -323,8 +303,7 @@ pub fn path_has_symlink_escape(
     )
 }
 
-/// Collects symlink escape info for a path without creating an authorization task.
-/// Returns `Some((display_path, canonical_target))` if the path escapes via symlink.
+/// Collects symlink escape info for a path without creating an authorization task. Returns `Some((display_path, canonical_target))` if the path escapes via symlink.
 pub fn detect_symlink_escape<'a>(
     project: &Project,
     display_path: &'a str,
@@ -339,13 +318,9 @@ pub fn detect_symlink_escape<'a>(
     }
 }
 
-/// Collects symlink escape info for two paths (source and destination) and
-/// returns any escapes found. This deduplicates the common pattern used by
-/// tools that operate on two paths (copy, move).
+/// Collects symlink escape info for two paths (source and destination) and returns any escapes found. This deduplicates the common pattern used by tools that operate on two paths (copy, move).
 ///
-/// Returns a `Vec` of `(display_path, canonical_target)` pairs for paths
-/// that escape the project via symlink. The returned vec borrows the display
-/// paths from the input strings.
+/// Returns a `Vec` of `(display_path, canonical_target)` pairs for paths that escape the project via symlink. The returned vec borrows the display paths from the input strings.
 pub fn collect_symlink_escapes<'a>(
     project: &Project,
     source_path: &'a str,
@@ -366,19 +341,13 @@ pub fn collect_symlink_escapes<'a>(
     escapes
 }
 
-/// Checks authorization for file edits, handling symlink escapes and
-/// sensitive settings paths.
+/// Checks authorization for file edits, handling symlink escapes and sensitive settings paths.
 ///
 /// # Authorization precedence
 ///
 /// When a symlink escape is detected, the symlink authorization prompt
 /// *replaces* (rather than supplements) the normal tool-permission prompt.
-/// This is intentional: the symlink prompt already requires explicit user
-/// approval and displays the canonical target, which provides strictly more
-/// security-relevant information than the generic tool confirmation. Requiring
-/// two sequential prompts for the same operation would degrade UX without
-/// meaningfully improving security, since the user must already approve the
-/// more specific symlink-escape prompt.
+/// This is intentional: the symlink prompt already requires explicit user approval and displays the canonical target, which provides strictly more security-relevant information than the generic tool confirmation. Requiring two sequential prompts for the same operation would degrade UX without meaningfully improving security, since the user must already approve the more specific symlink-escape prompt.
 pub fn authorize_file_edit(
     tool_name: &str,
     path: &Path,
@@ -522,37 +491,27 @@ pub fn authorize_file_edit(
     })
 }
 
-/// The user's choice when prompted about how to handle unsaved changes
-/// in a buffer that the agent wants to edit or overwrite.
+/// The user's choice when prompted about how to handle unsaved changes in a buffer that the agent wants to edit or overwrite.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirtyBufferDecision {
-    /// Save the buffer's pending edits to disk, then proceed.
-    /// (Edit-mode prompt only.)
+    /// Save the buffer's pending edits to disk, then proceed. (Edit-mode prompt only.)
     Save,
     /// Discard the buffer's pending edits (reload from disk), then proceed.
     Discard,
-    /// Keep the buffer's pending edits and cancel the agent's operation.
-    /// (Overwrite-mode prompt only.)
+    /// Keep the buffer's pending edits and cancel the agent's operation. (Overwrite-mode prompt only.)
     Keep,
 }
 
 /// Which prompt to show when the agent encounters a dirty buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirtyBufferPromptKind {
-    /// The agent wants to apply targeted edits on top of the current
-    /// content. Offers Save (persist edits, then edit on top) vs Discard
-    /// (revert to disk, then edit).
+    /// The agent wants to apply targeted edits on top of the current content. Offers Save (persist edits, then edit on top) vs Discard (revert to disk, then edit).
     Edit,
-    /// The agent wants to overwrite the file's entire contents. Offers
-    /// Keep (cancel the overwrite to preserve the user's work) vs
-    /// Discard (reload from disk and let the agent overwrite).
+    /// The agent wants to overwrite the file's entire contents. Offers Keep (cancel the overwrite to preserve the user's work) vs Discard (reload from disk and let the agent overwrite).
     Overwrite,
 }
 
-/// Prompts the user about how to handle a dirty buffer that the agent
-/// wants to edit or overwrite. Returns the chosen action; the caller is
-/// responsible for actually performing the corresponding side effect
-/// (save / reload / cancel) before continuing.
+/// Prompts the user about how to handle a dirty buffer that the agent wants to edit or overwrite. Returns the chosen action; the caller is responsible for actually performing the corresponding side effect (save / reload / cancel) before continuing.
 pub fn authorize_dirty_buffer(
     kind: DirtyBufferPromptKind,
     event_stream: &ToolCallEventStream,

--- a/crates/agent/src/tools/web_search_tool.rs
+++ b/crates/agent/src/tools/web_search_tool.rs
@@ -15,9 +15,7 @@ use ui::prelude::*;
 use util::markdown::MarkdownInlineCode;
 use web_search::WebSearchRegistry;
 
-/// Search the web for information using your query.
-/// Use this when you need real-time information, facts, or data that might not be in your training.
-/// Results will include snippets and links from relevant web pages.
+/// Search the web for information using your query. Use this when you need real-time information, facts, or data that might not be in your training. Results will include snippets and links from relevant web pages.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct WebSearchToolInput {
     /// The search term or question to query on the web.

--- a/crates/agent/src/tools/write_file_tool.rs
+++ b/crates/agent/src/tools/write_file_tool.rs
@@ -46,8 +46,7 @@ pub struct WriteFileToolInput {
     /// </example>
     pub path: PathBuf,
 
-    /// The complete content for the file.
-    /// This field should contain the entire file content.
+    /// The complete content for the file. This field should contain the entire file content.
     pub content: String,
 }
 
@@ -1091,9 +1090,7 @@ mod tests {
         );
     }
 
-    /// When the buffer has unsaved user edits and the user picks
-    /// "Discard my edits", the pending edits are reverted to match disk
-    /// and the agent's overwrite proceeds.
+    /// When the buffer has unsaved user edits and the user picks "Discard my edits", the pending edits are reverted to match disk and the agent's overwrite proceeds.
     #[gpui::test]
     async fn test_streaming_write_dirty_buffer_discard(cx: &mut TestAppContext) {
         let (write_tool, project, _action_log, fs, _thread) =
@@ -1170,9 +1167,7 @@ mod tests {
         assert_eq!(on_disk, "agent overwrote it");
     }
 
-    /// When the buffer has unsaved user edits and the user picks
-    /// "Keep my edits", the overwrite is cancelled with an error and the
-    /// user's pending edits are preserved.
+    /// When the buffer has unsaved user edits and the user picks "Keep my edits", the overwrite is cancelled with an error and the user's pending edits are preserved.
     #[gpui::test]
     async fn test_streaming_write_dirty_buffer_keep(cx: &mut TestAppContext) {
         let (write_tool, project, _action_log, fs, _thread) =
@@ -1232,10 +1227,7 @@ mod tests {
         assert_eq!(on_disk, "on disk content");
     }
 
-    /// When the user manually saves the buffer (e.g. cmd-s) while the
-    /// overwrite prompt is visible, that's treated as "Keep my edits":
-    /// the user just deliberately persisted their work, so we cancel the
-    /// agent's overwrite to avoid clobbering it.
+    /// When the user manually saves the buffer (e.g. cmd-s) while the overwrite prompt is visible, that's treated as "Keep my edits": the user just deliberately persisted their work, so we cancel the agent's overwrite to avoid clobbering it.
     #[gpui::test]
     async fn test_streaming_write_dirty_buffer_resolved_externally(cx: &mut TestAppContext) {
         let (write_tool, project, _action_log, fs, _thread) =


### PR DESCRIPTION
Doc comments on agent tool input types (and the tool structs themselves) are serialized verbatim into the JSON tool descriptions sent to language models. Mid-paragraph line wraps add newlines that have no semantic meaning, fragment the prose for the model, and waste tokens. Each prose paragraph should be a single physical line; paragraphs are separated by an empty `///` line.

This is a follow-up to the same kind of cleanup done in #56164. It applies the rule mechanically to every wrapped `///` paragraph under `crates/agent/src/tools`.

## Rule applied

A paragraph is a contiguous run of non-empty `///` lines whose content does not start with a list/heading/quote/table marker (`-`, `*`, `+`, `#`, `>`, `|`), an HTML/XML tag (`<…>`), a fenced code marker (` ``` `), a numbered list prefix (`1.`, `2)`, …), or whitespace. Within such a paragraph, all lines are joined with a single space.

The whitespace exclusion preserves markdown continuation lines for bullets like:

```rust
/// - `Ok(SymlinkEscape { .. })` — the path resolves
///   through a symlink to a location outside the project.
```

These remain untouched, since the indented continuation is part of the bullet, not a separate paragraph.

## Verification

- `cargo check -p agent` passes.
- `cargo test -p agent --lib --no-run` builds the test binary.
- The diff carries 0 logic changes; only `///` line breaks inside prose paragraphs are collapsed.

## Files touched

24 files under `crates/agent/src/tools/`: 89 insertions, 237 deletions.

Release Notes:

- Improved tool descriptions sent to language models by removing mid-paragraph line wraps from agent tool doc comments.
