### PR TITLE
edit_prediction_ui: Show unavailable provider in dropdown when API key is reset

### DIFF
--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -586,8 +586,26 @@ impl EditPredictionButton {
             .filter(|p| *p != EditPredictionProvider::None)
             .collect();
 
-        if !providers.is_empty() {
+        let current_is_available = providers.contains(&current_provider);
+        let has_unavailable_selected = !current_is_available
+            && current_provider != EditPredictionProvider::None;
+
+        if !providers.is_empty() || has_unavailable_selected {
             menu = menu.separator().header("Providers");
+
+            if has_unavailable_selected {
+                if let Some(name) = current_provider.display_name() {
+                    menu = menu.item(
+                        ContextMenuEntry::new(name)
+                            .toggleable(IconPosition::Start, true)
+                            .disabled(true)
+                            .documentation_aside(DocumentationSide::Left, |_cx| {
+                                Label::new("Requires API key or configuration")
+                                    .into_any_element()
+                            }),
+                    );
+                }
+            }
 
             for provider in providers {
                 let Some(name) = provider.display_name() else {

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -6,10 +6,10 @@ use edit_prediction::{
 };
 use edit_prediction_ui::{get_available_providers, set_completion_provider};
 use gpui::{App, Entity, ScrollHandle, TaskExt, prelude::*};
-use language::language_settings::AllLanguageSettings;
+use language::language_settings::{AllLanguageSettings, EditPredictionProvider};
 
 use settings::Settings as _;
-use ui::{ButtonLink, ConfiguredApiCard, ContextMenu, DropdownMenu, DropdownStyle, prelude::*};
+use ui::{ButtonLink, ConfiguredApiCard, ContextMenu, ContextMenuEntry, DocumentationSide, DropdownMenu, DropdownStyle, prelude::*};
 use workspace::AppState;
 
 const OLLAMA_API_URL_PLACEHOLDER: &str = "http://localhost:11434";
@@ -120,6 +120,21 @@ fn render_provider_dropdown(window: &mut Window, cx: &mut App) -> AnyElement {
     let menu = ContextMenu::build(window, cx, move |mut menu, _, cx| {
         let available_providers = get_available_providers(cx);
         let fs = <dyn fs::Fs>::global(cx);
+
+        let current_is_available = available_providers.contains(&current_provider);
+        if !current_is_available && current_provider != EditPredictionProvider::None {
+            if let Some(name) = current_provider.display_name() {
+                menu = menu.item(
+                    ContextMenuEntry::new(name)
+                        .toggleable(IconPosition::Start, true)
+                        .disabled(true)
+                        .documentation_aside(DocumentationSide::Left, |_cx| {
+                            Label::new("Requires API key or configuration")
+                                .into_any_element()
+                        }),
+                );
+            }
+        }
 
         for provider in available_providers {
             let Some(name) = provider.display_name() else {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56311

## What

When an edit prediction provider's API key is cleared/reset, the provider was being silently removed from the provider dropdown (both in the status bar button's context menu and in the Settings UI provider dropdown). This left the UI in an inconsistent state: the dropdown label/button showed the previously-selected provider as active, but that provider was absent from the menu items.

## How

Two files changed:

- **`crates/edit_prediction_ui/src/edit_prediction_button.rs`** — `add_provider_switching_section`: if the currently-selected provider is not in the available-providers list, it is inserted at the top of the Providers section as a **disabled, checked** entry with a `"Requires API key or configuration"` documentation aside. The section is also shown even when there are no other available providers.

- **`crates/settings_ui/src/pages/edit_prediction_provider_setup.rs`** — `render_provider_dropdown`: same logic — if the current provider is not available, it is prepended to the dropdown as a disabled, checked entry with the same documentation aside.

This matches the approach suggested in the issue: keep the selected provider visible in the dropdown and mark it as unavailable, rather than silently omitting it.

Release Notes:

- Fixed edit prediction provider dropdown showing an inconsistent state when the selected provider's API key is reset
