### PR TITLE
ui: Render ListItem end_slot_on_hover even with no end_slot

### DIFF
--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -350,31 +350,50 @@ impl RenderOnce for ListItem {
                             .children(self.start_slot)
                             .children(self.children),
                     )
-                    .when(self.end_slot.is_some(), |this| this.justify_between())
-                    .when_some(self.end_slot, |this, end_slot| {
-                        this.child(match self.end_slot_visibility {
-                            EndSlotVisibility::Always => {
-                                h_flex().flex_shrink().overflow_hidden().child(end_slot)
+                    .map(|this| {
+                        let end_section = match (self.end_slot, self.end_slot_visibility) {
+                            (None, EndSlotVisibility::Always | EndSlotVisibility::OnHover) => {
+                                None
                             }
-                            EndSlotVisibility::OnHover => h_flex()
-                                .flex_shrink()
-                                .overflow_hidden()
-                                .visible_on_hover("list_item")
-                                .child(end_slot),
-                            EndSlotVisibility::SwapOnHover(hover_slot) => h_flex()
-                                .relative()
-                                .flex_shrink()
-                                .child(h_flex().visible_on_hover("list_item").child(hover_slot))
-                                .child(
-                                    h_flex()
-                                        .absolute()
-                                        .inset_0()
-                                        .justify_end()
-                                        .overflow_hidden()
-                                        .group_hover("list_item", |this| this.invisible())
-                                        .child(end_slot),
-                                ),
-                        })
+                            (Some(end_slot), EndSlotVisibility::Always) => {
+                                Some(h_flex().flex_shrink().overflow_hidden().child(end_slot))
+                            }
+                            (Some(end_slot), EndSlotVisibility::OnHover) => Some(
+                                h_flex()
+                                    .flex_shrink()
+                                    .overflow_hidden()
+                                    .visible_on_hover("list_item")
+                                    .child(end_slot),
+                            ),
+                            (Some(end_slot), EndSlotVisibility::SwapOnHover(hover_slot)) => Some(
+                                h_flex()
+                                    .relative()
+                                    .flex_shrink()
+                                    .child(
+                                        h_flex().visible_on_hover("list_item").child(hover_slot),
+                                    )
+                                    .child(
+                                        h_flex()
+                                            .absolute()
+                                            .inset_0()
+                                            .justify_end()
+                                            .overflow_hidden()
+                                            .group_hover("list_item", |this| this.invisible())
+                                            .child(end_slot),
+                                    ),
+                            ),
+                            (None, EndSlotVisibility::SwapOnHover(hover_slot)) => Some(
+                                h_flex()
+                                    .flex_shrink()
+                                    .overflow_hidden()
+                                    .visible_on_hover("list_item")
+                                    .child(hover_slot),
+                            ),
+                        };
+                        match end_section {
+                            Some(end_section) => this.justify_between().child(end_section),
+                            None => this,
+                        }
                     }),
             )
     }


### PR DESCRIPTION
ListItem::end_slot_on_hover(...) silently does nothing unless ListItem::end_slot(...) is also set. The render path wraps the entire end-slot region — including the SwapOnHover hover content — inside a when_some(self.end_slot, ...), so when end_slot is None the hover slot is never instantiated, regardless of end_slot_visibility.

This causes user-visible breakage in the rules library picker (crates/rules_library/src/rules_library.rs::render_match): rows for non-default, non-built-in rules call `end_slot::<IconButton>(None)` plus `end_slot_on_hover(trash + plus)`. Today, hovering such a row reveals nothing (no 🗑️, no ➕ ) and ther's no way to delete the rule or toggle it into the default set from the picker. Default-rule rows happen to work only because their always-visible end_slot is populated with the 📎 , which is what causes ListItem to also render the hover slot.

Refactor the end-slot rendering to match on (end_slot, end_slot_visibility) jointly:

  - (Some, Always)        → render end_slot.
  - (Some, OnHover)       → render end_slot, visible on row hover.
  - (Some, SwapOnHover)   → stack: hover_slot revealed on hover, end_slot hidden on hover. Unchanged.
  - (None, SwapOnHover)   → render hover_slot, visible on row hover. NEW: previously dropped.
  - (None, Always|OnHover) → nothing. Preserved as before; OnHover with no slot has nothing to reveal.

justify_between() now fires whenever any right-side section is rendered, including the (None, SwapOnHover) case.

This fixes the picker bug without any change to call sites: existing rules_library code that wanted both icons on non-default rows simply starts working.

Release Notes:

- Fixed missing trash and add-to-default-rules icons when hovering non-default user rules in the rules library picker.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56507

Release Notes:

- Added action icons for non-default rules in the Rules library (delete, make default)
