### PR TITLE
ci: Improve nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,7 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 1 }
+failure-output = "immediate-final"
+retries = 1
 
 [test-groups]
 sequential-db-tests = { max-threads = 1 }


### PR DESCRIPTION
As noted in https://nexte.st/docs/configuration/reference/?h=list+wrapper#default-configuration, `immediate-final` is the recommended setting for `failure-output` for large test suites, as is definitely the case for this repository.

Furthermore, allow one flaky run for the ocasionally flaky tests that we do have. We will add some tracking for which tests are flaky at a later point. 

Release Notes:

- N/A
