### PR TITLE
editor: Show jump indicator for nearby edit predictions in multi-buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5743,6 +5743,7 @@ dependencies = [
  "client",
  "clock",
  "collections",
+ "component",
  "convert_case 0.11.0",
  "ctor",
  "dap",

--- a/crates/component/src/component.rs
+++ b/crates/component/src/component.rs
@@ -302,6 +302,8 @@ pub enum ComponentScope {
     #[strum(serialize = "Data Display")]
     DataDisplay,
     Editor,
+    #[strum(serialize = "Edit Predictions")]
+    EditPredictions,
     #[strum(serialize = "Images & Icons")]
     Images,
     #[strum(serialize = "Forms & Input")]

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -39,6 +39,7 @@ breadcrumbs.workspace = true
 client.workspace = true
 clock.workspace = true
 collections.workspace = true
+component.workspace = true
 convert_case.workspace = true
 dap.workspace = true
 db.workspace = true

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -34,7 +34,7 @@ pub(super) enum EditPrediction {
     /// Move to a specific location in the active editor
     MoveWithin {
         target: Anchor,
-        snapshot: BufferSnapshot,
+        accept_action: Option<EditPredictionJumpAction>,
     },
     /// Move to a specific location in a different editor (not the active one)
     MoveOutside {
@@ -48,6 +48,60 @@ pub(super) struct EditPredictionState {
     pub(super) completion: EditPrediction,
     pub(super) completion_id: Option<SharedString>,
     pub(super) invalidation_range: Option<Range<Anchor>>,
+}
+
+pub(super) enum EditPredictionJumpAction {
+    ExpandExcerpt(EditPredictionExcerptExpansion),
+    Open {
+        target: language::Anchor,
+        snapshot: BufferSnapshot,
+    },
+}
+
+impl EditPredictionJumpAction {
+    pub(super) fn hidden_edit_direction(
+        &self,
+        snapped_target: Anchor,
+        snapshot: &MultiBufferSnapshot,
+        cx: &App,
+    ) -> Option<Direction> {
+        let (snapped_target, snapped_target_snapshot) =
+            snapshot.anchor_to_buffer_anchor(snapped_target)?;
+        let snapped_target_row = snapped_target.to_point(&snapped_target_snapshot).row;
+
+        let hidden_target_row = match self {
+            Self::ExpandExcerpt(expansion) => {
+                let hidden_target_snapshot = expansion.buffer.read(cx).snapshot();
+                if hidden_target_snapshot.remote_id() != snapped_target_snapshot.remote_id() {
+                    return None;
+                }
+
+                expansion.target.to_point(&hidden_target_snapshot).row
+            }
+            Self::Open { target, snapshot } => {
+                if snapshot.remote_id() != snapped_target_snapshot.remote_id() {
+                    return None;
+                }
+
+                target.to_point(snapshot).row
+            }
+        };
+
+        if hidden_target_row < snapped_target_row {
+            Some(Direction::Prev)
+        } else if hidden_target_row > snapped_target_row {
+            Some(Direction::Next)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct EditPredictionExcerptExpansion {
+    buffer: Entity<Buffer>,
+    target: language::Anchor,
+    ranges: Vec<Range<Point>>,
 }
 
 pub(super) enum EditPredictionSettings {
@@ -370,10 +424,67 @@ impl Editor {
         }
 
         match &active_edit_prediction.completion {
-            EditPrediction::MoveWithin { target, .. } => {
+            EditPrediction::MoveWithin {
+                target,
+                accept_action,
+                ..
+            } => {
                 let target = *target;
 
                 if matches!(granularity, EditPredictionGranularity::Full) {
+                    match accept_action {
+                        Some(EditPredictionJumpAction::Open { target, snapshot }) => {
+                            if let Some(workspace) = self.workspace() {
+                                Self::open_editor_at_anchor(
+                                    snapshot, *target, &workspace, window, cx,
+                                )
+                                .detach_and_log_err(cx);
+                            }
+                            return;
+                        }
+                        Some(EditPredictionJumpAction::ExpandExcerpt(expansion)) => {
+                            self.buffer.update(cx, |multi_buffer, cx| {
+                                let buffer_snapshot = expansion.buffer.read(cx).snapshot();
+                                let snapshot = multi_buffer.snapshot(cx);
+                                let path = snapshot
+                                    .path_for_buffer(buffer_snapshot.remote_id())
+                                    .cloned()
+                                    .unwrap_or_else(|| PathKey::for_buffer(&expansion.buffer, cx));
+                                let mut ranges = snapshot
+                                    .excerpts_for_buffer(buffer_snapshot.remote_id())
+                                    .map(|excerpt| excerpt.primary.to_point(&buffer_snapshot))
+                                    .collect::<Vec<_>>();
+                                ranges.extend(expansion.ranges.clone());
+                                multi_buffer.update_excerpts_for_path(
+                                    path,
+                                    expansion.buffer.clone(),
+                                    ranges,
+                                    multibuffer_context_lines(cx),
+                                    cx,
+                                );
+                            });
+
+                            if let Some(target) = self
+                                .buffer
+                                .read(cx)
+                                .snapshot(cx)
+                                .anchor_in_excerpt(expansion.target)
+                            {
+                                self.change_selections(
+                                    SelectionEffects::scroll(Autoscroll::newest()),
+                                    window,
+                                    cx,
+                                    |selections| {
+                                        selections.select_anchor_ranges([target..target]);
+                                    },
+                                );
+                                self.update_visible_edit_prediction(window, cx);
+                            }
+                            return;
+                        }
+                        None => {}
+                    }
+
                     if let Some(position_map) = &self.last_position_map {
                         let target_row = target.to_display_point(&position_map.snapshot).row();
                         let is_visible = position_map.visible_row_range.contains(&target_row);
@@ -907,16 +1018,8 @@ impl Editor {
             }
         };
 
-        let edits = edits
-            .into_iter()
-            .flat_map(|(range, new_text)| {
-                Some((
-                    multibuffer.buffer_anchor_range_to_anchor_range(range)?,
-                    new_text,
-                ))
-            })
-            .collect::<Vec<_>>();
-        if edits.is_empty() {
+        let buffer_edits = edits;
+        if buffer_edits.is_empty() {
             return None;
         }
 
@@ -925,26 +1028,41 @@ impl Editor {
             Some((anchor, predicted.offset))
         });
 
-        let Some((first_edit_range, _)) = edits.first() else {
-            return None;
-        };
-        let Some((last_edit_range, _)) = edits.last() else {
-            return None;
-        };
-
-        let first_edit_start = first_edit_range.start;
-        let first_edit_start_point = first_edit_start.to_point(&multibuffer);
-        let edit_start_row = first_edit_start_point.row.saturating_sub(2);
-
-        let last_edit_end = last_edit_range.end;
-        let last_edit_end_point = last_edit_end.to_point(&multibuffer);
-        let edit_end_row = cmp::min(multibuffer.max_point().row, last_edit_end_point.row + 2);
-
-        let cursor_row = cursor.to_point(&multibuffer).row;
-
         let snapshot = multibuffer
             .buffer_for_id(cursor_text_anchor.buffer_id)
             .cloned()?;
+
+        let (first_buffer_edit_range, _) = buffer_edits.first()?;
+        let first_buffer_edit_start_point = first_buffer_edit_range.start.to_point(&snapshot);
+
+        let mut edits = Vec::new();
+        let mut hidden_edits = Vec::new();
+        for (range, new_text) in &buffer_edits {
+            if let Some(range) = multibuffer.buffer_anchor_range_to_anchor_range(range.clone()) {
+                edits.push((range, new_text.clone()));
+            } else {
+                hidden_edits.push((
+                    range.clone(),
+                    range.start.to_point(&snapshot)..range.end.to_point(&snapshot),
+                ));
+            }
+        }
+
+        let first_edit_start = edits.first().map(|(range, _)| range.start).or_else(|| {
+            self.buffer
+                .read(cx)
+                .buffer_point_to_anchor(&buffer, first_buffer_edit_start_point, cx)
+        })?;
+        let first_edit_start_point = first_edit_start.to_point(&multibuffer);
+        let edit_start_row = first_edit_start_point.row.saturating_sub(2);
+
+        let last_edit_end_point = edits
+            .last()
+            .map(|(range, _)| range.end.to_point(&multibuffer))
+            .unwrap_or(first_edit_start_point);
+        let edit_end_row = cmp::min(multibuffer.max_point().row, last_edit_end_point.row + 2);
+
+        let cursor_row = cursor.to_point(&multibuffer).row;
 
         let mut inlay_ids = Vec::new();
         let invalidation_row_range;
@@ -961,8 +1079,14 @@ impl Editor {
             .map(|provider| provider.provider.supports_jump_to_edit())
             .unwrap_or(true);
 
+        let prediction_fully_visible = hidden_edits.is_empty();
         let is_move = supports_jump
-            && (move_invalidation_row_range.is_some() || self.edit_predictions_hidden_for_vim_mode);
+            && (!prediction_fully_visible
+                || move_invalidation_row_range.is_some()
+                || self.edit_predictions_hidden_for_vim_mode);
+        if edits.is_empty() && !is_move {
+            return None;
+        }
         let completion = if is_move {
             if let Some(provider) = &self.edit_prediction_provider {
                 provider.provider.did_show(SuggestionDisplayType::Jump, cx);
@@ -970,11 +1094,71 @@ impl Editor {
             invalidation_row_range =
                 move_invalidation_row_range.unwrap_or(edit_start_row..edit_end_row);
 
-            let (_, snapshot) = multibuffer.anchor_to_buffer_anchor(first_edit_start)?;
+            let target = if prediction_fully_visible {
+                first_edit_start
+            } else {
+                hidden_edits
+                    .first()
+                    .and_then(|(_, range)| {
+                        // The indicator snaps to the nearest visible excerpt edge; accept still targets the edit itself.
+                        self.buffer
+                            .read(cx)
+                            .buffer_point_to_anchor(&buffer, range.start, cx)
+                    })
+                    .unwrap_or(first_edit_start)
+            };
+
+            let (_, target_snapshot) = multibuffer.anchor_to_buffer_anchor(target)?;
+            let accept_action = if prediction_fully_visible {
+                None
+            } else {
+                let furthest_hidden_edit_distance = hidden_edits
+                    .iter()
+                    .filter_map(|(_, hidden_edit_range)| {
+                        let hidden_edit_row_range =
+                            hidden_edit_range.start.row..hidden_edit_range.end.row;
+                        multibuffer
+                            .excerpts_for_buffer(target_snapshot.remote_id())
+                            .map(|excerpt| {
+                                let excerpt_range = excerpt.context.to_point(&target_snapshot);
+                                if hidden_edit_row_range.end < excerpt_range.start.row {
+                                    excerpt_range.start.row - hidden_edit_row_range.end
+                                } else if hidden_edit_row_range.start > excerpt_range.end.row {
+                                    hidden_edit_row_range.start - excerpt_range.end.row
+                                } else {
+                                    0
+                                }
+                            })
+                            .min()
+                    })
+                    .max();
+
+                if furthest_hidden_edit_distance.is_some_and(|distance| distance <= 10) {
+                    Some(EditPredictionJumpAction::ExpandExcerpt(
+                        EditPredictionExcerptExpansion {
+                            buffer,
+                            target: hidden_edits
+                                .first()
+                                .map_or(first_buffer_edit_range.start, |(range, _)| range.start),
+                            ranges: hidden_edits
+                                .iter()
+                                .map(|(_, range)| range.clone())
+                                .collect(),
+                        },
+                    ))
+                } else {
+                    Some(EditPredictionJumpAction::Open {
+                        target: hidden_edits
+                            .first()
+                            .map_or(first_buffer_edit_range.start, |(range, _)| range.start),
+                        snapshot: target_snapshot.clone(),
+                    })
+                }
+            };
 
             EditPrediction::MoveWithin {
-                target: first_edit_start,
-                snapshot: snapshot.clone(),
+                target,
+                accept_action,
             }
         } else {
             let show_completions_in_menu = self.has_visible_completions_menu();
@@ -1101,8 +1285,18 @@ impl Editor {
         }
 
         match &active_edit_prediction.completion {
-            EditPrediction::MoveWithin { target, .. } => {
+            EditPrediction::MoveWithin {
+                target,
+                accept_action,
+            } => {
                 let target_display_point = target.to_display_point(editor_snapshot);
+                let hidden_edit_direction = accept_action.as_ref().and_then(|accept_action| {
+                    accept_action.hidden_edit_direction(
+                        *target,
+                        &self.buffer.read(cx).snapshot(cx),
+                        cx,
+                    )
+                });
 
                 if self.edit_prediction_requires_modifier() {
                     if !self.edit_prediction_preview_is_active() {
@@ -1131,7 +1325,9 @@ impl Editor {
                         scroll_bottom,
                         line_height,
                         scroll_pixel_position,
+                        newest_selection_head,
                         target_display_point,
+                        hidden_edit_direction,
                         editor_width,
                         window,
                         cx,
@@ -1152,9 +1348,10 @@ impl Editor {
 
                 self.render_edit_prediction_end_of_line_popover(
                     "Accept",
+                    None,
                     editor_snapshot,
-                    visible_row_range,
                     target_display_point,
+                    visible_row_range,
                     line_height,
                     scroll_pixel_position,
                     content_origin,
@@ -1194,8 +1391,10 @@ impl Editor {
                     .into_any();
 
                 let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
-                let origin_x = text_bounds.size.width - size.width - px(30.);
-                let origin = text_bounds.origin + gpui::Point::new(origin_x, px(16.));
+                let origin_x = text_bounds.size.width - right_margin - size.width - px(2.);
+                let origin_y = FILE_HEADER_HEIGHT as f32 * line_height
+                    + (line_height - size.height).max(Pixels::ZERO) / 2.;
+                let origin = text_bounds.origin + gpui::Point::new(origin_x, origin_y);
                 element.prepaint_at(origin, window, cx);
 
                 Some((element, origin))
@@ -1248,10 +1447,11 @@ impl Editor {
                             .rounded_tl(px(0.))
                             .overflow_hidden()
                             .child(div().px_1p5().child(match &prediction.completion {
-                                EditPrediction::MoveWithin { target, snapshot } => {
-                                    use text::ToPoint as _;
-                                    if target.text_anchor_in(&snapshot).to_point(snapshot).row
-                                        > cursor_point.row
+                                EditPrediction::MoveWithin { target, .. } => {
+                                    let display_snapshot = self.display_snapshot(cx);
+                                    let cursor_row =
+                                        cursor_point.to_display_point(&display_snapshot).row();
+                                    if target.to_display_point(&display_snapshot).row() > cursor_row
                                     {
                                         Icon::new(icons.down)
                                     } else {
@@ -1820,7 +2020,9 @@ impl Editor {
         scroll_bottom: ScrollOffset,
         line_height: Pixels,
         scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
+        newest_selection_head: Option<DisplayPoint>,
         target_display_point: DisplayPoint,
+        hidden_edit_direction: Option<Direction>,
         editor_width: Pixels,
         window: &mut Window,
         cx: &mut App,
@@ -1864,11 +2066,28 @@ impl Editor {
             element.prepaint_at(origin, window, cx);
             Some((element, origin))
         } else {
+            let cursor_row = newest_selection_head?.row();
+            let icon = if target_display_point.row() < visible_row_range.start {
+                IconName::ArrowUp
+            } else if target_display_point.row() >= visible_row_range.end {
+                IconName::ArrowDown
+            } else if target_display_point.row() < cursor_row {
+                IconName::ArrowUp
+            } else if target_display_point.row() == cursor_row {
+                match hidden_edit_direction {
+                    Some(Direction::Prev) => IconName::ArrowUp,
+                    Some(Direction::Next) | None => IconName::ArrowDown,
+                }
+            } else {
+                IconName::ArrowDown
+            };
+
             self.render_edit_prediction_end_of_line_popover(
                 "Jump to Edit",
+                Some(icon),
                 editor_snapshot,
-                visible_row_range,
                 target_display_point,
+                visible_row_range,
                 line_height,
                 scroll_pixel_position,
                 content_origin,
@@ -1882,9 +2101,10 @@ impl Editor {
     fn render_edit_prediction_end_of_line_popover(
         self: &mut Editor,
         label: &'static str,
+        icon: Option<IconName>,
         editor_snapshot: &EditorSnapshot,
-        visible_row_range: Range<DisplayRow>,
         target_display_point: DisplayPoint,
+        visible_row_range: Range<DisplayRow>,
         line_height: Pixels,
         scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
         content_origin: gpui::Point<Pixels>,
@@ -1898,7 +2118,7 @@ impl Editor {
         );
 
         let mut element = self
-            .render_edit_prediction_line_popover(label, None, window, cx)
+            .render_edit_prediction_line_popover(label, icon, window, cx)
             .into_any();
 
         let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
@@ -1909,29 +2129,26 @@ impl Editor {
         let start_point = content_origin - point(scroll_pixel_position.x.into(), Pixels::ZERO);
         let mut origin = start_point
             + line_origin
-            + point(Self::EDIT_PREDICTION_POPOVER_PADDING_X, Pixels::ZERO);
+            + point(
+                Self::EDIT_PREDICTION_POPOVER_PADDING_X,
+                (line_height - size.height) / 2.,
+            );
         origin.x = origin.x.max(content_origin.x);
 
         let max_x = content_origin.x + editor_width - size.width;
 
         if origin.x > max_x {
+            let place_below = match icon {
+                Some(IconName::ArrowUp) => true,
+                Some(IconName::ArrowDown) => false,
+                _ => visible_row_range.contains(&(target_display_point.row() + 2)),
+            };
             let offset = line_height + Self::EDIT_PREDICTION_POPOVER_PADDING_Y;
 
-            let icon = if visible_row_range.contains(&(target_display_point.row() + 2)) {
-                origin.y += offset;
-                IconName::ArrowUp
-            } else {
-                origin.y -= offset;
-                IconName::ArrowDown
-            };
-
-            element = self
-                .render_edit_prediction_line_popover(label, Some(icon), window, cx)
-                .into_any();
-
-            let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
-
             origin.x = content_origin.x + editor_width - size.width - px(2.);
+            let origin_y_offset = if place_below { offset } else { -offset };
+            origin.y =
+                start_point.y + line_origin.y + (line_height - size.height) / 2. + origin_y_offset;
         }
 
         element.prepaint_at(origin, window, cx);
@@ -2373,17 +2590,15 @@ impl Editor {
         style: &EditorStyle,
         cx: &mut Context<Editor>,
     ) -> Option<Div> {
-        use text::ToPoint as _;
-
         fn render_relative_row_jump(
             prefix: impl Into<String>,
-            current_row: u32,
-            target_row: u32,
+            current_row: DisplayRow,
+            target_row: DisplayRow,
         ) -> Div {
             let (row_diff, arrow) = if target_row < current_row {
-                (current_row - target_row, IconName::ArrowUp)
+                ((current_row - target_row).0, IconName::ArrowUp)
             } else {
-                (target_row - current_row, IconName::ArrowDown)
+                ((target_row - current_row).0, IconName::ArrowDown)
             };
 
             h_flex()
@@ -2402,22 +2617,22 @@ impl Editor {
             .unwrap_or(true);
 
         let icons = Self::get_prediction_provider_icons(&self.edit_prediction_provider, cx);
+        let display_snapshot = self.display_snapshot(cx);
+        let cursor_row = cursor_point.to_display_point(&display_snapshot).row();
 
         match &completion.completion {
-            EditPrediction::MoveWithin {
-                target, snapshot, ..
-            } => {
+            EditPrediction::MoveWithin { target, .. } => {
                 if !supports_jump {
                     return None;
                 }
-                let (target, _) = self.display_snapshot(cx).anchor_to_buffer_anchor(*target)?;
+                let target_row = target.to_display_point(&display_snapshot).row();
 
                 Some(
                     h_flex()
                         .px_2()
                         .gap_2()
                         .flex_1()
-                        .child(if target.to_point(snapshot).row > cursor_point.row {
+                        .child(if target_row > cursor_row {
                             Icon::new(icons.down)
                         } else {
                             Icon::new(icons.up)
@@ -2445,12 +2660,12 @@ impl Editor {
                 snapshot,
                 ..
             } => {
-                let first_edit_row = self
-                    .display_snapshot(cx)
-                    .anchor_to_buffer_anchor(edits.first()?.0.start)?
+                let first_edit_row = edits
+                    .first()?
                     .0
-                    .to_point(snapshot)
-                    .row;
+                    .start
+                    .to_display_point(&display_snapshot)
+                    .row();
 
                 let (highlighted_edits, has_more_lines) =
                     if let Some(edit_preview) = edit_preview.as_ref() {
@@ -2476,9 +2691,8 @@ impl Editor {
                     .child(styled_text)
                     .when(has_more_lines, |parent| parent.child("…"));
 
-                let left = if supports_jump && first_edit_row != cursor_point.row {
-                    render_relative_row_jump("", cursor_point.row, first_edit_row)
-                        .into_any_element()
+                let left = if supports_jump && first_edit_row != cursor_row {
+                    render_relative_row_jump("", cursor_row, first_edit_row).into_any_element()
                 } else {
                     Icon::new(icons.base).into_any_element()
                 };

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -106,7 +106,7 @@ pub(super) struct EditPredictionExcerptExpansion {
 
 #[derive(Clone)]
 struct EditPredictionPreviewDelegate {
-    prediction: edit_prediction_types::EditPrediction,
+    prediction: Option<edit_prediction_types::EditPrediction>,
 }
 
 impl EditPredictionDelegate for EditPredictionPreviewDelegate {
@@ -144,7 +144,9 @@ impl EditPredictionDelegate for EditPredictionPreviewDelegate {
     ) {
     }
 
-    fn accept(&mut self, _cx: &mut Context<Self>) {}
+    fn accept(&mut self, _cx: &mut Context<Self>) {
+        self.prediction = None;
+    }
 
     fn discard(&mut self, _reason: EditPredictionDiscardReason, _cx: &mut Context<Self>) {}
 
@@ -154,12 +156,321 @@ impl EditPredictionDelegate for EditPredictionPreviewDelegate {
         _: language::Anchor,
         _: &mut Context<Self>,
     ) -> Option<edit_prediction_types::EditPrediction> {
-        Some(self.prediction.clone())
+        self.prediction.clone()
     }
 }
 
 #[derive(RegisterComponent)]
 struct EditPredictionMultiBufferPreview;
+
+#[derive(Clone, Copy)]
+pub struct EditPredictionMultiBufferPreviewCase {
+    pub title: &'static str,
+    #[allow(dead_code)]
+    pub test_name: &'static str,
+    kind: EditPredictionMultiBufferPreviewCaseKind,
+}
+
+#[derive(Clone, Copy)]
+enum EditPredictionMultiBufferPreviewCaseKind {
+    FullyVisibleHunk,
+    CrossExcerptJump,
+    TopExcerptExpandsUpward,
+    TopExcerptBoundaryExpandsUpward,
+    BottomExcerptExpandsDownward,
+    MiddleExcerptExpandsUpward,
+    MiddleExcerptExpandsDownward,
+    PartiallyVisibleFarFromExcerpt,
+    AdjacentMultiEditCluster,
+    DifferentFileJump,
+}
+
+pub fn edit_prediction_multibuffer_preview_cases() -> &'static [EditPredictionMultiBufferPreviewCase]
+{
+    use EditPredictionMultiBufferPreviewCaseKind::*;
+
+    &[
+        EditPredictionMultiBufferPreviewCase {
+            title: "Fully visible hunk",
+            test_name: "edit_prediction_multibuffer_fully_visible_hunk",
+            kind: FullyVisibleHunk,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Cross-excerpt jump",
+            test_name: "edit_prediction_multibuffer_cross_excerpt_jump",
+            kind: CrossExcerptJump,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Top excerpt expands upward",
+            test_name: "edit_prediction_multibuffer_top_excerpt_expands_upward",
+            kind: TopExcerptExpandsUpward,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Top excerpt boundary expands upward",
+            test_name: "edit_prediction_multibuffer_top_excerpt_boundary_expands_upward",
+            kind: TopExcerptBoundaryExpandsUpward,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Bottom excerpt expands downward",
+            test_name: "edit_prediction_multibuffer_bottom_excerpt_expands_downward",
+            kind: BottomExcerptExpandsDownward,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Middle excerpt expands upward",
+            test_name: "edit_prediction_multibuffer_middle_excerpt_expands_upward",
+            kind: MiddleExcerptExpandsUpward,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Middle excerpt expands downward",
+            test_name: "edit_prediction_multibuffer_middle_excerpt_expands_downward",
+            kind: MiddleExcerptExpandsDownward,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Partially visible, far from excerpt",
+            test_name: "edit_prediction_multibuffer_partially_visible_far_from_excerpt",
+            kind: PartiallyVisibleFarFromExcerpt,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Adjacent multi-edit cluster",
+            test_name: "edit_prediction_multibuffer_adjacent_multi_edit_cluster",
+            kind: AdjacentMultiEditCluster,
+        },
+        EditPredictionMultiBufferPreviewCase {
+            title: "Different file jump",
+            test_name: "edit_prediction_multibuffer_different_file_jump",
+            kind: DifferentFileJump,
+        },
+    ]
+}
+
+pub fn edit_prediction_multibuffer_preview_editor(
+    case: &EditPredictionMultiBufferPreviewCase,
+    window: &mut Window,
+    cx: &mut App,
+) -> Entity<Editor> {
+    use EditPredictionMultiBufferPreviewCaseKind::*;
+
+    let text = "fn main() {\n    let value = compute();\n    println!(\"{}\", value);\n}\n\nfn helper() {\n    let enabled = true;\n    dbg!(enabled);\n}\n\nfn far_away() {\n    let name = \"zed\";\n    println!(\"{name}\");\n}\n\nfn distant() {\n    let first = 1;\n    let second = 2;\n    let third = 3;\n    let fourth = 4;\n    let fifth = 5;\n    let sixth = 6;\n}\n";
+
+    match case.kind {
+        FullyVisibleHunk => editor_preview(
+            text,
+            vec![Point::row_range(0..4), Point::row_range(10..12)],
+            Point::new(1, 14),
+            vec![(
+                Point::new(2, 4)..Point::new(2, 4),
+                "let doubled = value * 2;\n    ",
+            )],
+            window,
+            cx,
+        ),
+        CrossExcerptJump => editor_preview(
+            text,
+            vec![Point::row_range(0..2), Point::row_range(10..12)],
+            Point::new(1, 14),
+            vec![(
+                Point::new(11, 4)..Point::new(11, 4),
+                "let greeting = format!(\"hello {name}\");\n    ",
+            )],
+            window,
+            cx,
+        ),
+        TopExcerptExpandsUpward => editor_preview(
+            text,
+            vec![Point::row_range(5..7), Point::row_range(10..12)],
+            Point::new(6, 18),
+            vec![(Point::new(4, 0)..Point::new(4, 0), "fn nearby() {}\n\n")],
+            window,
+            cx,
+        ),
+        TopExcerptBoundaryExpandsUpward => editor_preview(
+            text,
+            vec![Point::row_range(5..7), Point::row_range(10..12)],
+            Point::new(5, 0),
+            vec![(Point::new(4, 0)..Point::new(4, 0), "fn boundary() {}\n\n")],
+            window,
+            cx,
+        ),
+        BottomExcerptExpandsDownward => editor_preview(
+            text,
+            vec![Point::row_range(0..2), Point::row_range(5..8)],
+            Point::new(6, 18),
+            vec![(Point::new(10, 0)..Point::new(10, 0), "fn inserted() {}\n\n")],
+            window,
+            cx,
+        ),
+        MiddleExcerptExpandsUpward => editor_preview(
+            text,
+            vec![
+                Point::row_range(0..2),
+                Point::row_range(5..7),
+                Point::row_range(10..12),
+            ],
+            Point::new(6, 18),
+            vec![(
+                Point::new(4, 0)..Point::new(4, 0),
+                "fn above_middle() {}\n\n",
+            )],
+            window,
+            cx,
+        ),
+        MiddleExcerptExpandsDownward => editor_preview(
+            text,
+            vec![
+                Point::row_range(0..2),
+                Point::row_range(5..7),
+                Point::row_range(10..12),
+            ],
+            Point::new(6, 18),
+            vec![(
+                Point::new(8, 0)..Point::new(8, 0),
+                "fn below_middle() {}\n\n",
+            )],
+            window,
+            cx,
+        ),
+        PartiallyVisibleFarFromExcerpt => editor_preview(
+            text,
+            vec![Point::row_range(0..2), Point::row_range(5..7)],
+            Point::new(1, 14),
+            vec![(
+                Point::new(20, 4)..Point::new(20, 4),
+                "let target = sixth + 1;\n    ",
+            )],
+            window,
+            cx,
+        ),
+        AdjacentMultiEditCluster => editor_preview(
+            text,
+            vec![
+                Point::row_range(0..2),
+                Point::row_range(4..8),
+                Point::row_range(10..12),
+            ],
+            Point::new(6, 18),
+            vec![
+                (Point::new(6, 4)..Point::new(6, 4), "let count = 1;\n    "),
+                (Point::new(7, 4)..Point::new(7, 4), "dbg!(count);\n    "),
+            ],
+            window,
+            cx,
+        ),
+        DifferentFileJump => jump_preview(
+            "fn main() {\n    work();\n}\n",
+            "fn other() {\n    target();\n}\n",
+            window,
+            cx,
+        ),
+    }
+}
+
+fn editor_preview(
+    text: &'static str,
+    excerpt_ranges: Vec<Range<Point>>,
+    cursor: Point,
+    edits: Vec<(Range<Point>, &'static str)>,
+    window: &mut Window,
+    cx: &mut App,
+) -> Entity<Editor> {
+    cx.new(|cx| {
+        let buffer = cx.new(|cx| Buffer::local(text, cx));
+        let other_buffer = cx.new(|cx| {
+            Buffer::local(
+                "pub fn shared_helper() {\n    trace!(\"other file\");\n}\n",
+                cx,
+            )
+        });
+        let snapshot = buffer.read(cx).snapshot();
+        let prediction = edit_prediction_types::EditPrediction::Local {
+            id: Some("preview".into()),
+            edits: edits
+                .into_iter()
+                .map(|(range, text)| {
+                    (
+                        snapshot.anchor_before(range.start)..snapshot.anchor_before(range.end),
+                        Arc::<str>::from(text),
+                    )
+                })
+                .collect(),
+            cursor_position: None,
+            edit_preview: None,
+        };
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
+            multi_buffer.set_excerpts_for_path(
+                PathKey::sorted(0),
+                other_buffer,
+                [Point::row_range(0..2)],
+                0,
+                cx,
+            );
+            multi_buffer.set_excerpts_for_path(
+                PathKey::sorted(1),
+                buffer.clone(),
+                excerpt_ranges,
+                0,
+                cx,
+            );
+            multi_buffer
+        });
+        let provider = cx.new(|_| EditPredictionPreviewDelegate {
+            prediction: Some(prediction),
+        });
+        let mut editor = Editor::for_multibuffer(multi_buffer.clone(), None, window, cx);
+        if let Some(cursor) = multi_buffer
+            .read(cx)
+            .buffer_point_to_anchor(&buffer, cursor, cx)
+        {
+            editor.change_selections(
+                SelectionEffects::scroll(Autoscroll::fit()),
+                window,
+                cx,
+                |selections| {
+                    selections.select_anchor_ranges([cursor..cursor]);
+                },
+            );
+        }
+        editor.set_edit_prediction_provider(Some(provider), window, cx);
+        editor.update_visible_edit_prediction(window, cx);
+        editor
+    })
+}
+
+fn jump_preview(
+    text: &'static str,
+    target_text: &'static str,
+    window: &mut Window,
+    cx: &mut App,
+) -> Entity<Editor> {
+    cx.new(|cx| {
+        let buffer = cx.new(|cx| Buffer::local(text, cx));
+        let target_buffer = cx.new(|cx| Buffer::local(target_text, cx));
+        let target_snapshot = target_buffer.read(cx).snapshot();
+        let prediction = edit_prediction_types::EditPrediction::Jump {
+            id: Some("preview".into()),
+            snapshot: target_snapshot.clone(),
+            target: target_snapshot.anchor_before(Point::new(1, 4)),
+        };
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
+            multi_buffer.set_excerpts_for_path(
+                PathKey::for_buffer(&buffer, cx),
+                buffer.clone(),
+                [Point::row_range(0..2)],
+                0,
+                cx,
+            );
+            multi_buffer
+        });
+        let provider = cx.new(|_| EditPredictionPreviewDelegate {
+            prediction: Some(prediction),
+        });
+        let mut editor = Editor::for_multibuffer(multi_buffer, None, window, cx);
+        editor.set_edit_prediction_provider(Some(provider), window, cx);
+        editor.update_visible_edit_prediction(window, cx);
+        editor
+    })
+}
 
 impl Component for EditPredictionMultiBufferPreview {
     fn scope() -> ComponentScope {
@@ -193,236 +504,15 @@ impl Component for EditPredictionMultiBufferPreview {
                 .into_any_element()
         }
 
-        fn editor_preview(
-            text: &'static str,
-            excerpt_ranges: Vec<Range<Point>>,
-            cursor: Point,
-            edits: Vec<(Range<Point>, &'static str)>,
-            window: &mut Window,
-            cx: &mut App,
-        ) -> Entity<Editor> {
-            cx.new(|cx| {
-                let buffer = cx.new(|cx| Buffer::local(text, cx));
-                let other_buffer = cx.new(|cx| {
-                    Buffer::local(
-                        "pub fn shared_helper() {\n    trace!(\"other file\");\n}\n",
-                        cx,
-                    )
-                });
-                let snapshot = buffer.read(cx).snapshot();
-                let prediction = edit_prediction_types::EditPrediction::Local {
-                    id: Some("preview".into()),
-                    edits: edits
-                        .into_iter()
-                        .map(|(range, text)| {
-                            (
-                                snapshot.anchor_before(range.start)
-                                    ..snapshot.anchor_before(range.end),
-                                Arc::<str>::from(text),
-                            )
-                        })
-                        .collect(),
-                    cursor_position: None,
-                    edit_preview: None,
-                };
-                let multi_buffer = cx.new(|cx| {
-                    let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
-                    multi_buffer.set_excerpts_for_path(
-                        PathKey::sorted(0),
-                        other_buffer,
-                        [Point::row_range(0..2)],
-                        0,
-                        cx,
-                    );
-                    multi_buffer.set_excerpts_for_path(
-                        PathKey::sorted(1),
-                        buffer.clone(),
-                        excerpt_ranges,
-                        0,
-                        cx,
-                    );
-                    multi_buffer
-                });
-                let provider = cx.new(|_| EditPredictionPreviewDelegate { prediction });
-                let mut editor = Editor::for_multibuffer(multi_buffer.clone(), None, window, cx);
-                if let Some(cursor) = multi_buffer
-                    .read(cx)
-                    .buffer_point_to_anchor(&buffer, cursor, cx)
-                {
-                    editor.change_selections(
-                        SelectionEffects::scroll(Autoscroll::fit()),
-                        window,
-                        cx,
-                        |selections| {
-                            selections.select_anchor_ranges([cursor..cursor]);
-                        },
-                    );
-                }
-                editor.set_edit_prediction_provider(Some(provider), window, cx);
-                editor.update_visible_edit_prediction(window, cx);
-                editor
+        edit_prediction_multibuffer_preview_cases()
+            .iter()
+            .fold(v_flex().gap_4(), |parent, preview_case| {
+                parent.child(case(
+                    preview_case.title,
+                    edit_prediction_multibuffer_preview_editor(preview_case, window, cx),
+                    cx,
+                ))
             })
-        }
-
-        fn jump_preview(
-            text: &'static str,
-            target_text: &'static str,
-            window: &mut Window,
-            cx: &mut App,
-        ) -> Entity<Editor> {
-            cx.new(|cx| {
-                let buffer = cx.new(|cx| Buffer::local(text, cx));
-                let target_buffer = cx.new(|cx| Buffer::local(target_text, cx));
-                let target_snapshot = target_buffer.read(cx).snapshot();
-                let prediction = edit_prediction_types::EditPrediction::Jump {
-                    id: Some("preview".into()),
-                    snapshot: target_snapshot.clone(),
-                    target: target_snapshot.anchor_before(Point::new(1, 4)),
-                };
-                let multi_buffer = cx.new(|cx| {
-                    let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
-                    multi_buffer.set_excerpts_for_path(
-                        PathKey::for_buffer(&buffer, cx),
-                        buffer.clone(),
-                        [Point::row_range(0..2)],
-                        0,
-                        cx,
-                    );
-                    multi_buffer
-                });
-                let provider = cx.new(|_| EditPredictionPreviewDelegate { prediction });
-                let mut editor = Editor::for_multibuffer(multi_buffer, None, window, cx);
-                editor.set_edit_prediction_provider(Some(provider), window, cx);
-                editor.update_visible_edit_prediction(window, cx);
-                editor
-            })
-        }
-
-        let text = "fn main() {\n    let value = compute();\n    println!(\"{}\", value);\n}\n\nfn helper() {\n    let enabled = true;\n    dbg!(enabled);\n}\n\nfn far_away() {\n    let name = \"zed\";\n    println!(\"{name}\");\n}\n\nfn distant() {\n    let first = 1;\n    let second = 2;\n    let third = 3;\n    let fourth = 4;\n    let fifth = 5;\n    let sixth = 6;\n}\n";
-
-        v_flex()
-            .gap_4()
-            .child(case(
-                "Fully visible hunk",
-                editor_preview(
-                    text,
-                    vec![Point::row_range(0..4), Point::row_range(10..12)],
-                    Point::new(1, 14),
-                    vec![(
-                        Point::new(2, 4)..Point::new(2, 4),
-                        "let doubled = value * 2;\n    ",
-                    )],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Top excerpt expands upward",
-                editor_preview(
-                    text,
-                    vec![Point::row_range(5..7), Point::row_range(10..12)],
-                    Point::new(6, 18),
-                    vec![(Point::new(4, 0)..Point::new(4, 0), "fn nearby() {}\n\n")],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Bottom excerpt expands downward",
-                editor_preview(
-                    text,
-                    vec![Point::row_range(0..2), Point::row_range(5..8)],
-                    Point::new(6, 18),
-                    vec![(Point::new(10, 0)..Point::new(10, 0), "fn inserted() {}\n\n")],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Middle excerpt expands upward",
-                editor_preview(
-                    text,
-                    vec![
-                        Point::row_range(0..2),
-                        Point::row_range(5..7),
-                        Point::row_range(10..12),
-                    ],
-                    Point::new(6, 18),
-                    vec![(
-                        Point::new(4, 0)..Point::new(4, 0),
-                        "fn above_middle() {}\n\n",
-                    )],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Middle excerpt expands downward",
-                editor_preview(
-                    text,
-                    vec![
-                        Point::row_range(0..2),
-                        Point::row_range(5..7),
-                        Point::row_range(10..12),
-                    ],
-                    Point::new(6, 18),
-                    vec![(
-                        Point::new(8, 0)..Point::new(8, 0),
-                        "fn below_middle() {}\n\n",
-                    )],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Partially visible, far from excerpt",
-                editor_preview(
-                    text,
-                    vec![Point::row_range(0..2), Point::row_range(5..7)],
-                    Point::new(1, 14),
-                    vec![(
-                        Point::new(20, 4)..Point::new(20, 4),
-                        "let target = sixth + 1;\n    ",
-                    )],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Adjacent multi-edit cluster",
-                editor_preview(
-                    text,
-                    vec![
-                        Point::row_range(0..2),
-                        Point::row_range(4..8),
-                        Point::row_range(10..12),
-                    ],
-                    Point::new(6, 18),
-                    vec![
-                        (Point::new(6, 4)..Point::new(6, 4), "let count = 1;\n    "),
-                        (Point::new(7, 4)..Point::new(7, 4), "dbg!(count);\n    "),
-                    ],
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
-            .child(case(
-                "Different file jump",
-                jump_preview(
-                    "fn main() {\n    work();\n}\n",
-                    "fn other() {\n    target();\n}\n",
-                    window,
-                    cx,
-                ),
-                cx,
-            ))
             .into_any_element()
     }
 }

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -104,6 +104,329 @@ pub(super) struct EditPredictionExcerptExpansion {
     ranges: Vec<Range<Point>>,
 }
 
+#[derive(Clone)]
+struct EditPredictionPreviewDelegate {
+    prediction: edit_prediction_types::EditPrediction,
+}
+
+impl EditPredictionDelegate for EditPredictionPreviewDelegate {
+    fn name() -> &'static str {
+        "edit-prediction-preview"
+    }
+
+    fn display_name() -> &'static str {
+        "Edit Prediction Preview"
+    }
+
+    fn show_predictions_in_menu() -> bool {
+        true
+    }
+
+    fn icons(&self, _cx: &App) -> edit_prediction_types::EditPredictionIconSet {
+        edit_prediction_types::EditPredictionIconSet::new(IconName::ZedPredict)
+    }
+
+    fn is_enabled(&self, _: &Entity<Buffer>, _: language::Anchor, _: &App) -> bool {
+        true
+    }
+
+    fn is_refreshing(&self, _cx: &App) -> bool {
+        false
+    }
+
+    fn refresh(
+        &mut self,
+        _: Entity<Buffer>,
+        _: language::Anchor,
+        _: bool,
+        _: EditPredictionRequestTrigger,
+        _: &mut Context<Self>,
+    ) {
+    }
+
+    fn accept(&mut self, _cx: &mut Context<Self>) {}
+
+    fn discard(&mut self, _reason: EditPredictionDiscardReason, _cx: &mut Context<Self>) {}
+
+    fn suggest(
+        &mut self,
+        _: &Entity<Buffer>,
+        _: language::Anchor,
+        _: &mut Context<Self>,
+    ) -> Option<edit_prediction_types::EditPrediction> {
+        Some(self.prediction.clone())
+    }
+}
+
+#[derive(RegisterComponent)]
+struct EditPredictionMultiBufferPreview;
+
+impl Component for EditPredictionMultiBufferPreview {
+    fn scope() -> ComponentScope {
+        ComponentScope::EditPredictions
+    }
+
+    fn name() -> &'static str {
+        "MultiBuffer Jumps"
+    }
+
+    fn description() -> &'static str {
+        "Real editor previews for multi-buffer edit prediction states."
+    }
+
+    fn preview(window: &mut Window, cx: &mut App) -> AnyElement {
+        fn case(title: &'static str, editor: Entity<Editor>, cx: &mut App) -> AnyElement {
+            v_flex()
+                .gap_2()
+                .p_3()
+                .border_1()
+                .border_color(cx.theme().colors().border)
+                .rounded(px(8.))
+                .child(Label::new(title).size(LabelSize::Large))
+                .child(
+                    div()
+                        .h(px(220.))
+                        .border_1()
+                        .border_color(cx.theme().colors().border)
+                        .child(editor),
+                )
+                .into_any_element()
+        }
+
+        fn editor_preview(
+            text: &'static str,
+            excerpt_ranges: Vec<Range<Point>>,
+            cursor: Point,
+            edits: Vec<(Range<Point>, &'static str)>,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> Entity<Editor> {
+            cx.new(|cx| {
+                let buffer = cx.new(|cx| Buffer::local(text, cx));
+                let other_buffer = cx.new(|cx| {
+                    Buffer::local(
+                        "pub fn shared_helper() {\n    trace!(\"other file\");\n}\n",
+                        cx,
+                    )
+                });
+                let snapshot = buffer.read(cx).snapshot();
+                let prediction = edit_prediction_types::EditPrediction::Local {
+                    id: Some("preview".into()),
+                    edits: edits
+                        .into_iter()
+                        .map(|(range, text)| {
+                            (
+                                snapshot.anchor_before(range.start)
+                                    ..snapshot.anchor_before(range.end),
+                                Arc::<str>::from(text),
+                            )
+                        })
+                        .collect(),
+                    cursor_position: None,
+                    edit_preview: None,
+                };
+                let multi_buffer = cx.new(|cx| {
+                    let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
+                    multi_buffer.set_excerpts_for_path(
+                        PathKey::sorted(0),
+                        other_buffer,
+                        [Point::row_range(0..2)],
+                        0,
+                        cx,
+                    );
+                    multi_buffer.set_excerpts_for_path(
+                        PathKey::sorted(1),
+                        buffer.clone(),
+                        excerpt_ranges,
+                        0,
+                        cx,
+                    );
+                    multi_buffer
+                });
+                let provider = cx.new(|_| EditPredictionPreviewDelegate { prediction });
+                let mut editor = Editor::for_multibuffer(multi_buffer.clone(), None, window, cx);
+                if let Some(cursor) = multi_buffer
+                    .read(cx)
+                    .buffer_point_to_anchor(&buffer, cursor, cx)
+                {
+                    editor.change_selections(
+                        SelectionEffects::scroll(Autoscroll::fit()),
+                        window,
+                        cx,
+                        |selections| {
+                            selections.select_anchor_ranges([cursor..cursor]);
+                        },
+                    );
+                }
+                editor.set_edit_prediction_provider(Some(provider), window, cx);
+                editor.update_visible_edit_prediction(window, cx);
+                editor
+            })
+        }
+
+        fn jump_preview(
+            text: &'static str,
+            target_text: &'static str,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> Entity<Editor> {
+            cx.new(|cx| {
+                let buffer = cx.new(|cx| Buffer::local(text, cx));
+                let target_buffer = cx.new(|cx| Buffer::local(target_text, cx));
+                let target_snapshot = target_buffer.read(cx).snapshot();
+                let prediction = edit_prediction_types::EditPrediction::Jump {
+                    id: Some("preview".into()),
+                    snapshot: target_snapshot.clone(),
+                    target: target_snapshot.anchor_before(Point::new(1, 4)),
+                };
+                let multi_buffer = cx.new(|cx| {
+                    let mut multi_buffer = MultiBuffer::new(Capability::ReadWrite);
+                    multi_buffer.set_excerpts_for_path(
+                        PathKey::for_buffer(&buffer, cx),
+                        buffer.clone(),
+                        [Point::row_range(0..2)],
+                        0,
+                        cx,
+                    );
+                    multi_buffer
+                });
+                let provider = cx.new(|_| EditPredictionPreviewDelegate { prediction });
+                let mut editor = Editor::for_multibuffer(multi_buffer, None, window, cx);
+                editor.set_edit_prediction_provider(Some(provider), window, cx);
+                editor.update_visible_edit_prediction(window, cx);
+                editor
+            })
+        }
+
+        let text = "fn main() {\n    let value = compute();\n    println!(\"{}\", value);\n}\n\nfn helper() {\n    let enabled = true;\n    dbg!(enabled);\n}\n\nfn far_away() {\n    let name = \"zed\";\n    println!(\"{name}\");\n}\n\nfn distant() {\n    let first = 1;\n    let second = 2;\n    let third = 3;\n    let fourth = 4;\n    let fifth = 5;\n    let sixth = 6;\n}\n";
+
+        v_flex()
+            .gap_4()
+            .child(case(
+                "Fully visible hunk",
+                editor_preview(
+                    text,
+                    vec![Point::row_range(0..4), Point::row_range(10..12)],
+                    Point::new(1, 14),
+                    vec![(
+                        Point::new(2, 4)..Point::new(2, 4),
+                        "let doubled = value * 2;\n    ",
+                    )],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Top excerpt expands upward",
+                editor_preview(
+                    text,
+                    vec![Point::row_range(5..7), Point::row_range(10..12)],
+                    Point::new(6, 18),
+                    vec![(Point::new(4, 0)..Point::new(4, 0), "fn nearby() {}\n\n")],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Bottom excerpt expands downward",
+                editor_preview(
+                    text,
+                    vec![Point::row_range(0..2), Point::row_range(5..8)],
+                    Point::new(6, 18),
+                    vec![(Point::new(10, 0)..Point::new(10, 0), "fn inserted() {}\n\n")],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Middle excerpt expands upward",
+                editor_preview(
+                    text,
+                    vec![
+                        Point::row_range(0..2),
+                        Point::row_range(5..7),
+                        Point::row_range(10..12),
+                    ],
+                    Point::new(6, 18),
+                    vec![(
+                        Point::new(4, 0)..Point::new(4, 0),
+                        "fn above_middle() {}\n\n",
+                    )],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Middle excerpt expands downward",
+                editor_preview(
+                    text,
+                    vec![
+                        Point::row_range(0..2),
+                        Point::row_range(5..7),
+                        Point::row_range(10..12),
+                    ],
+                    Point::new(6, 18),
+                    vec![(
+                        Point::new(8, 0)..Point::new(8, 0),
+                        "fn below_middle() {}\n\n",
+                    )],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Partially visible, far from excerpt",
+                editor_preview(
+                    text,
+                    vec![Point::row_range(0..2), Point::row_range(5..7)],
+                    Point::new(1, 14),
+                    vec![(
+                        Point::new(20, 4)..Point::new(20, 4),
+                        "let target = sixth + 1;\n    ",
+                    )],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Adjacent multi-edit cluster",
+                editor_preview(
+                    text,
+                    vec![
+                        Point::row_range(0..2),
+                        Point::row_range(4..8),
+                        Point::row_range(10..12),
+                    ],
+                    Point::new(6, 18),
+                    vec![
+                        (Point::new(6, 4)..Point::new(6, 4), "let count = 1;\n    "),
+                        (Point::new(7, 4)..Point::new(7, 4), "dbg!(count);\n    "),
+                    ],
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .child(case(
+                "Different file jump",
+                jump_preview(
+                    "fn main() {\n    work();\n}\n",
+                    "fn other() {\n    target();\n}\n",
+                    window,
+                    cx,
+                ),
+                cx,
+            ))
+            .into_any_element()
+    }
+}
+
 pub(super) enum EditPredictionSettings {
     Disabled,
     Enabled {

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -1,5 +1,5 @@
 use edit_prediction_types::{
-    EditPredictionDelegate, EditPredictionIconSet, EditPredictionRequestTrigger,
+    Direction, EditPredictionDelegate, EditPredictionIconSet, EditPredictionRequestTrigger,
     PredictedCursorPosition,
 };
 use futures::StreamExt;
@@ -10,7 +10,7 @@ use gpui::{
 use indoc::indoc;
 use language::EditPredictionsMode;
 use language::{Buffer, CodeLabel};
-use multi_buffer::{Anchor, MultiBufferSnapshot, ToPoint};
+use multi_buffer::{Anchor, MultiBufferSnapshot, PathKey, ToPoint};
 use project::{Completion, CompletionResponse, CompletionSource};
 use std::{
     ops::Range,
@@ -21,13 +21,14 @@ use std::{
         atomic::{self, AtomicUsize},
     },
 };
-use text::{Point, ToOffset};
+use text::{OffsetRangeExt, Point, ToOffset, ToPoint as TextToPoint};
 use ui::prelude::*;
 
 use crate::{
     AcceptEditPrediction, CodeContextMenu, CompletionContext, CompletionProvider, EditPrediction,
     EditPredictionKeybindAction, EditPredictionKeybindSurface, MenuEditPredictionsPolicy,
     MultiBuffer, ShowCompletions,
+    edit_prediction::EditPredictionJumpAction,
     editor_tests::{init_test, update_test_language_settings},
     test::{
         build_editor, editor_lsp_test_context::EditorLspTestContext,
@@ -518,6 +519,343 @@ async fn test_edit_prediction_jump_disabled_for_non_zed_providers(cx: &mut gpui:
                 }
             }
         }
+    });
+}
+
+#[gpui::test]
+async fn test_edit_prediction_fully_hidden_non_jump_provider_creates_no_prediction(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeNonZedEditPredictionDelegate::default());
+    assign_editor_completion_provider_non_zed(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        row 0
+        row ˇ1
+        row 2
+        row 3
+        row 4
+        row 5
+    "});
+    set_editor_excerpts(&mut cx, [Point::new(0, 0)..Point::new(2, 0)]);
+
+    propose_edits_non_zed(
+        &provider,
+        vec![(Point::new(4, 5)..Point::new(4, 5), " hidden")],
+        &mut cx,
+    );
+
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx.editor(|editor, _, _| {
+        assert!(editor.active_edit_prediction.is_none());
+    });
+}
+
+#[gpui::test]
+async fn test_edit_prediction_jump_expansion_preserves_unrelated_excerpts(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        row 0
+        row ˇ1
+        row 2
+        row 3
+        row 4
+        row 5
+        row 6
+        row 7
+        row 8
+        row 9
+        row 10
+        row 11
+    "});
+    set_editor_excerpts(
+        &mut cx,
+        [
+            Point::new(0, 0)..Point::new(2, 0),
+            Point::new(10, 0)..Point::new(11, 0),
+        ],
+    );
+
+    propose_edits(
+        &provider,
+        vec![(Point::new(4, 5)..Point::new(4, 5), " changed")],
+        &mut cx,
+    );
+
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    accept_completion(&mut cx);
+
+    let excerpt_rows = editor_excerpt_rows(&mut cx);
+    assert!(
+        excerpt_rows
+            .iter()
+            .any(|range| range.start <= 4 && range.end >= 4),
+        "expanded excerpt should include the hidden edit, got {excerpt_rows:?}"
+    );
+    assert!(
+        excerpt_rows
+            .iter()
+            .any(|range| range.start <= 10 && range.end >= 11),
+        "unrelated visible excerpt should be preserved, got {excerpt_rows:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_edit_prediction_cross_excerpt_visible_jump_only_moves_cursor(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        row 0
+        row ˇ1
+        row 2
+        row 3
+        row 4
+        row 5
+        row 6
+        row 7
+        row 8
+        row 9
+        row 10
+        row 11
+    "});
+    set_editor_excerpts(
+        &mut cx,
+        [
+            Point::new(0, 0)..Point::new(2, 0),
+            Point::new(10, 0)..Point::new(12, 0),
+        ],
+    );
+
+    let edit_location = Point::new(10, 5);
+    propose_edits(
+        &provider,
+        vec![(edit_location..edit_location, " changed")],
+        &mut cx,
+    );
+
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx.editor(|editor, _, cx| {
+        let Some(completion_state) = &editor.active_edit_prediction else {
+            panic!("editor has no active completion");
+        };
+        let EditPrediction::MoveWithin {
+            target,
+            accept_action: None,
+        } = &completion_state.completion
+        else {
+            panic!("expected visible cross-excerpt edit to produce a pure move completion");
+        };
+
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let (target, target_snapshot) = snapshot
+            .anchor_to_buffer_anchor(*target)
+            .expect("target should resolve to buffer anchor");
+        assert_eq!(target.to_point(&target_snapshot), edit_location);
+    });
+
+    let excerpt_rows_before = editor_excerpt_rows(&mut cx);
+    accept_completion(&mut cx);
+
+    cx.editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let cursor = editor.selections.newest_anchor().head();
+        let (cursor, cursor_snapshot) = snapshot
+            .anchor_to_buffer_anchor(cursor)
+            .expect("cursor should resolve to buffer anchor");
+        assert_eq!(cursor.to_point(&cursor_snapshot), edit_location);
+    });
+    assert_eq!(editor_excerpt_rows(&mut cx), excerpt_rows_before);
+}
+
+#[gpui::test]
+async fn test_edit_prediction_jump_expansion_preserves_sorted_path_key(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        row 0
+        row ˇ1
+        row 2
+        row 3
+        row 4
+        row 5
+        row 6
+    "});
+
+    let sorted_path = PathKey::sorted(1);
+    set_editor_excerpts_for_path(
+        &mut cx,
+        sorted_path.clone(),
+        [Point::new(0, 0)..Point::new(2, 0)],
+    );
+    assert_eq!(
+        editor_single_buffer_path(&mut cx),
+        Some(sorted_path.clone())
+    );
+
+    propose_edits(
+        &provider,
+        vec![(Point::new(4, 5)..Point::new(4, 5), " changed")],
+        &mut cx,
+    );
+
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    accept_completion(&mut cx);
+
+    assert_eq!(editor_single_buffer_path(&mut cx), Some(sorted_path));
+    let excerpt_rows = editor_excerpt_rows(&mut cx);
+    assert!(
+        excerpt_rows
+            .iter()
+            .any(|range| range.start <= 4 && range.end >= 4),
+        "expanded excerpt should include the hidden edit, got {excerpt_rows:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_edit_prediction_jump_uses_hidden_edit_distance(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        row 0
+        row ˇ1
+        row 2
+        row 3
+        row 4
+        row 5
+        row 6
+        row 7
+        row 8
+        row 9
+        row 10
+        row 11
+        row 12
+        row 13
+        row 14
+        row 15
+        row 16
+        row 17
+        row 18
+        row 19
+        row 20
+        row 21
+        row 22
+        row 23
+        row 24
+        row 25
+        row 26
+        row 27
+        row 28
+        row 29
+        row 30
+        row 31
+    "});
+    set_editor_excerpts(
+        &mut cx,
+        [
+            Point::new(0, 0)..Point::new(2, 0),
+            Point::new(30, 0)..Point::new(31, 0),
+        ],
+    );
+
+    propose_edits(
+        &provider,
+        vec![
+            (Point::new(1, 5)..Point::new(1, 5), " visible"),
+            (Point::new(18, 6)..Point::new(18, 6), " hidden"),
+        ],
+        &mut cx,
+    );
+
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx.editor(|editor, _, _| {
+        let Some(completion_state) = &editor.active_edit_prediction else {
+            panic!("editor has no active completion");
+        };
+        if let EditPrediction::MoveWithin {
+            accept_action: Some(EditPredictionJumpAction::Open { target, snapshot }),
+            ..
+        } = &completion_state.completion
+        {
+            assert_eq!(target.to_point(snapshot), Point::new(18, 6));
+        } else {
+            panic!("expected hidden edit beyond threshold to open on accept");
+        };
+    });
+}
+
+#[gpui::test]
+async fn test_edit_prediction_hidden_edit_direction_uses_unsnapped_target(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state(indoc! {"
+        row 0
+        row 1
+        row 2
+        row 3
+        row 4
+        ˇrow 5
+        row 6
+        row 7
+    "});
+    set_editor_excerpts(&mut cx, [Point::new(5, 0)..Point::new(7, 0)]);
+
+    propose_edits(
+        &provider,
+        vec![(Point::new(4, 0)..Point::new(4, 0), "hidden above\n")],
+        &mut cx,
+    );
+
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx.editor(|editor, _, cx| {
+        let Some(completion_state) = &editor.active_edit_prediction else {
+            panic!("editor has no active completion");
+        };
+        let EditPrediction::MoveWithin {
+            target,
+            accept_action: Some(accept_action),
+        } = &completion_state.completion
+        else {
+            panic!("expected hidden edit to produce a move completion");
+        };
+
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let (snapped_target, snapped_target_snapshot) = snapshot
+            .anchor_to_buffer_anchor(*target)
+            .expect("target should resolve to buffer anchor");
+        assert_eq!(
+            snapped_target.to_point(&snapped_target_snapshot),
+            Point::new(5, 0)
+        );
+        assert!(matches!(
+            accept_action.hidden_edit_direction(*target, &snapshot, cx),
+            Some(Direction::Prev)
+        ));
     });
 }
 
@@ -1492,6 +1830,56 @@ async fn test_discard_clears_delegate_completion(cx: &mut gpui::TestAppContext) 
 fn accept_completion(cx: &mut EditorTestContext) {
     cx.update_editor(|editor, window, cx| {
         editor.accept_edit_prediction(&crate::AcceptEditPrediction, window, cx)
+    })
+}
+
+fn set_editor_excerpts<const COUNT: usize>(
+    cx: &mut EditorTestContext,
+    ranges: [Range<Point>; COUNT],
+) {
+    let path = cx.multibuffer(|multi_buffer, cx| {
+        let Some(buffer) = multi_buffer.as_singleton() else {
+            panic!("expected a singleton buffer");
+        };
+        PathKey::for_buffer(&buffer, cx)
+    });
+    set_editor_excerpts_for_path(cx, path, ranges);
+}
+
+fn set_editor_excerpts_for_path<const COUNT: usize>(
+    cx: &mut EditorTestContext,
+    path: PathKey,
+    ranges: [Range<Point>; COUNT],
+) {
+    cx.update_multibuffer(|multi_buffer, cx| {
+        let Some(buffer) = multi_buffer.as_singleton() else {
+            panic!("expected a singleton buffer");
+        };
+        multi_buffer.set_excerpts_for_path(path, buffer, ranges, 0, cx);
+    });
+}
+
+fn editor_single_buffer_path(cx: &mut EditorTestContext) -> Option<PathKey> {
+    cx.multibuffer(|multi_buffer, cx| {
+        let snapshot = multi_buffer.snapshot(cx);
+        let buffer = snapshot.as_singleton()?;
+        snapshot.path_for_buffer(buffer.remote_id()).cloned()
+    })
+}
+
+fn editor_excerpt_rows(cx: &mut EditorTestContext) -> Vec<Range<u32>> {
+    cx.multibuffer(|multi_buffer, cx| {
+        let snapshot = multi_buffer.snapshot(cx);
+        let Some(buffer) = snapshot.as_singleton() else {
+            panic!("expected a singleton buffer");
+        };
+        snapshot
+            .excerpts_for_buffer(buffer.remote_id())
+            .map(|excerpt| {
+                let range = excerpt.context.to_point(&buffer);
+                range.start.row..range.end.row
+            })
+            .collect()
     })
 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -94,6 +94,11 @@ pub(crate) use edit_prediction::{
 pub(crate) use edit_prediction::{
     EditPredictionKeybindAction, EditPredictionKeybindSurface, edit_prediction_edit_text,
 };
+#[cfg(any(test, feature = "test-support"))]
+pub use edit_prediction::{
+    EditPredictionMultiBufferPreviewCase, edit_prediction_multibuffer_preview_cases,
+    edit_prediction_multibuffer_preview_editor,
+};
 pub use edit_prediction_types::Direction;
 pub use edit_prediction_types::EditPredictionRequestTrigger;
 pub use editor_settings::{

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -103,8 +103,8 @@ use {
     feature_flags::FeatureFlagAppExt as _,
     git_ui::project_diff::ProjectDiff,
     gpui::{
-        App, AppContext as _, Bounds, Entity, KeyBinding, Modifiers, VisualTestAppContext,
-        WindowBounds, WindowHandle, WindowOptions, point, px, size,
+        App, AppContext as _, Bounds, Entity, IntoElement, KeyBinding, Modifiers, Render,
+        VisualTestAppContext, WindowBounds, WindowHandle, WindowOptions, point, px, size,
     },
     image::RgbaImage,
     project::{AgentId, Project},
@@ -231,6 +231,20 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
             editor::actions::ToggleBreakpoint,
             Some("Editor"),
         )]);
+        cx.bind_keys([
+            KeyBinding::new(
+                "alt-tab",
+                editor::actions::AcceptEditPrediction,
+                Some("Editor && edit_prediction"),
+            ),
+            KeyBinding::new(
+                "tab",
+                editor::actions::AcceptEditPrediction,
+                Some(
+                    "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
+                ),
+            ),
+        ]);
 
         // Disable agent notifications during visual tests to avoid popup windows
         agent_settings::AgentSettings::override_global(
@@ -547,6 +561,26 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
         }
         Err(e) => {
             eprintln!("✗ diff_review_button: FAILED - {}", e);
+            failed += 1;
+        }
+    }
+
+    // Run Test: Edit prediction multi-buffer jump visual tests
+    println!(
+        "\n--- Test: edit_prediction_multibuffer_jumps ({} variants) ---",
+        editor::edit_prediction_multibuffer_preview_cases().len()
+    );
+    match run_edit_prediction_multibuffer_jump_visual_tests(&mut cx, update_baseline) {
+        Ok(TestResult::Passed) => {
+            println!("✓ edit_prediction_multibuffer_jumps: PASSED");
+            passed += 1;
+        }
+        Ok(TestResult::BaselineUpdated(_)) => {
+            println!("✓ edit_prediction_multibuffer_jumps: Baselines updated");
+            updated += 1;
+        }
+        Err(e) => {
+            eprintln!("✗ edit_prediction_multibuffer_jumps: FAILED - {}", e);
             failed += 1;
         }
     }
@@ -3266,6 +3300,194 @@ fn run_thread_item_icon_decorations_visual_tests(
     }
 
     Ok(test_result)
+}
+
+#[cfg(target_os = "macos")]
+struct EditPredictionMultiBufferVisualTestView {
+    editor: Entity<editor::Editor>,
+}
+
+#[cfg(target_os = "macos")]
+impl Render for EditPredictionMultiBufferVisualTestView {
+    fn render(
+        &mut self,
+        _window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) -> impl IntoElement {
+        use ui::prelude::*;
+
+        div()
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .child(self.editor.clone())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_edit_prediction_multibuffer_jump_visual_tests(
+    cx: &mut VisualTestAppContext,
+    update_baseline: bool,
+) -> Result<TestResult> {
+    let mut has_baseline_update = None;
+    let mut first_error = None;
+
+    for preview_case in editor::edit_prediction_multibuffer_preview_cases() {
+        println!("  Capturing {}", preview_case.title);
+        let bounds = Bounds {
+            origin: point(px(0.0), px(0.0)),
+            size: size(px(780.0), px(260.0)),
+        };
+        let window = match cx.update(|cx| {
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    focus: false,
+                    show: false,
+                    ..Default::default()
+                },
+                |window, cx| {
+                    let editor = editor::edit_prediction_multibuffer_preview_editor(
+                        preview_case,
+                        window,
+                        cx,
+                    );
+                    cx.new(|_| EditPredictionMultiBufferVisualTestView { editor })
+                },
+            )
+        }) {
+            Ok(window) => window,
+            Err(error) => {
+                if first_error.is_none() {
+                    first_error =
+                        Some(error.context(format!("Failed to open {}", preview_case.title)));
+                }
+                continue;
+            }
+        };
+
+        for _ in 0..5 {
+            cx.advance_clock(Duration::from_millis(100));
+            cx.run_until_parked();
+        }
+
+        let result = run_visual_test(preview_case.test_name, window.into(), cx, update_baseline);
+
+        match result {
+            Ok(TestResult::Passed) => {}
+            Ok(TestResult::BaselineUpdated(path)) => {
+                has_baseline_update = Some(path);
+            }
+            Err(error) => {
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+
+        if preview_case.test_name == "edit_prediction_multibuffer_top_excerpt_expands_upward" {
+            let before_accept_result = run_visual_test(
+                "edit_prediction_multibuffer_top_excerpt_expands_upward_before_accept",
+                window.into(),
+                cx,
+                update_baseline,
+            );
+
+            match before_accept_result {
+                Ok(TestResult::Passed) => {}
+                Ok(TestResult::BaselineUpdated(path)) => {
+                    has_baseline_update = Some(path);
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+
+            window
+                .update(cx, |view, window, cx| {
+                    view.editor.update(cx, |editor, cx| {
+                        editor.accept_edit_prediction(
+                            &editor::actions::AcceptEditPrediction,
+                            window,
+                            cx,
+                        );
+                    });
+                })
+                .context("Failed to accept top excerpt edit prediction")?;
+            cx.run_until_parked();
+
+            let after_jump_result = run_visual_test(
+                "edit_prediction_multibuffer_top_excerpt_expands_upward_after_jump",
+                window.into(),
+                cx,
+                update_baseline,
+            );
+
+            match after_jump_result {
+                Ok(TestResult::Passed) => {}
+                Ok(TestResult::BaselineUpdated(path)) => {
+                    has_baseline_update = Some(path);
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+
+            window
+                .update(cx, |view, window, cx| {
+                    view.editor.update(cx, |editor, cx| {
+                        editor.accept_edit_prediction(
+                            &editor::actions::AcceptEditPrediction,
+                            window,
+                            cx,
+                        );
+                    });
+                })
+                .context("Failed to accept expanded top excerpt edit prediction")?;
+            cx.run_until_parked();
+
+            let after_accept_result = run_visual_test(
+                "edit_prediction_multibuffer_top_excerpt_expands_upward_after_accept",
+                window.into(),
+                cx,
+                update_baseline,
+            );
+
+            match after_accept_result {
+                Ok(TestResult::Passed) => {}
+                Ok(TestResult::BaselineUpdated(path)) => {
+                    has_baseline_update = Some(path);
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+        }
+
+        cx.update_window(window.into(), |_, window, _cx| {
+            window.remove_window();
+        })
+        .log_err();
+        cx.run_until_parked();
+    }
+
+    for _ in 0..15 {
+        cx.advance_clock(Duration::from_millis(100));
+        cx.run_until_parked();
+    }
+
+    if let Some(error) = first_error {
+        Err(error)
+    } else if let Some(path) = has_baseline_update {
+        Ok(TestResult::BaselineUpdated(path))
+    } else {
+        Ok(TestResult::Passed)
+    }
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
When an edit prediction's edits fall outside (or partially outside) the visible excerpts of a multi-buffer, we previously discarded the prediction entirely. This PR classifies such predictions as jumps and shows the jump indicator with a directional arrow. On accept:

- If every hidden edit is within 10 rows of an existing excerpt for that buffer, the excerpts are expanded permanently and additively (existing excerpts and path keys are preserved), the cursor moves to the edit, and the prediction then renders normally (inline preview in eager mode, subtle indicator in subtle mode) so a second accept applies it.
- Otherwise, the target buffer is opened in a separate editor at the edit position.

<details>
<summary>Screenshots</summary>

A prediction targets a hidden edit above the excerpt, so the jump pill appears:

<img width="1560" height="520" alt="edit_prediction_multibuffer_top_excerpt_expands_upward_before_accept" src="https://github.com/user-attachments/assets/c63b0e16-6a2d-4ec1-9120-aef98ff6c06a" />

Accepting expands the excerpt permanently, moves the cursor, and the prediction renders as a normal inline preview:

<img width="1560" height="520" alt="edit_prediction_multibuffer_top_excerpt_expands_upward_after_jump" src="https://github.com/user-attachments/assets/e77fc53e-b09c-468f-9768-1c917e3759fe" />

Accepting again applies the edit:

<img width="1560" height="520" alt="edit_prediction_multibuffer_top_excerpt_expands_upward_after_accept" src="https://github.com/user-attachments/assets/d7405cdb-f3fe-4deb-9eee-2c65e11f8ec6" />

</details>

Also included:

- A `MultiBuffer Jumps` component preview (new `Edit Predictions` component scope) rendering real editors for each state: fully visible hunk, top/bottom/middle excerpt expansion, boundary-line jump, far-from-excerpt open-on-accept, adjacent multi-edit cluster, and different-file jump.
- Visual regression tests covering the same scenarios plus the jump-accept flow (before / after jump / after apply) via `zed_visual_test_runner`, sharing the preview case setup.
- Jump indicator fixes surfaced by the visual tests: end-of-line jump pills now always carry an up/down arrow computed in display coordinates (previously arrows were driven by horizontal overflow and buffer-point rows, which are wrong across excerpts, and could point the wrong way when the cursor sat on the boundary-snapped line), the `MoveOutside` pill no longer overlaps the excerpt header/scrollbar, and pills are vertically centered on their line.

Release Notes:

- Improved edit predictions in multi-buffers: predictions that make edits just outside of an excerpt are no longer discarded. Instead a jump indicator is shown, which expands the excerpt to preview the prediction upon hitting `tab`