### PR TITLE
agent: Fix tool paths preferring files in subdirectories named after the project root

### DIFF
--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -536,7 +536,6 @@ mod test {
         );
     }
 
-    // Regression test for https://github.com/zed-industries/zed/issues/56225
     // When a worktree is named "foo" and contains a subdirectory also named "foo",
     // read_file({"path": "foo/test.txt"}) should return the file at the worktree
     // root (as the tool schema promises), not the one inside the foo/ subdirectory.

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -536,6 +536,48 @@ mod test {
         );
     }
 
+    // Regression test for https://github.com/zed-industries/zed/issues/56225
+    // When a worktree is named "foo" and contains a subdirectory also named "foo",
+    // read_file({"path": "foo/test.txt"}) should return the file at the worktree
+    // root (as the tool schema promises), not the one inside the foo/ subdirectory.
+    #[gpui::test]
+    async fn test_read_file_worktree_root_not_shadowed_by_subdir(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/foo"),
+            json!({
+                "test.txt": "root content",
+                "foo": {
+                    "test.txt": "subdir content"
+                }
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/foo").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let tool = Arc::new(ReadFileTool::new(project, action_log, true));
+
+        // The tool schema says the first component must be the worktree root name,
+        // so "foo/test.txt" means test.txt at the root of the "foo" worktree.
+        let result = cx
+            .update(|cx| {
+                let input = ReadFileToolInput {
+                    path: "foo/test.txt".into(),
+                    start_line: None,
+                    end_line: None,
+                };
+                tool.run(
+                    ToolInput::resolved(input),
+                    ToolCallEventStream::test().0,
+                    cx,
+                )
+            })
+            .await;
+        assert_eq!(result.unwrap(), "root content".into());
+    }
+
     #[gpui::test]
     async fn test_read_file_with_line_range(cx: &mut TestAppContext) {
         init_test(cx);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4979,11 +4979,7 @@ impl Project {
         } else {
             // First pass: for each worktree, try two interpretations of the path and
             // return whichever finds an existing entry first:
-            //   (a) Strip the worktree root name as a prefix. Tool definitions instruct
-            //       the model that "the first component of the path should always be a
-            //       root directory in a project", so e.g. "foo/file.txt" means file.txt
-            //       at the root of the "foo" worktree. This takes priority so that a
-            //       subdirectory that shares the worktree's name doesn't shadow root files.
+            //   (a) Strip the worktree root name as a prefix.
             //   (b) Treat the path as a literal worktree-relative path.
             for worktree in worktree_store.visible_worktrees(cx) {
                 let worktree = worktree.read(cx);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4977,18 +4977,37 @@ impl Project {
                 }
             }
         } else {
+            // First pass: for each worktree, try two interpretations of the path and
+            // return whichever finds an existing entry first:
+            //   (a) Strip the worktree root name as a prefix. Tool definitions instruct
+            //       the model that "the first component of the path should always be a
+            //       root directory in a project", so e.g. "foo/file.txt" means file.txt
+            //       at the root of the "foo" worktree. This takes priority so that a
+            //       subdirectory that shares the worktree's name doesn't shadow root files.
+            //   (b) Treat the path as a literal worktree-relative path.
             for worktree in worktree_store.visible_worktrees(cx) {
                 let worktree = worktree.read(cx);
-                if let Ok(rel_path) = RelPath::new(path, path_style) {
-                    if let Some(entry) = worktree.entry_for_path(&rel_path) {
-                        return Some(ProjectPath {
-                            worktree_id: worktree.id(),
-                            path: entry.path.clone(),
-                        });
-                    }
+                if let Ok(relative_path) = path.strip_prefix(worktree.root_name().as_std_path())
+                    && let Ok(rel_path) = RelPath::new(relative_path, path_style)
+                    && let Some(entry) = worktree.entry_for_path(&rel_path)
+                {
+                    return Some(ProjectPath {
+                        worktree_id: worktree.id(),
+                        path: entry.path.clone(),
+                    });
+                }
+                if let Ok(rel_path) = RelPath::new(path, path_style)
+                    && let Some(entry) = worktree.entry_for_path(&rel_path)
+                {
+                    return Some(ProjectPath {
+                        worktree_id: worktree.id(),
+                        path: entry.path.clone(),
+                    });
                 }
             }
 
+            // Second pass: strip the worktree root name prefix without requiring the
+            // entry to exist, to allow resolving paths that don't exist yet.
             for worktree in worktree_store.visible_worktrees(cx) {
                 let worktree_root_name = worktree.read(cx).root_name();
                 if let Ok(relative_path) = path.strip_prefix(worktree_root_name.as_std_path())


### PR DESCRIPTION
The tool definition is very clearly contradicting the previous behavior. Performance impact is unclear to me, we increase the work in a potentially expensive loop, but it seems necessary to have both the specified behavior from the tool definition, as well as the heuristic/fallback for misbehaving models that seems to be intended.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #56225

Release Notes:

- Fixed tool paths preferring files in subdirectories named after the project root
