### PR TITLE
Parse SKILL.md frontmatter and lazy-load skill bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,10 +342,14 @@ dependencies = [
 name = "agent_skills"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "fs",
  "futures 0.3.32",
  "gpui",
  "paths",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
  "util",
 ]
 
@@ -16037,6 +16041,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.11.4",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.11.4",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,6 +712,7 @@ schemars = { version = "1.0", features = ["indexmap2"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0.221", features = ["derive", "rc"] }
 serde_json = { version = "1.0.144", features = ["preserve_order", "raw_value"] }
+serde_yaml_ng = "0.10"
 serde_json_lenient = { version = "0.2", features = [
     "preserve_order",
     "raw_value",

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -29,8 +29,8 @@ use acp_thread::{
 };
 use agent_client_protocol::schema as acp;
 use agent_skills::{
-    Skill, SkillScopeId, SkillSource, global_skills_dir, load_skills_from_directory,
-    project_skills_relative_path,
+    Skill, SkillLoadError, SkillScopeId, SkillSource, global_skills_dir,
+    load_skills_from_directory, project_skills_relative_path,
 };
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Utc};
@@ -753,49 +753,49 @@ impl NativeAgent {
         let trusted_worktrees = TrustedWorktrees::try_get_global(cx);
         let worktree_store = project.read(cx).worktree_store();
         let project_skills_task = if skills_enabled {
-            let project_skills_futures: Vec<futures::future::BoxFuture<'static, Vec<Skill>>> =
-                worktrees
-                    .iter()
-                    .filter_map(|worktree| {
-                        let worktree_id = worktree.read(cx).id();
-                        let is_trusted =
-                            trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
-                                trusted_worktrees.update(cx, |trusted_worktrees, cx| {
-                                    trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
-                                })
-                            });
-                        if !is_trusted {
-                            return None;
-                        }
-                        let worktree_snapshot = worktree.read(cx);
-                        let abs_path = worktree_snapshot.abs_path();
-                        let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
-                        // Capture scan_complete *before* spawning so we don't have to re-borrow
-                        // the worktree from inside the async task (which would require a cx).
-                        let scan_complete = worktree_snapshot
-                            .as_local()
-                            .map(|local| local.scan_complete());
-                        let skills_dir = abs_path.join(project_skills_relative_path());
-                        let fs = fs.clone();
-                        Some(
-                            async move {
-                                if let Some(scan_complete) = scan_complete {
-                                    scan_complete.await;
-                                }
-                                load_skills_from_directory(
-                                    &fs,
-                                    &skills_dir,
-                                    SkillSource::ProjectLocal {
-                                        worktree_id: SkillScopeId(worktree_id.to_usize()),
-                                        worktree_root_name,
-                                    },
-                                )
-                                .await
+            let project_skills_futures: Vec<
+                futures::future::BoxFuture<'static, Vec<Result<Skill, SkillLoadError>>>,
+            > = worktrees
+                .iter()
+                .filter_map(|worktree| {
+                    let worktree_id = worktree.read(cx).id();
+                    let is_trusted = trusted_worktrees.as_ref().is_none_or(|trusted_worktrees| {
+                        trusted_worktrees.update(cx, |trusted_worktrees, cx| {
+                            trusted_worktrees.can_trust(&worktree_store, worktree_id, cx)
+                        })
+                    });
+                    if !is_trusted {
+                        return None;
+                    }
+                    let worktree_snapshot = worktree.read(cx);
+                    let abs_path = worktree_snapshot.abs_path();
+                    let worktree_root_name: Arc<str> = worktree_snapshot.root_name_str().into();
+                    // Capture scan_complete *before* spawning so we don't have to re-borrow
+                    // the worktree from inside the async task (which would require a cx).
+                    let scan_complete = worktree_snapshot
+                        .as_local()
+                        .map(|local| local.scan_complete());
+                    let skills_dir = abs_path.join(project_skills_relative_path());
+                    let fs = fs.clone();
+                    Some(
+                        async move {
+                            if let Some(scan_complete) = scan_complete {
+                                scan_complete.await;
                             }
-                            .boxed(),
-                        )
-                    })
-                    .collect();
+                            load_skills_from_directory(
+                                &fs,
+                                &skills_dir,
+                                SkillSource::ProjectLocal {
+                                    worktree_id: SkillScopeId(worktree_id.to_usize()),
+                                    worktree_root_name,
+                                },
+                            )
+                            .await
+                        }
+                        .boxed(),
+                    )
+                })
+                .collect();
             cx.background_spawn(async move { future::join_all(project_skills_futures).await })
         } else {
             Task::ready(Vec::new())
@@ -852,13 +852,28 @@ impl NativeAgent {
             // Concatenate global skills followed by each worktree's
             // project-local skills. `find_skill_files`'s sort plus this
             // iteration order gives a deterministic-enough ordering for
-            // our needs (parsing and conflict resolution happen in a
-            // follow-up PR).
+            // our needs (conflict resolution happens in a follow-up PR).
+            //
+            // `load_skills_from_directory` returns `Vec<Result<Skill, SkillLoadError>>`
+            // so that a future PR can surface parse errors in the UI. For
+            // now, we silently drop the errors after logging them.
+            fn drain_skills(results: Vec<Result<Skill, SkillLoadError>>) -> Vec<Skill> {
+                results
+                    .into_iter()
+                    .filter_map(|result| match result {
+                        Ok(skill) => Some(skill),
+                        Err(err) => {
+                            log::warn!("Failed to load skill: {err}");
+                            None
+                        }
+                    })
+                    .collect()
+            }
             let global_skills = global_skills_task.await;
             let project_skills_results = project_skills_task.await;
-            let mut skills: Vec<Skill> = global_skills;
+            let mut skills: Vec<Skill> = drain_skills(global_skills);
             for project_skills in project_skills_results {
-                skills.extend(project_skills);
+                skills.extend(drain_skills(project_skills));
             }
 
             let project_context = ProjectContext::new(worktrees, default_user_rules);
@@ -2627,8 +2642,11 @@ mod internal_tests {
         let initial_skill_dir = skills_dir.join("my-skill");
         let initial_skill_path = initial_skill_dir.join("SKILL.md");
         fs.create_dir(&initial_skill_dir).await.unwrap();
-        fs.insert_file(&initial_skill_path, b"placeholder".to_vec())
-            .await;
+        fs.insert_file(
+            &initial_skill_path,
+            b"---\nname: my-skill\ndescription: First version\n---\n\nbody".to_vec(),
+        )
+        .await;
 
         let project = Project::test(fs.clone(), [], cx).await;
         let thread_store = cx.new(|cx| ThreadStore::new(cx));
@@ -2659,21 +2677,24 @@ mod internal_tests {
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].skill_file_path, initial_skill_path);
+            assert_eq!(state.skills[0].name, "my-skill");
+            assert_eq!(state.skills[0].description, "First version");
         });
 
         // Modify the SKILL.md and verify the watcher re-fires and the
-        // skill list is rebuilt. With parsing deferred, we just confirm
-        // the entry continues to point at the same path.
-        fs.write(&initial_skill_path, b"placeholder-v2")
-            .await
-            .unwrap();
+        // skill list is rebuilt with the new description.
+        fs.write(
+            &initial_skill_path,
+            b"---\nname: my-skill\ndescription: Second version\n---\n\nbody",
+        )
+        .await
+        .unwrap();
         cx.run_until_parked();
 
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].skill_file_path, initial_skill_path);
+            assert_eq!(state.skills[0].description, "Second version");
         });
     }
 
@@ -2729,8 +2750,11 @@ mod internal_tests {
         let new_skill_dir = skills_dir.join("late-skill");
         let new_skill_path = new_skill_dir.join("SKILL.md");
         fs.create_dir(&new_skill_dir).await.unwrap();
-        fs.insert_file(&new_skill_path, b"placeholder".to_vec())
-            .await;
+        fs.insert_file(
+            &new_skill_path,
+            b"---\nname: late-skill\ndescription: Created after startup\n---\n\nbody".to_vec(),
+        )
+        .await;
 
         // Fire the trigger again, simulating the user interacting with
         // the agent panel after creating the skills directory. The
@@ -2744,7 +2768,8 @@ mod internal_tests {
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project.entity_id()).unwrap();
             assert_eq!(state.skills.len(), 1);
-            assert_eq!(state.skills[0].skill_file_path, new_skill_path);
+            assert_eq!(state.skills[0].name, "late-skill");
+            assert_eq!(state.skills[0].description, "Created after startup");
         });
     }
 
@@ -2770,7 +2795,7 @@ mod internal_tests {
                 ".agents": {
                     "skills": {
                         "my-skill": {
-                            "SKILL.md": "placeholder"
+                            "SKILL.md": "---\nname: my-skill\ndescription: A trusted skill\n---\n\nbody"
                         }
                     }
                 }
@@ -2837,15 +2862,8 @@ mod internal_tests {
 
         agent.read_with(cx, |agent, _cx| {
             let state = agent.projects.get(&project_id).unwrap();
-            let paths: Vec<PathBuf> = state
-                .skills
-                .iter()
-                .map(|s| s.skill_file_path.clone())
-                .collect();
-            assert_eq!(
-                paths,
-                vec![PathBuf::from("/project/.agents/skills/my-skill/SKILL.md")]
-            );
+            let names: Vec<&str> = state.skills.iter().map(|s| s.name.as_str()).collect();
+            assert_eq!(names, vec!["my-skill"]);
         });
     }
 

--- a/crates/agent_skills/Cargo.toml
+++ b/crates/agent_skills/Cargo.toml
@@ -12,12 +12,16 @@ workspace = true
 path = "agent_skills.rs"
 
 [dependencies]
+anyhow.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 paths.workspace = true
+serde.workspace = true
+serde_yaml_ng.workspace = true
 util.workspace = true
 
 [dev-dependencies]
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
+serde_json.workspace = true

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -1,5 +1,8 @@
+use anyhow::{Context as _, Result};
 use fs::Fs;
 use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use util::paths::component_matches_ignore_ascii_case;
@@ -25,19 +28,29 @@ pub struct SkillScopeId(pub usize);
 /// operations, potentially exhausting file descriptors or stalling the app.
 const SKILL_IO_CONCURRENCY: usize = 16;
 
+/// Maximum size for a single SKILL.md file (100KB)
+pub const MAX_SKILL_FILE_SIZE: usize = 100 * 1024;
+
+/// Maximum total size for skill descriptions in system prompt (50KB)
+pub const MAX_SKILL_DESCRIPTIONS_SIZE: usize = 50 * 1024;
+
 /// The name of the skill definition file
 pub const SKILL_FILE_NAME: &str = "SKILL.md";
 
-/// A skill discovered on disk. This PR only records paths; the
-/// `SKILL.md` contents (name, description, body) are parsed in a
-/// follow-up PR.
-#[derive(Debug, Clone, Eq, PartialEq)]
+/// Represents a loaded skill with all its metadata and content.
+#[derive(Debug, Clone)]
 pub struct Skill {
+    pub name: String,
+    pub description: String,
     pub source: SkillSource,
-    /// Absolute path to the skill directory (e.g. `~/.agents/skills/foo`).
+    /// Absolute path to the skill directory
     pub directory_path: PathBuf,
-    /// Absolute path to the `SKILL.md` file inside the skill directory.
+    /// Absolute path to the SKILL.md file
     pub skill_file_path: PathBuf,
+    /// When `true`, this skill is hidden from the model's catalog and the
+    /// `skill` tool refuses to load it. The user can still invoke it as a
+    /// slash command.
+    pub disable_model_invocation: bool,
 }
 
 /// Indicates where a skill was loaded from.
@@ -52,34 +65,239 @@ pub enum SkillSource {
     },
 }
 
+/// Just the frontmatter, used for parsing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillMetadata {
+    pub name: String,
+    pub description: String,
+    #[serde(default, rename = "disable-model-invocation")]
+    pub disable_model_invocation: bool,
+}
+
+/// Minimal skill info for system prompt (not full content).
+///
+/// `Serialize` is required for handlebars rendering of the system prompt
+/// template (see `ProjectContext` in `prompt_store`). `PartialEq, Eq` lets
+/// the agent compare freshly-built `ProjectContext`s and skip pushing an
+/// unchanged value through the project_context entity (which would
+/// otherwise look like a system-prompt change to the model and invalidate
+/// the API's prompt cache).
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct SkillSummary {
+    pub name: String,
+    pub description: String,
+    /// Absolute path to the SKILL.md file, so the model can resolve
+    /// references relative to the skill's directory when reading bundled
+    /// resources.
+    pub location: String,
+}
+
+impl From<&Skill> for SkillSummary {
+    fn from(skill: &Skill) -> Self {
+        Self {
+            name: skill.name.clone(),
+            description: skill.description.clone(),
+            location: skill.skill_file_path.to_string_lossy().into_owned(),
+        }
+    }
+}
+
+/// Error that occurred while loading a skill
+#[derive(Debug, Clone)]
+pub struct SkillLoadError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl std::fmt::Display for SkillLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+impl std::error::Error for SkillLoadError {}
+
+/// Parse the frontmatter of a SKILL.md file into a `Skill` struct.
+///
+/// The file must have YAML frontmatter between `---` delimiters containing
+/// `name` and `description` fields. The body (everything after the closing
+/// `---`) is intentionally NOT returned — it's read on demand via
+/// `read_skill_body` when the skill is actually being materialized for the
+/// model, so we don't pay N × body-size in memory for N skills.
+///
+/// `content` only needs to contain bytes up through the closing `---`; any
+/// trailing body bytes are ignored.
+pub fn parse_skill_frontmatter(
+    skill_file_path: &Path,
+    content: &str,
+    source: SkillSource,
+) -> Result<Skill> {
+    if content.len() > MAX_SKILL_FILE_SIZE {
+        anyhow::bail!(
+            "SKILL.md file exceeds maximum size of {}KB",
+            MAX_SKILL_FILE_SIZE / 1024
+        );
+    }
+
+    let (metadata, _body) = extract_frontmatter(content)?;
+
+    validate_name(&metadata.name)?;
+    validate_description(&metadata.description)?;
+
+    let directory_path = skill_file_path
+        .parent()
+        .context("SKILL.md file has no parent directory")?
+        .to_path_buf();
+
+    Ok(Skill {
+        name: metadata.name,
+        description: metadata.description,
+        source,
+        directory_path,
+        skill_file_path: skill_file_path.to_path_buf(),
+        disable_model_invocation: metadata.disable_model_invocation,
+    })
+}
+
+fn extract_frontmatter(content: &str) -> Result<(SkillMetadata, &str)> {
+    let content = content.trim_start();
+
+    if !content.starts_with("---") {
+        anyhow::bail!("SKILL.md must start with YAML frontmatter (---)");
+    }
+
+    // Find every candidate closing `---` line: a line consisting EXACTLY of
+    // `---` (followed by `\n`, `\r\n`, or EOF) at column 0, excluding the
+    // opening line itself. The opener occupies bytes 0..(first line ending),
+    // and our scan starts after each `\n`, so the opener is naturally skipped.
+    //
+    // For each candidate we record the byte position right after its line
+    // ending; that's both where the YAML stream slice ends and where the body
+    // begins.
+    let bytes = content.as_bytes();
+    let mut candidates: Vec<usize> = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'\n' {
+            continue;
+        }
+        let line_start = i + 1;
+        if line_start + 3 > bytes.len() {
+            continue;
+        }
+        if &bytes[line_start..line_start + 3] != b"---" {
+            continue;
+        }
+        let after_dashes = line_start + 3;
+        let end = if after_dashes == bytes.len() {
+            after_dashes
+        } else if bytes[after_dashes] == b'\n' {
+            after_dashes + 1
+        } else if after_dashes + 1 < bytes.len()
+            && bytes[after_dashes] == b'\r'
+            && bytes[after_dashes + 1] == b'\n'
+        {
+            after_dashes + 2
+        } else {
+            // Line is something like `---trailing` or `----`; not a candidate.
+            continue;
+        };
+        candidates.push(end);
+    }
+
+    if candidates.is_empty() {
+        anyhow::bail!("SKILL.md missing closing frontmatter delimiter (---)");
+    }
+
+    // Try each candidate in order: slice content up through the candidate's
+    // terminator and ask `serde_yaml_ng` to parse it as a YAML stream. If the
+    // first document deserializes into `SkillMetadata`, that candidate is the
+    // real closer. Otherwise an earlier candidate may have cut the YAML in the
+    // middle of a scalar / quoted string; try the next one.
+    let mut last_error: Option<anyhow::Error> = None;
+    for end in candidates {
+        let prefix = &content[..end];
+        let mut docs = serde_yaml_ng::Deserializer::from_str(prefix);
+        let Some(first_doc) = docs.next() else {
+            continue;
+        };
+        match SkillMetadata::deserialize(first_doc) {
+            Ok(metadata) => return Ok((metadata, &content[end..])),
+            Err(e) => last_error = Some(anyhow::Error::new(e)),
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("could not parse YAML frontmatter"))
+        .context("Invalid YAML frontmatter"))
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Skill name cannot be empty");
+    }
+
+    if name.len() > 64 {
+        anyhow::bail!("Skill name must be at most 64 characters");
+    }
+
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        anyhow::bail!("Skill name must contain only lowercase letters, numbers, and hyphens");
+    }
+
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<()> {
+    if description.is_empty() {
+        anyhow::bail!("Skill description cannot be empty");
+    }
+
+    if description.len() > 1024 {
+        anyhow::bail!("Skill description must be at most 1024 characters");
+    }
+
+    Ok(())
+}
+
 pub async fn load_skills_from_directory(
     fs: &Arc<dyn Fs>,
     directory: &Path,
     source: SkillSource,
-) -> Vec<Skill> {
+) -> Vec<Result<Skill, SkillLoadError>> {
     if !fs.is_dir(directory).await {
         return Vec::new();
     }
 
     let skill_files = find_skill_files(fs, directory).await;
 
-    let mut skills: Vec<Skill> = skill_files
-        .into_iter()
-        .filter_map(|skill_file_path| {
-            let directory_path = skill_file_path.parent()?.to_path_buf();
-            Some(Skill {
-                source: source.clone(),
-                directory_path,
-                skill_file_path,
-            })
+    let mut results: Vec<Result<Skill, SkillLoadError>> = futures::stream::iter(skill_files)
+        .map(|path| {
+            let fs = fs.clone();
+            let source = source.clone();
+            async move { load_skill_frontmatter(fs, path, source).await }
         })
-        .collect();
+        .buffer_unordered(SKILL_IO_CONCURRENCY)
+        .collect()
+        .await;
 
-    // Sort by path for deterministic ordering — `fs.read_dir` order is
-    // filesystem-dependent.
-    skills.sort_by(|a, b| a.skill_file_path.cmp(&b.skill_file_path));
+    // Sort by path so name-conflict resolution in `merge_skills` is
+    // deterministic — `fs.read_dir` order is filesystem-dependent.
+    results.sort_by(|a, b| {
+        let path_a: &Path = match a {
+            Ok(skill) => &skill.skill_file_path,
+            Err(error) => &error.path,
+        };
+        let path_b: &Path = match b {
+            Ok(skill) => &skill.skill_file_path,
+            Err(error) => &error.path,
+        };
+        path_a.cmp(path_b)
+    });
 
-    skills
+    results
 }
 
 /// Find every `<skills_root>/<name>/SKILL.md` directly under `directory`.
@@ -117,6 +335,146 @@ async fn find_skill_files(fs: &Arc<dyn Fs>, directory: &Path) -> Vec<PathBuf> {
         .filter_map(|x| async move { x })
         .collect()
         .await
+}
+
+/// Returns the byte index ONE PAST the end of the closing frontmatter
+/// delimiter line in `bytes`, or `None` if no closing delimiter has been
+/// seen yet. Used by the chunked reader to know when it has enough
+/// bytes to stop pulling from disk.
+///
+/// Scans for the first `\n---` line followed by `\n`, `\r\n`, or EOF
+/// (excluding the opening line itself, which sits at byte 0 and is
+/// naturally skipped because we only consider lines following a `\n`).
+/// This may overshoot in pathological cases (e.g. `---` inside a quoted
+/// YAML string), but `parse_skill_frontmatter`'s candidate-and-validate
+/// logic still produces a correct result or a YAML parse error.
+fn closing_delimiter_end(bytes: &[u8]) -> Option<usize> {
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'\n' {
+            continue;
+        }
+        let line_start = i + 1;
+        if line_start + 3 > bytes.len() {
+            continue;
+        }
+        if &bytes[line_start..line_start + 3] != b"---" {
+            continue;
+        }
+        let after_dashes = line_start + 3;
+        if after_dashes == bytes.len() {
+            return Some(after_dashes);
+        }
+        if bytes[after_dashes] == b'\n' {
+            return Some(after_dashes + 1);
+        }
+        if after_dashes + 1 < bytes.len()
+            && bytes[after_dashes] == b'\r'
+            && bytes[after_dashes + 1] == b'\n'
+        {
+            return Some(after_dashes + 2);
+        }
+        // Line is `---trailing` or `----`; keep scanning.
+    }
+    None
+}
+
+/// Read just enough of `skill_file_path` from disk to parse its
+/// frontmatter. The SKILL.md body is NOT loaded — that's deferred to
+/// `read_skill_body`, called only when a skill is actually being
+/// materialized for the model. Reading in 4KB chunks keeps the peak
+/// memory cost of loading N skills proportional to total frontmatter
+/// size, not total file size.
+pub async fn load_skill_frontmatter(
+    fs: Arc<dyn Fs>,
+    skill_file_path: PathBuf,
+    source: SkillSource,
+) -> Result<Skill, SkillLoadError> {
+    // Short-circuit on oversized files before reading any of their
+    // contents, so a stray multi-GB file named `SKILL.md` can't OOM the
+    // app. We only act on a positive signal that the file is too large;
+    // if metadata fails or is unavailable, we fall through to the read
+    // loop, which is itself capped at `MAX_SKILL_FILE_SIZE`.
+    if let Ok(Some(metadata)) = fs.metadata(&skill_file_path).await
+        && metadata.len > MAX_SKILL_FILE_SIZE as u64
+    {
+        return Err(SkillLoadError {
+            path: skill_file_path.clone(),
+            message: format!(
+                "SKILL.md file exceeds maximum size of {}KB",
+                MAX_SKILL_FILE_SIZE / 1024
+            ),
+        });
+    }
+
+    let mut reader = fs
+        .open_sync(&skill_file_path)
+        .await
+        .map_err(|e| SkillLoadError {
+            path: skill_file_path.clone(),
+            message: format!("Failed to open file: {}", e),
+        })?;
+
+    // The chunked read is intentionally synchronous: `Fs::open_sync`
+    // returns a synchronous `Read` (RealFs uses `std::fs::File`), and
+    // production callers already wrap `load_skills_from_directory` in
+    // `cx.background_spawn`, so any blocking happens on the background
+    // executor — not on the foreground thread. Routing through
+    // `smol::unblock` instead would schedule the work on smol's blocking
+    // pool, whose wakeups don't drive GPUI's test scheduler and therefore
+    // panic with "Parking forbidden" under `TestAppContext`.
+    let read_result: Result<Vec<u8>, io::Error> = (|| {
+        let mut accumulated: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let n = reader.read(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            accumulated.extend_from_slice(&chunk[..n]);
+            if closing_delimiter_end(&accumulated).is_some() {
+                break;
+            }
+            if accumulated.len() > MAX_SKILL_FILE_SIZE {
+                break;
+            }
+        }
+        Ok(accumulated)
+    })();
+    let accumulated = read_result.map_err(|e| SkillLoadError {
+        path: skill_file_path.clone(),
+        message: format!("Failed to read file: {}", e),
+    })?;
+
+    let content = std::str::from_utf8(&accumulated).map_err(|e| SkillLoadError {
+        path: skill_file_path.clone(),
+        message: format!("SKILL.md is not valid UTF-8: {}", e),
+    })?;
+
+    parse_skill_frontmatter(&skill_file_path, content, source).map_err(|e| SkillLoadError {
+        path: skill_file_path.clone(),
+        message: e.to_string(),
+    })
+}
+
+/// Read the body of a SKILL.md from disk — everything after the closing
+/// `---`. Called only when a skill is being materialized for the model
+/// (via `SkillTool` or a slash invocation). The body is intentionally
+/// NOT kept in memory between materializations.
+pub async fn read_skill_body(
+    fs: &dyn Fs,
+    skill_file_path: &Path,
+) -> Result<String, SkillLoadError> {
+    let content = fs.load(skill_file_path).await.map_err(|e| SkillLoadError {
+        path: skill_file_path.to_path_buf(),
+        message: format!("Failed to read file: {}", e),
+    })?;
+
+    let (_metadata, body) = extract_frontmatter(&content).map_err(|e| SkillLoadError {
+        path: skill_file_path.to_path_buf(),
+        message: e.to_string(),
+    })?;
+
+    Ok(body.trim().to_string())
 }
 
 /// Returns the global skills directory: `~/.agents/skills`.
@@ -182,10 +540,440 @@ mod tests {
     use fs::FakeFs;
     use gpui::TestAppContext;
 
+    #[test]
+    fn test_parse_valid_skill() {
+        let content = r#"---
+name: my-skill
+description: A test skill for testing purposes
+---
+
+# My Skill
+
+## Instructions
+Do the thing.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/my-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("Should parse successfully");
+
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "A test skill for testing purposes");
+        assert_eq!(skill.directory_path, Path::new("/skills/my-skill"));
+        // Default: skill is invocable by both model and user.
+        assert!(!skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_true() {
+        let content = r#"---
+name: deploy
+description: Deploy the application to production.
+disable-model-invocation: true
+---
+
+Steps to deploy.
+"#;
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/deploy/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("should parse");
+        assert!(skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_explicit_false() {
+        let content = r#"---
+name: helper
+description: A helper skill.
+disable-model-invocation: false
+---
+
+Help.
+"#;
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/helper/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("should parse");
+        assert!(!skill.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_parse_missing_frontmatter() {
+        let content = "# My Skill\n\nNo frontmatter here.";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must start with YAML frontmatter")
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_closing_delimiter() {
+        let content = r#"---
+name: test
+description: Test
+# No closing delimiter
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_frontmatter_closing_on_next_line() {
+        // An empty frontmatter (closer immediately after the opener) is a real
+        // authoring case. Parsing should ultimately fail because the empty YAML
+        // doc lacks `name` and `description`, but the error must be the proper
+        // YAML/missing-field error rather than "missing closing frontmatter
+        // delimiter" — the closer is right there.
+        let content = "---\n---\nbody\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            !err_chain.contains("missing closing frontmatter delimiter"),
+            "Error should NOT be the missing-closer error since the closer is present: {}",
+            err_chain
+        );
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("name")
+                || err_chain.contains("description")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing name/description field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_name() {
+        let content = r#"---
+description: A test skill
+---
+
+Content here.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("name")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing name field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_description() {
+        let content = r#"---
+name: test-skill
+---
+
+Content here.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_chain = format!("{:?}", err);
+        assert!(
+            err_chain.contains("missing field")
+                || err_chain.contains("description")
+                || err_chain.contains("Invalid YAML"),
+            "Error should mention missing description field or invalid YAML: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn test_parse_name_too_long() {
+        let long_name = "a".repeat(65);
+        let content = format!(
+            r#"---
+name: {long_name}
+description: Test
+---
+
+Content.
+"#
+        );
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 64 characters")
+        );
+    }
+
+    #[test]
+    fn test_parse_name_invalid_chars() {
+        let content = r#"---
+name: My_Skill
+description: Test
+---
+
+Content.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("lowercase letters, numbers, and hyphens")
+        );
+    }
+
+    #[test]
+    fn test_parse_description_too_long() {
+        let long_desc = "a".repeat(1025);
+        let content = format!(
+            r#"---
+name: test
+description: {long_desc}
+---
+
+Content.
+"#
+        );
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 1024 characters")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_description() {
+        let content = r#"---
+name: test
+description: ""
+---
+
+Content.
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_file_too_large() {
+        let large_content = format!(
+            r#"---
+name: test
+description: Test skill
+---
+
+{}"#,
+            "x".repeat(MAX_SKILL_FILE_SIZE + 1)
+        );
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &large_content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn test_parse_empty_body_after_frontmatter() {
+        let content = r#"---
+name: minimal-skill
+description: A skill with no body content
+---
+"#;
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/minimal/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+
+        let skill = result.expect("Empty body should be allowed");
+        assert_eq!(skill.name, "minimal-skill");
+        assert_eq!(skill.description, "A skill with no body content");
+    }
+
+    #[test]
+    fn test_parse_whitespace_only_body() {
+        let content = "---\nname: whitespace-skill\ndescription: Test\n---\n\n   \n\n   \n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/ws/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+
+        let skill = result.expect("Whitespace-only body should be allowed");
+        assert_eq!(skill.name, "whitespace-skill");
+    }
+
+    #[test]
+    fn test_parse_skill_with_crlf_line_endings() {
+        let content = "---\r\nname: crlf-skill\r\ndescription: A skill with CRLF line endings\r\n---\r\n\r\n# CRLF Skill\r\n\r\nDo the thing.\r\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/crlf-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("CRLF document should parse successfully");
+
+        assert_eq!(skill.name, "crlf-skill");
+        assert_eq!(skill.description, "A skill with CRLF line endings");
+    }
+
+    #[test]
+    fn test_parse_skill_with_mixed_line_endings() {
+        let content = "---\r\nname: mixed-skill\r\ndescription: Frontmatter uses CRLF, body uses LF\r\n---\r\n\n# Mixed Skill\n\nBody uses LF only.\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/mixed-skill/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        let skill = result.expect("Mixed line endings should parse successfully");
+
+        assert_eq!(skill.name, "mixed-skill");
+        assert_eq!(skill.description, "Frontmatter uses CRLF, body uses LF");
+    }
+
+    #[test]
+    fn test_parse_rejects_closing_delimiter_with_trailing_chars() {
+        // The only `---` after the opener has trailing junk on the same line,
+        // so it isn't a valid closing delimiter and parsing must error.
+        let content = "---\nname: foo\ndescription: bar\n---trailing-junk\nbody content\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
+    #[test]
+    fn test_parse_accepts_only_truly_terminated_closing_delimiter() {
+        // The first `---trailing` appears inside a quoted YAML string and is
+        // NOT alone on its line, so it must not be treated as the closer.
+        // The real closer comes later as `\n---\n`.
+        let content = "---\nname: skill-name\ndescription: A real description\nsummary: \"---trailing\"\n---\nbody content\n";
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/skill-name/SKILL.md"),
+            content,
+            SkillSource::Global,
+        )
+        .expect("Should pick the truly-terminated closing delimiter");
+
+        assert_eq!(skill.name, "skill-name");
+        assert_eq!(skill.description, "A real description");
+    }
+
+    #[test]
+    fn test_parse_accepts_four_dashes_as_invalid_closer() {
+        // A line of four dashes is NOT a valid closing delimiter; with no
+        // valid closer following, parsing must error.
+        let content = "---\nname: foo\ndescription: bar\n----\nbody content\n";
+
+        let result = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            content,
+            SkillSource::Global,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing closing frontmatter delimiter")
+        );
+    }
+
     #[gpui::test]
     async fn test_load_skills_from_empty_directory(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills")).await.unwrap();
+        fs.insert_tree("/skills", serde_json::json!({})).await;
 
         let results = load_skills_from_directory(
             &(fs as Arc<dyn Fs>),
@@ -199,105 +987,13 @@ mod tests {
     #[gpui::test]
     async fn test_load_single_skill(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/my-skill")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/my-skill/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        assert_eq!(
-            results,
-            vec![Skill {
-                source: SkillSource::Global,
-                directory_path: PathBuf::from("/skills/my-skill"),
-                skill_file_path: PathBuf::from("/skills/my-skill/SKILL.md"),
-            }]
-        );
-    }
-
-    #[gpui::test]
-    async fn test_load_nested_skills(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/skill-one")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/skill-one/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-        fs.create_dir(Path::new("/skills/skill-two")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/skill-two/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
-        assert_eq!(
-            paths,
-            vec![
-                PathBuf::from("/skills/skill-one/SKILL.md"),
-                PathBuf::from("/skills/skill-two/SKILL.md"),
-            ]
-        );
-    }
-
-    #[gpui::test]
-    async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        for name in ["charlie", "alpha", "bravo", "delta"] {
-            let dir = PathBuf::from("/skills").join(name);
-            fs.create_dir(&dir).await.unwrap();
-            fs.insert_file(&dir.join("SKILL.md"), b"placeholder".to_vec())
-                .await;
-        }
-
-        let results = load_skills_from_directory(
-            &(fs as Arc<dyn Fs>),
-            Path::new("/skills"),
-            SkillSource::Global,
-        )
-        .await;
-
-        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
-
-        let mut expected = paths.clone();
-        expected.sort();
-        assert_eq!(paths, expected);
-    }
-
-    #[gpui::test]
-    async fn test_load_ignores_non_skill_files(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/my-skill")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/my-skill/SKILL.md"),
-            b"placeholder".to_vec(),
-        )
-        .await;
-        fs.insert_file(
-            Path::new("/skills/not-a-skill.txt"),
-            b"This is not a skill".to_vec(),
-        )
-        .await;
-        fs.create_dir(Path::new("/skills/some-dir")).await.unwrap();
-        fs.insert_file(
-            Path::new("/skills/some-dir/other-file.md"),
-            b"Not a SKILL.md".to_vec(),
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n\n# Instructions\nDo stuff."
+                }
+            }),
         )
         .await;
 
@@ -309,10 +1005,154 @@ mod tests {
         .await;
 
         assert_eq!(results.len(), 1);
-        assert_eq!(
-            results[0].skill_file_path,
-            PathBuf::from("/skills/my-skill/SKILL.md")
-        );
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "Test skill");
+    }
+
+    #[gpui::test]
+    async fn test_load_nested_skills(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "skill-one": {
+                    "SKILL.md": "---\nname: skill-one\ndescription: First skill\n---\n\nContent one"
+                },
+                "skill-two": {
+                    "SKILL.md": "---\nname: skill-two\ndescription: Second skill\n---\n\nContent two"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|s| s.name.as_str())
+            .collect();
+        assert!(names.contains(&"skill-one"));
+        assert!(names.contains(&"skill-two"));
+    }
+
+    #[gpui::test]
+    async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
+        // `merge_skills` resolves name conflicts by keeping the first
+        // entry in iteration order. Without a stable sort here, the
+        // result depends on `fs.read_dir`, which is OS/filesystem-
+        // dependent. Assert the contract: results come back sorted by
+        // skill file path regardless of insertion order.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "charlie": {
+                    "SKILL.md": "---\nname: charlie\ndescription: C\n---\n\nC"
+                },
+                "alpha": {
+                    "SKILL.md": "---\nname: alpha\ndescription: A\n---\n\nA"
+                },
+                "bravo": {
+                    "SKILL.md": "---\nname: bravo\ndescription: B\n---\n\nB"
+                },
+                "delta": {
+                    "SKILL.md": "No frontmatter, will fail"
+                },
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 4);
+
+        let paths: Vec<PathBuf> = results
+            .iter()
+            .map(|r| match r {
+                Ok(skill) => skill.skill_file_path.clone(),
+                Err(error) => error.path.clone(),
+            })
+            .collect();
+
+        let mut expected = paths.clone();
+        expected.sort();
+        assert_eq!(paths, expected);
+    }
+
+    #[gpui::test]
+    async fn test_load_ignores_non_skill_files(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test\n---\n\nContent"
+                },
+                "not-a-skill.txt": "This is not a skill",
+                "some-dir": {
+                    "other-file.md": "Not a SKILL.md"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+    }
+
+    #[gpui::test]
+    async fn test_load_returns_errors_for_invalid_skills(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "valid-skill": {
+                    "SKILL.md": "---\nname: valid-skill\ndescription: Valid\n---\n\nContent"
+                },
+                "invalid-skill": {
+                    "SKILL.md": "No frontmatter here"
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 2);
+
+        let (successes, errors): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.is_ok());
+
+        assert_eq!(successes.len(), 1);
+        assert_eq!(errors.len(), 1);
+
+        let error = errors[0].as_ref().unwrap_err();
+        assert!(error.path.to_string_lossy().contains("invalid-skill"));
     }
 
     #[gpui::test]
@@ -329,21 +1169,39 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    #[test]
+    fn test_skill_summary_from_skill() {
+        let skill = Skill {
+            name: "test-skill".to_string(),
+            description: "A test description".to_string(),
+            source: SkillSource::Global,
+            directory_path: PathBuf::from("/skills/test-skill"),
+            skill_file_path: PathBuf::from("/skills/test-skill/SKILL.md"),
+            disable_model_invocation: false,
+        };
+
+        let summary = SkillSummary::from(&skill);
+        assert_eq!(summary.name, "test-skill");
+        assert_eq!(summary.description, "A test description");
+        assert_eq!(summary.location, "/skills/test-skill/SKILL.md");
+    }
+
     #[gpui::test]
     async fn test_nested_skill_md_inside_skill_resources_is_not_loaded(cx: &mut TestAppContext) {
         // We only look at immediate children of the skills root, so a
         // `SKILL.md` nested inside a skill's resources directory cannot
         // accidentally be picked up as a separate skill.
         let fs = FakeFs::new(cx.executor());
-        fs.create_dir(Path::new("/skills/outer")).await.unwrap();
-        fs.insert_file(Path::new("/skills/outer/SKILL.md"), b"placeholder".to_vec())
-            .await;
-        fs.create_dir(Path::new("/skills/outer/references"))
-            .await
-            .unwrap();
-        fs.insert_file(
-            Path::new("/skills/outer/references/SKILL.md"),
-            b"placeholder".to_vec(),
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "outer": {
+                    "SKILL.md": "---\nname: outer\ndescription: Outer skill\n---\n\nBody",
+                    "references": {
+                        "SKILL.md": "---\nname: bogus-inner\ndescription: Should not load\n---\n\nBody"
+                    },
+                },
+            }),
         )
         .await;
 
@@ -354,8 +1212,127 @@ mod tests {
         )
         .await;
 
-        let paths: Vec<PathBuf> = results.iter().map(|s| s.skill_file_path.clone()).collect();
-        assert_eq!(paths, vec![PathBuf::from("/skills/outer/SKILL.md")]);
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["outer"]);
+    }
+
+    #[gpui::test]
+    async fn test_load_oversized_skill_file_short_circuits(cx: &mut TestAppContext) {
+        // A `SKILL.md` whose size exceeds `MAX_SKILL_FILE_SIZE` must be
+        // rejected via metadata before we read its contents into memory.
+        // Otherwise a stray multi-GB file dropped into a skill directory
+        // would OOM the application before `parse_skill`'s size check fires.
+        let fs = FakeFs::new(cx.executor());
+        let oversized_body = "x".repeat(MAX_SKILL_FILE_SIZE + 1);
+        let oversized_content = format!(
+            "---\nname: huge\ndescription: Too big\n---\n\n{}",
+            oversized_body
+        );
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "huge": {
+                    "SKILL.md": oversized_content,
+                }
+            }),
+        )
+        .await;
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let err = results[0].as_ref().expect_err("Oversized file must error");
+        assert!(
+            err.message.contains("exceeds maximum size"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[gpui::test]
+    async fn test_load_skill_frontmatter_parses_metadata_without_body(cx: &mut TestAppContext) {
+        // `load_skill_frontmatter` should read just enough of the file to
+        // parse the frontmatter and return a `Skill` with name/description/
+        // disable_model_invocation populated. The body is intentionally not
+        // surfaced; callers go through `read_skill_body` for that.
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: A skill for tests\ndisable-model-invocation: true\n---\n\n# Body\n\nLots of body text here.\n"
+                }
+            }),
+        )
+        .await;
+
+        let skill = load_skill_frontmatter(
+            fs as Arc<dyn Fs>,
+            PathBuf::from("/skills/my-skill/SKILL.md"),
+            SkillSource::Global,
+        )
+        .await
+        .expect("frontmatter should parse");
+
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "A skill for tests");
+        assert!(skill.disable_model_invocation);
+        assert_eq!(
+            skill.skill_file_path,
+            PathBuf::from("/skills/my-skill/SKILL.md")
+        );
+        assert_eq!(skill.directory_path, PathBuf::from("/skills/my-skill"));
+    }
+
+    #[gpui::test]
+    async fn test_read_skill_body_returns_trimmed_body(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "my-skill": {
+                    "SKILL.md": "---\nname: my-skill\ndescription: Test skill\n---\n\n# Instructions\n\nDo the thing.\n\n"
+                }
+            }),
+        )
+        .await;
+
+        let body = read_skill_body(fs.as_ref(), Path::new("/skills/my-skill/SKILL.md"))
+            .await
+            .expect("body should load");
+
+        // Trimmed: no leading blank line after the closing `---`, and no
+        // trailing whitespace.
+        assert_eq!(body, "# Instructions\n\nDo the thing.");
+    }
+
+    #[gpui::test]
+    async fn test_read_skill_body_for_skill_without_body(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/skills",
+            serde_json::json!({
+                "empty": {
+                    "SKILL.md": "---\nname: empty\ndescription: No body\n---\n"
+                }
+            }),
+        )
+        .await;
+
+        let body = read_skill_body(fs.as_ref(), Path::new("/skills/empty/SKILL.md"))
+            .await
+            .expect("body should load");
+
+        assert!(body.is_empty(), "expected empty body, got: {body:?}");
     }
 
     #[test]


### PR DESCRIPTION
> Third PR in the stacked-skills series. Stacked on top of #56473 (AI-218), which is stacked on top of #56456 (AI-217).

Adds **frontmatter parsing** for skills. The `Skill` struct now carries `name`, `description`, and `disable_model_invocation` in memory; the body stays on disk and is read on demand only when a skill is actually being materialized for the model.

### What's in here

- `parse_skill_frontmatter`: parses YAML frontmatter, strict validation per the agent-skills spec (`name` matches `[a-z0-9-]{1,64}`, `description` is 1–1024 chars, optional `disable-model-invocation` bool).
- `load_skill_frontmatter`: chunked reader. Uses `fs.open_sync` + inline 4KB chunks, stops as soon as the closing `---` is found (or `MAX_SKILL_FILE_SIZE` is hit). Memory cost of loading N skills is O(total frontmatter size), not O(total file size).
- `read_skill_body`: `fs.load` + extract body. Public API, but **not yet called by anything in this PR** — it's there for the user-facing PR (#56464) to consume.
- `load_skills_from_directory` now returns `Vec<Result<Skill, SkillLoadError>>` so a future PR can surface parse errors in the UI banner. `build_project_context` filter-maps Ok variants for now, logging errors at `log::warn` level.
- Test fixtures in `agent.rs` updated from placeholder bytes to valid frontmatter; assertions strengthened to check parsed `name` / `description`.

### Why split this out

[#56473 (AI-218)](https://github.com/zed-industries/zed/pull/56473) landed `Skill = paths only` — enough for discovery but nothing else. The user-facing PR ([#56464](https://github.com/zed-industries/zed/pull/56464)) needs parsed metadata everywhere (catalog, slash commands, `skill` tool). This PR is just the metadata layer so the user-facing PR can focus on wiring it into the UI/tool surface.

### Explicitly out of scope (saved for #56464)

- `SkillTool` (the model-facing `skill` tool) and its rendering pipeline.
- System-prompt catalog of available skills.
- Slash-command surfacing of loaded skills.
- Loading-error UI banners.
- Default profile changes.

Closes AI-221

Release Notes:

- N/A
