### PR TITLE
Enable CLI socket for LocalPath builds on macOS

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1357,6 +1357,20 @@ mod mac_os {
                 }
 
                 Self::LocalPath { executable, .. } => {
+                    // Check if a running instance is listening on the socket (like Linux does).
+                    let data_dir = user_data_dir
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| paths::data_dir().clone());
+                    let sock_path = data_dir.join(format!(
+                        "zed-{}.sock",
+                        *release_channel::RELEASE_CHANNEL_NAME
+                    ));
+                    let sock = std::os::unix::net::UnixDatagram::unbound()?;
+                    if sock.connect(&sock_path).is_ok() {
+                        sock.send(url.as_bytes())?;
+                        return Ok(());
+                    }
+
                     let executable_parent = executable
                         .parent()
                         .with_context(|| format!("Executable {executable:?} path has no parent"))?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -848,6 +848,28 @@ fn prompt_open_behavior() -> Option<cli::CliBehaviorSetting> {
     })
 }
 
+/// Try to send a URL to a running Zed instance via its Unix socket.
+/// Returns `true` if successful, `false` if no instance is listening or on any error.
+#[cfg(unix)]
+fn try_connect_to_running_instance(url: &str, user_data_dir: Option<&str>) -> bool {
+    use std::os::unix::net::UnixDatagram;
+
+    let data_dir = user_data_dir
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| paths::data_dir().clone());
+    let sock_path = data_dir.join(format!(
+        "zed-{}.sock",
+        *release_channel::RELEASE_CHANNEL_NAME
+    ));
+    let Ok(sock) = UnixDatagram::unbound() else {
+        return false;
+    };
+    if sock.connect(&sock_path).is_err() {
+        return false;
+    }
+    sock.send(url.as_bytes()).is_ok()
+}
+
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 mod linux {
     use std::{
@@ -912,19 +934,8 @@ mod linux {
         }
 
         fn launch(&self, ipc_url: String, user_data_dir: Option<&str>) -> anyhow::Result<()> {
-            let data_dir = user_data_dir
-                .map(PathBuf::from)
-                .unwrap_or_else(|| paths::data_dir().clone());
-
-            let sock_path = data_dir.join(format!(
-                "zed-{}.sock",
-                *release_channel::RELEASE_CHANNEL_NAME
-            ));
-            let sock = UnixDatagram::unbound()?;
-            if sock.connect(&sock_path).is_err() {
+            if !crate::try_connect_to_running_instance(&ipc_url, user_data_dir) {
                 self.boot_background(ipc_url, user_data_dir)?;
-            } else {
-                sock.send(ipc_url.as_bytes())?;
             }
             Ok(())
         }
@@ -1358,16 +1369,7 @@ mod mac_os {
 
                 Self::LocalPath { executable, .. } => {
                     // Check if a running instance is listening on the socket (like Linux does).
-                    let data_dir = user_data_dir
-                        .map(PathBuf::from)
-                        .unwrap_or_else(|| paths::data_dir().clone());
-                    let sock_path = data_dir.join(format!(
-                        "zed-{}.sock",
-                        *release_channel::RELEASE_CHANNEL_NAME
-                    ));
-                    let sock = std::os::unix::net::UnixDatagram::unbound()?;
-                    if sock.connect(&sock_path).is_ok() {
-                        sock.send(url.as_bytes())?;
+                    if crate::try_connect_to_running_instance(&url, user_data_dir) {
                         return Ok(());
                     }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -377,6 +377,9 @@ fn main() {
         #[cfg(target_os = "macos")]
         {
             use zed::mac_only_instance::*;
+            // Also listen on a Unix socket so the CLI can connect to a running
+            // LocalPath instance (not just .app bundles via LSOpenFromURLSpec).
+            let _ = crate::zed::listen_for_cli_connections(open_listener.clone());
             ensure_only_instance() != IsOnlyInstance::Yes
         }
     };

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -420,7 +420,7 @@ impl OpenListener {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 pub fn listen_for_cli_connections(opener: OpenListener) -> Result<()> {
     use release_channel::RELEASE_CHANNEL_NAME;
     use std::os::unix::net::UnixDatagram;


### PR DESCRIPTION
# enable CLI socket for LocalPath builds on macOS

## Summary

When building Zed from source on macOS and using the CLI shim with `--zed /path/to/binary`, the `-a` (add to workspace) flag always spawns a new process instead of connecting to the running instance. This is because `listen_for_cli_connections` was gated to Linux/FreeBSD only, and the macOS `LocalPath` launch path had no socket check.

This extends the existing Unix socket mechanism to macOS so the CLI can connect to a running LocalPath instance, matching the Linux behavior.

## Changes

- `open_listener.rs`: Expand `listen_for_cli_connections` cfg gate to include `target_os = "macos"`
- `main.rs` (zed): Call `listen_for_cli_connections` in the macOS single-instance block
- `main.rs` (cli): Add socket check in macOS `Bundle::LocalPath::launch` before spawning

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] ~~The content is consistent with the UI/UX checklist~~ (no UI changes)
- [ ] Tests cover the new/changed behavior — the existing Linux socket path is also untested; happy to try and add an integration test if requested. I did test locally and observed that doing `zed -a ...` no longer starts a new process/window.
- [x] Performance impact has been considered and is acceptable (single socket connect attempt on launch)

Release Notes:

- Fixed CLI `-a`/`--add` flag spawning a new window instead of adding to the existing instance on macOS when using `--zed` with a local binary path.

