### PR TITLE
editor: Clip flex editor blocks to the text viewport

### DIFF
--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -340,7 +340,7 @@ impl Editor {
             let props = BlockProperties {
                 placement: BlockPlacement::Above(anchor),
                 height: Some(1),
-                style: BlockStyle::Flex,
+                style: BlockStyle::Spacer,
                 render: build_code_lens_renderer(new_line.clone(), editor_handle.clone()),
                 priority: 0,
             };
@@ -644,7 +644,7 @@ fn build_code_lens_renderer(line: CodeLensLine, editor: WeakEntity<Editor>) -> R
 
         div()
             .id(cx.block_id)
-            .pl(cx.margins.gutter.full_width() + cx.em_width * (line.indent_column as f32 + 0.5))
+            .pl(cx.em_width * (line.indent_column as f32 + 0.5))
             .h_full()
             .flex()
             .flex_row()


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/56518

This diff fixes code lens decorations continuing to paint into the gutter when the editor is horizontally
scrolled. Code lens entries were rendered as flex editor blocks with explicit gutter padding, which allowed them to bypass the text viewport clipping used by content-only blocks.

With this change, code lens entries render as spacer-style custom blocks instead. Spacer blocks already scroll with buffer content and paint through the text-side mask, so the code lens padding can be relative to the editor text area and decorations clip at the left edge of the viewport.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/dc567ce5-ad04-4ba2-9156-ec4ec087bd41" controls width="320"></video> | <video src="https://github.com/user-attachments/assets/abb5ba2c-981f-4399-903b-0f8fa9a560e4" controls width="320"></video> |

Release Notes:
- Fixed code lens decorations painting outside the editor viewport when horizontally scrolling.
