### PR TITLE
git: Avoid watching home for missing global config

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3161,11 +3161,29 @@ impl GitPanel {
             ];
 
             cx.spawn_in(window, async move |git_panel, cx| {
-                git_panel.update(cx, |git_panel, cx| {
+                let task = git_panel.update(cx, |git_panel, cx| {
                     git_panel.project.read(cx).git_config(path, args, cx)
-                })
+                })?;
+                let result = task.await;
+
+                match result {
+                    Ok(_) => {
+                        let project =
+                            git_panel.read_with(cx, |git_panel, _| git_panel.project.clone())?;
+                        project.update(cx, |project, cx| {
+                            project.global_git_configuration_updated(cx);
+                        });
+                    }
+                    Err(e) => {
+                        git_panel.update(cx, |git_panel, cx| {
+                            git_panel.show_error_toast("trust directory", e, cx)
+                        })?;
+                    }
+                }
+
+                anyhow::Ok(())
             })
-            .detach();
+            .detach_and_log_err(cx);
         }
     }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -542,21 +542,15 @@ impl GitStore {
                 let fs = fs.clone();
 
                 cx.spawn(async move |this, cx| {
+                    if !fs.is_file(&path).await {
+                        return;
+                    }
+
                     let watcher = fs.watch(&path, Duration::from_millis(100));
                     let (mut watcher, _) = watcher.await;
                     while let Some(_) = watcher.next().await {
                         let Ok(_) = this.update(cx, |this, cx| {
-                            for repo in this.repositories.values() {
-                                repo.update(cx, |this, cx| {
-                                    if this.job_sender.is_closed() {
-                                        let (job_sender, state) = (this.refetch_repo_state)(cx);
-                                        this.repository_state = state;
-                                        this.job_sender = job_sender;
-                                        this.schedule_scan(None, cx);
-                                    }
-                                })
-                            }
-                            cx.emit(GitStoreEvent::GlobalConfigurationUpdated);
+                            this.global_configuration_updated(cx);
                         }) else {
                             return;
                         };
@@ -690,6 +684,15 @@ impl GitStore {
 
     pub fn is_local(&self) -> bool {
         matches!(self.state, GitStoreState::Local { .. })
+    }
+
+    pub fn global_configuration_updated(&mut self, cx: &mut Context<Self>) {
+        for repo in self.repositories.values() {
+            repo.update(cx, |repo, cx| {
+                repo.refetch_state_if_closed(cx);
+            });
+        }
+        cx.emit(GitStoreEvent::GlobalConfigurationUpdated);
     }
 
     fn set_active_repo_id(&mut self, repo_id: RepositoryId, cx: &mut Context<Self>) {
@@ -8189,6 +8192,15 @@ impl Repository {
         }
         self.pending_ops.edit(edits, ());
         ids
+    }
+
+    fn refetch_state_if_closed(&mut self, cx: &mut Context<Self>) {
+        if self.job_sender.is_closed() {
+            let (job_sender, state) = (self.refetch_repo_state)(cx);
+            self.repository_state = state;
+            self.job_sender = job_sender;
+            self.schedule_scan(None, cx);
+        }
     }
 
     pub fn access(&mut self, _cx: &App) -> oneshot::Receiver<GitAccess> {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6033,6 +6033,12 @@ impl Project {
         self.git_store.read(cx).git_config(path, args, cx)
     }
 
+    pub fn global_git_configuration_updated(&self, cx: &mut Context<Self>) {
+        self.git_store.update(cx, |git_store, cx| {
+            git_store.global_configuration_updated(cx);
+        });
+    }
+
     pub fn buffer_store(&self) -> &Entity<BufferStore> {
         &self.buffer_store
     }


### PR DESCRIPTION
Self-Review Checklist:

- [ ] ~I've reviewed my own diff for quality, security, and reliability~
- [ ] ~Unsafe blocks (if any) have justifying comments~
- [ ] ~The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)~
- [ ] ~Tests cover the new/changed behavior~
- [ ] ~Performance impact has been considered and is acceptable~

> [!IMPORTANT]  
This fix is just a draft fix that codex generated that successfully fixes the "Stuck in 'Starting proxy...'" issue for me. You will probably *not* want to merge this PR and instead write your own solution for this.

(maybe?) closes #52633

problematic commit: 1afe44c1b6

## Summary

Fixes a remote startup hang caused by the global Git config watchers added for unsafe repository handling.

`RealFs::watch` watches the nearest existing ancestor when asked to watch a path that does not exist. For `~/.gitconfig`, that means a user without a global Git config file ends up watching `$HOME`. On remote filesystems that use the polling watcher, this becomes a recursive poll of the entire home directory, which can keep the remote server busy reading a large home tree while the client is stuck at "Starting proxy...".

Release Notes:

- Fixed a remote startup hang caused by polling the entire home directory when global Git config files are missing
