### PR TITLE
collab: Remove unused `From` impl for `User` model to `proto::User`

### DIFF
--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -1,6 +1,5 @@
 use crate::db::UserId;
 use chrono::NaiveDateTime;
-use rpc::proto;
 use sea_orm::entity::prelude::*;
 use serde::Serialize;
 
@@ -29,20 +28,6 @@ impl From<Model> for crate::entities::User {
             name: user.name,
             admin: user.admin,
             connected_once: user.connected_once,
-        }
-    }
-}
-
-impl From<Model> for proto::User {
-    fn from(user: Model) -> Self {
-        Self {
-            id: user.id.to_proto(),
-            avatar_url: format!(
-                "https://avatars.githubusercontent.com/u/{}?s=128&v=4",
-                user.github_user_id
-            ),
-            github_login: user.github_login,
-            name: user.name,
         }
     }
 }


### PR DESCRIPTION
This PR removes a `From` impl from the database `User` model to `proto::User`, as it is no longer used.

Release Notes:

- N/A
