### PR TITLE
terminal_view: Hide agent actions in embedded terminal menus

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -511,13 +511,16 @@ impl TerminalView {
                 .action("Paste Text", Box::new(PasteText))
                 .action("Select All", Box::new(SelectAll))
                 .action("Clear", Box::new(Clear))
-                .when(assistant_enabled, |menu| {
-                    menu.separator()
-                        .action("Inline Assist", Box::new(InlineAssist::default()))
-                        .when(has_selection, |menu| {
-                            menu.action("Add to Agent Thread", Box::new(AddSelectionToThread))
-                        })
-                })
+                .when(
+                    assistant_enabled && !matches!(self.mode, TerminalMode::Embedded { .. }),
+                    |menu| {
+                        menu.separator()
+                            .action("Inline Assist", Box::new(InlineAssist::default()))
+                            .when(has_selection, |menu| {
+                                menu.action("Add to Agent Thread", Box::new(AddSelectionToThread))
+                            })
+                    },
+                )
                 .separator()
                 .action(
                     "Close Terminal Tab",


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/56138

This diff hides terminal agent actions from context menus shown by embedded terminal views, such as terminal tool output in agent threads. Those surfaces render through `TerminalView`, but they are not normal interactive terminal panes, and actions like Inline Assist and Add to Agent Thread do not currently resolve the embedded terminal as their target.

Previously, choosing Inline Assist from terminal tool output could target the workspace’s active editor instead of the terminal output. The context menu now limits these agent actions to non-embedded terminal views, so regular terminal panes keep their existing behavior while terminal tool output no longer offers actions that cannot resolve to it.

Add to Agent Thread _could_ make sense for embedded terminal selections in the future, but it would need explicit target-resolution support for focused embedded terminals. This change keeps that as separate follow-up work instead of leaving a misleading menu item that does not reliably act on the selected tool output.

Release Notes:

- Fixed embedded terminal context menus showing agent actions that could target the wrong item.