### PR TITLE
Windows: Fix files opened by UNC path getting no language servers

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -256,6 +256,10 @@ impl SanitizedPath {
 
         #[cfg(target_os = "windows")]
         {
+            let path = match path.to_str().and_then(|s| s.strip_prefix(r"\\?\UNC\")) {
+                Some(rest) => PathBuf::from(format!(r"\\{rest}")).into(),
+                None => path,
+            };
             let simplified = dunce::simplified(path.as_ref());
             if simplified == path.as_ref() {
                 // safe because `Path` and `SanitizedPath` have the same repr and Drop impl
@@ -2850,6 +2854,17 @@ mod tests {
         assert_eq!(
             sanitized_path.to_string(),
             "C:\\Users\\someone\\test_file.rs"
+        );
+    }
+
+    #[perf]
+    #[cfg(target_os = "windows")]
+    fn test_sanitized_path_verbatim_unc() {
+        let path: Arc<Path> = PathBuf::from("\\\\?\\UNC\\server\\share\\file.txt").into();
+        let sanitized_path = SanitizedPath::from_arc(path);
+        assert_eq!(
+            sanitized_path.to_string(),
+            "\\\\server\\share\\file.txt"
         );
     }
 


### PR DESCRIPTION
Opening a file like `zed "\\server\share\file.txt"` leaves it with no language servers attached, and the tab shows the ugly `\\?\UNC\...` path.

The problem is the verbatim `\\?\UNC\` prefix Windows adds during path canonicalization. We rely on dunce to strip these prefixes, but it doesn't handle the UNC case, so the path stays in a form that breaks LSP URL conversion.

Fixed by stripping the prefix ourselves in `SanitizedPath` before handing off to dunce.

Before:
<img width="446" height="257" alt="Screenshot 2026-06-12 075128" src="https://github.com/user-attachments/assets/4177e8de-8d13-42f1-a19b-d7dd52c10b32" />

After: (note the correct tooltip and the syntax error highlighting)
<img width="423" height="268" alt="Screenshot 2026-06-12 083651" src="https://github.com/user-attachments/assets/83e98200-6bed-4a9e-b463-abbc067f6a5d" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) — N/A, no UI changes
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — one extra string-prefix check per worktree creation

Release Notes:

- Fixed: language servers now run when opening files via UNC paths on Windows (e.g. `\\server\share\file.txt`).