### PR TITLE
markdown: Preserve emphasis when joining lines

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7833,16 +7833,15 @@ impl Editor {
                                 .documentation_comment()
                                 .map(|c| c.prefix.as_ref())
                                 .filter(|p| !p.is_empty());
-                            let all_prefixes = language_scope
+                            let comment_prefixes = language_scope
                                 .line_comment_prefixes()
                                 .iter()
                                 .map(|p| p.as_ref())
                                 .chain(block_prefix)
-                                .chain(doc_prefix)
-                                .chain(language_scope.unordered_list().iter().map(|p| p.as_ref()));
+                                .chain(doc_prefix);
 
                             let mut longest_prefix_len = None;
-                            for prefix in all_prefixes {
+                            for prefix in comment_prefixes {
                                 let trimmed = prefix.trim_end();
                                 if line_text_after_indent.starts_with(trimmed) {
                                     let candidate_len =
@@ -7851,6 +7850,16 @@ impl Editor {
                                         } else {
                                             trimmed.len()
                                         };
+                                    if longest_prefix_len.map_or(true, |len| candidate_len > len) {
+                                        longest_prefix_len = Some(candidate_len);
+                                    }
+                                }
+                            }
+
+                            for prefix in language_scope.unordered_list() {
+                                if line_text_after_indent.starts_with(prefix.as_ref()) {
+                                    let candidate_len = prefix.len();
+
                                     if longest_prefix_len.map_or(true, |len| candidate_len > len) {
                                         longest_prefix_len = Some(candidate_len);
                                     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7857,9 +7857,19 @@ impl Editor {
                             }
 
                             for prefix in language_scope.unordered_list() {
-                                if line_text_after_indent.starts_with(prefix.as_ref()) {
-                                    let candidate_len = prefix.len();
+                                let prefix = prefix.as_ref();
 
+                                let trimmed = prefix.trim_end();
+
+                                let candidate_len = if line_text_after_indent.starts_with(prefix) {
+                                    Some(prefix.len())
+                                } else if line_text_after_indent == trimmed {
+                                    Some(trimmed.len())
+                                } else {
+                                    None
+                                };
+
+                                if let Some(candidate_len) = candidate_len {
                                     if longest_prefix_len.map_or(true, |len| candidate_len > len) {
                                         longest_prefix_len = Some(candidate_len);
                                     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6060,6 +6060,10 @@ async fn test_join_lines_strips_comment_prefix(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.join_lines(&JoinLines, window, cx));
         cx.assert_editor_state("fooˇ *bar*");
 
+        cx.set_state("- fooˇ\n-");
+        cx.update_editor(|e, window, cx| e.join_lines(&JoinLines, window, cx));
+        cx.assert_editor_state("- fooˇ");
+
         // No-whitespace join also strips the list marker.
         cx.set_state(indoc! {"
             - ˇfoo

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6056,6 +6056,10 @@ async fn test_join_lines_strips_comment_prefix(cx: &mut TestAppContext) {
             + fooˇ bar
         "});
 
+        cx.set_state("fooˇ\n\t*bar*");
+        cx.update_editor(|e, window, cx| e.join_lines(&JoinLines, window, cx));
+        cx.assert_editor_state("fooˇ *bar*");
+
         // No-whitespace join also strips the list marker.
         cx.set_state(indoc! {"
             - ˇfoo


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/56358

This diff fixes Markdown line joining when the joined-in line starts with emphasized text such as `*foo*`. Previously, `join_lines_impl` treated Markdown unordered-list markers and comment prefixes the same way by trimming trailing whitespace before matching. That made the configured `* ` list marker match a bare leading `*`, so joining a line like `\t*foo*` stripped the opening emphasis marker.

With this change, comment prefixes still support trimmed matching so existing bare comment-prefix behavior is preserved, but unordered-list markers must match their configured marker exactly. Markdown list items such as `* foo` are still joined by stripping the list marker, while emphasis text such as `*foo*` is preserved.

Release Notes:

- Fixed Markdown line joining stripping the opening `*` from emphasized text.