### PR TITLE
Add launchpad.enabled setting to control launchpad visibility

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -138,6 +138,11 @@
   //  3. Do not restore previous workspaces
   //         "restore_on_startup": "none",
   "restore_on_startup": "last_session",
+  // Launchpad related settings
+  "launchpad": {
+    // Whether to show the launchpad when starting Zed.
+    "enabled": true,
+  },
   // The default behavior when opening paths from the CLI without
   // an explicit `-e` (existing window) or `-n` (new window) flag.
   //

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1031,6 +1031,7 @@ impl VsCodeSettings {
             resize_all_panels_in_dock: None,
             restore_on_file_reopen: self.read_bool("workbench.editor.restoreViewState"),
             restore_on_startup: None,
+            launchpad: None,
             window_decorations: None,
             show_call_status_icon: None,
             use_system_path_prompts: self.read_bool("files.simpleDialog.enable"),

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -49,6 +49,8 @@ pub struct WorkspaceSettingsContent {
     /// Values: empty_tab, last_workspace, last_session, launchpad
     /// Default: last_session
     pub restore_on_startup: Option<RestoreOnStartupBehavior>,
+    /// Launchpad related settings.
+    pub launchpad: Option<LaunchpadSettings>,
     /// The default behavior when opening paths from the CLI without
     /// an explicit `-e` or `-n` flag.
     ///
@@ -1019,6 +1021,15 @@ impl DocumentSymbols {
     pub fn lsp_enabled(&self) -> bool {
         self == &Self::On
     }
+}
+
+#[with_fallible_options]
+#[derive(Copy, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
+pub struct LaunchpadSettings {
+    /// Whether to show the launchpad when starting Zed.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1645,7 +1645,8 @@ impl Workspace {
                 cx,
             );
             center_pane.set_can_split(Some(Arc::new(|_, _, _, _| true)));
-            center_pane.set_should_display_welcome_page(true);
+            center_pane
+                .set_should_display_welcome_page(WorkspaceSettings::get_global(cx).show_launchpad);
             center_pane
         });
         cx.subscribe_in(&center_pane, window, Self::handle_pane_event)

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -20,6 +20,7 @@ pub struct WorkspaceSettings {
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
     pub restore_on_startup: settings::RestoreOnStartupBehavior,
+    pub show_launchpad: bool,
     pub cli_default_open_behavior: settings::CliDefaultOpenBehavior,
     pub restore_on_file_reopen: bool,
     pub drop_target_size: f32,
@@ -100,6 +101,10 @@ impl Settings for WorkspaceSettings {
             show_call_status_icon: workspace.show_call_status_icon.unwrap(),
             autosave: workspace.autosave.unwrap(),
             restore_on_startup: workspace.restore_on_startup.unwrap(),
+            show_launchpad: workspace
+                .launchpad
+                .and_then(|launchpad| launchpad.enabled)
+                .unwrap_or(true),
             cli_default_open_behavior: workspace.cli_default_open_behavior.unwrap(),
             restore_on_file_reopen: workspace.restore_on_file_reopen.unwrap(),
             drop_target_size: workspace.drop_target_size.unwrap(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1539,20 +1539,21 @@ pub(crate) async fn restore_or_create_workspace(
                     app_state.clone(),
                     cx,
                     |workspace, window, cx| {
-                        let restore_on_startup =
-                            WorkspaceSettings::get_global(cx).restore_on_startup;
-                        match restore_on_startup {
-                            workspace::RestoreOnStartupBehavior::Launchpad => {}
-                            _ => {
-                                Editor::new_file(workspace, &Default::default(), window, cx);
-                            }
+                        let workspace_settings = WorkspaceSettings::get_global(cx);
+                        if workspace_settings.restore_on_startup
+                            != workspace::RestoreOnStartupBehavior::Launchpad
+                            || !workspace_settings.show_launchpad
+                        {
+                            Editor::new_file(workspace, &Default::default(), window, cx);
                         }
                     },
                 )
             })
             .await?;
         }
-    } else if matches!(kvp.read_kvp(FIRST_OPEN), Ok(None)) {
+    } else if matches!(kvp.read_kvp(FIRST_OPEN), Ok(None))
+        && cx.update(|cx| WorkspaceSettings::get_global(cx).show_launchpad)
+    {
         cx.update(|cx| show_onboarding_view(app_state, cx)).await?;
     } else {
         cx.update(|cx| {
@@ -1561,12 +1562,12 @@ pub(crate) async fn restore_or_create_workspace(
                 app_state,
                 cx,
                 |workspace, window, cx| {
-                    let restore_on_startup = WorkspaceSettings::get_global(cx).restore_on_startup;
-                    match restore_on_startup {
-                        workspace::RestoreOnStartupBehavior::Launchpad => {}
-                        _ => {
-                            Editor::new_file(workspace, &Default::default(), window, cx);
-                        }
+                    let workspace_settings = WorkspaceSettings::get_global(cx);
+                    if workspace_settings.restore_on_startup
+                        != workspace::RestoreOnStartupBehavior::Launchpad
+                        || !workspace_settings.show_launchpad
+                    {
+                        Editor::new_file(workspace, &Default::default(), window, cx);
                     }
                 },
             )

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -667,7 +667,9 @@ async fn open_workspaces(
     if grouped_locations.is_empty() {
         // If we have no paths to open, show the welcome screen if this is the first launch
         let kvp = cx.update(|cx| KeyValueStore::global(cx));
-        if matches!(kvp.read_kvp(FIRST_OPEN), Ok(None)) {
+        if matches!(kvp.read_kvp(FIRST_OPEN), Ok(None))
+            && cx.update(|cx| workspace::WorkspaceSettings::get_global(cx).show_launchpad)
+        {
             cx.update(|cx| show_onboarding_view(app_state, cx).detach());
         }
         // If not the first launch, show an empty window with empty editor


### PR DESCRIPTION
### Goal

This PR makes launchpad visibility explicitly user-configurable through `launchpad.enabled`.  
The goal is to ensure that when users disable launchpad, it is not shown automatically in any startup or empty-workspace fallback path.

### Related
Discussion: [#47805](https://github.com/zed-industries/zed/discussions/47805)
Issue: [#47075](https://github.com/zed-industries/zed/issues/47075) _Requires Repro/Verification_

### Summary

- Added a new workspace setting: `launchpad.enabled` (boolean, default `true`).
- Updated startup logic so automatic launchpad/onboarding display is gated by `launchpad.enabled`.
- Updated empty-pane welcome fallback (after closing last tab) to also respect `launchpad.enabled`.
- Updated VS Code import struct construction with `launchpad: None` for `WorkspaceSettingsContent` completeness.

### Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

### Release Notes:

- Improved launchpad startup behavior by adding `launchpad.enabled` and applying it consistently across automatic startup and welcome fallback paths.