### PR TITLE
edit_prediction_ui: Fix edit prediction provider checkmark

### DIFF
--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -594,15 +594,15 @@ impl EditPredictionButton {
                     continue;
                 };
                 let is_current = provider == current_provider;
-                let is_provider_disabled =
+                let is_disabled_zed_provider =
                     provider == EditPredictionProvider::Zed && is_zed_provider_disabled;
                 let fs = self.fs.clone();
 
                 menu = menu.item(
                     ContextMenuEntry::new(name)
-                        .toggleable(IconPosition::Start, is_current && !is_provider_disabled)
-                        .disabled(is_provider_disabled)
-                        .when(is_provider_disabled, |item| {
+                        .toggleable(IconPosition::Start, is_current && !is_disabled_zed_provider)
+                        .disabled(is_disabled_zed_provider)
+                        .when(is_disabled_zed_provider, |item| {
                             item.documentation_aside(DocumentationSide::Left, move |_cx| {
                                 Label::new("Edit predictions are disabled for this organization.")
                                     .into_any_element()

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -594,30 +594,20 @@ impl EditPredictionButton {
                     continue;
                 };
                 let is_current = provider == current_provider;
+                let is_provider_disabled =
+                    provider == EditPredictionProvider::Zed && is_zed_provider_disabled;
                 let fs = self.fs.clone();
 
                 menu = menu.item(
                     ContextMenuEntry::new(name)
-                        .toggleable(
-                            IconPosition::Start,
-                            is_current
-                                && !(provider == EditPredictionProvider::Zed
-                                    && is_zed_provider_disabled),
-                        )
-                        .disabled(
-                            provider == EditPredictionProvider::Zed && is_zed_provider_disabled,
-                        )
-                        .when(
-                            provider == EditPredictionProvider::Zed && is_zed_provider_disabled,
-                            |item| {
-                                item.documentation_aside(DocumentationSide::Left, move |_cx| {
-                                    Label::new(
-                                        "Edit predictions are disabled for this organization.",
-                                    )
+                        .toggleable(IconPosition::Start, is_current && !is_provider_disabled)
+                        .disabled(is_provider_disabled)
+                        .when(is_provider_disabled, |item| {
+                            item.documentation_aside(DocumentationSide::Left, move |_cx| {
+                                Label::new("Edit predictions are disabled for this organization.")
                                     .into_any_element()
-                                })
-                            },
-                        )
+                            })
+                        })
                         .handler(move |_, cx| {
                             set_completion_provider(fs.clone(), cx, provider);
                         }),

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -601,8 +601,8 @@ impl EditPredictionButton {
                         .toggleable(
                             IconPosition::Start,
                             is_current
-                                && (provider == EditPredictionProvider::Zed
-                                    && !is_zed_provider_disabled),
+                                && !(provider == EditPredictionProvider::Zed
+                                    && is_zed_provider_disabled),
                         )
                         .disabled(
                             provider == EditPredictionProvider::Zed && is_zed_provider_disabled,


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/56129

The edit prediction status bar menu only showed a checkmark for the active provider when that provider was Zed AI. Non-Zed providers such as Mercury could be selected and active, but the Providers section rendered them as unchecked because the toggle condition required `provider = EditPredictionProvider::Zed`.

This updates the menu condition to show the checkmark for any active provider, while preserving the existing exception that hides the Zed AI checkmark when Zed AI is disabled by organization policy.

<div align="center">
<img width="371" height="187" alt="Screenshot 2026-05-08 at 11 27 49 PM" src="https://github.com/user-attachments/assets/5278a102-bd7d-44a5-a655-74c6ed90b0f9" />
</div>

Release Notes:
- Fixed edit prediction provider menu checkmarks for active non-Zed providers.
