### PR TITLE
extension_host: Fix cross-device extension installs

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -117,6 +117,7 @@ pub struct ExtensionStore {
     pub reload_tx: UnboundedSender<Option<Arc<str>>>,
     pub reload_complete_senders: Vec<oneshot::Sender<()>>,
     pub installed_dir: PathBuf,
+    pub staging_dir: PathBuf,
     pub outstanding_operations: BTreeMap<Arc<str>, ExtensionOperation>,
     pub index_path: PathBuf,
     pub modified_extensions: HashSet<Arc<str>>,
@@ -246,6 +247,7 @@ impl ExtensionStore {
         let work_dir = extensions_dir.join("work");
         let build_dir = build_dir.unwrap_or_else(|| extensions_dir.join("build"));
         let installed_dir = extensions_dir.join("installed");
+        let staging_dir = extensions_dir.join("staging");
         let index_path = extensions_dir.join("index.json");
 
         let (reload_tx, mut reload_rx) = unbounded();
@@ -254,6 +256,7 @@ impl ExtensionStore {
             proxy: extension_host_proxy.clone(),
             extension_index: Default::default(),
             installed_dir,
+            staging_dir,
             index_path,
             builder: Arc::new(ExtensionBuilder::new(builder_client, build_dir)),
             outstanding_operations: Default::default(),
@@ -708,6 +711,7 @@ impl ExtensionStore {
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
         let extension_dir = self.installed_dir.join(extension_id.as_ref());
+        let staging_dir = self.staging_dir.clone();
         let http_client = self.http_client.clone();
         let fs = self.fs.clone();
 
@@ -764,7 +768,12 @@ impl ExtensionStore {
                     )
                 };
 
-                match tempfile::tempdir_in(paths::temp_dir()).or_else(|_| tempfile::tempdir()) {
+                let temp_dir = fs
+                    .create_dir(&staging_dir)
+                    .await
+                    .and_then(|()| tempfile::tempdir_in(&staging_dir).map_err(Into::into));
+
+                match temp_dir {
                     Ok(temp_dir) => {
                         archive.unpack(temp_dir.path()).await?;
                         remove_dir().await?;


### PR DESCRIPTION
This fixes extension installation when Zed's cache directory and data directory are on different filesystems or mount points. On my Linux system, `~/.cache` is a separate btrfs subvolume so it can be excluded from system snapshots, while `~/.local/share` is on the main home subvolume. Installing extensions failed because extension archives were unpacked under `paths::temp_dir()` and then renamed into the installed extensions directory.

The error showed up as:
```text
2026-05-11T17:08:57+02:00 INFO  [extension_host] installing extension dockerfile latest version
2026-05-11T17:08:58+02:00 ERROR [crates/extension_host/src/extension_host.rs:842] Invalid cross-device link (os error 18)
```

Linux rename(2) returns EXDEV (os error 18) across filesystem boundaries. This is the same class of issue addressed for settings writes in #8437 and later generalized in 2b3e453d2f3abaaa47c9def4ce5fc63fc017af03. The regression was introduced by #54355, which made extension updates safer by unpacking into a temporary directory before renaming into place.

This change creates the temporary unpack directory inside the installed extensions directory instead. That keeps the final rename on the same filesystem as the destination while preserving the existing direct-unpack fallback if creating the temporary directory fails. A possible alternative would be to create a dedicated temporary install directory under `extensions/`, alongside `extensions/installed/`. I chose, however, to keep the temporary directory directly beside the final destination because that matches the destination-local temp-file approach used in the earlier fixes referenced above.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

No separate issue. The change is small and includes the reproduction context here. I did not add a regression test because the failure depends on cache and data directories being on different filesystems/subvolumes; this was verified manually by reproducing EXDEV when installing extensions with `~/.cache` on a separate btrfs subvolume, then confirming the patch fixes extension installation.

Release Notes:

- Fixed installing extensions when Zed's cache and data directories are on different filesystems.