### PR TITLE
gpui_macos: Drop legacy pre-macOS 12 blur path and its private CGS APIs

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -9,12 +9,11 @@ use anyhow::Result;
 use block::ConcreteBlock;
 use cocoa::{
     appkit::{
-        NSAppKitVersionNumber, NSAppKitVersionNumber12_0, NSApplication, NSBackingStoreBuffered,
-        NSColor, NSEvent, NSEventModifierFlags, NSFilenamesPboardType, NSPasteboard,
-        NSRequestUserAttentionType, NSScreen, NSView, NSViewHeightSizable, NSViewWidthSizable,
-        NSVisualEffectMaterial, NSVisualEffectState, NSVisualEffectView, NSWindow,
-        NSWindowCollectionBehavior, NSWindowOcclusionState, NSWindowOrderingMode,
-        NSWindowStyleMask, NSWindowTitleVisibility,
+        NSApplication, NSBackingStoreBuffered, NSColor, NSEventModifierFlags,
+        NSFilenamesPboardType, NSPasteboard, NSRequestUserAttentionType, NSScreen, NSView,
+        NSViewHeightSizable, NSViewWidthSizable, NSVisualEffectMaterial, NSVisualEffectState,
+        NSVisualEffectView, NSWindow, NSWindowCollectionBehavior, NSWindowOcclusionState,
+        NSWindowOrderingMode, NSWindowStyleMask, NSWindowTitleVisibility,
     },
     base::{id, nil},
     foundation::{
@@ -114,17 +113,6 @@ pub enum UserTabbingPreference {
     Never,
     Always,
     InFullScreen,
-}
-
-#[link(name = "CoreGraphics", kind = "framework")]
-unsafe extern "C" {
-    // Widely used private APIs; Apple uses them for their Terminal.app.
-    fn CGSMainConnectionID() -> id;
-    fn CGSSetWindowBackgroundBlurRadius(
-        connection_id: id,
-        window_id: NSInteger,
-        radius: i64,
-    ) -> i32;
 }
 
 #[ctor(unsafe)]
@@ -1539,42 +1527,25 @@ impl PlatformWindow for MacWindow {
             };
             this.native_window.setBackgroundColor_(background_color);
 
-            if NSAppKitVersionNumber < NSAppKitVersionNumber12_0 {
-                // Whether `-[NSVisualEffectView respondsToSelector:@selector(_updateProxyLayer)]`.
-                // On macOS Catalina/Big Sur `NSVisualEffectView` doesn’t own concrete sublayers
-                // but uses a `CAProxyLayer`. Use the legacy WindowServer API.
-                let blur_radius = if background_appearance == WindowBackgroundAppearance::Blurred {
-                    80
-                } else {
-                    0
-                };
-
-                let window_number = this.native_window.windowNumber();
-                CGSSetWindowBackgroundBlurRadius(CGSMainConnectionID(), window_number, blur_radius);
-            } else {
-                // On newer macOS `NSVisualEffectView` manages the effect layer directly. Using it
-                // could have a better performance (it downsamples the backdrop) and more control
-                // over the effect layer.
-                if background_appearance != WindowBackgroundAppearance::Blurred {
-                    if let Some(blur_view) = this.blurred_view {
-                        NSView::removeFromSuperview(blur_view);
-                        this.blurred_view = None;
-                    }
-                } else if this.blurred_view.is_none() {
-                    let content_view = this.native_window.contentView();
-                    let frame = NSView::bounds(content_view);
-                    let mut blur_view: id = msg_send![BLURRED_VIEW_CLASS, alloc];
-                    blur_view = NSView::initWithFrame_(blur_view, frame);
-                    blur_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable);
-
-                    let _: () = msg_send![
-                        content_view,
-                        addSubview: blur_view
-                        positioned: NSWindowOrderingMode::NSWindowBelow
-                        relativeTo: nil
-                    ];
-                    this.blurred_view = Some(blur_view.autorelease());
+            if background_appearance != WindowBackgroundAppearance::Blurred {
+                if let Some(blur_view) = this.blurred_view {
+                    NSView::removeFromSuperview(blur_view);
+                    this.blurred_view = None;
                 }
+            } else if this.blurred_view.is_none() {
+                let content_view = this.native_window.contentView();
+                let frame = NSView::bounds(content_view);
+                let mut blur_view: id = msg_send![BLURRED_VIEW_CLASS, alloc];
+                blur_view = NSView::initWithFrame_(blur_view, frame);
+                blur_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable);
+
+                let _: () = msg_send![
+                    content_view,
+                    addSubview: blur_view
+                    positioned: NSWindowOrderingMode::NSWindowBelow
+                    relativeTo: nil
+                ];
+                this.blurred_view = Some(blur_view.autorelease());
             }
         }
     }


### PR DESCRIPTION
## Summary

`gpui_macos` links two private CoreGraphics Services APIs unconditionally:

```rust
#[link(name = "CoreGraphics", kind = "framework")]
unsafe extern "C" {
    fn CGSMainConnectionID() -> id;
    fn CGSSetWindowBackgroundBlurRadius(...) -> i32;
}
```

Apple rejects App Store submissions that reference private APIs, so any
application built on GPUI is ineligible for the Mac App Store — regardless of
whether it ever sets `WindowBackgroundAppearance::Blurred`, since the symbols are
linked either way.

Their only call site is the `NSAppKitVersionNumber < NSAppKitVersionNumber12_0`
branch: macOS 11 and earlier. On macOS 12+ the same effect already goes through
`NSVisualEffectView`, which the existing comment notes is the better path anyway
(it downsamples the backdrop and gives more control over the effect layer).

This deletes the legacy branch and the extern block.

## Changed from the previous revision of this PR

This originally added a `macos_app_store` feature gate. @reflectronic suggested
deleting the legacy `WindowBackgroundAppearance::Blurred` support instead of
carrying a flag — that is the better call and this PR now does that.

It is the stronger fix on the merits, not just the smaller one: deleting makes
every GPUI consumer App Store eligible, whereas a feature flag only helps those
who opt in and leaves the default build ineligible. It also removes a
conditional-compilation path rather than adding one. The diff went from
3 files / +13 −7 to **1 file / +23 −52**.

## Notes for review

Two details that are easy to miss:

- `this.native_window.windowNumber()` resolved through cocoa's **`NSEvent`**
  trait rather than `NSWindow` — `id` is untyped, so it picks up every trait in
  scope. Removing that call makes the `NSEvent` import genuinely unused, so it is
  dropped. Verified against a build of unmodified `main`, which does not emit
  that warning, to confirm this is a consequence of the change and not
  pre-existing.
- `NSAppKitVersionNumber` and `NSAppKitVersionNumber12_0` had no other users and
  are dropped with it.

The `NSVisualEffectView` branch is preserved verbatim; the only change to it is
one level of de-indentation.

## Behaviour change

On macOS 11 and earlier, `WindowBackgroundAppearance::Blurred` no longer applies
a blur — the window falls back to the `NSVisualEffectView` path, which those
releases handle via `CAProxyLayer` rather than concrete sublayers. macOS 11 is
past end of life. Every other platform and macOS 12+ are unaffected.

## Verification

`cargo check -p gpui_macos` on macOS — clean, no errors and no new warnings.

The identical change was also applied to a downstream GPUI fork and built against
a ~60k-line application using `gpui-component`, where CI passed on macOS, Ubuntu
and Windows.

Release Notes:

- N/A
