### PR TITLE
Respect restore_on_startup setting in NewWindow and CloseProject

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1159,6 +1159,11 @@ fn register_actions(
                     cx,
                     |workspace, window, cx| {
                         cx.activate(true);
+                        if WorkspaceSettings::get_global(cx).restore_on_startup
+                            == workspace::RestoreOnStartupBehavior::Launchpad
+                        {
+                            return;
+                        }
                         // Create buffer synchronously to avoid flicker
                         let project = workspace.project().clone();
                         let buffer = project.update(cx, |project, cx| {
@@ -1208,6 +1213,11 @@ fn register_actions(
                                 cx,
                                 |workspace, window, cx| {
                                     cx.activate(true);
+                                    if WorkspaceSettings::get_global(cx).restore_on_startup
+                                        == workspace::RestoreOnStartupBehavior::Launchpad
+                                    {
+                                        return;
+                                    }
                                     let project = workspace.project().clone();
                                     let buffer = project.update(cx, |project, cx| {
                                         project.create_local_buffer("", None, true, cx)


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] ~Unsafe blocks (if any) have justifying comments~ (N/A)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Previously, both `NewWindow` and `CloseProject` always created an empty untitled buffer regardless of the `restore_on_startup` setting. Now they check the setting and skip creating the editor when it's `"launchpad"`, allowing the welcome page to display instead - consistent with startup behaviour.

I was unable to find an issue or PR that mentions this specifically.

Release Notes:

- Fixed `NewWindow` and `CloseProject` ignoring the `restore_on_startup` setting.