### PR TITLE
editor: Show file icon in breadcrumbs when tab bar is hidden

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -53,7 +53,7 @@ use workspace::{
     },
 };
 use workspace::{
-    Pane, WorkspaceSettings,
+    Pane, TabBarSettings, WorkspaceSettings,
     item::{FollowEvent, ProjectItemKind},
     searchable::SearchOptions,
 };
@@ -1049,6 +1049,20 @@ impl Item for Editor {
         } else {
             None
         }
+    }
+
+    fn breadcrumb_prefix(
+        &self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        (!TabBarSettings::get_global(cx).show && ItemSettings::get_global(cx).file_icons)
+            .then(|| {
+                path_for_buffer(&self.buffer, 0, true, cx)
+                    .and_then(|path| FileIcons::get_icon(Path::new(&*path), cx))
+            })
+            .flatten()
+            .map(|icon_path| Icon::from_path(icon_path).into_any_element())
     }
 
     fn added_to_workspace(


### PR DESCRIPTION

[Screencast_20260509_113456.webm](https://github.com/user-attachments/assets/8165246f-6266-4e23-bede-0755e8636a19)

Release Notes: 

- Made file icons be displayed when tab bar is hidden and file icons are turned on for tabs.
