### PR TITLE
terminal_panel: Fix tooltip not reflecting custom keybindings

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -639,7 +639,7 @@
       "ctrl-n": "workspace::NewFile",
       "shift-new": "workspace::NewWindow",
       "ctrl-shift-n": "workspace::NewWindow",
-      "ctrl-`": "terminal_panel::Toggle",
+      "ctrl-`": "terminal_panel::ToggleFocus",
       "f10": ["app_menu::OpenApplicationMenu", "Zed"],
       "alt-1": ["workspace::ActivatePane", 0],
       "alt-2": ["workspace::ActivatePane", 1],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -695,7 +695,7 @@
       "alt-shift-enter": "toast::RunAction",
       "cmd-shift-s": "workspace::SaveAs",
       "cmd-shift-n": "workspace::NewWindow",
-      "ctrl-`": "terminal_panel::Toggle",
+      "ctrl-`": "terminal_panel::ToggleFocus",
       "cmd-1": ["workspace::ActivatePane", 0],
       "cmd-2": ["workspace::ActivatePane", 1],
       "cmd-3": ["workspace::ActivatePane", 2],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -631,7 +631,7 @@
       "ctrl-shift-s": "workspace::SaveAs",
       "ctrl-n": "workspace::NewFile",
       "ctrl-shift-n": "workspace::NewWindow",
-      "ctrl-`": "terminal_panel::Toggle",
+      "ctrl-`": "terminal_panel::ToggleFocus",
       "f10": ["app_menu::OpenApplicationMenu", "Zed"],
       "alt-1": ["workspace::ActivatePane", 0],
       "alt-2": ["workspace::ActivatePane", 1],

--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -144,7 +144,7 @@
   {
     "context": "Workspace || Editor",
     "bindings": {
-      "alt-f12": "terminal_panel::Toggle",
+      "alt-f12": "terminal_panel::ToggleFocus",
       "ctrl-shift-k": "git::Push",
     },
   },

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -147,7 +147,7 @@
   {
     "context": "Workspace || Editor",
     "bindings": {
-      "alt-f12": "terminal_panel::Toggle",
+      "alt-f12": "terminal_panel::ToggleFocus",
       "cmd-shift-k": "git::Push",
     },
   },

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1656,7 +1656,7 @@ impl Panel for TerminalPanel {
     }
 
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
-        Box::new(Toggle)
+        Box::new(ToggleFocus)
     }
 
     fn pane(&self) -> Option<Entity<Pane>> {


### PR DESCRIPTION
The terminal panel's `toggle_action()` returned `Toggle` while all other panels return `ToggleFocus`. This caused the status bar tooltip to always
show the default keybinding for `Toggle` rather than the user's custom binding for `ToggleFocus`.

Change `toggle_action()` to return `ToggleFocus` and update default keymaps to bind `ctrl-\`` / `alt-f12` to `terminal_panel::ToggleFocus` for consistency with other panels.

Closes https://github.com/zed-industries/zed/issues/56241

Release Notes:

- Fixed tooltip not reflecting custom keybindings
