### PR TITLE
git: Refresh `git: branch diff` when project changes and command is rerun

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -117,12 +117,52 @@ impl ProjectDiff {
     ) {
         telemetry::event!("Git Branch Diff Opened");
         let project = workspace.project().clone();
+        let intended_repo = project.read(cx).active_repository(cx);
 
         let existing = workspace
             .items_of_type::<Self>(cx)
             .find(|item| matches!(item.read(cx).diff_base(cx), DiffBase::Merge { .. }));
         if let Some(existing) = existing {
             workspace.activate_item(&existing, true, true, window, cx);
+
+            if let Some(intended_repo) = intended_repo {
+                let needs_switch = existing
+                    .read(cx)
+                    .branch_diff
+                    .read(cx)
+                    .repo()
+                    .map_or(true, |current| {
+                        current.read(cx).id != intended_repo.read(cx).id
+                    });
+
+                if needs_switch {
+                    let default_branch =
+                        intended_repo.update(cx, |repo, _| repo.default_branch(true));
+                    let existing = existing.downgrade();
+                    let workspace = cx.entity().downgrade();
+                    window
+                        .spawn(cx, async move |cx| {
+                            let default_branch = default_branch
+                                .await??
+                                .context("Could not determine default branch")?;
+
+                            existing.update(cx, |project_diff, cx| {
+                                project_diff.branch_diff.update(cx, |branch_diff, cx| {
+                                    branch_diff.set_repo(Some(intended_repo), cx);
+                                    branch_diff.set_diff_base(
+                                        DiffBase::Merge {
+                                            base_ref: default_branch,
+                                        },
+                                        cx,
+                                    );
+                                });
+                            })?;
+                            anyhow::Ok(())
+                        })
+                        .detach_and_notify_err(workspace, window, cx);
+                }
+            }
+
             return;
         }
         let workspace = cx.entity();

--- a/crates/project/src/git_store/branch_diff.rs
+++ b/crates/project/src/git_store/branch_diff.rs
@@ -110,6 +110,15 @@ impl BranchDiff {
         &self.diff_base
     }
 
+    pub fn set_diff_base(&mut self, diff_base: DiffBase, cx: &mut Context<Self>) {
+        self.diff_base = diff_base;
+        self.tree_diff = None;
+        self.base_commit = None;
+        self.head_commit = None;
+        cx.emit(BranchDiffEvent::FileListChanged);
+        *self.update_needed.borrow_mut() = ();
+    }
+
     pub fn set_repo(&mut self, repo: Option<Entity<Repository>>, cx: &mut Context<Self>) {
         self.repo = repo;
         self.tree_diff = None;


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- Fixed an issue where re-running the `git: branch diff` after changing the active project would not refresh the branch diff to show the branch diff of the active project
