### PR TITLE
Use available width for the labels in the debug modal

### DIFF
--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -1588,6 +1588,8 @@ impl PickerDelegate for DebugDelegate {
                 .toggle_state(selected)
                 .child(
                     v_flex()
+                        .w_full()
+                        .min_w_0()
                         .items_start()
                         .child(highlighted_location.render(window, cx))
                         .when_some(subtitle, |this, subtitle_text| {


### PR DESCRIPTION
AI disclosure: the PR has been made with claude code assistance

Before:
<img width="681" height="307" alt="Screenshot 2026-05-12 at 10 06 02" src="https://github.com/user-attachments/assets/8ea24d32-345c-402f-ba4c-b29c80d97d3c" />

After:
<img width="678" height="312" alt="Screenshot 2026-05-12 at 10 05 46" src="https://github.com/user-attachments/assets/1b3c42dc-a66b-46d0-a156-ff76769b7bb8" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56505

Release Notes:

- Fixed eagerly truncated labels in the Debug modal.
