### PR TITLE
rules_library: Clarify Default Rules tooltips: attached to every *turn*

### DIFF
--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -338,11 +338,18 @@ impl PickerDelegate for RulePickerDelegate {
     ) -> Option<Self::ListItem> {
         match self.filtered_entries.get(ix)? {
             RulePickerEntry::Header(title) => {
-                let tooltip_text = if title.as_ref() == "Built-in Rules" {
-                    "Built-in rules are those included out of the box with Zed."
-                } else {
-                    "Default Rules are attached by default with every new thread."
-                };
+                let (tooltip_title, tooltip_meta): (&'static str, &'static str) =
+                    if title.as_ref() == "Built-in Rules" {
+                        (
+                            "Built-in Rules",
+                            "These rules are included out of the box with Zed.",
+                        )
+                    } else {
+                        (
+                            "Default Rules",
+                            "Included in every thread's system prompt.\nEdits take effect on the next turn."
+                        )
+                    };
 
                 Some(
                     ListSubHeader::new(title.clone())
@@ -351,7 +358,9 @@ impl PickerDelegate for RulePickerDelegate {
                                 .style(ButtonStyle::Transparent)
                                 .icon_size(IconSize::Small)
                                 .icon_color(Color::Muted)
-                                .tooltip(Tooltip::text(tooltip_text))
+                                .tooltip(move |_window, cx| {
+                                    Tooltip::with_meta(tooltip_title, None, tooltip_meta, cx)
+                                })
                                 .into_any_element(),
                         )
                         .inset(true)
@@ -420,7 +429,7 @@ impl PickerDelegate for RulePickerDelegate {
                                                         Tooltip::with_meta(
                                                             "Add to Default Rules",
                                                             None,
-                                                            "Always included in every thread.",
+                                                            "Included in every thread's system prompt.\nEdits take effect on the next turn.",
                                                             cx,
                                                         )
                                                     })
@@ -1199,7 +1208,7 @@ impl RulesLibrary {
                                 Tooltip::with_meta(
                                     "Add to Default Rules",
                                     None,
-                                    "Always included in every thread.",
+                                    "Included in every thread's system prompt.\nEdits take effect on the next turn.",
                                     cx,
                                 )
                             })


### PR DESCRIPTION
Two tooltips in the rules library implied that default rules are baked into a thread's system prompt at thread creation, which is wrong.

The "Add to Default Rules" button (two locations - [separate bug](https://github.com/zed-industries/zed/issues/56507)) said:

  Always included in every thread.

The (i) icon next to the "Default Rules" header said:

  Default Rules are attached by default with every new thread.

Both phrasings answer the scope question (which threads is this attached to?) but invite the reading that an edit won't reach an already-open thread, and that the attachment is a one-time event at thread creation. Neither is true: ProjectContext is a per-project, live entity that's rebuilt on PromptsUpdatedEvent and re-rendered into the system prompt on every turn (see [crates/agent/src/agent.rs::build_project_context](https://github.com/zed-industries/zed/blob/a5bf443ef68382222a5bd64f3f10ffdcf37246a7/crates/agent/src/agent.rs#L520-L583) and [crates/agent/src/thread.rs::build_request_messages](https://github.com/zed-industries/zed/blob/a5bf443ef68382222a5bd64f3f10ffdcf37246a7/crates/agent/src/thread.rs#L3055-L3094)). Existing threads pick up rule edits on their next turn.

Reword both tooltips to the same two-line meta string:
- where it goes ("Included in every thread's system prompt.") and
- when edits take effect ("Edits take effect on the next turn.")

The \n renders as a hard line break, consistent with existing multi-line tooltips elsewhere in the codebase (recent_projects, remote_servers, tasks_ui/modal).

The (i) icon tooltip is migrated from Tooltip::text to Tooltip::with_meta to accommodate the two-line format and to match the "Add to Default Rules" tooltips' style. The Built-in Rules branch is migrated alongside it for consistency, keeping the same content rephrased as a title + meta pair.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56503 (mostly)

Release Notes:
- Improved Rules library tooltips for Default rules

### On caching

The proposed tooltips deliberately don't mention caching, because that varies per provider. However, their phrasing does beg the question.

Fortunately, re-sending the system prompt every turn isn't wasteful for most users because the major providers cache it:

| Provider | Zed-side caching wiring |
|---|---|
| Anthropic (direct + cloud) | `cache_control: { type: "ephemeral" }` on the last content segment (`crates/anthropic/src/completion.rs`) |
| OpenAI (direct + cloud) | `prompt_cache_key = thread_id`; all OpenAI models opt in via `supports_prompt_cache_key() -> true` |
| Bedrock | `CachePoint` blocks for Claude models with a `cache_configuration` (Sonnet 4, Haiku 4.5, …) |
| Google Gemini | Implicit server-side; Zed observes `cached_content_token_count` in usage metadata |
| OpenAI-compatible / Vercel AI Gateway | Per-model `prompt_cache_key` capability detection |
| xAI, OpenRouter, DeepSeek, Mistral, Ollama, LM Studio, Copilot Chat, OpenCode | None wired up Zed-side (some may cache server-side regardless) |
