### PR TITLE
editor: Extend underlines into inlay hints

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1815,7 +1815,12 @@ impl DisplaySnapshot {
                 edit_prediction: Some(editor_style.edit_prediction_styles),
             },
         )
-        .flat_map(|chunk| {
+        .flat_map({
+            // track the current underline style so that we can apply it to
+            // inlay hints within the diagnostic's span
+            let mut current_diagnostic_underline: Option<UnderlineStyle> = None;
+            
+            move |chunk| {
             let syntax_highlight_style = chunk
                 .syntax_highlight_id
                 .and_then(|id| editor_style.syntax.get(id).cloned());
@@ -1838,30 +1843,42 @@ impl DisplaySnapshot {
                 }
             });
 
-            let diagnostic_highlight = chunk
-                .diagnostic_severity
-                .filter(|severity| {
-                    self.diagnostics_max_severity
-                        .into_lsp()
-                        .is_some_and(|max_severity| severity <= &max_severity)
-                })
-                .map(|severity| HighlightStyle {
-                    fade_out: chunk
-                        .is_unnecessary
-                        .then_some(editor_style.unnecessary_code_fade),
-                    underline: (chunk.underline
-                        && editor_style.show_underlines
-                        && !(chunk.is_unnecessary && severity > lsp::DiagnosticSeverity::WARNING))
-                        .then(|| {
-                            let diagnostic_color = diagnostic_style(severity, &editor_style.status);
-                            UnderlineStyle {
-                                color: Some(diagnostic_color),
-                                thickness: 1.0.into(),
-                                wavy: true,
-                            }
-                        }),
+            let diagnostic_highlight = if chunk.is_inlay {
+                current_diagnostic_underline.map(|underline| HighlightStyle {
+                    underline: Some(underline),
                     ..Default::default()
-                });
+                })
+            } else {
+                let highlight = chunk
+                    .diagnostic_severity
+                    .filter(|severity| {
+                        self.diagnostics_max_severity
+                            .into_lsp()
+                            .is_some_and(|max_severity| severity <= &max_severity)
+                    })
+                    .map(|severity| HighlightStyle {
+                        fade_out: chunk
+                            .is_unnecessary
+                            .then_some(editor_style.unnecessary_code_fade),
+                        underline: (chunk.underline
+                            && editor_style.show_underlines
+                            && !(chunk.is_unnecessary
+                                && severity > lsp::DiagnosticSeverity::WARNING))
+                            .then(|| {
+                                let diagnostic_color =
+                                    diagnostic_style(severity, &editor_style.status);
+                                UnderlineStyle {
+                                    color: Some(diagnostic_color),
+                                    thickness: 1.0.into(),
+                                    wavy: true,
+                                }
+                            }),
+                        ..Default::default()
+                    });
+
+                current_diagnostic_underline = highlight.as_ref().and_then(|h| h.underline);
+                highlight
+            };
 
             let style = [
                 syntax_highlight_style,
@@ -1880,7 +1897,7 @@ impl DisplaySnapshot {
                 replacement: chunk.renderer.map(ChunkReplacement::Renderer),
             }
             .highlight_invisibles(editor_style)
-        })
+        }})
     }
 
     /// Returns combined highlight styles (tree-sitter syntax + semantic tokens)

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1819,85 +1819,86 @@ impl DisplaySnapshot {
             // track the current underline style so that we can apply it to
             // inlay hints within the diagnostic's span
             let mut current_diagnostic_underline: Option<UnderlineStyle> = None;
-            
+
             move |chunk| {
-            let syntax_highlight_style = chunk
-                .syntax_highlight_id
-                .and_then(|id| editor_style.syntax.get(id).cloned());
+                let syntax_highlight_style = chunk
+                    .syntax_highlight_id
+                    .and_then(|id| editor_style.syntax.get(id).cloned());
 
-            let chunk_highlight = chunk.highlight_style.map(|chunk_highlight| {
-                HighlightStyle {
-                    // For color inlays, blend the color with the editor background
-                    // if the color has transparency (alpha < 1.0)
-                    color: chunk_highlight.color.map(|color| {
-                        if chunk.is_inlay && !color.is_opaque() {
-                            editor_style.background.blend(color)
-                        } else {
-                            color
-                        }
-                    }),
-                    underline: chunk_highlight
-                        .underline
-                        .filter(|_| editor_style.show_underlines),
-                    ..chunk_highlight
-                }
-            });
+                let chunk_highlight = chunk.highlight_style.map(|chunk_highlight| {
+                    HighlightStyle {
+                        // For color inlays, blend the color with the editor background
+                        // if the color has transparency (alpha < 1.0)
+                        color: chunk_highlight.color.map(|color| {
+                            if chunk.is_inlay && !color.is_opaque() {
+                                editor_style.background.blend(color)
+                            } else {
+                                color
+                            }
+                        }),
+                        underline: chunk_highlight
+                            .underline
+                            .filter(|_| editor_style.show_underlines),
+                        ..chunk_highlight
+                    }
+                });
 
-            let diagnostic_highlight = if chunk.is_inlay {
-                current_diagnostic_underline.map(|underline| HighlightStyle {
-                    underline: Some(underline),
-                    ..Default::default()
-                })
-            } else {
-                let highlight = chunk
-                    .diagnostic_severity
-                    .filter(|severity| {
-                        self.diagnostics_max_severity
-                            .into_lsp()
-                            .is_some_and(|max_severity| severity <= &max_severity)
-                    })
-                    .map(|severity| HighlightStyle {
-                        fade_out: chunk
-                            .is_unnecessary
-                            .then_some(editor_style.unnecessary_code_fade),
-                        underline: (chunk.underline
-                            && editor_style.show_underlines
-                            && !(chunk.is_unnecessary
-                                && severity > lsp::DiagnosticSeverity::WARNING))
-                            .then(|| {
-                                let diagnostic_color =
-                                    diagnostic_style(severity, &editor_style.status);
-                                UnderlineStyle {
-                                    color: Some(diagnostic_color),
-                                    thickness: 1.0.into(),
-                                    wavy: true,
-                                }
-                            }),
+                let diagnostic_highlight = if chunk.is_inlay {
+                    current_diagnostic_underline.map(|underline| HighlightStyle {
+                        underline: Some(underline),
                         ..Default::default()
-                    });
+                    })
+                } else {
+                    let highlight = chunk
+                        .diagnostic_severity
+                        .filter(|severity| {
+                            self.diagnostics_max_severity
+                                .into_lsp()
+                                .is_some_and(|max_severity| severity <= &max_severity)
+                        })
+                        .map(|severity| HighlightStyle {
+                            fade_out: chunk
+                                .is_unnecessary
+                                .then_some(editor_style.unnecessary_code_fade),
+                            underline: (chunk.underline
+                                && editor_style.show_underlines
+                                && !(chunk.is_unnecessary
+                                    && severity > lsp::DiagnosticSeverity::WARNING))
+                                .then(|| {
+                                    let diagnostic_color =
+                                        diagnostic_style(severity, &editor_style.status);
+                                    UnderlineStyle {
+                                        color: Some(diagnostic_color),
+                                        thickness: 1.0.into(),
+                                        wavy: true,
+                                    }
+                                }),
+                            ..Default::default()
+                        });
 
-                current_diagnostic_underline = highlight.as_ref().and_then(|h| h.underline);
-                highlight
-            };
+                    current_diagnostic_underline = highlight.as_ref().and_then(|h| h.underline);
+                    highlight
+                };
 
-            let style = [
-                syntax_highlight_style,
-                chunk_highlight,
-                diagnostic_highlight,
-            ]
-            .into_iter()
-            .flatten()
-            .reduce(|acc, highlight| acc.highlight(highlight));
+                let style = [
+                    syntax_highlight_style,
+                    chunk_highlight,
+                    diagnostic_highlight,
+                ]
+                .into_iter()
+                .flatten()
+                .reduce(|acc, highlight| acc.highlight(highlight));
 
-            HighlightedChunk {
-                text: chunk.text,
-                style,
-                is_tab: chunk.is_tab,
-                is_inlay: chunk.is_inlay,
-                replacement: chunk.renderer.map(ChunkReplacement::Renderer),
+                HighlightedChunk {
+                    text: chunk.text,
+                    style,
+                    is_tab: chunk.is_tab,
+                    is_inlay: chunk.is_inlay,
+                    replacement: chunk.renderer.map(ChunkReplacement::Renderer),
+                }
+                .highlight_invisibles(editor_style)
             }
-            .highlight_invisibles(editor_style)
-        }})
+        })
     }
 
     /// Returns combined highlight styles (tree-sitter syntax + semantic tokens)


### PR DESCRIPTION
bad:
<img width="577" height="118" alt="image" src="https://github.com/user-attachments/assets/52fc13a3-d644-42c3-bd69-048caf85d7bd" />
good:
<img width="617" height="130" alt="image" src="https://github.com/user-attachments/assets/040b26b7-8ee9-4202-bc26-2c995c735286" />

Release Notes:

- N/A or Added/Fixed/Improved ...
