### PR TITLE
Fix gitignored files being ignored from agent file search

### DIFF
--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1881,7 +1881,7 @@ pub(crate) fn search_files(
 
                 PathMatchCandidateSet {
                     snapshot: worktree.snapshot(),
-                    include_ignored: worktree.root_entry().is_some_and(|entry| entry.is_ignored),
+                    include_ignored: true,
                     include_root_name,
                     candidates: project::Candidates::Entries,
                 }


### PR DESCRIPTION
Changed a parameter in a PathMatchCandidateSet initialization in the search_files() function.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55637

Release Notes:

- Fix gitignored files being ignored from agent file search
