### PR TITLE
Add Auto-Resolve for non-conflicting merge regions

### DIFF
--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -110,6 +110,13 @@ actions!(
         AddToGitignore,
         /// Copies the current branch name to the clipboard.
         CopyBranchName,
+        /// Auto-resolves conflict regions in the current file where one side
+        /// matches the diff3 base, leaving genuine conflicts for manual
+        /// resolution. Requires merge.conflictStyle=diff3 (or zdiff3).
+        AutoResolveNonConflicting,
+        /// Auto-resolves conflict regions in every file in the project where
+        /// one side matches the diff3 base.
+        AutoResolveNonConflictingInProject,
     ]
 );
 

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -9,16 +9,18 @@ use gpui::{
     App, ClickEvent, Context, Empty, Entity, InteractiveElement as _, ParentElement as _,
     Subscription, Task, WeakEntity,
 };
-use language::{Anchor, Buffer, BufferId};
+use language::{Anchor, Buffer, BufferId, BufferSnapshot};
 use project::{
-    ConflictRegion, ConflictSet, ConflictSetUpdate, Project, ProjectItem as _,
+    ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate, Project, ProjectItem as _,
     git_store::{GitStore, GitStoreEvent, RepositoryEvent},
 };
 use settings::Settings;
 use std::{ops::Range, sync::Arc};
 use ui::{ButtonLike, Divider, Tooltip, prelude::*};
 use util::{ResultExt as _, debug_panic, maybe};
-use workspace::{HideStatusItem, StatusItemView, Workspace, item::ItemHandle};
+use workspace::{
+    HideStatusItem, StatusItemView, Workspace, item::ItemHandle, notifications::NotificationId,
+};
 use zed_actions::agent::{
     ConflictContent, ResolveConflictedFilesWithAgent, ResolveConflictsWithAgent,
 };
@@ -37,9 +39,19 @@ impl ConflictAddon {
 
 struct BufferConflicts {
     block_ids: Vec<(Range<Anchor>, CustomBlockId)>,
+    banner_block_id: Option<CustomBlockId>,
     conflict_set: Entity<ConflictSet>,
     _subscription: Subscription,
 }
+
+#[derive(Debug, Clone, Copy)]
+enum BannerState {
+    Resolvable { resolvable: usize, total: usize },
+    NoneResolvable,
+    NoBase,
+}
+
+struct AutoResolveToast;
 
 impl editor::Addon for ConflictAddon {
     fn to_any(&self) -> &dyn std::any::Any {
@@ -100,6 +112,7 @@ fn buffer_ranges_updated(editor: &mut Editor, buffer: Entity<Buffer>, cx: &mut C
             let subscription = cx.subscribe(&conflict_set, conflicts_updated);
             BufferConflicts {
                 block_ids: Vec::new(),
+                banner_block_id: None,
                 conflict_set,
                 _subscription: subscription,
             }
@@ -239,6 +252,81 @@ fn conflicts_updated(
                 .map(|conflict| conflict.range.clone())
                 .zip(new_block_ids),
         );
+    }
+
+    update_auto_resolve_banner(editor, buffer_id, &conflict_set, &snapshot, cx);
+}
+
+fn update_auto_resolve_banner(
+    editor: &mut Editor,
+    buffer_id: BufferId,
+    conflict_snapshot: &ConflictSetSnapshot,
+    multibuffer_snapshot: &editor::MultiBufferSnapshot,
+    cx: &mut Context<Editor>,
+) {
+    let existing_banner = editor
+        .addon_mut::<ConflictAddon>()
+        .unwrap()
+        .buffers
+        .get_mut(&buffer_id)
+        .and_then(|bc| bc.banner_block_id.take());
+    if let Some(block_id) = existing_banner {
+        editor.remove_blocks(HashSet::from_iter([block_id]), None, cx);
+    }
+
+    if conflict_snapshot.conflicts.is_empty() {
+        return;
+    }
+
+    let Some(buffer_entity) = editor.buffer().read(cx).buffer(buffer_id) else {
+        return;
+    };
+    let buffer_snapshot = buffer_entity.read(cx).snapshot();
+    let Some(state) = banner_state_for(conflict_snapshot, &buffer_snapshot) else {
+        return;
+    };
+
+    // Anchor at the buffer's first position so the banner is the first thing
+    // the user sees when opening a conflicted file, decoupled from any single
+    // conflict region. In multibuffer views (e.g. project diff) the buffer's
+    // first position may sit before the first excerpt, in which case we fall
+    // back to the first conflict's start so the banner is at least visible
+    // somewhere within the multibuffer.
+    let buffer_start = buffer_snapshot.anchor_before(0);
+    let anchor = multibuffer_snapshot
+        .anchor_in_excerpt(buffer_start)
+        .or_else(|| {
+            conflict_snapshot
+                .conflicts
+                .first()
+                .and_then(|conflict| multibuffer_snapshot.anchor_in_excerpt(conflict.range.start))
+        });
+    let Some(anchor) = anchor else {
+        return;
+    };
+
+    let editor_handle = cx.weak_entity();
+    let buffer_handle = buffer_entity.downgrade();
+
+    let block = BlockProperties {
+        placement: BlockPlacement::Above(anchor),
+        height: Some(1),
+        style: BlockStyle::Sticky,
+        render: Arc::new(move |cx| {
+            render_auto_resolve_banner(state, buffer_handle.clone(), editor_handle.clone(), cx)
+        }),
+        priority: 0,
+    };
+
+    let new_block_ids = editor.insert_blocks(vec![block], None, cx);
+    if let Some(banner_id) = new_block_ids.into_iter().next()
+        && let Some(buffer_conflicts) = editor
+            .addon_mut::<ConflictAddon>()
+            .unwrap()
+            .buffers
+            .get_mut(&buffer_id)
+    {
+        buffer_conflicts.banner_block_id = Some(banner_id);
     }
 }
 
@@ -409,6 +497,179 @@ fn render_conflict_buttons(
             )
         })
         .into_any()
+}
+
+fn banner_state_for(
+    conflict_snapshot: &ConflictSetSnapshot,
+    buffer_snapshot: &BufferSnapshot,
+) -> Option<BannerState> {
+    let total = conflict_snapshot.conflicts.len();
+    if total == 0 {
+        return None;
+    }
+    let any_with_base = conflict_snapshot
+        .conflicts
+        .iter()
+        .any(|conflict| conflict.base.is_some());
+    if !any_with_base {
+        return Some(BannerState::NoBase);
+    }
+    let resolvable = conflict_snapshot.auto_resolvable(buffer_snapshot).count();
+    if resolvable == 0 {
+        return Some(BannerState::NoneResolvable);
+    }
+    Some(BannerState::Resolvable { resolvable, total })
+}
+
+fn render_auto_resolve_banner(
+    state: BannerState,
+    buffer: WeakEntity<Buffer>,
+    editor: WeakEntity<Editor>,
+    cx: &mut BlockContext,
+) -> AnyElement {
+    let label: SharedString = match state {
+        BannerState::Resolvable { resolvable, total } => {
+            let remaining = total.saturating_sub(resolvable);
+            format!(
+                "Auto-Resolve — {} non-conflicting change{} • {} will remain",
+                resolvable,
+                if resolvable == 1 { "" } else { "s" },
+                remaining,
+            )
+            .into()
+        }
+        BannerState::NoneResolvable => {
+            "Auto-Resolve — no non-conflicting changes detected".into()
+        }
+        BannerState::NoBase => {
+            "Auto-Resolve — requires diff3 conflict markers (run `git config merge.conflictStyle zdiff3`)"
+                .into()
+        }
+    };
+
+    let tooltip_text: Option<SharedString> = match state {
+        BannerState::Resolvable { .. } => None,
+        BannerState::NoneResolvable => {
+            Some("All conflicts have changes on both sides; manual resolution required.".into())
+        }
+        BannerState::NoBase => Some(
+            "Run `git config merge.conflictStyle zdiff3` in your terminal to enable diff3 markers for future merges."
+                .into(),
+        ),
+    };
+
+    let enabled = matches!(state, BannerState::Resolvable { .. });
+    let mut button = Button::new("auto-resolve", label)
+        .label_size(LabelSize::Small)
+        .disabled(!enabled);
+
+    if enabled {
+        button = button.on_click(move |_, window, cx| {
+            auto_resolve_buffer(buffer.clone(), editor.clone(), window, cx);
+        });
+    }
+
+    if let Some(tooltip_text) = tooltip_text {
+        button = button.tooltip(move |_, cx| Tooltip::simple(tooltip_text.clone(), cx));
+    }
+
+    h_flex()
+        .id(cx.block_id)
+        .h(cx.line_height)
+        .ml(cx.margins.gutter.width)
+        .gap_1()
+        .bg(cx.theme().colors().editor_background)
+        .child(button)
+        .into_any()
+}
+
+pub(crate) fn auto_resolve_buffer(
+    buffer: WeakEntity<Buffer>,
+    editor: WeakEntity<Editor>,
+    _window: &mut Window,
+    cx: &mut App,
+) {
+    let Some(buffer) = buffer.upgrade() else {
+        return;
+    };
+    let Some(editor) = editor.upgrade() else {
+        return;
+    };
+
+    let buffer_id = buffer.read(cx).remote_id();
+    let conflict_set = editor
+        .read(cx)
+        .addon::<ConflictAddon>()
+        .and_then(|addon| addon.conflict_set(buffer_id));
+    let Some(conflict_set) = conflict_set else {
+        return;
+    };
+
+    let conflict_snapshot = conflict_set.read(cx).snapshot();
+    let total = conflict_snapshot.conflicts.len();
+
+    let edits = {
+        let buffer_snapshot = buffer.read(cx).snapshot();
+        conflict_snapshot.auto_resolution_edits(&buffer_snapshot)
+    };
+    if edits.is_empty() {
+        return;
+    }
+    let resolved = conflict_snapshot
+        .auto_resolvable(&buffer.read(cx).snapshot())
+        .count();
+    let remaining = total.saturating_sub(resolved);
+
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit(edits, None, cx);
+    });
+
+    if let Some(workspace) = editor.read(cx).workspace() {
+        let message = format!(
+            "Auto-resolved {} of {} conflict{}; {} remain",
+            resolved,
+            total,
+            if total == 1 { "" } else { "s" },
+            remaining,
+        );
+        workspace.update(cx, |workspace, cx| {
+            workspace.show_toast(
+                workspace::Toast::new(NotificationId::unique::<AutoResolveToast>(), message),
+                cx,
+            );
+        });
+    }
+}
+
+pub(crate) fn auto_resolve_in_editor(
+    editor: Entity<Editor>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let buffer_ids: Vec<BufferId> = editor
+        .read(cx)
+        .addon::<ConflictAddon>()
+        .map(|addon| addon.buffers.keys().copied().collect())
+        .unwrap_or_default();
+
+    let multibuffer = editor.read(cx).buffer().clone();
+    for buffer_id in buffer_ids {
+        let Some(buffer) = multibuffer.read(cx).buffer(buffer_id) else {
+            continue;
+        };
+        auto_resolve_buffer(buffer.downgrade(), editor.downgrade(), window, cx);
+    }
+}
+
+pub(crate) fn auto_resolve_in_project(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let editors: Vec<Entity<Editor>> = workspace.items_of_type::<Editor>(cx).collect();
+    for editor in editors {
+        auto_resolve_in_editor(editor, window, cx);
+    }
 }
 
 fn collect_conflicted_file_paths(project: &Project, cx: &App) -> Vec<String> {

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -197,6 +197,19 @@ pub fn init(cx: &mut App) {
                 });
             });
         }
+        workspace.register_action(
+            |workspace, _: &git::AutoResolveNonConflicting, window, cx| {
+                let Some(editor) = workspace.active_item_as::<Editor>(cx) else {
+                    return;
+                };
+                conflict_view::auto_resolve_in_editor(editor, window, cx);
+            },
+        );
+        workspace.register_action(
+            |workspace, _: &git::AutoResolveNonConflictingInProject, window, cx| {
+                conflict_view::auto_resolve_in_project(workspace, window, cx);
+            },
+        );
         workspace.register_action(|workspace, action: &git::StashAll, window, cx| {
             let Some(panel) = workspace.panel::<git_panel::GitPanel>(cx) else {
                 return;

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -18,7 +18,9 @@ use askpass::{AskPassDelegate, EncryptedPassword, IKnowWhatIAmDoingAndIHaveReadT
 use buffer_diff::{BufferDiff, BufferDiffEvent};
 use client::ProjectId;
 use collections::HashMap;
-pub use conflict_set::{ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate};
+pub use conflict_set::{
+    AutoResolution, ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate,
+};
 use fs::{Fs, RemoveOptions};
 use futures::{
     FutureExt, SinkExt, Stream, StreamExt,

--- a/crates/project/src/git_store/conflict_set.rs
+++ b/crates/project/src/git_store/conflict_set.rs
@@ -49,6 +49,30 @@ impl ConflictSetSnapshot {
         &self.conflicts[start_ix..end_ix]
     }
 
+    pub fn auto_resolvable<'a>(
+        &'a self,
+        buffer: &'a text::BufferSnapshot,
+    ) -> impl Iterator<Item = (&'a ConflictRegion, AutoResolution)> + 'a {
+        self.conflicts
+            .iter()
+            .filter_map(move |conflict| conflict.auto_resolution(buffer).map(|r| (conflict, r)))
+    }
+
+    pub fn auto_resolution_edits(
+        &self,
+        buffer: &text::BufferSnapshot,
+    ) -> Vec<(Range<usize>, &'static str)> {
+        self.auto_resolvable(buffer)
+            .flat_map(|(conflict, resolution)| {
+                let kept = match resolution {
+                    AutoResolution::TakeOurs | AutoResolution::Identical => &conflict.ours,
+                    AutoResolution::TakeTheirs => &conflict.theirs,
+                };
+                conflict.resolution_edits(std::slice::from_ref(kept), buffer)
+            })
+            .collect()
+    }
+
     pub fn compare(&self, other: &Self, buffer: &text::BufferSnapshot) -> ConflictSetUpdate {
         let common_prefix_len = self
             .conflicts
@@ -100,31 +124,64 @@ pub struct ConflictRegion {
     pub base: Option<Range<Anchor>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoResolution {
+    TakeOurs,
+    TakeTheirs,
+    Identical,
+}
+
 impl ConflictRegion {
+    pub fn auto_resolution(&self, buffer: &text::BufferSnapshot) -> Option<AutoResolution> {
+        let base_range = self.base.as_ref()?;
+        let base_text = buffer.text_for_range(base_range.clone()).collect::<String>();
+        let ours_text = buffer.text_for_range(self.ours.clone()).collect::<String>();
+        let theirs_text = buffer.text_for_range(self.theirs.clone()).collect::<String>();
+
+        if ours_text == theirs_text {
+            Some(AutoResolution::Identical)
+        } else if ours_text == base_text {
+            Some(AutoResolution::TakeTheirs)
+        } else if theirs_text == base_text {
+            Some(AutoResolution::TakeOurs)
+        } else {
+            None
+        }
+    }
+
+    pub fn resolution_edits(
+        &self,
+        kept_ranges: &[Range<Anchor>],
+        buffer: &text::BufferSnapshot,
+    ) -> Vec<(Range<usize>, &'static str)> {
+        let mut deletions = Vec::new();
+        let outer_range = self.range.to_offset(buffer);
+        let mut offset = outer_range.start;
+        for kept_range in kept_ranges {
+            let kept_range = kept_range.to_offset(buffer);
+            if kept_range.start > offset {
+                deletions.push((offset..kept_range.start, ""));
+            }
+            offset = kept_range.end;
+        }
+        if outer_range.end > offset {
+            deletions.push((offset..outer_range.end, ""));
+        }
+        deletions
+    }
+
     pub fn resolve(
         &self,
         buffer: Entity<language::Buffer>,
         ranges: &[Range<Anchor>],
         cx: &mut App,
     ) {
-        let buffer_snapshot = buffer.read(cx).snapshot();
-        let mut deletions = Vec::new();
-        let empty = "";
-        let outer_range = self.range.to_offset(&buffer_snapshot);
-        let mut offset = outer_range.start;
-        for kept_range in ranges {
-            let kept_range = kept_range.to_offset(&buffer_snapshot);
-            if kept_range.start > offset {
-                deletions.push((offset..kept_range.start, empty));
-            }
-            offset = kept_range.end;
-        }
-        if outer_range.end > offset {
-            deletions.push((offset..outer_range.end, empty));
-        }
-
+        let edits = {
+            let buffer_snapshot = buffer.read(cx).snapshot();
+            self.resolution_edits(ranges, &buffer_snapshot)
+        };
         buffer.update(cx, |buffer, cx| {
-            buffer.edit(deletions, None, cx);
+            buffer.edit(edits, None, cx);
         });
     }
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -47,7 +47,7 @@ use crate::{
 pub use agent_registry_store::{AgentRegistryStore, RegistryAgent};
 pub use agent_server_store::{AgentId, AgentServerStore, AgentServersUpdated, ExternalAgentSource};
 pub use git_store::{
-    ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate,
+    AutoResolution, ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate,
     git_traversal::{ChildEntriesGitIter, GitEntry, GitEntryRef, GitTraversal},
     linked_worktree_short_name, repo_identity_path, worktrees_directory_for_repo,
 };

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -268,6 +268,242 @@ mod conflict_set_tests {
         );
     }
 
+    #[test]
+    fn test_auto_resolution_take_ours() {
+        let test_content = r#"
+            <<<<<<< HEAD
+            modified
+            ||||||| base
+            original
+            =======
+            original
+            >>>>>>> branch
+        "#
+        .unindent();
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let conflict_snapshot = ConflictSet::parse(&snapshot);
+        assert_eq!(conflict_snapshot.conflicts.len(), 1);
+        assert_eq!(
+            conflict_snapshot.conflicts[0].auto_resolution(&snapshot),
+            Some(AutoResolution::TakeOurs)
+        );
+    }
+
+    #[test]
+    fn test_auto_resolution_take_theirs() {
+        let test_content = r#"
+            <<<<<<< HEAD
+            original
+            ||||||| base
+            original
+            =======
+            modified
+            >>>>>>> branch
+        "#
+        .unindent();
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let conflict_snapshot = ConflictSet::parse(&snapshot);
+        assert_eq!(conflict_snapshot.conflicts.len(), 1);
+        assert_eq!(
+            conflict_snapshot.conflicts[0].auto_resolution(&snapshot),
+            Some(AutoResolution::TakeTheirs)
+        );
+    }
+
+    #[test]
+    fn test_auto_resolution_identical() {
+        let test_content = r#"
+            <<<<<<< HEAD
+            same edit
+            ||||||| base
+            original
+            =======
+            same edit
+            >>>>>>> branch
+        "#
+        .unindent();
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let conflict_snapshot = ConflictSet::parse(&snapshot);
+        assert_eq!(conflict_snapshot.conflicts.len(), 1);
+        assert_eq!(
+            conflict_snapshot.conflicts[0].auto_resolution(&snapshot),
+            Some(AutoResolution::Identical)
+        );
+    }
+
+    #[test]
+    fn test_auto_resolution_genuine_conflict() {
+        let test_content = r#"
+            <<<<<<< HEAD
+            ours edit
+            ||||||| base
+            original
+            =======
+            theirs edit
+            >>>>>>> branch
+        "#
+        .unindent();
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let conflict_snapshot = ConflictSet::parse(&snapshot);
+        assert_eq!(conflict_snapshot.conflicts.len(), 1);
+        assert_eq!(
+            conflict_snapshot.conflicts[0].auto_resolution(&snapshot),
+            None
+        );
+    }
+
+    #[test]
+    fn test_auto_resolution_no_base() {
+        let test_content = r#"
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+        "#
+        .unindent();
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let conflict_snapshot = ConflictSet::parse(&snapshot);
+        assert_eq!(conflict_snapshot.conflicts.len(), 1);
+        assert_eq!(
+            conflict_snapshot.conflicts[0].auto_resolution(&snapshot),
+            None
+        );
+    }
+
+    #[test]
+    fn test_auto_resolve_applies_edits_in_one_transaction() {
+        // 3 conflicts: 1 take-ours, 1 take-theirs, 1 genuine.
+        // After auto-resolve, only the genuine conflict remains.
+        // A single undo restores all 3.
+        let test_content = r#"
+            <<<<<<< HEAD
+            ours-only
+            ||||||| base
+            base
+            =======
+            base
+            >>>>>>> branch
+
+            <<<<<<< HEAD
+            base
+            ||||||| base
+            base
+            =======
+            theirs-only
+            >>>>>>> branch
+
+            <<<<<<< HEAD
+            ours
+            ||||||| base
+            original
+            =======
+            theirs
+            >>>>>>> branch
+        "#
+        .unindent();
+
+        let buffer_id = BufferId::new(1).unwrap();
+        let mut buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let initial_conflicts = ConflictSet::parse(&snapshot);
+        assert_eq!(initial_conflicts.conflicts.len(), 3);
+
+        let edits = initial_conflicts.auto_resolution_edits(&snapshot);
+        assert!(!edits.is_empty());
+        buffer.edit(edits);
+
+        let after_conflicts = ConflictSet::parse(&buffer.snapshot());
+        assert_eq!(
+            after_conflicts.conflicts.len(),
+            1,
+            "only the genuine conflict should remain"
+        );
+
+        buffer
+            .undo()
+            .expect("auto-resolve should produce an undoable transaction");
+
+        let restored_conflicts = ConflictSet::parse(&buffer.snapshot());
+        assert_eq!(
+            restored_conflicts.conflicts.len(),
+            3,
+            "single undo should restore all 3 conflicts"
+        );
+    }
+
+    #[test]
+    fn test_auto_resolvable_mixed() {
+        let test_content = r#"
+            <<<<<<< HEAD
+            ours-only
+            ||||||| base
+            base
+            =======
+            base
+            >>>>>>> branch
+
+            <<<<<<< HEAD
+            base
+            ||||||| base
+            base
+            =======
+            theirs-only
+            >>>>>>> branch
+
+            <<<<<<< HEAD
+            same
+            ||||||| base
+            original
+            =======
+            same
+            >>>>>>> branch
+
+            <<<<<<< HEAD
+            ours
+            ||||||| base
+            original
+            =======
+            theirs
+            >>>>>>> branch
+
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+        "#
+        .unindent();
+        let buffer_id = BufferId::new(1).unwrap();
+        let buffer = Buffer::new(ReplicaId::LOCAL, buffer_id, test_content);
+        let snapshot = buffer.snapshot();
+        let conflict_snapshot = ConflictSet::parse(&snapshot);
+        assert_eq!(conflict_snapshot.conflicts.len(), 5);
+
+        let resolved: Vec<AutoResolution> = conflict_snapshot
+            .auto_resolvable(&snapshot)
+            .map(|(_, resolution)| resolution)
+            .collect();
+        assert_eq!(
+            resolved,
+            vec![
+                AutoResolution::TakeOurs,
+                AutoResolution::TakeTheirs,
+                AutoResolution::Identical,
+            ]
+        );
+    }
+
     #[gpui::test]
     async fn test_conflict_updates(executor: BackgroundExecutor, cx: &mut TestAppContext) {
         zlog::init_test();

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -234,6 +234,48 @@ Click a button to resolve that conflict. The conflict markers are removed and re
 
 > **Tip:** For complex conflicts that need manual editing, you can edit the file directly. Remove the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and keep the content you want.
 
+### Auto-Resolving Non-Conflicting Changes
+
+When a merge or rebase produces conflicts, many regions often have changes on only one side — your branch made an edit, but the incoming branch did not, or vice versa. These are not real conflicts; they appear as conflict markers because Git couldn't auto-resolve them without the merge base. **Auto-Resolve** handles all of these unambiguous regions in one click, leaving only genuinely conflicting regions for you to resolve manually.
+
+#### Requirements
+
+Auto-Resolve needs `diff3` or `zdiff3` conflict markers, which include the merge base alongside your changes and the incoming changes. Enable this once per repository:
+
+```sh
+git config merge.conflictStyle zdiff3
+```
+
+This setting only affects future merges. Conflict markers from a merge already in progress cannot be retroactively populated with the base.
+
+#### Using Auto-Resolve
+
+When a file with conflicts is open, an Auto-Resolve banner appears at the top of the file. Clicking the banner auto-resolves all non-conflicting regions in that file in a single, undoable transaction. A toast confirms how many regions were resolved and how many genuine conflicts remain.
+
+You can also invoke Auto-Resolve from the Command Palette:
+
+- {#action git::AutoResolveNonConflicting} — auto-resolve conflicts in the current file
+- {#action git::AutoResolveNonConflictingInProject} — auto-resolve across every conflicted file currently open in the project
+
+A single undo reverts the entire batch.
+
+#### What Auto-Resolve handles
+
+For each conflict region, Auto-Resolve compares all three sides — yours, theirs, and the merge base — using strict equality:
+
+- If only your side changed (theirs equals base), your change is kept
+- If only the incoming side changed (yours equals base), the incoming change is kept
+- If both sides made the identical change, that change is kept
+- Otherwise the region is left untouched for manual resolution
+
+#### Banner states
+
+The banner is shown whenever conflicts exist in the file. Its state depends on whether anything is auto-resolvable:
+
+- **Auto-Resolve — N non-conflicting changes • K will remain** — at least one region can be resolved automatically; click to apply
+- **Auto-Resolve — no non-conflicting changes detected** — every conflict has changes on both sides, so manual resolution is required for all of them
+- **Auto-Resolve — requires diff3 conflict markers** — the markers don't include the merge base; enable `merge.conflictStyle = zdiff3` and re-run the merge to populate them
+
 ## Stashing
 
 Git stash allows you to temporarily save your uncommitted changes and revert your working directory to a clean state. This is particularly useful when you need to quickly switch branches or pull updates without committing incomplete work.
@@ -376,6 +418,8 @@ When viewing files with changes, Zed displays diff hunks that can be expanded or
 | {#action git::CheckoutBranch}             | {#kb git::CheckoutBranch}             |
 | {#action git::Worktree}                   | {#kb git::Worktree}                   |
 | {#action git::Blame}                      | {#kb git::Blame}                      |
+| {#action git::AutoResolveNonConflicting}  | {#kb git::AutoResolveNonConflicting}  |
+| {#action git::AutoResolveNonConflictingInProject} | {#kb git::AutoResolveNonConflictingInProject} |
 | {#action git::StashAll}                   | {#kb git::StashAll}                   |
 | {#action git::StashPop}                   | {#kb git::StashPop}                   |
 | {#action git::StashApply}                 | {#kb git::StashApply}                 |


### PR DESCRIPTION
## Summary

- Adds Auto-Resolve for merge conflicts: handles every region where one side matches the diff3 merge base in a single, undoable transaction
- File-level banner at the top of conflicted buffers, with three states (resolvable / none / no diff3 base)
- Two new actions: `git::AutoResolveNonConflicting` (file scope) and `git::AutoResolveNonConflictingInProject` (workspace scope)

For each conflict region the algorithm compares ours, theirs, and base using strict equality. If only one side diverged from base, the other side is taken; if both sides made the identical change, that change is taken; otherwise the region is left for manual resolution. Inspired by IntelliJ's "Apply All Non-Conflicting Changes" and kdiff3's auto-merge.

Tracked in #51541.

### Out of scope (possible follow-ups)

- One-click "Enable diff3" affordance that runs `git config merge.conflictStyle zdiff3` (would expand the `GitRepository` trait surface; deferred to keep this PR narrow)
- Sub-hunk decomposition inside a single conflict region (kdiff3-style)
- Whitespace-only / regex-based auto-merge

## Test plan

- [x] Unit tests covering all four `AutoResolution` outcomes plus a mixed-buffer case (`crates/project/tests/integration/git_store.rs`)
- [x] Integration test verifying single-transaction undo
- [x] Manual smoke test on macOS — all three banner states, Cmd+Z reverts the batch
- [ ] Manual smoke test on Linux

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added an Auto-Resolve action for merge conflicts that resolves regions where one side matches the diff3 base, leaving genuine conflicts for manual resolution