### PR TITLE
Unbind Vim-only keys in Helix mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -928,6 +928,23 @@
     },
   },
   {
+    "context": "(vim_mode == helix_normal || vim_mode == helix_select) && !menu",
+    "unbind": {
+      "$": "vim::EndOfLine",
+      "_": "vim::StartOfLineDownward",
+      "shift-v": "vim::ToggleVisualLine",
+      "shift-d": "vim::DeleteToEndOfLine",
+      "ctrl-r": "vim::Redo",
+      "g t": "vim::GoToTab",
+    },
+  },
+  {
+    "context": "(vim_mode == helix_normal || vim_mode == helix_select) && !menu",
+    "unbind": {
+      "ctrl-r": "projects::OpenRecent",
+    },
+  },
+  {
     "context": "!Editor && !Terminal",
     "bindings": {
       ":": "command_palette::Toggle",


### PR DESCRIPTION
## Summary

- add Helix-mode targeted unbinds for Vim-only bindings that still leak through
- preserve the Helix `g t` window-top binding while suppressing the later Vim tab binding
- suppress the workspace `ctrl-r` fallback in Helix mode so `ctrl-r` is unbound instead of opening recent projects

Closes #54495
/claim #54495

## Testing

- `git diff --check`
- Parsed `assets/keymaps/vim.json` with a local JSONC check and verified the new Helix unbinds are ordered after the inherited Vim bindings

Not run: `cargo test -p settings keymap_section_unbinds_are_loaded_before_bindings --lib` because this environment does not have `cargo` installed.