### PR TITLE
rules_library: Allow closing agent rules window with escape

### DIFF
--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -3,9 +3,9 @@ use collections::{HashMap, HashSet};
 use editor::SelectionEffects;
 use editor::{CurrentLineHighlight, Editor, EditorElement, EditorEvent, EditorStyle, actions::Tab};
 use gpui::{
-    App, Bounds, DEFAULT_ADDITIONAL_WINDOW_SIZE, Entity, EventEmitter, Focusable, PromptLevel,
-    Subscription, Task, TaskExt, TextStyle, Tiling, TitlebarOptions, WindowBounds, WindowHandle,
-    WindowOptions, actions, point, size, transparent_black,
+    App, Bounds, DEFAULT_ADDITIONAL_WINDOW_SIZE, DismissEvent, Entity, EventEmitter, Focusable,
+    PromptLevel, Subscription, Task, TaskExt, TextStyle, Tiling, TitlebarOptions, WindowBounds,
+    WindowHandle, WindowOptions, actions, point, size, transparent_black,
 };
 use language::{Buffer, LanguageRegistry, language_settings::SoftWrap};
 use language_model::{ConfiguredModel, LanguageModelRegistry};
@@ -509,7 +509,14 @@ impl RulesLibrary {
             active_rule_id: None,
             pending_load: Task::ready(()),
             inline_assist_delegate,
-            _subscriptions: vec![cx.subscribe_in(&picker, window, Self::handle_picker_event)],
+            _subscriptions: vec![
+                cx.subscribe_in(&picker, window, Self::handle_picker_event),
+                cx.subscribe_in(
+                    &picker,
+                    window,
+                    |_: &mut Self, _, _: &DismissEvent, window, _| window.remove_window(),
+                ),
+            ],
             picker,
         }
     }

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -936,6 +936,19 @@ impl RulesLibrary {
     }
 
     fn focus_picker(&mut self, _: &menu::Cancel, window: &mut Window, cx: &mut Context<Self>) {
+        self.focus_rule_picker(window, cx);
+    }
+
+    fn focus_picker_from_editor_cancel(
+        &mut self,
+        _: &editor::actions::Cancel,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.focus_rule_picker(window, cx);
+    }
+
+    fn focus_rule_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.picker
             .update(cx, |picker, cx| picker.focus(window, cx));
     }
@@ -1140,6 +1153,7 @@ impl RulesLibrary {
                 })
             })
             .on_action(cx.listener(Self::focus_picker))
+            .on_action(cx.listener(Self::focus_picker_from_editor_cancel))
             .on_action(cx.listener(Self::move_down_from_title))
             .child(EditorElement::new(
                 &editor,
@@ -1277,6 +1291,7 @@ impl RulesLibrary {
                         .child(
                             div()
                                 .on_action(cx.listener(Self::focus_picker))
+                                .on_action(cx.listener(Self::focus_picker_from_editor_cancel))
                                 .on_action(cx.listener(Self::inline_assist))
                                 .on_action(cx.listener(Self::move_up_from_body))
                                 .h_full()

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -1139,6 +1139,7 @@ impl RulesLibrary {
                     this.border_color(cx.theme().colors().border_variant)
                 })
             })
+            .on_action(cx.listener(Self::focus_picker))
             .on_action(cx.listener(Self::move_down_from_title))
             .child(EditorElement::new(
                 &editor,


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/56083

This diff fixes the agent rules window staying open when pressing escape from the picker. The picker already emits `DismissEvent` on cancel, but the rules window was not subscribed to that event, so the action had no visible effect.

This wires the picker dismissal to close the floating rules window. Escape behaviour while editing rule text is unchanged, i.e. the rule editor continues to handle escape itself.

https://github.com/user-attachments/assets/96ca7af6-07c3-465c-b0ed-eafff3c343d1

Release Notes:
- Fixed escape not closing the agent rules window from the rule picker.
