### PR TITLE
opencode: Update Free models

### DIFF
--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -395,6 +395,7 @@ impl Model {
             | Self::MimoV2_5Pro
             | Self::Glm5
             | Self::Glm5_1
+            | Self::BigPickle
             | Self::Ring2_6_1TFree => true,
 
             Self::Custom {

--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -141,6 +141,8 @@ pub enum Model {
     MimoV2_5,
     #[serde(rename = "big-pickle")]
     BigPickle,
+    #[serde(rename = "ring-2.6-1t-free")]
+    Ring2_6_1TFree,
     #[serde(rename = "nemotron-3-super-free")]
     Nemotron3SuperFree,
     #[serde(rename = "qwen3.5-plus")]
@@ -202,9 +204,10 @@ impl Model {
             | Self::DeepSeekV4Flash => &[OpenCodeSubscription::Go],
 
             // Free models
-            Self::MiniMaxM2_5Free | Self::Nemotron3SuperFree | Self::BigPickle => {
-                &[OpenCodeSubscription::Free]
-            }
+            Self::MiniMaxM2_5Free
+            | Self::Nemotron3SuperFree
+            | Self::BigPickle
+            | Self::Ring2_6_1TFree => &[OpenCodeSubscription::Free],
 
             // Custom models get their subscription from settings, not from here
             Self::Custom { .. } => &[],
@@ -260,6 +263,7 @@ impl Model {
             Self::Qwen3_5Plus => "qwen3.5-plus",
             Self::Qwen3_6Plus => "qwen3.6-plus",
             Self::BigPickle => "big-pickle",
+            Self::Ring2_6_1TFree => "ring-2.6-1t-free",
             Self::Nemotron3SuperFree => "nemotron-3-super-free",
 
             Self::Custom { name, .. } => name,
@@ -312,6 +316,7 @@ impl Model {
             Self::Qwen3_5Plus => "Qwen3.5 Plus",
             Self::Qwen3_6Plus => "Qwen3.6 Plus",
             Self::BigPickle => "Big Pickle",
+            Self::Ring2_6_1TFree => "Ring 2.6 1T Free",
             Self::Nemotron3SuperFree => "Nemotron 3 Super Free",
 
             Self::Custom {
@@ -373,6 +378,7 @@ impl Model {
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
             | Self::BigPickle
+            | Self::Ring2_6_1TFree
             | Self::Nemotron3SuperFree => ApiProtocol::OpenAiChat,
 
             Self::Custom { protocol, .. } => *protocol,
@@ -388,7 +394,8 @@ impl Model {
             | Self::MimoV2_5
             | Self::MimoV2_5Pro
             | Self::Glm5
-            | Self::Glm5_1 => true,
+            | Self::Glm5_1
+            | Self::Ring2_6_1TFree => true,
 
             Self::Custom {
                 interleaved_reasoning,
@@ -434,6 +441,7 @@ impl Model {
             Self::MimoV2_5 => 1_000_000,
             Self::Qwen3_5Plus | Self::Qwen3_6Plus => 262_144,
             Self::BigPickle => 200_000,
+            Self::Ring2_6_1TFree => 262_000,
             Self::Nemotron3SuperFree => 204_800,
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => 1_000_000,
 
@@ -479,6 +487,7 @@ impl Model {
             Self::MiniMaxM2_5 | Self::MiniMaxM2_5Free => Some(131_072),
             Self::Glm5 | Self::Glm5_1 => Some(32_768),
             Self::BigPickle => Some(128_000),
+            Self::Ring2_6_1TFree => Some(66_000),
             Self::KimiK2_6 | Self::KimiK2_5 => Some(65_536),
             Self::Qwen3_5Plus | Self::Qwen3_6Plus => Some(65_536),
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => Some(384_000),
@@ -546,6 +555,7 @@ impl Model {
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
             | Self::BigPickle
+            | Self::Ring2_6_1TFree
             | Self::Nemotron3SuperFree => false,
 
             Self::Custom { protocol, .. } => matches!(
@@ -560,7 +570,7 @@ impl Model {
 
     pub fn supported_reasoning_effort_levels(&self) -> Option<Vec<ReasoningEffort>> {
         match self {
-            Self::MimoV2_5Pro | Self::MimoV2_5 => Some(vec![
+            Self::Ring2_6_1TFree | Self::MimoV2_5Pro | Self::MimoV2_5 => Some(vec![
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,


### PR DESCRIPTION
Of course, right after yesterday's PR which was merged super-fast we get even more model updates from OpenCode:
- **Big Pickle**: now supports interleaved reasoning as per https://github.com/anomalyco/models.dev/commit/06908cbf36164dfa727251d5fad357c6e98cc983
- **Ring 2.6 1T Free**: a new free model [available for a limited time](https://x.com/opencode/status/2053393732221739498) as per https://github.com/anomalyco/models.dev/commit/359fd879b8c4a98b58347ad4de21c7e2d3f306af. Reasoning levels were discovered by manually checking what's available in OpenCode CLI.

This PR was tested by asking both models to do a simple task (_"in this file rename Bob to Potato"_) at different reasoning levels. Both models successfully accomplished the task!

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- OpenCode Free: updated models (BigPickle and Ring 2.6 1T Free)