### PR TITLE
Limit recursive poll file watching

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -18,6 +18,15 @@ pub enum WatcherMode {
     Poll,
 }
 
+impl WatcherMode {
+    fn is_recursive(self) -> bool {
+        match self {
+            WatcherMode::Native => cfg!(any(target_os = "windows", target_os = "macos")),
+            WatcherMode::Poll => false,
+        }
+    }
+}
+
 pub struct FsWatcher {
     tx: async_channel::Sender<()>,
     pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
@@ -61,7 +70,7 @@ impl Watcher for FsWatcher {
         let tx = self.tx.clone();
         let pending_path_events = self.pending_path_events.clone();
 
-        if (self.mode == WatcherMode::Poll || cfg!(any(target_os = "windows", target_os = "macos")))
+        if self.mode.is_recursive()
             && let Some((watched_path, _)) = self
                 .registrations
                 .lock()
@@ -337,7 +346,7 @@ impl GlobalWatcher {
                     .lock()
                     .as_mut()
                     .expect("poll watcher initialized")
-                    .watch(path, notify::RecursiveMode::Recursive)?;
+                    .watch(path, notify::RecursiveMode::NonRecursive)?;
             }
         }
 
@@ -390,7 +399,7 @@ fn path_already_covered(
     path_registrations: &HashMap<Arc<std::path::Path>, u32>,
     mode: WatcherMode,
 ) -> bool {
-    (mode == WatcherMode::Poll || cfg!(any(target_os = "windows", target_os = "macos")))
+    mode.is_recursive()
         && path_registrations
             .keys()
             .any(|existing| path.starts_with(existing.as_ref()) && path != existing.as_ref())

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4108,6 +4108,9 @@ impl BackgroundScanner {
             fs_events_rx = Box::pin(events.map(|events| events.into_iter().collect()));
 
             let state = self.state.lock().await;
+            for path in state.watched_dir_abs_paths_by_entry_id.values() {
+                self.watcher.add(path).log_err();
+            }
             for target in state.symlink_paths_by_target.keys() {
                 if !target.starts_with(root_abs_path.as_path()) {
                     self.watcher.add(target).log_err();


### PR DESCRIPTION
Draft PR to highlight a file watcher issue seen on NFS-backed paths.

Zed switches these paths to the polling watcher. The poll watcher can then recurse from the worktree root and repeatedly walk large generated or ignored directories. In my case this kept the Zed server process busy and completely prevented the file tree and search from populating.

The important issue is that recursive polling appears too broad for this filesystem case.
