### PR TITLE
agent: Add setting to auto-resolve external ACP permission requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "acp_thread",
  "action_log",
  "agent-client-protocol",
+ "agent_settings",
  "anyhow",
  "async-channel 2.5.0",
  "chrono",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1094,6 +1094,12 @@
         // },
       },
     },
+    // Default response to permission requests from external ACP agents
+    // (e.g. Claude Agent, Codex, Gemini CLI). One of "prompt" (default),
+    // "allow_once", "allow_always". When set to allow_*, Zed answers the
+    // request automatically when the agent offers the matching option,
+    // and otherwise falls back to the UI prompt.
+    "external_acp_permission_default": "prompt",
     // When enabled, agent edits will be displayed in single-file editors for review
     "single_file_review": false,
     // When enabled, show voting thumbs for feedback on agent edits.

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -600,6 +600,7 @@ mod tests {
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
+            external_acp_permission_default: Default::default(),
         }
     }
 

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 [dependencies]
 acp_thread.workspace = true
 action_log.workspace = true
+agent_settings.workspace = true
 async-channel.workspace = true
 agent-client-protocol.workspace = true
 anyhow.workspace = true

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -7,6 +7,7 @@ use agent_client_protocol::schema::{self as acp, ErrorCode};
 use agent_client_protocol::{
     Agent, Client, ConnectionTo, JsonRpcResponse, Lines, Responder, SentRequest,
 };
+use agent_settings::AgentSettings;
 use anyhow::anyhow;
 use async_channel;
 use collections::HashMap;
@@ -19,6 +20,7 @@ use project::agent_server_store::{AgentServerCommand, AgentServerStore};
 use project::{AgentId, Project};
 use remote::remote_client::Interactive;
 use serde::Deserialize;
+use settings::{ExternalAcpPermissionDefault, Settings as _};
 use std::path::PathBuf;
 use std::process::{ExitStatus, Stdio};
 use std::rc::Rc;
@@ -3351,6 +3353,28 @@ fn handle_request_permission(
         Ok(t) => t,
         Err(e) => return respond_err(responder, e),
     };
+
+    let auto_kind = cx.update(|cx| {
+        match AgentSettings::get_global(cx).external_acp_permission_default {
+            ExternalAcpPermissionDefault::Prompt => None,
+            ExternalAcpPermissionDefault::AllowOnce => Some(acp::PermissionOptionKind::AllowOnce),
+            ExternalAcpPermissionDefault::AllowAlways => {
+                Some(acp::PermissionOptionKind::AllowAlways)
+            }
+        }
+    });
+
+    if let Some(kind) = auto_kind
+        && let Some(option) = args.options.iter().find(|o| o.kind == kind)
+    {
+        let outcome = acp::RequestPermissionOutcome::Selected(
+            acp::SelectedPermissionOutcome::new(option.option_id.clone()),
+        );
+        responder
+            .respond(acp::RequestPermissionResponse::new(outcome))
+            .log_err();
+        return;
+    }
 
     cx.spawn(async move |cx| {
         let result: Result<_, acp::Error> = async {

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -13,10 +13,11 @@ use project::DisableAiSettings;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockPosition, DockSide, LanguageModelParameters, LanguageModelSelection,
-    NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting, Settings, SettingsContent,
-    SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ToolPermissionMode,
-    update_settings_file, update_settings_file_with_completion,
+    DockPosition, DockSide, ExternalAcpPermissionDefault, LanguageModelParameters,
+    LanguageModelSelection, NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting,
+    Settings, SettingsContent, SettingsStore, SidebarDockPosition, SidebarSide,
+    ThinkingBlockDisplay, ToolPermissionMode, update_settings_file,
+    update_settings_file_with_completion,
 };
 
 pub use crate::agent_profile::*;
@@ -168,6 +169,7 @@ pub struct AgentSettings {
     pub show_turn_stats: bool,
     pub show_merge_conflict_indicator: bool,
     pub tool_permissions: ToolPermissions,
+    pub external_acp_permission_default: ExternalAcpPermissionDefault,
 }
 
 impl AgentSettings {
@@ -672,6 +674,7 @@ impl Settings for AgentSettings {
             show_turn_stats: agent.show_turn_stats.unwrap(),
             show_merge_conflict_indicator: agent.show_merge_conflict_indicator.unwrap(),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
+            external_acp_permission_default: agent.external_acp_permission_default.unwrap_or_default(),
         }
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -718,6 +718,7 @@ mod tests {
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
+            external_acp_permission_default: Default::default(),
         };
 
         cx.update(|cx| {

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -211,6 +211,11 @@ pub struct AgentSettingsContent {
     /// `always_confirm`) match against the tool's text input (command, path,
     /// URL, etc.).
     pub tool_permissions: Option<ToolPermissionsContent>,
+    /// Default response for `session/request_permission` calls from external
+    /// ACP agents. When set to a value other than `prompt`, Zed answers the
+    /// request automatically when the agent offers the matching option, and
+    /// otherwise falls back to the UI prompt.
+    pub external_acp_permission_default: Option<ExternalAcpPermissionDefault>,
 }
 
 impl AgentSettingsContent {
@@ -682,6 +687,21 @@ pub enum ToolPermissionMode {
     /// Always prompt for confirmation (default behavior).
     #[default]
     Confirm,
+}
+
+/// Default response for `session/request_permission` from external ACP agents.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalAcpPermissionDefault {
+    /// Always show the UI prompt.
+    #[default]
+    Prompt,
+    /// Auto-respond with `allow_once` when the agent offers it.
+    AllowOnce,
+    /// Auto-respond with `allow_always` when the agent offers it.
+    AllowAlways,
 }
 
 impl std::fmt::Display for ToolPermissionMode {

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -272,7 +272,7 @@ When you start an external agent thread, Zed sends:
 **Not forwarded:**
 
 - [Profiles](./agent-panel.md#profiles) — profiles only apply to Zed's first-party agent
-- [Tool permissions](./tool-permissions.md) settings — external agents request permissions at runtime via UI prompts
+- [Tool permissions](./tool-permissions.md) settings — external agents request permissions at runtime via UI prompts (auto-resolution available via [`agent.external_acp_permission_default`](./tool-permissions.md#external-acp-agent-permissions))
 - Rules files — Zed's [rules system](./rules.md) only applies to Zed's first-party agent (external agents read their own rules files directly)
 
 ### What External Agents Read Directly {#native-config}

--- a/docs/src/ai/tool-permissions.md
+++ b/docs/src/ai/tool-permissions.md
@@ -187,6 +187,30 @@ Selecting "Always for <tool>" sets `tools.<tool>.default` to allow or deny.
 When a pattern can be safely extracted, selecting "Always for <pattern>" adds an `always_allow` or `always_deny` rule for that input.
 MCP tools only support the tool-level option.
 
+## External ACP Agent Permissions {#external-acp-agent-permissions}
+
+External agents (Claude Agent, Codex, Gemini CLI, etc.) request permissions at runtime via UI prompts; the `tool_permissions` setting above only applies to Zed's first-party agent.
+
+To answer those requests automatically, set `agent.external_acp_permission_default`:
+
+```json [settings]
+{
+  "agent": {
+    "external_acp_permission_default": "allow_once"
+  }
+}
+```
+
+| Value           | Behavior                                                           |
+| --------------- | ------------------------------------------------------------------ |
+| `prompt`        | Always show the UI prompt (default).                               |
+| `allow_once`    | Auto-respond with `allow_once` when the agent offers it.           |
+| `allow_always`  | Auto-respond with `allow_always` when the agent offers it.         |
+
+If the agent doesn't offer the requested option, Zed falls back to the UI prompt.
+
+> **Warning:** This bypasses UI confirmation for external agent tools. Use only in trusted workspaces.
+
 ## Examples
 
 ### Terminal: Auto-Approve Build Commands


### PR DESCRIPTION
Auto-resolves external ACP permission popups when enabled via setting.

Release Notes:

- Added auto-resolve setting for external ACP permissions