### PR TITLE
search: set pending_external_query in use_selection_for_find when search bar is dismissed

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1249,14 +1249,18 @@ impl BufferSearchBar {
         self.query_editor.update(cx, |query_editor, cx| {
             query_editor.buffer().update(cx, |query_buffer, cx| {
                 let len = query_buffer.len(cx);
-                query_buffer.edit([(MultiBufferOffset(0)..len, search_text)], None, cx);
+                query_buffer.edit([(MultiBufferOffset(0)..len, search_text.clone())], None, cx);
             });
         });
         #[cfg(target_os = "macos")]
-        self.update_find_pasteboard(cx);
+        {
+            self.update_find_pasteboard(cx);
+            if self.dismissed {
+                self.pending_external_query = Some((search_text, self.search_options));
+            }
+        }
         cx.notify();
     }
-
     pub fn focus_editor(&mut self, _: &FocusEditor, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(active_editor) = self.active_searchable_item.as_ref() {
             let handle = active_editor.item_focus_handle(cx);


### PR DESCRIPTION
Fixes cmd-e / cmd-g regression where using cmd-e (UseSelectionForFind) 
while the search bar is dismissed would update the find pasteboard but 
not set `pending_external_query`, causing cmd-g (SelectNextMatch) to 
silently no-op via `WithResultsOrExternalQuery` (which gates on 
`pending_external_query.is_some() || active_match_index.is_some()`).

When the search bar is dismissed, `use_selection_for_find` now also 
sets `pending_external_query` with the selected text and current search 
options, mirroring the same pattern used in the `on_focus` handler 
(line ~715). The next cmd-g then picks up the pending query, runs the 
search, and activates the first match as expected.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55619