### PR TITLE
zed: Fix local files not opening with focus on remote workspaces

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1290,11 +1290,17 @@ pub enum Event {
     WorktreeCreationChanged,
 }
 
+/// Controls which types of items should be made visible in the project panel
+/// when opened.
 #[derive(Debug, Clone)]
 pub enum OpenVisible {
+    /// Make all opened items visible (both files and directories).
     All,
+    /// Don't make any opened items visible.
     None,
+    /// Only make opened files visible, not directories.
     OnlyFiles,
+    /// Only make opened directories visible, not files.
     OnlyDirectories,
 }
 
@@ -2104,7 +2110,7 @@ impl Workspace {
                 })
                 .log_err();
 
-            if open_mode == OpenMode::NewWindow {
+            if open_mode == OpenMode::NewWindow || open_mode == OpenMode::Activate {
                 window
                     .update(cx, |_, window, _cx| {
                         window.activate_window();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2361,7 +2361,7 @@ fn open_settings_file(
                 workspace.with_local_or_wsl_workspace(window, cx, move |workspace, window, cx| {
                     let project = workspace.project().clone();
 
-                    cx.spawn_in(window, async move |ws, cx| {
+                    cx.spawn_in(window, async move |workspace, cx| {
                         let config_dir = project
                             .update(cx, |project, cx| {
                                 project.try_windows_path_to_wsl(paths::config_dir().as_path(), cx)
@@ -2382,7 +2382,7 @@ fn open_settings_file(
                             })
                             .await?;
 
-                        ws.update_in(cx, |_, window, cx| {
+                        workspace.update_in(cx, |_, window, cx| {
                             create_and_open_local_file(abs_path, window, cx, default_content)
                         })?
                         .await?;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2356,12 +2356,12 @@ fn open_settings_file(
     cx: &mut Context<Workspace>,
 ) {
     cx.spawn_in(window, async move |workspace, cx| {
-        let (worktree_creation_task, settings_open_task) = workspace
+        workspace
             .update_in(cx, |workspace, window, cx| {
                 workspace.with_local_or_wsl_workspace(window, cx, move |workspace, window, cx| {
                     let project = workspace.project().clone();
 
-                    let worktree_creation_task = cx.spawn_in(window, async move |_, cx| {
+                    cx.spawn_in(window, async move |ws, cx| {
                         let config_dir = project
                             .update(cx, |project, cx| {
                                 project.try_windows_path_to_wsl(paths::config_dir().as_path(), cx)
@@ -2376,20 +2376,22 @@ fn open_settings_file(
                         // drag and drop from OS) still have their worktrees
                         // released on file close, causing LSP servers'
                         // restarts.
-                        project
+                        let (_worktree, _) = project
                             .update(cx, |project, cx| {
                                 project.find_or_create_worktree(&config_dir, false, cx)
                             })
-                            .await
-                    });
-                    let settings_open_task =
-                        create_and_open_local_file(abs_path, window, cx, default_content);
-                    (worktree_creation_task, settings_open_task)
+                            .await?;
+
+                        ws.update_in(cx, |_, window, cx| {
+                            create_and_open_local_file(abs_path, window, cx, default_content)
+                        })?
+                        .await?;
+                        anyhow::Ok(())
+                    })
                 })
             })?
+            .await?
             .await?;
-        let _ = worktree_creation_task.await?;
-        let _ = settings_open_task.await?;
         anyhow::Ok(())
     })
     .detach_and_log_err(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2382,10 +2382,11 @@ fn open_settings_file(
                             })
                             .await?;
 
-                        workspace.update_in(cx, |_, window, cx| {
-                            create_and_open_local_file(abs_path, window, cx, default_content)
-                        })?
-                        .await?;
+                        workspace
+                            .update_in(cx, |_, window, cx| {
+                                create_and_open_local_file(abs_path, window, cx, default_content)
+                            })?
+                            .await?;
                         anyhow::Ok(())
                     })
                 })


### PR DESCRIPTION


Closes https://github.com/zed-industries/zed/issues/55554

Release Notes:

- Fixed an issue where local settings files would not correctly open on remote workspaces
