### PR TITLE
Scan and load agent skills (without surfacing them yet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,14 +342,10 @@ dependencies = [
 name = "agent_skills"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "fs",
  "futures 0.3.32",
  "gpui",
  "paths",
- "serde",
- "serde_json",
- "serde_yaml_ng",
  "util",
 ]
 
@@ -16041,19 +16037,6 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.11.4",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.11.4",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,10 +342,14 @@ dependencies = [
 name = "agent_skills"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "fs",
  "futures 0.3.32",
  "gpui",
  "paths",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
  "util",
 ]
 
@@ -16037,6 +16041,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.11.4",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.11.4",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,14 @@ dependencies = [
 name = "agent_skills"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "fs",
+ "futures 0.3.32",
+ "gpui",
  "paths",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
  "util",
 ]
 
@@ -16034,6 +16041,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.11.4",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.11.4",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,6 +712,7 @@ schemars = { version = "1.0", features = ["indexmap2"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0.221", features = ["derive", "rc"] }
 serde_json = { version = "1.0.144", features = ["preserve_order", "raw_value"] }
+serde_yaml_ng = "0.10"
 serde_json_lenient = { version = "0.2", features = [
     "preserve_order",
     "raw_value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -718,7 +718,6 @@ serde_json_lenient = { version = "0.2", features = [
 ] }
 serde_path_to_error = "0.1.17"
 serde_urlencoded = "0.7"
-serde_yaml_ng = "0.10"
 sha2 = "0.10"
 shellexpand = "3.1"
 shlex = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -718,6 +718,7 @@ serde_json_lenient = { version = "0.2", features = [
 ] }
 serde_path_to_error = "0.1.17"
 serde_urlencoded = "0.7"
+serde_yaml_ng = "0.10"
 sha2 = "0.10"
 shellexpand = "3.1"
 shlex = "1.3.0"

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -29,8 +29,8 @@ use acp_thread::{
 };
 use agent_client_protocol::schema as acp;
 use agent_skills::{
-    Skill, SkillLoadError, SkillScopeId, SkillSource, global_skills_dir,
-    load_skills_from_directory, project_skills_relative_path,
+    Skill, SkillScopeId, SkillSource, global_skills_dir, load_skills_from_directory,
+    project_skills_relative_path,
 };
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Utc};
@@ -72,28 +72,10 @@ pub struct RulesLoadingError {
     pub message: SharedString,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct SkillLoadingError {
-    pub project_id: EntityId,
-    pub path: PathBuf,
-    pub message: SharedString,
-}
-
-/// Emitted whenever the set of skill loading errors for a project changes.
-/// The `errors` field is the full replacement list; subscribers should treat
-/// it as a snapshot rather than appending. An empty `errors` list means all
-/// previously-reported errors have been resolved.
-#[derive(Clone, Debug)]
-pub struct SkillLoadingErrorsUpdated {
-    pub project_id: EntityId,
-    pub errors: Vec<SkillLoadingError>,
-}
-
 struct ProjectState {
     project: Entity<Project>,
     project_context: Entity<ProjectContext>,
     skills: Arc<Vec<Skill>>,
-    skill_loading_errors: Vec<SkillLoadingError>,
     project_context_needs_refresh: watch::Sender<()>,
     _maintain_project_context: Task<Result<()>>,
     context_server_registry: Entity<ContextServerRegistry>,
@@ -313,8 +295,6 @@ enum SkillsState {
     /// back to `Idle` if the watched directory itself is removed.
     Watching,
 }
-
-impl gpui::EventEmitter<SkillLoadingErrorsUpdated> for NativeAgent {}
 
 static RULES_FILE_REL_PATHS: LazyLock<Vec<Arc<RelPath>>> = LazyLock::new(|| {
     RULES_FILE_NAMES
@@ -664,7 +644,6 @@ impl NativeAgent {
                 project,
                 project_context,
                 skills: Arc::new(Vec::new()),
-                skill_loading_errors: Vec::new(),
                 project_context_needs_refresh: project_context_needs_refresh_tx,
                 _maintain_project_context: cx.spawn(async move |this, cx| {
                     Self::maintain_project_context(
@@ -706,34 +685,11 @@ impl NativeAgent {
                     cx,
                 ))
             })??;
-            let (project_context, skills, skill_errors) = task.await;
+            let (project_context, skills) = task.await;
             let skills = Arc::new(skills);
-            let skill_loading_errors: Vec<SkillLoadingError> = skill_errors
-                .into_iter()
-                .map(|skill_error| SkillLoadingError {
-                    project_id,
-                    path: skill_error.path,
-                    message: skill_error.message.into(),
-                })
-                .collect();
             this.update(cx, |this, cx| {
-                // Only emit SkillLoadingErrorsUpdated when the error list
-                // actually changed. Refreshes happen frequently (prompt-store
-                // updates, rules-file edits, worktree events, trust-state
-                // changes), and re-emitting an unchanged list causes the UI
-                // to redisplay errors the user has already dismissed.
-                // Transitions from non-empty to empty still count as a change,
-                // so subscribers continue to receive an empty list to clear
-                // previously-displayed errors when they get resolved.
-                let errors_changed = this
-                    .projects
-                    .get(&project_id)
-                    .map(|state| state.skill_loading_errors != skill_loading_errors)
-                    .unwrap_or(true);
-
                 if let Some(state) = this.projects.get_mut(&project_id) {
                     state.skills = skills;
-                    state.skill_loading_errors = skill_loading_errors.clone();
                     state
                         .project_context
                         .update(cx, |current_project_context, cx| {
@@ -741,17 +697,10 @@ impl NativeAgent {
                             cx.notify();
                         });
                 }
-                if errors_changed {
-                    cx.emit(SkillLoadingErrorsUpdated {
-                        project_id,
-                        errors: skill_loading_errors,
-                    });
-                }
                 // Skills appear in the slash-command list, so a change in
                 // the loaded skills needs to be pushed out to active sessions.
                 // This runs unconditionally because MCP prompts (also part of
-                // the available commands) can change without affecting the
-                // skill error list.
+                // the available commands) can change as well.
                 this.update_available_commands_for_project(project_id, cx);
             })?;
         }
@@ -764,7 +713,7 @@ impl NativeAgent {
         prompt_store: Option<&Entity<PromptStore>>,
         fs: Arc<dyn Fs>,
         cx: &mut App,
-    ) -> Task<(ProjectContext, Vec<Skill>, Vec<SkillLoadError>)> {
+    ) -> Task<(ProjectContext, Vec<Skill>)> {
         let worktrees = project.read(cx).visible_worktrees(cx).collect::<Vec<_>>();
         let worktree_tasks = worktrees
             .iter()
@@ -804,49 +753,49 @@ impl NativeAgent {
         let trusted_worktrees = TrustedWorktrees::try_get_global(cx);
         let worktree_store = project.read(cx).worktree_store();
         let project_skills_task = if skills_enabled {
-            let project_skills_futures: Vec<
-                futures::future::BoxFuture<'static, Vec<Result<Skill, SkillLoadError>>>,
-            > = worktrees
-                .iter()
-                .filter_map(|worktree| {
-                    let worktree_id = worktree.read(cx).id();
-                    let is_trusted = trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
-                        trusted_worktrees.update(cx, |trusted_worktrees, cx| {
-                            trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
-                        })
-                    });
-                    if !is_trusted {
-                        return None;
-                    }
-                    let worktree_snapshot = worktree.read(cx);
-                    let abs_path = worktree_snapshot.abs_path();
-                    let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
-                    // Capture scan_complete *before* spawning so we don't have to re-borrow
-                    // the worktree from inside the async task (which would require a cx).
-                    let scan_complete = worktree_snapshot
-                        .as_local()
-                        .map(|local| local.scan_complete());
-                    let skills_dir = abs_path.join(project_skills_relative_path());
-                    let fs = fs.clone();
-                    Some(
-                        async move {
-                            if let Some(scan_complete) = scan_complete {
-                                scan_complete.await;
-                            }
-                            load_skills_from_directory(
-                                &fs,
-                                &skills_dir,
-                                SkillSource::ProjectLocal {
-                                    worktree_id: SkillScopeId(worktree_id.to_usize()),
-                                    worktree_root_name,
-                                },
-                            )
-                            .await
+            let project_skills_futures: Vec<futures::future::BoxFuture<'static, Vec<Skill>>> =
+                worktrees
+                    .iter()
+                    .filter_map(|worktree| {
+                        let worktree_id = worktree.read(cx).id();
+                        let is_trusted =
+                            trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
+                                trusted_worktrees.update(cx, |trusted_worktrees, cx| {
+                                    trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
+                                })
+                            });
+                        if !is_trusted {
+                            return None;
                         }
-                        .boxed(),
-                    )
-                })
-                .collect();
+                        let worktree_snapshot = worktree.read(cx);
+                        let abs_path = worktree_snapshot.abs_path();
+                        let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
+                        // Capture scan_complete *before* spawning so we don't have to re-borrow
+                        // the worktree from inside the async task (which would require a cx).
+                        let scan_complete = worktree_snapshot
+                            .as_local()
+                            .map(|local| local.scan_complete());
+                        let skills_dir = abs_path.join(project_skills_relative_path());
+                        let fs = fs.clone();
+                        Some(
+                            async move {
+                                if let Some(scan_complete) = scan_complete {
+                                    scan_complete.await;
+                                }
+                                load_skills_from_directory(
+                                    &fs,
+                                    &skills_dir,
+                                    SkillSource::ProjectLocal {
+                                        worktree_id: SkillScopeId(worktree_id.to_usize()),
+                                        worktree_root_name,
+                                    },
+                                )
+                                .await
+                            }
+                            .boxed(),
+                        )
+                    })
+                    .collect();
             cx.background_spawn(async move { future::join_all(project_skills_futures).await })
         } else {
             Task::ready(Vec::new())
@@ -900,14 +849,20 @@ impl NativeAgent {
                 })
                 .collect::<Vec<_>>();
 
-            // Load and merge skills
+            // Concatenate global skills followed by each worktree's
+            // project-local skills. `find_skill_files`'s sort plus this
+            // iteration order gives a deterministic-enough ordering for
+            // our needs (parsing and conflict resolution happen in a
+            // follow-up PR).
             let global_skills = global_skills_task.await;
             let project_skills_results = project_skills_task.await;
-            let (skills, skill_errors) =
-                merge_skills(global_skills, project_skills_results.into_iter().flatten());
+            let mut skills: Vec<Skill> = global_skills;
+            for project_skills in project_skills_results {
+                skills.extend(project_skills);
+            }
 
             let project_context = ProjectContext::new(worktrees, default_user_rules);
-            (project_context, skills, skill_errors)
+            (project_context, skills)
         })
     }
 
@@ -2556,68 +2511,6 @@ impl TerminalHandle for AcpTerminalHandle {
     }
 }
 
-/// Merge global and project-local skills.
-/// Project-local skills override global skills with the same name.
-fn merge_skills(
-    global: Vec<Result<Skill, SkillLoadError>>,
-    project: impl Iterator<Item = Result<Skill, SkillLoadError>>,
-) -> (Vec<Skill>, Vec<SkillLoadError>) {
-    let mut skills = Vec::new();
-    let mut errors = Vec::new();
-    let mut seen_names: HashMap<String, (usize, SkillSource, PathBuf)> = HashMap::default();
-
-    for result in global.into_iter().chain(project) {
-        match result {
-            Ok(skill) => {
-                if let Some((existing_index, existing_source, existing_path)) =
-                    seen_names.get(&skill.name).cloned()
-                {
-                    match (&existing_source, &skill.source) {
-                        (SkillSource::Global, SkillSource::ProjectLocal { .. }) => {
-                            log::warn!(
-                                "Project skill '{}' at '{}' overrides global skill at '{}'",
-                                skill.name,
-                                skill.skill_file_path.display(),
-                                existing_path.display()
-                            );
-                            seen_names.insert(
-                                skill.name.clone(),
-                                (
-                                    existing_index,
-                                    skill.source.clone(),
-                                    skill.skill_file_path.clone(),
-                                ),
-                            );
-                            skills[existing_index] = skill;
-                        }
-                        _ => {
-                            log::warn!(
-                                "Skill '{}' at '{}' conflicts with skill at '{}'; keeping the first one",
-                                skill.name,
-                                skill.skill_file_path.display(),
-                                existing_path.display()
-                            );
-                        }
-                    }
-                } else {
-                    seen_names.insert(
-                        skill.name.clone(),
-                        (
-                            skills.len(),
-                            skill.source.clone(),
-                            skill.skill_file_path.clone(),
-                        ),
-                    );
-                    skills.push(skill);
-                }
-            }
-            Err(e) => errors.push(e),
-        }
-    }
-
-    (skills, errors)
-}
-
 #[cfg(test)]
 mod internal_tests {
     use std::path::Path;
@@ -2634,39 +2527,6 @@ mod internal_tests {
     use serde_json::json;
     use settings::SettingsStore;
     use util::{path, rel_path::rel_path};
-
-    #[test]
-    fn test_project_skills_override_global_skills() {
-        let global_skill = Skill {
-            name: "review".to_string(),
-            description: "Global review".to_string(),
-            source: SkillSource::Global,
-            directory_path: PathBuf::from("/home/user/.agents/skills/review"),
-            skill_file_path: PathBuf::from("/home/user/.agents/skills/review/SKILL.md"),
-            content: "global".to_string(),
-            disable_model_invocation: false,
-        };
-        let project_skill = Skill {
-            name: "review".to_string(),
-            description: "Project review".to_string(),
-            source: SkillSource::ProjectLocal {
-                worktree_id: SkillScopeId(1),
-                worktree_root_name: "project".into(),
-            },
-            directory_path: PathBuf::from("/project/.agents/skills/review"),
-            skill_file_path: PathBuf::from("/project/.agents/skills/review/SKILL.md"),
-            content: "project".to_string(),
-            disable_model_invocation: false,
-        };
-
-        let (skills, errors) =
-            merge_skills(vec![Ok(global_skill)], vec![Ok(project_skill)].into_iter());
-
-        assert!(errors.is_empty());
-        assert_eq!(skills.len(), 1);
-        assert_eq!(skills[0].description, "Project review");
-        assert_eq!(skills[0].content, "project");
-    }
 
     #[gpui::test]
     async fn test_maintaining_project_context(cx: &mut TestAppContext) {
@@ -2767,11 +2627,8 @@ mod internal_tests {
         let initial_skill_dir = skills_dir.join("my-skill");
         let initial_skill_path = initial_skill_dir.join("SKILL.md");
         fs.create_dir(&initial_skill_dir).await.unwrap();
-        fs.insert_file(
-            &initial_skill_path,
-            b"---\nname: my-skill\ndescription: First version\n---\n\nbody-v1".to_vec(),
-        )
-        .await;
+        fs.insert_file(&initial_skill_path, b"placeholder".to_vec())
+            .await;
 
         let project = Project::test(fs.clone(), [], cx).await;
         let thread_store = cx.new(|cx| ThreadStore::new(cx));
@@ -2802,23 +2659,21 @@ mod internal_tests {
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].name, "my-skill");
-            assert_eq!(state.skills[0].description, "First version");
+            assert_eq!(state.skills[0].skill_file_path, initial_skill_path);
         });
 
-        // Modify the SKILL.md and verify the project context refreshes.
-        fs.write(
-            &initial_skill_path,
-            b"---\nname: my-skill\ndescription: Second version\n---\n\nbody-v2",
-        )
-        .await
-        .unwrap();
+        // Modify the SKILL.md and verify the watcher re-fires and the
+        // skill list is rebuilt. With parsing deferred, we just confirm
+        // the entry continues to point at the same path.
+        fs.write(&initial_skill_path, b"placeholder-v2")
+            .await
+            .unwrap();
         cx.run_until_parked();
 
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].description, "Second version");
+            assert_eq!(state.skills[0].skill_file_path, initial_skill_path);
         });
     }
 
@@ -2872,12 +2727,10 @@ mod internal_tests {
 
         // Create the global skills directory and a skill within it.
         let new_skill_dir = skills_dir.join("late-skill");
+        let new_skill_path = new_skill_dir.join("SKILL.md");
         fs.create_dir(&new_skill_dir).await.unwrap();
-        fs.insert_file(
-            &new_skill_dir.join("SKILL.md"),
-            b"---\nname: late-skill\ndescription: Created after startup\n---\n\nbody".to_vec(),
-        )
-        .await;
+        fs.insert_file(&new_skill_path, b"placeholder".to_vec())
+            .await;
 
         // Fire the trigger again, simulating the user interacting with
         // the agent panel after creating the skills directory. The
@@ -2891,8 +2744,7 @@ mod internal_tests {
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].name, "late-skill");
-            assert_eq!(state.skills[0].description, "Created after startup");
+            assert_eq!(state.skills[0].skill_file_path, new_skill_path);
         });
     }
 
@@ -2918,7 +2770,7 @@ mod internal_tests {
                 ".agents": {
                     "skills": {
                         "my-skill": {
-                            "SKILL.md": "---\nname: my-skill\ndescription: A project skill\n---\n\nbody"
+                            "SKILL.md": "placeholder"
                         }
                     }
                 }
@@ -2963,7 +2815,7 @@ mod internal_tests {
                 state
                     .skills
                     .iter()
-                    .map(|s| s.name.as_str())
+                    .map(|s| s.skill_file_path.clone())
                     .collect::<Vec<_>>()
             );
         });
@@ -2985,8 +2837,15 @@ mod internal_tests {
 
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project_id).unwrap();
-            let names: Vec<&str> = state.skills.iter().map(|s| s.name.as_str()).collect();
-            assert_eq!(names, vec!["my-skill"]);
+            let paths: Vec<PathBuf> = state
+                .skills
+                .iter()
+                .map(|s| s.skill_file_path.clone())
+                .collect();
+            assert_eq!(
+                paths,
+                vec![PathBuf::from("/project/.agents/skills/my-skill/SKILL.md")]
+            );
         });
     }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1224,16 +1224,7 @@ impl NativeAgent {
             Some(command)
         });
 
-        // Skills are exposed as slash commands regardless of
-        // `disable_model_invocation`. The flag controls catalog visibility
-        // for the model, not user-driven invocation — that's the whole
-        // point of marking a skill model-disabled.
-        let skill_commands = state
-            .skills
-            .iter()
-            .map(|skill| acp::AvailableCommand::new(skill.name.clone(), skill.description.clone()));
-
-        mcp_commands.chain(skill_commands).collect()
+        mcp_commands.collect()
     }
 
     pub fn load_thread(
@@ -2906,73 +2897,6 @@ mod internal_tests {
     }
 
     #[gpui::test]
-    async fn test_skills_appear_as_slash_commands(cx: &mut TestAppContext) {
-        init_test(cx);
-        cx.update(|cx| {
-            cx.update_flags(true, vec!["skills".to_string()]);
-        });
-        let fs = FakeFs::new(cx.executor());
-        let skills_dir = global_skills_dir();
-
-        // Two skills: one model-invocable (default), one slash-only via
-        // `disable-model-invocation: true`. Both should still appear as
-        // slash commands.
-        let visible_dir = skills_dir.join("visible-skill");
-        fs.create_dir(&visible_dir).await.unwrap();
-        fs.insert_file(
-            &visible_dir.join("SKILL.md"),
-            b"---\nname: visible-skill\ndescription: Visible skill\n---\n\nbody".to_vec(),
-        )
-        .await;
-
-        let hidden_dir = skills_dir.join("deploy");
-        fs.create_dir(&hidden_dir).await.unwrap();
-        fs.insert_file(
-            &hidden_dir.join("SKILL.md"),
-            b"---\nname: deploy\ndescription: Deploy to prod\ndisable-model-invocation: true\n---\n\nbody"
-                .to_vec(),
-        )
-        .await;
-
-        let project = Project::test(fs.clone(), [], cx).await;
-        let thread_store = cx.new(|cx| ThreadStore::new(cx));
-        let agent =
-            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
-
-        let connection = NativeAgentConnection(agent.clone());
-        let _acp_thread = cx
-            .update(|cx| {
-                Rc::new(connection).new_session(
-                    project.clone(),
-                    PathList::new(&[Path::new("/")]),
-                    cx,
-                )
-            })
-            .await
-            .unwrap();
-        cx.run_until_parked();
-
-        let project_id = project.entity_id();
-
-        // Both skills should be exposed as slash commands.
-        agent.read_with(cx, |agent, cx| {
-            let commands = NativeAgent::build_available_commands_for_project(
-                agent.projects.get(&project_id),
-                cx,
-            );
-            let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
-            assert!(
-                names.contains(&"visible-skill"),
-                "visible skill missing from slash commands: {names:?}"
-            );
-            assert!(
-                names.contains(&"deploy"),
-                "slash-only skill missing from slash commands: {names:?}"
-            );
-        });
-    }
-
-    #[gpui::test]
     async fn test_project_skills_require_worktree_trust(cx: &mut TestAppContext) {
         use collections::{HashMap, HashSet};
         use project::trusted_worktrees::{self, PathTrust, TrustedWorktrees};
@@ -3031,7 +2955,7 @@ mod internal_tests {
 
         // Untrusted: project skills are excluded from the loaded list and
         // never make it into the catalog or slash commands.
-        agent.read_with(cx, |agent, cx| {
+        agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project_id).unwrap();
             assert!(
                 state.skills.is_empty(),
@@ -3042,16 +2966,10 @@ mod internal_tests {
                     .map(|s| s.name.as_str())
                     .collect::<Vec<_>>()
             );
-            let commands = NativeAgent::build_available_commands_for_project(Some(state), cx);
-            let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
-            assert!(
-                !names.contains(&"my-skill"),
-                "untrusted skill leaked into slash commands: {names:?}"
-            );
         });
 
         // Granting trust should trigger a context refresh; the skill then
-        // appears in both the catalog and the slash-command list.
+        // appears in `state.skills`.
         cx.update(|cx| {
             let trusted_worktrees = TrustedWorktrees::try_get_global(cx)
                 .expect("trusted worktrees global initialized by test_with_worktree_trust");
@@ -3065,16 +2983,10 @@ mod internal_tests {
         });
         cx.run_until_parked();
 
-        agent.read_with(cx, |agent, cx| {
+        agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project_id).unwrap();
             let names: Vec<&str> = state.skills.iter().map(|s| s.name.as_str()).collect();
             assert_eq!(names, vec!["my-skill"]);
-            let commands = NativeAgent::build_available_commands_for_project(Some(state), cx);
-            let command_names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
-            assert!(
-                command_names.contains(&"my-skill"),
-                "trusted skill should appear in slash commands: {command_names:?}"
-            );
         });
     }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -29,8 +29,8 @@ use acp_thread::{
 };
 use agent_client_protocol::schema as acp;
 use agent_skills::{
-    Skill, SkillScopeId, SkillSource, global_skills_dir, load_skills_from_directory,
-    project_skills_relative_path,
+    Skill, SkillLoadError, SkillScopeId, SkillSource, global_skills_dir,
+    load_skills_from_directory, project_skills_relative_path,
 };
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Utc};
@@ -753,49 +753,49 @@ impl NativeAgent {
         let trusted_worktrees = TrustedWorktrees::try_get_global(cx);
         let worktree_store = project.read(cx).worktree_store();
         let project_skills_task = if skills_enabled {
-            let project_skills_futures: Vec<futures::future::BoxFuture<'static, Vec<Skill>>> =
-                worktrees
-                    .iter()
-                    .filter_map(|worktree| {
-                        let worktree_id = worktree.read(cx).id();
-                        let is_trusted =
-                            trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
-                                trusted_worktrees.update(cx, |trusted_worktrees, cx| {
-                                    trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
-                                })
-                            });
-                        if !is_trusted {
-                            return None;
-                        }
-                        let worktree_snapshot = worktree.read(cx);
-                        let abs_path = worktree_snapshot.abs_path();
-                        let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
-                        // Capture scan_complete *before* spawning so we don't have to re-borrow
-                        // the worktree from inside the async task (which would require a cx).
-                        let scan_complete = worktree_snapshot
-                            .as_local()
-                            .map(|local| local.scan_complete());
-                        let skills_dir = abs_path.join(project_skills_relative_path());
-                        let fs = fs.clone();
-                        Some(
-                            async move {
-                                if let Some(scan_complete) = scan_complete {
-                                    scan_complete.await;
-                                }
-                                load_skills_from_directory(
-                                    &fs,
-                                    &skills_dir,
-                                    SkillSource::ProjectLocal {
-                                        worktree_id: SkillScopeId(worktree_id.to_usize()),
-                                        worktree_root_name,
-                                    },
-                                )
-                                .await
+            let project_skills_futures: Vec<
+                futures::future::BoxFuture<'static, Vec<Result<Skill, SkillLoadError>>>,
+            > = worktrees
+                .iter()
+                .filter_map(|worktree| {
+                    let worktree_id = worktree.read(cx).id();
+                    let is_trusted = trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
+                        trusted_worktrees.update(cx, |trusted_worktrees, cx| {
+                            trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
+                        })
+                    });
+                    if !is_trusted {
+                        return None;
+                    }
+                    let worktree_snapshot = worktree.read(cx);
+                    let abs_path = worktree_snapshot.abs_path();
+                    let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
+                    // Capture scan_complete *before* spawning so we don't have to re-borrow
+                    // the worktree from inside the async task (which would require a cx).
+                    let scan_complete = worktree_snapshot
+                        .as_local()
+                        .map(|local| local.scan_complete());
+                    let skills_dir = abs_path.join(project_skills_relative_path());
+                    let fs = fs.clone();
+                    Some(
+                        async move {
+                            if let Some(scan_complete) = scan_complete {
+                                scan_complete.await;
                             }
-                            .boxed(),
-                        )
-                    })
-                    .collect();
+                            load_skills_from_directory(
+                                &fs,
+                                &skills_dir,
+                                SkillSource::ProjectLocal {
+                                    worktree_id: SkillScopeId(worktree_id.to_usize()),
+                                    worktree_root_name,
+                                },
+                            )
+                            .await
+                        }
+                        .boxed(),
+                    )
+                })
+                .collect();
             cx.background_spawn(async move { future::join_all(project_skills_futures).await })
         } else {
             Task::ready(Vec::new())
@@ -852,13 +852,28 @@ impl NativeAgent {
             // Concatenate global skills followed by each worktree's
             // project-local skills. `find_skill_files`'s sort plus this
             // iteration order gives a deterministic-enough ordering for
-            // our needs (parsing and conflict resolution happen in a
-            // follow-up PR).
+            // our needs (conflict resolution happens in a follow-up PR).
+            //
+            // `load_skills_from_directory` returns `Vec<Result<Skill, SkillLoadError>>`
+            // so that a future PR can surface parse errors in the UI. For
+            // now, we silently drop the errors after logging them.
+            fn drain_skills(results: Vec<Result<Skill, SkillLoadError>>) -> Vec<Skill> {
+                results
+                    .into_iter()
+                    .filter_map(|result| match result {
+                        Ok(skill) => Some(skill),
+                        Err(err) => {
+                            log::warn!("Failed to load skill: {err}");
+                            None
+                        }
+                    })
+                    .collect()
+            }
             let global_skills = global_skills_task.await;
             let project_skills_results = project_skills_task.await;
-            let mut skills: Vec<Skill> = global_skills;
+            let mut skills: Vec<Skill> = drain_skills(global_skills);
             for project_skills in project_skills_results {
-                skills.extend(project_skills);
+                skills.extend(drain_skills(project_skills));
             }
 
             let project_context = ProjectContext::new(worktrees, default_user_rules);
@@ -2627,8 +2642,11 @@ mod internal_tests {
         let initial_skill_dir = skills_dir.join("my-skill");
         let initial_skill_path = initial_skill_dir.join("SKILL.md");
         fs.create_dir(&initial_skill_dir).await.unwrap();
-        fs.insert_file(&initial_skill_path, b"placeholder".to_vec())
-            .await;
+        fs.insert_file(
+            &initial_skill_path,
+            b"---\nname: my-skill\ndescription: First version\n---\n\nbody".to_vec(),
+        )
+        .await;
 
         let project = Project::test(fs.clone(), [], cx).await;
         let thread_store = cx.new(|cx| ThreadStore::new(cx));
@@ -2659,21 +2677,24 @@ mod internal_tests {
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].skill_file_path, initial_skill_path);
+            assert_eq!(state.skills[0].name, "my-skill");
+            assert_eq!(state.skills[0].description, "First version");
         });
 
         // Modify the SKILL.md and verify the watcher re-fires and the
-        // skill list is rebuilt. With parsing deferred, we just confirm
-        // the entry continues to point at the same path.
-        fs.write(&initial_skill_path, b"placeholder-v2")
-            .await
-            .unwrap();
+        // skill list is rebuilt with the new description.
+        fs.write(
+            &initial_skill_path,
+            b"---\nname: my-skill\ndescription: Second version\n---\n\nbody",
+        )
+        .await
+        .unwrap();
         cx.run_until_parked();
 
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].skill_file_path, initial_skill_path);
+            assert_eq!(state.skills[0].description, "Second version");
         });
     }
 
@@ -2729,8 +2750,11 @@ mod internal_tests {
         let new_skill_dir = skills_dir.join("late-skill");
         let new_skill_path = new_skill_dir.join("SKILL.md");
         fs.create_dir(&new_skill_dir).await.unwrap();
-        fs.insert_file(&new_skill_path, b"placeholder".to_vec())
-            .await;
+        fs.insert_file(
+            &new_skill_path,
+            b"---\nname: late-skill\ndescription: Created after startup\n---\n\nbody".to_vec(),
+        )
+        .await;
 
         // Fire the trigger again, simulating the user interacting with
         // the agent panel after creating the skills directory. The
@@ -2744,7 +2768,8 @@ mod internal_tests {
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].skill_file_path, new_skill_path);
+            assert_eq!(state.skills[0].name, "late-skill");
+            assert_eq!(state.skills[0].description, "Created after startup");
         });
     }
 
@@ -2770,7 +2795,7 @@ mod internal_tests {
                 ".agents": {
                     "skills": {
                         "my-skill": {
-                            "SKILL.md": "placeholder"
+                            "SKILL.md": "---\nname: my-skill\ndescription: A trusted skill\n---\n\nbody"
                         }
                     }
                 }
@@ -2837,15 +2862,8 @@ mod internal_tests {
 
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project_id).unwrap();
-            let paths: Vec<PathBuf> = state
-                .skills
-                .iter()
-                .map(|s| s.skill_file_path.clone())
-                .collect();
-            assert_eq!(
-                paths,
-                vec![PathBuf::from("/project/.agents/skills/my-skill/SKILL.md")]
-            );
+            let names: Vec<&str> = state.skills.iter().map(|s| s.name.as_str()).collect();
+            assert_eq!(names, vec!["my-skill"]);
         });
     }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -28,9 +28,14 @@ use acp_thread::{
     AgentSessionListResponse, TokenUsageRatio, UserMessageId,
 };
 use agent_client_protocol::schema as acp;
+use agent_skills::{
+    Skill, SkillLoadError, SkillScopeId, SkillSource, global_skills_dir,
+    load_skills_from_directory, project_skills_relative_path,
+};
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Utc};
 use collections::{HashMap, HashSet, IndexMap};
+use feature_flags::{FeatureFlagAppExt as _, SkillsFeatureFlag};
 use fs::Fs;
 use futures::channel::{mpsc, oneshot};
 use futures::future::Shared;
@@ -40,7 +45,9 @@ use gpui::{
     TaskExt, WeakEntity,
 };
 use language_model::{IconOrSvg, LanguageModel, LanguageModelProvider, LanguageModelRegistry};
-use project::{AgentId, Project, ProjectItem, ProjectPath, Worktree};
+use project::{
+    AgentId, Project, ProjectItem, ProjectPath, Worktree, trusted_worktrees::TrustedWorktrees,
+};
 use prompt_store::{
     ProjectContext, PromptStore, RULES_FILE_NAMES, RulesFileContext, UserRulesContext,
     WorktreeContext,
@@ -65,9 +72,28 @@ pub struct RulesLoadingError {
     pub message: SharedString,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SkillLoadingError {
+    pub project_id: EntityId,
+    pub path: PathBuf,
+    pub message: SharedString,
+}
+
+/// Emitted whenever the set of skill loading errors for a project changes.
+/// The `errors` field is the full replacement list; subscribers should treat
+/// it as a snapshot rather than appending. An empty `errors` list means all
+/// previously-reported errors have been resolved.
+#[derive(Clone, Debug)]
+pub struct SkillLoadingErrorsUpdated {
+    pub project_id: EntityId,
+    pub errors: Vec<SkillLoadingError>,
+}
+
 struct ProjectState {
     project: Entity<Project>,
     project_context: Entity<ProjectContext>,
+    skills: Arc<Vec<Skill>>,
+    skill_loading_errors: Vec<SkillLoadingError>,
     project_context_needs_refresh: watch::Sender<()>,
     _maintain_project_context: Task<Result<()>>,
     context_server_registry: Entity<ContextServerRegistry>,
@@ -263,7 +289,45 @@ pub struct NativeAgent {
     prompt_store: Option<Entity<PromptStore>>,
     fs: Arc<dyn Fs>,
     _subscriptions: Vec<Subscription>,
+    /// Tracks the lifecycle of global skills directory observation. We
+    /// don't eagerly watch (or even check for) `~/.agents/skills/` at
+    /// startup; users who never engage with the agent panel pay zero
+    /// filesystem cost. The watch is kicked off lazily by
+    /// [`Self::ensure_skills_scan_started`], which is called from the
+    /// three agent-panel interaction points: input box focus, slash
+    /// autocomplete, and conversation submit.
+    skills_state: SkillsState,
 }
+
+#[derive(Default)]
+enum SkillsState {
+    /// No scan or watch is active. A user-interaction trigger will kick
+    /// off a fresh scan.
+    #[default]
+    Idle,
+    /// A one-shot scan task is in flight. It checks whether
+    /// `~/.agents/skills/` exists; if so, transitions to `Watching`,
+    /// otherwise back to `Idle`.
+    Scanning,
+    /// A watch task is observing `~/.agents/skills/`. It transitions
+    /// back to `Idle` if the watched directory itself is removed.
+    Watching,
+}
+
+impl gpui::EventEmitter<SkillLoadingErrorsUpdated> for NativeAgent {}
+
+static RULES_FILE_REL_PATHS: LazyLock<Vec<Arc<RelPath>>> = LazyLock::new(|| {
+    RULES_FILE_NAMES
+        .iter()
+        .filter_map(|name| RelPath::unix(name).ok().map(|path| path.into_arc()))
+        .collect()
+});
+
+static SKILLS_PREFIX: LazyLock<Option<Arc<RelPath>>> = LazyLock::new(|| {
+    RelPath::unix(project_skills_relative_path())
+        .ok()
+        .map(|path| path.into_arc())
+});
 
 impl NativeAgent {
     pub fn new(
@@ -294,8 +358,131 @@ impl NativeAgent {
                 prompt_store,
                 fs,
                 _subscriptions: subscriptions,
+                skills_state: SkillsState::default(),
             }
         })
+    }
+
+    /// Kicks off a one-time scan of the global skills directory if one
+    /// isn't already in progress and a watch isn't already active.
+    ///
+    /// Idempotent and cheap: returns immediately if the user lacks the
+    /// skills feature flag, or if a scan or watch is already running.
+    /// The expected callers are user-interaction events from the agent
+    /// panel (input focus, slash autocomplete, conversation submit);
+    /// firing this from any of them is equivalent and safe to repeat.
+    ///
+    /// The scan itself runs detached on the foreground executor. If
+    /// `~/.agents/skills/` exists it transitions state to
+    /// [`SkillsState::Watching`] and starts a recursive watch;
+    /// otherwise it transitions back to [`SkillsState::Idle`] so the
+    /// next trigger retries (covering the case where the user creates
+    /// the directory after the first scan).
+    pub fn ensure_skills_scan_started(&mut self, cx: &mut Context<Self>) {
+        if !cx.has_flag::<SkillsFeatureFlag>() {
+            return;
+        }
+        if !matches!(self.skills_state, SkillsState::Idle) {
+            return;
+        }
+        self.skills_state = SkillsState::Scanning;
+        let fs = self.fs.clone();
+        cx.spawn(async move |this, cx| Self::run_skills_scan(this, fs, cx).await)
+            .detach();
+    }
+
+    async fn run_skills_scan(this: WeakEntity<Self>, fs: Arc<dyn Fs>, cx: &mut AsyncApp) {
+        let skills_dir = global_skills_dir();
+        if !fs.is_dir(&skills_dir).await {
+            // Skills directory doesn't exist; revert state so the next
+            // user trigger retries.
+            let _ = this.update(cx, |this, _cx| {
+                this.skills_state = SkillsState::Idle;
+            });
+            return;
+        }
+
+        // Skills directory exists. Start a watch and trigger a refresh
+        // of every project's context so the freshly-discovered skills
+        // get loaded.
+        let _ = this.update(cx, |this, cx| {
+            cx.spawn({
+                let fs = fs.clone();
+                let skills_dir = skills_dir.clone();
+                async move |this, cx| Self::run_skills_watch(this, fs, skills_dir, cx).await
+            })
+            .detach();
+            this.skills_state = SkillsState::Watching;
+            for state in this.projects.values_mut() {
+                state.project_context_needs_refresh.send(()).ok();
+            }
+        });
+    }
+
+    async fn run_skills_watch(
+        this: WeakEntity<Self>,
+        fs: Arc<dyn Fs>,
+        skills_dir: PathBuf,
+        cx: &mut AsyncApp,
+    ) {
+        let (mut events, watcher) = fs
+            .watch(&skills_dir, std::time::Duration::from_millis(500))
+            .await;
+
+        // Linux's inotify backend is non-recursive, so a watch on
+        // `skills_dir` only fires for direct children. Skill discovery
+        // is intentionally one level deep (`<skills_dir>/<skill>/SKILL.md`),
+        // so we only register watches on each immediate child directory
+        // and deliberately do NOT recurse: a stray `node_modules`,
+        // `target`, or `.git` inside a skill folder would otherwise
+        // register watches for tens of thousands of subdirectories.
+        // These per-child adds are cheap no-ops on macOS/Windows where
+        // the OS-level watch is already recursive.
+        if let Ok(mut entries) = fs.read_dir(&skills_dir).await {
+            while let Some(entry) = entries.next().await {
+                let Ok(path) = entry else { continue };
+                if let Ok(Some(metadata)) = fs.metadata(&path).await
+                    && metadata.is_dir
+                {
+                    watcher.add(&path).ok();
+                }
+            }
+        }
+
+        while let Some(events) = events.next().await {
+            // When a new immediate child directory of `skills_dir` is
+            // created, add a single watch for it so changes to its
+            // `SKILL.md` are observed on Linux. We intentionally do not
+            // recurse into the new directory — skill discovery is only
+            // one level deep.
+            for event in &events {
+                if event.kind == Some(fs::PathEventKind::Created)
+                    && event.path.parent() == Some(skills_dir.as_path())
+                    && fs.is_dir(&event.path).await
+                {
+                    watcher.add(&event.path).ok();
+                }
+            }
+
+            let watched_root_removed = events.iter().any(|event| {
+                event.path == skills_dir && event.kind == Some(fs::PathEventKind::Removed)
+            });
+
+            let updated = this.update(cx, |this, _cx| {
+                for state in this.projects.values_mut() {
+                    state.project_context_needs_refresh.send(()).ok();
+                }
+                if watched_root_removed {
+                    // Drop back to Idle so the next user trigger
+                    // retries the scan; the next trigger will rediscover
+                    // the directory if the user has recreated it.
+                    this.skills_state = SkillsState::Idle;
+                }
+            });
+            if updated.is_err() || watched_root_removed {
+                return;
+            }
+        }
     }
 
     fn new_session(
@@ -441,7 +628,7 @@ impl NativeAgent {
         let context_server_registry =
             cx.new(|cx| ContextServerRegistry::new(context_server_store.clone(), cx));
 
-        let subscriptions = vec![
+        let mut subscriptions = vec![
             cx.subscribe(&project, Self::handle_project_event),
             cx.subscribe(
                 &context_server_store,
@@ -452,6 +639,21 @@ impl NativeAgent {
                 Self::handle_context_server_registry_event,
             ),
         ];
+        // When the user trusts a worktree (or revokes trust), project-local
+        // skills become eligible (or ineligible) for loading. Trigger a
+        // refresh so the catalog and slash-command list update without a
+        // restart. This is unconditional — a `Trusted` event for any
+        // worktree under any project is cheap to handle and keeps the
+        // logic straightforward.
+        if let Some(trusted_worktrees) = TrustedWorktrees::try_get_global(cx) {
+            subscriptions.push(
+                cx.subscribe(&trusted_worktrees, move |this, _, _event, _cx| {
+                    if let Some(state) = this.projects.get_mut(&project_id) {
+                        state.project_context_needs_refresh.send(()).ok();
+                    }
+                }),
+            );
+        }
 
         let (project_context_needs_refresh_tx, project_context_needs_refresh_rx) =
             watch::channel(());
@@ -461,6 +663,8 @@ impl NativeAgent {
             ProjectState {
                 project,
                 project_context,
+                skills: Arc::new(Vec::new()),
+                skill_loading_errors: Vec::new(),
                 project_context_needs_refresh: project_context_needs_refresh_tx,
                 _maintain_project_context: cx.spawn(async move |this, cx| {
                     Self::maintain_project_context(
@@ -490,27 +694,65 @@ impl NativeAgent {
         cx: &mut AsyncApp,
     ) -> Result<()> {
         while needs_refresh.changed().await.is_ok() {
-            let project_context = this
-                .update(cx, |this, cx| {
-                    let state = this
-                        .projects
-                        .get(&project_id)
-                        .context("project state not found")?;
-                    anyhow::Ok(Self::build_project_context(
-                        &state.project,
-                        this.prompt_store.as_ref(),
-                        cx,
-                    ))
-                })??
-                .await;
+            let task = this.update(cx, |this, cx| {
+                let state = this
+                    .projects
+                    .get(&project_id)
+                    .context("project state not found")?;
+                anyhow::Ok(Self::build_project_context(
+                    &state.project,
+                    this.prompt_store.as_ref(),
+                    this.fs.clone(),
+                    cx,
+                ))
+            })??;
+            let (project_context, skills, skill_errors) = task.await;
+            let skills = Arc::new(skills);
+            let skill_loading_errors: Vec<SkillLoadingError> = skill_errors
+                .into_iter()
+                .map(|skill_error| SkillLoadingError {
+                    project_id,
+                    path: skill_error.path,
+                    message: skill_error.message.into(),
+                })
+                .collect();
             this.update(cx, |this, cx| {
-                if let Some(state) = this.projects.get(&project_id) {
+                // Only emit SkillLoadingErrorsUpdated when the error list
+                // actually changed. Refreshes happen frequently (prompt-store
+                // updates, rules-file edits, worktree events, trust-state
+                // changes), and re-emitting an unchanged list causes the UI
+                // to redisplay errors the user has already dismissed.
+                // Transitions from non-empty to empty still count as a change,
+                // so subscribers continue to receive an empty list to clear
+                // previously-displayed errors when they get resolved.
+                let errors_changed = this
+                    .projects
+                    .get(&project_id)
+                    .map(|state| state.skill_loading_errors != skill_loading_errors)
+                    .unwrap_or(true);
+
+                if let Some(state) = this.projects.get_mut(&project_id) {
+                    state.skills = skills;
+                    state.skill_loading_errors = skill_loading_errors.clone();
                     state
                         .project_context
-                        .update(cx, |current_project_context, _cx| {
+                        .update(cx, |current_project_context, cx| {
                             *current_project_context = project_context;
+                            cx.notify();
                         });
                 }
+                if errors_changed {
+                    cx.emit(SkillLoadingErrorsUpdated {
+                        project_id,
+                        errors: skill_loading_errors,
+                    });
+                }
+                // Skills appear in the slash-command list, so a change in
+                // the loaded skills needs to be pushed out to active sessions.
+                // This runs unconditionally because MCP prompts (also part of
+                // the available commands) can change without affecting the
+                // skill error list.
+                this.update_available_commands_for_project(project_id, cx);
             })?;
         }
 
@@ -520,15 +762,95 @@ impl NativeAgent {
     fn build_project_context(
         project: &Entity<Project>,
         prompt_store: Option<&Entity<PromptStore>>,
+        fs: Arc<dyn Fs>,
         cx: &mut App,
-    ) -> Task<ProjectContext> {
+    ) -> Task<(ProjectContext, Vec<Skill>, Vec<SkillLoadError>)> {
         let worktrees = project.read(cx).visible_worktrees(cx).collect::<Vec<_>>();
         let worktree_tasks = worktrees
-            .into_iter()
+            .iter()
             .map(|worktree| {
-                Self::load_worktree_info_for_system_prompt(worktree, project.clone(), cx)
+                Self::load_worktree_info_for_system_prompt(worktree.clone(), project.clone(), cx)
             })
             .collect::<Vec<_>>();
+
+        // Skills are gated behind the "skills" feature flag. Without it we
+        // skip all on-disk lookups so users see no behavior change.
+        let skills_enabled = cx.has_flag::<SkillsFeatureFlag>();
+
+        // Load global skills
+        let global_skills_task = if skills_enabled {
+            let global_skills_dir = global_skills_dir();
+            let global_skills_fs = fs.clone();
+            cx.background_spawn(async move {
+                load_skills_from_directory(
+                    &global_skills_fs,
+                    &global_skills_dir,
+                    SkillSource::Global,
+                )
+                .await
+            })
+        } else {
+            Task::ready(Vec::new())
+        };
+
+        // Load project-local skills, but only from worktrees the user has
+        // trusted. Skills in `.agents/skills/` ship with the project; a
+        // freshly cloned untrusted repo can carry hostile descriptions or
+        // bodies, so we keep them out of the catalog and the slash-command
+        // list until trust is granted. The subscription in
+        // `register_project_with_initial_context` triggers a context
+        // refresh when a worktree's trust state changes, so newly trusted
+        // worktrees pick up their skills without restarting.
+        let trusted_worktrees = TrustedWorktrees::try_get_global(cx);
+        let worktree_store = project.read(cx).worktree_store();
+        let project_skills_task = if skills_enabled {
+            let project_skills_futures: Vec<
+                futures::future::BoxFuture<'static, Vec<Result<Skill, SkillLoadError>>>,
+            > = worktrees
+                .iter()
+                .filter_map(|worktree| {
+                    let worktree_id = worktree.read(cx).id();
+                    let is_trusted = trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
+                        trusted_worktrees.update(cx, |trusted_worktrees, cx| {
+                            trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
+                        })
+                    });
+                    if !is_trusted {
+                        return None;
+                    }
+                    let worktree_snapshot = worktree.read(cx);
+                    let abs_path = worktree_snapshot.abs_path();
+                    let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
+                    // Capture scan_complete *before* spawning so we don't have to re-borrow
+                    // the worktree from inside the async task (which would require a cx).
+                    let scan_complete = worktree_snapshot
+                        .as_local()
+                        .map(|local| local.scan_complete());
+                    let skills_dir = abs_path.join(project_skills_relative_path());
+                    let fs = fs.clone();
+                    Some(
+                        async move {
+                            if let Some(scan_complete) = scan_complete {
+                                scan_complete.await;
+                            }
+                            load_skills_from_directory(
+                                &fs,
+                                &skills_dir,
+                                SkillSource::ProjectLocal {
+                                    worktree_id: SkillScopeId(worktree_id.to_usize()),
+                                    worktree_root_name,
+                                },
+                            )
+                            .await
+                        }
+                        .boxed(),
+                    )
+                })
+                .collect();
+            cx.background_spawn(async move { future::join_all(project_skills_futures).await })
+        } else {
+            Task::ready(Vec::new())
+        };
         let default_user_rules_task = if let Some(prompt_store) = prompt_store.as_ref() {
             prompt_store.read_with(cx, |prompt_store, cx| {
                 let prompts = prompt_store.default_prompt_metadata();
@@ -578,7 +900,14 @@ impl NativeAgent {
                 })
                 .collect::<Vec<_>>();
 
-            ProjectContext::new(worktrees, default_user_rules)
+            // Load and merge skills
+            let global_skills = global_skills_task.await;
+            let project_skills_results = project_skills_task.await;
+            let (skills, skill_errors) =
+                merge_skills(global_skills, project_skills_results.into_iter().flatten());
+
+            let project_context = ProjectContext::new(worktrees, default_user_rules);
+            (project_context, skills, skill_errors)
         })
     }
 
@@ -629,11 +958,11 @@ impl NativeAgent {
     ) -> Option<Task<Result<RulesFileContext>>> {
         let worktree = worktree.read(cx);
         let worktree_id = worktree.id();
-        let selected_rules_file = RULES_FILE_NAMES
-            .into_iter()
+        let selected_rules_file = RULES_FILE_REL_PATHS
+            .iter()
             .filter_map(|name| {
                 worktree
-                    .entry_for_path(RelPath::unix(name).unwrap())
+                    .entry_for_path(name)
                     .filter(|entry| entry.is_file())
                     .map(|entry| entry.path.clone())
             })
@@ -711,7 +1040,7 @@ impl NativeAgent {
         &mut self,
         project: Entity<Project>,
         event: &project::Event,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         let project_id = project.entity_id();
         let Some(state) = self.projects.get_mut(&project_id) else {
@@ -722,10 +1051,16 @@ impl NativeAgent {
                 state.project_context_needs_refresh.send(()).ok();
             }
             project::Event::WorktreeUpdatedEntries(_, items) => {
+                let skills_enabled = cx.has_flag::<SkillsFeatureFlag>();
                 if items.iter().any(|(path, _, _)| {
-                    RULES_FILE_NAMES
+                    let path_ref = path.as_ref();
+                    RULES_FILE_REL_PATHS
                         .iter()
-                        .any(|name| path.as_ref() == RelPath::unix(name).unwrap())
+                        .any(|rules_path| path_ref == rules_path.as_ref())
+                        || (skills_enabled
+                            && SKILLS_PREFIX
+                                .as_ref()
+                                .is_some_and(|prefix| path_ref.starts_with(prefix)))
                 }) {
                     state.project_context_needs_refresh.send(()).ok();
                 }
@@ -853,46 +1188,52 @@ impl NativeAgent {
                 .or_insert(0) += 1;
         }
 
-        registry
-            .prompts()
-            .flat_map(|context_server_prompt| {
-                let prompt = &context_server_prompt.prompt;
+        let mcp_commands = registry.prompts().flat_map(|context_server_prompt| {
+            let prompt = &context_server_prompt.prompt;
 
-                let should_prefix = prompt_name_counts
-                    .get(prompt.name.as_str())
-                    .copied()
-                    .unwrap_or(0)
-                    > 1;
+            let should_prefix = prompt_name_counts
+                .get(prompt.name.as_str())
+                .copied()
+                .unwrap_or(0)
+                > 1;
 
-                let name = if should_prefix {
-                    format!("{}.{}", context_server_prompt.server_id, prompt.name)
-                } else {
-                    prompt.name.clone()
-                };
+            let name = if should_prefix {
+                format!("{}.{}", context_server_prompt.server_id, prompt.name)
+            } else {
+                prompt.name.clone()
+            };
 
-                let mut command = acp::AvailableCommand::new(
-                    name,
-                    prompt.description.clone().unwrap_or_default(),
-                );
+            let mut command =
+                acp::AvailableCommand::new(name, prompt.description.clone().unwrap_or_default());
 
-                match prompt.arguments.as_deref() {
-                    Some([arg]) => {
-                        let hint = format!("<{}>", arg.name);
+            match prompt.arguments.as_deref() {
+                Some([arg]) => {
+                    let hint = format!("<{}>", arg.name);
 
-                        command = command.input(acp::AvailableCommandInput::Unstructured(
-                            acp::UnstructuredCommandInput::new(hint),
-                        ));
-                    }
-                    Some([]) | None => {}
-                    Some(_) => {
-                        // skip >1 argument commands since we don't support them yet
-                        return None;
-                    }
+                    command = command.input(acp::AvailableCommandInput::Unstructured(
+                        acp::UnstructuredCommandInput::new(hint),
+                    ));
                 }
+                Some([]) | None => {}
+                Some(_) => {
+                    // skip >1 argument commands since we don't support them yet
+                    return None;
+                }
+            }
 
-                Some(command)
-            })
-            .collect()
+            Some(command)
+        });
+
+        // Skills are exposed as slash commands regardless of
+        // `disable_model_invocation`. The flag controls catalog visibility
+        // for the model, not user-driven invocation — that's the whole
+        // point of marking a skill model-disabled.
+        let skill_commands = state
+            .skills
+            .iter()
+            .map(|skill| acp::AvailableCommand::new(skill.name.clone(), skill.description.clone()));
+
+        mcp_commands.chain(skill_commands).collect()
     }
 
     pub fn load_thread(
@@ -1222,6 +1563,16 @@ impl NativeAgentConnection {
             .sessions
             .get(session_id)
             .map(|session| session.thread.clone())
+    }
+
+    /// Forwards to [`NativeAgent::ensure_skills_scan_started`]. The
+    /// agent panel calls this from its three user-interaction trigger
+    /// points (input box focus, slash-autocomplete invocation, and
+    /// conversation submit) so that the skills directory is observed
+    /// only when the user is actually engaging with the panel.
+    pub fn ensure_skills_scan_started(&self, cx: &mut App) {
+        self.0
+            .update(cx, |agent, cx| agent.ensure_skills_scan_started(cx));
     }
 
     pub fn load_thread(
@@ -1601,6 +1952,10 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
         };
 
         if let Some(parsed_command) = Command::parse(&params.prompt) {
+            // MCP prompts and skills both register slash commands. MCP
+            // prompts are checked first — if a user has both an MCP prompt
+            // and a skill with the same name, the MCP prompt wins (matching
+            // the order they appear in the catalog).
             let registry = project_state.context_server_registry.read(cx);
 
             let explicit_server_id = parsed_command
@@ -2210,6 +2565,68 @@ impl TerminalHandle for AcpTerminalHandle {
     }
 }
 
+/// Merge global and project-local skills.
+/// Project-local skills override global skills with the same name.
+fn merge_skills(
+    global: Vec<Result<Skill, SkillLoadError>>,
+    project: impl Iterator<Item = Result<Skill, SkillLoadError>>,
+) -> (Vec<Skill>, Vec<SkillLoadError>) {
+    let mut skills = Vec::new();
+    let mut errors = Vec::new();
+    let mut seen_names: HashMap<String, (usize, SkillSource, PathBuf)> = HashMap::default();
+
+    for result in global.into_iter().chain(project) {
+        match result {
+            Ok(skill) => {
+                if let Some((existing_index, existing_source, existing_path)) =
+                    seen_names.get(&skill.name).cloned()
+                {
+                    match (&existing_source, &skill.source) {
+                        (SkillSource::Global, SkillSource::ProjectLocal { .. }) => {
+                            log::warn!(
+                                "Project skill '{}' at '{}' overrides global skill at '{}'",
+                                skill.name,
+                                skill.skill_file_path.display(),
+                                existing_path.display()
+                            );
+                            seen_names.insert(
+                                skill.name.clone(),
+                                (
+                                    existing_index,
+                                    skill.source.clone(),
+                                    skill.skill_file_path.clone(),
+                                ),
+                            );
+                            skills[existing_index] = skill;
+                        }
+                        _ => {
+                            log::warn!(
+                                "Skill '{}' at '{}' conflicts with skill at '{}'; keeping the first one",
+                                skill.name,
+                                skill.skill_file_path.display(),
+                                existing_path.display()
+                            );
+                        }
+                    }
+                } else {
+                    seen_names.insert(
+                        skill.name.clone(),
+                        (
+                            skills.len(),
+                            skill.source.clone(),
+                            skill.skill_file_path.clone(),
+                        ),
+                    );
+                    skills.push(skill);
+                }
+            }
+            Err(e) => errors.push(e),
+        }
+    }
+
+    (skills, errors)
+}
+
 #[cfg(test)]
 mod internal_tests {
     use std::path::Path;
@@ -2226,6 +2643,39 @@ mod internal_tests {
     use serde_json::json;
     use settings::SettingsStore;
     use util::{path, rel_path::rel_path};
+
+    #[test]
+    fn test_project_skills_override_global_skills() {
+        let global_skill = Skill {
+            name: "review".to_string(),
+            description: "Global review".to_string(),
+            source: SkillSource::Global,
+            directory_path: PathBuf::from("/home/user/.agents/skills/review"),
+            skill_file_path: PathBuf::from("/home/user/.agents/skills/review/SKILL.md"),
+            content: "global".to_string(),
+            disable_model_invocation: false,
+        };
+        let project_skill = Skill {
+            name: "review".to_string(),
+            description: "Project review".to_string(),
+            source: SkillSource::ProjectLocal {
+                worktree_id: SkillScopeId(1),
+                worktree_root_name: "project".into(),
+            },
+            directory_path: PathBuf::from("/project/.agents/skills/review"),
+            skill_file_path: PathBuf::from("/project/.agents/skills/review/SKILL.md"),
+            content: "project".to_string(),
+            disable_model_invocation: false,
+        };
+
+        let (skills, errors) =
+            merge_skills(vec![Ok(global_skill)], vec![Ok(project_skill)].into_iter());
+
+        assert!(errors.is_empty());
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].description, "Project review");
+        assert_eq!(skills[0].content, "project");
+    }
 
     #[gpui::test]
     async fn test_maintaining_project_context(cx: &mut TestAppContext) {
@@ -2311,6 +2761,319 @@ mod internal_tests {
             assert_eq!(
                 thread.read(cx).project_context().read(cx).worktrees,
                 expected_worktrees
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_global_skills_load_and_reload(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            cx.update_flags(true, vec!["skills".to_string()]);
+        });
+        let fs = FakeFs::new(cx.executor());
+        let skills_dir = global_skills_dir();
+        let initial_skill_dir = skills_dir.join("my-skill");
+        let initial_skill_path = initial_skill_dir.join("SKILL.md");
+        fs.create_dir(&initial_skill_dir).await.unwrap();
+        fs.insert_file(
+            &initial_skill_path,
+            b"---\nname: my-skill\ndescription: First version\n---\n\nbody-v1".to_vec(),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+
+        // Simulate the user-interaction trigger that the agent panel
+        // fires (input focus, slash autocomplete, or submit). In tests
+        // we call it directly because there's no panel.
+        cx.update(|cx| {
+            agent.update(cx, |agent, cx| agent.ensure_skills_scan_started(cx));
+        });
+
+        let connection = NativeAgentConnection(agent.clone());
+        let _acp_thread = cx
+            .update(|cx| {
+                Rc::new(connection).new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/")]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // The pre-existing skill should be loaded into the project state.
+        agent.read_with(cx, |agent, _cx| {
+            let state = agent.projects.get(&project.entity_id()).unwrap();
+            assert_eq!(state.skills.len(), 1);
+            assert_eq!(state.skills[0].name, "my-skill");
+            assert_eq!(state.skills[0].description, "First version");
+        });
+
+        // Modify the SKILL.md and verify the project context refreshes.
+        fs.write(
+            &initial_skill_path,
+            b"---\nname: my-skill\ndescription: Second version\n---\n\nbody-v2",
+        )
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, _cx| {
+            let state = agent.projects.get(&project.entity_id()).unwrap();
+            assert_eq!(state.skills.len(), 1);
+            assert_eq!(state.skills[0].description, "Second version");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_global_skills_dir_created_after_startup(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            cx.update_flags(true, vec!["skills".to_string()]);
+        });
+        let fs = FakeFs::new(cx.executor());
+        let skills_dir = global_skills_dir();
+
+        // Intentionally do NOT pre-create `skills_dir`. The first scan
+        // trigger should find no directory and leave the watch state
+        // idle; a later trigger after the directory is created should
+        // attach to the deepest existing ancestor and react when the
+        // directory is created later.
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+
+        // First scan trigger: nothing on disk yet, state stays idle.
+        cx.update(|cx| {
+            agent.update(cx, |agent, cx| agent.ensure_skills_scan_started(cx));
+        });
+
+        let connection = NativeAgentConnection(agent.clone());
+        let _acp_thread = cx
+            .update(|cx| {
+                Rc::new(connection).new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/")]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // No skills directory exists yet, so no skills should be loaded.
+        agent.read_with(cx, |agent, _cx| {
+            let state = agent.projects.get(&project.entity_id()).unwrap();
+            assert!(
+                state.skills.is_empty(),
+                "expected no skills before the global skills dir exists, got {:?}",
+                state.skills
+            );
+        });
+
+        // Create the global skills directory and a skill within it.
+        let new_skill_dir = skills_dir.join("late-skill");
+        fs.create_dir(&new_skill_dir).await.unwrap();
+        fs.insert_file(
+            &new_skill_dir.join("SKILL.md"),
+            b"---\nname: late-skill\ndescription: Created after startup\n---\n\nbody".to_vec(),
+        )
+        .await;
+
+        // Fire the trigger again, simulating the user interacting with
+        // the agent panel after creating the skills directory. The
+        // second scan should find the directory and start the watch,
+        // which refreshes project context.
+        cx.update(|cx| {
+            agent.update(cx, |agent, cx| agent.ensure_skills_scan_started(cx));
+        });
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, _cx| {
+            let state = agent.projects.get(&project.entity_id()).unwrap();
+            assert_eq!(state.skills.len(), 1);
+            assert_eq!(state.skills[0].name, "late-skill");
+            assert_eq!(state.skills[0].description, "Created after startup");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_skills_appear_as_slash_commands(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            cx.update_flags(true, vec!["skills".to_string()]);
+        });
+        let fs = FakeFs::new(cx.executor());
+        let skills_dir = global_skills_dir();
+
+        // Two skills: one model-invocable (default), one slash-only via
+        // `disable-model-invocation: true`. Both should still appear as
+        // slash commands.
+        let visible_dir = skills_dir.join("visible-skill");
+        fs.create_dir(&visible_dir).await.unwrap();
+        fs.insert_file(
+            &visible_dir.join("SKILL.md"),
+            b"---\nname: visible-skill\ndescription: Visible skill\n---\n\nbody".to_vec(),
+        )
+        .await;
+
+        let hidden_dir = skills_dir.join("deploy");
+        fs.create_dir(&hidden_dir).await.unwrap();
+        fs.insert_file(
+            &hidden_dir.join("SKILL.md"),
+            b"---\nname: deploy\ndescription: Deploy to prod\ndisable-model-invocation: true\n---\n\nbody"
+                .to_vec(),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+
+        let connection = NativeAgentConnection(agent.clone());
+        let _acp_thread = cx
+            .update(|cx| {
+                Rc::new(connection).new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/")]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let project_id = project.entity_id();
+
+        // Both skills should be exposed as slash commands.
+        agent.read_with(cx, |agent, cx| {
+            let commands = NativeAgent::build_available_commands_for_project(
+                agent.projects.get(&project_id),
+                cx,
+            );
+            let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+            assert!(
+                names.contains(&"visible-skill"),
+                "visible skill missing from slash commands: {names:?}"
+            );
+            assert!(
+                names.contains(&"deploy"),
+                "slash-only skill missing from slash commands: {names:?}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_project_skills_require_worktree_trust(cx: &mut TestAppContext) {
+        use collections::{HashMap, HashSet};
+        use project::trusted_worktrees::{self, PathTrust, TrustedWorktrees};
+
+        init_test(cx);
+        cx.update(|cx| {
+            cx.update_flags(true, vec!["skills".to_string()]);
+            // The trust global isn't created by `init_test`. We need it
+            // for `Project::test_with_worktree_trust` to actually wire up
+            // trust tracking and for our subscription in
+            // `register_project_with_initial_context` to fire.
+            trusted_worktrees::init(HashMap::default(), cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            json!({
+                ".agents": {
+                    "skills": {
+                        "my-skill": {
+                            "SKILL.md": "---\nname: my-skill\ndescription: A project skill\n---\n\nbody"
+                        }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        // `test_with_worktree_trust` initializes the trust system and
+        // starts every worktree as restricted, mirroring production
+        // behavior on a freshly opened folder.
+        let project =
+            Project::test_with_worktree_trust(fs.clone(), [Path::new("/project")], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), None, fs.clone(), cx));
+
+        let connection = NativeAgentConnection(agent.clone());
+        let _acp_thread = cx
+            .update(|cx| {
+                Rc::new(connection).new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/project")]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let project_id = project.entity_id();
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+
+        // Untrusted: project skills are excluded from the loaded list and
+        // never make it into the catalog or slash commands.
+        agent.read_with(cx, |agent, cx| {
+            let state = agent.projects.get(&project_id).unwrap();
+            assert!(
+                state.skills.is_empty(),
+                "untrusted worktree skills should not load: {:?}",
+                state
+                    .skills
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect::<Vec<_>>()
+            );
+            let commands = NativeAgent::build_available_commands_for_project(Some(state), cx);
+            let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+            assert!(
+                !names.contains(&"my-skill"),
+                "untrusted skill leaked into slash commands: {names:?}"
+            );
+        });
+
+        // Granting trust should trigger a context refresh; the skill then
+        // appears in both the catalog and the slash-command list.
+        cx.update(|cx| {
+            let trusted_worktrees = TrustedWorktrees::try_get_global(cx)
+                .expect("trusted worktrees global initialized by test_with_worktree_trust");
+            trusted_worktrees.update(cx, |trusted_worktrees, cx| {
+                trusted_worktrees.trust(
+                    &project.read(cx).worktree_store(),
+                    HashSet::from_iter([PathTrust::Worktree(worktree_id)]),
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, cx| {
+            let state = agent.projects.get(&project_id).unwrap();
+            let names: Vec<&str> = state.skills.iter().map(|s| s.name.as_str()).collect();
+            assert_eq!(names, vec!["my-skill"]);
+            let commands = NativeAgent::build_available_commands_for_project(Some(state), cx);
+            let command_names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+            assert!(
+                command_names.contains(&"my-skill"),
+                "trusted skill should appear in slash commands: {command_names:?}"
             );
         });
     }

--- a/crates/agent_skills/Cargo.toml
+++ b/crates/agent_skills/Cargo.toml
@@ -12,12 +12,16 @@ workspace = true
 path = "agent_skills.rs"
 
 [dependencies]
+anyhow.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 paths.workspace = true
+serde.workspace = true
+serde_yaml_ng.workspace = true
 util.workspace = true
 
 [dev-dependencies]
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
+serde_json.workspace = true

--- a/crates/agent_skills/Cargo.toml
+++ b/crates/agent_skills/Cargo.toml
@@ -12,5 +12,16 @@ workspace = true
 path = "agent_skills.rs"
 
 [dependencies]
+anyhow.workspace = true
+fs.workspace = true
+futures.workspace = true
+gpui.workspace = true
 paths.workspace = true
+serde.workspace = true
+serde_yaml_ng.workspace = true
 util.workspace = true
+
+[dev-dependencies]
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+serde_json.workspace = true

--- a/crates/agent_skills/Cargo.toml
+++ b/crates/agent_skills/Cargo.toml
@@ -12,16 +12,12 @@ workspace = true
 path = "agent_skills.rs"
 
 [dependencies]
-anyhow.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 paths.workspace = true
-serde.workspace = true
-serde_yaml_ng.workspace = true
 util.workspace = true
 
 [dev-dependencies]
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
-serde_json.workspace = true

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -1,12 +1,9 @@
-//! Paths and constants describing where agent skills live on disk.
-//!
-//! Skill discovery, parsing, and loading are intentionally *not* in this
-//! crate yet — the only thing here is the directory layout, so other code
-//! (e.g. the agent's tool-permission machinery) can recognize and protect
-//! paths inside the agent skills tree without needing to know anything
-//! about the skill format itself.
-
+use anyhow::{Context as _, Result};
+use fs::Fs;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use util::paths::component_matches_ignore_ascii_case;
 
 /// First segment of the skills directory path: `.agents`.
@@ -15,8 +12,357 @@ pub const AGENTS_DIR_NAME: &str = ".agents";
 /// Second segment of the skills directory path: `skills`.
 pub const SKILLS_DIR_NAME: &str = "skills";
 
-/// The name of a skill definition file, e.g. `<skills_dir>/<skill>/SKILL.md`.
+/// Opaque identifier for the project scope a skill was loaded from.
+///
+/// `agent_skills` is a leaf crate and intentionally does not depend on
+/// `worktree`. Callers (e.g. the `agent` crate) construct these from
+/// `worktree::WorktreeId::to_usize()` and recover the original ID via
+/// `worktree::WorktreeId::from_usize()` when needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SkillScopeId(pub usize);
+
+/// Cap on concurrent filesystem operations during skill discovery and loading.
+/// Without this bound, a `.agents/skills` directory containing thousands of
+/// entries would fan out an equally large number of concurrent OS-level I/O
+/// operations, potentially exhausting file descriptors or stalling the app.
+const SKILL_IO_CONCURRENCY: usize = 16;
+
+/// Maximum size for a single SKILL.md file (100KB)
+pub const MAX_SKILL_FILE_SIZE: usize = 100 * 1024;
+
+/// Maximum total size for skill descriptions in system prompt (50KB)
+pub const MAX_SKILL_DESCRIPTIONS_SIZE: usize = 50 * 1024;
+
+/// The name of the skill definition file
 pub const SKILL_FILE_NAME: &str = "SKILL.md";
+
+/// Represents a loaded skill with all its metadata and content.
+#[derive(Debug, Clone)]
+pub struct Skill {
+    pub name: String,
+    pub description: String,
+    pub source: SkillSource,
+    /// Absolute path to the skill directory
+    pub directory_path: PathBuf,
+    /// Absolute path to the SKILL.md file
+    pub skill_file_path: PathBuf,
+    /// The full content of SKILL.md (excluding frontmatter)
+    pub content: String,
+    /// When `true`, this skill is hidden from the model's catalog and the
+    /// `skill` tool refuses to load it. The user can still invoke it as a
+    /// slash command.
+    pub disable_model_invocation: bool,
+}
+
+/// Indicates where a skill was loaded from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillSource {
+    /// From ~/.agents/skills/
+    Global,
+    /// From {project}/.agents/skills/
+    ProjectLocal {
+        worktree_id: SkillScopeId,
+        worktree_root_name: Arc<str>,
+    },
+}
+
+/// Just the frontmatter, used for parsing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillMetadata {
+    pub name: String,
+    pub description: String,
+    #[serde(default, rename = "disable-model-invocation")]
+    pub disable_model_invocation: bool,
+}
+
+/// Minimal skill info for system prompt (not full content).
+///
+/// `Serialize` is required for handlebars rendering of the system prompt
+/// template (see `ProjectContext` in `prompt_store`). `PartialEq, Eq` lets
+/// the agent compare freshly-built `ProjectContext`s and skip pushing an
+/// unchanged value through the project_context entity (which would
+/// otherwise look like a system-prompt change to the model and invalidate
+/// the API's prompt cache).
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct SkillSummary {
+    pub name: String,
+    pub description: String,
+    /// Absolute path to the SKILL.md file, so the model can resolve
+    /// references relative to the skill's directory when reading bundled
+    /// resources.
+    pub location: String,
+}
+
+impl From<&Skill> for SkillSummary {
+    fn from(skill: &Skill) -> Self {
+        Self {
+            name: skill.name.clone(),
+            description: skill.description.clone(),
+            location: skill.skill_file_path.to_string_lossy().into_owned(),
+        }
+    }
+}
+
+/// Error that occurred while loading a skill
+#[derive(Debug, Clone)]
+pub struct SkillLoadError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl std::fmt::Display for SkillLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+impl std::error::Error for SkillLoadError {}
+
+/// Parse a SKILL.md file into a Skill struct.
+///
+/// The file must have YAML frontmatter between `---` delimiters containing
+/// `name` and `description` fields. The content after frontmatter becomes
+/// the skill's instructions.
+pub fn parse_skill(skill_file_path: &Path, content: &str, source: SkillSource) -> Result<Skill> {
+    if content.len() > MAX_SKILL_FILE_SIZE {
+        anyhow::bail!(
+            "SKILL.md file exceeds maximum size of {}KB",
+            MAX_SKILL_FILE_SIZE / 1024
+        );
+    }
+
+    let (metadata, body) = extract_frontmatter(content)?;
+
+    validate_name(&metadata.name)?;
+    validate_description(&metadata.description)?;
+
+    let directory_path = skill_file_path
+        .parent()
+        .context("SKILL.md file has no parent directory")?
+        .to_path_buf();
+
+    Ok(Skill {
+        name: metadata.name,
+        description: metadata.description,
+        source,
+        directory_path,
+        skill_file_path: skill_file_path.to_path_buf(),
+        content: body.trim().to_string(),
+        disable_model_invocation: metadata.disable_model_invocation,
+    })
+}
+
+fn extract_frontmatter(content: &str) -> Result<(SkillMetadata, &str)> {
+    let content = content.trim_start();
+
+    if !content.starts_with("---") {
+        anyhow::bail!("SKILL.md must start with YAML frontmatter (---)");
+    }
+
+    // Find every candidate closing `---` line: a line consisting EXACTLY of
+    // `---` (followed by `\n`, `\r\n`, or EOF) at column 0, excluding the
+    // opening line itself. The opener occupies bytes 0..(first line ending),
+    // and our scan starts after each `\n`, so the opener is naturally skipped.
+    //
+    // For each candidate we record the byte position right after its line
+    // ending; that's both where the YAML stream slice ends and where the body
+    // begins.
+    let bytes = content.as_bytes();
+    let mut candidates: Vec<usize> = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'\n' {
+            continue;
+        }
+        let line_start = i + 1;
+        if line_start + 3 > bytes.len() {
+            continue;
+        }
+        if &bytes[line_start..line_start + 3] != b"---" {
+            continue;
+        }
+        let after_dashes = line_start + 3;
+        let end = if after_dashes == bytes.len() {
+            after_dashes
+        } else if bytes[after_dashes] == b'\n' {
+            after_dashes + 1
+        } else if after_dashes + 1 < bytes.len()
+            && bytes[after_dashes] == b'\r'
+            && bytes[after_dashes + 1] == b'\n'
+        {
+            after_dashes + 2
+        } else {
+            // Line is something like `---trailing` or `----`; not a candidate.
+            continue;
+        };
+        candidates.push(end);
+    }
+
+    if candidates.is_empty() {
+        anyhow::bail!("SKILL.md missing closing frontmatter delimiter (---)");
+    }
+
+    // Try each candidate in order: slice content up through the candidate's
+    // terminator and ask `serde_yaml_ng` to parse it as a YAML stream. If the
+    // first document deserializes into `SkillMetadata`, that candidate is the
+    // real closer. Otherwise an earlier candidate may have cut the YAML in the
+    // middle of a scalar / quoted string; try the next one.
+    let mut last_error: Option<anyhow::Error> = None;
+    for end in candidates {
+        let prefix = &content[..end];
+        let mut docs = serde_yaml_ng::Deserializer::from_str(prefix);
+        let Some(first_doc) = docs.next() else {
+            continue;
+        };
+        match SkillMetadata::deserialize(first_doc) {
+            Ok(metadata) => return Ok((metadata, &content[end..])),
+            Err(e) => last_error = Some(anyhow::Error::new(e)),
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("could not parse YAML frontmatter"))
+        .context("Invalid YAML frontmatter"))
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Skill name cannot be empty");
+    }
+
+    if name.len() > 64 {
+        anyhow::bail!("Skill name must be at most 64 characters");
+    }
+
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        anyhow::bail!("Skill name must contain only lowercase letters, numbers, and hyphens");
+    }
+
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<()> {
+    if description.is_empty() {
+        anyhow::bail!("Skill description cannot be empty");
+    }
+
+    if description.len() > 1024 {
+        anyhow::bail!("Skill description must be at most 1024 characters");
+    }
+
+    Ok(())
+}
+
+pub async fn load_skills_from_directory(
+    fs: &Arc<dyn Fs>,
+    directory: &Path,
+    source: SkillSource,
+) -> Vec<Result<Skill, SkillLoadError>> {
+    if !fs.is_dir(directory).await {
+        return Vec::new();
+    }
+
+    let skill_files = find_skill_files(fs, directory).await;
+
+    let mut results: Vec<Result<Skill, SkillLoadError>> = futures::stream::iter(skill_files)
+        .map(|path| {
+            let fs = fs.clone();
+            let source = source.clone();
+            async move { load_single_skill(fs, path, source).await }
+        })
+        .buffer_unordered(SKILL_IO_CONCURRENCY)
+        .collect()
+        .await;
+
+    // Sort by path so name-conflict resolution in `merge_skills` is
+    // deterministic — `fs.read_dir` order is filesystem-dependent.
+    results.sort_by(|a, b| {
+        let path_a: &Path = match a {
+            Ok(skill) => &skill.skill_file_path,
+            Err(error) => &error.path,
+        };
+        let path_b: &Path = match b {
+            Ok(skill) => &skill.skill_file_path,
+            Err(error) => &error.path,
+        };
+        path_a.cmp(path_b)
+    });
+
+    results
+}
+
+/// Find every `<skills_root>/<name>/SKILL.md` directly under `directory`.
+///
+/// Discovery is intentionally one level deep: a skill is the immediate
+/// child directory of the skills root, and `SKILL.md` is the file that
+/// names it. See `crates/agent_skills/README.md` for why we don't recurse.
+async fn find_skill_files(fs: &Arc<dyn Fs>, directory: &Path) -> Vec<PathBuf> {
+    let Ok(mut entries) = fs.read_dir(directory).await else {
+        return Vec::new();
+    };
+
+    let mut entry_paths = Vec::new();
+    while let Some(entry) = entries.next().await {
+        if let Ok(entry_path) = entry {
+            entry_paths.push(entry_path);
+        }
+    }
+
+    futures::stream::iter(entry_paths)
+        .map(|entry_path| {
+            let fs = fs.clone();
+            async move {
+                let Ok(Some(metadata)) = fs.metadata(&entry_path).await else {
+                    return None;
+                };
+                if !metadata.is_dir {
+                    return None;
+                }
+                let skill_file = entry_path.join(SKILL_FILE_NAME);
+                fs.is_file(&skill_file).await.then_some(skill_file)
+            }
+        })
+        .buffer_unordered(SKILL_IO_CONCURRENCY)
+        .filter_map(|x| async move { x })
+        .collect()
+        .await
+}
+
+async fn load_single_skill(
+    fs: Arc<dyn Fs>,
+    path: PathBuf,
+    source: SkillSource,
+) -> Result<Skill, SkillLoadError> {
+    // Short-circuit on oversized files before loading their contents into
+    // memory, so a stray multi-GB file named `SKILL.md` can't OOM the app.
+    // We only act on a positive signal that the file is too large; if
+    // metadata fails or is unavailable, we fall through to `fs.load`,
+    // which will surface its own error (and `parse_skill` enforces the
+    // same limit as a defense-in-depth backstop).
+    if let Ok(Some(metadata)) = fs.metadata(&path).await
+        && metadata.len > MAX_SKILL_FILE_SIZE as u64
+    {
+        return Err(SkillLoadError {
+            path: path.clone(),
+            message: format!(
+                "SKILL.md file exceeds maximum size of {}KB",
+                MAX_SKILL_FILE_SIZE / 1024
+            ),
+        });
+    }
+
+    let content = fs.load(&path).await.map_err(|e| SkillLoadError {
+        path: path.clone(),
+        message: format!("Failed to read file: {}", e),
+    })?;
+
+    parse_skill(&path, &content, source).map_err(|e| SkillLoadError {
+        path: path.clone(),
+        message: e.to_string(),
+    })
+}
 
 /// Returns the global skills directory: `~/.agents/skills`.
 ///
@@ -78,21 +424,751 @@ pub fn is_agents_skills_path(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fs::FakeFs;
+    use gpui::TestAppContext;
 
     #[test]
-    fn simple_positive() {
+    fn test_parse_valid_skill() {
+        let content = r#"---
+name: my-skill
+description: A test skill for testing purposes
+---
+
+# My Skill
+
+## Instructions
+Do the thing.
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/my-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("Should parse successfully");
+
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "A test skill for testing purposes");
+        assert_eq!(skill.directory_path, Path::new("/skills/my-skill"));
+        assert!(skill.content.contains("# My Skill"));
+        assert!(skill.content.contains("Do the thing."));
+        // Default: skill is invocable by both model and user.
+        assert!(!skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_true() {
+        let content = r#"---
+name: deploy
+description: Deploy the application to production.
+disable-model-invocation: true
+---
+
+Steps to deploy.
+"#;
+
+        let skill = parse_skill(
+            Path::new("/skills/deploy/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("should parse");
+        assert!(skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_explicit_false() {
+        let content = r#"---
+name: helper
+description: A helper skill.
+disable-model-invocation: false
+---
+
+Help.
+"#;
+
+        let skill = parse_skill(
+            Path::new("/skills/helper/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("should parse");
+        assert!(!skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_missing_frontmatter() {
+        let content = "# My Skill\n\nNo frontmatter here.";
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must start with YAML frontmatter")
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_closing_delimiter() {
+        let content = r#"---
+name: test
+description: Test
+# No closing delimiter
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_frontmatter_closing_on_next_line() {
+        // An empty frontmatter (closer immediately after the opener) is a real
+        // authoring case. Parsing should ultimately fail because the empty YAML
+        // doc lacks `name` and `description`, but the error must be the proper
+        // YAML/missing-field error rather than "missing closing frontmatter
+        // delimiter" — the closer is right there.
+        let content = "---\n---\nbody\n";
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            !err_chain.contains("missing closing frontmatter delimiter"),
+            "Error should NOT be the missing-closer error since the closer is present: {}",
+            err_chain
+        );
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("name")
+                || err_chain.contains("description")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing name/description field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_name() {
+        let content = r#"---
+description: A test skill
+---
+
+Content here.
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("name")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing name field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_description() {
+        let content = r#"---
+name: test-skill
+---
+
+Content here.
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("description")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing description field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_name_too_long() {
+        let long_name = "a".repeat(65);
+        let content = format!(
+            r#"---
+name: {long_name}
+description: Test
+---
+
+Content.
+"#
+        );
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 64 characters")
+        );
+    }
+
+    #[test]
+    fn test_parse_name_invalid_chars() {
+        let content = r#"---
+name: My_Skill
+description: Test
+---
+
+Content.
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("lowercase letters, numbers, and hyphens")
+        );
+    }
+
+    #[test]
+    fn test_parse_description_too_long() {
+        let long_desc = "a".repeat(1025);
+        let content = format!(
+            r#"---
+name: test
+description: {long_desc}
+---
+
+Content.
+"#
+        );
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 1024 characters")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_description() {
+        let content = r#"---
+name: test
+description: ""
+---
+
+Content.
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_file_too_large() {
+        let large_content = format!(
+            r#"---
+name: test
+description: Test skill
+---
+
+{}"#,
+            "x".repeat(MAX_SKILL_FILE_SIZE + 1)
+        );
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            &large_content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn test_parse_empty_body_after_frontmatter() {
+        let content = r#"---
+name: minimal-skill
+description: A skill with no body content
+---
+"#;
+
+        let result = parse_skill(
+            Path::new("/skills/minimal/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+
+        let skill = result.expect("Empty body should be allowed");
+        assert_eq!(skill.name, "minimal-skill");
+        assert_eq!(skill.description, "A skill with no body content");
+        assert!(skill.content.is_empty() || skill.content.trim().is_empty());
+    }
+
+    #[test]
+    fn test_parse_whitespace_only_body() {
+        let content = "---\nname: whitespace-skill\ndescription: Test\n---\n\n   \n\n   \n";
+
+        let result = parse_skill(
+            Path::new("/skills/ws/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+
+        let skill = result.expect("Whitespace-only body should be allowed");
+        assert!(skill.content.trim().is_empty());
+    }
+
+    #[test]
+    fn test_parse_skill_with_crlf_line_endings() {
+        let content = "---\r\nname: crlf-skill\r\ndescription: A skill with CRLF line endings\r\n---\r\n\r\n# CRLF Skill\r\n\r\nDo the thing.\r\n";
+
+        let result = parse_skill(
+            Path::new("/skills/crlf-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("CRLF document should parse successfully");
+
+        assert_eq!(skill.name, "crlf-skill");
+        assert_eq!(skill.description, "A skill with CRLF line endings");
+        assert!(skill.content.contains("# CRLF Skill"));
+        assert!(skill.content.contains("Do the thing."));
+    }
+
+    #[test]
+    fn test_parse_skill_with_mixed_line_endings() {
+        let content = "---\r\nname: mixed-skill\r\ndescription: Frontmatter uses CRLF, body uses LF\r\n---\r\n\n# Mixed Skill\n\nBody uses LF only.\n";
+
+        let result = parse_skill(
+            Path::new("/skills/mixed-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("Mixed line endings should parse successfully");
+
+        assert_eq!(skill.name, "mixed-skill");
+        assert_eq!(skill.description, "Frontmatter uses CRLF, body uses LF");
+        assert!(skill.content.contains("# Mixed Skill"));
+        assert!(skill.content.contains("Body uses LF only."));
+    }
+
+    #[test]
+    fn test_parse_rejects_closing_delimiter_with_trailing_chars() {
+        // The only `---` after the opener has trailing junk on the same line,
+        // so it isn't a valid closing delimiter and parsing must error.
+        let content = "---\nname: foo\ndescription: bar\n---trailing-junk\nbody content\n";
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[test]
+    fn test_parse_accepts_only_truly_terminated_closing_delimiter() {
+        // The first `---trailing` appears inside a quoted YAML string and is
+        // NOT alone on its line, so it must not be treated as the closer.
+        // The real closer comes later as `\n---\n`.
+        let content = "---\nname: skill-name\ndescription: A real description\nsummary: \"---trailing\"\n---\nbody content\n";
+
+        let skill = parse_skill(
+            Path::new("/skills/skill-name/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("Should pick the truly-terminated closing delimiter");
+
+        assert_eq!(skill.name, "skill-name");
+        assert_eq!(skill.description, "A real description");
+        assert_eq!(skill.content, "body content");
+    }
+
+    #[test]
+    fn test_parse_accepts_four_dashes_as_invalid_closer() {
+        // A line of four dashes is NOT a valid closing delimiter; with no
+        // valid closer following, parsing must error.
+        let content = "---\nname: foo\ndescription: bar\n----\nbody content\n";
+
+        let result = parse_skill(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[gpui::test]
+    async fn test_load_skills_from_empty_directory(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/skills", serde_json::json!({})).await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+        assert!(results.is_empty());
+    }
+
+    #[gpui::test]
+    async fn test_load_single_skill(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n\n# Instructions\nDo stuff."
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "Test skill");
+        assert!(skill.content.contains("# Instructions"));
+    }
+
+    #[gpui::test]
+    async fn test_load_nested_skills(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "skill-one": {
+                    "SKILL.md": "---\nname: skill-one\ndescription: First skill\n---\n\nContent one"
+                },
+                "skill-two": {
+                    "SKILL.md": "---\nname: skill-two\ndescription: Second skill\n---\n\nContent two"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|s| s.name.as_str())
+            .collect();
+        assert!(names.contains(&"skill-one"));
+        assert!(names.contains(&"skill-two"));
+    }
+
+    #[gpui::test]
+    async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
+        // `merge_skills` resolves name conflicts by keeping the first
+        // entry in iteration order. Without a stable sort here, the
+        // result depends on `fs.read_dir`, which is OS/filesystem-
+        // dependent. Assert the contract: results come back sorted by
+        // skill file path regardless of insertion order.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "charlie": {
+                    "SKILL.md": "---\nname: charlie\ndescription: C\n---\n\nC"
+                },
+                "alpha": {
+                    "SKILL.md": "---\nname: alpha\ndescription: A\n---\n\nA"
+                },
+                "bravo": {
+                    "SKILL.md": "---\nname: bravo\ndescription: B\n---\n\nB"
+                },
+                "delta": {
+                    "SKILL.md": "No frontmatter, will fail"
+                },
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 4);
+
+        let paths: Vec<PathBuf> = results
+            .iter()
+            .map(|r| match r {
+                Ok(skill) => skill.skill_file_path.clone(),
+                Err(error) => error.path.clone(),
+            })
+            .collect();
+
+        let mut expected = paths.clone();
+        expected.sort();
+        assert_eq!(paths, expected);
+    }
+
+    #[gpui::test]
+    async fn test_load_ignores_non_skill_files(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test\n---\n\nContent"
+                },
+                "not-a-skill.txt": "This is not a skill",
+                "some-dir": {
+                    "other-file.md": "Not a SKILL.md"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+    }
+
+    #[gpui::test]
+    async fn test_load_returns_errors_for_invalid_skills(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "valid-skill": {
+                    "SKILL.md": "---\nname: valid-skill\ndescription: Valid\n---\n\nContent"
+                },
+                "invalid-skill": {
+                    "SKILL.md": "No frontmatter here"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+
+        let (successes, errors): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.is_ok());
+
+        assert_eq!(successes.len(), 1);
+        assert_eq!(errors.len(), 1);
+
+        let error = errors[0].as_ref().unwrap_err();
+        assert!(error.path.to_string_lossy().contains("invalid-skill"));
+    }
+
+    #[gpui::test]
+    async fn test_load_from_nonexistent_directory(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/nonexistent"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_skill_summary_from_skill() {
+        let skill = Skill {
+            name: "test-skill".to_string(),
+            description: "A test description".to_string(),
+            source: SkillSource::Global,
+            directory_path: PathBuf::from("/skills/test-skill"),
+            skill_file_path: PathBuf::from("/skills/test-skill/SKILL.md"),
+            content: "Instructions here".to_string(),
+            disable_model_invocation: false,
+        };
+
+        let summary = SkillSummary::from(&skill);
+        assert_eq!(summary.name, "test-skill");
+        assert_eq!(summary.description, "A test description");
+        assert_eq!(summary.location, "/skills/test-skill/SKILL.md");
+    }
+
+    #[gpui::test]
+    async fn test_nested_skill_md_inside_skill_resources_is_not_loaded(cx: &mut TestAppContext) {
+        // We only look at immediate children of the skills root, so a
+        // `SKILL.md` nested inside a skill's resources directory cannot
+        // accidentally be picked up as a separate skill.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "outer": {
+                    "SKILL.md": "---\nname: outer\ndescription: Outer skill\n---\n\nBody",
+                    "references": {
+                        "SKILL.md": "---\nname: bogus-inner\ndescription: Should not load\n---\n\nBody"
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["outer"]);
+    }
+
+    #[gpui::test]
+    async fn test_load_oversized_skill_file_short_circuits(cx: &mut TestAppContext) {
+        // A `SKILL.md` whose size exceeds `MAX_SKILL_FILE_SIZE` must be
+        // rejected via metadata before we read its contents into memory.
+        // Otherwise a stray multi-GB file dropped into a skill directory
+        // would OOM the application before `parse_skill`'s size check fires.
+        let fs = FakeFs::new(cx.executor());
+        let oversized_body = "x".repeat(MAX_SKILL_FILE_SIZE + 1);
+        let oversized_content = format!(
+            "---\nname: huge\ndescription: Too big\n---\n\n{}",
+            oversized_body
+        );
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "huge": {
+                    "SKILL.md": oversized_content,
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let err = results[0].as_ref().expect_err("Oversized file must error");
+        assert!(
+            err.message.contains("exceeds maximum size"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn is_agents_skills_path_simple_positive() {
         assert!(is_agents_skills_path(Path::new(
             "foo/.agents/skills/my-skill/SKILL.md"
         )));
     }
 
     #[test]
-    fn simple_negative() {
+    fn is_agents_skills_path_simple_negative() {
         assert!(!is_agents_skills_path(Path::new("foo/bar/baz")));
     }
 
     #[test]
-    fn double_agents() {
+    fn is_agents_skills_path_double_agents() {
         // `foo/.agents/.agents/skills` contains a `.agents/skills` pair at
         // depths 2-3. Any-depth matching catches it; this is intentional, so
         // a `.agents/skills` directory the user wasn't expecting to be
@@ -103,22 +1179,22 @@ mod tests {
     }
 
     #[test]
-    fn agents_without_skills() {
+    fn is_agents_skills_path_agents_without_skills() {
         assert!(!is_agents_skills_path(Path::new("foo/.agents/other")));
     }
 
     #[test]
-    fn at_start() {
+    fn is_agents_skills_path_at_start() {
         assert!(is_agents_skills_path(Path::new(".agents/skills")));
     }
 
     #[test]
-    fn trailing_agents() {
+    fn is_agents_skills_path_trailing_agents() {
         assert!(!is_agents_skills_path(Path::new("foo/.agents")));
     }
 
     #[test]
-    fn deep_match() {
+    fn is_agents_skills_path_deep_match() {
         // Any-depth matching: nested `.agents/skills` directories — e.g.
         // inside vendored sources — are flagged too. We prefer the extra
         // prompt over silently letting the agent edit something named
@@ -130,7 +1206,7 @@ mod tests {
     }
 
     #[test]
-    fn absolute() {
+    fn is_agents_skills_path_absolute() {
         // Absolute paths into a project-local `.agents/skills/` are caught
         // by the same consecutive-component match.
         assert!(is_agents_skills_path(Path::new(
@@ -140,7 +1216,7 @@ mod tests {
     }
 
     #[test]
-    fn case_insensitive() {
+    fn is_agents_skills_path_case_insensitive() {
         // Filesystems on macOS/Windows are case-insensitive by default; the
         // classifier must agree.
         assert!(is_agents_skills_path(Path::new(".AGENTS/skills/foo")));

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -1,7 +1,5 @@
-use anyhow::{Context as _, Result};
 use fs::Fs;
 use futures::StreamExt;
-use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use util::paths::component_matches_ignore_ascii_case;
@@ -27,31 +25,19 @@ pub struct SkillScopeId(pub usize);
 /// operations, potentially exhausting file descriptors or stalling the app.
 const SKILL_IO_CONCURRENCY: usize = 16;
 
-/// Maximum size for a single SKILL.md file (100KB)
-pub const MAX_SKILL_FILE_SIZE: usize = 100 * 1024;
-
-/// Maximum total size for skill descriptions in system prompt (50KB)
-pub const MAX_SKILL_DESCRIPTIONS_SIZE: usize = 50 * 1024;
-
 /// The name of the skill definition file
 pub const SKILL_FILE_NAME: &str = "SKILL.md";
 
-/// Represents a loaded skill with all its metadata and content.
-#[derive(Debug, Clone)]
+/// A skill discovered on disk. This PR only records paths; the
+/// `SKILL.md` contents (name, description, body) are parsed in a
+/// follow-up PR.
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Skill {
-    pub name: String,
-    pub description: String,
     pub source: SkillSource,
-    /// Absolute path to the skill directory
+    /// Absolute path to the skill directory (e.g. `~/.agents/skills/foo`).
     pub directory_path: PathBuf,
-    /// Absolute path to the SKILL.md file
+    /// Absolute path to the `SKILL.md` file inside the skill directory.
     pub skill_file_path: PathBuf,
-    /// The full content of SKILL.md (excluding frontmatter)
-    pub content: String,
-    /// When `true`, this skill is hidden from the model's catalog and the
-    /// `skill` tool refuses to load it. The user can still invoke it as a
-    /// slash command.
-    pub disable_model_invocation: bool,
 }
 
 /// Indicates where a skill was loaded from.
@@ -66,231 +52,34 @@ pub enum SkillSource {
     },
 }
 
-/// Just the frontmatter, used for parsing
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SkillMetadata {
-    pub name: String,
-    pub description: String,
-    #[serde(default, rename = "disable-model-invocation")]
-    pub disable_model_invocation: bool,
-}
-
-/// Minimal skill info for system prompt (not full content).
-///
-/// `Serialize` is required for handlebars rendering of the system prompt
-/// template (see `ProjectContext` in `prompt_store`). `PartialEq, Eq` lets
-/// the agent compare freshly-built `ProjectContext`s and skip pushing an
-/// unchanged value through the project_context entity (which would
-/// otherwise look like a system-prompt change to the model and invalidate
-/// the API's prompt cache).
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
-pub struct SkillSummary {
-    pub name: String,
-    pub description: String,
-    /// Absolute path to the SKILL.md file, so the model can resolve
-    /// references relative to the skill's directory when reading bundled
-    /// resources.
-    pub location: String,
-}
-
-impl From<&Skill> for SkillSummary {
-    fn from(skill: &Skill) -> Self {
-        Self {
-            name: skill.name.clone(),
-            description: skill.description.clone(),
-            location: skill.skill_file_path.to_string_lossy().into_owned(),
-        }
-    }
-}
-
-/// Error that occurred while loading a skill
-#[derive(Debug, Clone)]
-pub struct SkillLoadError {
-    pub path: PathBuf,
-    pub message: String,
-}
-
-impl std::fmt::Display for SkillLoadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.path.display(), self.message)
-    }
-}
-
-impl std::error::Error for SkillLoadError {}
-
-/// Parse a SKILL.md file into a Skill struct.
-///
-/// The file must have YAML frontmatter between `---` delimiters containing
-/// `name` and `description` fields. The content after frontmatter becomes
-/// the skill's instructions.
-pub fn parse_skill(skill_file_path: &Path, content: &str, source: SkillSource) -> Result<Skill> {
-    if content.len() > MAX_SKILL_FILE_SIZE {
-        anyhow::bail!(
-            "SKILL.md file exceeds maximum size of {}KB",
-            MAX_SKILL_FILE_SIZE / 1024
-        );
-    }
-
-    let (metadata, body) = extract_frontmatter(content)?;
-
-    validate_name(&metadata.name)?;
-    validate_description(&metadata.description)?;
-
-    let directory_path = skill_file_path
-        .parent()
-        .context("SKILL.md file has no parent directory")?
-        .to_path_buf();
-
-    Ok(Skill {
-        name: metadata.name,
-        description: metadata.description,
-        source,
-        directory_path,
-        skill_file_path: skill_file_path.to_path_buf(),
-        content: body.trim().to_string(),
-        disable_model_invocation: metadata.disable_model_invocation,
-    })
-}
-
-fn extract_frontmatter(content: &str) -> Result<(SkillMetadata, &str)> {
-    let content = content.trim_start();
-
-    if !content.starts_with("---") {
-        anyhow::bail!("SKILL.md must start with YAML frontmatter (---)");
-    }
-
-    // Find every candidate closing `---` line: a line consisting EXACTLY of
-    // `---` (followed by `\n`, `\r\n`, or EOF) at column 0, excluding the
-    // opening line itself. The opener occupies bytes 0..(first line ending),
-    // and our scan starts after each `\n`, so the opener is naturally skipped.
-    //
-    // For each candidate we record the byte position right after its line
-    // ending; that's both where the YAML stream slice ends and where the body
-    // begins.
-    let bytes = content.as_bytes();
-    let mut candidates: Vec<usize> = Vec::new();
-    for (i, &b) in bytes.iter().enumerate() {
-        if b != b'\n' {
-            continue;
-        }
-        let line_start = i + 1;
-        if line_start + 3 > bytes.len() {
-            continue;
-        }
-        if &bytes[line_start..line_start + 3] != b"---" {
-            continue;
-        }
-        let after_dashes = line_start + 3;
-        let end = if after_dashes == bytes.len() {
-            after_dashes
-        } else if bytes[after_dashes] == b'\n' {
-            after_dashes + 1
-        } else if after_dashes + 1 < bytes.len()
-            && bytes[after_dashes] == b'\r'
-            && bytes[after_dashes + 1] == b'\n'
-        {
-            after_dashes + 2
-        } else {
-            // Line is something like `---trailing` or `----`; not a candidate.
-            continue;
-        };
-        candidates.push(end);
-    }
-
-    if candidates.is_empty() {
-        anyhow::bail!("SKILL.md missing closing frontmatter delimiter (---)");
-    }
-
-    // Try each candidate in order: slice content up through the candidate's
-    // terminator and ask `serde_yaml_ng` to parse it as a YAML stream. If the
-    // first document deserializes into `SkillMetadata`, that candidate is the
-    // real closer. Otherwise an earlier candidate may have cut the YAML in the
-    // middle of a scalar / quoted string; try the next one.
-    let mut last_error: Option<anyhow::Error> = None;
-    for end in candidates {
-        let prefix = &content[..end];
-        let mut docs = serde_yaml_ng::Deserializer::from_str(prefix);
-        let Some(first_doc) = docs.next() else {
-            continue;
-        };
-        match SkillMetadata::deserialize(first_doc) {
-            Ok(metadata) => return Ok((metadata, &content[end..])),
-            Err(e) => last_error = Some(anyhow::Error::new(e)),
-        }
-    }
-
-    Err(last_error
-        .unwrap_or_else(|| anyhow::anyhow!("could not parse YAML frontmatter"))
-        .context("Invalid YAML frontmatter"))
-}
-
-fn validate_name(name: &str) -> Result<()> {
-    if name.is_empty() {
-        anyhow::bail!("Skill name cannot be empty");
-    }
-
-    if name.len() > 64 {
-        anyhow::bail!("Skill name must be at most 64 characters");
-    }
-
-    if !name
-        .chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-    {
-        anyhow::bail!("Skill name must contain only lowercase letters, numbers, and hyphens");
-    }
-
-    Ok(())
-}
-
-fn validate_description(description: &str) -> Result<()> {
-    if description.is_empty() {
-        anyhow::bail!("Skill description cannot be empty");
-    }
-
-    if description.len() > 1024 {
-        anyhow::bail!("Skill description must be at most 1024 characters");
-    }
-
-    Ok(())
-}
-
 pub async fn load_skills_from_directory(
     fs: &Arc<dyn Fs>,
     directory: &Path,
     source: SkillSource,
-) -> Vec<Result<Skill, SkillLoadError>> {
+) -> Vec<Skill> {
     if !fs.is_dir(directory).await {
         return Vec::new();
     }
 
     let skill_files = find_skill_files(fs, directory).await;
 
-    let mut results: Vec<Result<Skill, SkillLoadError>> = futures::stream::iter(skill_files)
-        .map(|path| {
-            let fs = fs.clone();
-            let source = source.clone();
-            async move { load_single_skill(fs, path, source).await }
+    let mut skills: Vec<Skill> = skill_files
+        .into_iter()
+        .filter_map(|skill_file_path| {
+            let directory_path = skill_file_path.parent()?.to_path_buf();
+            Some(Skill {
+                source: source.clone(),
+                directory_path,
+                skill_file_path,
+            })
         })
-        .buffer_unordered(SKILL_IO_CONCURRENCY)
-        .collect()
-        .await;
+        .collect();
 
-    // Sort by path so name-conflict resolution in `merge_skills` is
-    // deterministic — `fs.read_dir` order is filesystem-dependent.
-    results.sort_by(|a, b| {
-        let path_a: &Path = match a {
-            Ok(skill) => &skill.skill_file_path,
-            Err(error) => &error.path,
-        };
-        let path_b: &Path = match b {
-            Ok(skill) => &skill.skill_file_path,
-            Err(error) => &error.path,
-        };
-        path_a.cmp(path_b)
-    });
+    // Sort by path for deterministic ordering — `fs.read_dir` order is
+    // filesystem-dependent.
+    skills.sort_by(|a, b| a.skill_file_path.cmp(&b.skill_file_path));
 
-    results
+    skills
 }
 
 /// Find every `<skills_root>/<name>/SKILL.md` directly under `directory`.
@@ -328,40 +117,6 @@ async fn find_skill_files(fs: &Arc<dyn Fs>, directory: &Path) -> Vec<PathBuf> {
         .filter_map(|x| async move { x })
         .collect()
         .await
-}
-
-async fn load_single_skill(
-    fs: Arc<dyn Fs>,
-    path: PathBuf,
-    source: SkillSource,
-) -> Result<Skill, SkillLoadError> {
-    // Short-circuit on oversized files before loading their contents into
-    // memory, so a stray multi-GB file named `SKILL.md` can't OOM the app.
-    // We only act on a positive signal that the file is too large; if
-    // metadata fails or is unavailable, we fall through to `fs.load`,
-    // which will surface its own error (and `parse_skill` enforces the
-    // same limit as a defense-in-depth backstop).
-    if let Ok(Some(metadata)) = fs.metadata(&path).await
-        && metadata.len > MAX_SKILL_FILE_SIZE as u64
-    {
-        return Err(SkillLoadError {
-            path: path.clone(),
-            message: format!(
-                "SKILL.md file exceeds maximum size of {}KB",
-                MAX_SKILL_FILE_SIZE / 1024
-            ),
-        });
-    }
-
-    let content = fs.load(&path).await.map_err(|e| SkillLoadError {
-        path: path.clone(),
-        message: format!("Failed to read file: {}", e),
-    })?;
-
-    parse_skill(&path, &content, source).map_err(|e| SkillLoadError {
-        path: path.clone(),
-        message: e.to_string(),
-    })
 }
 
 /// Returns the global skills directory: `~/.agents/skills`.
@@ -427,448 +182,10 @@ mod tests {
     use fs::FakeFs;
     use gpui::TestAppContext;
 
-    #[test]
-    fn test_parse_valid_skill() {
-        let content = r#"---
-name: my-skill
-description: A test skill for testing purposes
----
-
-# My Skill
-
-## Instructions
-Do the thing.
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/my-skill/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        let skill = result.expect("Should parse successfully");
-
-        assert_eq!(skill.name, "my-skill");
-        assert_eq!(skill.description, "A test skill for testing purposes");
-        assert_eq!(skill.directory_path, Path::new("/skills/my-skill"));
-        assert!(skill.content.contains("# My Skill"));
-        assert!(skill.content.contains("Do the thing."));
-        // Default: skill is invocable by both model and user.
-        assert!(!skill.disable_model_invocation);
-    }
-
-    #[test]
-    fn test_parse_disable_model_invocation_true() {
-        let content = r#"---
-name: deploy
-description: Deploy the application to production.
-disable-model-invocation: true
----
-
-Steps to deploy.
-"#;
-
-        let skill = parse_skill(
-            Path::new("/skills/deploy/SKILL.md"),
-            content,
-            SkillSource::Global,
-        )
-        .expect("should parse");
-        assert!(skill.disable_model_invocation);
-    }
-
-    #[test]
-    fn test_parse_disable_model_invocation_explicit_false() {
-        let content = r#"---
-name: helper
-description: A helper skill.
-disable-model-invocation: false
----
-
-Help.
-"#;
-
-        let skill = parse_skill(
-            Path::new("/skills/helper/SKILL.md"),
-            content,
-            SkillSource::Global,
-        )
-        .expect("should parse");
-        assert!(!skill.disable_model_invocation);
-    }
-
-    #[test]
-    fn test_parse_missing_frontmatter() {
-        let content = "# My Skill\n\nNo frontmatter here.";
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("must start with YAML frontmatter")
-        );
-    }
-
-    #[test]
-    fn test_parse_missing_closing_delimiter() {
-        let content = r#"---
-name: test
-description: Test
-# No closing delimiter
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("missing closing frontmatter delimiter")
-        );
-    }
-
-    #[test]
-    fn test_parse_empty_frontmatter_closing_on_next_line() {
-        // An empty frontmatter (closer immediately after the opener) is a real
-        // authoring case. Parsing should ultimately fail because the empty YAML
-        // doc lacks `name` and `description`, but the error must be the proper
-        // YAML/missing-field error rather than "missing closing frontmatter
-        // delimiter" — the closer is right there.
-        let content = "---\n---\nbody\n";
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        let err_chain = format!("{:?}", err);
-        assert!(
-            !err_chain.contains("missing closing frontmatter delimiter"),
-            "Error should NOT be the missing-closer error since the closer is present: {}",
-            err_chain
-        );
-        assert!(
-            err_chain.contains("missing field")
-                || err_chain.contains("name")
-                || err_chain.contains("description")
-                || err_chain.contains("Invalid YAML"),
-            "Error should mention missing name/description field or invalid YAML: {}",
-            err_chain
-        );
-    }
-
-    #[test]
-    fn test_parse_missing_name() {
-        let content = r#"---
-description: A test skill
----
-
-Content here.
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        let err_chain = format!("{:?}", err);
-        assert!(
-            err_chain.contains("missing field")
-                || err_chain.contains("name")
-                || err_chain.contains("Invalid YAML"),
-            "Error should mention missing name field or invalid YAML: {}",
-            err_chain
-        );
-    }
-
-    #[test]
-    fn test_parse_missing_description() {
-        let content = r#"---
-name: test-skill
----
-
-Content here.
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        let err_chain = format!("{:?}", err);
-        assert!(
-            err_chain.contains("missing field")
-                || err_chain.contains("description")
-                || err_chain.contains("Invalid YAML"),
-            "Error should mention missing description field or invalid YAML: {}",
-            err_chain
-        );
-    }
-
-    #[test]
-    fn test_parse_name_too_long() {
-        let long_name = "a".repeat(65);
-        let content = format!(
-            r#"---
-name: {long_name}
-description: Test
----
-
-Content.
-"#
-        );
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            &content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("at most 64 characters")
-        );
-    }
-
-    #[test]
-    fn test_parse_name_invalid_chars() {
-        let content = r#"---
-name: My_Skill
-description: Test
----
-
-Content.
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("lowercase letters, numbers, and hyphens")
-        );
-    }
-
-    #[test]
-    fn test_parse_description_too_long() {
-        let long_desc = "a".repeat(1025);
-        let content = format!(
-            r#"---
-name: test
-description: {long_desc}
----
-
-Content.
-"#
-        );
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            &content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("at most 1024 characters")
-        );
-    }
-
-    #[test]
-    fn test_parse_empty_description() {
-        let content = r#"---
-name: test
-description: ""
----
-
-Content.
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
-    }
-
-    #[test]
-    fn test_parse_file_too_large() {
-        let large_content = format!(
-            r#"---
-name: test
-description: Test skill
----
-
-{}"#,
-            "x".repeat(MAX_SKILL_FILE_SIZE + 1)
-        );
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            &large_content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
-    }
-
-    #[test]
-    fn test_parse_empty_body_after_frontmatter() {
-        let content = r#"---
-name: minimal-skill
-description: A skill with no body content
----
-"#;
-
-        let result = parse_skill(
-            Path::new("/skills/minimal/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-
-        let skill = result.expect("Empty body should be allowed");
-        assert_eq!(skill.name, "minimal-skill");
-        assert_eq!(skill.description, "A skill with no body content");
-        assert!(skill.content.is_empty() || skill.content.trim().is_empty());
-    }
-
-    #[test]
-    fn test_parse_whitespace_only_body() {
-        let content = "---\nname: whitespace-skill\ndescription: Test\n---\n\n   \n\n   \n";
-
-        let result = parse_skill(
-            Path::new("/skills/ws/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-
-        let skill = result.expect("Whitespace-only body should be allowed");
-        assert!(skill.content.trim().is_empty());
-    }
-
-    #[test]
-    fn test_parse_skill_with_crlf_line_endings() {
-        let content = "---\r\nname: crlf-skill\r\ndescription: A skill with CRLF line endings\r\n---\r\n\r\n# CRLF Skill\r\n\r\nDo the thing.\r\n";
-
-        let result = parse_skill(
-            Path::new("/skills/crlf-skill/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        let skill = result.expect("CRLF document should parse successfully");
-
-        assert_eq!(skill.name, "crlf-skill");
-        assert_eq!(skill.description, "A skill with CRLF line endings");
-        assert!(skill.content.contains("# CRLF Skill"));
-        assert!(skill.content.contains("Do the thing."));
-    }
-
-    #[test]
-    fn test_parse_skill_with_mixed_line_endings() {
-        let content = "---\r\nname: mixed-skill\r\ndescription: Frontmatter uses CRLF, body uses LF\r\n---\r\n\n# Mixed Skill\n\nBody uses LF only.\n";
-
-        let result = parse_skill(
-            Path::new("/skills/mixed-skill/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        let skill = result.expect("Mixed line endings should parse successfully");
-
-        assert_eq!(skill.name, "mixed-skill");
-        assert_eq!(skill.description, "Frontmatter uses CRLF, body uses LF");
-        assert!(skill.content.contains("# Mixed Skill"));
-        assert!(skill.content.contains("Body uses LF only."));
-    }
-
-    #[test]
-    fn test_parse_rejects_closing_delimiter_with_trailing_chars() {
-        // The only `---` after the opener has trailing junk on the same line,
-        // so it isn't a valid closing delimiter and parsing must error.
-        let content = "---\nname: foo\ndescription: bar\n---trailing-junk\nbody content\n";
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("missing closing frontmatter delimiter")
-        );
-    }
-
-    #[test]
-    fn test_parse_accepts_only_truly_terminated_closing_delimiter() {
-        // The first `---trailing` appears inside a quoted YAML string and is
-        // NOT alone on its line, so it must not be treated as the closer.
-        // The real closer comes later as `\n---\n`.
-        let content = "---\nname: skill-name\ndescription: A real description\nsummary: \"---trailing\"\n---\nbody content\n";
-
-        let skill = parse_skill(
-            Path::new("/skills/skill-name/SKILL.md"),
-            content,
-            SkillSource::Global,
-        )
-        .expect("Should pick the truly-terminated closing delimiter");
-
-        assert_eq!(skill.name, "skill-name");
-        assert_eq!(skill.description, "A real description");
-        assert_eq!(skill.content, "body content");
-    }
-
-    #[test]
-    fn test_parse_accepts_four_dashes_as_invalid_closer() {
-        // A line of four dashes is NOT a valid closing delimiter; with no
-        // valid closer following, parsing must error.
-        let content = "---\nname: foo\ndescription: bar\n----\nbody content\n";
-
-        let result = parse_skill(
-            Path::new("/skills/test/SKILL.md"),
-            content,
-            SkillSource::Global,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("missing closing frontmatter delimiter")
-        );
-    }
-
     #[gpui::test]
     async fn test_load_skills_from_empty_directory(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree("/skills", serde_json::json!({})).await;
+        fs.create_dir(Path::new("/skills")).await.unwrap();
 
         let results = load_skills_from_directory(
             &(fs as Arc<dyn Fs>),
@@ -882,13 +199,10 @@ description: A skill with no body content
     #[gpui::test]
     async fn test_load_single_skill(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "my-skill": {
-                    "SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n\n# Instructions\nDo stuff."
-                }
-            }),
+        fs.create_dir(Path::new("/skills/my-skill")).await.unwrap();
+        fs.insert_file(
+            Path::new("/skills/my-skill/SKILL.md"),
+            b"placeholder".to_vec(),
         )
         .await;
 
@@ -899,26 +213,29 @@ description: A skill with no body content
         )
         .await;
 
-        assert_eq!(results.len(), 1);
-        let skill = results[0].as_ref().expect("Should load successfully");
-        assert_eq!(skill.name, "my-skill");
-        assert_eq!(skill.description, "Test skill");
-        assert!(skill.content.contains("# Instructions"));
+        assert_eq!(
+            results,
+            vec![Skill {
+                source: SkillSource::Global,
+                directory_path: PathBuf::from("/skills/my-skill"),
+                skill_file_path: PathBuf::from("/skills/my-skill/SKILL.md"),
+            }]
+        );
     }
 
     #[gpui::test]
     async fn test_load_nested_skills(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "skill-one": {
-                    "SKILL.md": "---\nname: skill-one\ndescription: First skill\n---\n\nContent one"
-                },
-                "skill-two": {
-                    "SKILL.md": "---\nname: skill-two\ndescription: Second skill\n---\n\nContent two"
-                }
-            }),
+        fs.create_dir(Path::new("/skills/skill-one")).await.unwrap();
+        fs.insert_file(
+            Path::new("/skills/skill-one/SKILL.md"),
+            b"placeholder".to_vec(),
+        )
+        .await;
+        fs.create_dir(Path::new("/skills/skill-two")).await.unwrap();
+        fs.insert_file(
+            Path::new("/skills/skill-two/SKILL.md"),
+            b"placeholder".to_vec(),
         )
         .await;
 
@@ -929,42 +246,25 @@ description: A skill with no body content
         )
         .await;
 
-        assert_eq!(results.len(), 2);
-        let names: Vec<&str> = results
-            .iter()
-            .filter_map(|r| r.as_ref().ok())
-            .map(|s| s.name.as_str())
-            .collect();
-        assert!(names.contains(&"skill-one"));
-        assert!(names.contains(&"skill-two"));
+        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/skills/skill-one/SKILL.md"),
+                PathBuf::from("/skills/skill-two/SKILL.md"),
+            ]
+        );
     }
 
     #[gpui::test]
     async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
-        // `merge_skills` resolves name conflicts by keeping the first
-        // entry in iteration order. Without a stable sort here, the
-        // result depends on `fs.read_dir`, which is OS/filesystem-
-        // dependent. Assert the contract: results come back sorted by
-        // skill file path regardless of insertion order.
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "charlie": {
-                    "SKILL.md": "---\nname: charlie\ndescription: C\n---\n\nC"
-                },
-                "alpha": {
-                    "SKILL.md": "---\nname: alpha\ndescription: A\n---\n\nA"
-                },
-                "bravo": {
-                    "SKILL.md": "---\nname: bravo\ndescription: B\n---\n\nB"
-                },
-                "delta": {
-                    "SKILL.md": "No frontmatter, will fail"
-                },
-            }),
-        )
-        .await;
+        for name in ["charlie", "alpha", "bravo", "delta"] {
+            let dir = PathBuf::from("/skills").join(name);
+            fs.create_dir(&dir).await.unwrap();
+            fs.insert_file(&dir.join("SKILL.md"), b"placeholder".to_vec())
+                .await;
+        }
 
         let results = load_skills_from_directory(
             &(fs as Arc<dyn Fs>),
@@ -973,15 +273,7 @@ description: A skill with no body content
         )
         .await;
 
-        assert_eq!(results.len(), 4);
-
-        let paths: Vec<PathBuf> = results
-            .iter()
-            .map(|r| match r {
-                Ok(skill) => skill.skill_file_path.clone(),
-                Err(error) => error.path.clone(),
-            })
-            .collect();
+        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
 
         let mut expected = paths.clone();
         expected.sort();
@@ -991,17 +283,21 @@ description: A skill with no body content
     #[gpui::test]
     async fn test_load_ignores_non_skill_files(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "my-skill": {
-                    "SKILL.md": "---\nname: my-skill\ndescription: Test\n---\n\nContent"
-                },
-                "not-a-skill.txt": "This is not a skill",
-                "some-dir": {
-                    "other-file.md": "Not a SKILL.md"
-                }
-            }),
+        fs.create_dir(Path::new("/skills/my-skill")).await.unwrap();
+        fs.insert_file(
+            Path::new("/skills/my-skill/SKILL.md"),
+            b"placeholder".to_vec(),
+        )
+        .await;
+        fs.insert_file(
+            Path::new("/skills/not-a-skill.txt"),
+            b"This is not a skill".to_vec(),
+        )
+        .await;
+        fs.create_dir(Path::new("/skills/some-dir")).await.unwrap();
+        fs.insert_file(
+            Path::new("/skills/some-dir/other-file.md"),
+            b"Not a SKILL.md".to_vec(),
         )
         .await;
 
@@ -1013,42 +309,10 @@ description: A skill with no body content
         .await;
 
         assert_eq!(results.len(), 1);
-        let skill = results[0].as_ref().expect("Should load successfully");
-        assert_eq!(skill.name, "my-skill");
-    }
-
-    #[gpui::test]
-    async fn test_load_returns_errors_for_invalid_skills(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "valid-skill": {
-                    "SKILL.md": "---\nname: valid-skill\ndescription: Valid\n---\n\nContent"
-                },
-                "invalid-skill": {
-                    "SKILL.md": "No frontmatter here"
-                }
-            }),
-        )
-        .await;
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        assert_eq!(results.len(), 2);
-
-        let (successes, errors): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.is_ok());
-
-        assert_eq!(successes.len(), 1);
-        assert_eq!(errors.len(), 1);
-
-        let error = errors[0].as_ref().unwrap_err();
-        assert!(error.path.to_string_lossy().contains("invalid-skill"));
+        assert_eq!(
+            results[0].skill_file_path,
+            PathBuf::from("/skills/my-skill/SKILL.md")
+        );
     }
 
     #[gpui::test]
@@ -1065,40 +329,21 @@ description: A skill with no body content
         assert!(results.is_empty());
     }
 
-    #[test]
-    fn test_skill_summary_from_skill() {
-        let skill = Skill {
-            name: "test-skill".to_string(),
-            description: "A test description".to_string(),
-            source: SkillSource::Global,
-            directory_path: PathBuf::from("/skills/test-skill"),
-            skill_file_path: PathBuf::from("/skills/test-skill/SKILL.md"),
-            content: "Instructions here".to_string(),
-            disable_model_invocation: false,
-        };
-
-        let summary = SkillSummary::from(&skill);
-        assert_eq!(summary.name, "test-skill");
-        assert_eq!(summary.description, "A test description");
-        assert_eq!(summary.location, "/skills/test-skill/SKILL.md");
-    }
-
     #[gpui::test]
     async fn test_nested_skill_md_inside_skill_resources_is_not_loaded(cx: &mut TestAppContext) {
         // We only look at immediate children of the skills root, so a
         // `SKILL.md` nested inside a skill's resources directory cannot
         // accidentally be picked up as a separate skill.
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "outer": {
-                    "SKILL.md": "---\nname: outer\ndescription: Outer skill\n---\n\nBody",
-                    "references": {
-                        "SKILL.md": "---\nname: bogus-inner\ndescription: Should not load\n---\n\nBody"
-                    },
-                },
-            }),
+        fs.create_dir(Path::new("/skills/outer")).await.unwrap();
+        fs.insert_file(Path::new("/skills/outer/SKILL.md"), b"placeholder".to_vec())
+            .await;
+        fs.create_dir(Path::new("/skills/outer/references"))
+            .await
+            .unwrap();
+        fs.insert_file(
+            Path::new("/skills/outer/references/SKILL.md"),
+            b"placeholder".to_vec(),
         )
         .await;
 
@@ -1109,50 +354,8 @@ description: A skill with no body content
         )
         .await;
 
-        let names: Vec<&str> = results
-            .iter()
-            .filter_map(|r| r.as_ref().ok())
-            .map(|s| s.name.as_str())
-            .collect();
-        assert_eq!(names, vec!["outer"]);
-    }
-
-    #[gpui::test]
-    async fn test_load_oversized_skill_file_short_circuits(cx: &mut TestAppContext) {
-        // A `SKILL.md` whose size exceeds `MAX_SKILL_FILE_SIZE` must be
-        // rejected via metadata before we read its contents into memory.
-        // Otherwise a stray multi-GB file dropped into a skill directory
-        // would OOM the application before `parse_skill`'s size check fires.
-        let fs = FakeFs::new(cx.executor());
-        let oversized_body = "x".repeat(MAX_SKILL_FILE_SIZE + 1);
-        let oversized_content = format!(
-            "---\nname: huge\ndescription: Too big\n---\n\n{}",
-            oversized_body
-        );
-        fs.insert_tree(
-            "/skills",
-            serde_json::json!({
-                "huge": {
-                    "SKILL.md": oversized_content,
-                }
-            }),
-        )
-        .await;
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        assert_eq!(results.len(), 1);
-        let err = results[0].as_ref().expect_err("Oversized file must error");
-        assert!(
-            err.message.contains("exceeds maximum size"),
-            "unexpected error message: {}",
-            err.message
-        );
+        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
+        assert_eq!(paths, vec![PathBuf::from("/skills/outer/SKILL.md")]);
     }
 
     #[test]

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -1,5 +1,8 @@
+use anyhow::{Context as _, Result};
 use fs::Fs;
 use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use util::paths::component_matches_ignore_ascii_case;
@@ -25,19 +28,29 @@ pub struct SkillScopeId(pub usize);
 /// operations, potentially exhausting file descriptors or stalling the app.
 const SKILL_IO_CONCURRENCY: usize = 16;
 
+/// Maximum size for a single SKILL.md file (100KB)
+pub const MAX_SKILL_FILE_SIZE: usize = 100 * 1024;
+
+/// Maximum total size for skill descriptions in system prompt (50KB)
+pub const MAX_SKILL_DESCRIPTIONS_SIZE: usize = 50 * 1024;
+
 /// The name of the skill definition file
 pub const SKILL_FILE_NAME: &str = "SKILL.md";
 
-/// A skill discovered on disk. This PR only records paths; the
-/// `SKILL.md` contents (name, description, body) are parsed in a
-/// follow-up PR.
-#[derive(Debug, Clone, Eq, PartialEq)]
+/// Represents a loaded skill with all its metadata and content.
+#[derive(Debug, Clone)]
 pub struct Skill {
+    pub name: String,
+    pub description: String,
     pub source: SkillSource,
-    /// Absolute path to the skill directory (e.g. `~/.agents/skills/foo`).
+    /// Absolute path to the skill directory
     pub directory_path: PathBuf,
-    /// Absolute path to the `SKILL.md` file inside the skill directory.
+    /// Absolute path to the SKILL.md file
     pub skill_file_path: PathBuf,
+    /// When `true`, this skill is hidden from the model's catalog and the
+    /// `skill` tool refuses to load it. The user can still invoke it as a
+    /// slash command.
+    pub disable_model_invocation: bool,
 }
 
 /// Indicates where a skill was loaded from.
@@ -52,34 +65,239 @@ pub enum SkillSource {
     },
 }
 
+/// Just the frontmatter, used for parsing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillMetadata {
+    pub name: String,
+    pub description: String,
+    #[serde(default, rename = "disable-model-invocation")]
+    pub disable_model_invocation: bool,
+}
+
+/// Minimal skill info for system prompt (not full content).
+///
+/// `Serialize` is required for handlebars rendering of the system prompt
+/// template (see `ProjectContext` in `prompt_store`). `PartialEq, Eq` lets
+/// the agent compare freshly-built `ProjectContext`s and skip pushing an
+/// unchanged value through the project_context entity (which would
+/// otherwise look like a system-prompt change to the model and invalidate
+/// the API's prompt cache).
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct SkillSummary {
+    pub name: String,
+    pub description: String,
+    /// Absolute path to the SKILL.md file, so the model can resolve
+    /// references relative to the skill's directory when reading bundled
+    /// resources.
+    pub location: String,
+}
+
+impl From<&Skill> for SkillSummary {
+    fn from(skill: &Skill) -> Self {
+        Self {
+            name: skill.name.clone(),
+            description: skill.description.clone(),
+            location: skill.skill_file_path.to_string_lossy().into_owned(),
+        }
+    }
+}
+
+/// Error that occurred while loading a skill
+#[derive(Debug, Clone)]
+pub struct SkillLoadError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl std::fmt::Display for SkillLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+impl std::error::Error for SkillLoadError {}
+
+/// Parse the frontmatter of a SKILL.md file into a `Skill` struct.
+///
+/// The file must have YAML frontmatter between `---` delimiters containing
+/// `name` and `description` fields. The body (everything after the closing
+/// `---`) is intentionally NOT returned — it's read on demand via
+/// `read_skill_body` when the skill is actually being materialized for the
+/// model, so we don't pay N × body-size in memory for N skills.
+///
+/// `content` only needs to contain bytes up through the closing `---`; any
+/// trailing body bytes are ignored.
+pub fn parse_skill_frontmatter(
+    skill_file_path: &Path,
+    content: &str,
+    source: SkillSource,
+) -> Result<Skill> {
+    if content.len() > MAX_SKILL_FILE_SIZE {
+        anyhow::bail!(
+            "SKILL.md file exceeds maximum size of {}KB",
+            MAX_SKILL_FILE_SIZE / 1024
+        );
+    }
+
+    let (metadata, _body) = extract_frontmatter(content)?;
+
+    validate_name(&metadata.name)?;
+    validate_description(&metadata.description)?;
+
+    let directory_path = skill_file_path
+        .parent()
+        .context("SKILL.md file has no parent directory")?
+        .to_path_buf();
+
+    Ok(Skill {
+        name: metadata.name,
+        description: metadata.description,
+        source,
+        directory_path,
+        skill_file_path: skill_file_path.to_path_buf(),
+        disable_model_invocation: metadata.disable_model_invocation,
+    })
+}
+
+fn extract_frontmatter(content: &str) -> Result<(SkillMetadata, &str)> {
+    let content = content.trim_start();
+
+    if !content.starts_with("---") {
+        anyhow::bail!("SKILL.md must start with YAML frontmatter (---)");
+    }
+
+    // Find every candidate closing `---` line: a line consisting EXACTLY of
+    // `---` (followed by `\n`, `\r\n`, or EOF) at column 0, excluding the
+    // opening line itself. The opener occupies bytes 0..(first line ending),
+    // and our scan starts after each `\n`, so the opener is naturally skipped.
+    //
+    // For each candidate we record the byte position right after its line
+    // ending; that's both where the YAML stream slice ends and where the body
+    // begins.
+    let bytes = content.as_bytes();
+    let mut candidates: Vec<usize> = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'\n' {
+            continue;
+        }
+        let line_start = i + 1;
+        if line_start + 3 > bytes.len() {
+            continue;
+        }
+        if &bytes[line_start..line_start + 3] != b"---" {
+            continue;
+        }
+        let after_dashes = line_start + 3;
+        let end = if after_dashes == bytes.len() {
+            after_dashes
+        } else if bytes[after_dashes] == b'\n' {
+            after_dashes + 1
+        } else if after_dashes + 1 < bytes.len()
+            && bytes[after_dashes] == b'\r'
+            && bytes[after_dashes + 1] == b'\n'
+        {
+            after_dashes + 2
+        } else {
+            // Line is something like `---trailing` or `----`; not a candidate.
+            continue;
+        };
+        candidates.push(end);
+    }
+
+    if candidates.is_empty() {
+        anyhow::bail!("SKILL.md missing closing frontmatter delimiter (---)");
+    }
+
+    // Try each candidate in order: slice content up through the candidate's
+    // terminator and ask `serde_yaml_ng` to parse it as a YAML stream. If the
+    // first document deserializes into `SkillMetadata`, that candidate is the
+    // real closer. Otherwise an earlier candidate may have cut the YAML in the
+    // middle of a scalar / quoted string; try the next one.
+    let mut last_error: Option<anyhow::Error> = None;
+    for end in candidates {
+        let prefix = &content[..end];
+        let mut docs = serde_yaml_ng::Deserializer::from_str(prefix);
+        let Some(first_doc) = docs.next() else {
+            continue;
+        };
+        match SkillMetadata::deserialize(first_doc) {
+            Ok(metadata) => return Ok((metadata, &content[end..])),
+            Err(e) => last_error = Some(anyhow::Error::new(e)),
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("could not parse YAML frontmatter"))
+        .context("Invalid YAML frontmatter"))
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Skill name cannot be empty");
+    }
+
+    if name.len() > 64 {
+        anyhow::bail!("Skill name must be at most 64 characters");
+    }
+
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        anyhow::bail!("Skill name must contain only lowercase letters, numbers, and hyphens");
+    }
+
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<()> {
+    if description.is_empty() {
+        anyhow::bail!("Skill description cannot be empty");
+    }
+
+    if description.len() > 1024 {
+        anyhow::bail!("Skill description must be at most 1024 characters");
+    }
+
+    Ok(())
+}
+
 pub async fn load_skills_from_directory(
     fs: &Arc<dyn Fs>,
     directory: &Path,
     source: SkillSource,
-) -> Vec<Skill> {
+) -> Vec<Result<Skill, SkillLoadError>> {
     if !fs.is_dir(directory).await {
         return Vec::new();
     }
 
     let skill_files = find_skill_files(fs, directory).await;
 
-    let mut skills: Vec<Skill> = skill_files
-        .into_iter()
-        .filter_map(|skill_file_path| {
-            let directory_path = skill_file_path.parent()?.to_path_buf();
-            Some(Skill {
-                source: source.clone(),
-                directory_path,
-                skill_file_path,
-            })
+    let mut results: Vec<Result<Skill, SkillLoadError>> = futures::stream::iter(skill_files)
+        .map(|path| {
+            let fs = fs.clone();
+            let source = source.clone();
+            async move { load_skill_frontmatter(fs, path, source).await }
         })
-        .collect();
+        .buffer_unordered(SKILL_IO_CONCURRENCY)
+        .collect()
+        .await;
 
-    // Sort by path for deterministic ordering — `fs.read_dir` order is
-    // filesystem-dependent.
-    skills.sort_by(|a, b| a.skill_file_path.cmp(&b.skill_file_path));
+    // Sort by path so name-conflict resolution in `merge_skills` is
+    // deterministic — `fs.read_dir` order is filesystem-dependent.
+    results.sort_by(|a, b| {
+        let path_a: &Path = match a {
+            Ok(skill) => &skill.skill_file_path,
+            Err(error) => &error.path,
+        };
+        let path_b: &Path = match b {
+            Ok(skill) => &skill.skill_file_path,
+            Err(error) => &error.path,
+        };
+        path_a.cmp(path_b)
+    });
 
-    skills
+    results
 }
 
 /// Find every `<skills_root>/<name>/SKILL.md` directly under `directory`.
@@ -117,6 +335,146 @@ async fn find_skill_files(fs: &Arc<dyn Fs>, directory: &Path) -> Vec<PathBuf> {
         .filter_map(|x| async move { x })
         .collect()
         .await
+}
+
+/// Returns the byte index ONE PAST the end of the closing frontmatter
+/// delimiter line in `bytes`, or `None` if no closing delimiter has been
+/// seen yet. Used by the chunked reader to know when it has enough
+/// bytes to stop pulling from disk.
+///
+/// Scans for the first `\n---` line followed by `\n`, `\r\n`, or EOF
+/// (excluding the opening line itself, which sits at byte 0 and is
+/// naturally skipped because we only consider lines following a `\n`).
+/// This may overshoot in pathological cases (e.g. `---` inside a quoted
+/// YAML string), but `parse_skill_frontmatter`'s candidate-and-validate
+/// logic still produces a correct result or a YAML parse error.
+fn closing_delimiter_end(bytes: &[u8]) -> Option<usize> {
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'\n' {
+            continue;
+        }
+        let line_start = i + 1;
+        if line_start + 3 > bytes.len() {
+            continue;
+        }
+        if &bytes[line_start..line_start + 3] != b"---" {
+            continue;
+        }
+        let after_dashes = line_start + 3;
+        if after_dashes == bytes.len() {
+            return Some(after_dashes);
+        }
+        if bytes[after_dashes] == b'\n' {
+            return Some(after_dashes + 1);
+        }
+        if after_dashes + 1 < bytes.len()
+            && bytes[after_dashes] == b'\r'
+            && bytes[after_dashes + 1] == b'\n'
+        {
+            return Some(after_dashes + 2);
+        }
+        // Line is `---trailing` or `----`; keep scanning.
+    }
+    None
+}
+
+/// Read just enough of `skill_file_path` from disk to parse its
+/// frontmatter. The SKILL.md body is NOT loaded — that's deferred to
+/// `read_skill_body`, called only when a skill is actually being
+/// materialized for the model. Reading in 4KB chunks keeps the peak
+/// memory cost of loading N skills proportional to total frontmatter
+/// size, not total file size.
+pub async fn load_skill_frontmatter(
+    fs: Arc<dyn Fs>,
+    skill_file_path: PathBuf,
+    source: SkillSource,
+) -> Result<Skill, SkillLoadError> {
+    // Short-circuit on oversized files before reading any of their
+    // contents, so a stray multi-GB file named `SKILL.md` can't OOM the
+    // app. We only act on a positive signal that the file is too large;
+    // if metadata fails or is unavailable, we fall through to the read
+    // loop, which is itself capped at `MAX_SKILL_FILE_SIZE`.
+    if let Ok(Some(metadata)) = fs.metadata(&skill_file_path).await
+        && metadata.len > MAX_SKILL_FILE_SIZE as u64
+    {
+        return Err(SkillLoadError {
+            path: skill_file_path.clone(),
+            message: format!(
+                "SKILL.md file exceeds maximum size of {}KB",
+                MAX_SKILL_FILE_SIZE / 1024
+            ),
+        });
+    }
+
+    let mut reader = fs
+        .open_sync(&skill_file_path)
+        .await
+        .map_err(|e| SkillLoadError {
+            path: skill_file_path.clone(),
+            message: format!("Failed to open file: {}", e),
+        })?;
+
+    // The chunked read is intentionally synchronous: `Fs::open_sync`
+    // returns a synchronous `Read` (RealFs uses `std::fs::File`), and
+    // production callers already wrap `load_skills_from_directory` in
+    // `cx.background_spawn`, so any blocking happens on the background
+    // executor — not on the foreground thread. Routing through
+    // `smol::unblock` instead would schedule the work on smol's blocking
+    // pool, whose wakeups don't drive GPUI's test scheduler and therefore
+    // panic with "Parking forbidden" under `TestAppContext`.
+    let read_result: Result<Vec<u8>, io::Error> = (|| {
+        let mut accumulated: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let n = reader.read(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            accumulated.extend_from_slice(&chunk[..n]);
+            if closing_delimiter_end(&accumulated).is_some() {
+                break;
+            }
+            if accumulated.len() > MAX_SKILL_FILE_SIZE {
+                break;
+            }
+        }
+        Ok(accumulated)
+    })();
+    let accumulated = read_result.map_err(|e| SkillLoadError {
+        path: skill_file_path.clone(),
+        message: format!("Failed to read file: {}", e),
+    })?;
+
+    let content = std::str::from_utf8(&accumulated).map_err(|e| SkillLoadError {
+        path: skill_file_path.clone(),
+        message: format!("SKILL.md is not valid UTF-8: {}", e),
+    })?;
+
+    parse_skill_frontmatter(&skill_file_path, content, source).map_err(|e| SkillLoadError {
+        path: skill_file_path.clone(),
+        message: e.to_string(),
+    })
+}
+
+/// Read the body of a SKILL.md from disk — everything after the closing
+/// `---`. Called only when a skill is being materialized for the model
+/// (via `SkillTool` or a slash invocation). The body is intentionally
+/// NOT kept in memory between materializations.
+pub async fn read_skill_body(
+    fs: &dyn Fs,
+    skill_file_path: &Path,
+) -> Result<String, SkillLoadError> {
+    let content = fs.load(skill_file_path).await.map_err(|e| SkillLoadError {
+        path: skill_file_path.to_path_buf(),
+        message: format!("Failed to read file: {}", e),
+    })?;
+
+    let (_metadata, body) = extract_frontmatter(&content).map_err(|e| SkillLoadError {
+        path: skill_file_path.to_path_buf(),
+        message: e.to_string(),
+    })?;
+
+    Ok(body.trim().to_string())
 }
 
 /// Returns the global skills directory: `~/.agents/skills`.
@@ -182,10 +540,440 @@ mod tests {
     use fs::FakeFs;
     use gpui::TestAppContext;
 
+    #[test]
+    fn test_parse_valid_skill() {
+        let content = r#"---
+name: my-skill
+description: A test skill for testing purposes
+---
+
+# My Skill
+
+## Instructions
+Do the thing.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/my-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("Should parse successfully");
+
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "A test skill for testing purposes");
+        assert_eq!(skill.directory_path, Path::new("/skills/my-skill"));
+        // Default: skill is invocable by both model and user.
+        assert!(!skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_true() {
+        let content = r#"---
+name: deploy
+description: Deploy the application to production.
+disable-model-invocation: true
+---
+
+Steps to deploy.
+"#;
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/deploy/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("should parse");
+        assert!(skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_explicit_false() {
+        let content = r#"---
+name: helper
+description: A helper skill.
+disable-model-invocation: false
+---
+
+Help.
+"#;
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/helper/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("should parse");
+        assert!(!skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_missing_frontmatter() {
+        let content = "# My Skill\n\nNo frontmatter here.";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must start with YAML frontmatter")
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_closing_delimiter() {
+        let content = r#"---
+name: test
+description: Test
+# No closing delimiter
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_frontmatter_closing_on_next_line() {
+        // An empty frontmatter (closer immediately after the opener) is a real
+        // authoring case. Parsing should ultimately fail because the empty YAML
+        // doc lacks `name` and `description`, but the error must be the proper
+        // YAML/missing-field error rather than "missing closing frontmatter
+        // delimiter" — the closer is right there.
+        let content = "---\n---\nbody\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            !err_chain.contains("missing closing frontmatter delimiter"),
+            "Error should NOT be the missing-closer error since the closer is present: {}",
+            err_chain
+        );
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("name")
+                || err_chain.contains("description")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing name/description field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_name() {
+        let content = r#"---
+description: A test skill
+---
+
+Content here.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("name")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing name field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_description() {
+        let content = r#"---
+name: test-skill
+---
+
+Content here.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("description")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing description field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_name_too_long() {
+        let long_name = "a".repeat(65);
+        let content = format!(
+            r#"---
+name: {long_name}
+description: Test
+---
+
+Content.
+"#
+        );
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 64 characters")
+        );
+    }
+
+    #[test]
+    fn test_parse_name_invalid_chars() {
+        let content = r#"---
+name: My_Skill
+description: Test
+---
+
+Content.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("lowercase letters, numbers, and hyphens")
+        );
+    }
+
+    #[test]
+    fn test_parse_description_too_long() {
+        let long_desc = "a".repeat(1025);
+        let content = format!(
+            r#"---
+name: test
+description: {long_desc}
+---
+
+Content.
+"#
+        );
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 1024 characters")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_description() {
+        let content = r#"---
+name: test
+description: ""
+---
+
+Content.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_file_too_large() {
+        let large_content = format!(
+            r#"---
+name: test
+description: Test skill
+---
+
+{}"#,
+            "x".repeat(MAX_SKILL_FILE_SIZE + 1)
+        );
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &large_content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn test_parse_empty_body_after_frontmatter() {
+        let content = r#"---
+name: minimal-skill
+description: A skill with no body content
+---
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/minimal/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+
+        let skill = result.expect("Empty body should be allowed");
+        assert_eq!(skill.name, "minimal-skill");
+        assert_eq!(skill.description, "A skill with no body content");
+    }
+
+    #[test]
+    fn test_parse_whitespace_only_body() {
+        let content = "---\nname: whitespace-skill\ndescription: Test\n---\n\n   \n\n   \n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/ws/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+
+        let skill = result.expect("Whitespace-only body should be allowed");
+        assert_eq!(skill.name, "whitespace-skill");
+    }
+
+    #[test]
+    fn test_parse_skill_with_crlf_line_endings() {
+        let content = "---\r\nname: crlf-skill\r\ndescription: A skill with CRLF line endings\r\n---\r\n\r\n# CRLF Skill\r\n\r\nDo the thing.\r\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/crlf-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("CRLF document should parse successfully");
+
+        assert_eq!(skill.name, "crlf-skill");
+        assert_eq!(skill.description, "A skill with CRLF line endings");
+    }
+
+    #[test]
+    fn test_parse_skill_with_mixed_line_endings() {
+        let content = "---\r\nname: mixed-skill\r\ndescription: Frontmatter uses CRLF, body uses LF\r\n---\r\n\n# Mixed Skill\n\nBody uses LF only.\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/mixed-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("Mixed line endings should parse successfully");
+
+        assert_eq!(skill.name, "mixed-skill");
+        assert_eq!(skill.description, "Frontmatter uses CRLF, body uses LF");
+    }
+
+    #[test]
+    fn test_parse_rejects_closing_delimiter_with_trailing_chars() {
+        // The only `---` after the opener has trailing junk on the same line,
+        // so it isn't a valid closing delimiter and parsing must error.
+        let content = "---\nname: foo\ndescription: bar\n---trailing-junk\nbody content\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[test]
+    fn test_parse_accepts_only_truly_terminated_closing_delimiter() {
+        // The first `---trailing` appears inside a quoted YAML string and is
+        // NOT alone on its line, so it must not be treated as the closer.
+        // The real closer comes later as `\n---\n`.
+        let content = "---\nname: skill-name\ndescription: A real description\nsummary: \"---trailing\"\n---\nbody content\n";
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/skill-name/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("Should pick the truly-terminated closing delimiter");
+
+        assert_eq!(skill.name, "skill-name");
+        assert_eq!(skill.description, "A real description");
+    }
+
+    #[test]
+    fn test_parse_accepts_four_dashes_as_invalid_closer() {
+        // A line of four dashes is NOT a valid closing delimiter; with no
+        // valid closer following, parsing must error.
+        let content = "---\nname: foo\ndescription: bar\n----\nbody content\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
     #[gpui::test]
     async fn test_load_skills_from_empty_directory(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills")).await.unwrap();
+        fs.insert_tree("/skills", serde_json::json!({})).await;
 
         let results = load_skills_from_directory(
             &(fs as Arc<dyn Fs>),
@@ -199,105 +987,13 @@ mod tests {
     #[gpui::test]
     async fn test_load_single_skill(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/my-skill")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/my-skill/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        assert_eq!(
-            results,
-            vec![Skill {
-                source: SkillSource::Global,
-                directory_path: PathBuf::from("/skills/my-skill"),
-                skill_file_path: PathBuf::from("/skills/my-skill/SKILL.md"),
-            }]
-        );
-    }
-
-    #[gpui::test]
-    async fn test_load_nested_skills(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/skill-one")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/skill-one/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-        fs.create_dir(Path::new("/skills/skill-two")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/skill-two/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
-        assert_eq!(
-            paths,
-            vec![
-                PathBuf::from("/skills/skill-one/SKILL.md"),
-                PathBuf::from("/skills/skill-two/SKILL.md"),
-            ]
-        );
-    }
-
-    #[gpui::test]
-    async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        for name in ["charlie", "alpha", "bravo", "delta"] {
-            let dir = PathBuf::from("/skills").join(name);
-            fs.create_dir(&dir).await.unwrap();
-            fs.insert_file(&dir.join("SKILL.md"), b"placeholder".to_vec())
-                .await;
-        }
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
-
-        let mut expected = paths.clone();
-        expected.sort();
-        assert_eq!(paths, expected);
-    }
-
-    #[gpui::test]
-    async fn test_load_ignores_non_skill_files(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/my-skill")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/my-skill/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-        fs.insert_file(
-            Path::new("/skills/not-a-skill.txt"),
-            b"This is not a skill".to_vec(),
-        )
-        .await;
-        fs.create_dir(Path::new("/skills/some-dir")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/some-dir/other-file.md"),
-            b"Not a SKILL.md".to_vec(),
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n\n# Instructions\nDo stuff."
+                }
+            }),
         )
         .await;
 
@@ -309,10 +1005,154 @@ mod tests {
         .await;
 
         assert_eq!(results.len(), 1);
-        assert_eq!(
-            results[0].skill_file_path,
-            PathBuf::from("/skills/my-skill/SKILL.md")
-        );
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "Test skill");
+    }
+
+    #[gpui::test]
+    async fn test_load_nested_skills(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "skill-one": {
+                    "SKILL.md": "---\nname: skill-one\ndescription: First skill\n---\n\nContent one"
+                },
+                "skill-two": {
+                    "SKILL.md": "---\nname: skill-two\ndescription: Second skill\n---\n\nContent two"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|s| s.name.as_str())
+            .collect();
+        assert!(names.contains(&"skill-one"));
+        assert!(names.contains(&"skill-two"));
+    }
+
+    #[gpui::test]
+    async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
+        // `merge_skills` resolves name conflicts by keeping the first
+        // entry in iteration order. Without a stable sort here, the
+        // result depends on `fs.read_dir`, which is OS/filesystem-
+        // dependent. Assert the contract: results come back sorted by
+        // skill file path regardless of insertion order.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "charlie": {
+                    "SKILL.md": "---\nname: charlie\ndescription: C\n---\n\nC"
+                },
+                "alpha": {
+                    "SKILL.md": "---\nname: alpha\ndescription: A\n---\n\nA"
+                },
+                "bravo": {
+                    "SKILL.md": "---\nname: bravo\ndescription: B\n---\n\nB"
+                },
+                "delta": {
+                    "SKILL.md": "No frontmatter, will fail"
+                },
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 4);
+
+        let paths: Vec<PathBuf> = results
+            .iter()
+            .map(|r| match r {
+                Ok(skill) => skill.skill_file_path.clone(),
+                Err(error) => error.path.clone(),
+            })
+            .collect();
+
+        let mut expected = paths.clone();
+        expected.sort();
+        assert_eq!(paths, expected);
+    }
+
+    #[gpui::test]
+    async fn test_load_ignores_non_skill_files(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test\n---\n\nContent"
+                },
+                "not-a-skill.txt": "This is not a skill",
+                "some-dir": {
+                    "other-file.md": "Not a SKILL.md"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+    }
+
+    #[gpui::test]
+    async fn test_load_returns_errors_for_invalid_skills(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "valid-skill": {
+                    "SKILL.md": "---\nname: valid-skill\ndescription: Valid\n---\n\nContent"
+                },
+                "invalid-skill": {
+                    "SKILL.md": "No frontmatter here"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+
+        let (successes, errors): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.is_ok());
+
+        assert_eq!(successes.len(), 1);
+        assert_eq!(errors.len(), 1);
+
+        let error = errors[0].as_ref().unwrap_err();
+        assert!(error.path.to_string_lossy().contains("invalid-skill"));
     }
 
     #[gpui::test]
@@ -329,21 +1169,39 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    #[test]
+    fn test_skill_summary_from_skill() {
+        let skill = Skill {
+            name: "test-skill".to_string(),
+            description: "A test description".to_string(),
+            source: SkillSource::Global,
+            directory_path: PathBuf::from("/skills/test-skill"),
+            skill_file_path: PathBuf::from("/skills/test-skill/SKILL.md"),
+            disable_model_invocation: false,
+        };
+
+        let summary = SkillSummary::from(&skill);
+        assert_eq!(summary.name, "test-skill");
+        assert_eq!(summary.description, "A test description");
+        assert_eq!(summary.location, "/skills/test-skill/SKILL.md");
+    }
+
     #[gpui::test]
     async fn test_nested_skill_md_inside_skill_resources_is_not_loaded(cx: &mut TestAppContext) {
         // We only look at immediate children of the skills root, so a
         // `SKILL.md` nested inside a skill's resources directory cannot
         // accidentally be picked up as a separate skill.
         let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/outer")).await.unwrap();
-        fs.insert_file(Path::new("/skills/outer/SKILL.md"), b"placeholder".to_vec())
-            .await;
-        fs.create_dir(Path::new("/skills/outer/references"))
-            .await
-            .unwrap();
-        fs.insert_file(
-            Path::new("/skills/outer/references/SKILL.md"),
-            b"placeholder".to_vec(),
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "outer": {
+                    "SKILL.md": "---\nname: outer\ndescription: Outer skill\n---\n\nBody",
+                    "references": {
+                        "SKILL.md": "---\nname: bogus-inner\ndescription: Should not load\n---\n\nBody"
+                    },
+                },
+            }),
         )
         .await;
 
@@ -354,8 +1212,127 @@ mod tests {
         )
         .await;
 
-        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
-        assert_eq!(paths, vec![PathBuf::from("/skills/outer/SKILL.md")]);
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["outer"]);
+    }
+
+    #[gpui::test]
+    async fn test_load_oversized_skill_file_short_circuits(cx: &mut TestAppContext) {
+        // A `SKILL.md` whose size exceeds `MAX_SKILL_FILE_SIZE` must be
+        // rejected via metadata before we read its contents into memory.
+        // Otherwise a stray multi-GB file dropped into a skill directory
+        // would OOM the application before `parse_skill`'s size check fires.
+        let fs = FakeFs::new(cx.executor());
+        let oversized_body = "x".repeat(MAX_SKILL_FILE_SIZE + 1);
+        let oversized_content = format!(
+            "---\nname: huge\ndescription: Too big\n---\n\n{}",
+            oversized_body
+        );
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "huge": {
+                    "SKILL.md": oversized_content,
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let err = results[0].as_ref().expect_err("Oversized file must error");
+        assert!(
+            err.message.contains("exceeds maximum size"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[gpui::test]
+    async fn test_load_skill_frontmatter_parses_metadata_without_body(cx: &mut TestAppContext) {
+        // `load_skill_frontmatter` should read just enough of the file to
+        // parse the frontmatter and return a `Skill` with name/description/
+        // disable_model_invocation populated. The body is intentionally not
+        // surfaced; callers go through `read_skill_body` for that.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: A skill for tests\ndisable-model-invocation: true\n---\n\n# Body\n\nLots of body text here.\n"
+                }
+            }),
+        )
+        .await;
+
+        let skill = load_skill_frontmatter(
+            fs as Arc<dyn Fs>,
+            PathBuf::from("/skills/my-skill/SKILL.md"),
+            SkillSource::Global,
+        )
+        .await
+        .expect("frontmatter should parse");
+
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "A skill for tests");
+        assert!(skill.disable_model_invocation);
+        assert_eq!(
+            skill.skill_file_path,
+            PathBuf::from("/skills/my-skill/SKILL.md")
+        );
+        assert_eq!(skill.directory_path, PathBuf::from("/skills/my-skill"));
+    }
+
+    #[gpui::test]
+    async fn test_read_skill_body_returns_trimmed_body(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n\n# Instructions\n\nDo the thing.\n\n"
+                }
+            }),
+        )
+        .await;
+
+        let body = read_skill_body(fs.as_ref(), Path::new("/skills/my-skill/SKILL.md"))
+            .await
+            .expect("body should load");
+
+        // Trimmed: no leading blank line after the closing `---`, and no
+        // trailing whitespace.
+        assert_eq!(body, "# Instructions\n\nDo the thing.");
+    }
+
+    #[gpui::test]
+    async fn test_read_skill_body_for_skill_without_body(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "empty": {
+                    "SKILL.md": "---\nname: empty\ndescription: No body\n---\n"
+                }
+            }),
+        )
+        .await;
+
+        let body = read_skill_body(fs.as_ref(), Path::new("/skills/empty/SKILL.md"))
+            .await
+            .expect("body should load");
+
+        assert!(body.is_empty(), "expected empty body, got: {body:?}");
     }
 
     #[test]

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -313,6 +313,12 @@ pub trait PromptCompletionProviderDelegate: Send + Sync + 'static {
 
     fn available_commands(&self, cx: &App) -> Vec<AvailableCommand>;
     fn confirm_command(&self, cx: &mut App);
+
+    /// Called once each time the user opens slash-command autocomplete
+    /// in the editor this delegate serves. Implementations may use it
+    /// to lazily kick off work that produces commands (for example,
+    /// scanning the global skills directory). The default is a no-op.
+    fn slash_autocomplete_invoked(&self, _cx: &mut App) {}
 }
 
 pub struct PromptCompletionProvider<T: PromptCompletionProviderDelegate> {
@@ -817,6 +823,13 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
     }
 
     fn search_slash_commands(&self, query: String, cx: &mut App) -> Task<Vec<AvailableCommand>> {
+        // Notify the delegate that slash autocomplete is being
+        // invoked, so it can lazily kick off any work that produces
+        // additional commands. Whatever it produces won't be visible
+        // in the current autocomplete pass (we read `available_commands`
+        // synchronously below), but will appear on the next invocation.
+        self.source.slash_autocomplete_invoked(cx);
+
         let commands = self.source.available_commands(cx);
         if commands.is_empty() {
             return Task::ready(Vec::new());

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -610,6 +610,24 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // The three skill-watcher trigger points all live here:
+        // - `Focus` fires when the user clicks into the input box.
+        // - `SlashAutocompleteOpened` fires when the completion
+        //   provider is asked for slash commands.
+        // - `Send` fires when the user submits the conversation.
+        // All three triggers are idempotent; firing the same one
+        // repeatedly is a no-op once a scan or watch is active.
+        if matches!(
+            event,
+            MessageEditorEvent::Focus
+                | MessageEditorEvent::SlashAutocompleteOpened
+                | MessageEditorEvent::Send
+        ) {
+            if let Some(connection) = self.as_native_connection(cx) {
+                connection.ensure_skills_scan_started(cx);
+            }
+        }
+
         match event {
             MessageEditorEvent::Send => self.send(window, cx),
             MessageEditorEvent::SendImmediately => self.interrupt_and_send(window, cx),
@@ -618,6 +636,7 @@ impl ThreadView {
                 self.cancel_editing(&Default::default(), window, cx);
             }
             MessageEditorEvent::LostFocus => {}
+            MessageEditorEvent::SlashAutocompleteOpened => {}
             MessageEditorEvent::InputAttempted { .. } => {}
         }
     }
@@ -756,6 +775,8 @@ impl ThreadView {
             }
             ViewEvent::MessageEditorEvent(_editor, MessageEditorEvent::Cancel) => {
                 self.cancel_editing(&Default::default(), window, cx);
+            }
+            ViewEvent::MessageEditorEvent(_editor, MessageEditorEvent::SlashAutocompleteOpened) => {
             }
             ViewEvent::MessageEditorEvent(_editor, MessageEditorEvent::InputAttempted { .. }) => {}
             ViewEvent::OpenDiffLocation {

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -131,6 +131,14 @@ impl PromptCompletionProviderDelegate for MessageEditorCompletionDelegate {
         self.session_capabilities.read().completion_commands()
     }
 
+    fn slash_autocomplete_invoked(&self, cx: &mut App) {
+        if let Some(editor) = self.message_editor.upgrade() {
+            editor.update(cx, |_editor, cx| {
+                cx.emit(MessageEditorEvent::SlashAutocompleteOpened);
+            });
+        }
+    }
+
     fn confirm_command(&self, cx: &mut App) {
         let _ = self.message_editor.update(cx, |this, cx| this.send(cx));
     }
@@ -160,6 +168,10 @@ pub enum MessageEditorEvent {
     Cancel,
     Focus,
     LostFocus,
+    /// Emitted when the user opens slash-command autocomplete in this
+    /// editor. Used by `ThreadView` to fire the global-skills scan
+    /// trigger; see `NativeAgent::ensure_skills_scan_started`.
+    SlashAutocompleteOpened,
     InputAttempted {
         attempt: InputAttempt,
         cursor_offset: usize,
@@ -2043,13 +2055,15 @@ mod tests {
     use text::Point;
     use ui::{App, Context, IntoElement, Render, SharedString, Window};
     use util::{path, paths::PathStyle, rel_path::rel_path};
-    use workspace::{AppState, Item, MultiWorkspace};
+    use workspace::{AppState, Item, MultiWorkspace, Workspace};
 
     use crate::completion_provider::{AgentContextSelection, PromptContextType};
     use crate::{
         conversation_view::tests::init_test,
         mention_set::insert_crease_for_mention,
-        message_editor::{Mention, MessageEditor, SessionCapabilities, parse_mention_links},
+        message_editor::{
+            Mention, MessageEditor, MessageEditorEvent, SessionCapabilities, parse_mention_links,
+        },
     };
 
     #[test]
@@ -2558,6 +2572,102 @@ mod tests {
             assert_eq!(editor.display_text(cx), "/say-hell");
             assert!(!editor.has_visible_completions_menu());
         });
+    }
+
+    /// Opening slash-command autocomplete must emit
+    /// [`MessageEditorEvent::SlashAutocompleteOpened`]. `ThreadView`
+    /// subscribes to that event to fire the global-skills scan trigger
+    /// (see `NativeAgent::ensure_skills_scan_started`); without the
+    /// event the trigger never runs and lazily-discovered skills never
+    /// appear in autocomplete.
+    #[gpui::test]
+    async fn test_slash_autocomplete_emits_opened_event(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let app_state = cx.update(AppState::test);
+
+        cx.update(|cx| {
+            editor::init(cx);
+            workspace::init(app_state.clone(), cx);
+        });
+
+        let project = Project::test(app_state.fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+
+        let session_capabilities = Arc::new(RwLock::new(SessionCapabilities::new(
+            acp::PromptCapabilities::default(),
+            vec![acp::AvailableCommand::new("hello", "Say hello")],
+        )));
+
+        // Track every event emitted by the message editor across the
+        // lifetime of the test. We expect to see Focus (from the focus
+        // call below) and SlashAutocompleteOpened (from typing "/").
+        let received_events: Arc<parking_lot::Mutex<Vec<MessageEditorEvent>>> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        let editor = workspace.update_in(&mut cx, |workspace, window, cx| {
+            let workspace_handle = cx.weak_entity();
+            let message_editor = cx.new(|cx| {
+                MessageEditor::new(
+                    workspace_handle,
+                    project.downgrade(),
+                    None,
+                    None,
+                    session_capabilities.clone(),
+                    "Test Agent".into(),
+                    "Test",
+                    EditorMode::AutoHeight {
+                        max_lines: None,
+                        min_lines: 1,
+                    },
+                    window,
+                    cx,
+                )
+            });
+            workspace.active_pane().update(cx, |pane, cx| {
+                pane.add_item(
+                    Box::new(cx.new(|_| MessageEditorItem(message_editor.clone()))),
+                    true,
+                    true,
+                    None,
+                    window,
+                    cx,
+                );
+            });
+
+            let received_events = received_events.clone();
+            cx.subscribe(
+                &message_editor,
+                move |_editor: &mut Workspace, _, event: &MessageEditorEvent, _cx| {
+                    received_events.lock().push(event.clone());
+                },
+            )
+            .detach();
+
+            message_editor.read(cx).focus_handle(cx).focus(window, cx);
+            message_editor.read(cx).editor().clone()
+        });
+
+        cx.simulate_input("/");
+
+        editor.update_in(&mut cx, |editor, _window, cx| {
+            assert_eq!(editor.text(cx), "/");
+            assert!(editor.has_visible_completions_menu());
+        });
+
+        let events = received_events.lock();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MessageEditorEvent::SlashAutocompleteOpened)),
+            "expected SlashAutocompleteOpened to have been emitted; saw events: {events:?}",
+        );
     }
 
     #[gpui::test]

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -139,3 +139,15 @@ impl FeatureFlag for AutoWatchFeatureFlag {
     type Value = PresenceFlag;
 }
 register_feature_flag!(AutoWatchFeatureFlag);
+
+pub struct SkillsFeatureFlag;
+
+impl FeatureFlag for SkillsFeatureFlag {
+    const NAME: &'static str = "skills";
+    type Value = PresenceFlag;
+
+    fn enabled_for_staff() -> bool {
+        false
+    }
+}
+register_feature_flag!(SkillsFeatureFlag);


### PR DESCRIPTION
> Stacked on top of #56456 (AI-217). Review that first.

Second PR in the stacked-skills series. Lands the **on-disk-discovery half** of the skills feature — but **does not wire the loaded data into anything the user or model can see yet**. The catalog, slash-command surfacing, and `skill` tool follow in subsequent PRs.

### What's in here

- **Skill parsing**: `SKILL.md` frontmatter (YAML) + body, strict validation per the [agent skills spec](https://github.com/anthropics/skills).
- **Skill discovery and loading**:
  - Global skills at `~/.agents/skills/<name>/SKILL.md`.
  - Project-local skills at `<worktree>/.agents/skills/<name>/SKILL.md`, gated on worktree trust (so a freshly cloned untrusted repo can't ship hostile skills).
- **File-system observation**:
  - Lazy global watcher — nothing on disk is touched until the user first interacts with the agent panel.
  - Project-local paths picked up via the existing worktree change events.
- **Just-in-time triggers**: input focus, slash-command autocomplete, and conversation submit each call `ensure_skills_scan_started` (idempotent — no-op once a scan or watch is active).
- **`SkillsFeatureFlag` gating**: without the flag, none of the skill code paths run.
- **Tests**: parsing edge cases (frontmatter, CRLF, validation, oversized files), scan/watch behavior, trust gating, JIT-trigger plumbing.

The loaded skills land in `state.skills` on `ProjectState`. That's it — nothing reads from there in this PR. The data is shaped and ready for the follow-up PRs to surface.

### What's not in here (saved for follow-ups)

- `SkillTool` and the `skill` tool registration (model-driven activation).
- System-prompt catalog integration (`with_skills` on `ProjectContext`, the `<available_skills>` block in the system prompt template, the description-budget enforcement).
- Slash-command activation surface (loaded skills don't appear in the slash list yet).
- Skill loading error UI banners.
- Default Write/Ask profile changes (`"skill": true`).
- The `agent_skills` README.

Closes AI-218

Release Notes:

- N/A
