### PR TITLE
Attempt to make macOS test runs faster

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         mkdir -p ./../.cargo
         cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::disable_macos_gatekeeper
+      run: sudo spctl --master-disable
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
       with:
@@ -158,6 +160,8 @@ jobs:
       run: |
         mkdir -p ./../.cargo
         cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::disable_macos_gatekeeper
+      run: sudo spctl --master-disable
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
       with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -255,6 +255,8 @@ jobs:
       run: |
         mkdir -p ./../.cargo
         cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::disable_macos_gatekeeper
+      run: sudo spctl --master-disable
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
       with:
@@ -286,6 +288,8 @@ jobs:
       run: |
         mkdir -p ./../.cargo
         cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::disable_macos_gatekeeper
+      run: sudo spctl --master-disable
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
       with:
@@ -419,6 +423,8 @@ jobs:
       run: |
         mkdir -p ./../.cargo
         cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::disable_macos_gatekeeper
+      run: sudo spctl --master-disable
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
       with:
@@ -550,6 +556,8 @@ jobs:
       run: |
         mkdir -p ./../.cargo
         cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::disable_macos_gatekeeper
+      run: sudo spctl --master-disable
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
       with:

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -528,10 +528,13 @@ pub(crate) fn clippy(platform: Platform, arch: Option<Arch>) -> NamedJob {
         .runs_on(runner)
         .add_step(steps::checkout_repo())
         .add_step(steps::setup_cargo_config(platform))
-        .when(
-            platform == Platform::Linux || platform == Platform::Mac,
-            |this| this.add_step(steps::cache_rust_dependencies_namespace()),
-        )
+        .when(platform == Platform::Mac, |this| {
+            this.add_step(steps::disable_macos_gatekeeper())
+                .add_step(steps::cache_rust_dependencies_namespace())
+        })
+        .when(platform == Platform::Linux, |this| {
+            this.add_step(steps::cache_rust_dependencies_namespace())
+        })
         .when(
             platform == Platform::Linux,
             steps::install_linux_dependencies,
@@ -587,7 +590,8 @@ fn run_platform_tests_impl(platform: Platform, filter_packages: bool) -> NamedJo
             .add_step(steps::checkout_repo())
             .add_step(steps::setup_cargo_config(platform))
             .when(platform == Platform::Mac, |this| {
-                this.add_step(steps::cache_rust_dependencies_namespace())
+                this.add_step(steps::disable_macos_gatekeeper())
+                    .add_step(steps::cache_rust_dependencies_namespace())
             })
             .when(platform == Platform::Linux, |this| {
                 use_clang(this.add_step(steps::cache_rust_dependencies_namespace()))
@@ -626,6 +630,7 @@ fn build_visual_tests_binary() -> NamedJob {
             .runs_on(runners::MAC_DEFAULT)
             .add_step(steps::checkout_repo())
             .add_step(steps::setup_cargo_config(Platform::Mac))
+            .add_step(steps::disable_macos_gatekeeper())
             .add_step(steps::cache_rust_dependencies_namespace())
             .add_step(cargo_build_visual_tests())
             .add_step(steps::cleanup_cargo_config(Platform::Mac)),

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -303,6 +303,10 @@ pub fn cache_nix_store_macos() -> Step<Use> {
     .add_with(("path", "~/nix-cache"))
 }
 
+pub fn disable_macos_gatekeeper() -> Step<Run> {
+    named::bash("sudo spctl --master-disable")
+}
+
 pub fn setup_linux() -> Step<Run> {
     named::bash("./script/linux")
 }


### PR DESCRIPTION
Claude's analysis shows we have a roughyl 1.2s overhead per test on macOS runners only

Release Notes:

- N/A
