### PR TITLE
workspace: Add preview_tabs.enable_preview_from_git setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1334,6 +1334,9 @@
     // Whether to keep tabs in preview mode when code navigation is used to navigate away from them.
     // If `enable_preview_file_from_code_navigation` or `enable_preview_multibuffer_from_code_navigation` is also true, the new tab may replace the existing one.
     "enable_keep_preview_on_code_navigation": false,
+    // Whether to open commit views in preview mode when opened from any Git surface
+    // (commit panel, git graph, blame, stash picker, etc.).
+    "enable_preview_from_git": false,
   },
   // Settings related to the file finder.
   "file_finder": {

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -35,7 +35,7 @@ use std::{
 use theme::ActiveTheme;
 use ui::{ContextMenu, DiffStat, Disclosure, Divider, Tooltip, WithScrollbar, prelude::*};
 use util::{ResultExt, paths::PathStyle, rel_path::RelPath, truncate_and_trailoff};
-use workspace::item::TabTooltipContent;
+use workspace::item::{PreviewTabsSettings, TabTooltipContent};
 use workspace::{
     Item, ItemHandle, ItemNavHistory, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,
     Workspace,
@@ -205,6 +205,10 @@ impl CommitView {
                             )
                         });
 
+                        let preview_settings = PreviewTabsSettings::get_global(cx);
+                        let allow_preview =
+                            preview_settings.enabled && preview_settings.enable_preview_from_git;
+
                         let pane = workspace.active_pane();
                         pane.update(cx, |pane, cx| {
                             let ix = pane.items().position(|item| {
@@ -218,8 +222,11 @@ impl CommitView {
                                     .filter_map(|item| item.downcast::<CommitView>())
                                     .find(|view| view.read(cx).commit.sha == commit_sha)
                                     .unwrap();
+                                let was_preview =
+                                    pane.preview_item_id() == Some(existing.item_id());
 
                                 pane.remove_item(existing.item_id(), false, false, window, cx);
+                                let new_id = commit_view.entity_id();
                                 pane.add_item(
                                     Box::new(commit_view),
                                     true,
@@ -228,8 +235,27 @@ impl CommitView {
                                     window,
                                     cx,
                                 );
+                                if allow_preview && was_preview {
+                                    pane.replace_preview_item_id(new_id, window, cx);
+                                }
                             } else {
-                                pane.add_item(Box::new(commit_view), true, true, None, window, cx);
+                                let destination = if allow_preview {
+                                    pane.close_current_preview_item(window, cx)
+                                } else {
+                                    None
+                                };
+                                let new_id = commit_view.entity_id();
+                                pane.add_item(
+                                    Box::new(commit_view),
+                                    true,
+                                    true,
+                                    destination,
+                                    window,
+                                    cx,
+                                );
+                                if allow_preview {
+                                    pane.replace_preview_item_id(new_id, window, cx);
+                                }
                             }
                         })
                     })

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -764,6 +764,7 @@ impl VsCodeSettings {
             enable_preview_file_from_code_navigation: None,
             enable_keep_preview_on_code_navigation: self
                 .read_bool("workbench.editor.enablePreviewFromCodeNavigation"),
+            enable_preview_from_git: None,
         })
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -195,6 +195,11 @@ pub struct PreviewTabsSettingsContent {
     ///
     /// Default: false
     pub enable_keep_preview_on_code_navigation: Option<bool>,
+    /// Whether to open commit views in preview mode when opened from any Git
+    /// surface (commit panel, git graph, blame, stash picker, etc.).
+    ///
+    /// Default: false
+    pub enable_preview_from_git: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4389,7 +4389,7 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn preview_tabs_section() -> [SettingsPageItem; 8] {
+    fn preview_tabs_section() -> [SettingsPageItem; 9] {
         [
             SettingsPageItem::SectionHeader("Preview Tabs"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4544,6 +4544,29 @@ fn window_and_layout_page() -> SettingsPage {
                             .preview_tabs
                             .get_or_insert_default()
                             .enable_keep_preview_on_code_navigation = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Enable Preview From Git",
+                description: "Whether to open commit views in preview mode when opened from any Git surface (commit panel, git graph, blame, stash picker, etc.).",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("preview_tabs.enable_preview_from_git"),
+                    pick: |settings_content| {
+                        settings_content
+                            .preview_tabs
+                            .as_ref()?
+                            .enable_preview_from_git
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .preview_tabs
+                            .get_or_insert_default()
+                            .enable_preview_from_git = value;
                     },
                 }),
                 metadata: None,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -72,6 +72,7 @@ pub struct PreviewTabsSettings {
     pub enable_preview_multibuffer_from_code_navigation: bool,
     pub enable_preview_file_from_code_navigation: bool,
     pub enable_keep_preview_on_code_navigation: bool,
+    pub enable_preview_from_git: bool,
 }
 
 impl Settings for ItemSettings {
@@ -114,6 +115,7 @@ impl Settings for PreviewTabsSettings {
             enable_keep_preview_on_code_navigation: preview_tabs
                 .enable_keep_preview_on_code_navigation
                 .unwrap(),
+            enable_preview_from_git: preview_tabs.enable_preview_from_git.unwrap(),
         }
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3264,7 +3264,8 @@ Examples:
     "enable_preview_from_multibuffer": true,
     "enable_preview_multibuffer_from_code_navigation": false,
     "enable_preview_file_from_code_navigation": true,
-    "enable_keep_preview_on_code_navigation": false
+    "enable_keep_preview_on_code_navigation": false,
+    "enable_preview_from_git": false
   }
 }
 ```
@@ -3323,6 +3324,16 @@ Examples:
 
 - Description: Determines whether to keep tabs in preview mode when code navigation is used to navigate away from them. If `enable_preview_file_from_code_navigation` or `enable_preview_multibuffer_from_code_navigation` is also true, the new tab may replace the existing one.
 - Setting: `enable_keep_preview_on_code_navigation`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
+### Enable preview from git
+
+- Description: Determines whether to open commit views in preview mode when opened from any Git surface (commit panel, git graph, blame, stash picker, etc.).
+- Setting: `enable_preview_from_git`
 - Default: `false`
 
 **Options**


### PR DESCRIPTION
When enabled, opening a commit from any Git surface (git panel, git graph, blame, stash picker, etc.) opens the commit view as a preview tab so consecutive clicks reuse the same slot. Defaults to false to preserve the existing behavior.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Added a `preview_tabs.enable_preview_from_git` setting (default `false`) that opens commit views as preview tabs when triggered from any Git surface (git panel, git graph, blame, stash picker).
