### PR TITLE
languages: Highlight bash conditionals and arithmetic operators

### DIFF
--- a/crates/grammars/src/bash/highlights.scm
+++ b/crates/grammars/src/bash/highlights.scm
@@ -72,6 +72,7 @@
 [
   "$"
   "&&"
+  "||"
   ">"
   "<<"
   ">>"
@@ -86,8 +87,36 @@
   "%%"
   "#"
   "##"
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "**="
+  "<<="
+  ">>="
+  "&="
+  "^="
+  "|="
   "="
+  "=~"
   "=="
+  "!="
+  "-o"
+  "-a"
+  "^"
+  "&"
+  "<="
+  ">="
+  "+"
+  "-"
+  "*"
+  "**"
+  "!"
+  "++"
+  "--"
+  "~"
+  "?"
 ] @operator
 
 (test_operator) @keyword.operator
@@ -103,6 +132,18 @@
   "]"
 ] @punctuation.bracket
 
+(test_command
+  [
+    "[["
+    "]]"
+  ] @punctuation.bracket)
+
+(compound_statement
+  [
+    "(("
+    "))"
+  ] @punctuation.bracket)
+
 (simple_expansion
   "$" @punctuation.special)
 
@@ -113,6 +154,14 @@
 (command_substitution
   "$(" @punctuation.special
   ")" @punctuation.special)
+
+(arithmetic_expansion
+  [
+    "$(("
+    "$["
+    "))"
+    "]"
+  ] @punctuation.special)
 
 ((command
   (_) @constant)


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/56478

This diff fixes Bash syntax highlighting for conditional and arithmetic expressions. The Bash parser already recognizes tokens like `[[`, `]]`, `((`, `))`, `$((`, `!=`, and `||`, but Zed’s Bash highlight query was not capturing several of them.

With this change, the Bash highlight query styles those operators and delimiters consistently with existing shell operators, brackets, and special punctuation.

| Before | After |
| --- | --- |
| <img width="1667" height="1088" alt="ayu-old" src="https://github.com/user-attachments/assets/0a89bd71-0a13-4ebe-8bc9-abc27ab42ed8" /> | <img width="1667" height="1088" alt="ayu-new" src="https://github.com/user-attachments/assets/afa5e8ab-f94a-4f5e-8fe8-770bac07559a" /> |

Release Notes:
- Fixed bash syntax highlighting for conditional expressions, arithmetic expressions, and related operators.
